### PR TITLE
force check and sort image_list

### DIFF
--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -60,6 +60,9 @@ ImageReader::ImageReader(const ImageReaderOptions& options, Database* database)
     options_.image_list = GetRecursiveFileList(options_.image_path);
     std::sort(options_.image_list.begin(), options_.image_list.end());
   } else {
+    if (!std::is_sorted(options_.image_list.begin(), options_.image_list.end())) {
+      std::sort(options_.image_list.begin(), options_.image_list.end());
+    }
     for (auto& image_name : options_.image_list) {
       image_name = JoinPaths(options_.image_path, image_name);
     }


### PR DESCRIPTION
In documentation not required what `image_list`, which contains in `image_list_path` must be sorted. However, in realization this is expected and need for `single_camera_per_folder` mode.