### PR TITLE
Remove deprecated qt foreach

### DIFF
--- a/src/ui/movie_grabber_widget.cc
+++ b/src/ui/movie_grabber_widget.cc
@@ -136,7 +136,7 @@ void MovieGrabberWidget::Add() {
 
 void MovieGrabberWidget::Delete() {
   QModelIndexList selection = table_->selectionModel()->selectedIndexes();
-  for (const auto& index: selection) { table_->removeRow(index.row()); }
+  for (const auto& index : selection) { table_->removeRow(index.row()); }
   UpdateViews();
   model_viewer_widget_->UpdateMovieGrabber();
 }
@@ -278,7 +278,7 @@ void MovieGrabberWidget::TimeChanged(QTableWidgetItem* item) {
 
 void MovieGrabberWidget::SelectionChanged(const QItemSelection& selected,
                                           const QItemSelection& deselected) {
-  for (const auto& index: table_->selectionModel()->selectedIndexes()) {
+  for (const auto& index : table_->selectionModel()->selectedIndexes()) {
     model_viewer_widget_->SelectMoviewGrabberView(index.row());
   }
 }

--- a/src/ui/movie_grabber_widget.cc
+++ b/src/ui/movie_grabber_widget.cc
@@ -136,7 +136,7 @@ void MovieGrabberWidget::Add() {
 
 void MovieGrabberWidget::Delete() {
   QModelIndexList selection = table_->selectionModel()->selectedIndexes();
-  foreach (QModelIndex index, selection) { table_->removeRow(index.row()); }
+  for (const auto& index: selection) { table_->removeRow(index.row()); }
   UpdateViews();
   model_viewer_widget_->UpdateMovieGrabber();
 }
@@ -278,7 +278,7 @@ void MovieGrabberWidget::TimeChanged(QTableWidgetItem* item) {
 
 void MovieGrabberWidget::SelectionChanged(const QItemSelection& selected,
                                           const QItemSelection& deselected) {
-  foreach (QModelIndex index, table_->selectionModel()->selectedIndexes()) {
+  for (const auto& index: table_->selectionModel()->selectedIndexes()) {
     model_viewer_widget_->SelectMoviewGrabberView(index.row());
   }
 }


### PR DESCRIPTION
QT foreach is on deprecation path (https://codereview.qt-project.org/c/qt/qtbase/+/147363) and already may not be available in qt depending on build configuration.
Change to C++11+ range for should be forward-compatible, and as far as I can see C++11 is the current minimum version