### PR TITLE
Issue 1033 prior intrinsic for multiple cameras

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -158,8 +158,10 @@ the available options, e.g.::
           --database_path arg
           --image_path arg
           --image_list_path arg
+          --camera_params_per_folder_path arg
           --ImageReader.camera_model arg (=SIMPLE_RADIAL)
           --ImageReader.single_camera arg (=0)
+          --ImageReader.single_camera_per_folder arg (=0)
           --ImageReader.camera_params arg
           --ImageReader.default_focal_length_factor arg (=1.2)
           --SiftExtraction.num_threads arg (=-1)

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -65,6 +65,62 @@ a final global bundle adjustment by setting ``Reconstruction > Bundle adj.
 options > refine_*`` and then running ``Reconstruction > Bundle adjustment``.
 
 
+.. _faq-prior-intrinsic
+
+Prior intrinsics
+----------------
+
+Prior intrinsics could provide by Comma-separated values (csv) string::
+
+    $ colmap feature_extractor \
+        --database_path <output sqlite file> \
+        --image_path <image path>
+        --ImageReader.camera_model SIMPLE_RADIAL
+        --ImageReader.camera_params "<f>, <cx>, <cy>, <k>"
+
+In this case all photos will be with one share camera.
+
+If you have photos from different cameras, you should put photos
+from different cameras to different subfolders and enable flag
+``--ImageReader.single_camera_per_folder``.
+In this case photos with same subfolder will share same camera.
+
+Example file structure for multiple cameras::
+
+    +── path/to/root/images/path
+    │   +── camera_1
+    │   |   +── photo1.jpg
+    │   |   +── photo2.jpg
+    │   |   +── photo3.jpg
+    │   +── camera_2
+    │   |   +── photo1.jpg
+    │   |   +── photo2.jpg
+    │   |   +── photo3.jpg
+    │   +── camera_3
+    │   |   +── photo1.jpg
+    │   |   +── photo2.jpg
+    │   |   +── photo3.jpg
+
+To specify prior intrinsics per camera, you should
+provide config file to ``--camera_params_per_folder_path`` parameter.
+The structure of config file::
+
+    <camera(path) name 1>
+    <camera model string> <CSV string with parameters>
+    <camera(path) name 2>
+    <camera model string> <CSV string with parameters>
+    <camera(path) name 3>
+    <camera model string> <CSV string with parameters>
+
+Example::
+
+    camera_1
+    FULL_OPENCV 7174.9, 7174.9, 3723.3, 2402.9, -0.05, -0.006, 0.001, -0.001, 0.07, 0.0, 0.0, 0.0
+    camera_2
+    RADIAL 7174, 3723, 2402, -0.05, -0.006
+
+If camera not specified, camera model and params will be set by default.
+
 Principal point refinement
 --------------------------
 

--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -191,7 +191,19 @@ ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
              kInvalidCameraId) ||
         (options_.single_camera_per_folder &&
          image_folders_.count(image_folder) == 0)) {
-      if (options_.camera_params.empty()) {
+      prev_camera_.SetModelIdFromName(options_.camera_model);
+      if (options_.single_camera_per_folder &&
+          options_.camera_params_per_folder.count(GetPathBaseName(image_folder))) {
+        std::string line = options_.camera_params_per_folder.at(GetPathBaseName(image_folder));
+        StringTrim(&line);
+        const size_t split_idx = line.find_first_of(" \t");
+        const std::string model_name = line.substr(0, split_idx);
+        const std::string params = line.substr(split_idx);
+        prev_camera_.SetModelIdFromName(model_name);
+        prev_camera_.SetParamsFromString(params);
+        prev_camera_.SetPriorFocalLength(true);
+      }
+      else if (options_.camera_params.empty()) {
         // Extract focal length.
         double focal_length = 0.0;
         if (bitmap->ExifFocalLength(&focal_length)) {

--- a/src/base/image_reader.h
+++ b/src/base/image_reader.h
@@ -33,6 +33,7 @@
 #define COLMAP_SRC_BASE_IMAGE_READER_H_
 
 #include <unordered_set>
+#include <unordered_map>
 
 #include "base/database.h"
 #include "util/bitmap.h"
@@ -76,6 +77,9 @@ struct ImageReaderOptions {
   // Manual specification of camera parameters. If empty, camera parameters
   // will be extracted from EXIF, i.e. principal point and focal length.
   std::string camera_params = "";
+
+  // Manual specification of camera parameters per folder.
+  std::unordered_map<std::string, std::string> camera_params_per_folder;
 
   // If camera parameters are not specified manually and the image does not
   // have focal length EXIF information, the focal length is set to the

--- a/src/exe/feature.cc
+++ b/src/exe/feature.cc
@@ -67,11 +67,13 @@ bool VerifyCameraParams(const std::string& camera_model,
 
 int RunFeatureExtractor(int argc, char** argv) {
   std::string image_list_path;
+  std::string camera_params_per_folder_path;
 
   OptionManager options;
   options.AddDatabaseOptions();
   options.AddImageOptions();
   options.AddDefaultOption("image_list_path", &image_list_path);
+  options.AddDefaultOption("camera_params_per_folder_path", &camera_params_per_folder_path);
   options.AddExtractionOptions();
   options.Parse(argc, argv);
 
@@ -83,6 +85,20 @@ int RunFeatureExtractor(int argc, char** argv) {
     reader_options.image_list = ReadTextFileLines(image_list_path);
     if (reader_options.image_list.empty()) {
       return EXIT_SUCCESS;
+    }
+  }
+
+  if (!camera_params_per_folder_path.empty()) {
+    std::vector<std::string> lines = ReadTextFileLines(camera_params_per_folder_path);
+    size_t i = 0;
+    while (i + 1 < lines.size()) {
+      if (lines[i].empty()) {
+        ++i;
+      }
+      else {
+        reader_options.camera_params_per_folder.emplace(lines[i], lines[i+1]);
+        i += 2;
+      }
     }
   }
 


### PR DESCRIPTION
fixes #1033 

Extended functionality by allowing users to specify a prior intrinsics for multiple cameras.
Also extended documentation for new functionality.

API was changed, but saved backward compatibility.

Code was hand tested,  but unit tests are not exists. I don't now how create tests for CLI module.