### PR TITLE
Fix cuda version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(COLMAP)
 
@@ -74,8 +74,9 @@ find_package(GLUT REQUIRED)
 find_package(Glew REQUIRED)
 find_package(Git)
 
+set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)
-    find_package(CUDA QUIET)
+    find_package(CUDA ${CUDA_MIN_VERSION} QUIET)
 endif()
 
 find_package(Qt5 REQUIRED)
@@ -141,6 +142,10 @@ if(CUDA_FOUND)
 else()
     set(CUDA_ENABLED FALSE)
     message(STATUS "Disabling CUDA support")
+    if(CUDA_VERSION_STRING)
+      message(STATUS "CUDA version found (${CUDA_VERSION_STRING}) is not supported, "
+                      "version at least ${CUDA_MIN_VERSION} required.")
+    endif()
 endif()
 
 list(APPEND CUDA_NVCC_FLAGS "-Wno-deprecated-gpu-targets")


### PR DESCRIPTION
The bug: If having CUDA < 7.0, Colmap's build files will try to build CUDA-enabled libriaries but Colmap uses std=c++11 with nvcc, which CUDA < 7.0 doesn't handle. This results in a compilation error if the system compiling has CUDA < 7.0.

This PR adds a bit of logic to the main CMakeLists file to detect that we have the minimum CUDA version required for colmap to build with Cuda enabled.