### PR TITLE
Expose BA options in IncrementalMapper

### DIFF
--- a/src/controllers/incremental_mapper.cc
+++ b/src/controllers/incremental_mapper.cc
@@ -212,7 +212,7 @@ IncrementalTriangulator::Options IncrementalMapperOptions::Triangulation()
 BundleAdjustmentOptions IncrementalMapperOptions::LocalBundleAdjustment()
     const {
   BundleAdjustmentOptions options;
-  options.solver_options.function_tolerance = 0.0;
+  options.solver_options.function_tolerance = ba_local_function_tolerance;
   options.solver_options.gradient_tolerance = 10.0;
   options.solver_options.parameter_tolerance = 0.0;
   options.solver_options.max_num_iterations = ba_local_max_num_iterations;
@@ -237,7 +237,7 @@ BundleAdjustmentOptions IncrementalMapperOptions::LocalBundleAdjustment()
 BundleAdjustmentOptions IncrementalMapperOptions::GlobalBundleAdjustment()
     const {
   BundleAdjustmentOptions options;
-  options.solver_options.function_tolerance = 0.0;
+  options.solver_options.function_tolerance = ba_global_function_tolerance;
   options.solver_options.gradient_tolerance = 1.0;
   options.solver_options.parameter_tolerance = 0.0;
   options.solver_options.max_num_iterations = ba_global_max_num_iterations;

--- a/src/controllers/incremental_mapper.h
+++ b/src/controllers/incremental_mapper.h
@@ -93,6 +93,9 @@ struct IncrementalMapperOptions {
   // The number of images to optimize in local bundle adjustment.
   int ba_local_num_images = 6;
 
+  // Ceres solver function tolerance for local bundle adjustment
+  double ba_local_function_tolerance = 0.0;
+
   // The maximum number of local bundle adjustment iterations.
   int ba_local_max_num_iterations = 25;
 
@@ -107,6 +110,9 @@ struct IncrementalMapperOptions {
   double ba_global_points_ratio = 1.1;
   int ba_global_images_freq = 500;
   int ba_global_points_freq = 250000;
+
+  // Ceres solver function tolerance for global bundle adjustment
+  double ba_global_function_tolerance = 0.0;
 
   // The maximum number of global bundle adjustment iterations.
   int ba_global_max_num_iterations = 50;

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1054,6 +1054,11 @@ int RunMapper(int argc, char** argv) {
   mapper.Start();
   mapper.Wait();
 
+  if (reconstruction_manager.Size() == 0) {
+    std::cerr << "ERROR: failed to create sparse model" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // In case the reconstruction is continued from an existing reconstruction, do
   // not create sub-folders but directly write the results.
   if (input_path != "" && reconstruction_manager.Size() > 0) {
@@ -1092,6 +1097,11 @@ int RunHierarchicalMapper(int argc, char** argv) {
       &reconstruction_manager);
   hierarchical_mapper.Start();
   hierarchical_mapper.Wait();
+
+  if (reconstruction_manager.Size() == 0) {
+    std::cerr << "ERROR: failed to create sparse model" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   reconstruction_manager.Write(output_path, &options);
 

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -504,6 +504,8 @@ void OptionManager::AddMapperOptions() {
       &mapper->ba_min_num_residuals_for_multi_threading);
   AddAndRegisterDefaultOption("Mapper.ba_local_num_images",
                               &mapper->ba_local_num_images);
+  AddAndRegisterDefaultOption("Mapper.ba_local_function_tolerance",
+                              &mapper->ba_local_function_tolerance);
   AddAndRegisterDefaultOption("Mapper.ba_local_max_num_iterations",
                               &mapper->ba_local_max_num_iterations);
   AddAndRegisterDefaultOption("Mapper.ba_global_use_pba",
@@ -518,6 +520,8 @@ void OptionManager::AddMapperOptions() {
                               &mapper->ba_global_images_freq);
   AddAndRegisterDefaultOption("Mapper.ba_global_points_freq",
                               &mapper->ba_global_points_freq);
+  AddAndRegisterDefaultOption("Mapper.ba_global_function_tolerance",
+                              &mapper->ba_global_function_tolerance);
   AddAndRegisterDefaultOption("Mapper.ba_global_max_num_iterations",
                               &mapper->ba_global_max_num_iterations);
   AddAndRegisterDefaultOption("Mapper.ba_global_max_refinements",


### PR DESCRIPTION
Incremental mapper now exposes the function tolerance option for local and global BA. This allows for control over the BA convergence by explicitly setting this option when using `mapper` or `hierarchical_mapper`