### PR TITLE
added an option to build cmake without building the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,16 @@ endif()
 # Options
 ################################################################################
 
-enable_testing()
-
 option(OPENMP_ENABLED "Whether to enable OpenMP" ON)
 option(LTO_ENABLED "Whether to enable link-time optimization" ON)
 option(CUDA_ENABLED "Whether to enable CUDA, if available" ON)
 option(PROFILING_ENABLED "Whether to enable google-perftools linker flags" OFF)
 option(BOOST_STATIC "Whether to enable static boost library linker flags" ON)
+option(WITH_TESTS "Whether to build test binaries" ON)
+
+if(WITH_TESTS)
+    enable_testing()
+endif()
 
 if(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS ON)

--- a/cmake/CMakeHelper.cmake
+++ b/cmake/CMakeHelper.cmake
@@ -221,20 +221,24 @@ endmacro(COLMAP_ADD_UI_EXECUTABLE)
 
 # Wrapper for test executables
 macro(COLMAP_ADD_TEST TARGET_NAME)
-    # ${ARGN} will store the list of source files passed to this function.
-    add_executable(${TARGET_NAME} ${ARGN})
-    target_link_libraries(${TARGET_NAME} ${COLMAP_LIBRARIES})
-    COLMAP_ADD_TARGET_HELPER(${TARGET_NAME})
-    add_test("${FOLDER_NAME}/${TARGET_NAME}" ${TARGET_NAME})
-    install(TARGETS ${TARGET_NAME} DESTINATION test/)
+    if(WITH_TESTS)
+        # ${ARGN} will store the list of source files passed to this function.
+        add_executable(${TARGET_NAME} ${ARGN})
+        target_link_libraries(${TARGET_NAME} ${COLMAP_LIBRARIES})
+        COLMAP_ADD_TARGET_HELPER(${TARGET_NAME})
+        add_test("${FOLDER_NAME}/${TARGET_NAME}" ${TARGET_NAME})
+        install(TARGETS ${TARGET_NAME} DESTINATION test/)
+    endif()
 endmacro(COLMAP_ADD_TEST)
 
 # Wrapper for CUDA test executables
 macro(COLMAP_CUDA_ADD_TEST TARGET_NAME)
-    # ${ARGN} will store the list of source files passed to this function.
-    cuda_add_executable(${TARGET_NAME} ${ARGN})
-    target_link_libraries(${TARGET_NAME} ${COLMAP_LIBRARIES})
-    COLMAP_ADD_TARGET_HELPER(${TARGET_NAME})
-    add_test("${FOLDER_NAME}/${TARGET_NAME}" ${TARGET_NAME})
-    install(TARGETS ${TARGET_NAME} DESTINATION test/)
+    if(WITH_TESTS)
+        # ${ARGN} will store the list of source files passed to this function.
+        cuda_add_executable(${TARGET_NAME} ${ARGN})
+        target_link_libraries(${TARGET_NAME} ${COLMAP_LIBRARIES})
+        COLMAP_ADD_TARGET_HELPER(${TARGET_NAME})
+        add_test("${FOLDER_NAME}/${TARGET_NAME}" ${TARGET_NAME})
+        install(TARGETS ${TARGET_NAME} DESTINATION test/)
+    endif()
 endmacro(COLMAP_CUDA_ADD_TEST)


### PR DESCRIPTION
building colmap for just using it does not need the test binaries,
so here is an option to turn them off.

Not sure exactly about the default value, maybe off is better than on?