### PR TITLE
Add CUDA_SAFE_CALL to cudaGetDeviceCount.

### DIFF
--- a/src/util/cuda.cc
+++ b/src/util/cuda.cc
@@ -56,7 +56,7 @@ bool CompareCudaDevice(const cudaDeviceProp& d1, const cudaDeviceProp& d2) {
 
 int GetNumCudaDevices() {
   int num_cuda_devices;
-  cudaGetDeviceCount(&num_cuda_devices);
+  CUDA_SAFE_CALL(cudaGetDeviceCount(&num_cuda_devices));
   return num_cuda_devices;
 }
 


### PR DESCRIPTION
Otherwise if there's an error `GetNumCudaDevices` returns uninitialized memory.