### PR TITLE
Allow partial image prefix for nested subfolder rig BA

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1322,9 +1322,9 @@ std::vector<CameraRig> ReadCameraRigConfig(
     for (const auto image_id : reconstruction.RegImageIds()) {
       const auto& image = reconstruction.Image(image_id);
       for (const auto& image_prefix : image_prefixes) {
-        if (StringStartsWith(image.Name(), image_prefix)) {
+        if (StringContains(image.Name(), image_prefix)) {
           const std::string image_suffix =
-              StringReplace(image.Name(), image_prefix, "");
+              StringGetAfter(image.Name(), image_prefix);
           snapshots[image_suffix].push_back(image_id);
         }
       }

--- a/src/util/string.cc
+++ b/src/util/string.cc
@@ -152,14 +152,14 @@ std::string StringReplace(const std::string& str, const std::string& old_str,
 }
 
 std::string StringGetAfter(const std::string& str, const std::string& key) {
-	if (key.empty()) {
-		return str;
-	}
-	std::size_t found = str.rfind(key);
-	if (found != std::string::npos) {
-		return str.substr(found + key.length(), str.length() - (found + key.length()));
-	}
-	return "";
+  if (key.empty()) {
+    return str;
+  }
+  std::size_t found = str.rfind(key);
+  if (found != std::string::npos) {
+    return str.substr(found + key.length(), str.length() - (found + key.length()));
+  }
+  return "";
 }
 
 std::vector<std::string> StringSplit(const std::string& str,

--- a/src/util/string.cc
+++ b/src/util/string.cc
@@ -151,6 +151,17 @@ std::string StringReplace(const std::string& str, const std::string& old_str,
   return mod_str;
 }
 
+std::string StringGetAfter(const std::string& str, const std::string& key) {
+	if (key.empty()) {
+		return str;
+	}
+	std::size_t found = str.rfind(key);
+	if (found != std::string::npos) {
+		return str.substr(found + key.length(), str.length() - (found + key.length()));
+	}
+	return "";
+}
+
 std::vector<std::string> StringSplit(const std::string& str,
                                      const std::string& delim) {
   std::vector<std::string> elems;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -46,6 +46,9 @@ std::string StringPrintf(const char* format, ...);
 std::string StringReplace(const std::string& str, const std::string& old_str,
                           const std::string& new_str);
 
+// Get substring of string after search key
+std::string StringGetAfter(const std::string& str, const std::string& key);
+
 // Split string into list of words using the given delimiters.
 std::vector<std::string> StringSplit(const std::string& str,
                                      const std::string& delim);

--- a/src/util/string_test.cc
+++ b/src/util/string_test.cc
@@ -64,6 +64,15 @@ BOOST_AUTO_TEST_CASE(TestStringReplace) {
   BOOST_CHECK_EQUAL(StringReplace("ttt", "ttt", "+++"), "+++");
 }
 
+BOOST_AUTO_TEST_CASE(TestStringGetAfter) {
+  BOOST_CHECK_EQUAL(StringGetAfter("test", ""), "test");
+  BOOST_CHECK_EQUAL(StringGetAfter("test", "notinit"), "");
+  BOOST_CHECK_EQUAL(StringGetAfter("test", "e"), "st");
+  BOOST_CHECK_EQUAL(StringGetAfter("test, multiple tests", "test"), "s");
+  BOOST_CHECK_EQUAL(StringGetAfter("", ""), "");
+  BOOST_CHECK_EQUAL(StringGetAfter("path/to/dataset/sub1/image.png", "sub1/"), "image.png");
+}
+
 BOOST_AUTO_TEST_CASE(TestStringSplit) {
   const std::vector<std::string> list1 = StringSplit("1,2,3,4,5 , 6", ",");
   BOOST_CHECK_EQUAL(list1.size(), 6);


### PR DESCRIPTION
I made this small change so that the following folder structure can be supported by rig BA:
```
dataset:
- sub_dataset1:
  - left:
    - img0001.png
    - ...
  - right:
- sub_dataset2:
  - left:
  - right:
...
```

This was previously not possible, because the "sub_dataset" string would prevent image names from matching.