### PR TITLE
Show a COLMAP reconstruction with Open3D (python script)

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -57,7 +57,7 @@ To convert between various formats from the CLI, use the ``model_converter``
 executable.
 
 There are two source files to conveniently read the sparse reconstructions using
-Python (``scripts/python/read_model.py`` supporting binary and text) and Matlab
+Python (``scripts/python/read_write_model.py`` supporting binary and text) and Matlab
 (``scripts/matlab/read_model.m`` supporting text).
 
 

--- a/scripts/python/colmap.py
+++ b/scripts/python/colmap.py
@@ -1,0 +1,167 @@
+import numpy as np
+import os
+import sys
+import collections
+import numpy as np
+import struct
+
+from read_write_model import read_model, write_model, qvec2rotmat, rotmat2qvec
+
+try:
+    import open3d
+except ImportError:
+    print('Open3D is not installed! Needed to display models.\n')
+    pass
+
+
+class Model:
+    def __init__(self):
+        self.cameras = []
+        self.images = []
+        self.points3D = []
+        self.__vis = []
+
+    def read_model(self, path, ext=""):
+        self.cameras, self.images, self.points3D = \
+            read_model(path, ext)
+
+    def write_model(self, path, ext=".bin"):
+        write_model(self.cameras, self.images, self.points3D, path, ext)
+
+    def show_points(self, remove_statistical_outlier=True):
+        pcd = open3d.geometry.PointCloud()
+
+        xyz = []
+        rgb = []
+        for id, point3D in self.points3D.items():
+            # ignore 'track_len' smaller than 'track_len_threshold'
+            track_len_threshold = 3
+            track_len = len(point3D.point2D_idxs)
+            if track_len < track_len_threshold:
+                continue
+            xyz.append(point3D.xyz)
+            rgb.append(point3D.rgb / 255)
+
+        pcd.points = open3d.utility.Vector3dVector(xyz)
+        pcd.colors = open3d.utility.Vector3dVector(rgb)
+
+        # remove obvious outliers
+        if remove_statistical_outlier:
+            [pcd, _] = pcd.remove_statistical_outlier(nb_neighbors=20,
+                                                      std_ratio=2.0)
+
+        # open3d.visualization.draw_geometries([pcd])
+        self.__vis.add_geometry(pcd)
+        self.__vis.poll_events()
+        self.__vis.update_renderer()
+
+    def show_cameras(self, scale=1):
+        frames = []
+        for id, img in self.images.items():
+            # rotation
+            R = qvec2rotmat(img.qvec)
+
+            # translation
+            t = img.tvec
+
+            # invert
+            t = -R.T @ t
+            R = R.T
+
+            # intrinsics
+            cam = self.cameras[img.camera_id]
+            fx = cam.params[0]
+            fy = cam.params[1]
+            cx = cam.params[2]
+            cy = cam.params[3]
+
+            # intrinsics
+            K = np.identity(3)
+            K[0, 0] = fx
+            K[1, 1] = fy
+            K[0, 2] = cx
+            K[1, 2] = cy
+
+            # create axis, plane and pyramed geometries that will be drawn
+            cam_model = draw_camera(K, R, t, cam.width, cam.height, scale)
+            frames.extend(cam_model)
+
+        # add geometries to visualizer
+        for i in frames:
+            self.__vis.add_geometry(i)
+
+    def create_window(self):
+        self.__vis = open3d.visualization.Visualizer()
+        self.__vis.create_window()
+
+    def render(self):
+        self.__vis.poll_events()
+        self.__vis.update_renderer()
+        self.__vis.run()
+        self.__vis.destroy_window()
+
+
+def draw_camera(K, R, t, w, h,
+                scale=1, color=[0.8, 0.2, 0.8]):
+    """ Create axis, plane and pyramed geometries in Open3D format
+    :   param K     : calibration matrix (camera intrinsics)
+    :   param R     : rotation matrix
+    :   param t     : translation
+    :   param w     : image width
+    :   param h     : image height
+    :   param scale : camera model scale
+    :   param color : color of the image plane and pyramid lines
+    :   return      : camera model geometries (axis, plane and pyramid)
+    """
+    # camera model scale
+    s = 1 / scale
+
+    # intrinsics
+    K[0, 0] = K[0, 0] * s
+    K[1, 1] = K[1, 1] * s
+    Kinv = np.linalg.inv(K)
+
+    # 4x4 transformation
+    T = np.column_stack((R, t))
+    T = np.vstack((T, (0, 0, 0, 1)))
+
+    # axis
+    axis = open3d.geometry.TriangleMesh.create_coordinate_frame(size=scale*0.5)
+    axis.transform(T)
+
+    # points in pixel
+    points_pixel = [
+        [0, 0, 0],
+        [0, 0, 1],
+        [w, 0, 1],
+        [0, h, 1],
+        [w, h, 1],
+    ]
+
+    # pixel to camera coordinate system
+    points = [scale * Kinv @ p for p in points_pixel]
+
+    # image plane
+    width = abs(points[1][0]) + abs(points[3][0])
+    height = abs(points[1][1]) + abs(points[3][1])
+    plane = open3d.geometry.TriangleMesh.create_box(width, height, depth=0.001)
+    plane.paint_uniform_color(color)
+    plane.transform(T)
+    plane.translate(R @ [points[1][0], points[1][1], scale])
+
+    # pyramid
+    points_in_world = [(R @ p + t) for p in points]
+    lines = [
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [0, 4],
+    ]
+    colors = [color for i in range(len(lines))]
+    line_set = open3d.geometry.LineSet(
+        points=open3d.utility.Vector3dVector(points_in_world),
+        lines=open3d.utility.Vector2iVector(lines))
+    line_set.colors = open3d.utility.Vector3dVector(colors)
+
+    # return as list in Open3D format
+    return [axis, plane, line_set]

--- a/scripts/python/read_write_model.py
+++ b/scripts/python/read_write_model.py
@@ -407,7 +407,27 @@ def write_points3d_binary(points3D, path_to_model_file):
                 write_next_bytes(fid, [image_id, point2D_id], "ii")
 
 
-def read_model(path, ext):
+def detect_model_format(path, ext):
+    if os.path.isfile(os.path.join(path, "cameras"  + ext)) and \
+       os.path.isfile(os.path.join(path, "images"   + ext)) and \
+       os.path.isfile(os.path.join(path, "points3D" + ext)):
+        print("Detected model format: '" + ext + "'")
+        return True
+
+    return False
+
+
+def read_model(path, ext=""):
+    # try to detect the extension automatically
+    if ext == "":
+        if detect_model_format(path, ".bin"):
+            ext = ".bin"
+        elif detect_model_format(path, ".txt"):
+            ext = ".txt"
+        else:
+            print("Provide model format: '.bin' or '.txt'")
+            return
+
     if ext == ".txt":
         cameras = read_cameras_text(os.path.join(path, "cameras" + ext))
         images = read_images_text(os.path.join(path, "images" + ext))
@@ -419,7 +439,7 @@ def read_model(path, ext):
     return cameras, images, points3D
 
 
-def write_model(cameras, images, points3D, path, ext):
+def write_model(cameras, images, points3D, path, ext=".bin"):
     if ext == ".txt":
         write_cameras_text(cameras, os.path.join(path, "cameras" + ext))
         write_images_text(images, os.path.join(path, "images" + ext))

--- a/scripts/python/run_example.py
+++ b/scripts/python/run_example.py
@@ -1,0 +1,35 @@
+import colmap
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description='Read and write COLMAP binary and text models')
+    parser.add_argument('--input_model', help='path to input model folder')
+    parser.add_argument('--input_format', choices=['.bin', '.txt'],
+                        help='input model format', default='')
+    parser.add_argument('--output_model', metavar='PATH',
+                        help='path to output model folder')
+    parser.add_argument('--output_format', choices=['.bin', '.txt'],
+                        help='outut model format', default='.txt')
+    args = parser.parse_args()
+
+    # read COLMAP model
+    model = colmap.Model()
+    model.read_model(args.input_model, ext=args.input_format)
+
+    print("num_cameras:", len(model.cameras))
+    print("num_images:", len(model.images))
+    print("num_points3D:", len(model.points3D))
+
+    # display using Open3D visualization tools
+    model.create_window()
+    model.show_points()
+    model.show_cameras(scale=0.25)
+    model.render()
+
+    # write COLMAP model
+    if args.output_model is not None:
+        model.write_model(path=args.output_model, ext=args.output_format)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For running the example:

    python run_example.py --input_model <colmap_reconstruction_path>/sparse

For non-blocking visualization with Open3D this kind of the logic in `run_example.py` is needed:

    import colmap

    model = colmap.Model()
    model.read_sparse(args.input_model, ext=args.input_format)

    # display
    model.create_window()
    model.show_points()
    model.show_cameras()
    model.render()



_**(This PR is a draft for the moment)**_

I would recommend to include the content of `read_write_model.py` inside `colmap.py` and remove the `test_read_write_model.py`. A better name for `run_example.py`. And add proper documentation.

Ideally, it would be nice to have everything in this class:

    colmap.database
    colmap.export_to_*()
    colmap.read_dense()
    ...
