### PR TITLE
Fix for EPnP estimator

### DIFF
--- a/src/estimators/absolute_pose.cc
+++ b/src/estimators/absolute_pose.cc
@@ -536,7 +536,7 @@ void EPNPEstimator::ComputePcs() {
 }
 
 void EPNPEstimator::SolveForSign() {
-  if (pcs_[0][2] < 0.0 || pcs_[0][2] > 0.0) {
+  if (pcs_[0][2] < 0.0) {
     for (int i = 0; i < 4; ++i) {
       ccs_[i] = -ccs_[i];
     }

--- a/src/estimators/absolute_pose_test.cc
+++ b/src/estimators/absolute_pose_test.cc
@@ -162,3 +162,48 @@ BOOST_AUTO_TEST_CASE(TestEPNP) {
     }
   }
 }
+
+
+BOOST_AUTO_TEST_CASE(TestEPNP_BrokenCase) {
+  
+  // This is one case where it was broken
+	std::vector<Eigen::Vector2d> points2D;
+	points2D.push_back(Eigen::Vector2d{ -2.6783007931074532e-01,5.3457197430746251e-01 });
+	points2D.push_back(Eigen::Vector2d{ -4.2629907287470264e-01,7.5623350319519789e-01 });
+	points2D.push_back(Eigen::Vector2d{ -1.6767413005963930e-01,-1.3387172544910089e-01 });
+	points2D.push_back(Eigen::Vector2d{ -5.6616329720373559e-02,2.3621156497739373e-01 });
+	points2D.push_back(Eigen::Vector2d{ -1.7721225948969935e-01,2.3395366792735982e-02 });
+	points2D.push_back(Eigen::Vector2d{ -5.1836259886632222e-02,-4.4380694271927049e-02 });
+	points2D.push_back(Eigen::Vector2d{ -3.5897765845560037e-01,1.6252721078589397e-01 });
+	points2D.push_back(Eigen::Vector2d{ 2.7057324473684058e-01,-1.4067450104631887e-01 });
+	points2D.push_back(Eigen::Vector2d{ -2.5811166424334520e-01,8.0167171300227366e-02 });
+	points2D.push_back(Eigen::Vector2d{ 2.0239567448222310e-02,-3.2845953375344145e-01 });
+	points2D.push_back(Eigen::Vector2d{ 4.2571014715170657e-01,-2.8321173570154773e-01 });
+	points2D.push_back(Eigen::Vector2d{ -5.4597596412987237e-01,9.1431935871671977e-02 });
+	std::vector<Eigen::Vector3d> points3D;
+	points3D.push_back(Eigen::Vector3d{ 4.4276865308679305e+00,-1.3384364366019632e+00,-3.5997423085253892e+00 });
+	points3D.push_back(Eigen::Vector3d{ 2.7278555252512309e+00,-3.8152996187231392e-01,-2.6558518399902824e+00 });
+	points3D.push_back(Eigen::Vector3d{ 4.8548566083054894e+00,-1.4756197433631739e+00,-6.8274946022490501e-01 });
+	points3D.push_back(Eigen::Vector3d{ 3.1523013527998449e+00,-1.3377020437938025e+00,-1.6443269301929087e+00 });
+	points3D.push_back(Eigen::Vector3d{ 3.8551679771512073e+00,-1.0557700545885551e+00,-1.1695994508851486e+00 });
+	points3D.push_back(Eigen::Vector3d{ 5.9571373150353812e+00,-2.6120646101684555e+00,-1.0841441206050342e+00 });
+	points3D.push_back(Eigen::Vector3d{ 6.3287088499358894e+00,-1.1761274755817175e+00,-2.5951879774151583e+00 });
+	points3D.push_back(Eigen::Vector3d{ 2.3005305990121250e+00,-1.4019796626800123e+00,-4.4485464455072321e-01 });
+	points3D.push_back(Eigen::Vector3d{ 5.9816859934587354e+00,-1.4211814511691452e+00,-2.0285923889293449e+00 });
+	points3D.push_back(Eigen::Vector3d{ 5.2543344690665457e+00,-2.3389255564264144e+00,4.3708173185524052e-01 });
+	points3D.push_back(Eigen::Vector3d{ 3.2181599245991688e+00,-2.8906671988445098e+00,2.6825718150064348e-01 });
+	points3D.push_back(Eigen::Vector3d{ 4.4592895306946758e+00,-9.1235241641579902e-03,-1.6555237117970871e+00 });
+
+ 
+  std::vector<EPNPEstimator::M_t> output = EPNPEstimator::Estimate(points2D, points3D);
+
+  BOOST_CHECK_EQUAL(output.size(), 1);
+
+  double reproj = 0.0;
+  for(size_t i = 0; i < points3D.size(); ++i) {
+    reproj += ((output[0] * points3D[i].homogeneous()).hnormalized() - points2D[i]).norm();
+  }
+
+  BOOST_CHECK(reproj < 0.2);
+
+}


### PR DESCRIPTION
I was doing some benchmarking with absolute pose solvers and found that COLMAP's implementation of EPnP was returning garbage in roughly 25% of cases. After comparing with the OpenGV implementation I found the problem. I have not done any extensive testing after the fix, but I think it should work better now.