### PR TITLE
Catch std::invalid_argument const& instead of std::exception in misc.cc.

### DIFF
--- a/src/util/misc.cc
+++ b/src/util/misc.cc
@@ -245,7 +245,7 @@ std::vector<int> CSVToVector(const std::string& csv) {
     }
     try {
       values.push_back(std::stoi(elem));
-    } catch (std::exception) {
+    } catch (std::invalid_argument const&) {
       return std::vector<int>(0);
     }
   }
@@ -264,7 +264,7 @@ std::vector<float> CSVToVector(const std::string& csv) {
     }
     try {
       values.push_back(std::stod(elem));
-    } catch (std::exception) {
+    } catch (std::invalid_argument const&) {
       return std::vector<float>(0);
     }
   }
@@ -283,7 +283,7 @@ std::vector<double> CSVToVector(const std::string& csv) {
     }
     try {
       values.push_back(std::stold(elem));
-    } catch (std::exception) {
+    } catch (std::invalid_argument const&) {
       return std::vector<double>(0);
     }
   }


### PR DESCRIPTION
Firstly, catching a polymorphic type like `std::exception` by value causes
warnings. Secondly, we don't want to accidentally catch `std::bad_alloc`,
we only want to catch the errors potentially generated by `std::stoi`, both
of which derive from `std::invalid_argument`:
https://en.cppreference.com/w/cpp/string/basic_string/stol#Exceptions