### PR TITLE
Avoid using database transactions during vocabulary tree matching

### DIFF
--- a/src/estimators/two_view_geometry.cc
+++ b/src/estimators/two_view_geometry.cc
@@ -411,13 +411,12 @@ void TwoViewGeometry::EstimateUncalibrated(
 
   if (H_F_inlier_ratio > options.max_H_inlier_ratio) {
     config = ConfigurationType::PLANAR_OR_PANORAMIC;
-    inlier_matches = ExtractInlierMatches(matches, H_report.support.num_inliers,
-                                          H_report.inlier_mask);
   } else {
     config = ConfigurationType::UNCALIBRATED;
-    inlier_matches = ExtractInlierMatches(matches, F_report.support.num_inliers,
-                                          F_report.inlier_mask);
   }
+
+  inlier_matches = ExtractInlierMatches(matches, F_report.support.num_inliers,
+                                        F_report.inlier_mask);
 
   if (options.detect_watermark &&
       DetectWatermark(camera1, matched_points1, camera2, matched_points2,

--- a/src/estimators/two_view_geometry.cc
+++ b/src/estimators/two_view_geometry.cc
@@ -411,12 +411,13 @@ void TwoViewGeometry::EstimateUncalibrated(
 
   if (H_F_inlier_ratio > options.max_H_inlier_ratio) {
     config = ConfigurationType::PLANAR_OR_PANORAMIC;
+    inlier_matches = ExtractInlierMatches(matches, H_report.support.num_inliers,
+                                          H_report.inlier_mask);
   } else {
     config = ConfigurationType::UNCALIBRATED;
+    inlier_matches = ExtractInlierMatches(matches, F_report.support.num_inliers,
+                                          F_report.inlier_mask);
   }
-
-  inlier_matches = ExtractInlierMatches(matches, F_report.support.num_inliers,
-                                        F_report.inlier_mask);
 
   if (options.detect_watermark &&
       DetectWatermark(camera1, matched_points1, camera2, matched_points2,

--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -753,8 +753,6 @@ void SiftFeatureMatcher::Match(
     return;
   }
 
-  DatabaseTransaction database_transaction(database_);
-
   //////////////////////////////////////////////////////////////////////////////
   // Match the image pairs
   //////////////////////////////////////////////////////////////////////////////
@@ -903,6 +901,7 @@ void ExhaustiveFeatureMatcher::Run() {
         }
       }
 
+      DatabaseTransaction database_transaction(&database_);
       matcher_.Match(image_pairs);
 
       PrintElapsedTime(timer);
@@ -1004,6 +1003,7 @@ void SequentialFeatureMatcher::RunSequentialMatching(
       }
     }
 
+    DatabaseTransaction database_transaction(&database_);
     matcher_.Match(image_pairs);
 
     PrintElapsedTime(timer);
@@ -1295,6 +1295,7 @@ void SpatialFeatureMatcher::Run() {
       image_pairs.emplace_back(image_id, nn_image_id);
     }
 
+    DatabaseTransaction database_transaction(&database_);
     matcher_.Match(image_pairs);
 
     PrintElapsedTime(timer);
@@ -1374,6 +1375,7 @@ void TransitiveFeatureMatcher::Run() {
                 num_batches += 1;
                 std::cout << StringPrintf("  Batch %d", num_batches)
                           << std::flush;
+                DatabaseTransaction database_transaction(&database_);
                 matcher_.Match(image_pairs);
                 image_pairs.clear();
                 PrintElapsedTime(timer);
@@ -1392,6 +1394,7 @@ void TransitiveFeatureMatcher::Run() {
 
     num_batches += 1;
     std::cout << StringPrintf("  Batch %d", num_batches) << std::flush;
+    DatabaseTransaction database_transaction(&database_);
     matcher_.Match(image_pairs);
     PrintElapsedTime(timer);
   }
@@ -1498,6 +1501,7 @@ void ImagePairsFeatureMatcher::Run() {
       block_image_pairs.push_back(image_pairs[j]);
     }
 
+    DatabaseTransaction database_transaction(&database_);
     matcher_.Match(block_image_pairs);
 
     PrintElapsedTime(timer);


### PR DESCRIPTION
Addresses Issue #527.

I added transactions for the other matching methods that don't have multithreaded database accesses, so the behavior should be the same as before for those. In addition to checking vocabulary tree matching on a large dataset, I also checked that exhaustive and sequential matching still work on the South Building dataset.