### PR TITLE
Fix inconsistent between the actual executed image reader option and the saved project.ini file

### DIFF
--- a/src/controllers/automatic_reconstruction.cc
+++ b/src/controllers/automatic_reconstruction.cc
@@ -85,7 +85,7 @@ AutomaticReconstructionController::AutomaticReconstructionController(
   option_manager_.mapper->num_threads = options_.num_threads;
   option_manager_.poisson_meshing->num_threads = options_.num_threads;
 
-  ImageReaderOptions reader_options = *option_manager_.image_reader;
+  ImageReaderOptions& reader_options = *option_manager_.image_reader;
   reader_options.database_path = *option_manager_.database_path;
   reader_options.image_path = *option_manager_.image_path;
   if (!options_.mask_path.empty()) {


### PR DESCRIPTION
In current AutomaticReconstructionController implementation, the cli args input are first parsed to construct the member variable `options_` of `AutomaticReconstructionController` class. 
Then the `options_`'s _ImageReader_ part is assigned to ` ImageReaderOptions reader_options`, which is a copy instead of a reference of `*option_manager_.image_reader`. Which means, user cli args input's _ImageReader_  setting (e.g. single_camera, camera_model) are only passed to `options_`, and will not be synced to `option_manager_`.
![image](https://user-images.githubusercontent.com/31894585/179265126-2b0406ac-234b-4ded-ac2b-6529c75b7960.png)

Although the ImageReaderOptions setting `reader_options` is used to construct the `SiftFeatureExtractor`, the executed setting is exactly what the user needed. Because the project.ini writing only follows the `option_manager_`'s values, thus when user modify the default automatic_reconstructor settings (by passing --single_camera=1 or --camera_model="OpenCV"), inconsistency happens between the actual executed image reader option and the saved project.ini file.
![image](https://user-images.githubusercontent.com/31894585/179266389-00f6d704-7673-4ab6-8633-05a789d783d7.png)

This bug can be easily fixed by obtaining `reader_options` by reference instead of a value copy.

------------
**- Bug case (using single_camera=1)**
**Pre Fix:** 
command: 
> .\build\src\exe\colmap.exe automatic_reconstructor --workspace_path=data/pre_fix/images --image_path=data/pre_fix/images **--single_camera=1**

**generated project.ini**
> log_to_stderr=false
random_seed=0
log_level=2
database_path=data/pre_fix/images\database.db
image_path=data/pre_fix/images
[ImageReader]
**single_camera=false**
single_camera_per_folder=false
single_camera_per_image=false
existing_camera_id=-1
default_focal_length_factor=1.2
mask_path=
camera_model=SIMPLE_RADIAL
camera_params=
camera_mask_path=
[SiftExtraction]
...
 
**After Fix**
command: 
>.\build\src\exe\colmap.exe automatic_reconstructor --workspace_path=data/fix/images --image_path=data/fix/images **--single_camera=1**
**generated project.ini**
> log_to_stderr=false
random_seed=0
log_level=2
database_path=data/fix/images\database.db
image_path=data/fix/images
[ImageReader]
**single_camera=true**
single_camera_per_folder=false
single_camera_per_image=false
existing_camera_id=-1
default_focal_length_factor=1.2
mask_path=
camera_model=SIMPLE_RADIAL
camera_params=
camera_mask_path=
[SiftExtraction]
...

**- Bug case (using --camera_model="OpenCV")**
**Pre Fix**
command: 
> .\build\src\exe\colmap.exe automatic_reconstructor --workspace_path=data/pre_fix/images_01 --image_path=data/pre_fix/images_01 **--camera_model=OPENCV**

**generated project.ini**
> log_to_stderr=false
random_seed=0
log_level=2
database_path=data/pre_fix/images_01\database.db
image_path=data/pre_fix/images_01
[ImageReader]
single_camera=false
single_camera_per_folder=false
single_camera_per_image=false
existing_camera_id=-1
default_focal_length_factor=1.2
mask_path=
**camera_model=SIMPLE_RADIAL**
camera_params=
camera_mask_path=
[SiftExtraction]
...

**After Fix**
command: 
> .\build\src\exe\colmap.exe automatic_reconstructor --workspace_path=data/fix/images_01 --image_path=data/fix/images_01 **--camera_model=OPENCV**

**generated preject.ini**
> log_to_stderr=false
random_seed=0
log_level=2
database_path=data/fix/images_01\database.db
image_path=data/fix/images_01
[ImageReader]
single_camera=false
single_camera_per_folder=false
single_camera_per_image=false
existing_camera_id=-1
default_focal_length_factor=1.2
mask_path=
**camera_model=OPENCV**
camera_params=
camera_mask_path=
[SiftExtraction]
...

