### PR TITLE
Fix cmake>3.6 compilation bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(COLMAP)
-add_definitions("-DCOLMAP_VERSION=\"2.1\"")
+add_definitions("-DCOLMAP_VERSION=2.1")
 
 
 ################################################################################


### PR DESCRIPTION
Escaping COLMAN_VERSION string causes #53 issue.

_Nvcc command line gets malformed
..we gets this_
`/opt/cuda/bin/nvcc -M -D__CUDACC__ /home/bartus/_src/colmap/src/ext/SiftGPU/ProgramCU.cu -o /home/bartus/_src/colmap/build-old/src/ext/SiftGPU/CMakeFiles/sift_gpu.dir//sift_gpu_generated_ProgramCU.cu.o.NVCC-depend -ccbin /usr/lib/colorgcc/bin/cc -m64 -DCOLMAP_VERSION= -D2.1\" -DOPENMP_ENABLED -DCUDA_ENABLED -DCUDA_SIFTGPU_ENABLED -D_FORCE_INLINES\" -Xcompiler ,\"-msse\",\"-msse2\",\"-msse3\",\"-msse4.1\",\"-msse4.2\",\"-mavx\",\"-Wno-maybe-uninitialized\",\"-fopenmp\",\"-fPIC\",\"-march=core2\",\"-mfpmath=sse\",\"-DWINDOW_PREFER_GLUT\",\"-DSIFTGPU_NO_DEVIL\",\"-O2\",\"-g\",\"-DNDEBUG\",\"-msse\",\"-msse2\",\"-msse3\",\"-msse4.1\",\"-msse4.2\",\"-mavx\" -gencode arch=compute_61,code=sm_61 -DNVCC -I/opt/cuda/include -I/home/bartus/_src/colmap/src/. -I/usr/include -I/usr/include/eigen3 -I/usr/include/qt -I/usr/include/qt/QtCore "-I/usr/lib/qt/mkspecs/linux-g++ /usr/include/qt" -I/usr/include/qt/QtOpenGL -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtGui -I/usr/lib/qt/mkspecs/linux-g++`
_..and there should be this instead_
`/opt/cuda/bin/nvcc -M -D__CUDACC__ /home/bartus/_src/colmap/src/ext/SiftGPU/ProgramCU.cu -o /home/bartus/_src/colmap/build/src/ext/SiftGPU/CMakeFiles/sift_gpu.dir//sift_gpu_generated_ProgramCU.cu.o.NVCC-depend -ccbin /usr/bin/gcc-5 -m64 -DCOLMAP_VERSION=2.1 -DBOOST_TEST_DYN_LINK -DOPENMP_ENABLED -DCUDA_ENABLED -DCUDA_SIFTGPU_ENABLED -D_FORCE_INLINES -Xcompiler ,\"-msse\",\"-msse2\",\"-msse3\",\"-msse4.1\",\"-msse4.2\",\"-mavx\",\"-Wno-maybe-uninitialized\",\"-fopenmp\",\"-fPIC\",\"-march=core2\",\"-mfpmath=sse\",\"-DWINDOW_PREFER_GLUT\",\"-DSIFTGPU_NO_DEVIL\",\"-O2\",\"-g\",\"-DNDEBUG\",\"-msse\",\"-msse2\",\"-msse3\",\"-msse4.1\",\"-msse4.2\",\"-mavx\" -gencode arch=compute_61,code=sm_61 -DNVCC -I/opt/cuda/include -I/home/bartus/_src/colmap/src/. -I/usr/include -I/usr/include/eigen3 -I/usr/include/qt -I/usr/include/qt/QtCore "-I/usr/lib/qt/mkspecs/linux-g++ /usr/include/qt" -I/usr/include/qt/QtOpenGL -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtGui -I/usr/lib/qt/mkspecs/linux-g++`

The difference starts at -DCOLMAN_VERSION and messes up the succeeding part of invocation.
Removing the escaping fixes the issue #53