### PR TITLE
Add utility to compare poses between two sparse models

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -2298,7 +2298,7 @@ int main(int argc, char** argv) {
   commands.emplace_back("matches_importer", &RunMatchesImporter);
   commands.emplace_back("model_aligner", &RunModelAligner);
   commands.emplace_back("model_analyzer", &RunModelAnalyzer);
-  commands.emplace_back("model_comparator", &RunModelComparator);
+  commands.emplace_back("model_comparer", &RunModelComparer);
   commands.emplace_back("model_converter", &RunModelConverter);
   commands.emplace_back("model_merger", &RunModelMerger);
   commands.emplace_back("model_orientation_aligner",

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1260,6 +1260,9 @@ void WriteComparisonErrors(const std::string& path,
                            const std::vector<double>& rotation_errors,
                            const std::vector<double>& translation_errors,
                            const std::vector<double>& proj_center_errors) {
+  CHECK_EQ(rotation_errors.size(), translation_errors.size());
+  CHECK_EQ(rotation_errors.size(), proj_center_errors.size());
+
   std::ofstream file(path, std::ios::trunc);
   CHECK(file.is_open()) << path;
 
@@ -1268,7 +1271,7 @@ void WriteComparisonErrors(const std::string& path,
        << std::endl;
   file << "# <rotation error (deg)>, <translation error>, <proj center error>"
        << std::endl;
-  for (int i = 0; i < rotation_errors.size(); ++i) {
+  for (size_t i = 0; i < rotation_errors.size(); ++i) {
     file << rotation_errors[i] << ", " << translation_errors[i] << ", "
          << proj_center_errors[i] << std::endl;
   }


### PR DESCRIPTION
`model_comparator` takes two sparse models as input and after aligning them it calculates some simple statistics on difference in pose parameters (translation, rotation, projection center) between them.