### PR TITLE
Enable BOOST in shared mode (optional).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,13 @@ option(OPENMP_ENABLED "Whether to enable OpenMP" ON)
 option(LTO_ENABLED "Whether to enable link-time optimization" ON)
 option(CUDA_ENABLED "Whether to enable CUDA, if available" ON)
 option(PROFILING_ENABLED "Whether to enable google-perftools linker flags" OFF)
+option(BOOST_STATIC "Whether to enable static boost library linker flags" ON)
 
-set(Boost_USE_STATIC_LIBS ON)
-
+if(BOOST_STATIC)
+  set(Boost_USE_STATIC_LIBS ON)
+else()
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
 
 ################################################################################
 # Find packages


### PR DESCRIPTION
  This little patch enables to build [COLMAP](https://colmap.github.io/) with shared [**Boost**](http://boost.org) library too without affecting current behaviour. Vast majority of distros ship shared boost library only, perhaps in future this shared mode **may** be considered as default.

 * To invoke this mode one can run:

  ```cmake . -DBOOST_STATIC=OFF```

 * Please notice the mandatory extra [-DBOOST_TEST_DYN_LINK](http://stackoverflow.com/questions/7781374/boost-test-linking) flag in this shared mode.