### PR TITLE
Prevent a divide by zero corner case.

### DIFF
--- a/src/optim/ransac.h
+++ b/src/optim/ransac.h
@@ -170,6 +170,10 @@ size_t RANSAC<Estimator, SupportMeasurer, Sampler>::ComputeNumTrials(
   if (denom <= 0) {
     return 1;
   }
+  // Prevent divide by zero below.
+  if (denom == 1.0) {
+    return std::numeric_limits<size_t>::max();
+  }
 
   return static_cast<size_t>(
       std::ceil(std::log(nom) / std::log(denom) * num_trials_multiplier));


### PR DESCRIPTION
This was observed to lead to a SIGILL error. It could be due to num_inliers being zero, or that inlier_ration ^ kMinNumSamples being so small, that it flushes to zero.