### PR TITLE
Parallelize stereo fusion; needs pre-loading of entire workspace

### DIFF
--- a/src/exe/colmap.cc
+++ b/src/exe/colmap.cc
@@ -44,6 +44,7 @@
 #include "feature/extraction.h"
 #include "feature/matching.h"
 #include "feature/utils.h"
+#include "mvs/fusion.h"
 #include "mvs/meshing.h"
 #include "mvs/patch_match.h"
 #include "retrieval/visual_index.h"
@@ -267,6 +268,7 @@ int RunStereoFuser(int argc, char** argv) {
   std::string pmvs_option_name = "option-all";
   std::string output_type = "PLY";
   std::string output_path;
+  std::string bbox_path;
 
   OptionManager options;
   options.AddRequiredOption("workspace_path", &workspace_path);
@@ -278,6 +280,7 @@ int RunStereoFuser(int argc, char** argv) {
   options.AddDefaultOption("output_type", &output_type,
                             "{BIN, TXT, PLY}");
   options.AddRequiredOption("output_path", &output_path);
+  options.AddDefaultOption("bbox_path", &bbox_path);
   options.AddStereoFusionOptions();
   options.Parse(argc, argv);
 
@@ -295,6 +298,20 @@ int RunStereoFuser(int argc, char** argv) {
                  "'photometric' and 'geometric'."
               << std::endl;
     return EXIT_FAILURE;
+  }
+
+  if (!bbox_path.empty()) {
+    std::ifstream file(bbox_path);
+    if (file.is_open()) {
+      auto& min_bound = options.stereo_fusion->bounds.first;
+      auto& max_bound = options.stereo_fusion->bounds.second;
+      file >> min_bound(0) >> min_bound(1) >> min_bound(2);
+      file >> max_bound(0) >> max_bound(1) >> max_bound(2);
+      file.close();
+    } else {
+      std::cout << "WARN: Invalid bounds path: \"" << bbox_path
+                << "\" - continuing without bounds check" << std::endl;
+    }
   }
 
   mvs::StereoFusion fuser(*options.stereo_fusion, workspace_path,

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -591,6 +591,8 @@ void OptionManager::AddPatchMatchStereoOptions() {
   }
   added_patch_match_stereo_options_ = true;
 
+  AddAndRegisterDefaultOption("StereoFusion.mask_path",
+                              &stereo_fusion->mask_path);
   AddAndRegisterDefaultOption("PatchMatchStereo.max_image_size",
                               &patch_match_stereo->max_image_size);
   AddAndRegisterDefaultOption("PatchMatchStereo.gpu_index",
@@ -638,6 +640,10 @@ void OptionManager::AddPatchMatchStereoOptions() {
       &patch_match_stereo->filter_geom_consistency_max_cost);
   AddAndRegisterDefaultOption("PatchMatchStereo.cache_size",
                               &patch_match_stereo->cache_size);
+  AddAndRegisterDefaultOption("StereoFusion.use_cache",
+                              &stereo_fusion->use_cache);
+  AddAndRegisterDefaultOption("StereoFusion.save_calculated_maps",
+                              &stereo_fusion->save_calculated_maps);
   AddAndRegisterDefaultOption("PatchMatchStereo.write_consistency_graph",
                               &patch_match_stereo->write_consistency_graph);
 }


### PR DESCRIPTION
Stereo fusion can now be done in parallel as long as the entire workspace gets pre-loaded. A new `NoCacheWorkspace` class can do that when initializing fusion. Parallel execution is the new default so to use the existing functionality with cache and sequential fusion `stereo_fusion` must be used with `--StereoFusion.use_cache 1`.

Also added options to:
- Use image masks that excludes pixels from the depth maps. Work similarly to masks in `ImageReaderOptions`
- Restrict the fused point cloud within a specified bounding box described from its two 3D corner points. The bounding box is in plan text format with space separated numeric values for the corner points, e.g. `<x1> <y1> <z1> <x2> <y2> <z2>.