### PR TITLE
 Return squared cosine distance as residuals in GP3PEstimator. 

### DIFF
--- a/src/estimators/generalized_absolute_pose.cc
+++ b/src/estimators/generalized_absolute_pose.cc
@@ -316,8 +316,10 @@ void GP3PEstimator::Residuals(const std::vector<X_t>& points2D,
       const double x_1 = points2D[i].xy(1);
       const double inv_x_norm = 1 / std::sqrt(x_0 * x_0 + x_1 * x_1 + 1);
 
-      (*residuals)[i] =
+      const double cosine_dist =
           1 - inv_pcx_norm * inv_x_norm * (pcx_0 * x_0 + pcx_1 * x_1 + pcx_2);
+      (*residuals)[i] = cosine_dist * cosine_dist;
+
     } else {
       (*residuals)[i] = std::numeric_limits<double>::max();
     }

--- a/src/estimators/generalized_absolute_pose.h
+++ b/src/estimators/generalized_absolute_pose.h
@@ -74,8 +74,9 @@ class GP3PEstimator {
   static std::vector<M_t> Estimate(const std::vector<X_t>& points2D,
                                    const std::vector<Y_t>& points3D);
 
-  // Calculate the cosine distance error between the rays given a set of 2D-3D
-  // point correspondences and a projection matrix of the generalized camera.
+  // Calculate the squared cosine distance error between the rays given a set of
+  // 2D-3D point correspondences and a projection matrix of the generalized
+  // camera.
   static void Residuals(const std::vector<X_t>& points2D,
                         const std::vector<Y_t>& points3D,
                         const M_t& proj_matrix, std::vector<double>* residuals);

--- a/src/estimators/generalized_absolute_pose_test.cc
+++ b/src/estimators/generalized_absolute_pose_test.cc
@@ -115,14 +115,14 @@ BOOST_AUTO_TEST_CASE(Estimate) {
       std::vector<double> residuals;
       GP3PEstimator::Residuals(points2D, points3D, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
-        BOOST_CHECK(residuals[i] < 1e-3);
+        BOOST_CHECK(residuals[i] < 1e-10);
       }
 
       // Test residuals of faulty points.
       GP3PEstimator::Residuals(points2D, points3D_faulty, report.model,
                                &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
-        BOOST_CHECK(residuals[i] > 0.1);
+        BOOST_CHECK(residuals[i] > 1e-10);
       }
     }
   }


### PR DESCRIPTION
This makes the GP3PEstimator consistent with all other estimators which return the squared distance (and RANSAC using the squared threshold for comparison).