### PR TITLE
Fix PoissonRecon build under GCC 10

### DIFF
--- a/lib/PoissonRecon/Geometry.h
+++ b/lib/PoissonRecon/Geometry.h
@@ -32,6 +32,7 @@ DAMAGE.
 #include <math.h>
 #include <vector>
 #include <stdlib.h>
+#include <cstdio>
 #include "Hash.h"
 
 template<class Real>


### PR DESCRIPTION
```
In file included from /home/user/colmap/lib/PoissonRecon/Geometry.cpp:28:
/home/user/colmap/lib/PoissonRecon/Geometry.h:344:2: error: ‘FILE’ does not name a type
  344 |  FILE* _fp;
      |  ^~~~
In file included from /home/user/colmap/lib/PoissonRecon/Geometry.cpp:28:
/home/user/colmap/lib/PoissonRecon/Geometry.h:36:1: note: ‘FILE’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
   35 | #include "Hash.h"
  +++ |+#include <cstdio>
   36 | 
```