### PR TITLE
VLFeat: unbreak build with GCC 9

### DIFF
--- a/lib/VLFeat/kmeans.c
+++ b/lib/VLFeat/kmeans.c
@@ -669,7 +669,7 @@ VL_XCAT(_vl_kmeans_quantize_, SFX)
 #endif
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) \
+#pragma omp parallel \
             shared(self, distances, assignments, numData, distFn, data) \
             num_threads(vl_get_max_threads())
 #endif


### PR DESCRIPTION
Pick up https://github.com/vlfeat/vlfeat/pull/200. See [error log](http://package22.nyi.freebsd.org/data/112amd64-default-PR238330/2019-06-09_20h29m30s/logs/errors/colmap-3.5_7.log).

For `master` branch. I haven't tested `dev` yet.
