### PR TITLE
adds functionality to align a reconstruction to a set of control points

### DIFF
--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -156,6 +156,16 @@ class Reconstruction {
   // registered images. Return true if the two reconstructions could be merged.
   bool Merge(const Reconstruction& reconstruction, const int min_common_images);
 
+  // Align the given reconstruction with a set of pre-defined camera positions.
+  // Assuming that camera_position[i] gives the 3D coordinates of the center
+  // of projection of the image with name image_names[i], use all images from
+  // camera_names also contained in this reconstruction to align the model
+  // with the specified coordinates using a similarity transformation.
+  bool AlignToCameraPositions(
+      const std::vector<std::string>& image_names,
+      const std::vector<Eigen::Vector3d>& camera_positions,
+      const int min_common_images);
+
   // Find image with name.
   //
   // @param name        Name of the image.

--- a/src/exe/CMakeLists.txt
+++ b/src/exe/CMakeLists.txt
@@ -26,6 +26,8 @@ COLMAP_ADD_EXECUTABLE(mapper mapper.cc)
 
 COLMAP_ADD_EXECUTABLE(matches_importer matches_importer.cc)
 
+COLMAP_ADD_EXECUTABLE(model_aligner model_aligner.cc)
+
 COLMAP_ADD_EXECUTABLE(model_converter model_converter.cc)
 
 COLMAP_ADD_EXECUTABLE(model_merger model_merger.cc)

--- a/src/exe/model_aligner.cc
+++ b/src/exe/model_aligner.cc
@@ -1,0 +1,89 @@
+// COLMAP - Structure-from-Motion and Multi-View Stereo.
+// Copyright (C) 2016  Johannes L. Schoenberger <jsch at inf.ethz.ch>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "base/reconstruction.h"
+#include "util/logging.h"
+#include "util/misc.h"
+#include "util/option_manager.h"
+
+#include <sstream>
+
+using namespace colmap;
+
+void ReadReferenceCameras(
+    const std::string& path, std::vector<std::string>* reference_image_names,
+    std::vector<Eigen::Vector3d>* reference_camera_positions) {
+  std::vector<std::string> lines = ReadTextFileLines(path);
+
+  for (const auto line : lines) {
+    std::stringstream line_parser(line);
+    std::string image_name = "";
+    Eigen::Vector3d camera_position;
+    line_parser >> image_name >> camera_position[0] >> camera_position[1]
+                >> camera_position[2];
+    reference_image_names->push_back(image_name);
+    reference_camera_positions->push_back(camera_position);
+  }
+}
+
+int main(int argc, char** argv) {
+  InitializeGlog(argv);
+
+  std::string input_model_path;
+  std::string reference_cameras_path;
+  std::string output_model_path;
+  int min_common_images = 3;
+
+  OptionManager options;
+  options.AddRequiredOption("input_model_path", &input_model_path);
+  options.AddRequiredOption("reference_cameras_path", &reference_cameras_path);
+  options.AddRequiredOption("output_model_path", &output_model_path);
+  options.AddDefaultOption("min_common_images", min_common_images,
+                           &min_common_images);
+
+  if (!options.Parse(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+
+  if (options.ParseHelp(argc, argv)) {
+    return EXIT_SUCCESS;
+  }
+
+  std::vector<std::string> reference_image_names;
+  std::vector<Eigen::Vector3d> reference_camera_positions;
+  ReadReferenceCameras(reference_cameras_path, &reference_image_names,
+                       &reference_camera_positions);
+
+  Reconstruction reconstruction;
+  reconstruction.Read(input_model_path);
+  PrintHeading2("Reconstruction ");
+  std::cout << StringPrintf("Images: %d", reconstruction.NumRegImages())
+            << std::endl;
+  std::cout << StringPrintf("Points: %d", reconstruction.NumPoints3D())
+            << std::endl;
+
+  PrintHeading2("Aligning reconstruction");
+  if (reconstruction.AlignToCameraPositions(reference_image_names,
+                                            reference_camera_positions,
+                                            min_common_images)) {
+    std::cout << "=> Alignment succeeded" << std::endl;
+    reconstruction.Write(output_model_path);
+  } else {
+    std::cout << "=> Alignment failed" << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Loads a list of image names with associated 3D coordinates and computes a similarity transform that aligns the cameras in the model with these control points. Writes out the resulting reconstruction in a directory specified by the user.

This has been tested on the Arts Quad dataset, where a reconstruction computed with Colmap was aligned with the east-north ground truth coordinates of a set of images. In order to facilitate the alignment, the y-coordinate of these ground truth points was set to 0.