### PR TITLE
Fix radial distortion in Cam format exporter

### DIFF
--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -924,16 +924,24 @@ bool Reconstruction::ExportCam(const std::string& path,
       k1 = 0.0;
       k2 = 0.0;
     } else if (camera.ModelId() == SimpleRadialCameraModel::model_id) {
-      k1 = -1 * camera.Params(SimpleRadialCameraModel::extra_params_idxs[0]);
+      k1 = camera.Params(SimpleRadialCameraModel::extra_params_idxs[0]);
       k2 = 0.0;
     } else if (camera.ModelId() == RadialCameraModel::model_id) {
-      k1 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[0]);
-      k2 = -1 * camera.Params(RadialCameraModel::extra_params_idxs[1]);
+      k1 = camera.Params(RadialCameraModel::extra_params_idxs[0]);
+      k2 = camera.Params(RadialCameraModel::extra_params_idxs[1]);
     } else {
       std::cout << "WARNING: CAM only supports `SIMPLE_RADIAL`, `RADIAL`, "
                    "and pinhole camera models."
                 << std::endl;
       return false;
+    }
+
+    // If both k1 and k2 values are non-zero, then the CAM format assumes
+    // a Bundler-like radial distortion model, which converts well from
+    // COLMAP. However, if k2 is zero, then a different model is used
+    // that does not translate as well, so we avoid setting k2 to zero.
+    if (k1 != 0.0 && k2 == 0.0) {
+      k2 = 1e-10;
     }
 
     double fx, fy;


### PR DESCRIPTION
The radial distortion parameters exported by the *.cam file format exporter are currently not computed properly. This PR fixes the `Reconstruction::ExportCam()` exporter so that the radial distortion parameters in *.cam files will accurately reflect the same distortion as in COLMAP.

If both of the two exported radial distortion parameters in a *.cam file are non-zero, then they are used in a distortion model very similar to the COLMAP and Bundler distortion models. However, if only the second parameter is non-zero, then a different camera model (similar to VisualSFM) is assumed for *.cam files.