### PR TITLE
Add to IncrementalMapper reusage of Ceres internal context

### DIFF
--- a/src/estimators/pose.h
+++ b/src/estimators/pose.h
@@ -97,6 +97,9 @@ struct AbsolutePoseRefinementOptions {
   // Whether to print final summary.
   bool print_summary = true;
 
+  // Number of threads to use during refinement.
+  int num_threads = 1;
+
   void Check() const {
     CHECK_GE(gradient_tolerance, 0.0);
     CHECK_GE(max_num_iterations, 0);
@@ -162,6 +165,7 @@ size_t EstimateRelativePose(const RANSACOptions& ransac_options,
 // @param rot_tvec_covariance  Estimated 6x6 covariance matrix of
 //                             the rotation (as axis-angle, in tangent space)
 //                             and translation terms (optional).
+// @param ceres_context        Ceres Solver internal context (optional).
 //
 // @return                     Whether the solution is usable.
 bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
@@ -170,7 +174,8 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
                         const std::vector<Eigen::Vector3d>& points3D,
                         Eigen::Vector4d* qvec, Eigen::Vector3d* tvec,
                         Camera* camera,
-                        Eigen::Matrix6d* rot_tvec_covariance = nullptr);
+                        Eigen::Matrix6d* rot_tvec_covariance = nullptr,
+                        ceres::Context* ceres_context = nullptr);
 
 // Refine relative pose of two cameras.
 //

--- a/src/optim/bundle_adjustment.cc
+++ b/src/optim/bundle_adjustment.cc
@@ -76,7 +76,10 @@ bool BundleAdjustmentOptions::Check() const {
 // BundleAdjustmentConfig
 ////////////////////////////////////////////////////////////////////////////////
 
-BundleAdjustmentConfig::BundleAdjustmentConfig() {}
+BundleAdjustmentConfig::BundleAdjustmentConfig() : ceres_context_(nullptr) {}
+
+BundleAdjustmentConfig::BundleAdjustmentConfig(ceres::Context* ceres_context)
+    : ceres_context_(ceres_context) {}
 
 size_t BundleAdjustmentConfig::NumImages() const { return image_ids_.size(); }
 
@@ -245,6 +248,10 @@ void BundleAdjustmentConfig::RemoveConstantPoint(const point3D_t point3D_id) {
   constant_point3D_ids_.erase(point3D_id);
 }
 
+ceres::Context* BundleAdjustmentConfig::GetCeresContext() const {
+  return ceres_context_;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // BundleAdjuster
 ////////////////////////////////////////////////////////////////////////////////
@@ -259,7 +266,9 @@ bool BundleAdjuster::Solve(Reconstruction* reconstruction) {
   CHECK_NOTNULL(reconstruction);
   CHECK(!problem_) << "Cannot use the same BundleAdjuster multiple times";
 
-  problem_.reset(new ceres::Problem());
+  ceres::Problem::Options problem_options;
+  problem_options.context = config_.GetCeresContext();
+  problem_.reset(new ceres::Problem(problem_options));
 
   ceres::LossFunction* loss_function = options_.CreateLossFunction();
   SetUp(reconstruction, loss_function);

--- a/src/optim/bundle_adjustment.h
+++ b/src/optim/bundle_adjustment.h
@@ -103,6 +103,7 @@ struct BundleAdjustmentOptions {
 class BundleAdjustmentConfig {
  public:
   BundleAdjustmentConfig();
+  explicit BundleAdjustmentConfig(ceres::Context *ceres_context);
 
   size_t NumImages() const;
   size_t NumPoints() const;
@@ -157,6 +158,7 @@ class BundleAdjustmentConfig {
   const std::unordered_set<point3D_t>& ConstantPoints() const;
   const std::vector<int>& ConstantTvec(const image_t image_id) const;
 
+  ceres::Context* GetCeresContext() const;
  private:
   std::unordered_set<camera_t> constant_camera_ids_;
   std::unordered_set<image_t> image_ids_;
@@ -164,6 +166,7 @@ class BundleAdjustmentConfig {
   std::unordered_set<point3D_t> constant_point3D_ids_;
   std::unordered_set<image_t> constant_poses_;
   std::unordered_map<image_t, std::vector<int>> constant_tvecs_;
+  ceres::Context* ceres_context_;
 };
 
 // Bundle adjustment based on Ceres-Solver. Enables most flexible configurations

--- a/src/sfm/incremental_mapper.h
+++ b/src/sfm/incremental_mapper.h
@@ -32,6 +32,8 @@
 #ifndef COLMAP_SRC_SFM_INCREMENTAL_MAPPER_H_
 #define COLMAP_SRC_SFM_INCREMENTAL_MAPPER_H_
 
+#include <ceres/context.h>
+
 #include "base/database.h"
 #include "base/database_cache.h"
 #include "base/reconstruction.h"
@@ -306,6 +308,8 @@ class IncrementalMapper {
   // This image list will be non-empty, if the reconstruction is continued from
   // an existing reconstruction.
   std::unordered_set<image_t> existing_image_ids_;
+
+  std::unique_ptr<ceres::Context> ceres_context_;
 };
 
 }  // namespace colmap


### PR DESCRIPTION
Avoid costs for Ceres internal threadpool initialization at each bundle adjustment instance solve, by reusing Ceres internal context.