### PR TITLE
Explicit namespace for std::isfinite(x)

### DIFF
--- a/src/ext/PBA/SparseBundleCPU.cpp
+++ b/src/ext/PBA/SparseBundleCPU.cpp
@@ -3481,7 +3481,7 @@ int SparseBundleCPU<Float>::SolveNormalEquationPCGX(float lambda) {
   if (__verbose_cg_iteration)
     std::cout << " --0,\t alpha = " << alpha0
               << ", t = " << BundleTimerGetNow(TIMER_CG_ITERATION) << "\n";
-  if (!isfinite(alpha0)) {
+  if (!std::isfinite(alpha0)) {
     return 0;
   }
   if (alpha0 == 0) {
@@ -3540,7 +3540,7 @@ int SparseBundleCPU<Float>::SolveNormalEquationPCGX(float lambda) {
                 << ", t = " << BundleTimerGetNow(TIMER_CG_ITERATION) << "\n";
 
     ///////////////////////////////////////////////////
-    if (!isfinite(alphak) || rtz_ratio > __cg_norm_guard) {
+    if (!std::isfinite(alphak) || rtz_ratio > __cg_norm_guard) {
       __recent_cg_status = 'X';
       break;
     }  // something doesn't converge..
@@ -3601,7 +3601,7 @@ int SparseBundleCPU<Float>::SolveNormalEquationPCGB(float lambda) {
   if (__verbose_cg_iteration)
     std::cout << " --0,\t alpha = " << alpha0
               << ", t = " << BundleTimerGetNow(TIMER_CG_ITERATION) << "\n";
-  if (!isfinite(alpha0)) {
+  if (!std::isfinite(alpha0)) {
     return 0;
   }
   if (alpha0 == 0) {
@@ -3664,7 +3664,7 @@ int SparseBundleCPU<Float>::SolveNormalEquationPCGB(float lambda) {
                 << ", t = " << BundleTimerGetNow(TIMER_CG_ITERATION) << "\n";
 
     ///////////////////////////////////////////////////
-    if (!isfinite(alphak) || rtz_ratio > __cg_norm_guard) {
+    if (!std::isfinite(alphak) || rtz_ratio > __cg_norm_guard) {
       __recent_cg_status = 'X';
       break;
     }  // something doesn't converge..
@@ -3992,7 +3992,7 @@ void SparseBundleCPU<Float>::NonlinearOptimizeLM() {
     float residual_reduction = _projection_sse - new_residual;
 
     // do we find a better solution?
-    if (isfinite(new_residual) && residual_reduction > 0) {
+    if (std::isfinite(new_residual) && residual_reduction > 0) {
       ////compute relative norm change
       float relative_reduction = 1.0f - (new_residual / _projection_sse);
 


### PR DESCRIPTION
Should fix compile problems on Ubuntu Xenial.