### PR TITLE
Retriangulate after AdjustGlobalBundle

### DIFF
--- a/src/controllers/incremental_mapper.cc
+++ b/src/controllers/incremental_mapper.cc
@@ -116,6 +116,7 @@ void IterativeGlobalRefinement(const IncrementalMapperOptions& options,
         mapper->GetReconstruction().ComputeNumObservations();
     size_t num_changed_observations = 0;
     AdjustGlobalBundle(options, mapper);
+    num_changed_observations += mapper->Retriangulate(options.Triangulation());
     num_changed_observations += CompleteAndMergeTracks(options, mapper);
     num_changed_observations += FilterPoints(options, mapper);
     const double changed =


### PR DESCRIPTION
https://github.com/colmap/colmap/issues/898
I think it's reasonable that images could generate new point3D, as the pose of images changed after global bundle.