### PR TITLE
fix camera model query

### DIFF
--- a/src/base/camera_database.cc
+++ b/src/base/camera_database.cc
@@ -45,10 +45,10 @@ bool CameraDatabase::QuerySensorWidth(const std::string& make,
   // Clean the strings from all separators.
   std::string cleaned_make = make;
   std::string cleaned_model = model;
-  StringReplace(cleaned_make, " ", "");
-  StringReplace(cleaned_model, " ", "");
-  StringReplace(cleaned_make, "-", "");
-  StringReplace(cleaned_model, "-", "");
+  cleaned_make = StringReplace(cleaned_make, " ", "");
+  cleaned_model = StringReplace(cleaned_model, " ", "");
+  cleaned_make = StringReplace(cleaned_make, "-", "");
+  cleaned_model = StringReplace(cleaned_model, "-", "");
   StringToLower(&cleaned_make);
   StringToLower(&cleaned_model);
 


### PR DESCRIPTION
The return value of StringReplace was not being used and therefore the query was done with the name still containing spaces and dashes.