### PR TITLE
check --input_path and --output_path when running bundle_adjuster command

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -187,6 +187,16 @@ int RunBundleAdjuster(int argc, char** argv) {
   options.AddBundleAdjustmentOptions();
   options.Parse(argc, argv);
 
+  if (!ExistsDir(input_path)) {
+    std::cerr << "ERROR: `input_path` is not a directory" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (!ExistsDir(output_path)) {
+    std::cerr << "ERROR: `output_path` is not a directory" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
 


### PR DESCRIPTION
When running bundle_adjust cli command, check that specified
--input_path and --output_path directories exist.

This way we get a nice error message right at the start,
instead of getting a more cryptic error message after
potentially lengthy processing.