### PR TITLE
Add missing directory change to Mac build instructions.

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -86,6 +86,7 @@ Configure and compile COLMAP::
 
     cd path/to/colmap
     mkdir build
+    cd build
     cmake ..
     make -j
 


### PR DESCRIPTION
Mac build instructions were missing

``` cd build ```

after

``` mkdir build ```

before running CMAKE