### PR TITLE
Update export_to_visualsfm.py

### DIFF
--- a/scripts/python/export_to_visualsfm.py
+++ b/scripts/python/export_to_visualsfm.py
@@ -100,7 +100,7 @@ def main():
             keypoints = np.zeros((0, 4), dtype=np.float32)
             descriptors = np.zeros((0, 128), dtype=np.uint8)
         else:
-            keypoints = np.fromstring(row[0], dtype=np.float32).reshape(-1, 4)
+            keypoints = np.fromstring(row[0], dtype=np.float32).reshape(-1, 6)
             cursor.execute("SELECT data FROM descriptors WHERE image_id=?;",
                            (image_id,))
             row = next(cursor)


### PR DESCRIPTION
Running the current version of the script leads to a crash since calling ```.reshape(-1, 4)``` in Line 103 leads to more keypoint positions that descriptors, resulting in an out-of-bound access in Line 114. Changing ```.reshape(-1, 4)``` to ```.reshape(-1, 6)``` should solve this problem as it takes into account that keypoints are stored with 6 attributes.