### PR TITLE
Allow custom config and missing dependencies for patch-match

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -426,6 +426,7 @@ int RunPatchMatchStereo(int argc, char** argv) {
   std::string workspace_path;
   std::string workspace_format = "COLMAP";
   std::string pmvs_option_name = "option-all";
+  std::string config_path;
 
   OptionManager options;
   options.AddRequiredOption(
@@ -434,6 +435,7 @@ int RunPatchMatchStereo(int argc, char** argv) {
   options.AddDefaultOption("workspace_format", &workspace_format,
                            "{COLMAP, PMVS}");
   options.AddDefaultOption("pmvs_option_name", &pmvs_option_name);
+  options.AddDefaultOption("config_path", &config_path);
   options.AddPatchMatchStereoOptions();
   options.Parse(argc, argv);
 
@@ -447,7 +449,7 @@ int RunPatchMatchStereo(int argc, char** argv) {
 
   mvs::PatchMatchController controller(*options.patch_match_stereo,
                                        workspace_path, workspace_format,
-                                       pmvs_option_name);
+                                       pmvs_option_name, config_path);
 
   controller.Start();
   controller.Wait();

--- a/src/mvs/patch_match.cc
+++ b/src/mvs/patch_match.cc
@@ -74,6 +74,7 @@ void PatchMatchOptions::Print() const {
   PrintOption(filter_min_num_consistent);
   PrintOption(filter_geom_consistency_max_cost);
   PrintOption(write_consistency_graph);
+  PrintOption(allow_missing_files);
 }
 
 void PatchMatch::Problem::Print() const {
@@ -183,11 +184,13 @@ ConsistencyGraph PatchMatch::GetConsistencyGraph() const {
 PatchMatchController::PatchMatchController(const PatchMatchOptions& options,
                                            const std::string& workspace_path,
                                            const std::string& workspace_format,
-                                           const std::string& pmvs_option_name)
+                                           const std::string& pmvs_option_name,
+                                           const std::string& config_path)
     : options_(options),
       workspace_path_(workspace_path),
       workspace_format_(workspace_format),
-      pmvs_option_name_(pmvs_option_name) {
+      pmvs_option_name_(pmvs_option_name),
+      config_path_(config_path) {
   std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
 }
 
@@ -262,9 +265,12 @@ void PatchMatchController::ReadProblems() {
 
   const auto& model = workspace_->GetModel();
 
-  std::vector<std::string> config = ReadTextFileLines(
-      JoinPaths(workspace_path_, workspace_->GetOptions().stereo_folder,
-                "patch-match.cfg"));
+  const std::string config_path =
+      config_path_.empty()
+          ? JoinPaths(workspace_path_, workspace_->GetOptions().stereo_folder,
+                      "patch-match.cfg")
+          : config_path_;
+  std::vector<std::string> config = ReadTextFileLines(config_path);
 
   std::vector<std::map<int, int>> shared_num_points;
   std::vector<std::map<int, float>> triangulation_angles;
@@ -432,8 +438,8 @@ void PatchMatchController::ProcessProblem(const PatchMatchOptions& options,
     return;
   }
 
-  PrintHeading1(StringPrintf("Processing view %d / %d", problem_idx + 1,
-                             problems_.size()));
+  PrintHeading1(StringPrintf("Processing view %d / %d for %s", problem_idx + 1,
+                             problems_.size(), image_name.c_str()));
 
   auto patch_match_options = options;
 
@@ -481,13 +487,41 @@ void PatchMatchController::ProcessProblem(const PatchMatchOptions& options,
     std::unique_lock<std::mutex> lock(workspace_mutex_);
 
     std::cout << "Reading inputs..." << std::endl;
+    std::vector<int> src_image_idxs;
     for (const auto image_idx : used_image_idxs) {
+      std::string image_path = workspace_->GetBitmapPath(image_idx);
+      std::string depth_path = workspace_->GetDepthMapPath(image_idx);
+      std::string normal_path = workspace_->GetNormalMapPath(image_idx);
+
+      if (!ExistsFile(image_path) ||
+          (options.geom_consistency && !ExistsFile(depth_path)) ||
+          (options.geom_consistency && !ExistsFile(normal_path))) {
+        if (options.allow_missing_files) {
+          std::cout << StringPrintf(
+                           "WARN: Skipping source image %d: %s for missing "
+                           "image or depth/normal map",
+                           image_idx, model.GetImageName(image_idx).c_str())
+                    << std::endl;
+          continue;
+        } else {
+          std::cout
+              << StringPrintf(
+                     "ERROR: Missing image or map dependency for image %d: %s",
+                     image_idx, model.GetImageName(image_idx).c_str())
+              << std::endl;
+        }
+      }
+
+      if (image_idx != problem.ref_image_idx) {
+        src_image_idxs.push_back(image_idx);
+      }
       images.at(image_idx).SetBitmap(workspace_->GetBitmap(image_idx));
       if (options.geom_consistency) {
         depth_maps.at(image_idx) = workspace_->GetDepthMap(image_idx);
         normal_maps.at(image_idx) = workspace_->GetNormalMap(image_idx);
       }
     }
+    problem.src_image_idxs = src_image_idxs;
   }
 
   problem.Print();

--- a/src/mvs/patch_match.h
+++ b/src/mvs/patch_match.h
@@ -134,6 +134,9 @@ struct PatchMatchOptions {
   // of memory, if the consistency graph is dense.
   double cache_size = 32.0;
 
+  // Whether to tolerate missing images/maps in the problem setup
+  bool allow_missing_files = false;
+
   // Whether to write the consistency graph.
   bool write_consistency_graph = false;
 
@@ -250,7 +253,8 @@ class PatchMatchController : public Thread {
   PatchMatchController(const PatchMatchOptions& options,
                        const std::string& workspace_path,
                        const std::string& workspace_format,
-                       const std::string& pmvs_option_name);
+                       const std::string& pmvs_option_name,
+                       const std::string& config_path = "");
 
  private:
   void Run();
@@ -264,6 +268,7 @@ class PatchMatchController : public Thread {
   const std::string workspace_path_;
   const std::string workspace_format_;
   const std::string pmvs_option_name_;
+  const std::string config_path_;
 
   std::unique_ptr<ThreadPool> thread_pool_;
   std::mutex workspace_mutex_;

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -638,6 +638,8 @@ void OptionManager::AddPatchMatchStereoOptions() {
       &patch_match_stereo->filter_geom_consistency_max_cost);
   AddAndRegisterDefaultOption("PatchMatchStereo.cache_size",
                               &patch_match_stereo->cache_size);
+  AddAndRegisterDefaultOption("PatchMatchStereo.allow_missing_files",
+                              &patch_match_stereo->allow_missing_files);
   AddAndRegisterDefaultOption("PatchMatchStereo.write_consistency_graph",
                               &patch_match_stereo->write_consistency_graph);
 }


### PR DESCRIPTION
`patch_match_stereo` can now use a custom config using the `--config_path` option instead of just relying on the default `patch-match.cfg` from the workspace. Also a new option for patch-match is introduced (`--PatchMatchStereo.allow_missing_files`) to allow the process to ignore missing source images or depth/normal maps and simply exclude that image index from the patch-match problem without error.