### PR TITLE
CMakeLists: Do not error out if finding CGAL fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,9 @@ find_package(OpenGL REQUIRED)
 find_package(Glew REQUIRED)
 find_package(Git)
 
-find_package(CGAL QUIET)
+if (CGAL_ENABLED)
+  find_package(CGAL QUIET)
+endif()
 
 set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)


### PR DESCRIPTION
The following line in CMakeLists.txt

find_package(CGAL QUIET)

causes problems on my system. What worked is to put it in the conditional: 

if (CGAL_ENABLED)
  find_package(CGAL QUIET)
endif()

I think this makes sense. If the user does not want CGAL, why try searching for it to start with. This fixed it.

Here's the error I get.  It is nasty. CGAL itself exists, but a Qt library having CGAL does not exist. 

CMake Error at /usr/lib/x86_64-linux-gnu/cmake/CGAL/CGALExports.cmake:83 (message):
  The imported target "CGAL::CGAL_Qt5" references the file

     "/usr/lib/x86_64-linux-gnu/libCGAL_Qt5.so.11.0.1"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/usr/lib/x86_64-linux-gnu/cmake/CGAL/CGALExports.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/CGAL/CGALConfig.cmake:12 (include)
  CMakeLists.txt:108 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/oalexan1/projects/colmap/CMakeFiles/CMakeOutput.log".
