### PR TITLE
Avoid calling copy constructors of  FeatureKeypoints and FeatureDescriptors

### DIFF
--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -68,8 +68,8 @@ void IndexImagesInVisualIndex(const int num_threads, const int num_checks,
     std::cout << StringPrintf("Indexing image [%d/%d]", i + 1, image_ids.size())
               << std::flush;
 
-    auto keypoints = cache->GetKeypoints(image_ids[i]);
-    auto descriptors = cache->GetDescriptors(image_ids[i]);
+    auto keypoints = *cache->GetKeypoints(image_ids[i]);
+    auto descriptors = *cache->GetDescriptors(image_ids[i]);
     if (max_num_features > 0 && descriptors.rows() > max_num_features) {
       ExtractTopScaleFeatures(&keypoints, &descriptors, max_num_features);
     }
@@ -107,8 +107,8 @@ void MatchNearestNeighborsInVisualIndex(
   query_options.num_checks = num_checks;
   query_options.num_images_after_verification = num_images_after_verification;
   auto QueryFunc = [&](const image_t image_id) {
-    auto keypoints = cache->GetKeypoints(image_id);
-    auto descriptors = cache->GetDescriptors(image_id);
+    auto keypoints = *cache->GetKeypoints(image_id);
+    auto descriptors = *cache->GetDescriptors(image_id);
     if (max_num_features > 0 && descriptors.rows() > max_num_features) {
       ExtractTopScaleFeatures(&keypoints, &descriptors, max_num_features);
     }
@@ -231,14 +231,16 @@ void FeatureMatcherCache::Setup() {
     images_cache_.emplace(image.ImageId(), image);
   }
 
-  keypoints_cache_.reset(new LRUCache<image_t, FeatureKeypoints>(
+  keypoints_cache_.reset(new LRUCache<image_t, FeatureKeypointsPtr>(
       cache_size_, [this](const image_t image_id) {
-        return database_->ReadKeypoints(image_id);
+        return std::make_shared<FeatureKeypoints>(
+            database_->ReadKeypoints(image_id));
       }));
 
-  descriptors_cache_.reset(new LRUCache<image_t, FeatureDescriptors>(
+  descriptors_cache_.reset(new LRUCache<image_t, FeatureDescriptorsPtr>(
       cache_size_, [this](const image_t image_id) {
-        return database_->ReadDescriptors(image_id);
+        return std::make_shared<FeatureDescriptors>(
+            database_->ReadDescriptors(image_id));
       }));
 
   keypoints_exists_cache_.reset(new LRUCache<image_t, bool>(
@@ -260,13 +262,12 @@ const Image& FeatureMatcherCache::GetImage(const image_t image_id) const {
   return images_cache_.at(image_id);
 }
 
-const FeatureKeypoints& FeatureMatcherCache::GetKeypoints(
-    const image_t image_id) {
+FeatureKeypointsPtr FeatureMatcherCache::GetKeypoints(const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
   return keypoints_cache_->Get(image_id);
 }
 
-const FeatureDescriptors& FeatureMatcherCache::GetDescriptors(
+FeatureDescriptorsPtr FeatureMatcherCache::GetDescriptors(
     const image_t image_id) {
   std::unique_lock<std::mutex> lock(database_mutex_);
   return descriptors_cache_->Get(image_id);
@@ -371,11 +372,10 @@ void SiftCPUFeatureMatcher::Run() {
         continue;
       }
 
-      const FeatureDescriptors descriptors1 =
-          cache_->GetDescriptors(data.image_id1);
-      const FeatureDescriptors descriptors2 =
-          cache_->GetDescriptors(data.image_id2);
-      MatchSiftFeaturesCPU(options_, descriptors1, descriptors2, &data.matches);
+      const auto descriptors1 = cache_->GetDescriptors(data.image_id1);
+      const auto descriptors2 = cache_->GetDescriptors(data.image_id2);
+      MatchSiftFeaturesCPU(options_, *descriptors1, *descriptors2,
+                           &data.matches);
 
       CHECK(output_queue_->Push(std::move(data)));
     }
@@ -450,7 +450,7 @@ void SiftGPUFeatureMatcher::GetDescriptorData(
     *descriptors_ptr = nullptr;
   } else {
     prev_uploaded_descriptors_[index] = cache_->GetDescriptors(image_id);
-    *descriptors_ptr = &prev_uploaded_descriptors_[index];
+    *descriptors_ptr = prev_uploaded_descriptors_[index].get();
     prev_uploaded_image_ids_[index] = image_id;
   }
 }
@@ -490,14 +490,13 @@ void GuidedSiftCPUFeatureMatcher::Run() {
         continue;
       }
 
-      const FeatureKeypoints keypoints1 = cache_->GetKeypoints(data.image_id1);
-      const FeatureKeypoints keypoints2 = cache_->GetKeypoints(data.image_id2);
-      const FeatureDescriptors descriptors1 =
-          cache_->GetDescriptors(data.image_id1);
-      const FeatureDescriptors descriptors2 =
-          cache_->GetDescriptors(data.image_id2);
-      MatchGuidedSiftFeaturesCPU(options_, keypoints1, keypoints2, descriptors1,
-                                 descriptors2, &data.two_view_geometry);
+      const auto keypoints1 = cache_->GetKeypoints(data.image_id1);
+      const auto keypoints2 = cache_->GetKeypoints(data.image_id2);
+      const auto descriptors1 = cache_->GetDescriptors(data.image_id1);
+      const auto descriptors2 = cache_->GetDescriptors(data.image_id2);
+      MatchGuidedSiftFeaturesCPU(options_, *keypoints1, *keypoints2,
+                                 *descriptors1, *descriptors2,
+                                 &data.two_view_geometry);
 
       CHECK(output_queue_->Push(std::move(data)));
     }
@@ -586,8 +585,8 @@ void GuidedSiftGPUFeatureMatcher::GetFeatureData(
   } else {
     prev_uploaded_keypoints_[index] = cache_->GetKeypoints(image_id);
     prev_uploaded_descriptors_[index] = cache_->GetDescriptors(image_id);
-    *keypoints_ptr = &prev_uploaded_keypoints_[index];
-    *descriptors_ptr = &prev_uploaded_descriptors_[index];
+    *keypoints_ptr = prev_uploaded_keypoints_[index].get();
+    *descriptors_ptr = prev_uploaded_descriptors_[index].get();
     prev_uploaded_image_ids_[index] = image_id;
   }
 }
@@ -635,8 +634,8 @@ void TwoViewGeometryVerifier::Run() {
           cache_->GetCamera(cache_->GetImage(data.image_id2).CameraId());
       const auto keypoints1 = cache_->GetKeypoints(data.image_id1);
       const auto keypoints2 = cache_->GetKeypoints(data.image_id2);
-      const auto points1 = FeatureKeypointsToPointsVector(keypoints1);
-      const auto points2 = FeatureKeypointsToPointsVector(keypoints2);
+      const auto& points1 = FeatureKeypointsToPointsVector(*keypoints1);
+      const auto& points2 = FeatureKeypointsToPointsVector(*keypoints2);
 
       if (options_.multiple_models) {
         data.two_view_geometry.EstimateMultiple(camera1, points1, camera2,
@@ -1691,8 +1690,8 @@ void FeaturePairsFeatureMatcher::Run() {
           match_options_.min_inlier_ratio;
 
       two_view_geometry.Estimate(
-          camera1, FeatureKeypointsToPointsVector(keypoints1), camera2,
-          FeatureKeypointsToPointsVector(keypoints2), matches,
+          camera1, FeatureKeypointsToPointsVector(*keypoints1), camera2,
+          FeatureKeypointsToPointsVector(*keypoints2), matches,
           two_view_geometry_options);
 
       database_.WriteTwoViewGeometry(image1.ImageId(), image2.ImageId(),

--- a/src/feature/matching.h
+++ b/src/feature/matching.h
@@ -176,6 +176,9 @@ struct FeatureMatcherData {
 
 }  // namespace internal
 
+using FeatureKeypointsPtr = std::shared_ptr<FeatureKeypoints>;
+using FeatureDescriptorsPtr = std::shared_ptr<FeatureDescriptors>;
+
 // Cache for feature matching to minimize database access during matching.
 class FeatureMatcherCache {
  public:
@@ -185,8 +188,8 @@ class FeatureMatcherCache {
 
   const Camera& GetCamera(const camera_t camera_id) const;
   const Image& GetImage(const image_t image_id) const;
-  const FeatureKeypoints& GetKeypoints(const image_t image_id);
-  const FeatureDescriptors& GetDescriptors(const image_t image_id);
+  FeatureKeypointsPtr GetKeypoints(const image_t image_id);
+  FeatureDescriptorsPtr GetDescriptors(const image_t image_id);
   FeatureMatches GetMatches(const image_t image_id1, const image_t image_id2);
   std::vector<image_t> GetImageIds() const;
 
@@ -210,8 +213,8 @@ class FeatureMatcherCache {
   std::mutex database_mutex_;
   EIGEN_STL_UMAP(camera_t, Camera) cameras_cache_;
   EIGEN_STL_UMAP(image_t, Image) images_cache_;
-  std::unique_ptr<LRUCache<image_t, FeatureKeypoints>> keypoints_cache_;
-  std::unique_ptr<LRUCache<image_t, FeatureDescriptors>> descriptors_cache_;
+  std::unique_ptr<LRUCache<image_t, FeatureKeypointsPtr>> keypoints_cache_;
+  std::unique_ptr<LRUCache<image_t, FeatureDescriptorsPtr>> descriptors_cache_;
   std::unique_ptr<LRUCache<image_t, bool>> keypoints_exists_cache_;
   std::unique_ptr<LRUCache<image_t, bool>> descriptors_exists_cache_;
 };
@@ -268,7 +271,7 @@ class SiftGPUFeatureMatcher : public FeatureMatcherThread {
 
   // The previously uploaded images to the GPU.
   std::array<image_t, 2> prev_uploaded_image_ids_;
-  std::array<FeatureDescriptors, 2> prev_uploaded_descriptors_;
+  std::array<FeatureDescriptorsPtr, 2> prev_uploaded_descriptors_;
 };
 
 class GuidedSiftCPUFeatureMatcher : public FeatureMatcherThread {
@@ -312,8 +315,8 @@ class GuidedSiftGPUFeatureMatcher : public FeatureMatcherThread {
 
   // The previously uploaded images to the GPU.
   std::array<image_t, 2> prev_uploaded_image_ids_;
-  std::array<FeatureKeypoints, 2> prev_uploaded_keypoints_;
-  std::array<FeatureDescriptors, 2> prev_uploaded_descriptors_;
+  std::array<FeatureKeypointsPtr, 2> prev_uploaded_keypoints_;
+  std::array<FeatureDescriptorsPtr, 2> prev_uploaded_descriptors_;
 };
 
 class TwoViewGeometryVerifier : public Thread {


### PR DESCRIPTION
Use std::shared_ptr in LRUCache for FeatureKeypoints and FeatureDescriptors.
Avoid (or reduce) calling copy constructors of FeatureKeypoints and FeatureDescriptors when accessing FeatureKeypoints and FeatureDescriptors.