### PR TITLE
 Expose exe internals - fix

### DIFF
--- a/src/exe/CMakeLists.txt
+++ b/src/exe/CMakeLists.txt
@@ -46,3 +46,8 @@ COLMAP_ADD_EXECUTABLE(colmap_exe
     sfm.cc
     vocab_tree.cc)
 set_target_properties(colmap_exe PROPERTIES OUTPUT_NAME colmap)
+
+COLMAP_ADD_SOURCES(
+    feature.h feature.cc
+    sfm.h sfm.cc
+)


### PR DESCRIPTION
PR https://github.com/colmap/colmap/pull/1366 exposed some functions in src/exe but I forgot to include these files in the exported library.