### PR TITLE
Minor correction of input argument for *_matcher's

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -79,7 +79,7 @@ If you want to run COLMAP on a computer (e.g., cluster or cloud service) without
 an attached display, you should run the ``feature_extractor`` and set the
 ``--SiftGPUExtraction.index 0`` explicitly if a CUDA device is available or with
 the option ``--use_gpu false``. Then, you should run the ``*_matcher`` with
-``--use_gpu true`` if a CUDA device is available or with ``--use_gpu false`` for
+``--SiftMatching.use_gpu true`` if a CUDA device is available or with ``--SiftMatching.use_gpu false`` for
 CPU-based feature matching.
 
 Help


### PR DESCRIPTION
The documentation advises to use the option "--use_gpu true" or "--use_gpu false", but the *_matcher's have instead as input argument "--SiftMatching.use_gpu".