### PR TITLE
Fix error of using urllib to download eigen from gitlab

### DIFF
--- a/scripts/python/build.py
+++ b/scripts/python/build.py
@@ -39,7 +39,7 @@ import argparse
 import zipfile
 import hashlib
 import ssl
-import urllib.request
+import requests
 import subprocess
 import multiprocessing
 
@@ -185,7 +185,9 @@ def check_md5_hash(path, md5_hash):
 
 def download_zipfile(url, archive_path, unzip_path, md5_hash):
     if not os.path.exists(archive_path):
-        urllib.request.urlretrieve(url, archive_path)
+        r = requests.get(url)
+        with open(archive_path, 'wb') as outfile:
+            outfile.write(r.content)
     check_md5_hash(archive_path, md5_hash)
     with zipfile.ZipFile(archive_path, "r") as fid:
         fid.extractall(unzip_path)


### PR DESCRIPTION
urllib.request.urlretrieve cannot download eigen from gitlab as mentioned in #973 .
This pull request solves this problem by using the requests library, but you need to install a third-party library requests in python 3 .

Before run build.py script, install requests by pip($ python -m pip install requests).
[Installing Requests](https://pypi.org/project/requests/)