### PR TITLE
signed/unsigned int color bug in matlab/read_model

### DIFF
--- a/scripts/matlab/read_model.m
+++ b/scripts/matlab/read_model.m
@@ -151,7 +151,7 @@ while ischar(tline)
     point = struct;
     point.point3D_id = int64(elems(1));
     point.xyz = elems(2:4);
-    point.rgb = int8(elems(5:7));
+    point.rgb = uint8(elems(5:7));
     point.error = elems(8);
     point.track = int64(elems(9:end));
     point.track = reshape(point.track, [2, numel(point.track) / 2])';


### PR DESCRIPTION
Color values are converted to signed 8bit integer so the range is limited from 0 to 127 (-128 to 127, but negative colors are not used). 
The correct type should be UNSIGNED 8bit integer (uint8) so the range is 0 to 255. 
This code change fixes this behaviour.