### PR TITLE
Enable writing relative poses into database

### DIFF
--- a/src/controllers/incremental_mapper.cc
+++ b/src/controllers/incremental_mapper.cc
@@ -350,7 +350,7 @@ bool IncrementalMapperController::LoadDatabase() {
   PrintHeading1("Loading database");
 
   // Make sure images of the given reconstruction are also included when
-  // manually specifying images for the reconstrunstruction procedure.
+  // manually specifying images for the reconstruction procedure.
   std::unordered_set<std::string> image_names = options_->image_names;
   if (reconstruction_manager_->Size() == 1 && !options_->image_names.empty()) {
     const Reconstruction& reconstruction = reconstruction_manager_->Get(0);

--- a/src/estimators/two_view_geometry.h
+++ b/src/estimators/two_view_geometry.h
@@ -181,12 +181,25 @@ struct TwoViewGeometry {
   // @param points1         Feature points in first image.
   // @param camera2         Camera of second image.
   // @param points2         Feature points in second image.
-  // @param matches         Feature matches between first and second image.
-  // @param options         Two-view geometry estimation options.
   bool EstimateRelativePose(const Camera& camera1,
                             const std::vector<Eigen::Vector2d>& points1,
                             const Camera& camera2,
                             const std::vector<Eigen::Vector2d>& points2);
+
+  // Estimate two-view geometry and its relative pose from a calibrated image pair.
+  //
+  // @param camera1         Camera of first image.
+  // @param points1         Feature points in first image.
+  // @param camera2         Camera of second image.
+  // @param points2         Feature points in second image.
+  // @param matches         Feature matches between first and second image.
+  // @param options         Two-view geometry estimation options.
+  void EstimateWithRelativePose(const Camera& camera1,
+                                const std::vector<Eigen::Vector2d>& points1,
+                                const Camera& camera2,
+                                const std::vector<Eigen::Vector2d>& points2,
+                                const FeatureMatches& matches,
+                                const Options& options);
 
   // Estimate two-view geometry from calibrated image pair.
   //

--- a/src/optim/bundle_adjustment.cc
+++ b/src/optim/bundle_adjustment.cc
@@ -62,6 +62,9 @@ ceres::LossFunction* BundleAdjustmentOptions::CreateLossFunction() const {
     case LossFunctionType::CAUCHY:
       loss_function = new ceres::CauchyLoss(loss_function_scale);
       break;
+    case LossFunctionType::HUBER:
+      loss_function = new ceres::HuberLoss(loss_function_scale);
+      break;
   }
   CHECK_NOTNULL(loss_function);
   return loss_function;

--- a/src/optim/bundle_adjustment.h
+++ b/src/optim/bundle_adjustment.h
@@ -48,7 +48,7 @@ namespace colmap {
 
 struct BundleAdjustmentOptions {
   // Loss function types: Trivial (non-robust) and Cauchy (robust) loss.
-  enum class LossFunctionType { TRIVIAL, SOFT_L1, CAUCHY };
+  enum class LossFunctionType { TRIVIAL, SOFT_L1, CAUCHY, HUBER };
   LossFunctionType loss_function_type = LossFunctionType::TRIVIAL;
 
   // Scaling factor determines residual at which robustification takes place.


### PR DESCRIPTION
In this PR, we are able to write relative poses into the database when performing feature matching.