### PR TITLE
Update maps to unordered for faster access/emplace times

### DIFF
--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -50,8 +50,8 @@ namespace {
 
 // Mutexes that ensure that only one thread extracts/matches on the same GPU
 // at the same time, since SiftGPU internally uses static variables.
-static std::map<int, std::unique_ptr<std::mutex>> sift_extraction_mutexes;
-static std::map<int, std::unique_ptr<std::mutex>> sift_matching_mutexes;
+static std::unordered_map<int, std::unique_ptr<std::mutex>> sift_extraction_mutexes;
+static std::unordered_map<int, std::unique_ptr<std::mutex>> sift_matching_mutexes;
 
 // VLFeat uses a different convention to store its descriptors. This transforms
 // the VLFeat format into the original SIFT format that is also used by SiftGPU.


### PR DESCRIPTION
Just caught my eye: unordered_maps will let you create faster `emplace` and `count` commands (due to hashing) and avoid the unnecessary ordering that `std::map` includes.