### PR TITLE
Back to not taking EXIF orientation into account

### DIFF
--- a/src/base/cost_functions.h
+++ b/src/base/cost_functions.h
@@ -151,6 +151,62 @@ class BundleAdjustmentConstantPoseCostFunction {
   const double observed_y_;
 };
 
+// Standard bundle adjustment cost function for variable
+// camera pose and calibration and constant point parameters.
+template <typename CameraModel>
+class BundleAdjustmentConstantPoint3DCostFunction {
+ public:
+  explicit BundleAdjustmentConstantPoint3DCostFunction(
+      const Eigen::Vector2d& point2D, const Eigen::Vector3d& point3D)
+      : observed_x_(point2D(0)),
+        observed_y_(point2D(1)),
+        point3D_x_(point3D(0)),
+        point3D_y_(point3D(1)),
+        point3D_z_(point3D(2)) {}
+
+  static ceres::CostFunction* Create(const Eigen::Vector2d& point2D,
+                                     const Eigen::Vector3d& point3D) {
+    return (new ceres::AutoDiffCostFunction<
+            BundleAdjustmentConstantPoint3DCostFunction<CameraModel>, 2, 4, 3,
+            CameraModel::kNumParams>(
+        new BundleAdjustmentConstantPoint3DCostFunction(point2D, point3D)));
+  }
+
+  template <typename T>
+  bool operator()(const T* const qvec, const T* const tvec,
+                  const T* const camera_params, T* residuals) const {
+    const T point3D[3] = {T(point3D_x_), T(point3D_y_), T(point3D_z_)};
+
+    // Rotate and translate.
+    T projection[3];
+    ceres::UnitQuaternionRotatePoint(qvec, point3D, projection);
+    projection[0] += tvec[0];
+    projection[1] += tvec[1];
+    projection[2] += tvec[2];
+
+    // Project to image plane.
+    projection[0] /= projection[2];
+    projection[1] /= projection[2];
+
+    // Distort and transform to pixel space.
+    CameraModel::WorldToImage(camera_params, projection[0], projection[1],
+                              &residuals[0], &residuals[1]);
+
+    // Re-projection error.
+    residuals[0] -= T(observed_x_);
+    residuals[1] -= T(observed_y_);
+
+    return true;
+  }
+
+ private:
+  const double observed_x_;
+  const double observed_y_;
+  const double point3D_x_;
+  const double point3D_y_;
+  const double point3D_z_;
+};
+
 // Rig bundle adjustment cost function for variable camera pose and calibration
 // and point parameters. Different from the standard bundle adjustment function,
 // this cost function is suitable for camera rigs with consistent relative poses

--- a/src/base/cost_functions_test.cc
+++ b/src/base/cost_functions_test.cc
@@ -98,6 +98,42 @@ BOOST_AUTO_TEST_CASE(TestBundleAdjustmentConstantPoseCostFunction) {
   BOOST_CHECK_EQUAL(residuals[1], 2);
 }
 
+BOOST_AUTO_TEST_CASE(TestBundleAdjustmentConstantPoint3DCostFunction) {
+  ceres::CostFunction* cost_function1 =
+      BundleAdjustmentConstantPoint3DCostFunction<
+          SimplePinholeCameraModel>::Create(Eigen::Vector2d::Zero(),
+                                            Eigen::Vector3d(0, 0, 1));
+  double qvec[4] = {1, 0, 0, 0};
+  double tvec[3] = {0, 0, 0};
+  double camera_params[3] = {1, 0, 0};
+  double residuals[2];
+  const double* parameters[4] = {qvec, tvec, camera_params};
+  BOOST_CHECK(cost_function1->Evaluate(parameters, residuals, nullptr));
+  BOOST_CHECK_EQUAL(residuals[0], 0);
+  BOOST_CHECK_EQUAL(residuals[1], 0);
+
+  ceres::CostFunction* cost_function2 =
+      BundleAdjustmentConstantPoint3DCostFunction<
+          SimplePinholeCameraModel>::Create(Eigen::Vector2d::Zero(),
+                                            Eigen::Vector3d(0, 1, 1));
+  BOOST_CHECK(cost_function2->Evaluate(parameters, residuals, nullptr));
+  BOOST_CHECK_EQUAL(residuals[0], 0);
+  BOOST_CHECK_EQUAL(residuals[1], 1);
+
+  camera_params[0] = 2;
+  BOOST_CHECK(cost_function2->Evaluate(parameters, residuals, nullptr));
+  BOOST_CHECK_EQUAL(residuals[0], 0);
+  BOOST_CHECK_EQUAL(residuals[1], 2);
+
+  ceres::CostFunction* cost_function3 =
+      BundleAdjustmentConstantPoint3DCostFunction<
+          SimplePinholeCameraModel>::Create(Eigen::Vector2d::Zero(),
+                                            Eigen::Vector3d(-1, 1, 1));
+  BOOST_CHECK(cost_function3->Evaluate(parameters, residuals, nullptr));
+  BOOST_CHECK_EQUAL(residuals[0], -2);
+  BOOST_CHECK_EQUAL(residuals[1], 2);
+}
+
 BOOST_AUTO_TEST_CASE(TestRigBundleAdjustmentCostFunction) {
   std::unique_ptr<ceres::CostFunction> cost_function(
       RigBundleAdjustmentCostFunction<SimplePinholeCameraModel>::Create(

--- a/src/estimators/pose.cc
+++ b/src/estimators/pose.cc
@@ -208,12 +208,6 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
   ceres::LossFunction* loss_function =
       new ceres::CauchyLoss(options.loss_function_scale);
 
-  double* camera_params_data = camera->ParamsData();
-  double* qvec_data = qvec->data();
-  double* tvec_data = tvec->data();
-
-  std::vector<Eigen::Vector3d> points3D_copy = points3D;
-
   ceres::Problem problem;
 
   for (size_t i = 0; i < points2D.size(); ++i) {
@@ -225,10 +219,11 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
     ceres::CostFunction* cost_function = nullptr;
 
     switch (camera->ModelId()) {
-#define CAMERA_MODEL_CASE(CameraModel)                                  \
-  case CameraModel::kModelId:                                           \
-    cost_function =                                                     \
-        BundleAdjustmentCostFunction<CameraModel>::Create(points2D[i]); \
+#define CAMERA_MODEL_CASE(CameraModel)                                    \
+  case CameraModel::kModelId:                                             \
+    cost_function =                                                       \
+        BundleAdjustmentConstantPoint3DCostFunction<CameraModel>::Create( \
+            points2D[i], points3D[i]);                                    \
     break;
 
       CAMERA_MODEL_SWITCH_CASES
@@ -236,9 +231,8 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
 #undef CAMERA_MODEL_CASE
     }
 
-    problem.AddResidualBlock(cost_function, loss_function, qvec_data, tvec_data,
-                             points3D_copy[i].data(), camera_params_data);
-    problem.SetParameterBlockConstant(points3D_copy[i].data());
+    problem.AddResidualBlock(cost_function, loss_function, qvec->data(),
+                             tvec->data(), camera->ParamsData());
   }
 
   if (problem.NumResiduals() > 0) {
@@ -246,7 +240,7 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
     *qvec = NormalizeQuaternion(*qvec);
     ceres::LocalParameterization* quaternion_parameterization =
         new ceres::QuaternionParameterization;
-    problem.SetParameterization(qvec_data, quaternion_parameterization);
+    problem.SetParameterization(qvec->data(), quaternion_parameterization);
 
     // Camera parameterization.
     if (!options.refine_focal_length && !options.refine_extra_params) {

--- a/src/util/bitmap.cc
+++ b/src/util/bitmap.cc
@@ -396,7 +396,7 @@ bool Bitmap::ExifLatitude(double* latitude) const {
     StringTrim(&str);
     StringToLower(&str);
     if (!str.empty() && str[0] == 's') {
-        sign = -1.0;
+      sign = -1.0;
     }
   }
   if (ReadExifTag(FIMD_EXIF_GPS, "GPSLatitude", &str)) {
@@ -469,7 +469,7 @@ bool Bitmap::Read(const std::string& path, const bool as_rgb) {
     return false;
   }
 
-  FIBITMAP* fi_bitmap = FreeImage_Load(format, path.c_str(), JPEG_EXIFROTATE);
+  FIBITMAP* fi_bitmap = FreeImage_Load(format, path.c_str());
   if (fi_bitmap == nullptr) {
     return false;
   }


### PR DESCRIPTION
Reverting back to the original implementation which did not use the EXIF orientation flag into account when reading images.