### PR TITLE
FOV-based undistortion

### DIFF
--- a/src/base/undistortion.h
+++ b/src/base/undistortion.h
@@ -35,6 +35,19 @@ struct UndistortCameraOptions {
 
   // Maximum image size in terms of width or height of the undistorted camera.
   int max_image_size = -1;
+
+  // Maximum FOV of rectified camera
+  double max_fov = 179.9;
+  double max_vertical_fov = 180.0;
+  double max_horizontal_fov = 180.0;
+  // Estimate focal length preserving FOV, instead of copying it
+  bool estimate_focal_length_from_fov = false;
+
+  // Overrides undistorted camera model. If empty, regular undistortion with
+  // undistorted model estimation takes place; otherwise, user-specified model
+  // is used as undistorted camera
+  std::string camera_model_override = "";
+  std::string camera_model_override_params = "";
 };
 
 // Undistort images and export undistorted cameras, as required by the

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -304,6 +304,24 @@ int RunExhaustiveMatcher(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
+bool VerifyCameraParams(const std::string& camera_model,
+                        const std::string& params) {
+  if (!ExistsCameraModelWithName(camera_model)) {
+    std::cerr << "ERROR: Camera model does not exist" << std::endl;
+    return false;
+  }
+
+  const std::vector<double> camera_params = CSVToVector<double>(params);
+  const int camera_model_id = CameraModelNameToId(camera_model);
+
+  if (camera_params.size() > 0 &&
+      !CameraModelVerifyParams(camera_model_id, camera_params)) {
+    std::cerr << "ERROR: Invalid camera parameters" << std::endl;
+    return false;
+  }
+  return true;
+}
+
 int RunFeatureExtractor(int argc, char** argv) {
   std::string image_list_path;
 
@@ -329,14 +347,8 @@ int RunFeatureExtractor(int argc, char** argv) {
     std::cerr << "ERROR: Camera model does not exist" << std::endl;
   }
 
-  const std::vector<double> camera_params =
-      CSVToVector<double>(options.image_reader->camera_params);
-  const int camera_model_id =
-      CameraModelNameToId(options.image_reader->camera_model);
-
-  if (camera_params.size() > 0 &&
-      !CameraModelVerifyParams(camera_model_id, camera_params)) {
-    std::cerr << "ERROR: Invalid camera parameters" << std::endl;
+  if (!VerifyCameraParams(options.image_reader->camera_model,
+                          options.image_reader->camera_params)) {
     return EXIT_FAILURE;
   }
 
@@ -381,14 +393,8 @@ int RunFeatureImporter(int argc, char** argv) {
     }
   }
 
-  const std::vector<double> camera_params =
-      CSVToVector<double>(options.image_reader->camera_params);
-  const int camera_model_id =
-      CameraModelNameToId(options.image_reader->camera_model);
-
-  if (camera_params.size() > 0 &&
-      !CameraModelVerifyParams(camera_model_id, camera_params)) {
-    std::cerr << "ERROR: Invalid camera parameters" << std::endl;
+  if (!VerifyCameraParams(options.image_reader->camera_model,
+                          options.image_reader->camera_params)) {
     return EXIT_FAILURE;
   }
 
@@ -448,7 +454,28 @@ int RunImageRectifier(int argc, char** argv) {
   options.AddDefaultOption("max_scale", &undistort_camera_options.max_scale);
   options.AddDefaultOption("max_image_size",
                            &undistort_camera_options.max_image_size);
+  options.AddDefaultOption("max_fov", &undistort_camera_options.max_fov);
+  options.AddDefaultOption(
+      "estimate_focal_length_from_fov",
+      &undistort_camera_options.estimate_focal_length_from_fov);
+  options.AddDefaultOption("max_vertical_fov",
+                           &undistort_camera_options.max_vertical_fov);
+  options.AddDefaultOption("max_horizontal_fov",
+                           &undistort_camera_options.max_horizontal_fov);
+  options.AddDefaultOption("camera_model_override",
+                           &undistort_camera_options.camera_model_override);
+  options.AddDefaultOption(
+      "camera_model_override_params",
+      &undistort_camera_options.camera_model_override_params);
+
   options.Parse(argc, argv);
+
+  if (undistort_camera_options.camera_model_override.size() &&
+      !VerifyCameraParams(
+          undistort_camera_options.camera_model_override,
+          undistort_camera_options.camera_model_override_params)) {
+    return EXIT_FAILURE;
+  }
 
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
@@ -554,7 +581,27 @@ int RunImageUndistorter(int argc, char** argv) {
   options.AddDefaultOption("max_scale", &undistort_camera_options.max_scale);
   options.AddDefaultOption("max_image_size",
                            &undistort_camera_options.max_image_size);
+  options.AddDefaultOption("max_fov", &undistort_camera_options.max_fov);
+  options.AddDefaultOption(
+      "estimate_focal_length_from_fov",
+      &undistort_camera_options.estimate_focal_length_from_fov);
+  options.AddDefaultOption("max_vertical_fov",
+                           &undistort_camera_options.max_vertical_fov);
+  options.AddDefaultOption("max_horizontal_fov",
+                           &undistort_camera_options.max_horizontal_fov);
+  options.AddDefaultOption("camera_model_override",
+                           &undistort_camera_options.camera_model_override);
+  options.AddDefaultOption(
+      "camera_model_override_params",
+      &undistort_camera_options.camera_model_override_params);
   options.Parse(argc, argv);
+
+  if (undistort_camera_options.camera_model_override.size() &&
+      !VerifyCameraParams(
+          undistort_camera_options.camera_model_override,
+          undistort_camera_options.camera_model_override_params)) {
+    return EXIT_FAILURE;
+  }
 
   CreateDirIfNotExists(output_path);
 


### PR DESCRIPTION
This pull request adds additional mode for undistorting, which might be used with fisheye images.

I've tried to solve the following problems:
* Focal length: previously focal length was copied from original camera; for some camera models (i.e. OPENCV_FISHEYE) focal length parameters are not directly connected with focal length of undistorted camera
* Valid region estimation: frequently fisheye images contain valid image data only in some circular region; moreover, model validity (i.e. monothonicity of distance-to-principal-point and angle-to-optical axis) is not guaranteed outside of this region (due to no data available during calibration)

With `estimate_fov` enabled, field-of-view of undistorted camera is estimated by iteratively testing monotonicity of angle-distance relationship (optionally, clamped by `max_fov`; and horizontal or vertical field-of-view if `clip_by_hfov` or `clip_by_vfov` are enabled).

Then, undistorted camera focal length is set to estimated diagonal field-of-view.

During inscribed/circumscribed valid region estimation, border points are clamped to maximal valid radius estimated during FOV estimation.

`estimate_fov`, `clip_by_hfov`, `clip_by_vfov` are disabled by default; `max_fov` is set to 150 degrees.