### PR TITLE
Fix for Issue#365

### DIFF
--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -159,8 +159,8 @@ ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
       }
 
       prev_camera_.InitializeWithId(prev_camera_.ModelId(), focal_length,
-                                    prev_camera_.Width(),
-                                    prev_camera_.Height());
+                                    bitmap->Width(),
+                                    bitmap->Height());
     }
 
     prev_camera_.SetWidth(static_cast<size_t>(bitmap->Width()));


### PR DESCRIPTION
Because of this bug the principal point of the first camera was always set
to (0, 0). Principal point of every subsequent camera was being set to the
center of the previous image, which could be a problem for input images of
different size.