### PR TITLE
Adding user-specified option for reconstructing purely planar scene. …

### DIFF
--- a/src/estimators/two_view_geometry.h
+++ b/src/estimators/two_view_geometry.h
@@ -104,6 +104,10 @@ struct TwoViewGeometry {
     // Whether to ignore watermark models in multiple model estimation.
     bool multiple_ignore_watermark = true;
 
+    // In case the user asks for it, only going to estimate a Homography
+    // between both cameras.
+    bool force_H_use = false;
+
     // Options used to robustly estimate the geometry.
     RANSACOptions ransac_options;
 
@@ -213,6 +217,22 @@ struct TwoViewGeometry {
                             const std::vector<Eigen::Vector2d>& points2,
                             const FeatureMatches& matches,
                             const Options& options);
+
+  // Estimate two-view geometry using a Homography,
+  // depending on the option was user specified or not.
+  //
+  // @param camera1         Camera of first image.
+  // @param points1         Feature points in first image.
+  // @param camera2         Camera of second image.
+  // @param points2         Feature points in second image.
+  // @param matches         Feature matches between first and second image.
+  // @param options         Two-view geometry estimation options.
+  void EstimateHomography(const Camera& camera1,
+                          const std::vector<Eigen::Vector2d>& points1,
+                          const Camera& camera2,
+                          const std::vector<Eigen::Vector2d>& points2,
+                          const FeatureMatches& matches,
+                          const Options& options);
 
   // Detect if inlier matches are caused by a watermark.
   // A watermark causes a pure translation in the border are of the image.

--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -611,6 +611,7 @@ TwoViewGeometryVerifier::TwoViewGeometryVerifier(
       static_cast<size_t>(options_.max_num_trials);
   two_view_geometry_options_.ransac_options.min_inlier_ratio =
       options_.min_inlier_ratio;
+  two_view_geometry_options_.force_H_use = options_.planar_scene;
 }
 
 void TwoViewGeometryVerifier::Run() {

--- a/src/feature/sift.h
+++ b/src/feature/sift.h
@@ -161,6 +161,9 @@ struct SiftMatchingOptions {
   // Whether to perform guided matching, if geometric verification succeeds.
   bool guided_matching = false;
 
+  // Force Homography use for Two-view Geometry (can help for planar scenes)
+  bool planar_scene = false;
+
   bool Check() const;
 };
 

--- a/src/ui/feature_matching_widget.cc
+++ b/src/ui/feature_matching_widget.cc
@@ -132,7 +132,8 @@ void FeatureMatchingTab::CreateGeneralOptions() {
                                  "multiple_models");
   options_widget_->AddOptionBool(&options_->sift_matching->guided_matching,
                                  "guided_matching");
-
+  options_widget_->AddOptionBool(&options_->sift_matching->planar_scene,
+                                 "pure_planar_scene");
   options_widget_->AddSpacer();
 
   QScrollArea* options_scroll_area = new QScrollArea(this);

--- a/src/ui/feature_matching_widget.cc
+++ b/src/ui/feature_matching_widget.cc
@@ -133,7 +133,7 @@ void FeatureMatchingTab::CreateGeneralOptions() {
   options_widget_->AddOptionBool(&options_->sift_matching->guided_matching,
                                  "guided_matching");
   options_widget_->AddOptionBool(&options_->sift_matching->planar_scene,
-                                 "pure_planar_scene");
+                                 "planar_scene");
   options_widget_->AddSpacer();
 
   QScrollArea* options_scroll_area = new QScrollArea(this);

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -320,7 +320,7 @@ void OptionManager::AddMatchingOptions() {
                               &sift_matching->multiple_models);
   AddAndRegisterDefaultOption("SiftMatching.guided_matching",
                               &sift_matching->guided_matching);
-  AddAndRegisterDefaultOption("SiftMatching.pure_planar_scene",
+  AddAndRegisterDefaultOption("SiftMatching.planar_scene",
                               &sift_matching->planar_scene);
 }
 

--- a/src/util/option_manager.cc
+++ b/src/util/option_manager.cc
@@ -320,6 +320,8 @@ void OptionManager::AddMatchingOptions() {
                               &sift_matching->multiple_models);
   AddAndRegisterDefaultOption("SiftMatching.guided_matching",
                               &sift_matching->guided_matching);
+  AddAndRegisterDefaultOption("SiftMatching.pure_planar_scene",
+                              &sift_matching->planar_scene);
 }
 
 void OptionManager::AddExhaustiveMatchingOptions() {
@@ -708,7 +710,7 @@ void OptionManager::AddDelaunayMeshingOptions() {
   AddAndRegisterDefaultOption("DelaunayMeshing.max_depth_dist",
                               &delaunay_meshing->max_depth_dist);
   AddAndRegisterDefaultOption("DelaunayMeshing.visibility_sigma",
-                              &delaunay_meshing->visibility_sigma);    
+                              &delaunay_meshing->visibility_sigma);
   AddAndRegisterDefaultOption("DelaunayMeshing.distance_sigma_factor",
                               &delaunay_meshing->distance_sigma_factor);
   AddAndRegisterDefaultOption("DelaunayMeshing.quality_regularization",


### PR DESCRIPTION
… If option is set, estimation of homography-based two-view geometry for matching will be forced.

In my tests, this option significantly improves the quality of the matching step when reconstructing planar scenes.

Feel free to merge it or not as it might be a bit specific.