### PR TITLE
enable high dpi scaling for qt > 5.6.0

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1606,6 +1606,11 @@ int ShowHelp(
 }
 
 int main(int argc, char** argv) {
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+  
   InitializeGlog(argv);
 
   std::vector<std::pair<std::string, command_func_t>> commands;


### PR DESCRIPTION
This fix enables highdpi scaling of the qt widgets for high dpi monitors