### PR TITLE
Replace deprecated Eigen nonZeros() call for most recent Eigen versions.

### DIFF
--- a/src/exe/model.cc
+++ b/src/exe/model.cc
@@ -765,10 +765,10 @@ int RunModelOrientationAligner(int argc, char** argv) {
     const Eigen::Matrix3d frame = EstimateManhattanWorldFrame(
         frame_estimation_options, reconstruction, *options.image_path);
 
-    if (frame.col(0).size() == 0) {
+    if (frame.col(0).lpNorm<1>() == 0) {
       std::cout << "Only aligning vertical axis" << std::endl;
       tform = RotationFromUnitVectors(frame.col(1), Eigen::Vector3d(0, 1, 0));
-    } else if (frame.col(1).size() == 0) {
+    } else if (frame.col(1).lpNorm<1>() == 0) {
       tform = RotationFromUnitVectors(frame.col(0), Eigen::Vector3d(1, 0, 0));
       std::cout << "Only aligning horizontal axis" << std::endl;
     } else {

--- a/src/exe/model.cc
+++ b/src/exe/model.cc
@@ -765,10 +765,10 @@ int RunModelOrientationAligner(int argc, char** argv) {
     const Eigen::Matrix3d frame = EstimateManhattanWorldFrame(
         frame_estimation_options, reconstruction, *options.image_path);
 
-    if (frame.col(0).nonZeros() == 0) {
+    if (frame.col(0).size() == 0) {
       std::cout << "Only aligning vertical axis" << std::endl;
       tform = RotationFromUnitVectors(frame.col(1), Eigen::Vector3d(0, 1, 0));
-    } else if (frame.col(1).nonZeros() == 0) {
+    } else if (frame.col(1).size() == 0) {
       tform = RotationFromUnitVectors(frame.col(0), Eigen::Vector3d(1, 0, 0));
       std::cout << "Only aligning horizontal axis" << std::endl;
     } else {


### PR DESCRIPTION
Hi team, 

Small change proposed which allows COLMAP to be built from source on the most recent versions of Eigen.

Removal of nonZeros() call which was deprecated in https://gitlab.com/libeigen/eigen/-/commit/08da52eb8537107e2853452bb13c369856d1f84a corresponding to a redundant function call to size().

Issue: COLMAP does not build on Eigen 3.4.90 (and presumably sub-releases since above commit).
Fix: Adjust nonZeros() call to be size().

This is a somewhat interesting issue, because if COLMAP intends to check the number of non-zero elements, the original implementation seemingly did not do that. If the intention was indeed to check non-zero elements a custom check of the matrices is needed pending an appropriate fix in Eigen.

More details on the Eigen front here:
https://gitlab.com/libeigen/eigen/-/issues/2382

Happy to discuss any other workarounds you can think of.

Cheers,
Jack