### PR TITLE
Geometry.h add missing <cstdio> include

### DIFF
--- a/lib/PoissonRecon/Geometry.h
+++ b/lib/PoissonRecon/Geometry.h
@@ -32,6 +32,7 @@ DAMAGE.
 #include <math.h>
 #include <vector>
 #include <stdlib.h>
+#include <cstdio>
 #include "Hash.h"
 
 template<class Real>


### PR DESCRIPTION
Does not compile otherwise because "FILE does not name a type" error on compilation in PoissonRec/Geometry.h