### PR TITLE
Avoid the calling of copy constructor/assignment

### DIFF
--- a/src/feature/extraction.cc
+++ b/src/feature/extraction.cc
@@ -209,9 +209,9 @@ void SiftFeatureExtractor::Run() {
     }
 
     if (sift_options_.max_image_size > 0) {
-      CHECK(resizer_queue_->Push(image_data));
+      CHECK(resizer_queue_->Push(std::move(image_data)));
     } else {
-      CHECK(extractor_queue_->Push(image_data));
+      CHECK(extractor_queue_->Push(std::move(image_data)));
     }
   }
 
@@ -313,9 +313,9 @@ void ImageResizerThread::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto image_data = input_job.Data();
+      auto& image_data = input_job.Data();
 
       if (image_data.status == ImageReader::Status::SUCCESS) {
         if (static_cast<int>(image_data.bitmap.Width()) > max_image_size_ ||
@@ -333,7 +333,7 @@ void ImageResizerThread::Run() {
         }
       }
 
-      output_queue_->Push(image_data);
+      output_queue_->Push(std::move(image_data));
     } else {
       break;
     }
@@ -380,9 +380,9 @@ void SiftFeatureExtractorThread::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto image_data = input_job.Data();
+      auto& image_data = input_job.Data();
 
       if (image_data.status == ImageReader::Status::SUCCESS) {
         bool success = false;
@@ -418,7 +418,7 @@ void SiftFeatureExtractorThread::Run() {
 
       image_data.bitmap.Deallocate();
 
-      output_queue_->Push(image_data);
+      output_queue_->Push(std::move(image_data));
     } else {
       break;
     }
@@ -437,7 +437,7 @@ void FeatureWriterThread::Run() {
       break;
     }
 
-    auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& image_data = input_job.Data();
 

--- a/src/feature/extraction.cc
+++ b/src/feature/extraction.cc
@@ -313,7 +313,7 @@ void ImageResizerThread::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& image_data = input_job.Data();
 
@@ -380,7 +380,7 @@ void SiftFeatureExtractorThread::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& image_data = input_job.Data();
 
@@ -437,7 +437,7 @@ void FeatureWriterThread::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& image_data = input_job.Data();
 

--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -151,7 +151,7 @@ void MatchNearestNeighborsInVisualIndex(
     }
 
     // Pop the next results from the retrieval queue.
-    auto&& retrieval = retrieval_queue.Pop();
+    auto retrieval = retrieval_queue.Pop();
     CHECK(retrieval.IsValid());
 
     const auto& image_id = retrieval.Data().image_id;
@@ -361,7 +361,7 @@ void SiftCPUFeatureMatcher::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& data = input_job.Data();
 
@@ -419,7 +419,7 @@ void SiftGPUFeatureMatcher::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& data = input_job.Data();
 
@@ -472,7 +472,7 @@ void GuidedSiftCPUFeatureMatcher::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& data = input_job.Data();
 
@@ -540,7 +540,7 @@ void GuidedSiftGPUFeatureMatcher::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& data = input_job.Data();
 
@@ -620,7 +620,7 @@ void TwoViewGeometryVerifier::Run() {
       break;
     }
 
-    auto&& input_job = input_queue_->Pop();
+    auto input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
       auto& data = input_job.Data();
 
@@ -863,7 +863,7 @@ void SiftFeatureMatcher::Match(
   //////////////////////////////////////////////////////////////////////////////
 
   for (size_t i = 0; i < num_outputs; ++i) {
-    auto&& output_job = output_queue_.Pop();
+    auto output_job = output_queue_.Pop();
     CHECK(output_job.IsValid());
     auto& output = output_job.Data();
 

--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -118,7 +118,7 @@ void MatchNearestNeighborsInVisualIndex(
     visual_index->Query(query_options, keypoints, descriptors,
                         &retrieval.image_scores);
 
-    CHECK(retrieval_queue.Push(retrieval));
+    CHECK(retrieval_queue.Push(std::move(retrieval)));
   };
 
   // Initially, make all retrieval threads busy and continue with the matching.
@@ -151,7 +151,7 @@ void MatchNearestNeighborsInVisualIndex(
     }
 
     // Pop the next results from the retrieval queue.
-    const auto retrieval = retrieval_queue.Pop();
+    auto&& retrieval = retrieval_queue.Pop();
     CHECK(retrieval.IsValid());
 
     const auto& image_id = retrieval.Data().image_id;
@@ -361,13 +361,13 @@ void SiftCPUFeatureMatcher::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto data = input_job.Data();
+      auto& data = input_job.Data();
 
       if (!cache_->ExistsDescriptors(data.image_id1) ||
           !cache_->ExistsDescriptors(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -377,7 +377,7 @@ void SiftCPUFeatureMatcher::Run() {
           cache_->GetDescriptors(data.image_id2);
       MatchSiftFeaturesCPU(options_, descriptors1, descriptors2, &data.matches);
 
-      CHECK(output_queue_->Push(data));
+      CHECK(output_queue_->Push(std::move(data)));
     }
   }
 }
@@ -419,13 +419,13 @@ void SiftGPUFeatureMatcher::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto data = input_job.Data();
+      auto& data = input_job.Data();
 
       if (!cache_->ExistsDescriptors(data.image_id1) ||
           !cache_->ExistsDescriptors(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -436,7 +436,7 @@ void SiftGPUFeatureMatcher::Run() {
       MatchSiftFeaturesGPU(options_, descriptors1_ptr, descriptors2_ptr,
                            &sift_match_gpu, &data.matches);
 
-      CHECK(output_queue_->Push(data));
+      CHECK(output_queue_->Push(std::move(data)));
     }
   }
 }
@@ -472,13 +472,13 @@ void GuidedSiftCPUFeatureMatcher::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto data = input_job.Data();
+      auto& data = input_job.Data();
 
       if (data.two_view_geometry.inlier_matches.size() <
           static_cast<size_t>(options_.min_num_inliers)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -486,7 +486,7 @@ void GuidedSiftCPUFeatureMatcher::Run() {
           !cache_->ExistsKeypoints(data.image_id2) ||
           !cache_->ExistsDescriptors(data.image_id1) ||
           !cache_->ExistsDescriptors(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -499,7 +499,7 @@ void GuidedSiftCPUFeatureMatcher::Run() {
       MatchGuidedSiftFeaturesCPU(options_, keypoints1, keypoints2, descriptors1,
                                  descriptors2, &data.two_view_geometry);
 
-      CHECK(output_queue_->Push(data));
+      CHECK(output_queue_->Push(std::move(data)));
     }
   }
 }
@@ -540,13 +540,13 @@ void GuidedSiftGPUFeatureMatcher::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto data = input_job.Data();
+      auto& data = input_job.Data();
 
       if (data.two_view_geometry.inlier_matches.size() <
           static_cast<size_t>(options_.min_num_inliers)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -554,7 +554,7 @@ void GuidedSiftGPUFeatureMatcher::Run() {
           !cache_->ExistsKeypoints(data.image_id2) ||
           !cache_->ExistsDescriptors(data.image_id1) ||
           !cache_->ExistsDescriptors(data.image_id2)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -569,7 +569,7 @@ void GuidedSiftGPUFeatureMatcher::Run() {
                                  descriptors1_ptr, descriptors2_ptr,
                                  &sift_match_gpu, &data.two_view_geometry);
 
-      CHECK(output_queue_->Push(data));
+      CHECK(output_queue_->Push(std::move(data)));
     }
   }
 }
@@ -620,12 +620,12 @@ void TwoViewGeometryVerifier::Run() {
       break;
     }
 
-    const auto input_job = input_queue_->Pop();
+    auto&& input_job = input_queue_->Pop();
     if (input_job.IsValid()) {
-      auto data = input_job.Data();
+      auto& data = input_job.Data();
 
       if (data.matches.size() < static_cast<size_t>(options_.min_num_inliers)) {
-        CHECK(output_queue_->Push(data));
+        CHECK(output_queue_->Push(std::move(data)));
         continue;
       }
 
@@ -648,7 +648,7 @@ void TwoViewGeometryVerifier::Run() {
                                         two_view_geometry_options_);
       }
 
-      CHECK(output_queue_->Push(data));
+      CHECK(output_queue_->Push(std::move(data)));
     }
   }
 }
@@ -852,9 +852,9 @@ void SiftFeatureMatcher::Match(
     if (exists_matches) {
       data.matches = cache_->GetMatches(image_pair.first, image_pair.second);
       cache_->DeleteMatches(image_pair.first, image_pair.second);
-      CHECK(verifier_queue_.Push(data));
+      CHECK(verifier_queue_.Push(std::move(data)));
     } else {
-      CHECK(matcher_queue_.Push(data));
+      CHECK(matcher_queue_.Push(std::move(data)));
     }
   }
 
@@ -863,9 +863,9 @@ void SiftFeatureMatcher::Match(
   //////////////////////////////////////////////////////////////////////////////
 
   for (size_t i = 0; i < num_outputs; ++i) {
-    const auto output_job = output_queue_.Pop();
+    auto&& output_job = output_queue_.Pop();
     CHECK(output_job.IsValid());
-    auto output = output_job.Data();
+    auto& output = output_job.Data();
 
     if (output.matches.size() < static_cast<size_t>(options_.min_num_inliers)) {
       output.matches = {};

--- a/src/mvs/meshing.cc
+++ b/src/mvs/meshing.cc
@@ -821,7 +821,7 @@ PlyMesh DelaunayMeshing(const DelaunayMeshingOptions& options,
       }
     }
 
-    CHECK(result_queue.Push(image_cell_graph_data));
+    CHECK(result_queue.Push(std::move(image_cell_graph_data)));
   };
 
   // Add first batch of images to the thread job queue.
@@ -849,7 +849,7 @@ PlyMesh DelaunayMeshing(const DelaunayMeshingOptions& options,
     }
 
     // Pop the next results from the queue.
-    const auto result = result_queue.Pop();
+    auto&& result = result_queue.Pop();
     CHECK(result.IsValid());
 
     // Accumulate the weights of the image into the global graph.

--- a/src/mvs/meshing.cc
+++ b/src/mvs/meshing.cc
@@ -849,7 +849,7 @@ PlyMesh DelaunayMeshing(const DelaunayMeshingOptions& options,
     }
 
     // Pop the next results from the queue.
-    auto&& result = result_queue.Pop();
+    auto result = result_queue.Pop();
     CHECK(result.IsValid());
 
     // Accumulate the weights of the image into the global graph.

--- a/src/util/threading.h
+++ b/src/util/threading.h
@@ -263,6 +263,7 @@ class JobQueue {
    public:
     Job() : valid_(false) {}
     explicit Job(const T& data) : data_(data), valid_(true) {}
+    explicit Job(T&& data) : data_(std::move(data)), valid_(true) {}
 
     // Check whether the data is valid.
     bool IsValid() const { return valid_; }
@@ -285,6 +286,8 @@ class JobQueue {
 
   // Push a new job to the queue. Waits if the number of jobs is exceeded.
   bool Push(const T& data);
+  // Push a new job to the queue. Waits if the number of jobs is exceeded.
+  bool Push(T&& data);
 
   // Pop a job from the queue. Waits if there is no job in the queue.
   Job Pop();
@@ -375,6 +378,21 @@ bool JobQueue<T>::Push(const T& data) {
 }
 
 template <typename T>
+bool JobQueue<T>::Push(T&& data) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (jobs_.size() >= max_num_jobs_ && !stop_) {
+    pop_condition_.wait(lock);
+  }
+  if (stop_) {
+    return false;
+  } else {
+    jobs_.push(std::move(data));
+    push_condition_.notify_one();
+    return true;
+  }
+}
+
+template <typename T>
 typename JobQueue<T>::Job JobQueue<T>::Pop() {
   std::unique_lock<std::mutex> lock(mutex_);
   while (jobs_.empty() && !stop_) {
@@ -383,13 +401,13 @@ typename JobQueue<T>::Job JobQueue<T>::Pop() {
   if (stop_) {
     return Job();
   } else {
-    const T data = jobs_.front();
+    Job job(std::move(jobs_.front()));
     jobs_.pop();
     pop_condition_.notify_one();
     if (jobs_.empty()) {
       empty_condition_.notify_all();
     }
-    return Job(data);
+    return std::move(job);
   }
 }
 

--- a/src/util/threading.h
+++ b/src/util/threading.h
@@ -354,6 +354,12 @@ JobQueue<T>::~JobQueue() {
 }
 
 template <typename T>
+size_t JobQueue<T>::Size() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return jobs_.size();
+}
+
+template <typename T>
 bool JobQueue<T>::Push(T data) {
   std::unique_lock<std::mutex> lock(mutex_);
   while (jobs_.size() >= max_num_jobs_ && !stop_) {


### PR DESCRIPTION
Features in this PR:

- Support move constructor when calling Push of JobQueue.
- Avoid copy constructor when calling Pop of JobQueue.

Using the above features, we can avoid calling the copy constructor/assignment in tasks such as feature extraction/machining or meshing.