### PR TITLE
Compute reprojection error in generalized absolute solver

### DIFF
--- a/src/estimators/generalized_absolute_pose.cc
+++ b/src/estimators/generalized_absolute_pose.cc
@@ -314,11 +314,19 @@ void GP3PEstimator::Residuals(const std::vector<X_t>& points2D,
 
       const double x_0 = points2D[i].xy(0);
       const double x_1 = points2D[i].xy(1);
-      const double inv_x_norm = 1 / std::sqrt(x_0 * x_0 + x_1 * x_1 + 1);
 
-      const double cosine_dist =
-          1 - inv_pcx_norm * inv_x_norm * (pcx_0 * x_0 + pcx_1 * x_1 + pcx_2);
-      (*residuals)[i] = cosine_dist * cosine_dist;
+      if (do_cosine_similarity) {
+        const double inv_x_norm = 1 / std::sqrt(x_0 * x_0 + x_1 * x_1 + 1);
+        const double cosine_dist =
+            1 - inv_pcx_norm * inv_x_norm * (pcx_0 * x_0 + pcx_1 * x_1 + pcx_2);
+        (*residuals)[i] = cosine_dist * cosine_dist;
+      } else {
+        const double inv_pcx_2 = 1.0 / pcx_2;
+        const double dx_0 = x_0 - pcx_0 * inv_pcx_2;
+        const double dx_1 = x_1 - pcx_1 * inv_pcx_2;
+        const double reproj_error = dx_0 * dx_0 + dx_1 * dx_1;
+        (*residuals)[i] = reproj_error;
+    }
 
     } else {
       (*residuals)[i] = std::numeric_limits<double>::max();

--- a/src/estimators/generalized_absolute_pose.cc
+++ b/src/estimators/generalized_absolute_pose.cc
@@ -315,19 +315,20 @@ void GP3PEstimator::Residuals(const std::vector<X_t>& points2D,
       const double x_0 = points2D[i].xy(0);
       const double x_1 = points2D[i].xy(1);
 
-      if (do_cosine_similarity) {
+      if (residual_type == ResidualType::CosineDistance) {
         const double inv_x_norm = 1 / std::sqrt(x_0 * x_0 + x_1 * x_1 + 1);
         const double cosine_dist =
             1 - inv_pcx_norm * inv_x_norm * (pcx_0 * x_0 + pcx_1 * x_1 + pcx_2);
         (*residuals)[i] = cosine_dist * cosine_dist;
-      } else {
+      } else if (residual_type == ResidualType::ReprojectionError) {
         const double inv_pcx_2 = 1.0 / pcx_2;
         const double dx_0 = x_0 - pcx_0 * inv_pcx_2;
         const double dx_1 = x_1 - pcx_1 * inv_pcx_2;
         const double reproj_error = dx_0 * dx_0 + dx_1 * dx_1;
         (*residuals)[i] = reproj_error;
-    }
-
+      } else {
+         LOG(FATAL) << "Invalid residual type";
+      }
     } else {
       (*residuals)[i] = std::numeric_limits<double>::max();
     }

--- a/src/estimators/generalized_absolute_pose.h
+++ b/src/estimators/generalized_absolute_pose.h
@@ -70,6 +70,9 @@ class GP3PEstimator {
   static const int kMinNumSamples = 3;
 
   // Whether to compute the cosine similarity or the reprojection error.
+  // [WARNING] The reprojection error being in normalized coordinates,
+  // the unique error threshold of RANSAC corresponds to different pixel values
+  // in the different cameras of the rig if they have different intrinsics.
   bool do_cosine_similarity = true;
 
   // Estimate the most probable solution of the GP3P problem from a set of

--- a/src/estimators/generalized_absolute_pose.h
+++ b/src/estimators/generalized_absolute_pose.h
@@ -69,11 +69,16 @@ class GP3PEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 3;
 
+  enum class ResidualType {
+    CosineDistance,
+    ReprojectionError,
+  };
+
   // Whether to compute the cosine similarity or the reprojection error.
   // [WARNING] The reprojection error being in normalized coordinates,
   // the unique error threshold of RANSAC corresponds to different pixel values
   // in the different cameras of the rig if they have different intrinsics.
-  bool do_cosine_similarity = true;
+  ResidualType residual_type = ResidualType::CosineDistance;
 
   // Estimate the most probable solution of the GP3P problem from a set of
   // three 2D-3D point correspondences.

--- a/src/estimators/generalized_absolute_pose.h
+++ b/src/estimators/generalized_absolute_pose.h
@@ -81,8 +81,8 @@ class GP3PEstimator {
   // 2D-3D point correspondences and a projection matrix of the generalized
   // camera.
   void Residuals(const std::vector<X_t>& points2D,
-                        const std::vector<Y_t>& points3D,
-                        const M_t& proj_matrix, std::vector<double>* residuals);
+                 const std::vector<Y_t>& points3D,
+                 const M_t& proj_matrix, std::vector<double>* residuals);
 };
 
 }  // namespace colmap

--- a/src/estimators/generalized_absolute_pose.h
+++ b/src/estimators/generalized_absolute_pose.h
@@ -69,6 +69,9 @@ class GP3PEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 3;
 
+  // Whether to compute the cosine similarity or the reprojection error.
+  bool do_cosine_similarity = true;
+
   // Estimate the most probable solution of the GP3P problem from a set of
   // three 2D-3D point correspondences.
   static std::vector<M_t> Estimate(const std::vector<X_t>& points2D,
@@ -77,7 +80,7 @@ class GP3PEstimator {
   // Calculate the squared cosine distance error between the rays given a set of
   // 2D-3D point correspondences and a projection matrix of the generalized
   // camera.
-  static void Residuals(const std::vector<X_t>& points2D,
+  void Residuals(const std::vector<X_t>& points2D,
                         const std::vector<Y_t>& points3D,
                         const M_t& proj_matrix, std::vector<double>* residuals);
 };

--- a/src/estimators/generalized_absolute_pose_test.cc
+++ b/src/estimators/generalized_absolute_pose_test.cc
@@ -113,14 +113,14 @@ BOOST_AUTO_TEST_CASE(Estimate) {
 
       // Test residuals of exact points.
       std::vector<double> residuals;
-      GP3PEstimator::Residuals(points2D, points3D, report.model, &residuals);
+      ransac.estimator.Residuals(points2D, points3D, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         BOOST_CHECK(residuals[i] < 1e-10);
       }
 
       // Test residuals of faulty points.
-      GP3PEstimator::Residuals(points2D, points3D_faulty, report.model,
-                               &residuals);
+      ransac.estimator.Residuals(points2D, points3D_faulty, report.model,
+                                 &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         BOOST_CHECK(residuals[i] > 1e-10);
       }


### PR DESCRIPTION
Currently the generalized absolute pose solver computes the squared cosine similarity:
https://github.com/colmap/colmap/blob/cf4a39cee879a1c1000bac7f92cdc024c4c4c523/src/estimators/generalized_absolute_pose.cc#L319-L321

This is not consistent with the single-camera solver, which uses the squared reprojection error, and makes it tricky to tune the RANSAC inlier threshold. This PR allows the GP3P solver to optionally instead compute the reprojection error.

Catch: in-class initialization of non-static data members requires C++>=11, but afaik COLMAP already assumed C++11.
@mihaidusmanu @ahojnnes @mgprt 