### PR TITLE
Fix ceres-solver folder name

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,9 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get -y install \
     libatlas-base-dev \
     libsuitesparse-dev
-RUN git clone https://github.com/ceres-solver/ceres-solver.git --tag 2.1.0
-RUN cd ceres-solver && \
+ARG CERES_SOLVER_VERSION=2.1.0
+RUN git clone https://github.com/ceres-solver/ceres-solver.git --tag ${CERES_SOLVER_VERSION}
+RUN cd ${CERES_SOLVER_VERSION} && \
 	mkdir build && \
 	cd build && \
 	cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF && \


### PR DESCRIPTION
This PR fixes the following issue when trying to build the docker image:
```
./build.sh 
Sending build context to Docker daemon  239.6kB
Step 1/8 : FROM nvidia/cuda:11.6.0-devel-ubuntu20.04
 ---> 88f06c9c4dd4
Step 2/8 : ENV DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> e642ae3f706b
Step 3/8 : RUN apt-get update && apt-get install -y     git     cmake     build-essential     libboost-program-options-dev     libboost-filesystem-dev     libboost-graph-dev     libboost-system-dev     libboost-test-dev     libeigen3-dev     libsuitesparse-dev     libfreeimage-dev     libmetis-dev     libgoogle-glog-dev     libgflags-dev     libglew-dev     qtbase5-dev     libqt5opengl5-dev     libcgal-dev
 ---> Using cache
 ---> a77a22ace47f
Step 4/8 : RUN apt-get -y install     libatlas-base-dev     libsuitesparse-dev
 ---> Using cache
 ---> c9031a61c55d
Step 5/8 : RUN git clone https://github.com/ceres-solver/ceres-solver.git --tag 2.1.0
 ---> Using cache
 ---> 9064c456e9ec
Step 6/8 : RUN cd ceres-solver &&   mkdir build &&  cd build &&   cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF &&  make -j4 &&   make install
 ---> Running in 1c0044ff599e
/bin/sh: 1: cd: can't cd to ceres-solver
The command '/bin/sh -c cd ceres-solver &&  mkdir build &&  cd build &&   cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF &&  make -j4 &&   make install' returned a non-zero code: 2
root@c0175ae36593:/working# 
```