### PR TITLE
Add type hints and docstrings to python IO file

### DIFF
--- a/scripts/python/read_write_model.py
+++ b/scripts/python/read_write_model.py
@@ -105,8 +105,11 @@ def write_next_bytes(fid: BinaryIO, data: Any, format_char_sequence: str, endian
 
 def read_cameras_text(path: str) -> Dict[int, Camera]:
     """Read intrinsic parameters of reconstructed cameras from text file.
-
+    
     Ref: https://colmap.github.io/format.html#cameras-txt
+    see: src/base/reconstruction.cc
+        void Reconstruction::WriteCamerasText(const std::string& path)
+        void Reconstruction::ReadCamerasText(const std::string& path)
 
     Args:
         path: path to cameras.txt file.
@@ -136,7 +139,10 @@ def read_cameras_binary(path_to_model_file: str) -> Dict[int, Camera]:
     """Read intrinsic parameters of reconstructed cameras from binary file.
 
     Ref: https://colmap.github.io/format.html#cameras-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::WriteCamerasBinary(const std::string& path)
+        void Reconstruction::ReadCamerasBinary(const std::string& path)
+        
     Args:
         path_to_model_file: path to cameras.bin file.
 
@@ -166,7 +172,10 @@ def write_cameras_text(cameras: Dict[int, Camera], path: str) -> None:
     """Write intrinsic parameters of reconstructed cameras to text file.
 
     Ref: https://colmap.github.io/format.html#cameras-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::WriteCamerasText(const std::string& path)
+        void Reconstruction::ReadCamerasText(const std::string& path)
+        
     Args:
         cameras: Dictionary of Camera(s).
         path: path to text file.
@@ -188,7 +197,10 @@ def write_cameras_binary(cameras: Dict[int, Camera], path_to_model_file: str) ->
     """Write intrinsic parameters of reconstructed cameras to binary file.
 
     Ref: https://colmap.github.io/format.html#cameras-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::WriteCamerasBinary(const std::string& path)
+        void Reconstruction::ReadCamerasBinary(const std::string& path)
+        
     Args:
         cameras: Dictionary of Camera(s).
         path_to_model_file: path to binary file.
@@ -207,7 +219,10 @@ def read_images_text(path: str) -> Dict[int, Image]:
     """Read pose and keypoints of all reconstructed images from text file.
 
     Ref: https://colmap.github.io/format.html#images-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadImagesText(const std::string& path)
+        void Reconstruction::WriteImagesText(const std::string& path)
+        
     Args:
         path: path to images.txt file.
 
@@ -249,7 +264,10 @@ def read_images_binary(path_to_model_file: str) -> Dict[int, Image]:
     Refs:
     - https://colmap.github.io/format.html#images-txt
     - https://colmap.github.io/format.html#binary-file-format
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadImagesBinary(const std::string& path)
+        void Reconstruction::WriteImagesBinary(const std::string& path)
+        
     Args:
         path_to_model_file: path to images.txt file.
 
@@ -290,7 +308,10 @@ def write_images_text(images: Dict[int, Image], path: str) -> None:
     """Write pose and keypoints of all reconstructed images to text file.
 
     Ref: https://colmap.github.io/format.html#images-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadImagesText(const std::string& path)
+        void Reconstruction::WriteImagesText(const std::string& path)
+        
     Args:
         images: Dictionary of Image(s) to write.
         path: file path to write data.
@@ -325,7 +346,10 @@ def write_images_binary(images, path_to_model_file):
     Refs:
     - https://colmap.github.io/format.html#images-txt
     - https://colmap.github.io/format.html#binary-file-format
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadImagesBinary(const std::string& path)
+        void Reconstruction::WriteImagesBinary(const std::string& path)
+        
     Args:
         images: Dictionary of Image(s) to write.
         path_to_model_file: file path to write data.
@@ -349,7 +373,10 @@ def read_points3D_text(path: str) -> Dict[int, Point3D]:
     """Read information of all reconstructed 3D points from text file.
 
     Ref: https://colmap.github.io/format.html#points3d-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadPoints3DText(const std::string& path)
+        void Reconstruction::WritePoints3DText(const std::string& path)
+        
     Args:
         path: path to points3d.txt file.
 
@@ -383,7 +410,10 @@ def read_points3D_binary(path_to_model_file: str) -> Dict[int, Point3D]:
     Refs:
     - https://colmap.github.io/format.html#points3d-txt
     - https://colmap.github.io/format.html#binary-file-format
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadPoints3DBinary(const std::string& path)
+        void Reconstruction::WritePoints3DBinary(const std::string& path)
+        
     Args:
         path_to_model_file: path to points3d.bin file.
 
@@ -413,7 +443,10 @@ def write_points3D_text(points3D: Dict[int, Point3D], path: str) -> None:
     """Write information of all reconstructed 3D points to text file.
 
     Ref: https://colmap.github.io/format.html#points3d-txt
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadPoints3DText(const std::string& path)
+        void Reconstruction::WritePoints3DText(const std::string& path)
+        
     Args:
         points3D: Dictionary of Point3D(s) to write.
         path: file path to write data.
@@ -445,7 +478,10 @@ def write_points3D_binary(points3D: Dict[int, Point3D], path_to_model_file: str)
     Refs:
     - https://colmap.github.io/format.html#points3d-txt
     - https://colmap.github.io/format.html#binary-file-format
-
+    see: src/base/reconstruction.cc
+        void Reconstruction::ReadPoints3DBinary(const std::string& path)
+        void Reconstruction::WritePoints3DBinary(const std::string& path)
+        
     Args:
         points3D: Dictionary of Point3D(s) to write.
         path_to_model_file: file path to write data.

--- a/scripts/python/read_write_model.py
+++ b/scripts/python/read_write_model.py
@@ -31,23 +31,24 @@
 
 import os
 import collections
-import numpy as np
 import struct
 import argparse
+from typing import Dict, Tuple, Any, BinaryIO
+
+import numpy as np
 
 
-CameraModel = collections.namedtuple(
-    "CameraModel", ["model_id", "model_name", "num_params"])
-Camera = collections.namedtuple(
-    "Camera", ["id", "model", "width", "height", "params"])
-BaseImage = collections.namedtuple(
-    "Image", ["id", "qvec", "tvec", "camera_id", "name", "xys", "point3D_ids"])
-Point3D = collections.namedtuple(
-    "Point3D", ["id", "xyz", "rgb", "error", "image_ids", "point2D_idxs"])
+CameraModel = collections.namedtuple("CameraModel", ["model_id", "model_name", "num_params"])
+Camera = collections.namedtuple("Camera", ["id", "model", "width", "height", "params"])
+BaseImage = collections.namedtuple("BaseImage", ["id", "qvec", "tvec", "camera_id", "name", "xys", "point3D_ids"])
+Point3D = collections.namedtuple("Point3D", ["id", "xyz", "rgb", "error", "image_ids", "point2D_idxs"])
 
 
 class Image(BaseImage):
+    """Class for relevant image data."""
+
     def qvec2rotmat(self):
+        """Convert quaternion to rotation matrix."""
         return qvec2rotmat(self.qvec)
 
 
@@ -62,34 +63,38 @@ CAMERA_MODELS = {
     CameraModel(model_id=7, model_name="FOV", num_params=5),
     CameraModel(model_id=8, model_name="SIMPLE_RADIAL_FISHEYE", num_params=4),
     CameraModel(model_id=9, model_name="RADIAL_FISHEYE", num_params=5),
-    CameraModel(model_id=10, model_name="THIN_PRISM_FISHEYE", num_params=12)
+    CameraModel(model_id=10, model_name="THIN_PRISM_FISHEYE", num_params=12),
 }
-CAMERA_MODEL_IDS = dict([(camera_model.model_id, camera_model)
-                         for camera_model in CAMERA_MODELS])
-CAMERA_MODEL_NAMES = dict([(camera_model.model_name, camera_model)
-                           for camera_model in CAMERA_MODELS])
+CAMERA_MODEL_IDS = dict([(camera_model.model_id, camera_model) for camera_model in CAMERA_MODELS])
+CAMERA_MODEL_NAMES = dict([(camera_model.model_name, camera_model) for camera_model in CAMERA_MODELS])
 
 
-def read_next_bytes(fid, num_bytes, format_char_sequence, endian_character="<"):
+def read_next_bytes(fid: BinaryIO, num_bytes: int, format_char_sequence: str, endian_character: str = "<") -> Tuple:
     """Read and unpack the next bytes from a binary file.
-    :param fid:
-    :param num_bytes: Sum of combination of {2, 4, 8}, e.g. 2, 6, 16, 30, etc.
-    :param format_char_sequence: List of {c, e, f, d, h, H, i, I, l, L, q, Q}.
-    :param endian_character: Any of {@, =, <, >, !}
-    :return: Tuple of read and unpacked values.
+
+    Args:
+        fid: file handle.
+        num_bytes: Sum of combination of {2, 4, 8}, e.g. 2, 6, 16, 30, etc.
+        format_char_sequence: List of {c, e, f, d, h, H, i, I, l, L, q, Q}.
+        endian_character: Any of {@, =, <, >, !}
+
+    Returns:
+        Tuple of read and unpacked values.
     """
     data = fid.read(num_bytes)
     return struct.unpack(endian_character + format_char_sequence, data)
 
 
-def write_next_bytes(fid, data, format_char_sequence, endian_character="<"):
-    """pack and write to a binary file.
-    :param fid:
-    :param data: data to send, if multiple elements are sent at the same time,
-    they should be encapsuled either in a list or a tuple
-    :param format_char_sequence: List of {c, e, f, d, h, H, i, I, l, L, q, Q}.
-    should be the same length as the data list or tuple
-    :param endian_character: Any of {@, =, <, >, !}
+def write_next_bytes(fid: BinaryIO, data: Any, format_char_sequence: str, endian_character="<") -> None:
+    """Pack and write to a binary file.
+
+    Args:
+        fid: file handle.
+        data: data to send, if multiple elements are sent at the same time,
+            they should be encapsuled either in a list or a tuple
+        format_char_sequence: List of {c, e, f, d, h, H, i, I, l, L, q, Q}.
+            should be the same length as the data list or tuple
+        endian_character: Any of {@, =, <, >, !}
     """
     if isinstance(data, (list, tuple)):
         bytes = struct.pack(endian_character + format_char_sequence, *data)
@@ -98,11 +103,16 @@ def write_next_bytes(fid, data, format_char_sequence, endian_character="<"):
     fid.write(bytes)
 
 
-def read_cameras_text(path):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::WriteCamerasText(const std::string& path)
-        void Reconstruction::ReadCamerasText(const std::string& path)
+def read_cameras_text(path: str) -> Dict[int, Camera]:
+    """Read intrinsic parameters of reconstructed cameras from text file.
+
+    Ref: https://colmap.github.io/format.html#cameras-txt
+
+    Args:
+        path: path to cameras.txt file.
+
+    Returns:
+        Dictionary of Camera objects referenced by (possibly noncontiguous) IDs.
     """
     cameras = {}
     with open(path, "r") as fid:
@@ -118,50 +128,54 @@ def read_cameras_text(path):
                 width = int(elems[2])
                 height = int(elems[3])
                 params = np.array(tuple(map(float, elems[4:])))
-                cameras[camera_id] = Camera(id=camera_id, model=model,
-                                            width=width, height=height,
-                                            params=params)
+                cameras[camera_id] = Camera(id=camera_id, model=model, width=width, height=height, params=params)
     return cameras
 
 
-def read_cameras_binary(path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::WriteCamerasBinary(const std::string& path)
-        void Reconstruction::ReadCamerasBinary(const std::string& path)
+def read_cameras_binary(path_to_model_file: str) -> Dict[int, Camera]:
+    """Read intrinsic parameters of reconstructed cameras from binary file.
+
+    Ref: https://colmap.github.io/format.html#cameras-txt
+
+    Args:
+        path_to_model_file: path to cameras.bin file.
+
+    Returns:
+        Dictionary of Camera objects referenced by (possibly noncontiguous) IDs.
     """
     cameras = {}
     with open(path_to_model_file, "rb") as fid:
         num_cameras = read_next_bytes(fid, 8, "Q")[0]
         for _ in range(num_cameras):
-            camera_properties = read_next_bytes(
-                fid, num_bytes=24, format_char_sequence="iiQQ")
+            camera_properties = read_next_bytes(fid, num_bytes=24, format_char_sequence="iiQQ")
             camera_id = camera_properties[0]
             model_id = camera_properties[1]
             model_name = CAMERA_MODEL_IDS[camera_properties[1]].model_name
             width = camera_properties[2]
             height = camera_properties[3]
             num_params = CAMERA_MODEL_IDS[model_id].num_params
-            params = read_next_bytes(fid, num_bytes=8*num_params,
-                                     format_char_sequence="d"*num_params)
-            cameras[camera_id] = Camera(id=camera_id,
-                                        model=model_name,
-                                        width=width,
-                                        height=height,
-                                        params=np.array(params))
+            params = read_next_bytes(fid, num_bytes=8 * num_params, format_char_sequence="d" * num_params)
+            cameras[camera_id] = Camera(
+                id=camera_id, model=model_name, width=width, height=height, params=np.array(params)
+            )
         assert len(cameras) == num_cameras
     return cameras
 
 
-def write_cameras_text(cameras, path):
+def write_cameras_text(cameras: Dict[int, Camera], path: str) -> None:
+    """Write intrinsic parameters of reconstructed cameras to text file.
+
+    Ref: https://colmap.github.io/format.html#cameras-txt
+
+    Args:
+        cameras: Dictionary of Camera(s).
+        path: path to text file.
     """
-    see: src/base/reconstruction.cc
-        void Reconstruction::WriteCamerasText(const std::string& path)
-        void Reconstruction::ReadCamerasText(const std::string& path)
-    """
-    HEADER = "# Camera list with one line of data per camera:\n" + \
-             "#   CAMERA_ID, MODEL, WIDTH, HEIGHT, PARAMS[]\n" + \
-             "# Number of cameras: {}\n".format(len(cameras))
+    HEADER = (
+        "# Camera list with one line of data per camera:\n"
+        + "#   CAMERA_ID, MODEL, WIDTH, HEIGHT, PARAMS[]\n"
+        + "# Number of cameras: {}\n".format(len(cameras))
+    )
     with open(path, "w") as fid:
         fid.write(HEADER)
         for _, cam in cameras.items():
@@ -170,31 +184,35 @@ def write_cameras_text(cameras, path):
             fid.write(line + "\n")
 
 
-def write_cameras_binary(cameras, path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::WriteCamerasBinary(const std::string& path)
-        void Reconstruction::ReadCamerasBinary(const std::string& path)
+def write_cameras_binary(cameras: Dict[int, Camera], path_to_model_file: str) -> None:
+    """Write intrinsic parameters of reconstructed cameras to binary file.
+
+    Ref: https://colmap.github.io/format.html#cameras-txt
+
+    Args:
+        cameras: Dictionary of Camera(s).
+        path_to_model_file: path to binary file.
     """
     with open(path_to_model_file, "wb") as fid:
         write_next_bytes(fid, len(cameras), "Q")
         for _, cam in cameras.items():
             model_id = CAMERA_MODEL_NAMES[cam.model].model_id
-            camera_properties = [cam.id,
-                                 model_id,
-                                 cam.width,
-                                 cam.height]
+            camera_properties = [cam.id, model_id, cam.width, cam.height]
             write_next_bytes(fid, camera_properties, "iiQQ")
             for p in cam.params:
                 write_next_bytes(fid, float(p), "d")
-    return cameras
 
 
-def read_images_text(path):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadImagesText(const std::string& path)
-        void Reconstruction::WriteImagesText(const std::string& path)
+def read_images_text(path: str) -> Dict[int, Image]:
+    """Read pose and keypoints of all reconstructed images from text file.
+
+    Ref: https://colmap.github.io/format.html#images-txt
+
+    Args:
+        path: path to images.txt file.
+
+    Returns:
+        Dictionary of Image objects referenced by (possibly noncontiguous) IDs.
     """
     images = {}
     with open(path, "r") as fid:
@@ -211,65 +229,82 @@ def read_images_text(path):
                 camera_id = int(elems[8])
                 image_name = elems[9]
                 elems = fid.readline().split()
-                xys = np.column_stack([tuple(map(float, elems[0::3])),
-                                       tuple(map(float, elems[1::3]))])
+                xys = np.column_stack([tuple(map(float, elems[0::3])), tuple(map(float, elems[1::3]))])
                 point3D_ids = np.array(tuple(map(int, elems[2::3])))
                 images[image_id] = Image(
-                    id=image_id, qvec=qvec, tvec=tvec,
-                    camera_id=camera_id, name=image_name,
-                    xys=xys, point3D_ids=point3D_ids)
+                    id=image_id,
+                    qvec=qvec,
+                    tvec=tvec,
+                    camera_id=camera_id,
+                    name=image_name,
+                    xys=xys,
+                    point3D_ids=point3D_ids,
+                )
     return images
 
 
-def read_images_binary(path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadImagesBinary(const std::string& path)
-        void Reconstruction::WriteImagesBinary(const std::string& path)
+def read_images_binary(path_to_model_file: str) -> Dict[int, Image]:
+    """Read pose and keypoints of all reconstructed images from binary file.
+
+    Refs:
+    - https://colmap.github.io/format.html#images-txt
+    - https://colmap.github.io/format.html#binary-file-format
+
+    Args:
+        path_to_model_file: path to images.txt file.
+
+    Returns:
+        Dictionary of Image objects referenced by (possibly noncontiguous) IDs.
     """
     images = {}
     with open(path_to_model_file, "rb") as fid:
         num_reg_images = read_next_bytes(fid, 8, "Q")[0]
         for _ in range(num_reg_images):
-            binary_image_properties = read_next_bytes(
-                fid, num_bytes=64, format_char_sequence="idddddddi")
+            binary_image_properties = read_next_bytes(fid, num_bytes=64, format_char_sequence="idddddddi")
             image_id = binary_image_properties[0]
             qvec = np.array(binary_image_properties[1:5])
             tvec = np.array(binary_image_properties[5:8])
             camera_id = binary_image_properties[8]
             image_name = ""
             current_char = read_next_bytes(fid, 1, "c")[0]
-            while current_char != b"\x00":   # look for the ASCII 0 entry
+            while current_char != b"\x00":  # look for the ASCII 0 entry
                 image_name += current_char.decode("utf-8")
                 current_char = read_next_bytes(fid, 1, "c")[0]
-            num_points2D = read_next_bytes(fid, num_bytes=8,
-                                           format_char_sequence="Q")[0]
-            x_y_id_s = read_next_bytes(fid, num_bytes=24*num_points2D,
-                                       format_char_sequence="ddq"*num_points2D)
-            xys = np.column_stack([tuple(map(float, x_y_id_s[0::3])),
-                                   tuple(map(float, x_y_id_s[1::3]))])
+            num_points2D = read_next_bytes(fid, num_bytes=8, format_char_sequence="Q")[0]
+            x_y_id_s = read_next_bytes(fid, num_bytes=24 * num_points2D, format_char_sequence="ddq" * num_points2D)
+            xys = np.column_stack([tuple(map(float, x_y_id_s[0::3])), tuple(map(float, x_y_id_s[1::3]))])
             point3D_ids = np.array(tuple(map(int, x_y_id_s[2::3])))
             images[image_id] = Image(
-                id=image_id, qvec=qvec, tvec=tvec,
-                camera_id=camera_id, name=image_name,
-                xys=xys, point3D_ids=point3D_ids)
+                id=image_id,
+                qvec=qvec,
+                tvec=tvec,
+                camera_id=camera_id,
+                name=image_name,
+                xys=xys,
+                point3D_ids=point3D_ids,
+            )
     return images
 
 
-def write_images_text(images, path):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadImagesText(const std::string& path)
-        void Reconstruction::WriteImagesText(const std::string& path)
+def write_images_text(images: Dict[int, Image], path: str) -> None:
+    """Write pose and keypoints of all reconstructed images to text file.
+
+    Ref: https://colmap.github.io/format.html#images-txt
+
+    Args:
+        images: Dictionary of Image(s) to write.
+        path: file path to write data.
     """
     if len(images) == 0:
         mean_observations = 0
     else:
-        mean_observations = sum((len(img.point3D_ids) for _, img in images.items()))/len(images)
-    HEADER = "# Image list with two lines of data per image:\n" + \
-             "#   IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME\n" + \
-             "#   POINTS2D[] as (X, Y, POINT3D_ID)\n" + \
-             "# Number of images: {}, mean observations per image: {}\n".format(len(images), mean_observations)
+        mean_observations = sum((len(img.point3D_ids) for _, img in images.items())) / len(images)
+    HEADER = (
+        "# Image list with two lines of data per image:\n"
+        + "#   IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME\n"
+        + "#   POINTS2D[] as (X, Y, POINT3D_ID)\n"
+        + "# Number of images: {}, mean observations per image: {}\n".format(len(images), mean_observations)
+    )
 
     with open(path, "w") as fid:
         fid.write(HEADER)
@@ -285,10 +320,15 @@ def write_images_text(images, path):
 
 
 def write_images_binary(images, path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadImagesBinary(const std::string& path)
-        void Reconstruction::WriteImagesBinary(const std::string& path)
+    """Write pose and keypoints of all reconstructed images to binary file.
+
+    Refs:
+    - https://colmap.github.io/format.html#images-txt
+    - https://colmap.github.io/format.html#binary-file-format
+
+    Args:
+        images: Dictionary of Image(s) to write.
+        path_to_model_file: file path to write data.
     """
     with open(path_to_model_file, "wb") as fid:
         write_next_bytes(fid, len(images), "Q")
@@ -305,11 +345,16 @@ def write_images_binary(images, path_to_model_file):
                 write_next_bytes(fid, [*xy, p3d_id], "ddq")
 
 
-def read_points3D_text(path):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadPoints3DText(const std::string& path)
-        void Reconstruction::WritePoints3DText(const std::string& path)
+def read_points3D_text(path: str) -> Dict[int, Point3D]:
+    """Read information of all reconstructed 3D points from text file.
+
+    Ref: https://colmap.github.io/format.html#points3d-txt
+
+    Args:
+        path: path to points3d.txt file.
+
+    Returns:
+        Dictionary of Point3D objects referenced by (possibly noncontiguous) IDs.
     """
     points3D = {}
     with open(path, "r") as fid:
@@ -326,55 +371,62 @@ def read_points3D_text(path):
                 error = float(elems[7])
                 image_ids = np.array(tuple(map(int, elems[8::2])))
                 point2D_idxs = np.array(tuple(map(int, elems[9::2])))
-                points3D[point3D_id] = Point3D(id=point3D_id, xyz=xyz, rgb=rgb,
-                                               error=error, image_ids=image_ids,
-                                               point2D_idxs=point2D_idxs)
+                points3D[point3D_id] = Point3D(
+                    id=point3D_id, xyz=xyz, rgb=rgb, error=error, image_ids=image_ids, point2D_idxs=point2D_idxs
+                )
     return points3D
 
 
-def read_points3D_binary(path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadPoints3DBinary(const std::string& path)
-        void Reconstruction::WritePoints3DBinary(const std::string& path)
+def read_points3D_binary(path_to_model_file: str) -> Dict[int, Point3D]:
+    """Read information of all reconstructed 3D points from binary file.
+
+    Refs:
+    - https://colmap.github.io/format.html#points3d-txt
+    - https://colmap.github.io/format.html#binary-file-format
+
+    Args:
+        path_to_model_file: path to points3d.bin file.
+
+    Returns:
+        Dictionary of Point3D objects referenced by (possibly noncontiguous) IDs.
     """
     points3D = {}
     with open(path_to_model_file, "rb") as fid:
         num_points = read_next_bytes(fid, 8, "Q")[0]
         for _ in range(num_points):
-            binary_point_line_properties = read_next_bytes(
-                fid, num_bytes=43, format_char_sequence="QdddBBBd")
+            binary_point_line_properties = read_next_bytes(fid, num_bytes=43, format_char_sequence="QdddBBBd")
             point3D_id = binary_point_line_properties[0]
             xyz = np.array(binary_point_line_properties[1:4])
             rgb = np.array(binary_point_line_properties[4:7])
             error = np.array(binary_point_line_properties[7])
-            track_length = read_next_bytes(
-                fid, num_bytes=8, format_char_sequence="Q")[0]
-            track_elems = read_next_bytes(
-                fid, num_bytes=8*track_length,
-                format_char_sequence="ii"*track_length)
+            track_length = read_next_bytes(fid, num_bytes=8, format_char_sequence="Q")[0]
+            track_elems = read_next_bytes(fid, num_bytes=8 * track_length, format_char_sequence="ii" * track_length)
             image_ids = np.array(tuple(map(int, track_elems[0::2])))
             point2D_idxs = np.array(tuple(map(int, track_elems[1::2])))
             points3D[point3D_id] = Point3D(
-                id=point3D_id, xyz=xyz, rgb=rgb,
-                error=error, image_ids=image_ids,
-                point2D_idxs=point2D_idxs)
+                id=point3D_id, xyz=xyz, rgb=rgb, error=error, image_ids=image_ids, point2D_idxs=point2D_idxs
+            )
     return points3D
 
 
-def write_points3D_text(points3D, path):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadPoints3DText(const std::string& path)
-        void Reconstruction::WritePoints3DText(const std::string& path)
+def write_points3D_text(points3D: Dict[int, Point3D], path: str) -> None:
+    """Write information of all reconstructed 3D points to text file.
+
+    Ref: https://colmap.github.io/format.html#points3d-txt
+
+    Args:
+        points3D: Dictionary of Point3D(s) to write.
+        path: file path to write data.
     """
     if len(points3D) == 0:
         mean_track_length = 0
     else:
-        mean_track_length = sum((len(pt.image_ids) for _, pt in points3D.items()))/len(points3D)
-    HEADER = "# 3D point list with one line of data per point:\n" + \
-             "#   POINT3D_ID, X, Y, Z, R, G, B, ERROR, TRACK[] as (IMAGE_ID, POINT2D_IDX)\n" + \
-             "# Number of points: {}, mean track length: {}\n".format(len(points3D), mean_track_length)
+        mean_track_length = sum((len(pt.image_ids) for _, pt in points3D.items())) / len(points3D)
+    HEADER = (
+        "# 3D point list with one line of data per point:\n"
+        + "#   POINT3D_ID, X, Y, Z, R, G, B, ERROR, TRACK[] as (IMAGE_ID, POINT2D_IDX)\n"
+        + "# Number of points: {}, mean track length: {}\n".format(len(points3D), mean_track_length)
+    )
 
     with open(path, "w") as fid:
         fid.write(HEADER)
@@ -387,11 +439,16 @@ def write_points3D_text(points3D, path):
             fid.write(" ".join(track_strings) + "\n")
 
 
-def write_points3D_binary(points3D, path_to_model_file):
-    """
-    see: src/base/reconstruction.cc
-        void Reconstruction::ReadPoints3DBinary(const std::string& path)
-        void Reconstruction::WritePoints3DBinary(const std::string& path)
+def write_points3D_binary(points3D: Dict[int, Point3D], path_to_model_file: str) -> None:
+    """Write information of all reconstructed 3D points to binary file.
+
+    Refs:
+    - https://colmap.github.io/format.html#points3d-txt
+    - https://colmap.github.io/format.html#binary-file-format
+
+    Args:
+        points3D: Dictionary of Point3D(s) to write.
+        path_to_model_file: file path to write data.
     """
     with open(path_to_model_file, "wb") as fid:
         write_next_bytes(fid, len(points3D), "Q")
@@ -406,17 +463,24 @@ def write_points3D_binary(points3D, path_to_model_file):
                 write_next_bytes(fid, [image_id, point2D_id], "ii")
 
 
-def detect_model_format(path, ext):
-    if os.path.isfile(os.path.join(path, "cameras"  + ext)) and \
-       os.path.isfile(os.path.join(path, "images"   + ext)) and \
-       os.path.isfile(os.path.join(path, "points3D" + ext)):
+def detect_model_format(path: str, ext: str) -> bool:
+    """Returns whether directory specified by `path` contains file with the extention `ext`."""
+    if (
+        os.path.isfile(os.path.join(path, "cameras" + ext))
+        and os.path.isfile(os.path.join(path, "images" + ext))
+        and os.path.isfile(os.path.join(path, "points3D" + ext))
+    ):
         print("Detected model format: '" + ext + "'")
         return True
 
     return False
 
 
-def read_model(path, ext=""):
+def read_model(path: str, ext: str = "") -> Tuple[Dict[int, Camera], Dict[int, Image], Dict[int, Point3D]]:
+    """Read model data.
+
+    Ref: https://colmap.github.io/format.html#
+    """
     # try to detect the extension automatically
     if ext == "":
         if detect_model_format(path, ".bin"):
@@ -424,8 +488,7 @@ def read_model(path, ext=""):
         elif detect_model_format(path, ".txt"):
             ext = ".txt"
         else:
-            print("Provide model format: '.bin' or '.txt'")
-            return
+            raise FileNotFoundError("Provide model format: '.bin' or '.txt'.")
 
     if ext == ".txt":
         cameras = read_cameras_text(os.path.join(path, "cameras" + ext))
@@ -438,7 +501,13 @@ def read_model(path, ext=""):
     return cameras, images, points3D
 
 
-def write_model(cameras, images, points3D, path, ext=".bin"):
+def write_model(
+    cameras: Dict[int, Camera], images: Dict[int, Image], points3D: Dict[int, Point3D], path: str, ext: str = ".bin"
+) -> None:
+    """Write model data.
+
+    Ref: https://colmap.github.io/format.html#
+    """
     if ext == ".txt":
         write_cameras_text(cameras, os.path.join(path, "cameras" + ext))
         write_images_text(images, os.path.join(path, "images" + ext))
@@ -447,29 +516,45 @@ def write_model(cameras, images, points3D, path, ext=".bin"):
         write_cameras_binary(cameras, os.path.join(path, "cameras" + ext))
         write_images_binary(images, os.path.join(path, "images" + ext))
         write_points3D_binary(points3D, os.path.join(path, "points3D") + ext)
-    return cameras, images, points3D
 
 
-def qvec2rotmat(qvec):
-    return np.array([
-        [1 - 2 * qvec[2]**2 - 2 * qvec[3]**2,
-         2 * qvec[1] * qvec[2] - 2 * qvec[0] * qvec[3],
-         2 * qvec[3] * qvec[1] + 2 * qvec[0] * qvec[2]],
-        [2 * qvec[1] * qvec[2] + 2 * qvec[0] * qvec[3],
-         1 - 2 * qvec[1]**2 - 2 * qvec[3]**2,
-         2 * qvec[2] * qvec[3] - 2 * qvec[0] * qvec[1]],
-        [2 * qvec[3] * qvec[1] - 2 * qvec[0] * qvec[2],
-         2 * qvec[2] * qvec[3] + 2 * qvec[0] * qvec[1],
-         1 - 2 * qvec[1]**2 - 2 * qvec[2]**2]])
+def qvec2rotmat(qvec: np.ndarray) -> np.ndarray:
+    """Converts unit quaternion to rotation matrix."""
+    return np.array(
+        [
+            [
+                1 - 2 * qvec[2] ** 2 - 2 * qvec[3] ** 2,
+                2 * qvec[1] * qvec[2] - 2 * qvec[0] * qvec[3],
+                2 * qvec[3] * qvec[1] + 2 * qvec[0] * qvec[2],
+            ],
+            [
+                2 * qvec[1] * qvec[2] + 2 * qvec[0] * qvec[3],
+                1 - 2 * qvec[1] ** 2 - 2 * qvec[3] ** 2,
+                2 * qvec[2] * qvec[3] - 2 * qvec[0] * qvec[1],
+            ],
+            [
+                2 * qvec[3] * qvec[1] - 2 * qvec[0] * qvec[2],
+                2 * qvec[2] * qvec[3] + 2 * qvec[0] * qvec[1],
+                1 - 2 * qvec[1] ** 2 - 2 * qvec[2] ** 2,
+            ],
+        ]
+    )
 
 
-def rotmat2qvec(R):
+def rotmat2qvec(R: np.ndarray) -> np.ndarray:
+    """Convert rotation matrix to unit quaternion."""
     Rxx, Ryx, Rzx, Rxy, Ryy, Rzy, Rxz, Ryz, Rzz = R.flat
-    K = np.array([
-        [Rxx - Ryy - Rzz, 0, 0, 0],
-        [Ryx + Rxy, Ryy - Rxx - Rzz, 0, 0],
-        [Rzx + Rxz, Rzy + Ryz, Rzz - Rxx - Ryy, 0],
-        [Ryz - Rzy, Rzx - Rxz, Rxy - Ryx, Rxx + Ryy + Rzz]]) / 3.0
+    K = (
+        np.array(
+            [
+                [Rxx - Ryy - Rzz, 0, 0, 0],
+                [Ryx + Rxy, Ryy - Rxx - Rzz, 0, 0],
+                [Rzx + Rxz, Rzy + Ryz, Rzz - Rxx - Ryy, 0],
+                [Ryz - Rzy, Rzx - Rxz, Rxy - Ryx, Rxx + Ryy + Rzz],
+            ]
+        )
+        / 3.0
+    )
     eigvals, eigvecs = np.linalg.eigh(K)
     qvec = eigvecs[[3, 0, 1, 2], np.argmax(eigvals)]
     if qvec[0] < 0:
@@ -478,14 +563,12 @@ def rotmat2qvec(R):
 
 
 def main():
+    """Program entrance."""
     parser = argparse.ArgumentParser(description="Read and write COLMAP binary and text models")
     parser.add_argument("--input_model", help="path to input model folder")
-    parser.add_argument("--input_format", choices=[".bin", ".txt"],
-                        help="input model format", default="")
-    parser.add_argument("--output_model",
-                        help="path to output model folder")
-    parser.add_argument("--output_format", choices=[".bin", ".txt"],
-                        help="outut model format", default=".txt")
+    parser.add_argument("--input_format", choices=[".bin", ".txt"], help="input model format", default="")
+    parser.add_argument("--output_model", help="path to output model folder")
+    parser.add_argument("--output_format", choices=[".bin", ".txt"], help="outut model format", default=".txt")
     args = parser.parse_args()
 
     cameras, images, points3D = read_model(path=args.input_model, ext=args.input_format)


### PR DESCRIPTION
Currently the `read_write_model.py` file is not very clear because the input and return types are not explained thoroughly. This PR updates the documentation for `scripts/python/read_write_model.py `.

- Reformatted docstrings to be consistent and in the google format (https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- Added type hints to improve readability.
- Reformatted code in the `python black` style for consistency.