### PR TITLE
Add auto_matcher command for feature matching

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -37,6 +37,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include "base/similarity_transform.h"
+#include "base/gps.h"
 #include "controllers/automatic_reconstruction.h"
 #include "controllers/bundle_adjustment.h"
 #include "controllers/hierarchical_mapper.h"
@@ -171,6 +172,132 @@ int RunAutomaticReconstructor(int argc, char** argv) {
                                                  &reconstruction_manager);
     controller.Start();
     controller.Wait();
+  }
+
+  return EXIT_SUCCESS;
+}
+
+static bool UseSpatialMatcher(const std::string& database_path,
+                              double max_distance, bool is_gps) {
+  PrintHeading1("Checking for spatial matching");
+  Database database(database_path);
+  constexpr double limit = std::numeric_limits<double>::max();
+  Eigen::Vector3d min_coord(limit, limit, limit);
+  Eigen::Vector3d max_coord(-limit, -limit, -limit);
+  GPSTransform gps(GPSTransform::WGS84);
+  std::vector<Image> images = database.ReadAllImages();
+  for (const Image& image : database.ReadAllImages()) {
+    if (!image.HasTvecPrior()) {
+      std::cout << "Found image with invalid location prior; using exhaustive "
+                   "matching"
+                << std::endl;
+      return false;
+    }
+    Eigen::Vector3d xyz;
+    if (is_gps) {
+      xyz = gps.EllToXYZ({image.TvecPrior()}).front();
+    } else {
+      xyz = image.TvecPrior();
+    }
+    min_coord = xyz.cwiseMin(min_coord);
+    max_coord = xyz.cwiseMax(max_coord);
+  }
+
+  const double image_distance = (max_coord - min_coord).norm();
+  std::cout << StringPrintf("Max matching distance %f vs max image distance %f",
+                            max_distance, image_distance)
+            << std::endl;
+  if (image_distance > max_distance) {
+    std::cout << "All images have valid location priors and distance; using "
+                 "spatial matching"
+              << std::endl;
+    return true;
+  } else {
+    std::cout << "Max matching distance exceeds max image distance; using "
+                 "exhaustive matching"
+              << std::endl;
+    return false;
+  }
+}
+
+static bool UseImagePairsMatcher(const std::string& database_path,
+                                 const std::string& match_list_path) {
+  PrintHeading1("Checking for fixed pair matching");
+  if (!ExistsFile(match_list_path)) {
+    std::cout << "Invalid matches file provided; trying spatial matching next"
+              << std::endl;
+    return false;
+  }
+  Database database(database_path);
+  size_t num_images_read = 0;
+  std::vector<std::string> match_image_pairs = ReadTextFileLines(match_list_path);
+  std::unordered_set<std::string> match_images;
+
+  for (const std::string image_name_pair : match_image_pairs) {
+    std::vector<std::string> image_names = StringSplit(image_name_pair, " ");
+    match_images.insert(image_names[0]);
+    match_images.insert(image_names[1]);
+  }
+
+  for (const Image& image : database.ReadAllImages()) {
+    if (match_images.count(image.Name()) == 0) {
+      std::cout << "Image " << image.Name()
+                << " exists in the DB, but was not found in the match file; "
+                   "fixed image matching cannot be used, trying spatial "
+                   "matching next."
+                << std::endl;
+      return false;
+    }
+    num_images_read++;
+  }
+
+  if (match_images.size() == num_images_read) {
+    std::cout << "All images have valid pairings in the database; using "
+                 "fixed matching."
+              << std::endl;
+  } else {
+    std::cout << "WARN: Matching file contains more images than DB; "
+                 "additional images will be ignored."
+              << std::endl;
+  }
+  return true;
+}
+
+int RunAutoMatcher(int argc, char** argv) {
+  OptionManager options;
+  options.AddDatabaseOptions();
+  options.AddAutoMatchingOptions();
+  options.Parse(argc, argv);
+
+  std::unique_ptr<QApplication> app;
+  if (options.sift_matching->use_gpu && kUseOpenGL) {
+    app.reset(new QApplication(argc, argv));
+  }
+
+  std::shared_ptr<Thread> feature_matcher;
+  if (!options.image_pairs_matching->match_list_path.empty() &&
+      UseImagePairsMatcher(*options.database_path,
+                           options.image_pairs_matching->match_list_path)) {
+    feature_matcher.reset(new ImagePairsFeatureMatcher(
+        *options.image_pairs_matching, *options.sift_matching,
+        *options.database_path));
+  } else if (UseSpatialMatcher(*options.database_path,
+                               options.spatial_matching->max_distance,
+                               options.spatial_matching->is_gps)) {
+    feature_matcher.reset(new SpatialFeatureMatcher(*options.spatial_matching,
+                                                    *options.sift_matching,
+                                                    *options.database_path));
+  } else {
+    feature_matcher.reset(new ExhaustiveFeatureMatcher(
+        *options.exhaustive_matching, *options.sift_matching,
+        *options.database_path));
+  }
+
+  if (options.sift_matching->use_gpu && kUseOpenGL) {
+    RunThreadWithOpenGLContext(feature_matcher.get());
+  } else {
+    feature_matcher->Start();
+    feature_matcher->Wait();
   }
 
   return EXIT_SUCCESS;
@@ -2138,6 +2265,7 @@ int main(int argc, char** argv) {
   std::vector<std::pair<std::string, command_func_t>> commands;
   commands.emplace_back("gui", &RunGraphicalUserInterface);
   commands.emplace_back("automatic_reconstructor", &RunAutomaticReconstructor);
+  commands.emplace_back("auto_matcher", &RunAutoMatcher);
   commands.emplace_back("bundle_adjuster", &RunBundleAdjuster);
   commands.emplace_back("color_extractor", &RunColorExtractor);
   commands.emplace_back("database_creator", &RunDatabaseCreator);

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -320,6 +320,18 @@ void OptionManager::AddMatchingOptions() {
                               &sift_matching->guided_matching);
 }
 
+void OptionManager::AddAutoMatchingOptions() {
+  if (added_auto_match_options_) {
+    return;
+  }
+  added_auto_match_options_ = true;
+
+  AddMatchingOptions();
+  AddExhaustiveMatchingOptions();
+  AddSpatialMatchingOptions();
+  AddImagePairsMatchingOptions();
+}
+
 void OptionManager::AddExhaustiveMatchingOptions() {
   if (added_exhaustive_match_options_) {
     return;
@@ -432,6 +444,8 @@ void OptionManager::AddImagePairsMatchingOptions() {
 
   AddAndRegisterDefaultOption("ImagePairsMatching.block_size",
                               &image_pairs_matching->block_size);
+  AddAndRegisterDefaultOption("ImagePairsMatching.match_list_path",
+                              &image_pairs_matching->match_list_path);
 }
 
 void OptionManager::AddBundleAdjustmentOptions() {
@@ -742,6 +756,7 @@ void OptionManager::Reset() {
   added_image_options_ = false;
   added_extraction_options_ = false;
   added_match_options_ = false;
+  added_auto_match_options_ = false;
   added_exhaustive_match_options_ = false;
   added_sequential_match_options_ = false;
   added_vocab_tree_match_options_ = false;

--- a/src/util/option_manager.h
+++ b/src/util/option_manager.h
@@ -86,6 +86,7 @@ class OptionManager {
   void AddImageOptions();
   void AddExtractionOptions();
   void AddMatchingOptions();
+  void AddAutoMatchingOptions();
   void AddExhaustiveMatchingOptions();
   void AddSequentialMatchingOptions();
   void AddVocabTreeMatchingOptions();
@@ -166,6 +167,7 @@ class OptionManager {
   bool added_image_options_;
   bool added_extraction_options_;
   bool added_match_options_;
+  bool added_auto_match_options_;
   bool added_exhaustive_match_options_;
   bool added_sequential_match_options_;
   bool added_vocab_tree_match_options_;


### PR DESCRIPTION
`auto_matcher` is a convenience feature matching command that chooses the best feature matching method based on the given option. The choices in order are:
1. ImagePairsFeatureMatcher: if the `--ImagePairsMatching.match_list_path` is set to a valid image pairs file that includes all images in the DB
2. SpatialFeatureMatcher: if the image pairs file is not given or is malformed in any way and the DB contains GPS priors for the images
3. ExhaustiveFeatureMatcher: This is a fallback that should always work if neither of the two earlier choices are usable. It is also used when the max matching distance of the spatial matcher is larger than the max distance of images in the DB; this happens because in such a case the spatial matcher devolves to exhausting matching anyway, and leveraging the batches of the exhaustive matcher speeds things up a bit