### PR TITLE
Avoid hard crash if Jacobian matrix is rank deficient

### DIFF
--- a/src/estimators/pose.cc
+++ b/src/estimators/pose.cc
@@ -308,7 +308,9 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
     ceres::Covariance::Options options;
     ceres::Covariance covariance(options);
     std::vector<const double*> parameter_blocks = {qvec_data, tvec_data};
-    covariance.Compute(parameter_blocks, &problem);
+    if (!covariance.Compute(parameter_blocks, &problem)) {
+      return false;
+    }
     // The rotation covariance is estimated in the tangent space of the
     // quaternion, which corresponds to the 3-DoF axis-angle local
     // parameterization.
@@ -490,7 +492,9 @@ bool RefineGeneralizedAbsolutePose(
     ceres::Covariance::Options options;
     ceres::Covariance covariance(options);
     std::vector<const double*> parameter_blocks = {qvec_data, tvec_data};
-    covariance.Compute(parameter_blocks, &problem);
+    if (!covariance.Compute(parameter_blocks, &problem)) {
+      return false;
+    }
     covariance.GetCovarianceMatrixInTangentSpace(parameter_blocks,
                                                  rot_tvec_covariance->data());
   }


### PR DESCRIPTION
Ceres hard crashes (`LOG(FATAL)`) in `covariance.GetCovarianceMatrixInTangentSpace` if the Jacobian matrix is rank deficient. In this case, `covariance.Compute` returns `false` as well. 

If the Jacobian computation fails, we can directly return false (refinement failed) to avoid the hard crash.