### PR TITLE
remove boost::regex dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,25 +35,25 @@ project(COLMAP)
  
 set(COLMAP_VERSION "3.6")
 set(COLMAP_VERSION_NUMBER "3600")
- 
- 
+
+
 ################################################################################
 # Include CMake dependencies
 ################################################################################
- 
+
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
- 
+
 include(CheckCXXCompilerFlag)
- 
+
 # Include helper macros and commands, and allow the included file to override
 # the CMake policies in this file
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeHelper.cmake NO_POLICY_SCOPE)
- 
- 
+
+
 ################################################################################
 # Options
 ################################################################################
- 
+
 option(SIMD_ENABLED "Whether to enable SIMD optimizations" ON)
 option(OPENMP_ENABLED "Whether to enable OpenMP parallelization" ON)
 option(IPO_ENABLED "Whether to enable interprocedural optimization" ON)
@@ -65,71 +65,71 @@ option(CGAL_ENABLED "Whether to enable the CGAL library" ON)
 option(BOOST_STATIC "Whether to enable static boost library linker flags" ON)
 set(CUDA_ARCHS "Auto" CACHE STRING "List of CUDA architectures for which to \
 generate code, e.g., Auto, All, Maxwell, Pascal, ...")
- 
+
 if(TESTS_ENABLED)
     enable_testing()
 endif()
- 
+
 if(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS ON)
 else()
     add_definitions("-DBOOST_TEST_DYN_LINK")
 endif()
- 
+
 ################################################################################
 # Find packages
 ################################################################################
- 
+
 if(OPENMP_ENABLED)
     find_package(OpenMP QUIET)
 endif()
- 
+
 find_package(Ceres REQUIRED)
- 
+
 find_package(Boost REQUIRED COMPONENTS
              program_options
              filesystem
              graph
              system
              unit_test_framework)
- 
+
 find_package(Eigen3 REQUIRED)
- 
+
 find_package(FreeImage REQUIRED)
- 
+
 find_package(Glog REQUIRED)
- 
+
 find_package(OpenGL REQUIRED)
 find_package(Glew REQUIRED)
 find_package(Git)
- 
+
 find_package(CGAL QUIET)
- 
+
 set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)
     find_package(CUDA ${CUDA_MIN_VERSION} QUIET)
 endif()
- 
+
 find_package(Qt5 5.4 REQUIRED COMPONENTS Core OpenGL Widgets)
- 
+
 if(Qt5_FOUND)
     message(STATUS "Found Qt")
     message(STATUS "  Module : ${Qt5Core_DIR}")
     message(STATUS "  Module : ${Qt5OpenGL_DIR}")
     message(STATUS "  Module : ${Qt5Widgets_DIR}")
 endif()
- 
+
 if(CGAL_FOUND)
     message(STATUS "Found CGAL")
     message(STATUS "  Includes : ${CGAL_INCLUDE_DIRS}")
     message(STATUS "  Libraries : ${CGAL_LIBRARY}")
 endif()
- 
- 
+
+
 ################################################################################
 # Compiler specific configuration
 ################################################################################
- 
+
 if(CMAKE_BUILD_TYPE)
     message(STATUS "Build type specified as ${CMAKE_BUILD_TYPE}")
 else()
@@ -137,7 +137,7 @@ else()
     set(CMAKE_BUILD_TYPE Release)
     set(IS_DEBUG OFF)
 endif()
- 
+
 if(IS_MSVC)
     # Some fixes for the Glog library.
     add_definitions("-DGLOG_NO_ABBREVIATED_SEVERITIES")
@@ -147,23 +147,23 @@ if(IS_MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
- 
+
 if(IS_GNU)
     # Hide incorrect warnings for uninitialized Eigen variables under GCC.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-maybe-uninitialized")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 endif()
- 
+
 if(IS_DEBUG)
     add_definitions("-DEIGEN_INITIALIZE_MATRICES_BY_NAN")
 endif()
- 
+
 if(SIMD_ENABLED)
     message(STATUS "Enabling SIMD support")
 else()
     message(STATUS "Disabling SIMD support")
 endif()
- 
+
 if(OPENMP_ENABLED AND OPENMP_FOUND)
     message(STATUS "Enabling OpenMP support")
     add_definitions("-DOPENMP_ENABLED")
@@ -172,29 +172,29 @@ if(OPENMP_ENABLED AND OPENMP_FOUND)
 else()
     message(STATUS "Disabling OpenMP support")
 endif()
- 
+
 if(IPO_ENABLED AND NOT IS_DEBUG AND NOT IS_GNU)
     message(STATUS "Enabling interprocedural optimization")
     set_property(DIRECTORY PROPERTY INTERPROCEDURAL_OPTIMIZATION 1)
 else()
     message(STATUS "Disabling interprocedural optimization")
 endif()
- 
+
 if(CUDA_FOUND)
     if(CUDA_ENABLED)
         add_definitions("-DCUDA_ENABLED")
- 
+
         include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SelectCudaComputeArch.cmake)
- 
+
         CUDA_SELECT_NVCC_ARCH_FLAGS(CUDA_ARCH_FLAGS ${CUDA_ARCHS})
- 
+
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_ARCH_FLAGS}")
- 
+
         # Fix for some combinations of CUDA and GCC (e.g. under Ubuntu 16.04).
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -D_FORCE_INLINES")
         # Do not show warnings if the architectures are deprecated.
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Wno-deprecated-gpu-targets")
- 
+
         message(STATUS "Enabling CUDA support (version: ${CUDA_VERSION_STRING},"
                        " archs: ${CUDA_ARCH_FLAGS_readable})")
     else()
@@ -210,14 +210,14 @@ else()
         message(STATUS "Disabling CUDA support")
     endif()
 endif()
- 
+
 if(OPENGL_ENABLED)
     add_definitions("-DOPENGL_ENABLED")
     message(STATUS "Enabling OpenGL support")
 else()
     message(STATUS "Disabling OpenGL support")
 endif()
- 
+
 if(PROFILING_ENABLED)
     message(STATUS "Enabling profiling support")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lprofiler -ltcmalloc")
@@ -225,7 +225,7 @@ if(PROFILING_ENABLED)
 else()
     message(STATUS "Disabling profiling support")
 endif()
- 
+
 if(CGAL_FOUND AND CGAL_ENABLED)
     message(STATUS "Enabling CGAL support")
     add_definitions("-DCGAL_ENABLED")
@@ -233,7 +233,7 @@ else()
     message(STATUS "Disabling CGAL support")
     set(CGAL_ENABLED OFF)
 endif()
- 
+
 # Qt5 was built with -reduce-relocations.
 if(Qt5_POSITION_INDEPENDENT_CODE)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -241,18 +241,18 @@ if(Qt5_POSITION_INDEPENDENT_CODE)
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --compiler-options -fPIC")
     endif()
 endif()
- 
+
 # Enable automatic compilation of Qt resource files.
 set(CMAKE_AUTORCC ON)
- 
- 
+
+
 ################################################################################
 # Add sources
 ################################################################################
  
 # Generate source file with version definitions.
 include(GenerateVersionDefinitions)
- 
+
 set(COLMAP_INCLUDE_DIRS
     ${Boost_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
@@ -264,11 +264,11 @@ set(COLMAP_INCLUDE_DIRS
     ${Qt5OpenGL_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
 )
- 
+
 set(COLMAP_LINK_DIRS
     ${Boost_LIBRARY_DIRS}
 )
- 
+
 set(COLMAP_EXTERNAL_LIBRARIES
     ${CMAKE_DL_LIBS}
     ${Boost_FILESYSTEM_LIBRARY}
@@ -283,17 +283,17 @@ set(COLMAP_EXTERNAL_LIBRARIES
     ${Qt5OpenGL_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
 )
- 
+
 if(CGAL_ENABLED)
     list(APPEND COLMAP_INCLUDE_DIRS ${CGAL_INCLUDE_DIRS} ${GMP_INCLUDE_DIR})
     list(APPEND COLMAP_EXTERNAL_LIBRARIES ${CGAL_LIBRARY} ${GMP_LIBRARIES})
     list(APPEND COLMAP_LINK_DIRS ${CGAL_LIBRARIES_DIR})
 endif()
- 
+
 if(UNIX)
     list(APPEND COLMAP_EXTERNAL_LIBRARIES pthread)
 endif()
- 
+
 set(COLMAP_INTERNAL_LIBRARIES
     colmap
     flann
@@ -305,32 +305,32 @@ set(COLMAP_INTERNAL_LIBRARIES
     sift_gpu
     vlfeat
 )
- 
+
 if(CUDA_ENABLED)
     list(APPEND COLMAP_INTERNAL_LIBRARIES colmap_cuda colmap)
 endif()
- 
+
 set(COLMAP_LIBRARIES
     ${COLMAP_INTERNAL_LIBRARIES}
     ${COLMAP_EXTERNAL_LIBRARIES}
 )
- 
+
 include_directories(
     lib
     src
     ${COLMAP_INCLUDE_DIRS}
 )
- 
+
 link_directories(${COLMAP_LINK_DIRS})
- 
+
 add_subdirectory(lib)
 add_subdirectory(src)
- 
- 
+
+
 ################################################################################
 # Generate source groups for Visual Studio, XCode, etc.
 ################################################################################
- 
+
 COLMAP_ADD_SOURCE_DIR(lib/FLANN LIB_FLANN_SRCS *.h *.cpp *.hpp *.cu)
 COLMAP_ADD_SOURCE_DIR(lib/Graclus LIB_GRACLUS_SRCS *.h *.c)
 COLMAP_ADD_SOURCE_DIR(lib/LSD LIB_LSD_SRCS *.h *.c)
@@ -339,7 +339,7 @@ COLMAP_ADD_SOURCE_DIR(lib/PoissonRecon LIB_POISSON_RECON_SRCS *.h *.cpp *.inl)
 COLMAP_ADD_SOURCE_DIR(lib/SiftGPU LIB_SIFT_GPU_SRCS *.h *.cpp *.cu)
 COLMAP_ADD_SOURCE_DIR(lib/SQLite LIB_SQLITE_SRCS *.h *.c)
 COLMAP_ADD_SOURCE_DIR(lib/VLFeat LIB_VLFEAT_SRCS *.h *.c *.tc)
- 
+
 COLMAP_ADD_SOURCE_DIR(src/base BASE_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/controllers CONTROLLERS_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/estimators ESTIMATORS_SRCS *.h *.cc)
@@ -352,7 +352,7 @@ COLMAP_ADD_SOURCE_DIR(src/sfm SFM_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/tools TOOLS_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/ui UI_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/util UTIL_SRCS *.h *.cc)
- 
+
 # Add all of the source files to a regular library target, as using a custom
 # target does not allow us to set its C++ include directories (and thus
 # intellisense can't find any of the included files).
@@ -379,18 +379,18 @@ add_library(
     ${UI_SRCS}
     ${UTIL_SRCS}
 )
- 
+
 # Prevent the library from being compiled automatically.
 set_target_properties(
     ${COLMAP_SRC_ROOT_FOLDER} PROPERTIES
     EXCLUDE_FROM_ALL 1
     EXCLUDE_FROM_DEFAULT_BUILD 1)
- 
- 
+
+
 ################################################################################
 # Install and uninstall scripts
 ################################################################################
- 
+
 # Install header files.
 install(DIRECTORY src/
         DESTINATION include/colmap
@@ -398,7 +398,7 @@ install(DIRECTORY src/
 install(DIRECTORY lib/
         DESTINATION include/colmap/lib
         FILES_MATCHING REGEX ".*[.]h|.*[.]hpp|.*[.]inl")
- 
+
 # Generate and install CMake configuration.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeConfig.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfig.cmake" @ONLY)
@@ -408,12 +408,12 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeConfigVersion.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfigVersion.cmake" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfigVersion.cmake"
         DESTINATION "share/colmap")
- 
+
 # Install find_package scripts for dependencies.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake
         DESTINATION share/colmap
         FILES_MATCHING PATTERN "Find*.cmake")
- 
+
 # Install batch scripts under Windows.
 if(IS_MSVC)
     install(FILES "scripts/shell/COLMAP.bat" "scripts/shell/RUN_TESTS.bat"
@@ -421,12 +421,12 @@ if(IS_MSVC)
                         GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
             DESTINATION "/")
 endif()
- 
+
 # Install application meny entry under Linux/Unix.
 if(UNIX AND NOT APPLE)
     install(FILES "doc/COLMAP.desktop" DESTINATION "share/applications")
 endif()
- 
+
 # Configure the uninstallation script.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeUninstall.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/CMakeUninstall.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,32 +28,32 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
-
+ 
 cmake_minimum_required(VERSION 3.0)
-
+ 
 project(COLMAP)
-
+ 
 set(COLMAP_VERSION "3.6")
 set(COLMAP_VERSION_NUMBER "3600")
-
-
+ 
+ 
 ################################################################################
 # Include CMake dependencies
 ################################################################################
-
+ 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-
+ 
 include(CheckCXXCompilerFlag)
-
+ 
 # Include helper macros and commands, and allow the included file to override
 # the CMake policies in this file
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeHelper.cmake NO_POLICY_SCOPE)
-
-
+ 
+ 
 ################################################################################
 # Options
 ################################################################################
-
+ 
 option(SIMD_ENABLED "Whether to enable SIMD optimizations" ON)
 option(OPENMP_ENABLED "Whether to enable OpenMP parallelization" ON)
 option(IPO_ENABLED "Whether to enable interprocedural optimization" ON)
@@ -65,72 +65,71 @@ option(CGAL_ENABLED "Whether to enable the CGAL library" ON)
 option(BOOST_STATIC "Whether to enable static boost library linker flags" ON)
 set(CUDA_ARCHS "Auto" CACHE STRING "List of CUDA architectures for which to \
 generate code, e.g., Auto, All, Maxwell, Pascal, ...")
-
+ 
 if(TESTS_ENABLED)
     enable_testing()
 endif()
-
+ 
 if(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS ON)
 else()
     add_definitions("-DBOOST_TEST_DYN_LINK")
 endif()
-
+ 
 ################################################################################
 # Find packages
 ################################################################################
-
+ 
 if(OPENMP_ENABLED)
     find_package(OpenMP QUIET)
 endif()
-
+ 
 find_package(Ceres REQUIRED)
-
+ 
 find_package(Boost REQUIRED COMPONENTS
              program_options
              filesystem
              graph
-             regex
              system
              unit_test_framework)
-
+ 
 find_package(Eigen3 REQUIRED)
-
+ 
 find_package(FreeImage REQUIRED)
-
+ 
 find_package(Glog REQUIRED)
-
+ 
 find_package(OpenGL REQUIRED)
 find_package(Glew REQUIRED)
 find_package(Git)
-
+ 
 find_package(CGAL QUIET)
-
+ 
 set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)
     find_package(CUDA ${CUDA_MIN_VERSION} QUIET)
 endif()
-
+ 
 find_package(Qt5 5.4 REQUIRED COMPONENTS Core OpenGL Widgets)
-
+ 
 if(Qt5_FOUND)
     message(STATUS "Found Qt")
     message(STATUS "  Module : ${Qt5Core_DIR}")
     message(STATUS "  Module : ${Qt5OpenGL_DIR}")
     message(STATUS "  Module : ${Qt5Widgets_DIR}")
 endif()
-
+ 
 if(CGAL_FOUND)
     message(STATUS "Found CGAL")
     message(STATUS "  Includes : ${CGAL_INCLUDE_DIRS}")
     message(STATUS "  Libraries : ${CGAL_LIBRARY}")
 endif()
-
-
+ 
+ 
 ################################################################################
 # Compiler specific configuration
 ################################################################################
-
+ 
 if(CMAKE_BUILD_TYPE)
     message(STATUS "Build type specified as ${CMAKE_BUILD_TYPE}")
 else()
@@ -138,7 +137,7 @@ else()
     set(CMAKE_BUILD_TYPE Release)
     set(IS_DEBUG OFF)
 endif()
-
+ 
 if(IS_MSVC)
     # Some fixes for the Glog library.
     add_definitions("-DGLOG_NO_ABBREVIATED_SEVERITIES")
@@ -148,23 +147,23 @@ if(IS_MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
-
+ 
 if(IS_GNU)
     # Hide incorrect warnings for uninitialized Eigen variables under GCC.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-maybe-uninitialized")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 endif()
-
+ 
 if(IS_DEBUG)
     add_definitions("-DEIGEN_INITIALIZE_MATRICES_BY_NAN")
 endif()
-
+ 
 if(SIMD_ENABLED)
     message(STATUS "Enabling SIMD support")
 else()
     message(STATUS "Disabling SIMD support")
 endif()
-
+ 
 if(OPENMP_ENABLED AND OPENMP_FOUND)
     message(STATUS "Enabling OpenMP support")
     add_definitions("-DOPENMP_ENABLED")
@@ -173,29 +172,29 @@ if(OPENMP_ENABLED AND OPENMP_FOUND)
 else()
     message(STATUS "Disabling OpenMP support")
 endif()
-
+ 
 if(IPO_ENABLED AND NOT IS_DEBUG AND NOT IS_GNU)
     message(STATUS "Enabling interprocedural optimization")
     set_property(DIRECTORY PROPERTY INTERPROCEDURAL_OPTIMIZATION 1)
 else()
     message(STATUS "Disabling interprocedural optimization")
 endif()
-
+ 
 if(CUDA_FOUND)
     if(CUDA_ENABLED)
         add_definitions("-DCUDA_ENABLED")
-
+ 
         include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SelectCudaComputeArch.cmake)
-
+ 
         CUDA_SELECT_NVCC_ARCH_FLAGS(CUDA_ARCH_FLAGS ${CUDA_ARCHS})
-
+ 
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_ARCH_FLAGS}")
-
+ 
         # Fix for some combinations of CUDA and GCC (e.g. under Ubuntu 16.04).
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -D_FORCE_INLINES")
         # Do not show warnings if the architectures are deprecated.
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Wno-deprecated-gpu-targets")
-
+ 
         message(STATUS "Enabling CUDA support (version: ${CUDA_VERSION_STRING},"
                        " archs: ${CUDA_ARCH_FLAGS_readable})")
     else()
@@ -211,14 +210,14 @@ else()
         message(STATUS "Disabling CUDA support")
     endif()
 endif()
-
+ 
 if(OPENGL_ENABLED)
     add_definitions("-DOPENGL_ENABLED")
     message(STATUS "Enabling OpenGL support")
 else()
     message(STATUS "Disabling OpenGL support")
 endif()
-
+ 
 if(PROFILING_ENABLED)
     message(STATUS "Enabling profiling support")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lprofiler -ltcmalloc")
@@ -226,7 +225,7 @@ if(PROFILING_ENABLED)
 else()
     message(STATUS "Disabling profiling support")
 endif()
-
+ 
 if(CGAL_FOUND AND CGAL_ENABLED)
     message(STATUS "Enabling CGAL support")
     add_definitions("-DCGAL_ENABLED")
@@ -234,7 +233,7 @@ else()
     message(STATUS "Disabling CGAL support")
     set(CGAL_ENABLED OFF)
 endif()
-
+ 
 # Qt5 was built with -reduce-relocations.
 if(Qt5_POSITION_INDEPENDENT_CODE)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -242,18 +241,18 @@ if(Qt5_POSITION_INDEPENDENT_CODE)
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --compiler-options -fPIC")
     endif()
 endif()
-
+ 
 # Enable automatic compilation of Qt resource files.
 set(CMAKE_AUTORCC ON)
-
-
+ 
+ 
 ################################################################################
 # Add sources
 ################################################################################
-
+ 
 # Generate source file with version definitions.
 include(GenerateVersionDefinitions)
-
+ 
 set(COLMAP_INCLUDE_DIRS
     ${Boost_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
@@ -265,16 +264,15 @@ set(COLMAP_INCLUDE_DIRS
     ${Qt5OpenGL_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
 )
-
+ 
 set(COLMAP_LINK_DIRS
     ${Boost_LIBRARY_DIRS}
 )
-
+ 
 set(COLMAP_EXTERNAL_LIBRARIES
     ${CMAKE_DL_LIBS}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${GLOG_LIBRARIES}
     ${FREEIMAGE_LIBRARIES}
@@ -285,17 +283,17 @@ set(COLMAP_EXTERNAL_LIBRARIES
     ${Qt5OpenGL_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
 )
-
+ 
 if(CGAL_ENABLED)
     list(APPEND COLMAP_INCLUDE_DIRS ${CGAL_INCLUDE_DIRS} ${GMP_INCLUDE_DIR})
     list(APPEND COLMAP_EXTERNAL_LIBRARIES ${CGAL_LIBRARY} ${GMP_LIBRARIES})
     list(APPEND COLMAP_LINK_DIRS ${CGAL_LIBRARIES_DIR})
 endif()
-
+ 
 if(UNIX)
     list(APPEND COLMAP_EXTERNAL_LIBRARIES pthread)
 endif()
-
+ 
 set(COLMAP_INTERNAL_LIBRARIES
     colmap
     flann
@@ -307,32 +305,32 @@ set(COLMAP_INTERNAL_LIBRARIES
     sift_gpu
     vlfeat
 )
-
+ 
 if(CUDA_ENABLED)
     list(APPEND COLMAP_INTERNAL_LIBRARIES colmap_cuda colmap)
 endif()
-
+ 
 set(COLMAP_LIBRARIES
     ${COLMAP_INTERNAL_LIBRARIES}
     ${COLMAP_EXTERNAL_LIBRARIES}
 )
-
+ 
 include_directories(
     lib
     src
     ${COLMAP_INCLUDE_DIRS}
 )
-
+ 
 link_directories(${COLMAP_LINK_DIRS})
-
+ 
 add_subdirectory(lib)
 add_subdirectory(src)
-
-
+ 
+ 
 ################################################################################
 # Generate source groups for Visual Studio, XCode, etc.
 ################################################################################
-
+ 
 COLMAP_ADD_SOURCE_DIR(lib/FLANN LIB_FLANN_SRCS *.h *.cpp *.hpp *.cu)
 COLMAP_ADD_SOURCE_DIR(lib/Graclus LIB_GRACLUS_SRCS *.h *.c)
 COLMAP_ADD_SOURCE_DIR(lib/LSD LIB_LSD_SRCS *.h *.c)
@@ -341,7 +339,7 @@ COLMAP_ADD_SOURCE_DIR(lib/PoissonRecon LIB_POISSON_RECON_SRCS *.h *.cpp *.inl)
 COLMAP_ADD_SOURCE_DIR(lib/SiftGPU LIB_SIFT_GPU_SRCS *.h *.cpp *.cu)
 COLMAP_ADD_SOURCE_DIR(lib/SQLite LIB_SQLITE_SRCS *.h *.c)
 COLMAP_ADD_SOURCE_DIR(lib/VLFeat LIB_VLFEAT_SRCS *.h *.c *.tc)
-
+ 
 COLMAP_ADD_SOURCE_DIR(src/base BASE_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/controllers CONTROLLERS_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/estimators ESTIMATORS_SRCS *.h *.cc)
@@ -354,7 +352,7 @@ COLMAP_ADD_SOURCE_DIR(src/sfm SFM_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/tools TOOLS_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/ui UI_SRCS *.h *.cc)
 COLMAP_ADD_SOURCE_DIR(src/util UTIL_SRCS *.h *.cc)
-
+ 
 # Add all of the source files to a regular library target, as using a custom
 # target does not allow us to set its C++ include directories (and thus
 # intellisense can't find any of the included files).
@@ -381,18 +379,18 @@ add_library(
     ${UI_SRCS}
     ${UTIL_SRCS}
 )
-
+ 
 # Prevent the library from being compiled automatically.
 set_target_properties(
     ${COLMAP_SRC_ROOT_FOLDER} PROPERTIES
     EXCLUDE_FROM_ALL 1
     EXCLUDE_FROM_DEFAULT_BUILD 1)
-
-
+ 
+ 
 ################################################################################
 # Install and uninstall scripts
 ################################################################################
-
+ 
 # Install header files.
 install(DIRECTORY src/
         DESTINATION include/colmap
@@ -400,7 +398,7 @@ install(DIRECTORY src/
 install(DIRECTORY lib/
         DESTINATION include/colmap/lib
         FILES_MATCHING REGEX ".*[.]h|.*[.]hpp|.*[.]inl")
-
+ 
 # Generate and install CMake configuration.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeConfig.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfig.cmake" @ONLY)
@@ -410,12 +408,12 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeConfigVersion.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfigVersion.cmake" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/COLMAPConfigVersion.cmake"
         DESTINATION "share/colmap")
-
+ 
 # Install find_package scripts for dependencies.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake
         DESTINATION share/colmap
         FILES_MATCHING PATTERN "Find*.cmake")
-
+ 
 # Install batch scripts under Windows.
 if(IS_MSVC)
     install(FILES "scripts/shell/COLMAP.bat" "scripts/shell/RUN_TESTS.bat"
@@ -423,12 +421,12 @@ if(IS_MSVC)
                         GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
             DESTINATION "/")
 endif()
-
+ 
 # Install application meny entry under Linux/Unix.
 if(UNIX AND NOT APPLE)
     install(FILES "doc/COLMAP.desktop" DESTINATION "share/applications")
 endif()
-
+ 
 # Configure the uninstallation script.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeUninstall.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/CMakeUninstall.cmake"

--- a/src/util/bitmap.cc
+++ b/src/util/bitmap.cc
@@ -34,7 +34,7 @@
 #include <unordered_map>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "base/camera_database.h"
 #include "VLFeat/imopv.h"
@@ -291,9 +291,9 @@ bool Bitmap::ExifFocalLength(double* focal_length) const {
   std::string focal_length_35mm_str;
   if (ReadExifTag(FIMD_EXIF_EXIF, "FocalLengthIn35mmFilm",
                   &focal_length_35mm_str)) {
-    const boost::regex regex(".*?([0-9.]+).*?mm.*?");
-    boost::cmatch result;
-    if (boost::regex_search(focal_length_35mm_str.c_str(), result, regex)) {
+    const std::regex regex(".*?([0-9.]+).*?mm.*?");
+    std::cmatch result;
+    if (std::regex_search(focal_length_35mm_str.c_str(), result, regex)) {
       const double focal_length_35 = std::stold(result[1]);
       if (focal_length_35 > 0) {
         *focal_length = focal_length_35 / 35.0 * max_size;
@@ -308,9 +308,9 @@ bool Bitmap::ExifFocalLength(double* focal_length) const {
 
   std::string focal_length_str;
   if (ReadExifTag(FIMD_EXIF_EXIF, "FocalLength", &focal_length_str)) {
-    boost::regex regex(".*?([0-9.]+).*?mm");
-    boost::cmatch result;
-    if (boost::regex_search(focal_length_str.c_str(), result, regex)) {
+    std::regex regex(".*?([0-9.]+).*?mm");
+    std::cmatch result;
+    if (std::regex_search(focal_length_str.c_str(), result, regex)) {
       const double focal_length_mm = std::stold(result[1]);
 
       // Lookup sensor width in database.
@@ -334,11 +334,11 @@ bool Bitmap::ExifFocalLength(double* focal_length) const {
           ReadExifTag(FIMD_EXIF_EXIF, "FocalPlaneXResolution", &x_res_str) &&
           ReadExifTag(FIMD_EXIF_EXIF, "FocalPlaneResolutionUnit",
                       &res_unit_str)) {
-        regex = boost::regex(".*?([0-9.]+).*?");
-        if (boost::regex_search(pixel_x_dim_str.c_str(), result, regex)) {
+        regex = std::regex(".*?([0-9.]+).*?");
+        if (std::regex_search(pixel_x_dim_str.c_str(), result, regex)) {
           const double pixel_x_dim = std::stold(result[1]);
-          regex = boost::regex(".*?([0-9.]+).*?/.*?([0-9.]+).*?");
-          if (boost::regex_search(x_res_str.c_str(), result, regex)) {
+          regex = std::regex(".*?([0-9.]+).*?/.*?([0-9.]+).*?");
+          if (std::regex_search(x_res_str.c_str(), result, regex)) {
             const double x_res = std::stold(result[2]) / std::stold(result[1]);
             // Use PixelXDimension instead of actual width of image, since
             // the image might have been resized, but the EXIF data preserved.
@@ -364,9 +364,9 @@ bool Bitmap::ExifFocalLength(double* focal_length) const {
 bool Bitmap::ExifLatitude(double* latitude) const {
   std::string str;
   if (ReadExifTag(FIMD_EXIF_GPS, "GPSLatitude", &str)) {
-    const boost::regex regex(".*?([0-9.]+):([0-9.]+):([0-9.]+).*?");
-    boost::cmatch result;
-    if (boost::regex_search(str.c_str(), result, regex)) {
+    const std::regex regex(".*?([0-9.]+):([0-9.]+):([0-9.]+).*?");
+    std::cmatch result;
+    if (std::regex_search(str.c_str(), result, regex)) {
       const double hours = std::stold(result[1]);
       const double minutes = std::stold(result[2]);
       const double seconds = std::stold(result[3]);
@@ -380,9 +380,9 @@ bool Bitmap::ExifLatitude(double* latitude) const {
 bool Bitmap::ExifLongitude(double* longitude) const {
   std::string str;
   if (ReadExifTag(FIMD_EXIF_GPS, "GPSLongitude", &str)) {
-    const boost::regex regex(".*?([0-9.]+):([0-9.]+):([0-9.]+).*?");
-    boost::cmatch result;
-    if (boost::regex_search(str.c_str(), result, regex)) {
+    const std::regex regex(".*?([0-9.]+):([0-9.]+):([0-9.]+).*?");
+    std::cmatch result;
+    if (std::regex_search(str.c_str(), result, regex)) {
       const double hours = std::stold(result[1]);
       const double minutes = std::stold(result[2]);
       const double seconds = std::stold(result[3]);
@@ -396,9 +396,9 @@ bool Bitmap::ExifLongitude(double* longitude) const {
 bool Bitmap::ExifAltitude(double* altitude) const {
   std::string str;
   if (ReadExifTag(FIMD_EXIF_GPS, "GPSAltitude", &str)) {
-    const boost::regex regex(".*?([0-9.]+).*?/.*?([0-9.]+).*?");
-    boost::cmatch result;
-    if (boost::regex_search(str.c_str(), result, regex)) {
+    const std::regex regex(".*?([0-9.]+).*?/.*?([0-9.]+).*?");
+    std::cmatch result;
+    if (std::regex_search(str.c_str(), result, regex)) {
       *altitude = std::stold(result[1]) / std::stold(result[2]);
       return true;
     }


### PR DESCRIPTION
I was able to compile by removing the boost/regex dependency (I just replaced every boost:: for std:: in the bitmap.cc file, similar to what is suggested in this issue (https://github.com/colmap/colmap/issues/36), and removing the regex dependency in the CMakeLists.txt. Actually, since this is the only place where boost/regex is used, and since it seems to be of an issue for other people, I will make a pull request with this change if that's ok.