### PR TITLE
8 point algorithm internal contraint fix

### DIFF
--- a/src/estimators/essential_matrix.cc
+++ b/src/estimators/essential_matrix.cc
@@ -185,20 +185,22 @@ EssentialMatrixEightPointEstimator::Estimate(const std::vector<X_t>& points1,
   const Eigen::VectorXd ematrix_nullspace = cmatrix_svd.matrixV().col(8);
   const Eigen::Map<const Eigen::Matrix3d> ematrix_t(ematrix_nullspace.data());
 
+  // De-normalize to image points.
+  const Eigen::Matrix3d E_raw = points2_norm_matrix.transpose() * ematrix_t.transpose() * points1_norm_matrix;
+
   // Enforcing the internal constraint that two singular values must be equal
   // and one must be zero.
-  Eigen::JacobiSVD<Eigen::Matrix3d> ematrix_svd(
-      ematrix_t.transpose(), Eigen::ComputeFullU | Eigen::ComputeFullV);
-  Eigen::Vector3d singular_values = ematrix_svd.singularValues();
+  Eigen::JacobiSVD<Eigen::Matrix3d> E_raw_svd(
+      E_raw, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Vector3d singular_values = E_raw_svd.singularValues();
   singular_values(0) = (singular_values(0) + singular_values(1)) / 2.0;
   singular_values(1) = singular_values(0);
   singular_values(2) = 0.0;
-  const Eigen::Matrix3d E = ematrix_svd.matrixU() *
+  const Eigen::Matrix3d E = E_raw_svd.matrixU() *
                             singular_values.asDiagonal() *
-                            ematrix_svd.matrixV().transpose();
+                            E_raw_svd.matrixV().transpose();
 
-  const std::vector<M_t> models = {points2_norm_matrix.transpose() * E *
-                                   points1_norm_matrix};
+  const std::vector<M_t> models = {E};
   return models;
 }
 

--- a/src/estimators/essential_matrix_test.cc
+++ b/src/estimators/essential_matrix_test.cc
@@ -111,14 +111,20 @@ BOOST_AUTO_TEST_CASE(TestEightPoint) {
   EssentialMatrixEightPointEstimator estimator;
   const auto E = estimator.Estimate(points1, points2)[0];
 
-  // Reference values obtained from Matlab.
-  BOOST_CHECK(std::abs(E(0, 0) - -0.0811666) < 1e-5);
-  BOOST_CHECK(std::abs(E(0, 1) - 0.255449) < 1e-5);
-  BOOST_CHECK(std::abs(E(0, 2) - -0.0478999) < 1e-5);
-  BOOST_CHECK(std::abs(E(1, 0) - -0.192392) < 1e-5);
-  BOOST_CHECK(std::abs(E(1, 1) - -0.0531675) < 1e-5);
-  BOOST_CHECK(std::abs(E(1, 2) - 0.119547) < 1e-5);
-  BOOST_CHECK(std::abs(E(2, 0) - 0.177784) < 1e-5);
-  BOOST_CHECK(std::abs(E(2, 1) - -0.22008) < 1e-5);
-  BOOST_CHECK(std::abs(E(2, 2) - -0.015203) < 1e-5);
+  // Reference values.
+  BOOST_CHECK(std::abs(E(0, 0) - -0.0368602) < 1e-5);
+  BOOST_CHECK(std::abs(E(0, 1) - 0.265019) < 1e-5);
+  BOOST_CHECK(std::abs(E(0, 2) - -0.0625948) < 1e-5);
+  BOOST_CHECK(std::abs(E(1, 0) - -0.299679) < 1e-5);
+  BOOST_CHECK(std::abs(E(1, 1) - -0.110667) < 1e-5);
+  BOOST_CHECK(std::abs(E(1, 2) - 0.147114) < 1e-5);
+  BOOST_CHECK(std::abs(E(2, 0) - 0.169381) < 1e-5);
+  BOOST_CHECK(std::abs(E(2, 1) - -0.21072) < 1e-5);
+  BOOST_CHECK(std::abs(E(2, 2) - -0.00401306) < 1e-5);
+  
+  // Check that the internal constraint is satisfied (two singular values equal and one zero).
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(E);
+  Eigen::Vector3d s = svd.singularValues();
+  BOOST_CHECK(std::abs(s(0) - s(1)) < 1e-5);
+  BOOST_CHECK(std::abs(s(2)) < 1e-5);
 }


### PR DESCRIPTION
De-normalize before enforcing the internal constraints and update the test accordingly. Fixes #861 