### PR TITLE
BuildImageModel: use std::vector instead of numbered arguments

### DIFF
--- a/src/ui/model_viewer_widget.cc
+++ b/src/ui/model_viewer_widget.cc
@@ -71,12 +71,8 @@ inline Eigen::Vector4f IndexToRGB(const size_t index) {
 void BuildImageModel(const Image& image, const Camera& camera,
                      const float image_size, const Eigen::Vector4f& plane_color,
                      const Eigen::Vector4f& frame_color,
-                     TrianglePainter::Data* triangle1,
-                     TrianglePainter::Data* triangle2, LinePainter::Data* line1,
-                     LinePainter::Data* line2, LinePainter::Data* line3,
-                     LinePainter::Data* line4, LinePainter::Data* line5,
-                     LinePainter::Data* line6, LinePainter::Data* line7,
-                     LinePainter::Data* line8) {
+                     std::vector<TrianglePainter::Data>& triangle_data,
+                     std::vector<LinePainter::Data>& line_data) {
   // Generate camera dimensions in OpenGL (world) coordinate space.
   const float kBaseCameraWidth = 1024.0f;
   const float image_width = image_size * camera.Width() / kBaseCameraWidth;
@@ -108,82 +104,84 @@ void BuildImageModel(const Image& image, const Camera& camera,
       Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
 
   // Image plane as two triangles.
+  triangle_data.resize(2);
 
-  triangle1->point1 =
+  triangle_data[0].point1 =
       PointPainter::Data(tl(0), tl(1), tl(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
-  triangle1->point2 =
+  triangle_data[0].point2 =
       PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
-  triangle1->point3 =
+  triangle_data[0].point3 =
       PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
 
-  triangle2->point1 =
+  triangle_data[1].point1 =
       PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
-  triangle2->point2 =
+  triangle_data[1].point2 =
       PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
-  triangle2->point3 =
+  triangle_data[1].point3 =
       PointPainter::Data(br(0), br(1), br(2), plane_color(0), plane_color(1),
                          plane_color(2), plane_color(3));
 
   // Frame around image plane and connecting lines to projection center.
+  line_data.resize(8);
 
-  line1->point1 =
+  line_data[0].point1 =
       PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line1->point2 =
+  line_data[0].point2 =
       PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line2->point1 =
+  line_data[1].point1 =
       PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line2->point2 =
+  line_data[1].point2 =
       PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line3->point1 =
+  line_data[2].point1 =
       PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line3->point2 =
+  line_data[2].point2 =
       PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line4->point1 =
+  line_data[3].point1 =
       PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line4->point2 =
+  line_data[3].point2 =
       PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line5->point1 =
+  line_data[4].point1 =
       PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line5->point2 =
+  line_data[4].point2 =
       PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line6->point1 =
+  line_data[5].point1 =
       PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line6->point2 =
+  line_data[5].point2 =
       PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line7->point1 =
+  line_data[6].point1 =
       PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line7->point2 =
+  line_data[6].point2 =
       PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 
-  line8->point1 =
+  line_data[7].point1 =
       PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
-  line8->point2 =
+  line_data[7].point2 =
       PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
                          frame_color(2), frame_color(3));
 }
@@ -896,27 +894,22 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
       }
     }
 
-    LinePainter::Data line1, line2, line3, line4, line5, line6, line7, line8;
-    TrianglePainter::Data triangle1, triangle2;
+    std::vector<LinePainter::Data> image_line_data;
+    std::vector<TrianglePainter::Data> image_triangle_data;
     BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                    &triangle1, &triangle2, &line1, &line2, &line3, &line4,
-                    &line5, &line6, &line7, &line8);
+                    image_triangle_data, image_line_data);
 
     // Lines are not colored with the indexed color in selection mode, so do not
     // show them, so they do not block the selection process
     if (!selection_mode) {
-      line_data.push_back(line1);
-      line_data.push_back(line2);
-      line_data.push_back(line3);
-      line_data.push_back(line4);
-      line_data.push_back(line5);
-      line_data.push_back(line6);
-      line_data.push_back(line7);
-      line_data.push_back(line8);
+      for (const LinePainter::Data& line : image_line_data) {
+        line_data.push_back(line);
+      }
     }
 
-    triangle_data.push_back(triangle1);
-    triangle_data.push_back(triangle2);
+    for (const TrianglePainter::Data& triangle : image_triangle_data) {
+      triangle_data.push_back(triangle);
+    }
   }
 
   image_line_painter_.Upload(line_data);
@@ -1035,23 +1028,17 @@ void ModelViewerWidget::UploadMovieGrabberData() {
         frame_color = kMovieGrabberImageFrameColor;
       }
 
-      LinePainter::Data line1, line2, line3, line4, line5, line6, line7, line8;
-      TrianglePainter::Data triangle1, triangle2;
+      std::vector<LinePainter::Data> image_line_data;
+      std::vector<TrianglePainter::Data> image_triangle_data;
       BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                      &triangle1, &triangle2, &line1, &line2, &line3, &line4,
-                      &line5, &line6, &line7, &line8);
+                      image_triangle_data, image_line_data);
 
-      line_data.push_back(line1);
-      line_data.push_back(line2);
-      line_data.push_back(line3);
-      line_data.push_back(line4);
-      line_data.push_back(line5);
-      line_data.push_back(line6);
-      line_data.push_back(line7);
-      line_data.push_back(line8);
-
-      triangle_data.push_back(triangle1);
-      triangle_data.push_back(triangle2);
+      for (const LinePainter::Data& line : image_line_data) {
+        line_data.push_back(line);
+      }
+      for (const TrianglePainter::Data& triangle : image_triangle_data) {
+        triangle_data.push_back(triangle);
+      }
     }
   }
 

--- a/src/ui/model_viewer_widget.cc
+++ b/src/ui/model_viewer_widget.cc
@@ -71,9 +71,8 @@ inline Eigen::Vector4f IndexToRGB(const size_t index) {
 void BuildImageModel(const Image& image, const Camera& camera,
                      const float image_size, const Eigen::Vector4f& plane_color,
                      const Eigen::Vector4f& frame_color,
-                     std::vector<TrianglePainter::Data>& triangle_data,
-                     std::vector<LinePainter::Data>& line_data,
-                     const bool show_lines = true) {
+                     std::vector<TrianglePainter::Data>* triangle_data,
+                     std::vector<LinePainter::Data>* line_data) {
   // Generate camera dimensions in OpenGL (world) coordinate space.
   const float kBaseCameraWidth = 1024.0f;
   const float image_width = image_size * camera.Width() / kBaseCameraWidth;
@@ -105,71 +104,70 @@ void BuildImageModel(const Image& image, const Camera& camera,
       Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
 
   // Image plane as two triangles.
-  triangle_data.reserve(triangle_data.size() + 2);
+  if (triangle_data != nullptr) {
+    triangle_data->emplace_back(
+        PointPainter::Data(tl(0), tl(1), tl(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)),
+        PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)),
+        PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)));
 
-  triangle_data.emplace_back(
-      PointPainter::Data(tl(0), tl(1), tl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)),
-      PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)),
-      PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)));
+    triangle_data->emplace_back(
+        PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)),
+        PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)),
+        PointPainter::Data(br(0), br(1), br(2), plane_color(0), plane_color(1),
+                           plane_color(2), plane_color(3)));
+  }
 
-  triangle_data.emplace_back(
-      PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)),
-      PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)),
-      PointPainter::Data(br(0), br(1), br(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3)));
-
-  if (show_lines) {
+  if (line_data != nullptr) {
     // Frame around image plane and connecting lines to projection center.
-    line_data.reserve(line_data.size() + 8);
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)));
 
-    line_data.emplace_back(
+    line_data->emplace_back(
         PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
                            frame_color(2), frame_color(3)),
         PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
@@ -888,7 +886,7 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
     // Lines are not colored with the indexed color in selection mode, so do not
     // show them, so they do not block the selection process
     BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                    triangle_data, line_data, !selection_mode);
+                    &triangle_data, selection_mode ? nullptr : &line_data);
   }
 
   image_line_painter_.Upload(line_data);
@@ -1008,7 +1006,7 @@ void ModelViewerWidget::UploadMovieGrabberData() {
       }
 
       BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                      triangle_data, line_data);
+                      &triangle_data, &line_data);
     }
   }
 

--- a/src/ui/model_viewer_widget.cc
+++ b/src/ui/model_viewer_widget.cc
@@ -72,7 +72,8 @@ void BuildImageModel(const Image& image, const Camera& camera,
                      const float image_size, const Eigen::Vector4f& plane_color,
                      const Eigen::Vector4f& frame_color,
                      std::vector<TrianglePainter::Data>& triangle_data,
-                     std::vector<LinePainter::Data>& line_data) {
+                     std::vector<LinePainter::Data>& line_data,
+                     const bool show_lines = true) {
   // Generate camera dimensions in OpenGL (world) coordinate space.
   const float kBaseCameraWidth = 1024.0f;
   const float image_width = image_size * camera.Width() / kBaseCameraWidth;
@@ -104,86 +105,76 @@ void BuildImageModel(const Image& image, const Camera& camera,
       Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
 
   // Image plane as two triangles.
-  triangle_data.resize(2);
+  triangle_data.reserve(triangle_data.size() + 2);
 
-  triangle_data[0].point1 =
+  triangle_data.emplace_back(
       PointPainter::Data(tl(0), tl(1), tl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
-  triangle_data[0].point2 =
+                         plane_color(2), plane_color(3)),
       PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
-  triangle_data[0].point3 =
+                         plane_color(2), plane_color(3)),
       PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
+                         plane_color(2), plane_color(3)));
 
-  triangle_data[1].point1 =
+  triangle_data.emplace_back(
       PointPainter::Data(bl(0), bl(1), bl(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
-  triangle_data[1].point2 =
+                         plane_color(2), plane_color(3)),
       PointPainter::Data(tr(0), tr(1), tr(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
-  triangle_data[1].point3 =
+                         plane_color(2), plane_color(3)),
       PointPainter::Data(br(0), br(1), br(2), plane_color(0), plane_color(1),
-                         plane_color(2), plane_color(3));
+                         plane_color(2), plane_color(3)));
 
-  // Frame around image plane and connecting lines to projection center.
-  line_data.resize(8);
+  if (show_lines) {
+    // Frame around image plane and connecting lines to projection center.
+    line_data.reserve(line_data.size() + 8);
 
-  line_data[0].point1 =
-      PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[0].point2 =
-      PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[1].point1 =
-      PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[1].point2 =
-      PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[2].point1 =
-      PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[2].point2 =
-      PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[3].point1 =
-      PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[3].point2 =
-      PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(pc(0), pc(1), pc(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[4].point1 =
-      PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[4].point2 =
-      PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[5].point1 =
-      PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[5].point2 =
-      PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(tr(0), tr(1), tr(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[6].point1 =
-      PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[6].point2 =
-      PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(br(0), br(1), br(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
 
-  line_data[7].point1 =
-      PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
-  line_data[7].point2 =
-      PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
-                         frame_color(2), frame_color(3));
+    line_data.emplace_back(
+        PointPainter::Data(bl(0), bl(1), bl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(tl(0), tl(1), tl(2), frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
+  }
 }
 
 }  // namespace
@@ -894,22 +885,10 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
       }
     }
 
-    std::vector<LinePainter::Data> image_line_data;
-    std::vector<TrianglePainter::Data> image_triangle_data;
-    BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                    image_triangle_data, image_line_data);
-
     // Lines are not colored with the indexed color in selection mode, so do not
     // show them, so they do not block the selection process
-    if (!selection_mode) {
-      for (const LinePainter::Data& line : image_line_data) {
-        line_data.push_back(line);
-      }
-    }
-
-    for (const TrianglePainter::Data& triangle : image_triangle_data) {
-      triangle_data.push_back(triangle);
-    }
+    BuildImageModel(image, camera, image_size_, plane_color, frame_color,
+                    triangle_data, line_data, !selection_mode);
   }
 
   image_line_painter_.Upload(line_data);
@@ -1028,17 +1007,8 @@ void ModelViewerWidget::UploadMovieGrabberData() {
         frame_color = kMovieGrabberImageFrameColor;
       }
 
-      std::vector<LinePainter::Data> image_line_data;
-      std::vector<TrianglePainter::Data> image_triangle_data;
       BuildImageModel(image, camera, image_size_, plane_color, frame_color,
-                      image_triangle_data, image_line_data);
-
-      for (const LinePainter::Data& line : image_line_data) {
-        line_data.push_back(line);
-      }
-      for (const TrianglePainter::Data& triangle : image_triangle_data) {
-        triangle_data.push_back(triangle);
-      }
+                      triangle_data, line_data);
     }
   }
 


### PR DESCRIPTION
I needed to make this change anyway in my fork and it looks quite upstreamable so I might as well send you this PR. I hope that this is useful and that I'm not missing some obvious reason why the previous version was implemented like that.