### PR TITLE
Fix bug in GpuMat::Rotate() implementation

### DIFF
--- a/src/mvs/cuda_rotate.h
+++ b/src/mvs/cuda_rotate.h
@@ -67,8 +67,8 @@ __global__ void CudaRotateKernel(T* output_data, const T* input_data,
   int output_x = input_y;
   int output_y = width - 1 - input_x;
 
-  output_data[output_y * output_pitch + output_x] =
-      input_data[input_y * input_pitch + input_x];
+  *((T*)((char*)output_data + output_y * output_pitch) + output_x) =
+      *((T*)((char*)input_data + input_y * input_pitch) + input_x);
 }
 
 }  // namespace internal
@@ -82,8 +82,7 @@ void CudaRotate(const T* input, T* output, const int width, const int height,
   grid_dim.y = height;
 
   internal::CudaRotateKernel<<<grid_dim, block_dim>>>(
-      output, input, width, height, pitch_input / sizeof(T),
-      pitch_output / sizeof(T));
+      output, input, width, height, pitch_input, pitch_output);
 }
 
 #undef TILE_DIM_ROTATE

--- a/src/mvs/gpu_mat.h
+++ b/src/mvs/gpu_mat.h
@@ -340,9 +340,9 @@ void GpuMat<T>::FlipHorizontal(GpuMat<T>* output) {
 template <typename T>
 void GpuMat<T>::Rotate(GpuMat<T>* output) {
   for (size_t slice = 0; slice < depth_; ++slice) {
-    CudaRotate(array_ptr_ + slice * pitch_ / sizeof(T) * GetHeight(),
-               output->GetPtr() +
-                   slice * output->pitch_ / sizeof(T) * output->GetHeight(),
+    CudaRotate((T*)((char*)array_ptr_ + slice * pitch_ * GetHeight()),
+               (T*)((char*)output->GetPtr() +
+                   slice * output->pitch_ * output->GetHeight()),
                width_, height_, pitch_, output->pitch_);
   }
   CUDA_SYNC_AND_CHECK();


### PR DESCRIPTION
In the COLMAP MVS code, the current implementation of `GpuMat::Rotate()` does not properly handle `GpuMat` objects for which the row pitch (in bytes) is not a multiple of the matrix data type size. So, this usage of the method:

https://github.com/colmap/colmap/blob/06d546bd9bd285263b285b60de19953bb96f9f13/src/mvs/patch_match_cuda.cu#L1672-L1678

does not work as intended, since the `GpuMatPRNG` matrix value data type (`curandState`) is 48 bytes long, which does not divide evenly into the pitch value returned by the `cudaMallocPitch()` memory allocation for many matrix sizes.

This pull request fixes this bug in `GpuMat::Rotate()`. Similar bugs may exist in other `GpuMat` methods (such as `Transpose()`, `FlipHorizontal()`), but they do not affect COLMAP behavior, and I haven't addressed them.