### PR TITLE
Use masks for stereo fusion on automatic reconstruction

### DIFF
--- a/src/controllers/automatic_reconstruction.cc
+++ b/src/controllers/automatic_reconstruction.cc
@@ -91,6 +91,7 @@ AutomaticReconstructionController::AutomaticReconstructionController(
   if (!options_.mask_path.empty()) {
     reader_options.mask_path = options_.mask_path;
     option_manager_.image_reader->mask_path = options_.mask_path;
+    option_manager_.stereo_fusion->mask_path = options_.mask_path;
   }
   reader_options.single_camera = options_.single_camera;
   reader_options.camera_model = options_.camera_model;


### PR DESCRIPTION
Hey @ahojnnes

The automatic reconstruction does not make use of the depth map masking (#1148), which I think makes sense if we have the masks available. Just a minor PR!