### PR TITLE
Only apply sqlite vacuum command when elements are deleted from the database.

### DIFF
--- a/src/base/database.cc
+++ b/src/base/database.cc
@@ -286,7 +286,10 @@ void Database::Open(const std::string& path) {
 void Database::Close() {
   if (database_ != nullptr) {
     FinalizeSQLStatements();
-    SQLITE3_EXEC(database_, "VACUUM", nullptr);
+    if (database_cleared_) {
+      SQLITE3_EXEC(database_, "VACUUM", nullptr);
+      database_cleared_ = false;
+    }
     sqlite3_close_v2(database_);
     database_ = nullptr;
   }
@@ -813,6 +816,7 @@ void Database::DeleteMatches(const image_t image_id1,
                                   static_cast<sqlite3_int64>(pair_id)));
   SQLITE3_CALL(sqlite3_step(sql_stmt_delete_matches_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_delete_matches_));
+  database_cleared_ = true;
 }
 
 void Database::DeleteInlierMatches(const image_t image_id1,
@@ -822,6 +826,7 @@ void Database::DeleteInlierMatches(const image_t image_id1,
                                   static_cast<sqlite3_int64>(pair_id)));
   SQLITE3_CALL(sqlite3_step(sql_stmt_delete_two_view_geometry_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_delete_two_view_geometry_));
+  database_cleared_ = true;
 }
 
 void Database::ClearAllTables() const {
@@ -836,31 +841,37 @@ void Database::ClearAllTables() const {
 void Database::ClearCameras() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_cameras_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_cameras_));
+  database_cleared_ = true;
 }
 
 void Database::ClearImages() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_images_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_images_));
+  database_cleared_ = true;
 }
 
 void Database::ClearDescriptors() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_descriptors_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_descriptors_));
+  database_cleared_ = true;
 }
 
 void Database::ClearKeypoints() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_keypoints_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_keypoints_));
+  database_cleared_ = true;
 }
 
 void Database::ClearMatches() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_matches_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_matches_));
+  database_cleared_ = true;
 }
 
 void Database::ClearTwoViewGeometries() const {
   SQLITE3_CALL(sqlite3_step(sql_stmt_clear_two_view_geometries_));
   SQLITE3_CALL(sqlite3_reset(sql_stmt_clear_two_view_geometries_));
+  database_cleared_ = true;
 }
 
 void Database::Merge(const Database& database1, const Database& database2,

--- a/src/base/database.h
+++ b/src/base/database.h
@@ -269,6 +269,10 @@ class Database {
 
   sqlite3* database_ = nullptr;
 
+  // Check if elements got removed from the database to only apply
+  // the VACUUM command in such case
+  mutable bool database_cleared_ = false;
+
   // Ensure that only one database object at a time updates the schema of a
   // database. Since the schema is updated every time a database is opened, this
   // is to ensure that there are no race conditions ("database locked" error


### PR DESCRIPTION
Fix for #1413 . Vacuum command was applied whenever the close function is called leading to important delay whenever accessing the database.  As the vacuum command is meant to decrease the size of db files by deleting allocated chunks of memory not used anymore, the PR only applies it when elements are deleted from the database.