### PR TITLE
Clarify about image id being the same as in the database

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -121,6 +121,11 @@ Example of images.txt::
 
     4 0.698777 0.714625 -0.023996 0.021129 -0.048184 0.004529 -0.313427 2 image0004.png
 
+Each image above must have the same image id (first column) as in the database (next step). 
+This database can be inspected either in the GUI (selecting from the menu ``Database management''
+from under ``Processing''), or, one can create a reconstruction with colmap and later export 
+it as as text in order to see the images.txt file it creates.
+
 To reconstruct a sparse map, you first have to recompute features from the
 images of the known camera poses as follows::
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -121,10 +121,10 @@ Example of images.txt::
 
     4 0.698777 0.714625 -0.023996 0.021129 -0.048184 0.004529 -0.313427 2 image0004.png
 
-Each image above must have the same image id (first column) as in the database (next step). 
-This database can be inspected either in the GUI (selecting from the menu ``Database management''
-from under ``Processing''), or, one can create a reconstruction with colmap and later export 
-it as text in order to see the images.txt file it creates.
+Each image above must have the same ``image_id`` (first column) as in the database (next step). 
+This database can be inspected either in the GUI (under ``Database management > Processing``),
+or, one can create a reconstruction with colmap and later export  it as text in order to see
+the images.txt file it creates.
 
 To reconstruct a sparse map, you first have to recompute features from the
 images of the known camera poses as follows::

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -124,7 +124,7 @@ Example of images.txt::
 Each image above must have the same image id (first column) as in the database (next step). 
 This database can be inspected either in the GUI (selecting from the menu ``Database management''
 from under ``Processing''), or, one can create a reconstruction with colmap and later export 
-it as as text in order to see the images.txt file it creates.
+it as text in order to see the images.txt file it creates.
 
 To reconstruct a sparse map, you first have to recompute features from the
 images of the known camera poses as follows::


### PR DESCRIPTION
This section starts by suggesting the user should create a text file with the cameras, and then run feature detection and matching, then use this text file to get the user cameras. The reality is more complicated. The text file should have image ids that agree with the database created during feature detection and matching. This text is clarifying that. 

