### PR TITLE
fix random seed set failed from external interface

### DIFF
--- a/src/util/random.cc
+++ b/src/util/random.cc
@@ -37,6 +37,8 @@ namespace colmap {
 
 thread_local std::unique_ptr<std::mt19937> PRNG;
 
+int kDefaultPRNGSeed = 0;
+
 void SetPRNGSeed(unsigned seed) {
   PRNG.reset(new std::mt19937(seed));
   // srand is not thread-safe.

--- a/src/util/random.h
+++ b/src/util/random.h
@@ -43,7 +43,7 @@ namespace colmap {
 
 extern thread_local std::unique_ptr<std::mt19937> PRNG;
 
-static int kDefaultPRNGSeed = 0;
+extern int kDefaultPRNGSeed;
 
 // Initialize the PRNG with the given seed.
 //


### PR DESCRIPTION
this will allow set random seed from external interface, like:
`--random_seed 10`
otherwise, random seed will always be defaulted value.