### PR TITLE
flann match

### DIFF
--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -110,19 +110,6 @@ Eigen::MatrixXi ComputeSiftDistanceMatrix(
 }
 
 
-struct ReverseDotDistance {
-  using ElementType = int;
-  using ResultType = int;
-
-  template <class Iterator1, class Iterator2>
-  ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const {
-    ResultType result = ResultType();
-    for (size_t i = 0; i < size; ++i) {
-      result -= (*a++) * (*b++);
-    }
-    return result;
-  }
-};
 void FlannMatch(const FeatureDescriptors& query,
                 const FeatureDescriptors& dataset,
                 Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> * indices,

--- a/src/feature/sift.h
+++ b/src/feature/sift.h
@@ -211,6 +211,14 @@ void LoadSiftFeaturesFromTextFile(const std::string& path,
                                   FeatureDescriptors* descriptors);
 
 // Match the given SIFT features on the CPU.
+void MatchSiftFeaturesCPUBruteForce(const SiftMatchingOptions& match_options,
+                                    const FeatureDescriptors& descriptors1,
+                                    const FeatureDescriptors& descriptors2,
+                                    FeatureMatches* matches);
+void MatchSiftFeaturesCPUFLANN(const SiftMatchingOptions& match_options,
+                               const FeatureDescriptors& descriptors1,
+                               const FeatureDescriptors& descriptors2,
+                               FeatureMatches* matches);
 void MatchSiftFeaturesCPU(const SiftMatchingOptions& match_options,
                           const FeatureDescriptors& descriptors1,
                           const FeatureDescriptors& descriptors2,
@@ -248,3 +256,4 @@ void MatchGuidedSiftFeaturesGPU(const SiftMatchingOptions& match_options,
 }  // namespace colmap
 
 #endif  // COLMAP_SRC_FEATURE_SIFT_H_
+

--- a/src/feature/sift_test.cc
+++ b/src/feature/sift_test.cc
@@ -324,6 +324,112 @@ BOOST_AUTO_TEST_CASE(TestMatchSiftFeaturesCPU) {
   BOOST_CHECK_EQUAL(matches.size(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(TestMatchSiftFeaturesCPUFLANNvsBruteForce) {
+  SiftMatchingOptions match_options;
+  match_options.max_num_matches = 1000;
+
+  auto TestFLANNvsBruteForce = [](
+      const SiftMatchingOptions& options,
+      const FeatureDescriptors& descriptors1,
+      const FeatureDescriptors& descriptors2) {
+    FeatureMatches matches_bf;
+    FeatureMatches matches_flann;
+
+    MatchSiftFeaturesCPUBruteForce(options, descriptors1, descriptors2,
+        &matches_bf);
+    MatchSiftFeaturesCPUFLANN(options, descriptors1, descriptors2,
+        &matches_flann);
+    CheckEqualMatches(matches_bf, matches_flann);
+
+    const size_t num_matches = matches_bf.size();
+
+    const FeatureDescriptors empty_descriptors =
+      CreateRandomFeatureDescriptors(0);
+
+    MatchSiftFeaturesCPUBruteForce(options, empty_descriptors, descriptors2, &matches_bf);
+    MatchSiftFeaturesCPUFLANN(options, empty_descriptors, descriptors2, &matches_flann);
+    CheckEqualMatches(matches_bf, matches_flann);
+
+    MatchSiftFeaturesCPUBruteForce(options, descriptors1, empty_descriptors, &matches_bf);
+    MatchSiftFeaturesCPUFLANN(options, descriptors1, empty_descriptors, &matches_flann);
+    CheckEqualMatches(matches_bf, matches_flann);
+
+    MatchSiftFeaturesCPUBruteForce(options, empty_descriptors, empty_descriptors, &matches_bf);
+    MatchSiftFeaturesCPUFLANN(options, empty_descriptors, empty_descriptors, &matches_flann);
+    CheckEqualMatches(matches_bf, matches_flann);
+
+    return num_matches;
+  };
+
+  {
+    const FeatureDescriptors descriptors1 =
+      CreateRandomFeatureDescriptors(100);
+    const FeatureDescriptors descriptors2 =
+      CreateRandomFeatureDescriptors(100);
+    SiftMatchingOptions match_options;
+    TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+  }
+
+  {
+    const FeatureDescriptors descriptors1 =
+      CreateRandomFeatureDescriptors(100);
+    const FeatureDescriptors descriptors2 =
+      descriptors1.colwise().reverse();
+    SiftMatchingOptions match_options;
+    const size_t num_matches =
+      TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+    BOOST_CHECK_EQUAL(num_matches, 100);
+  }
+
+  // Check the ratio test.
+  {
+    FeatureDescriptors descriptors1 = CreateRandomFeatureDescriptors(100);
+    FeatureDescriptors descriptors2 = descriptors1;
+
+    SiftMatchingOptions match_options;
+    const size_t num_matches1 =
+      TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+    BOOST_CHECK_EQUAL(num_matches1, 100);
+
+    descriptors2.row(99) = descriptors2.row(0);
+    descriptors2(0, 0) += 50.0f;
+    descriptors2.row(0) = FeatureDescriptorsToUnsignedByte(
+        L2NormalizeFeatureDescriptors(descriptors2.row(0).cast<float>()));
+    descriptors2(99, 0) += 100.0f;
+    descriptors2.row(99) = FeatureDescriptorsToUnsignedByte(
+        L2NormalizeFeatureDescriptors(descriptors2.row(99).cast<float>()));
+
+    match_options.max_ratio = 0.4;
+    const size_t num_matches2 =
+      TestFLANNvsBruteForce(match_options, descriptors1.topRows(99), descriptors2);
+    BOOST_CHECK_EQUAL(num_matches2, 98);
+
+    match_options.max_ratio = 0.5;
+    const size_t num_matches3 =
+      TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+    BOOST_CHECK_EQUAL(num_matches3, 99);
+  }
+
+  // Check the cross check.
+  {
+    FeatureDescriptors descriptors1 = CreateRandomFeatureDescriptors(100);
+    FeatureDescriptors descriptors2 = descriptors1;
+    descriptors1.row(0) = descriptors1.row(1);
+
+    SiftMatchingOptions match_options;
+
+    match_options.cross_check = false;
+    const size_t num_matches1 =
+      TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+    BOOST_CHECK_EQUAL(num_matches1, 100);
+
+    match_options.cross_check = true;
+    const size_t num_matches2 =
+      TestFLANNvsBruteForce(match_options, descriptors1, descriptors2);
+    BOOST_CHECK_EQUAL(num_matches2, 98);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(TestMatchGuidedSiftFeaturesCPU) {
   FeatureKeypoints empty_keypoints(0);
   FeatureKeypoints keypoints1(2);


### PR DESCRIPTION
As noted in [this](https://github.com/colmap/colmap/issues/165) issue, master version of COLMAP use brute force search for pairwise feature matching for both CPU and GPU.

This PR implement ANN search for CPU version of matching.
In my tests, ANN is 6-10 times faster than brute force.

Unfortunately, I could not save dot distance function.

I tried create dot distance function for FLANN:
```cpp
struct ReverseDotDistance {
  using ElementType = int;
  using ResultType = int;

  template <class Iterator1, class Iterator2>
  ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const {
    ResultType result = ResultType();
    for (size_t i = 0; i < size; ++i) {
      result -= (*a++) * (*b++);
    }
    return result;
  }
};
```
However, dot distance [can't be use in kdtree forest search](https://github.com/mariusmuja/flann/issues/143#issuecomment-28808790)

Dot distance still can be use in KMeans search (like in [this](https://github.com/turian/flann-1.2) repo), but L2 distance faster and create same result. So i decided use L2 and addinional compute dot for found neighbors.
```cpp
for (Eigen::MatrixXi::Index d1_idx = 0; d1_idx < indices->rows(); ++d1_idx) {
  for (int n_idx = 0; n_idx < indices->cols(); ++n_idx) {
    const int d2_idx = indices->coeff(d1_idx, n_idx);
    distances->coeffRef(d1_idx, n_idx) = query_int.row(d1_idx).dot(dataset_int.row(d2_idx));
  }
}
```
