### PR TITLE
Fix CameraModel tuples in read_model.py according to camera_models.h

### DIFF
--- a/scripts/python/read_model.py
+++ b/scripts/python/read_model.py
@@ -35,13 +35,13 @@ CAMERA_MODELS = {
     CameraModel(model_id=0, model_name="SIMPLE_PINHOLE", num_params=3),
     CameraModel(model_id=1, model_name="PINHOLE", num_params=4),
     CameraModel(model_id=2, model_name="SIMPLE_RADIAL", num_params=4),
-    CameraModel(model_id=3, model_name="SIMPLE_RADIAL_FISHEYE", num_params=4),
-    CameraModel(model_id=4, model_name="RADIAL", num_params=5),
-    CameraModel(model_id=5, model_name="RADIAL_FISHEYE", num_params=5),
-    CameraModel(model_id=6, model_name="OPENCV", num_params=8),
-    CameraModel(model_id=7, model_name="OPENCV_FISHEYE", num_params=8),
-    CameraModel(model_id=8, model_name="FULL_OPENCV", num_params=12),
-    CameraModel(model_id=9, model_name="FOV", num_params=5),
+    CameraModel(model_id=3, model_name="RADIAL", num_params=5),
+    CameraModel(model_id=4, model_name="OPENCV", num_params=8),
+    CameraModel(model_id=5, model_name="OPENCV_FISHEYE", num_params=8),
+    CameraModel(model_id=6, model_name="FULL_OPENCV", num_params=12),
+    CameraModel(model_id=7, model_name="FOV", num_params=5),
+    CameraModel(model_id=8, model_name="SIMPLE_RADIAL_FISHEYE", num_params=4),
+    CameraModel(model_id=9, model_name="RADIAL_FISHEYE", num_params=5),
     CameraModel(model_id=10, model_name="THIN_PRISM_FISHEYE", num_params=12)
 }
 CAMERA_MODEL_IDS = dict([(camera_model.model_id, camera_model) \


### PR DESCRIPTION
`model_name` and `num_params` of `CameraModel` namedtuples in `scripts/python/read_model.py` had not been identical with the ones in `src/base/camera_models.h`, so that sparse reconstruction outputs had not been parsed correctly.
I have corrected `read_model.py` according to `camera_models.h`.
  