### PR TITLE
Fix a reStructuredText issue

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -296,7 +296,7 @@ reconstruction pipelines, COLMAP offers you the following possibilities:
 
 - The sparse point cloud obtained with the ``mapper`` can be visualized via the
   COLMAP GUI by importing the following files: choose ``File > Import Model``
-  and select the folder where the three files, ``cameras.txt``,``images.txt``,
+  and select the folder where the three files, ``cameras.txt``, ``images.txt``,
   and ``points3d.txt`` are located.
 
 - The dense point cloud obtained with the ``stereo_fusion`` can be visualized


### PR DESCRIPTION
The missing space seems to prevent reStructuredText from properly rendering the word `images.txt` with code font.