### PR TITLE
Unbreak CGAL_ENABLED with CGAL 5.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ if(IS_MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3")
 elseif(IS_GNU OR IS_CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall")
 endif()
 
 add_subdirectory(base)


### PR DESCRIPTION
Found [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=245824). See [error log](https://github.com/colmap/colmap/files/4530640/colmap-3.6.d.3.22.log).
