### PR TITLE
Updated documentation for patch_match_stereo CLI options

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -174,8 +174,8 @@ now also requires a manual specification of the depth range::
 
     colmap patch_match_stereo \
         --workspace_path path/to/dense/workspace \
-        --DenseStereo.depth_min $MIN_DEPTH \
-        --DenseStereo.depth_max $MAX_DEPTH
+        --PatchMatchStereo.depth_min $MIN_DEPTH \
+        --PatchMatchStereo.depth_max $MAX_DEPTH
 
     colmap stereo_fusion \
         --workspace_path path/to/dense/workspace \
@@ -381,10 +381,10 @@ Improving dense reconstruction results for weakly textured surfaces
 -------------------------------------------------------------------
 
 For scenes with weakly textured surfaces it can help to have a high resolution
-of the input images (``--DenseStereo.max_image_size``) and a large patch window
-radius (``--DenseStereo.window_radius``). You may also want to reduce the
+of the input images (``--PatchMatchStereo.max_image_size``) and a large patch window
+radius (``--PatchMatchStereo.window_radius``). You may also want to reduce the
 filtering threshold for the photometric consistency cost
-(``--DenseStereo.filter_min_ncc``).
+(``--PatchMatchStereo.filter_min_ncc``).
 
 
 Surface mesh reconstruction
@@ -415,27 +415,27 @@ The dense reconstruction can be speeded up in multiple ways:
 
 - Put more GPUs in your system as the dense reconstruction can make use of
   multiple GPUs during the stereo reconstruction step. Put more RAM into your
-  system and increase the ``--DenseStereo.cache_size``,
+  system and increase the ``--PatchMatchStereo.cache_size``,
   ``--StereoFusion.cache_size`` to the largest possible value in order to
   speed up the dense fusion step.
 
 - Do not perform geometric dense stereo reconstruction
-  ``--DenseStereo.geom_consistency false``. Make sure to also enable
-  ``--DenseStereo.filter true`` in this case.
+  ``--PatchMatchStereo.geom_consistency false``. Make sure to also enable
+  ``--PatchMatchStereo.filter true`` in this case.
 
-- Reduce the ``--DenseStereo.max_image_size``, ``--StereoFusion.max_image_size``
+- Reduce the ``--PatchMatchStereo.max_image_size``, ``--StereoFusion.max_image_size``
   values to perform dense reconstruction on a maximum image resolution.
 
 - Reduce the number of source images per reference image to be considered, as
   described :ref:`here <faq-dense-memory>`.
 
-- Increase the patch windows step ``--DenseStereo.window_step`` to 2.
+- Increase the patch windows step ``--PatchMatchStereo.window_step`` to 2.
 
-- Reduce the patch window radius ``--DenseStereo.window_radius``.
+- Reduce the patch window radius ``--PatchMatchStereo.window_radius``.
 
-- Reduce the number of patch match iterations ``--DenseStereo.num_iterations``.
+- Reduce the number of patch match iterations ``--PatchMatchStereo.num_iterations``.
 
-- Reduce the number of sampled views ``--DenseStereo.num_samples``.
+- Reduce the number of sampled views ``--PatchMatchStereo.num_samples``.
 
 - To speedup the dense stereo and fusion step for very large reconstructions,
   you can use CMVS to partition your scene into multiple clusters and to prune
@@ -453,14 +453,14 @@ Reduce memory usage during dense reconstruction
 -----------------------------------------------
 
 If you run out of GPU memory during patch match stereo, you can either reduce
-the maximum image size by setting the option ``--DenseStereo.max_image_size`` or
+the maximum image size by setting the option ``--PatchMatchStereo.max_image_size`` or
 reduce the number of source images in the ``stereo/patch-match.cfg`` file from
 e.g. ``__auto__, 30`` to ``__auto__, 10``. Note that enabling the
 ``geom_consistency`` option increases the required GPU memory.
 
 If you run out of CPU memory during stereo or fusion, you can reduce the
-``--DenseStereo.cache_size`` or ``--StereoFusion.cache_size`` specified in
-gigabytes or you can reduce ``--DenseStereo.max_image_size`` or
+``--PatchMatchStereo.cache_size`` or ``--StereoFusion.cache_size`` specified in
+gigabytes or you can reduce ``--PatchMatchStereo.max_image_size`` or
 ``--StereoFusion.max_image_size``. Note that a too low value might lead to very
 slow processing and heavy load on the hard disk.
 
@@ -507,10 +507,10 @@ Multi-GPU support in dense reconstruction
 -----------------------------------------
 
 You can run dense reconstruction on multiple GPUs by specifying multiple indices
-for CUDA-enabled GPUs, e.g., ``--DenseStereo.gpu_index=0,1,2,3`` runs the dense
+for CUDA-enabled GPUs, e.g., ``--PatchMatchStereo.gpu_index=0,1,2,3`` runs the dense
 reconstruction on 4 GPUs in parallel. You can also run multiple dense
 reconstruction threads on the same GPU by specifying the same GPU index twice,
-e.g., ``--DenseStereo.gpu_index=0,0,1,1,2,3``. By default, COLMAP runs one
+e.g., ``--PatchMatchStereo.gpu_index=0,0,1,1,2,3``. By default, COLMAP runs one
 dense reconstruction thread per CUDA-enabled GPU.
 
 


### PR DESCRIPTION
Hi,

Just found that the FAQ documentation for `patch_match_stereo` was out of date since the options changed from `--DenseStereo.*` to `--PatchMatchStereo.*` (`3.5-dev.2` https://github.com/colmap/colmap/commit/f1ec0beba689d9d725fb2922b8e41913c394baf6).

Tis PR fixes that part of the documentation.

Thanks,