### PR TITLE
Fix bugs of sift feature matching

### DIFF
--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -240,6 +240,16 @@ void FeatureMatcherCache::Setup() {
       cache_size_, [this](const image_t image_id) {
         return database_->ReadDescriptors(image_id);
       }));
+
+  keypoints_exists_cache_.reset(new LRUCache<image_t, bool>(
+      images.size(), [this](const image_t image_id) {
+        return database_->ExistsKeypoints(image_id);
+      }));
+
+  descriptors_exists_cache_.reset(new LRUCache<image_t, bool>(
+      images.size(), [this](const image_t image_id) {
+        return database_->ExistsDescriptors(image_id);
+      }));
 }
 
 const Camera& FeatureMatcherCache::GetCamera(const camera_t camera_id) const {
@@ -279,12 +289,12 @@ std::vector<image_t> FeatureMatcherCache::GetImageIds() const {
 
 bool FeatureMatcherCache::ExistsKeypoints(const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
-  return database_->ExistsKeypoints(image_id);
+  return keypoints_exists_cache_->Get(image_id);
 }
 
 bool FeatureMatcherCache::ExistsDescriptors(const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
-  return database_->ExistsDescriptors(image_id);
+  return descriptors_exists_cache_->Get(image_id);
 }
 
 bool FeatureMatcherCache::ExistsMatches(const image_t image_id1,

--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -277,12 +277,12 @@ std::vector<image_t> FeatureMatcherCache::GetImageIds() const {
   return image_ids;
 }
 
-bool FeatureMatcherCache::ExiststKeypoints(const image_t image_id) {
+bool FeatureMatcherCache::ExistsKeypoints(const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
   return database_->ExistsKeypoints(image_id);
 }
 
-bool FeatureMatcherCache::ExiststDescriptors(const image_t image_id) {
+bool FeatureMatcherCache::ExistsDescriptors(const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
   return database_->ExistsDescriptors(image_id);
 }
@@ -355,8 +355,8 @@ void SiftCPUFeatureMatcher::Run() {
     if (input_job.IsValid()) {
       auto data = input_job.Data();
 
-      if (!cache_->ExiststDescriptors(data.image_id1) ||
-          !cache_->ExiststDescriptors(data.image_id2)) {
+      if (!cache_->ExistsDescriptors(data.image_id1) ||
+          !cache_->ExistsDescriptors(data.image_id2)) {
         CHECK(output_queue_->Push(data));
         continue;
       }
@@ -413,8 +413,8 @@ void SiftGPUFeatureMatcher::Run() {
     if (input_job.IsValid()) {
       auto data = input_job.Data();
 
-      if (!cache_->ExiststDescriptors(data.image_id1) ||
-          !cache_->ExiststDescriptors(data.image_id2)) {
+      if (!cache_->ExistsDescriptors(data.image_id1) ||
+          !cache_->ExistsDescriptors(data.image_id2)) {
         CHECK(output_queue_->Push(data));
         continue;
       }
@@ -472,14 +472,10 @@ void GuidedSiftCPUFeatureMatcher::Run() {
         continue;
       }
 
-      if (!cache_->ExiststKeypoints(data.image_id1) ||
-          !cache_->ExiststKeypoints(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
-        continue;
-      }
-
-      if (!cache_->ExiststDescriptors(data.image_id1) ||
-          !cache_->ExiststDescriptors(data.image_id2)) {
+      if (!cache_->ExistsKeypoints(data.image_id1) ||
+          !cache_->ExistsKeypoints(data.image_id2) ||
+          !cache_->ExistsDescriptors(data.image_id1) ||
+          !cache_->ExistsDescriptors(data.image_id2)) {
         CHECK(output_queue_->Push(data));
         continue;
       }
@@ -544,14 +540,10 @@ void GuidedSiftGPUFeatureMatcher::Run() {
         continue;
       }
 
-      if (!cache_->ExiststKeypoints(data.image_id1) ||
-          !cache_->ExiststKeypoints(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
-        continue;
-      }
-
-      if (!cache_->ExiststDescriptors(data.image_id1) ||
-          !cache_->ExiststDescriptors(data.image_id2)) {
+      if (!cache_->ExistsKeypoints(data.image_id1) ||
+          !cache_->ExistsKeypoints(data.image_id2) ||
+          !cache_->ExistsDescriptors(data.image_id1) ||
+          !cache_->ExistsDescriptors(data.image_id2)) {
         CHECK(output_queue_->Push(data));
         continue;
       }

--- a/src/feature/matching.h
+++ b/src/feature/matching.h
@@ -190,8 +190,8 @@ class FeatureMatcherCache {
   FeatureMatches GetMatches(const image_t image_id1, const image_t image_id2);
   std::vector<image_t> GetImageIds() const;
 
-  bool ExiststKeypoints(const image_t image_id);
-  bool ExiststDescriptors(const image_t image_id);
+  bool ExistsKeypoints(const image_t image_id);
+  bool ExistsDescriptors(const image_t image_id);
 
   bool ExistsMatches(const image_t image_id1, const image_t image_id2);
   bool ExistsInlierMatches(const image_t image_id1, const image_t image_id2);

--- a/src/feature/matching.h
+++ b/src/feature/matching.h
@@ -212,6 +212,8 @@ class FeatureMatcherCache {
   EIGEN_STL_UMAP(image_t, Image) images_cache_;
   std::unique_ptr<LRUCache<image_t, FeatureKeypoints>> keypoints_cache_;
   std::unique_ptr<LRUCache<image_t, FeatureDescriptors>> descriptors_cache_;
+  std::unique_ptr<LRUCache<image_t, bool>> keypoints_exists_cache_;
+  std::unique_ptr<LRUCache<image_t, bool>> descriptors_exists_cache_;
 };
 
 class FeatureMatcherThread : public Thread {

--- a/src/feature/matching.h
+++ b/src/feature/matching.h
@@ -190,6 +190,9 @@ class FeatureMatcherCache {
   FeatureMatches GetMatches(const image_t image_id1, const image_t image_id2);
   std::vector<image_t> GetImageIds() const;
 
+  bool ExiststKeypoints(const image_t image_id);
+  bool ExiststDescriptors(const image_t image_id);
+
   bool ExistsMatches(const image_t image_id1, const image_t image_id2);
   bool ExistsInlierMatches(const image_t image_id1, const image_t image_id2);
 

--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -214,7 +214,7 @@ void FindBestMatchesOneWayFLANN(
   const size_t kNumTreesInForest = 4;
 
   if (kNumNearestNeighbors > database.rows()) {
-    return false;
+    return;
   }
 
   indices->resize(query.rows(), kNumNearestNeighbors);

--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -206,22 +206,24 @@ void FindBestMatchesOneWayFLANN(
         indices,
     Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>*
         distances) {
+  if (query.rows() == 0 || database.rows() == 0) {
+    return;
+  }
+
   const size_t kNumNearestNeighbors = 2;
   const size_t kNumTreesInForest = 4;
 
-  indices->resize(query.rows(), std::min(kNumNearestNeighbors,
-                                         static_cast<size_t>(database.rows())));
-  distances->resize(
-      query.rows(),
-      std::min(kNumNearestNeighbors, static_cast<size_t>(database.rows())));
+  if (kNumNearestNeighbors > database.rows()) {
+    return false;
+  }
+
+  indices->resize(query.rows(), kNumNearestNeighbors);
+  distances->resize(query.rows(), kNumNearestNeighbors);
   const flann::Matrix<uint8_t> query_matrix(const_cast<uint8_t*>(query.data()),
                                             query.rows(), 128);
   const flann::Matrix<uint8_t> database_matrix(
       const_cast<uint8_t*>(database.data()), database.rows(), 128);
 
-  if (query.rows() == 0 || database.rows() == 0) {
-    return;
-  }
 
   flann::Matrix<int> indices_matrix(indices->data(), query.rows(),
                                     kNumNearestNeighbors);


### PR DESCRIPTION
1. Fix bug in sift feature matching, when features cannot be extracted from images lacking texture.

2. Fix bug in sift feature matching, when the number of feature points extracted from an image lacking texture is less than 2.