### PR TITLE
Expose exe internals

### DIFF
--- a/src/exe/feature.cc
+++ b/src/exe/feature.cc
@@ -73,38 +73,7 @@ bool VerifySiftGPUParams(const bool use_gpu) {
   return true;
 }
 
-// This enum can be used as optional input for feature_extractor and
-// feature_importer to ensure that the camera flags of ImageReader are set in an
-// exclusive and unambigous way. The table below explains the corespondence of
-// each setting with the flags
-//
-// -----------------------------------------------------------------------------------
-// |            |                         ImageReaderOptions                         |
-// | CameraMode | single_camera | single_camera_per_folder | single_camera_per_image |
-// |------------|---------------|--------------------------|-------------------------|
-// | AUTO       | false         | false                    | false                   |
-// | SINGLE     | true          | false                    | false                   |
-// | PER_FOLDER | false         | true                     | false                   |
-// | PER_IMAGE  | false         | false                    | true                    |
-// -----------------------------------------------------------------------------------
-//
-// Note: When using AUTO mode a camera model will be uniquely identified by the
-// following 5 parameters from EXIF tags:
-// 1. Camera Make
-// 2. Camera Model
-// 3. Focal Length
-// 4. Image Width
-// 5. Image Height
-//
-// If any of the tags is missing then a camera model is considered invalid and a
-// new camera is created similar to the PER_IMAGE mode.
-//
-// If these considered fields are not sufficient to uniquely identify a camera
-// then using the AUTO mode will lead to incorrect setup for the cameras, e.g.
-// the same camera is used with same focal length but different principal point
-// between captures. In these cases it is recommended to either use the
-// PER_FOLDER or PER_IMAGE settings.
-enum class CameraMode { AUTO = 0, SINGLE = 1, PER_FOLDER = 2, PER_IMAGE = 3 };
+}  // namespace
 
 void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
                                             CameraMode mode) {
@@ -131,8 +100,6 @@ void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
       break;
   }
 }
-
-}  // namespace
 
 int RunFeatureExtractor(int argc, char** argv) {
   std::string image_list_path;

--- a/src/exe/feature.h
+++ b/src/exe/feature.h
@@ -29,7 +29,48 @@
 //
 // Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
 
+#ifndef COLMAP_SRC_EXE_FEATURE_H_
+#define COLMAP_SRC_EXE_FEATURE_H_
+
+#include "base/image_reader.h"
+
 namespace colmap {
+
+// This enum can be used as optional input for feature_extractor and
+// feature_importer to ensure that the camera flags of ImageReader are set in an
+// exclusive and unambigous way. The table below explains the corespondence of
+// each setting with the flags
+//
+// -----------------------------------------------------------------------------------
+// |            |                         ImageReaderOptions                         |
+// | CameraMode | single_camera | single_camera_per_folder | single_camera_per_image |
+// |------------|---------------|--------------------------|-------------------------|
+// | AUTO       | false         | false                    | false                   |
+// | SINGLE     | true          | false                    | false                   |
+// | PER_FOLDER | false         | true                     | false                   |
+// | PER_IMAGE  | false         | false                    | true                    |
+// -----------------------------------------------------------------------------------
+//
+// Note: When using AUTO mode a camera model will be uniquely identified by the
+// following 5 parameters from EXIF tags:
+// 1. Camera Make
+// 2. Camera Model
+// 3. Focal Length
+// 4. Image Width
+// 5. Image Height
+//
+// If any of the tags is missing then a camera model is considered invalid and a
+// new camera is created similar to the PER_IMAGE mode.
+//
+// If these considered fields are not sufficient to uniquely identify a camera
+// then using the AUTO mode will lead to incorrect setup for the cameras, e.g.
+// the same camera is used with same focal length but different principal point
+// between captures. In these cases it is recommended to either use the
+// PER_FOLDER or PER_IMAGE settings.
+enum class CameraMode { AUTO = 0, SINGLE = 1, PER_FOLDER = 2, PER_IMAGE = 3 };
+
+void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
+                                            CameraMode mode);
 
 int RunFeatureExtractor(int argc, char** argv);
 int RunFeatureImporter(int argc, char** argv);
@@ -41,3 +82,5 @@ int RunTransitiveMatcher(int argc, char** argv);
 int RunVocabTreeMatcher(int argc, char** argv);
 
 }  // namespace colmap
+
+#endif  // COLMAP_SRC_EXE_FEATURE_H_

--- a/src/exe/sfm.cc
+++ b/src/exe/sfm.cc
@@ -362,13 +362,22 @@ int RunPointTriangulator(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  const auto& mapper_options = *options.mapper;
-
   PrintHeading1("Loading model");
 
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
 
+  return RunPointTriangulatorImpl(
+      reconstruction, *options.database_path, *options.image_path, output_path,
+      *options.mapper, clear_points);
+}
+
+int RunPointTriangulatorImpl(Reconstruction& reconstruction,
+                             const std::string database_path,
+                             const std::string image_path,
+                             const std::string output_path,
+                             const IncrementalMapperOptions& mapper_options,
+                             const bool clear_points) {
   PrintHeading1("Loading database");
 
   DatabaseCache database_cache;
@@ -377,7 +386,7 @@ int RunPointTriangulator(int argc, char** argv) {
     Timer timer;
     timer.Start();
 
-    Database database(*options.database_path);
+    Database database(database_path);
 
     const size_t min_num_matches =
         static_cast<size_t>(mapper_options.min_num_matches);
@@ -476,7 +485,7 @@ int RunPointTriangulator(int argc, char** argv) {
   }
 
   PrintHeading1("Extracting colors");
-  reconstruction.ExtractColorsForAllImages(*options.image_path);
+  reconstruction.ExtractColorsForAllImages(image_path);
 
   const bool kDiscardReconstruction = false;
   mapper.EndReconstruction(kDiscardReconstruction);

--- a/src/exe/sfm.h
+++ b/src/exe/sfm.h
@@ -29,7 +29,20 @@
 //
 // Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
 
+#ifndef COLMAP_SRC_EXE_SFM_H_
+#define COLMAP_SRC_EXE_SFM_H_
+
+#include "base/reconstruction.h"
+#include "controllers/incremental_mapper.h"
+
 namespace colmap {
+
+int RunPointTriangulatorImpl(Reconstruction& reconstruction,
+                             const std::string database_path,
+                             const std::string image_path,
+                             const std::string output_path,
+                             const IncrementalMapperOptions& mapper_options,
+                             const bool clear_points);
 
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);
@@ -41,3 +54,5 @@ int RunPointTriangulator(int argc, char** argv);
 int RunRigBundleAdjuster(int argc, char** argv);
 
 }  // namespace colmap
+
+#endif  // COLMAP_SRC_EXE_SFM_H_


### PR DESCRIPTION
In pycolmap we now bind some of the exe functions like RunPointTriangulator. See [pycolmap/pipeline.cc](https://github.com/colmap/pycolmap/blob/master/pipeline.cc). We therefore need COLMAP to expose some exe code that is currently hidden in anonymous namespace or argc-argv functions. Most of this code is likely useful for others and worthy to be publicly exposed, but src/exe is probably not the right place for it.

Any advice on where these bits should be moved?

@ahojnnes @mihaidusmanu @Phil26AT