### PR TITLE
drop unrecognised option from FAQ example

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -269,7 +269,6 @@ new images within this reconstruction, you can follow these steps::
 
     colmap image_registrator \
         --database_path $PROJECT_PATH/database.db \
-        --image_path $PROJECT_PATH/images \
         --input_path /path/to/existing-model \
         --output_path /path/to/model-with-new-images
 


### PR DESCRIPTION
Corrects FAQ example in _Register/localize new images into an existing reconstruction_ section.

The _colmap image_registrator_ command does not accept the --image_path argument.