### PR TITLE
Improvements to NVM, Cam, Recon3D, and Bundler exporters

### DIFF
--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -939,15 +939,16 @@ bool Reconstruction::ExportCam(const std::string& path,
     if (camera.FocalLengthIdxs().size() == 2) {
       fx = camera.FocalLengthX();
       fy = camera.FocalLengthY();
-    }
-    else
+    } else {
       fx = fy = camera.MeanFocalLength();
+    }
 
     double focal_length;
-    if (camera.Width() * fy < camera.Height() * fx)
+    if (camera.Width() * fy < camera.Height() * fx) {
       focal_length = fy / camera.Height();
-    else
+    } else {
       focal_length = fx / camera.Width();
+    }
 
     const Eigen::Matrix3d rot_mat = image.RotationMatrix();
     file << image.Tvec(0) << " " << image.Tvec(1) << " " << image.Tvec(2) << " "

--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -831,12 +831,15 @@ bool Reconstruction::ExportNVM(const std::string& path,
     const class Camera& camera = Camera(image.CameraId());
 
     double k;
-    if (skip_distortion) {
+    if (skip_distortion ||
+        camera.ModelId() == SimplePinholeCameraModel::model_id ||
+        camera.ModelId() == PinholeCameraModel::model_id) {
       k = 0.0;
     } else if (camera.ModelId() == SimpleRadialCameraModel::model_id) {
       k = -1 * camera.Params(SimpleRadialCameraModel::extra_params_idxs[0]);
     } else {
-      std::cout << "WARNING: NVM only supports `SIMPLE_RADIAL` camera model."
+      std::cout << "WARNING: NVM only supports `SIMPLE_RADIAL` "
+                   "and pinhole camera models."
                 << std::endl;
       return false;
     }
@@ -914,31 +917,46 @@ bool Reconstruction::ExportCam(const std::string& path,
     file.precision(17);
 
     double k1, k2;
-    if (skip_distortion) {
+    if (skip_distortion ||
+        camera.ModelId() == SimplePinholeCameraModel::model_id ||
+        camera.ModelId() == PinholeCameraModel::model_id) {
       k1 = 0.0;
       k2 = 0.0;
     } else if (camera.ModelId() == SimpleRadialCameraModel::model_id) {
       k1 = -1 * camera.Params(SimpleRadialCameraModel::extra_params_idxs[0]);
       k2 = 0.0;
-    } else if (camera.ModelId() != RadialCameraModel::model_id) {
+    } else if (camera.ModelId() == RadialCameraModel::model_id) {
       k1 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[0]);
       k2 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[1]);
     } else {
-      std::cout << "WARNING: CAM only supports `SIMPLE_RADIAL` and `RADIAL` "
-                   "camera model."
+      std::cout << "WARNING: CAM only supports `SIMPLE_RADIAL`, `RADIAL`, "
+                   "and pinhole camera models."
                 << std::endl;
       return false;
     }
 
+    double fx, fy;
+    if (camera.FocalLengthIdxs().size() == 2) {
+      fx = camera.FocalLengthX();
+      fy = camera.FocalLengthY();
+    }
+    else
+      fx = fy = camera.MeanFocalLength();
+
+    double focal_length;
+    if (camera.Width() * fy < camera.Height() * fx)
+      focal_length = fy / camera.Height();
+    else
+      focal_length = fx / camera.Width();
+
     const Eigen::Matrix3d rot_mat = image.RotationMatrix();
-    const double max_image_size = std::max(camera.Width(), camera.Height());
     file << image.Tvec(0) << " " << image.Tvec(1) << " " << image.Tvec(2) << " "
          << rot_mat(0, 0) << " " << rot_mat(0, 1) << " " << rot_mat(0, 2) << " "
          << rot_mat(1, 0) << " " << rot_mat(1, 1) << " " << rot_mat(1, 2) << " "
          << rot_mat(2, 0) << " " << rot_mat(2, 1) << " " << rot_mat(2, 2)
          << std::endl;
-    file << camera.MeanFocalLength() / max_image_size << " " << k1 << " " << k2
-         << " 1.0 " << camera.PrincipalPointX() / camera.Width() << " "
+    file << focal_length << " " << k1 << " " << k2 << " " << fy / fx << " "
+         << camera.PrincipalPointX() / camera.Width() << " "
          << camera.PrincipalPointY() / camera.Height() << std::endl;
   }
 
@@ -978,18 +996,20 @@ bool Reconstruction::ExportRecon3D(const std::string& path,
     const class Camera& camera = Camera(image.CameraId());
 
     double k1, k2;
-    if (skip_distortion) {
+    if (skip_distortion ||
+        camera.ModelId() == SimplePinholeCameraModel::model_id ||
+        camera.ModelId() == PinholeCameraModel::model_id) {
       k1 = 0.0;
       k2 = 0.0;
     } else if (camera.ModelId() == SimpleRadialCameraModel::model_id) {
       k1 = -1 * camera.Params(SimpleRadialCameraModel::extra_params_idxs[0]);
       k2 = 0.0;
-    } else if (camera.ModelId() != RadialCameraModel::model_id) {
+    } else if (camera.ModelId() == RadialCameraModel::model_id) {
       k1 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[0]);
       k2 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[1]);
     } else {
-      std::cout << "WARNING: Recon3D only supports `SIMPLE_RADIAL` and "
-                   "`RADIAL` camera model."
+      std::cout << "WARNING: Recon3D only supports `SIMPLE_RADIAL`, "
+                   "`RADIAL`, and pinhole camera models."
                 << std::endl;
       return false;
     }
@@ -1080,11 +1100,9 @@ bool Reconstruction::ExportBundler(const std::string& path,
     const class Camera& camera = Camera(image.CameraId());
 
     double k1, k2;
-    if (skip_distortion) {
-      k1 = 0.0;
-      k2 = 0.0;
-    } else if (camera.ModelId() == SimplePinholeCameraModel::model_id ||
-               camera.ModelId() == PinholeCameraModel::model_id) {
+    if (skip_distortion ||
+        camera.ModelId() == SimplePinholeCameraModel::model_id ||
+        camera.ModelId() == PinholeCameraModel::model_id) {
       k1 = 0.0;
       k2 = 0.0;
     } else if (camera.ModelId() == SimpleRadialCameraModel::model_id) {
@@ -1094,8 +1112,8 @@ bool Reconstruction::ExportBundler(const std::string& path,
       k1 = camera.Params(RadialCameraModel::extra_params_idxs[0]);
       k2 = camera.Params(RadialCameraModel::extra_params_idxs[1]);
     } else {
-      std::cout << "WARNING: Bundler only supports `SIMPLE_RADIAL` and "
-                   "`RADIAL` camera models."
+      std::cout << "WARNING: Bundler only supports `SIMPLE_RADIAL`, "
+                   "`RADIAL`, and pinhole camera models."
                 << std::endl;
       return false;
     }


### PR DESCRIPTION
This PR improves the code for some of the model_converter export formats:

1. Fix bugs introduced in PR #1147 affecting the export of Cam and Recon3D formats
2. Add support for non-square pixels to the Cam format exporter
3. Consistently support pinhole camera models for NVM, Cam, Recon3D, and Bundler exporters