### PR TITLE
image viewer enhancement

### DIFF
--- a/src/ui/dense_reconstruction_widget.cc
+++ b/src/ui/dense_reconstruction_widget.cc
@@ -425,7 +425,7 @@ void DenseReconstructionWidget::RefreshWorkspace() {
             [this, image_name, image_path]() {
               image_viewer_widget_->setWindowTitle(
                   QString("Image for %1").arg(image_name.c_str()));
-              image_viewer_widget_->ReadAndShow(image_path, true);
+              image_viewer_widget_->ReadAndShow(image_path);
             });
     table_widget_->setCellWidget(i, 1, image_button);
 
@@ -527,7 +527,7 @@ QWidget* DenseReconstructionWidget::GenerateTableButtonWidget(
               depth_map.Read(depth_map_path);
               image_viewer_widget_->setWindowTitle(
                   QString("Depth map for %1").arg(image_name.c_str()));
-              image_viewer_widget_->ShowBitmap(depth_map.ToBitmap(2, 98), true);
+              image_viewer_widget_->ShowBitmap(depth_map.ToBitmap(2, 98));
             });
   } else {
     depth_map_button->setEnabled(false);
@@ -547,7 +547,7 @@ QWidget* DenseReconstructionWidget::GenerateTableButtonWidget(
               normal_map.Read(normal_map_path);
               image_viewer_widget_->setWindowTitle(
                   QString("Normal map for %1").arg(image_name.c_str()));
-              image_viewer_widget_->ShowBitmap(normal_map.ToBitmap(), true);
+              image_viewer_widget_->ShowBitmap(normal_map.ToBitmap());
             });
   } else {
     normal_map_button->setEnabled(false);

--- a/src/ui/image_viewer_widget.h
+++ b/src/ui/image_viewer_widget.h
@@ -30,29 +30,39 @@ namespace colmap {
 
 class ModelViewerWidget;
 
+class ImageViewerGraphicsScene : public QGraphicsScene {
+ public:
+  ImageViewerGraphicsScene();
+
+  QGraphicsPixmapItem* ImagePixmapItem() const;
+
+ private:
+  QGraphicsPixmapItem* image_pixmap_item_ = nullptr;
+};
+
 class ImageViewerWidget : public QWidget {
  public:
   explicit ImageViewerWidget(QWidget* parent);
 
-  void ShowBitmap(const Bitmap& bitmap, const bool rescale);
-  void ShowPixmap(const QPixmap& pixmap, const bool rescale);
-  void ReadAndShow(const std::string& path, const bool rescale);
+  void ShowBitmap(const Bitmap& bitmap);
+  void ShowPixmap(const QPixmap& pixmap);
+  void ReadAndShow(const std::string& path);
 
- protected:
+ private:
   static const double kZoomFactor;
 
+  ImageViewerGraphicsScene graphics_scene_;
+  QGraphicsView* graphics_view_;
+
+ protected:
+  void resizeEvent(QResizeEvent* event);
   void closeEvent(QCloseEvent* event);
-  void Rescale(const double scale);
   void ZoomIn();
   void ZoomOut();
   void Save();
 
-  QPixmap pixmap_;
   QGridLayout* grid_layout_;
   QHBoxLayout* button_layout_;
-  QLabel* image_label_;
-  QScrollArea* image_scroll_area_;
-  double zoom_scale_;
 };
 
 class FeatureImageViewerWidget : public ImageViewerWidget {

--- a/src/ui/match_matrix_widget.cc
+++ b/src/ui/match_matrix_widget.cc
@@ -68,7 +68,7 @@ void MatchMatrixWidget::Show() {
     }
   }
 
-  ShowBitmap(match_matrix, true);
+  ShowBitmap(match_matrix);
 }
 
 }  // namespace colmap


### PR DESCRIPTION
Enhanced image viewer that automatically expands the image over the whole available display area while keeping the same aspectratio. Also works when the image viewer is resized/maximized.

QLabel usage has been removed and instead a GraphicsView is used. This will allow to later render even the correspondences and feature points as graphicsitems instead of rendering them directly to the pixmap.

I tested it and it works really nice on my system.