### PR TITLE
Change ReconstructionMaanger to write larger recons first

### DIFF
--- a/src/base/reconstruction_manager.cc
+++ b/src/base/reconstruction_manager.cc
@@ -82,10 +82,20 @@ size_t ReconstructionManager::Read(const std::string& path) {
 
 void ReconstructionManager::Write(const std::string& path,
                                   const OptionManager* options) const {
+  std::vector<std::pair<size_t, size_t>> recon_sizes(reconstructions_.size());
+  for (size_t i = 0; i < reconstructions_.size(); ++i) {
+    recon_sizes[i] = std::make_pair(i, reconstructions_[i]->NumPoints3D());
+  }
+  std::sort(recon_sizes.begin(), recon_sizes.end(),
+            [](const std::pair<size_t, size_t>& first,
+               const std::pair<size_t, size_t>& second) {
+              return first.second > second.second;
+            });
+
   for (size_t i = 0; i < reconstructions_.size(); ++i) {
     const std::string reconstruction_path = JoinPaths(path, std::to_string(i));
     CreateDirIfNotExists(reconstruction_path);
-    reconstructions_[i]->Write(reconstruction_path);
+    reconstructions_[recon_sizes[i].first]->Write(reconstruction_path);
     if (options != nullptr) {
       options->Write(JoinPaths(reconstruction_path, "project.ini"));
     }


### PR DESCRIPTION
ReconstructionManager::Write now uses the NumPoints3D as proxy for a reconstruction's size and writes the output in descending order based on size. This allows larger reconstructions to be written first which is a useful behavior since sparse models may end up with a large main recon and more much smaller ones, and with this change we ensure that if we only look at the first recon it will be the "main" one.