### PR TITLE
Implement masking of images in feature extraction

### DIFF
--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -80,7 +80,7 @@ ImageReader::ImageReader(const ImageReaderOptions& options, Database* database)
 }
 
 ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
-                                      Bitmap* bitmap) {
+                                      Bitmap* bitmap, Bitmap* mask) {
   CHECK_NOTNULL(camera);
   CHECK_NOTNULL(image);
   CHECK_NOTNULL(bitmap);
@@ -127,6 +127,20 @@ ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
 
   if (!bitmap->Read(image_path, false)) {
     return Status::BITMAP_ERROR;
+  }
+  
+  //////////////////////////////////////////////////////////////////////////////
+  // Read mask.
+  //////////////////////////////////////////////////////////////////////////////
+
+  if (mask && !options_.mask_path.empty()) {
+    const std::string mask_path =
+        JoinPaths(options_.mask_path,
+                  GetRelativePath(options_.image_path, image_path) + ".png");
+    if (ExistsFile(mask_path) && !mask->Read(mask_path, false)) {
+      // NOTE: Maybe introduce a separate error type MASK_ERROR?
+      return Status::BITMAP_ERROR;
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/base/image_reader.h
+++ b/src/base/image_reader.h
@@ -44,8 +44,17 @@ struct ImageReaderOptions {
   // Path to database in which to store the extracted data.
   std::string database_path = "";
 
-  // Root path to folder which contains the image.
+  // Root path to folder which contains the images.
   std::string image_path = "";
+
+  // Optional root path to folder which contains image masks. For a given image,
+  // the corresponding mask must have the same sub-path below this root as the
+  // image has below image_path. The filename must be equal, aside from the
+  // added extension .png. For example, for an image image_path/abc/012.jpg, the
+  // mask would be mask_path/abc/012.jpg.png. No features will be extracted in
+  // regions where the mask image is black (pixel intensity value 0 in
+  // grayscale).
+  std::string mask_path = "";
 
   // Optional list of images to read. The list must contain the relative path
   // of the images with respect to the image_path.
@@ -72,6 +81,11 @@ struct ImageReaderOptions {
   // have focal length EXIF information, the focal length is set to the
   // value `default_focal_length_factor * max(width, height)`.
   double default_focal_length_factor = 1.2;
+  
+  // Optional path to an image file specifying a mask for all images. No
+  // features will be extracted in regions where the mask is black (pixel
+  // intensity value 0 in grayscale).
+  std::string camera_mask_path = "";
 
   bool Check() const;
 };
@@ -93,7 +107,7 @@ class ImageReader {
 
   ImageReader(const ImageReaderOptions& options, Database* database);
 
-  Status Next(Camera* camera, Image* image, Bitmap* bitmap);
+  Status Next(Camera* camera, Image* image, Bitmap* bitmap, Bitmap* mask);
   size_t NextIndex() const;
   size_t NumImages() const;
 

--- a/src/feature/extraction.cc
+++ b/src/feature/extraction.cc
@@ -53,6 +53,33 @@ void ScaleKeypoints(const Bitmap& bitmap, const Camera& camera,
   }
 }
 
+void MaskKeypoints(const Bitmap& mask, FeatureKeypoints* keypoints,
+                   FeatureDescriptors* descriptors) {
+  unsigned int out_index = 0;
+  BitmapColor<uint8_t> color;
+  for (unsigned int i = 0; i < keypoints->size(); ++ i) {
+    if (mask.GetPixel(static_cast<int>(keypoints->at(i).x),
+                      static_cast<int>(keypoints->at(i).y),
+                      &color) &&
+        color.r == 0) {
+      // Delete this keypoint by not copying it to the output.
+    } else {
+      // Retain this keypoint by copying it to the output index (in case this
+      // index differs from its current position).
+      if (out_index != i) {
+        keypoints->at(out_index) = keypoints->at(i);
+        for (int col = 0; col < descriptors->cols(); ++ col) {
+          (*descriptors)(out_index, col) = (*descriptors)(i, col);
+        }
+      }
+      ++ out_index;
+    }
+  }
+  
+  keypoints->resize(out_index);
+  descriptors->conservativeResize(out_index, descriptors->cols());
+}
+
 }  // namespace
 
 SiftFeatureExtractor::SiftFeatureExtractor(
@@ -64,6 +91,21 @@ SiftFeatureExtractor::SiftFeatureExtractor(
       image_reader_(reader_options_, &database_) {
   CHECK(reader_options_.Check());
   CHECK(sift_options_.Check());
+  
+  std::shared_ptr<Bitmap> camera_mask;
+  if (!reader_options_.camera_mask_path.empty()) {
+    camera_mask = std::shared_ptr<Bitmap>(new Bitmap(), [](Bitmap* b){
+      b->Deallocate();
+      delete b;
+    });
+    if (!camera_mask->Read(reader_options_.camera_mask_path,
+                           /*as_rgb*/ false)) {
+      std::cerr << "  ERROR: Cannot read camera mask file: "
+                << reader_options_.camera_mask_path
+                << ". No mask is going to be used." << std::endl;
+      camera_mask.reset();
+    }
+  }
 
   const int num_threads = GetEffectiveNumThreads(sift_options_.num_threads);
   CHECK_GT(num_threads, 0);
@@ -101,14 +143,16 @@ SiftFeatureExtractor::SiftFeatureExtractor(
     for (const auto& gpu_index : gpu_indices) {
       sift_gpu_options.gpu_index = std::to_string(gpu_index);
       extractors_.emplace_back(new internal::SiftFeatureExtractorThread(
-          sift_gpu_options, extractor_queue_.get(), writer_queue_.get()));
+          sift_gpu_options, camera_mask, extractor_queue_.get(),
+          writer_queue_.get()));
     }
   } else {
     auto custom_sift_options = sift_options_;
     custom_sift_options.use_gpu = false;
     for (int i = 0; i < num_threads; ++i) {
       extractors_.emplace_back(new internal::SiftFeatureExtractorThread(
-          custom_sift_options, extractor_queue_.get(), writer_queue_.get()));
+          custom_sift_options, camera_mask, extractor_queue_.get(),
+          writer_queue_.get()));
     }
   }
 
@@ -146,7 +190,8 @@ void SiftFeatureExtractor::Run() {
 
     internal::ImageData image_data;
     image_data.status = image_reader_.Next(
-        &image_data.camera, &image_data.image, &image_data.bitmap);
+        &image_data.camera, &image_data.image, &image_data.bitmap,
+        &image_data.mask);
 
     if (image_data.status != ImageReader::Status::SUCCESS) {
       image_data.bitmap.Deallocate();
@@ -207,7 +252,7 @@ void FeatureImporter::Run() {
     Camera camera;
     Image image;
     Bitmap bitmap;
-    if (image_reader.Next(&camera, &image, &bitmap) !=
+    if (image_reader.Next(&camera, &image, &bitmap, nullptr) !=
         ImageReader::Status::SUCCESS) {
       continue;
     }
@@ -285,9 +330,12 @@ void ImageResizerThread::Run() {
 }
 
 SiftFeatureExtractorThread::SiftFeatureExtractorThread(
-    const SiftExtractionOptions& sift_options, JobQueue<ImageData>* input_queue,
+    const SiftExtractionOptions& sift_options,
+    const std::shared_ptr<Bitmap>& camera_mask,
+    JobQueue<ImageData>* input_queue,
     JobQueue<ImageData>* output_queue)
     : sift_options_(sift_options),
+      camera_mask_(camera_mask),
       input_queue_(input_queue),
       output_queue_(output_queue) {
   CHECK(sift_options_.Check());
@@ -345,6 +393,14 @@ void SiftFeatureExtractorThread::Run() {
         if (success) {
           ScaleKeypoints(image_data.bitmap, image_data.camera,
                          &image_data.keypoints);
+          if (camera_mask_) {
+            MaskKeypoints(*camera_mask_, &image_data.keypoints,
+                          &image_data.descriptors);
+          }
+          if (image_data.mask.Data()) {
+            MaskKeypoints(image_data.mask, &image_data.keypoints,
+                          &image_data.descriptors);
+          }
         } else {
           image_data.status = ImageReader::Status::FAILURE;
         }

--- a/src/feature/extraction.h
+++ b/src/feature/extraction.h
@@ -96,6 +96,7 @@ struct ImageData {
   Camera camera;
   Image image;
   Bitmap bitmap;
+  Bitmap mask;
 
   FeatureKeypoints keypoints;
   FeatureDescriptors descriptors;
@@ -118,6 +119,7 @@ class ImageResizerThread : public Thread {
 class SiftFeatureExtractorThread : public Thread {
  public:
   SiftFeatureExtractorThread(const SiftExtractionOptions& sift_options,
+                             const std::shared_ptr<Bitmap>& camera_mask,
                              JobQueue<ImageData>* input_queue,
                              JobQueue<ImageData>* output_queue);
 
@@ -125,6 +127,7 @@ class SiftFeatureExtractorThread : public Thread {
   void Run();
 
   const SiftExtractionOptions sift_options_;
+  std::shared_ptr<Bitmap> camera_mask_;
 
   std::unique_ptr<OpenGLContextManager> opengl_context_;
 

--- a/src/ui/feature_extraction_widget.cc
+++ b/src/ui/feature_extraction_widget.cc
@@ -75,6 +75,10 @@ ExtractionWidget::ExtractionWidget(QWidget* parent, OptionManager* options)
 SIFTExtractionWidget::SIFTExtractionWidget(QWidget* parent,
                                            OptionManager* options)
     : ExtractionWidget(parent, options) {
+  AddOptionDirPath(&options->image_reader->mask_path, "mask_path");
+  AddOptionFilePath(&options->image_reader->camera_mask_path,
+                    "camera_mask_path");
+  
   AddOptionInt(&options->sift_extraction->max_image_size, "max_image_size");
   AddOptionInt(&options->sift_extraction->max_num_features, "max_num_features");
   AddOptionInt(&options->sift_extraction->first_octave, "first_octave", -5);

--- a/src/util/misc.cc
+++ b/src/util/misc.cc
@@ -114,6 +114,45 @@ std::string GetParentDir(const std::string& path) {
   return boost::filesystem::path(path).parent_path().string();
 }
 
+std::string GetRelativePath(const std::string& from, const std::string& to) {
+  // This implementation is adapted from:
+  // https://stackoverflow.com/questions/10167382
+  // A native implementation in boost::filesystem is only available starting
+  // from boost version 1.60.
+  using namespace boost::filesystem;
+  
+  path from_path = canonical(path(from));
+  path to_path = canonical(path(to));
+  
+  // Start at the root path and while they are the same then do nothing then
+  // when they first diverge take the entire from path, swap it with '..'
+  // segments, and then append the remainder of the to path.
+  path::const_iterator from_iter = from_path.begin();
+  path::const_iterator to_iter = to_path.begin();
+
+  // Loop through both while they are the same to find nearest common directory
+  while (from_iter != from_path.end() && to_iter != to_path.end() &&
+        (*to_iter) == (*from_iter)) {
+    ++ to_iter;
+    ++ from_iter;
+  }
+
+  // Replace from path segments with '..' (from => nearest common directory)
+  path rel_path;
+  while (from_iter != from_path.end()) {
+    rel_path /= "..";
+    ++ from_iter;
+  }
+
+  // Append the remainder of the to path (nearest common directory => to)
+  while (to_iter != to_path.end()) {
+    rel_path /= *to_iter;
+    ++ to_iter;
+  }
+
+  return rel_path.string();
+}
+
 std::vector<std::string> GetFileList(const std::string& path) {
   std::vector<std::string> file_list;
   for (auto it = boost::filesystem::directory_iterator(path);

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -79,6 +79,10 @@ std::string GetPathBaseName(const std::string& path);
 // Get the path of the parent directory for the given path.
 std::string GetParentDir(const std::string& path);
 
+// Get the relative path between from and to. Both the from and to paths must
+// exist.
+std::string GetRelativePath(const std::string& from, const std::string& to);
+
 // Join multiple paths into one path.
 template <typename... T>
 std::string JoinPaths(T const&... paths);

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -213,6 +213,8 @@ void OptionManager::AddExtractionOptions() {
   }
   added_extraction_options_ = true;
 
+  AddAndRegisterDefaultOption("ImageReader.mask_path",
+                              &image_reader->mask_path);
   AddAndRegisterDefaultOption("ImageReader.camera_model",
                               &image_reader->camera_model);
   AddAndRegisterDefaultOption("ImageReader.single_camera",
@@ -225,6 +227,8 @@ void OptionManager::AddExtractionOptions() {
                               &image_reader->camera_params);
   AddAndRegisterDefaultOption("ImageReader.default_focal_length_factor",
                               &image_reader->default_focal_length_factor);
+  AddAndRegisterDefaultOption("ImageReader.camera_mask_path",
+                              &image_reader->camera_mask_path);
 
   AddAndRegisterDefaultOption("SiftExtraction.num_threads",
                               &sift_extraction->num_threads);


### PR DESCRIPTION
This implements masking of images for feature extraction (by removing extracted features at masked-out image locations). Corresponds to issue #208 (regarding sparse features; does not implement masking for dense reconstruction).

Two new image extraction parameters are introduced:

* ImageReader.mask_path to specify a root directory for per-image masks:
```
  // Optional root path to folder which contains image masks. For a given image,
  // the corresponding mask must have the same sub-path below this root as the
  // image has below image_path. The filename must be equal, aside from the
  // added extension .png. For example, for an image image_path/abc/012.jpg, the
  // mask would be mask_path/abc/012.jpg.png. No features will be extracted in
  // regions where the mask image is black (pixel intensity value 0 in
  // grayscale).
```

* ImageReader.camera_mask_path to specify the file path of a mask that globally applies to all images:
```
  // Optional path to an image file specifying a mask for all images. No
  // features will be extracted in regions where the mask is black (pixel
  // intensity value 0 in grayscale).
```

Open points:

* I did not run clang-format, since the version I have installed outputs the following error:
```
[...]/colmap/.clang-format: Invalid argument
Can't find usable .clang-format, using LLVM style
YAML:21:29: error: invalid boolean
BreakBeforeBinaryOperators: None
                            ^~~~
```
* The two new options are not self-explanatory. In the options list widget for feature extraction, there should ideally be some documentation on them.
* The options list for feature extraction becomes quite long vertically. At some point it will reach or has reached a point where it won't fit on small screens. Introducing a scroll bar would help.