### PR TITLE
Allow to save fused point cloud in colmap format when using command line

### DIFF
--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -864,13 +864,13 @@ void Reconstruction::ImportPLY(const std::string& path) {
   }
 }
 
-void Reconstruction::ImportPLY(const std::vector<PlyPoint> &plyPoints)
+void Reconstruction::ImportPLY(const std::vector<PlyPoint> &ply_points)
 {
   points3D_.clear();
-  points3D_.reserve(plyPoints.size());
-  for (const auto& plyPoint : plyPoints) {
-    AddPoint3D(Eigen::Vector3d(plyPoint.x, plyPoint.y, plyPoint.z), Track(),
-               Eigen::Vector3ub(plyPoint.r, plyPoint.g, plyPoint.b));
+  points3D_.reserve(ply_points.size());
+  for (const auto& ply_point : ply_points) {
+    AddPoint3D(Eigen::Vector3d(ply_point.x, ply_point.y, ply_point.z), Track(),
+               Eigen::Vector3ub(ply_point.r, ply_point.g, ply_point.b));
   }
 }
 

--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -864,6 +864,16 @@ void Reconstruction::ImportPLY(const std::string& path) {
   }
 }
 
+void Reconstruction::ImportPLY(const std::vector<PlyPoint> &plyPoints)
+{
+  points3D_.clear();
+  points3D_.reserve(plyPoints.size());
+  for (const auto& plyPoint : plyPoints) {
+    AddPoint3D(Eigen::Vector3d(plyPoint.x, plyPoint.y, plyPoint.z), Track(),
+               Eigen::Vector3ub(plyPoint.r, plyPoint.g, plyPoint.b));
+  }
+}
+
 bool Reconstruction::ExportNVM(const std::string& path) const {
   std::ofstream file(path, std::ios::trunc);
   CHECK(file.is_open()) << path;

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -266,7 +266,7 @@ class Reconstruction {
   // Import from other data formats. Note that these import functions are
   // only intended for visualization of data and usable for reconstruction.
   void ImportPLY(const std::string& path);
-  void ImportPLY(const std::vector<PlyPoint>& plyPoints);
+  void ImportPLY(const std::vector<PlyPoint>& ply_points);
 
   // Export to other data formats.
   bool ExportNVM(const std::string& path) const;

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -266,6 +266,7 @@ class Reconstruction {
   // Import from other data formats. Note that these import functions are
   // only intended for visualization of data and usable for reconstruction.
   void ImportPLY(const std::string& path);
+  void ImportPLY(const std::vector<PlyPoint>& plyPoints);
 
   // Export to other data formats.
   bool ExportNVM(const std::string& path) const;

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -306,11 +306,14 @@ int RunStereoFuser(int argc, char** argv) {
   Reconstruction reconstruction;
 
   // read data from sparse reconstruction
-  if (workspace_format == "colmap" )
+  if (workspace_format == "colmap") {
     reconstruction.Read(JoinPaths(workspace_path, "sparse"));
+  }
 
   // overwrite sparse point cloud with dense point cloud from fuser
   reconstruction.ImportPLY(fuser.GetFusedPoints());
+
+  std::cout << "Writing output: " << output_path << std::endl;
 
   // write output
   StringToLower(&output_type);
@@ -319,7 +322,6 @@ int RunStereoFuser(int argc, char** argv) {
   } else if (output_type == "txt") {
     reconstruction.WriteText(output_path);
   } else if (output_type == "ply") {
-    std::cout << "Writing output: " << output_path << std::endl;
     WriteBinaryPlyPoints(output_path, fuser.GetFusedPoints());
     mvs::WritePointsVisibility(output_path + ".vis",
                                fuser.GetFusedPointsVisibility());

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -265,8 +265,8 @@ int RunStereoFuser(int argc, char** argv) {
   std::string input_type = "geometric";
   std::string workspace_format = "COLMAP";
   std::string pmvs_option_name = "option-all";
+  std::string output_type = "PLY";
   std::string output_path;
-  std::string output_type;
 
   OptionManager options;
   options.AddRequiredOption("workspace_path", &workspace_path);
@@ -275,9 +275,9 @@ int RunStereoFuser(int argc, char** argv) {
   options.AddDefaultOption("pmvs_option_name", &pmvs_option_name);
   options.AddDefaultOption("input_type", &input_type,
                            "{photometric, geometric}");
-  options.AddRequiredOption("output_path", &output_path);
-  options.AddRequiredOption("output_type", &output_type,
+  options.AddDefaultOption("output_type", &output_type,
                             "{BIN, TXT, PLY}");
+  options.AddRequiredOption("output_path", &output_path);
   options.AddStereoFusionOptions();
   options.Parse(argc, argv);
 


### PR DESCRIPTION
* Adjusted src/base/reconstruction.cc to import point cloud from std::vector<PlyPoints>
* Adjusted src/exe/colmap.cc to allow saving in colmap format when calling stereo_fusion from command line

See Issue https://github.com/colmap/colmap/issues/738