### PR TITLE
checkout the expected version of ceres solver

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get -y install \
     libatlas-base-dev \
     libsuitesparse-dev
 ARG CERES_SOLVER_VERSION=2.1.0
-RUN git clone https://github.com/ceres-solver/ceres-solver.git --tag ${CERES_SOLVER_VERSION}
-RUN cd ${CERES_SOLVER_VERSION} && \
+RUN git clone https://github.com/ceres-solver/ceres-solver.git --branch ${CERES_SOLVER_VERSION}
+RUN cd ceres-solver && \
 	mkdir build && \
 	cd build && \
 	cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF && \


### PR DESCRIPTION
There is no `--tag` option for `git clone` only `--branch` [1]. What is happening is git seems to be ignoring the `--tag` flag and naming the clone 2.1.0. But it is *not* checking out that version. It checks out master. 

[1] https://git-scm.com/docs/git-clone