### PR TITLE
SiftGPU: Fix mismatched malloc-delete

### DIFF
--- a/lib/SiftGPU/SiftMatch.cpp
+++ b/lib/SiftGPU/SiftMatch.cpp
@@ -587,7 +587,7 @@ int SiftMatchGPU::_VerifyContextGL()
         && SiftMatchCU::CheckCudaDevice (GlobalUtil::_DeviceIndex))
     {
 		__language = SIFTMATCH_CUDA;
-		__matcher = new SiftMatchCU(__max_sift);
+		__matcher = ::new SiftMatchCU(__max_sift);
 	}else
 #else
     if((__language == SIFTMATCH_SAME_AS_SIFTGPU && GlobalUtil::_UseCUDA) || __language >= SIFTMATCH_CUDA)
@@ -600,7 +600,7 @@ int SiftMatchGPU::_VerifyContextGL()
 #endif
 	{
 		__language = SIFTMATCH_GLSL;
-		__matcher = new SiftMatchGL(__max_sift, 1);
+		__matcher = ::new SiftMatchGL(__max_sift, 1);
 	}
 
 	if(GlobalUtil::_verbose)


### PR DESCRIPTION
According to valgrind, for the allocation in `__matcher = new SiftMatchCU(__max_sift);` in SiftMatch.cpp, the custom new operator overload of SiftMatchGPU seems to be used. It uses malloc() internally. However, in the SiftMatchGPU destructor, the __matcher object is deleted using delete. This means that the malloc is mismatched with delete instead of free.

One possible solution is to use the global new to allocate __matcher, as proposed in this PR. However, I'm not entirely sure what the custom new's purpose is - the reasoning in a header file has something to do with some MSVC compiler flags I am not familiar with, but it seems like it might only be intended for allocation of SiftMatchGPU objects:
```
	//overload the new operator because delete operator is virtual
	//and it is operating on the heap inside the dll (due to the
	//compiler setting of /MT and /MTd). Without the overloaded operator
	//deleting a SiftGPU object will cause a heap corruption in the
	//static link case (but not for the runtime dll loading).
```
The alternative solution if it is desired to keep using the custom new would be to replace the delete in the destructor with free.