### PR TITLE
Backwards compatibility of model_aligner

### DIFF
--- a/src/exe/model.cc
+++ b/src/exe/model.cc
@@ -199,7 +199,7 @@ int RunModelAligner(int argc, char** argv) {
   std::string database_path;
   std::string ref_images_path;
   std::string transform_path;
-  std::string alignment_type = "plane";
+  std::string alignment_type = "custom";
   int min_common_images = 3;
   bool robust_alignment = true;
   bool estimate_scale = true;


### PR DESCRIPTION
In previous versions of Colmap, the `model_aligner` would align a 3D model to a set of camera poses. In this version, not setting the `alignment_type` option defaults to aligning the model with the dominant plane, which is not the behavior users would expect given previous versions (see #1239 ). I suggest to keep backwards compatibility by keeping the original behavior as the default.