### PR TITLE
add missing include <stdio.h> to lib/PoissonRecon/Geometry.h

### DIFF
--- a/lib/PoissonRecon/Geometry.h
+++ b/lib/PoissonRecon/Geometry.h
@@ -32,6 +32,7 @@ DAMAGE.
 #include <math.h>
 #include <vector>
 #include <stdlib.h>
+#include <stdio.h>
 #include "Hash.h"
 
 template<class Real>


### PR DESCRIPTION
Would not compile otherwise with GCC 10.1.0:
```
In file included from /tmp/tmp.ij35ejNwXQ/colmap/lib/PoissonRecon/Geometry.cpp:28:
/tmp/tmp.ij35ejNwXQ/colmap/lib/PoissonRecon/Geometry.h:344:2: error: ‘FILE’ does not name a type
  344 |  FILE* _fp;
      |  ^~~~
In file included from /tmp/tmp.ij35ejNwXQ/colmap/lib/PoissonRecon/Geometry.cpp:28:
/tmp/tmp.ij35ejNwXQ/colmap/lib/PoissonRecon/Geometry.h:36:1: note: ‘FILE’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
   35 | #include "Hash.h"
  +++ |+#include <cstdio>
   36 | 
```

Also mentioned in #886.