### PR TITLE
added functionality to undistort images without the need for a 3D model

### DIFF
--- a/src/base/undistortion.h
+++ b/src/base/undistortion.h
@@ -127,6 +127,27 @@ class CMPMVSUndistorter : public Thread {
   std::string output_path_;
   const Reconstruction& reconstruction_;
 };
+  
+// Undistort images and export undistorted cameras without the need for a
+// reconstruction. Instead, the image names and camera model information are
+// read from a text file.
+class PureImageUndistorter : public Thread {
+ public:
+  PureImageUndistorter(const UndistortCameraOptions& options,
+                       const std::string& image_path,
+                       const std::string& output_path,
+                       const std::vector<std::pair<std::string, Camera>>& image_names_and_cameras);
+  
+ private:
+  void Run();
+  
+  void Undistort(const size_t reg_image_idx) const;
+  
+  UndistortCameraOptions options_;
+  std::string image_path_;
+  std::string output_path_;
+  const std::vector<std::pair<std::string, Camera>>& image_names_and_cameras_;
+};
 
 // Rectify stereo image pairs.
 class StereoImageRectifier : public Thread {

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -793,6 +793,95 @@ int RunImageUndistorter(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
+int RunImageUndistorterStandalone(int argc, char** argv) {
+  std::string input_file;
+  std::string output_path;
+  
+  UndistortCameraOptions undistort_camera_options;
+  
+  OptionManager options;
+  options.AddImageOptions();
+  options.AddRequiredOption("input_file", &input_file);
+  options.AddRequiredOption("output_path", &output_path);
+  options.AddDefaultOption("blank_pixels",
+                           &undistort_camera_options.blank_pixels);
+  options.AddDefaultOption("min_scale", &undistort_camera_options.min_scale);
+  options.AddDefaultOption("max_scale", &undistort_camera_options.max_scale);
+  options.AddDefaultOption("max_image_size",
+                           &undistort_camera_options.max_image_size);
+  options.AddDefaultOption("roi_min_x", &undistort_camera_options.roi_min_x);
+  options.AddDefaultOption("roi_min_y", &undistort_camera_options.roi_min_y);
+  options.AddDefaultOption("roi_max_x", &undistort_camera_options.roi_max_x);
+  options.AddDefaultOption("roi_max_y", &undistort_camera_options.roi_max_y);
+  options.Parse(argc, argv);
+  
+  CreateDirIfNotExists(output_path);
+  
+  // Loads a text file containing the image names and camera information.
+  // The format of the text file is
+  //   image_name CAMERA_MODEL camera_params
+  std::vector<std::pair<std::string, Camera>> image_names_and_cameras;
+  
+  {
+    std::ifstream file(input_file);
+    CHECK(file.is_open()) << input_file;
+    
+    std::string line;
+    std::vector<std::string> lines;
+    while (std::getline(file, line)) {
+      StringTrim(&line);
+      
+      if (line.empty()) {
+        continue;
+      }
+      
+      std::string item;
+      std::stringstream line_stream(line);
+      
+      // Loads the image name.
+      std::string image_name;
+      std::getline(line_stream, image_name, ' ');
+      
+      // Loads the camera and its parameters
+      class Camera camera;
+      
+      std::getline(line_stream, item, ' ');
+      if (!ExistsCameraModelWithName(item)) {
+        std::cerr << "ERROR: Camera model " << item
+                  << " does not exist" << std::endl;
+        return EXIT_FAILURE;
+      }
+      camera.SetModelIdFromName(item);
+      
+      std::getline(line_stream, item, ' ');
+      camera.SetWidth(std::stoll(item));
+      
+      std::getline(line_stream, item, ' ');
+      camera.SetHeight(std::stoll(item));
+      
+      camera.Params().clear();
+      while (!line_stream.eof()) {
+        std::getline(line_stream, item, ' ');
+        camera.Params().push_back(std::stold(item));
+      }
+      
+      CHECK(camera.VerifyParams());
+      
+      image_names_and_cameras.emplace_back(image_name, camera);
+    }
+  }
+
+  std::unique_ptr<Thread> undistorter;
+  undistorter.reset(new PureImageUndistorter(undistort_camera_options,
+                                             *options.image_path, output_path,
+                                             image_names_and_cameras));
+  
+  undistorter->Start();
+  undistorter->Wait();
+  
+  return EXIT_SUCCESS;
+}
+
 int RunMapper(int argc, char** argv) {
   std::string input_path;
   std::string output_path;
@@ -1923,6 +2012,8 @@ int main(int argc, char** argv) {
   commands.emplace_back("image_rectifier", &RunImageRectifier);
   commands.emplace_back("image_registrator", &RunImageRegistrator);
   commands.emplace_back("image_undistorter", &RunImageUndistorter);
+  commands.emplace_back("image_undistorter_standalone",
+                        &RunImageUndistorterStandalone);
   commands.emplace_back("mapper", &RunMapper);
   commands.emplace_back("matches_importer", &RunMatchesImporter);
   commands.emplace_back("model_aligner", &RunModelAligner);


### PR DESCRIPTION
Implements functionality to undistort images without a 3D reconstruction by adding a new option to the `colmap` executable: `colmap image_undistorter_standalone`.
Rather than reading the image names and camera parameters from a reconstruction, `colmap image_undistorter_standalone` loads this information from a text file (paramter `--input_file`. Each line in the text file specifies the filename of an image and its camera parameters. Here is an example:
`day_hq/day_hq_00013.jpg SIMPLE_RADIAL_FISHEYE 1280 720 467.338 640 360 0.20964`