### PR TITLE
Support more formats in model_converter

### DIFF
--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -1127,6 +1127,9 @@ bool Reconstruction::ExportBundler(const std::string& path,
   std::ofstream list_file(list_path, std::ios::trunc);
   CHECK(list_file.is_open()) << list_path;
 
+  // Ensure that we don't lose any precision by storing in text.
+  synth_file.precision(17);
+
   file << "# Bundle file v0.3" << std::endl;
 
   file << reg_image_ids_.size() << " " << points3D_.size() << std::endl;

--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -1128,7 +1128,7 @@ bool Reconstruction::ExportBundler(const std::string& path,
   CHECK(list_file.is_open()) << list_path;
 
   // Ensure that we don't lose any precision by storing in text.
-  synth_file.precision(17);
+  file.precision(17);
 
   file << "# Bundle file v0.3" << std::endl;
 

--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -321,15 +321,6 @@ void Reconstruction::DeRegisterImage(const image_t image_id) {
       reg_image_ids_.end());
 }
 
-void Reconstruction::DeRegisterImages(const std::string& prefix) {
-  const auto reg_image_ids = reg_image_ids_;
-  for (auto id : reg_image_ids) {
-    if (StringContains(Image(id).Name(), prefix)) {
-      DeRegisterImage(id);
-    }
-  }
-}
-
 void Reconstruction::Normalize(const double extent, const double p0,
                                const double p1, const bool use_images) {
   CHECK_GT(extent, 0);

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -272,13 +272,71 @@ class Reconstruction {
   void ImportPLY(const std::vector<PlyPoint>& ply_points);
 
   // Export to other data formats.
+
+  // Exports in NVM format http://ccwu.me/vsfm/doc.html#nvm. Only supports
+  // SIMPLE_RADIAL camera model when exporting distortion parameters. When
+  // skip_distortion == true it supports all camera models with the caveat that
+  // it's using the mean focal length which will be inaccurate for camera models
+  // with two focal length parameters.
   bool ExportNVM(const std::string& path, bool skip_distortion = false) const;
+
+  // Exports in CAM format which is a simple text file that contains pose
+  // information and camera intrinsics for each image and exports one file per
+  // image; it does not include information on the 3D points. The format is as
+  // follows (2 lines of text with space separated numbers):
+  // <Tvec; 3 values> <Rotation matrix in row-major format; 9 values>
+  // <focal_length> <k1> <k2> 1.0 <principal point X> <principal point Y>
+  // Note that focal length is relative to the image max(width, height),
+  // and principal points x and y are relative to width and height respectively.
+  //
+  // Only supports SIMPLE_RADIAL and RADIAL camera models when exporting
+  // distortion parameters. When skip_distortion == true it supports all camera
+  // models with the caveat that it's using the mean focal length which will be
+  // inaccurate for camera models with two focal length parameters.
   bool ExportCam(const std::string& path, bool skip_distortion = false) const;
+
+  // Exports in Recon3D format which consists of three text files with the
+  // following format and content:
+  // 1) imagemap_0.txt: just a list of image numeric IDs with one entry per line.
+  // 2) urd-images.txt: A list of images with one entry per line as:
+  //    <image file name> <width> <height>
+  // 3) synth_0.out: Contains information for image poses, camera intrinsics,
+  //    and 3D points as:
+  //    <N; num images> <M; num points>
+  //    <N lines of image entries>
+  //    <M lines of point entries>
+  //
+  //    Each image entry consists of 5 lines as:
+  //    <focal length> <k1> <k2>
+  //    <Rotation matrix; 3x3 array>
+  //    <Tvec; 3 values>
+  //    Note that the focal length is scaled by 1 / max(width, height)
+  //
+  //    Each point entry consists of 3 lines as:
+  //    <point x, y, z coordinates>
+  //    <point RGB color>
+  //    <K; num track elements> <Track Element 1> ... <Track Element K>
+  //
+  //    Each track elemenet is a sequence of 5 values as:
+  //    <image ID> <2D point ID> -1.0 <X> <Y>
+  //    Note that the 2D point coordinates are centered around the principal
+  //    point and scaled by 1 / max(width, height).
   bool ExportRecon3D(const std::string& path,
                      bool skip_distortion = false) const;
+
+  // Exports in Bundler format https://www.cs.cornell.edu/~snavely/bundler/.
+  // Supports SIMPLE_PINHOLE, PINHOLE, SIMPLE_RADIAL and RADIAL camera models
+  // when exporting distortion parameters. When skip_distortion == true it
+  // supports all camera models with the caveat that it's using the mean focal
+  // length which will be inaccurate for camera models with two focal length
+  // parameters.
   bool ExportBundler(const std::string& path, const std::string& list_path,
                      bool skip_distortion = false) const;
+
+  // Exports 3D points only in PLY format.
   void ExportPLY(const std::string& path) const;
+
+  // Exports in VRML format https://en.wikipedia.org/wiki/VRML.
   void ExportVRML(const std::string& images_path,
                   const std::string& points3D_path, const double image_scale,
                   const Eigen::Vector3d& image_rgb) const;

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -277,7 +277,7 @@ class Reconstruction {
   // SIMPLE_RADIAL camera model when exporting distortion parameters. When
   // skip_distortion == true it supports all camera models with the caveat that
   // it's using the mean focal length which will be inaccurate for camera models
-  // with two focal length parameters.
+  // with two focal lengths and distortion.
   bool ExportNVM(const std::string& path, bool skip_distortion = false) const;
 
   // Exports in CAM format which is a simple text file that contains pose
@@ -292,7 +292,7 @@ class Reconstruction {
   // Only supports SIMPLE_RADIAL and RADIAL camera models when exporting
   // distortion parameters. When skip_distortion == true it supports all camera
   // models with the caveat that it's using the mean focal length which will be
-  // inaccurate for camera models with two focal length parameters.
+  // inaccurate for camera models with two focal lengths and distortion.
   bool ExportCam(const std::string& path, bool skip_distortion = false) const;
 
   // Exports in Recon3D format which consists of three text files with the
@@ -321,6 +321,10 @@ class Reconstruction {
   //    <image ID> <2D point ID> -1.0 <X> <Y>
   //    Note that the 2D point coordinates are centered around the principal
   //    point and scaled by 1 / max(width, height).
+  //
+  // When skip_distortion == true it supports all camera models with the
+  // caveat that it's using the mean focal length which will be inaccurate
+  // for camera models with two focal lengths and distortion.
   bool ExportRecon3D(const std::string& path,
                      bool skip_distortion = false) const;
 
@@ -328,8 +332,8 @@ class Reconstruction {
   // Supports SIMPLE_PINHOLE, PINHOLE, SIMPLE_RADIAL and RADIAL camera models
   // when exporting distortion parameters. When skip_distortion == true it
   // supports all camera models with the caveat that it's using the mean focal
-  // length which will be inaccurate for camera models with two focal length
-  // parameters.
+  // length which will be inaccurate for camera models with two focal lengths
+  // and distortion.
   bool ExportBundler(const std::string& path, const std::string& list_path,
                      bool skip_distortion = false) const;
 

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -162,6 +162,9 @@ class Reconstruction {
   // De-register an existing image, and all its references.
   void DeRegisterImage(const image_t image_id);
 
+  // De-register existing images with specific prefix and all their references.
+  void DeRegisterImages(const std::string& prefix);
+
   // Check if image is registered.
   inline bool IsImageRegistered(const image_t image_id) const;
 
@@ -269,9 +272,12 @@ class Reconstruction {
   void ImportPLY(const std::vector<PlyPoint>& ply_points);
 
   // Export to other data formats.
-  bool ExportNVM(const std::string& path) const;
-  bool ExportBundler(const std::string& path,
-                     const std::string& list_path) const;
+  bool ExportNVM(const std::string& path, bool skip_distortion = false) const;
+  bool ExportCam(const std::string& path, bool skip_distortion = false) const;
+  bool ExportRecon3D(const std::string& path,
+                     bool skip_distortion = false) const;
+  bool ExportBundler(const std::string& path, const std::string& list_path,
+                     bool skip_distortion = false) const;
   void ExportPLY(const std::string& path) const;
   void ExportVRML(const std::string& images_path,
                   const std::string& points3D_path, const double image_scale,

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -162,9 +162,6 @@ class Reconstruction {
   // De-register an existing image, and all its references.
   void DeRegisterImage(const image_t image_id);
 
-  // De-register existing images with specific prefix and all their references.
-  void DeRegisterImages(const std::string& prefix);
-
   // Check if image is registered.
   inline bool IsImageRegistered(const image_t image_id) const;
 

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1260,7 +1260,6 @@ int RunModelConverter(int argc, char** argv) {
   std::string input_path;
   std::string output_path;
   std::string output_type;
-  std::string remove_image_prefix;
   bool skip_distortion = false;
 
   OptionManager options;
@@ -1268,16 +1267,11 @@ int RunModelConverter(int argc, char** argv) {
   options.AddRequiredOption("output_path", &output_path);
   options.AddRequiredOption("output_type", &output_type,
                             "{BIN, TXT, NVM, Bundler, VRML, PLY, R3D, CAM}");
-  options.AddDefaultOption("remove_image_prefix", &remove_image_prefix);
   options.AddDefaultOption("skip_distortion", &skip_distortion);
   options.Parse(argc, argv);
 
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
-
-  if (!remove_image_prefix.empty()) {
-    reconstruction.DeRegisterImages(remove_image_prefix);
-  }
 
   StringToLower(&output_type);
   if (output_type == "bin") {

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1282,7 +1282,8 @@ int RunModelConverter(int argc, char** argv) {
     reconstruction.ExportNVM(output_path, skip_distortion);
   } else if (output_type == "bundler") {
     reconstruction.ExportBundler(output_path + ".bundle.out",
-                                 output_path + ".list.txt");
+                                 output_path + ".list.txt",
+                                 skip_distortion);
   } else if (output_type == "ply") {
     reconstruction.ExportPLY(output_path);
   } else if (output_type == "r3d") {

--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -1260,16 +1260,24 @@ int RunModelConverter(int argc, char** argv) {
   std::string input_path;
   std::string output_path;
   std::string output_type;
+  std::string remove_image_prefix;
+  bool skip_distortion = false;
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
   options.AddRequiredOption("output_path", &output_path);
   options.AddRequiredOption("output_type", &output_type,
-                            "{BIN, TXT, NVM, Bundler, VRML, PLY}");
+                            "{BIN, TXT, NVM, Bundler, VRML, PLY, R3D, CAM}");
+  options.AddDefaultOption("remove_image_prefix", &remove_image_prefix);
+  options.AddDefaultOption("skip_distortion", &skip_distortion);
   options.Parse(argc, argv);
 
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
+
+  if (!remove_image_prefix.empty()) {
+    reconstruction.DeRegisterImages(remove_image_prefix);
+  }
 
   StringToLower(&output_type);
   if (output_type == "bin") {
@@ -1277,12 +1285,16 @@ int RunModelConverter(int argc, char** argv) {
   } else if (output_type == "txt") {
     reconstruction.WriteText(output_path);
   } else if (output_type == "nvm") {
-    reconstruction.ExportNVM(output_path);
+    reconstruction.ExportNVM(output_path, skip_distortion);
   } else if (output_type == "bundler") {
     reconstruction.ExportBundler(output_path + ".bundle.out",
                                  output_path + ".list.txt");
   } else if (output_type == "ply") {
     reconstruction.ExportPLY(output_path);
+  } else if (output_type == "r3d") {
+    reconstruction.ExportRecon3D(output_path, skip_distortion);
+  } else if (output_type == "cam") {
+    reconstruction.ExportCam(output_path, skip_distortion);
   } else if (output_type == "vrml") {
     const auto base_path = output_path.substr(0, output_path.find_last_of("."));
     reconstruction.ExportVRML(base_path + ".images.wrl",


### PR DESCRIPTION
- model_converter changes:
  - Added support for 2 new formats (CAM and Recon3D)
  - New option `remove_image_prefix` allows de-registering of images before conversion
  - New option `skip_distortion` can be used to export the model without the distortion parameters (set to 0)