### PR TITLE
Fix AMD/Windows GUI visualization bug

### DIFF
--- a/src/ui/line_painter.cc
+++ b/src/ui/line_painter.cc
@@ -82,14 +82,14 @@ void LinePainter::Upload(const std::vector<LinePainter::Data>& data) {
                 static_cast<int>(data.size() * sizeof(LinePainter::Data)));
 
   // in_position
-  shader_program_.enableAttributeArray(0);
-  shader_program_.setAttributeBuffer(0, GL_FLOAT, 0, 3,
+  shader_program_.enableAttributeArray("a_pos");
+  shader_program_.setAttributeBuffer("a_pos", GL_FLOAT, 0, 3,
                                      sizeof(PointPainter::Data));
 
   // in_color
-  shader_program_.enableAttributeArray(1);
-  shader_program_.setAttributeBuffer(1, GL_FLOAT, 3 * sizeof(GLfloat), 4,
-                                     sizeof(PointPainter::Data));
+  shader_program_.enableAttributeArray("a_color");
+  shader_program_.setAttributeBuffer("a_color", GL_FLOAT, 3 * sizeof(GLfloat),
+                                     4, sizeof(PointPainter::Data));
 
   // Make sure they are not changed from the outside
   vbo_.release();

--- a/src/ui/point_painter.cc
+++ b/src/ui/point_painter.cc
@@ -80,14 +80,14 @@ void PointPainter::Upload(const std::vector<PointPainter::Data>& data) {
                 static_cast<int>(data.size() * sizeof(PointPainter::Data)));
 
   // in_position
-  shader_program_.enableAttributeArray(0);
-  shader_program_.setAttributeBuffer(0, GL_FLOAT, 0, 3,
+  shader_program_.enableAttributeArray("a_position");
+  shader_program_.setAttributeBuffer("a_position", GL_FLOAT, 0, 3,
                                      sizeof(PointPainter::Data));
 
   // in_color
-  shader_program_.enableAttributeArray(1);
-  shader_program_.setAttributeBuffer(1, GL_FLOAT, 3 * sizeof(GLfloat), 4,
-                                     sizeof(PointPainter::Data));
+  shader_program_.enableAttributeArray("a_color");
+  shader_program_.setAttributeBuffer("a_color", GL_FLOAT, 3 * sizeof(GLfloat),
+                                     4, sizeof(PointPainter::Data));
 
   // Make sure they are not changed from the outside
   vbo_.release();

--- a/src/ui/triangle_painter.cc
+++ b/src/ui/triangle_painter.cc
@@ -80,14 +80,14 @@ void TrianglePainter::Upload(const std::vector<TrianglePainter::Data>& data) {
                 static_cast<int>(data.size() * sizeof(TrianglePainter::Data)));
 
   // in_position
-  shader_program_.enableAttributeArray(0);
-  shader_program_.setAttributeBuffer(0, GL_FLOAT, 0, 3,
+  shader_program_.enableAttributeArray("a_position");
+  shader_program_.setAttributeBuffer("a_position", GL_FLOAT, 0, 3,
                                      sizeof(PointPainter::Data));
 
   // in_color
-  shader_program_.enableAttributeArray(1);
-  shader_program_.setAttributeBuffer(1, GL_FLOAT, 3 * sizeof(GLfloat), 4,
-                                     sizeof(PointPainter::Data));
+  shader_program_.enableAttributeArray("a_color");
+  shader_program_.setAttributeBuffer("a_color", GL_FLOAT, 3 * sizeof(GLfloat),
+                                     4, sizeof(PointPainter::Data));
 
   // Make sure they are not changed from the outside
   vbo_.release();


### PR DESCRIPTION
Throughout the lifetime of the COLMAP software, users on the Windows platform with AMD display drivers have reported problems visualizing 3D geometry in the main display window of the COLMAP GUI. See for example:
- #218 Reconstruction on AMD cards yields wrong results
- #865 Sparse reconstruction show is not normal when I use amd r5 3500u
- [Discussion thread on COLMAP Google Groups](https://groups.google.com/g/colmap/c/pvSB8SxZ3b4)

The source of these problems is an OpenGL programming bug resulting in mismatched vertex attribute indices (locations) between the shader code and the calling code. For example, this current COLMAP code:

https://github.com/colmap/colmap/blob/0aea04cbd9bc5042a70beb5618cd1e52977e13ac/src/ui/line_painter.cc#L84-L92

sets the vertex position attribute to correspond to location 0, and the vertex color attribute to location 1. However, these attribute locations are not specified in the GLSL shaders, and so different OpenGL implementations are free to assign different mappings for these vertex attributes. While Nvidia drivers seem to use choose locations 0 and 1 for the vertex position and color attributes, respectively, AMD drivers on Windows seem to be using the opposite configuration (location 0 for color, location 1 for position) when the COLMAP shaders are compiled. So, the vertex data is misinterpreted by the shaders on AMD cards.

There are several different ways in OpenGL to harmonize the vertex attribute locations with the shaders (`glGetAttribLocation()` queries, `glBindAttribLocation()` binding, `GL_ARB_explicit_attrib_location` in the shader code, etc.). In this PR, I've fixed the bug by using similar `QOpenGLShaderProgram` methods to those already in use by COLMAP, but calling them with the corresponding attribute names from the shader programs, rather than the hard-coded indices of 0 and 1. With this change, the vertex attributes are properly matched, and 3D geometry is rendered as expected on both NVidia and AMD systems.