### PR TITLE
use alpha channel to filter sift keypoints -- initial commit

### DIFF
--- a/src/base/feature_extraction.h
+++ b/src/base/feature_extraction.h
@@ -69,6 +69,9 @@ struct SiftExtractionOptions {
   // Note that this feature is only available in the OpenGL SiftGPU version.
   bool darkness_adaptivity = false;
 
+  // Whether to use the alpha channel to eliminate some keypoints
+  bool use_alpha = false;
+
   enum class Normalization {
     // L1-normalizes each descriptor followed by element-wise square rooting.
     // This normalization is usually better than standard L2-normalization.
@@ -183,6 +186,15 @@ struct ImageData {
 
   FeatureKeypoints keypoints;
   FeatureDescriptors descriptors;
+
+  // add a function to remove keypoints when they fall within bitmap.alpha_
+
+  void PrintKeypoints() {
+    for (auto kp : keypoints ) {
+      std::cout << "(" << kp.x << "," << kp.y << ") ";
+    }
+    std::cout << std::endl;
+  }
 };
 
 class ImageResizerThread : public Thread {

--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -101,7 +101,7 @@ ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
   // Read image.
   //////////////////////////////////////////////////////////////////////////////
 
-  if (!bitmap->Read(image_path, false)) {
+  if (!bitmap->Read(image_path, false, options_.use_alpha)) {
     return Status::BITMAP_ERROR;
   }
 

--- a/src/base/image_reader.h
+++ b/src/base/image_reader.h
@@ -54,6 +54,9 @@ class ImageReader {
     // value `default_focal_length_factor * max(width, height)`.
     double default_focal_length_factor = 1.2;
 
+    // If the image has an alpha channel it can be used to filter keypoints
+    bool use_alpha = true;
+
     bool Check() const;
   };
 

--- a/src/ui/feature_extraction_widget.cc
+++ b/src/ui/feature_extraction_widget.cc
@@ -42,6 +42,8 @@ class SIFTExtractionWidget : public ExtractionWidget {
  private:
   QRadioButton* sift_gpu_;
   QRadioButton* sift_cpu_;
+  QCheckBox* use_alpha_;
+
 };
 
 class ImportFeaturesWidget : public ExtractionWidget {
@@ -70,6 +72,8 @@ SIFTExtractionWidget::SIFTExtractionWidget(QWidget* parent,
   sift_cpu_ = new QRadioButton(tr("CPU"), this);
   grid_layout_->addWidget(sift_cpu_, grid_layout_->rowCount(), 1);
 
+  // use_alpha_ = new QCheckBox(tr("Use Alpha"), this);
+  // grid_layout_->addWidget(use_alpha_, grid_layout_->rowCount(), 1);
   AddSpacer();
 
   AddOptionInt(&options->sift_extraction->max_image_size, "max_image_size");
@@ -88,6 +92,7 @@ SIFTExtractionWidget::SIFTExtractionWidget(QWidget* parent,
   AddOptionInt(&options->sift_extraction->num_threads, "num_threads", -1);
   AddOptionBool(&options->sift_extraction->use_gpu, "use_gpu");
   AddOptionText(&options->sift_extraction->gpu_index, "gpu_index");
+  AddOptionBool(&options->sift_extraction->use_alpha, "use_alpha");
 }
 
 void SIFTExtractionWidget::Run() {
@@ -96,6 +101,7 @@ void SIFTExtractionWidget::Run() {
   ImageReader::Options reader_options = *options_->image_reader;
   reader_options.database_path = *options_->database_path;
   reader_options.image_path = *options_->image_path;
+  reader_options.use_alpha = options_->sift_extraction->use_alpha;
 
   Thread* extractor =
       new SiftFeatureExtractor(reader_options, *options_->sift_extraction);

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -127,11 +127,16 @@ void OptionManager::AddExtractionOptions() {
                               &image_reader->camera_params);
   AddAndRegisterDefaultOption("ImageReader.default_focal_length_factor",
                               &image_reader->default_focal_length_factor);
+  AddAndRegisterDefaultOption("ImageReader.use_alpha",
+                              &image_reader->use_alpha);
 
   AddAndRegisterDefaultOption("SiftExtraction.num_threads",
                               &sift_extraction->num_threads);
   AddAndRegisterDefaultOption("SiftExtraction.use_gpu",
                               &sift_extraction->use_gpu);
+  AddAndRegisterDefaultOption("SiftExtraction.use_alpha",
+                              &sift_extraction->use_alpha);
+
   AddAndRegisterDefaultOption("SiftExtraction.gpu_index",
                               &sift_extraction->gpu_index);
   AddAndRegisterDefaultOption("SiftExtraction.max_image_size",


### PR DESCRIPTION
Adds boolean option "use_alpha" to the feature extractor and image reader classes.

Changes the Bitmap class to hold alpha channels.

Adds a function in feature_extraction.cc, "RemoveKeypointsByAlpha" which can be called in "Sift[GPU|CPU]FeatureExtractorThread::Run()" and removes a keypoint if the alpha channel at its coordinate is less than 255.

util/bitmap.h: Changes many loop iterators from "int" to "unsigned int" to avoid compiler warnings resulting from adding the function Bitmap::GetAlphaPixel(...)

If all this is to your liking I can improve the code a bit to handle cases where Alpha channel is requested but does not actually exist. And whatever else I've overlooked.