### PR TITLE
Custom matching speedup

### DIFF
--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -1439,6 +1439,7 @@ void ImagePairsFeatureMatcher::Run() {
 
   std::string line;
   std::vector<std::pair<image_t, image_t>> image_pairs;
+  std::unordered_set<colmap::image_pair_t> image_pairs_set;
   while (std::getline(file, line)) {
     StringTrim(&line);
 
@@ -1467,8 +1468,16 @@ void ImagePairsFeatureMatcher::Run() {
       continue;
     }
 
-    image_pairs.emplace_back(image_name_to_image_id.at(image_name1),
-                             image_name_to_image_id.at(image_name2));
+    image_pairs_set.insert(
+        Database::ImagePairToPairId(image_name_to_image_id.at(image_name1),
+                                    image_name_to_image_id.at(image_name2)));
+  }
+
+  image_pairs.reserve(image_pairs_set.size());
+  for (const auto& pid : image_pairs_set) {
+    image_pairs.resize(image_pairs.size() + 1);
+    Database::PairIdToImagePair(pid, &image_pairs.back().first,
+                                &image_pairs.back().second);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/feature/matching.h
+++ b/src/feature/matching.h
@@ -147,7 +147,7 @@ struct TransitiveMatchingOptions {
 
 struct ImagePairsMatchingOptions {
   // Number of image pairs to match in one batch.
-  int block_size = 100;
+  int block_size = 1225;
 
   // Path to the file with the matches.
   std::string match_list_path = "";

--- a/src/ui/feature_matching_widget.cc
+++ b/src/ui/feature_matching_widget.cc
@@ -298,6 +298,8 @@ CustomMatchingTab::CustomMatchingTab(QWidget* parent, OptionManager* options)
   options_widget_->AddOptionRow("type", match_type_cb_, nullptr);
 
   options_widget_->AddOptionFilePath(&match_list_path_, "match_list_path");
+  options_widget_->AddOptionInt(&options_->image_pairs_matching->block_size,
+                                "block_size", 2);
 
   CreateGeneralOptions();
 }

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -65,6 +65,7 @@ OptionManager::OptionManager(bool add_project_options) {
   vocab_tree_matching.reset(new VocabTreeMatchingOptions());
   spatial_matching.reset(new SpatialMatchingOptions());
   transitive_matching.reset(new TransitiveMatchingOptions());
+  image_pairs_matching.reset(new ImagePairsMatchingOptions());
   bundle_adjustment.reset(new BundleAdjustmentOptions());
   mapper.reset(new IncrementalMapperOptions());
   patch_match_stereo.reset(new mvs::PatchMatchOptions());
@@ -177,6 +178,7 @@ void OptionManager::AddAllOptions() {
   AddVocabTreeMatchingOptions();
   AddSpatialMatchingOptions();
   AddTransitiveMatchingOptions();
+  AddImagePairsMatchingOptions();
   AddBundleAdjustmentOptions();
   AddMapperOptions();
   AddPatchMatchStereoOptions();
@@ -417,6 +419,18 @@ void OptionManager::AddTransitiveMatchingOptions() {
                               &transitive_matching->batch_size);
   AddAndRegisterDefaultOption("TransitiveMatching.num_iterations",
                               &transitive_matching->num_iterations);
+}
+
+void OptionManager::AddImagePairsMatchingOptions() {
+  if (added_image_pairs_match_options_) {
+    return;
+  }
+  added_image_pairs_match_options_ = true;
+
+  AddMatchingOptions();
+
+  AddAndRegisterDefaultOption("ImagePairsMatching.block_size",
+                              &image_pairs_matching->block_size);
 }
 
 void OptionManager::AddBundleAdjustmentOptions() {
@@ -730,6 +744,7 @@ void OptionManager::Reset() {
   added_vocab_tree_match_options_ = false;
   added_spatial_match_options_ = false;
   added_transitive_match_options_ = false;
+  added_image_pairs_match_options_ = false;
   added_ba_options_ = false;
   added_mapper_options_ = false;
   added_patch_match_stereo_options_ = false;
@@ -753,6 +768,7 @@ void OptionManager::ResetOptions(const bool reset_paths) {
   *vocab_tree_matching = VocabTreeMatchingOptions();
   *spatial_matching = SpatialMatchingOptions();
   *transitive_matching = TransitiveMatchingOptions();
+  *image_pairs_matching = ImagePairsMatchingOptions();
   *bundle_adjustment = BundleAdjustmentOptions();
   *mapper = IncrementalMapperOptions();
   *patch_match_stereo = mvs::PatchMatchOptions();
@@ -783,6 +799,8 @@ bool OptionManager::Check() {
   if (sequential_matching) success = success && sequential_matching->Check();
   if (vocab_tree_matching) success = success && vocab_tree_matching->Check();
   if (spatial_matching) success = success && spatial_matching->Check();
+  if (transitive_matching) success = success && transitive_matching->Check();
+  if (image_pairs_matching) success = success && image_pairs_matching->Check();
 
   if (bundle_adjustment) success = success && bundle_adjustment->Check();
   if (mapper) success = success && mapper->Check();

--- a/src/util/option_manager.h
+++ b/src/util/option_manager.h
@@ -48,6 +48,7 @@ struct SequentialMatchingOptions;
 struct VocabTreeMatchingOptions;
 struct SpatialMatchingOptions;
 struct TransitiveMatchingOptions;
+struct ImagePairsMatchingOptions;
 struct BundleAdjustmentOptions;
 struct IncrementalMapperOptions;
 struct RenderOptions;
@@ -90,6 +91,7 @@ class OptionManager {
   void AddVocabTreeMatchingOptions();
   void AddSpatialMatchingOptions();
   void AddTransitiveMatchingOptions();
+  void AddImagePairsMatchingOptions();
   void AddBundleAdjustmentOptions();
   void AddMapperOptions();
   void AddPatchMatchStereoOptions();
@@ -128,6 +130,7 @@ class OptionManager {
   std::shared_ptr<VocabTreeMatchingOptions> vocab_tree_matching;
   std::shared_ptr<SpatialMatchingOptions> spatial_matching;
   std::shared_ptr<TransitiveMatchingOptions> transitive_matching;
+  std::shared_ptr<ImagePairsMatchingOptions> image_pairs_matching;
 
   std::shared_ptr<BundleAdjustmentOptions> bundle_adjustment;
   std::shared_ptr<IncrementalMapperOptions> mapper;
@@ -168,6 +171,7 @@ class OptionManager {
   bool added_vocab_tree_match_options_;
   bool added_spatial_match_options_;
   bool added_transitive_match_options_;
+  bool added_image_pairs_match_options_;
   bool added_ba_options_;
   bool added_mapper_options_;
   bool added_patch_match_stereo_options_;


### PR DESCRIPTION
Default value for ImagePairsMatchingOptions.block_size should be the same as the number of image pairs to be matched based on default value of ExhaustiveMatchingOptions.block_size (block_size * (block_size - 1) / 2). Low value of this option decrease potential utilization of hardware resources. Also, utilization can be increased by filtering out non unique image pairs.