### PR TITLE
Fix SiftGPU bug with skipped levels.

### DIFF
--- a/lib/SiftGPU/PyramidCU.cpp
+++ b/lib/SiftGPU/PyramidCU.cpp
@@ -818,7 +818,14 @@ void PyramidCU::GenerateFeatureList()
 		//for(int j = 0; j < param._dog_level_num; j++, idx++)
         FOR_EACH_LEVEL(j, reverse)
 		{
-            if(GlobalUtil::_TruncateMethod && GlobalUtil::_FeatureCountThreshold > 0 && _featureNum > GlobalUtil::_FeatureCountThreshold) continue;
+            // (mgprt 20/06/2018) _levelFeatureNum can still contain old
+            // values for these levels, so if we do not reset them the sum
+            // of level features will not match the absolte number of features.
+            if (GlobalUtil::_TruncateMethod && GlobalUtil::_FeatureCountThreshold > 0 && _featureNum > GlobalUtil::_FeatureCountThreshold) {
+                int idx = i * param._dog_level_num + j;
+                _levelFeatureNum[idx] = 0;
+                continue;
+            }
 
 	        GenerateFeatureList(i, j, reduction_count, hbuffer);
 


### PR DESCRIPTION
If a image level is skipped due to a limit on the number of features, its feature counter can still contain data from the last image. This can lead to invalid features being returned and in the worst case a heap corruption since the total feature number does not match the sum of features per level.