### PR TITLE
Keep precision in the process of storing in text.

### DIFF
--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -1868,7 +1868,6 @@ void Reconstruction::WriteCamerasText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
-  file << std::fixed;
   file.precision(17);
 
   file << "# Camera list with one line of data per camera:" << std::endl;
@@ -1877,7 +1876,6 @@ void Reconstruction::WriteCamerasText(const std::string& path) const {
 
   for (const auto& camera : cameras_) {
     std::ostringstream line;
-    line << std::fixed;
     line.precision(17);
 
     line << camera.first << " ";
@@ -1901,7 +1899,6 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
-  file << std::fixed;
   file.precision(17);
 
   file << "# Image list with two lines of data per image:" << std::endl;
@@ -1919,7 +1916,6 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
     }
 
     std::ostringstream line;
-    line << std::fixed;
     line.precision(17);
 
     std::string line_string;
@@ -1948,7 +1944,6 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
     line.str("");
     line.clear();
 
-    line.precision(3);
     for (const Point2D& point2D : image.second.Points2D()) {
       line << point2D.X() << " ";
       line << point2D.Y() << " ";
@@ -1969,7 +1964,6 @@ void Reconstruction::WritePoints3DText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
-  file << std::fixed;
   file.precision(17);
 
   file << "# 3D point list with one line of data per point:" << std::endl;
@@ -1990,6 +1984,7 @@ void Reconstruction::WritePoints3DText(const std::string& path) const {
     file << point3D.second.Error() << " ";
 
     std::ostringstream line;
+    line.precision(17);
 
     for (const auto& track_el : point3D.second.Track().Elements()) {
       line << track_el.image_id << " ";

--- a/src/base/reconstruction.cc
+++ b/src/base/reconstruction.cc
@@ -1868,6 +1868,7 @@ void Reconstruction::WriteCamerasText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
+  file << std::fixed;
   file.precision(17);
 
   file << "# Camera list with one line of data per camera:" << std::endl;
@@ -1876,6 +1877,8 @@ void Reconstruction::WriteCamerasText(const std::string& path) const {
 
   for (const auto& camera : cameras_) {
     std::ostringstream line;
+    line << std::fixed;
+    line.precision(17);
 
     line << camera.first << " ";
     line << camera.second.ModelName() << " ";
@@ -1898,6 +1901,7 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
+  file << std::fixed;
   file.precision(17);
 
   file << "# Image list with two lines of data per image:" << std::endl;
@@ -1915,6 +1919,9 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
     }
 
     std::ostringstream line;
+    line << std::fixed;
+    line.precision(17);
+
     std::string line_string;
 
     line << image.first << " ";
@@ -1941,6 +1948,7 @@ void Reconstruction::WriteImagesText(const std::string& path) const {
     line.str("");
     line.clear();
 
+    line.precision(3);
     for (const Point2D& point2D : image.second.Points2D()) {
       line << point2D.X() << " ";
       line << point2D.Y() << " ";
@@ -1961,6 +1969,7 @@ void Reconstruction::WritePoints3DText(const std::string& path) const {
   CHECK(file.is_open()) << path;
 
   // Ensure that we don't loose any precision by storing in text.
+  file << std::fixed;
   file.precision(17);
 
   file << "# 3D point list with one line of data per point:" << std::endl;

--- a/src/exe/feature.cc
+++ b/src/exe/feature.cc
@@ -137,12 +137,15 @@ void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
 int RunFeatureExtractor(int argc, char** argv) {
   std::string image_list_path;
   int camera_mode = -1;
+  std::string descriptor_normalization = "l1_root";
 
   OptionManager options;
   options.AddDatabaseOptions();
   options.AddImageOptions();
   options.AddDefaultOption("camera_mode", &camera_mode);
   options.AddDefaultOption("image_list_path", &image_list_path);
+  options.AddDefaultOption("descriptor_normalization", &descriptor_normalization,
+                           "{'l1_root', 'l2'}");
   options.AddExtractionOptions();
   options.Parse(argc, argv);
 
@@ -153,6 +156,19 @@ int RunFeatureExtractor(int argc, char** argv) {
   if (camera_mode >= 0) {
     UpdateImageReaderOptionsFromCameraMode(reader_options,
                                            (CameraMode)camera_mode);
+  }
+
+  StringToLower(&descriptor_normalization);
+  if (descriptor_normalization == "l1_root") {
+    options.sift_extraction->normalization = 
+      SiftExtractionOptions::Normalization::L1_ROOT;
+  } else if (descriptor_normalization == "l2") {
+    options.sift_extraction->normalization = 
+      SiftExtractionOptions::Normalization::L2;
+  } else {
+    std::cerr << "ERROR: Invalid `descriptor_normalization`"
+              << std::endl;
+    return EXIT_FAILURE;
   }
 
   if (!image_list_path.empty()) {


### PR DESCRIPTION
When writing variables to std::ostringstream, we will loose precision of double variables if output manipulators were not applied.