### PR TITLE
bugfix: Fix subdirectories creation

### DIFF
--- a/src/util/misc.cc
+++ b/src/util/misc.cc
@@ -111,7 +111,7 @@ bool ExistsPath(const std::string& path) {
 
 void CreateDirIfNotExists(const std::string& path) {
   if (!ExistsDir(path)) {
-    CHECK(boost::filesystem::create_directory(path));
+    CHECK(boost::filesystem::create_directories(path));
   }
 }
 


### PR DESCRIPTION
When the source images are split into multiple subdirectories, the image undistortion would crash, because the subdirectories are not created by `boost::filesystem::create_directory(path)`.
We should use `boost::filesystem::create_directories(path)` instead.

Reproduce:
```
# Create a image folder with the following structure
images
├── part0
│   ├── IMG_4884.JPG
│   ├── IMG_4885.JPG
│   └── IMG_4886.JPG
└── part1
    ├── IMG_4887.JPG
    ├── IMG_4888.JPG
    └── IMG_4889.JPG
```

Run the automatic reconstructor from cmdline or GUI:
```
colmap automatic_reconstructor \
    --workspace_path $WORKSPACE_PATH \
    --image_path $IMAGES_PATH
```

Would result in the following error:
```
==============================================================================
Image undistortion
==============================================================================

terminate called after throwing an instance of 'boost::filesystem::filesystem_error'
  what():  boost::filesystem::create_directory: No such file or directory: "/path/to/images/part0"
*** Aborted at 1658152482 (unix time) try "date -d @1658152482" if you are using GNU date ***
PC: @     0x7fa5ba9a403b gsignal
*** SIGABRT (@0x3e800002efb) received by PID 12027 (TID 0x7fa5897fa700) from PID 12027; stack trace: ***
    @     0x7fa5cb28a631 (unknown)
    @     0x7fa5baf073c0 (unknown)
    @     0x7fa5ba9a403b gsignal
    @     0x7fa5ba983859 abort
    @     0x7fa5bad9d911 (unknown)
    @     0x7fa5bada938c (unknown)
    @     0x7fa5bada93f7 std::terminate()
    @     0x7fa5bada96a9 __cxa_throw
    @     0x55b106bb5e05 _ZN5boost10filesystem6detail16create_directoryERKNS0_4pathEPNS_6system10error_codeE.cold
    @     0x55b106e4de52 colmap::CreateDirIfNotExists()
    @     0x55b106c9c1e1 colmap::Reconstruction::CreateImageDirs()
    @     0x55b106cc09bc colmap::COLMAPUndistorter::Run()
    @     0x55b106e70b00 colmap::Thread::RunFunc()
    @     0x7fa5badd5de4 (unknown)
    @     0x7fa5baefb609 start_thread
    @     0x7fa5baa80163 clone
Aborted (core dumped)
```
