### PR TITLE
Fixed txt parsing error caused by incorrect LC_NUMERIC value

### DIFF
--- a/src/ui/main_window.cc
+++ b/src/ui/main_window.cc
@@ -29,6 +29,8 @@
 //
 // Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
 
+#include <clocale>
+
 #include "ui/main_window.h"
 
 #include "util/version.h"

--- a/src/ui/main_window.cc
+++ b/src/ui/main_window.cc
@@ -39,6 +39,7 @@ MainWindow::MainWindow(const OptionManager& options)
     : options_(options),
       thread_control_widget_(new ThreadControlWidget(this)),
       window_closed_(false) {
+  std::setlocale(LC_NUMERIC, "C");
   resize(1024, 600);
   UpdateWindowTitle();
 


### PR DESCRIPTION
This PR resolves #766 .

Currently, the imported results are potentially incorrect, since `std::stold` etc. depend on the value of `LC_NUMERIC` (see [stof()](https://en.cppreference.com/w/cpp/string/basic_string/stof) ).

Further, I observed that the value of `LC_NUMERIC` within colmap depends on how the corresponding code has been executed (command line vs gui). Concretely, `std::setlocale(LC_NUMERIC, NULL)` returned `C` using the command line (e.g. `colmap bundler_adjuster`) and `de_DE.UTF-8` using the gui (i.e. `colmap gui`). I guess that QT changes this value somewhere. 

Therefore, this PR adjusts the value of `LC_NUMMERIC` at a global gui level. (All functions loaded by the gui are affected and redundancy is avoided).

If you feel that the value should be changed somewhere else just let me know

Bests
Sebastian