### PR TITLE
Fixed the collection of arguments in colmap.bat

### DIFF
--- a/scripts/shell/colmap.bat
+++ b/scripts/shell/colmap.bat
@@ -36,16 +36,7 @@ set SCRIPT_PATH=%~dp0
 set PATH=%SCRIPT_PATH%\lib;%PATH%
 set QT_PLUGIN_PATH=%SCRIPT_PATH%\lib;%QT_PLUGIN_PATH%
 
-set COMMAND=%1
-set ARGUMENTS=
-shift
-:extract_argument_loop
-if "%1"=="" goto after_extract_argument_loop
-set ARGUMENTS=%ARGUMENTS% %1
-shift
-goto extract_argument_loop
-:after_extract_argument_loop
+set ARGUMENTS=%*
+if "%ARGUMENTS%"=="" set ARGUMENTS=gui
 
-if "%COMMAND%"=="" set COMMAND=gui
-
-"%SCRIPT_PATH%\bin\colmap" %COMMAND% %ARGUMENTS%
+"%SCRIPT_PATH%\bin\colmap" %ARGUMENTS%


### PR DESCRIPTION
The previous use of the shift-operator in colmap.bat lead to splitting ""-encapsulated comma-separated values (e.g. "1,2,3") into individual arguments. Therefore, parameters like --ImageReader.camera_params could not be used on Windows (see screenshot).

![grafik](https://user-images.githubusercontent.com/79084722/107936014-66704f00-6f82-11eb-863f-5856a8f29a71.png)

This pull request replaces the previous mechanism that uses the shift-operator by simply using the %* operator. This way, using --ImageReader.camera_params on Windows works flawlessly.