### PR TITLE
Exposed descriptor normalization to command line.

### DIFF
--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -510,14 +510,10 @@ bool ExtractSiftFeaturesCPU(const SiftExtractionOptions& options,
           Eigen::MatrixXf desc(1, 128);
           vl_sift_calc_keypoint_descriptor(sift.get(), desc.data(),
                                            &vl_keypoints[i], angles[o]);
-          if (options.normalization ==
-              SiftExtractionOptions::Normalization::L2) {
-            desc = L2NormalizeFeatureDescriptors(desc);
-          } else if (options.normalization ==
-                     SiftExtractionOptions::Normalization::L1_ROOT) {
+          if (options.rootsift) {
             desc = L1RootNormalizeFeatureDescriptors(desc);
           } else {
-            LOG(FATAL) << "Normalization type not supported";
+            desc = L2NormalizeFeatureDescriptors(desc);
           }
 
           level_descriptors.back().row(level_idx) =
@@ -730,13 +726,10 @@ bool ExtractCovariantSiftFeaturesCPU(const SiftExtractionOptions& options,
         descriptor = scaled_descriptors;
       }
 
-      if (options.normalization == SiftExtractionOptions::Normalization::L2) {
-        descriptor = L2NormalizeFeatureDescriptors(descriptor);
-      } else if (options.normalization ==
-                 SiftExtractionOptions::Normalization::L1_ROOT) {
+      if (options.rootsift) {
         descriptor = L1RootNormalizeFeatureDescriptors(descriptor);
       } else {
-        LOG(FATAL) << "Normalization type not supported";
+        descriptor = L2NormalizeFeatureDescriptors(descriptor);
       }
 
       descriptors->row(i) = FeatureDescriptorsToUnsignedByte(descriptor);
@@ -889,13 +882,10 @@ bool ExtractSiftFeaturesGPU(const SiftExtractionOptions& options,
   }
 
   // Save and normalize the descriptors.
-  if (options.normalization == SiftExtractionOptions::Normalization::L2) {
-    descriptors_float = L2NormalizeFeatureDescriptors(descriptors_float);
-  } else if (options.normalization ==
-             SiftExtractionOptions::Normalization::L1_ROOT) {
+  if (options.rootsift) {
     descriptors_float = L1RootNormalizeFeatureDescriptors(descriptors_float);
   } else {
-    LOG(FATAL) << "Normalization type not supported";
+    descriptors_float = L2NormalizeFeatureDescriptors(descriptors_float);
   }
 
   *descriptors = FeatureDescriptorsToUnsignedByte(descriptors_float);

--- a/src/feature/sift.h
+++ b/src/feature/sift.h
@@ -83,6 +83,13 @@ struct SiftExtractionOptions {
   // Fix the orientation to 0 for upright features.
   bool upright = false;
 
+  // Whether to use RootSIFT descriptors.
+  // L1-normalizes each descriptor followed by element-wise square rooting.
+  // This normalization is usually better than standard L2-normalization.
+  // See "Three things everyone should know to improve object retrieval",
+  // Relja Arandjelovic and Andrew Zisserman, CVPR 2012.
+  bool rootsift = true;
+
   // Whether to adapt the feature detection depending on the image darkness.
   // Note that this feature is only available in the OpenGL SiftGPU version.
   bool darkness_adaptivity = false;
@@ -98,17 +105,6 @@ struct SiftExtractionOptions {
   double dsp_min_scale = 1.0 / 6.0;
   double dsp_max_scale = 3.0;
   int dsp_num_scales = 10;
-
-  enum class Normalization {
-    // L1-normalizes each descriptor followed by element-wise square rooting.
-    // This normalization is usually better than standard L2-normalization.
-    // See "Three things everyone should know to improve object retrieval",
-    // Relja Arandjelovic and Andrew Zisserman, CVPR 2012.
-    L1_ROOT,
-    // Each vector is L2-normalized.
-    L2,
-  };
-  Normalization normalization = Normalization::L1_ROOT;
 
   bool Check() const;
 };

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -277,6 +277,8 @@ void OptionManager::AddExtractionOptions() {
                               &sift_extraction->max_num_orientations);
   AddAndRegisterDefaultOption("SiftExtraction.upright",
                               &sift_extraction->upright);
+  AddAndRegisterDefaultOption("SiftExtraction.rootsift",
+                              &sift_extraction->rootsift);
   AddAndRegisterDefaultOption("SiftExtraction.domain_size_pooling",
                               &sift_extraction->domain_size_pooling);
   AddAndRegisterDefaultOption("SiftExtraction.dsp_min_scale",


### PR DESCRIPTION
This allows the user to choose between RootSIFT and SIFT descriptors directly from the command line without requiring to recompile from sources. This is useful for benchmarking purposes, but reduces the ease of adding new normalizations in the future. Not sure how to keep both, but I am open to suggestions :).