### PR TITLE
Fix broken loading of image masks on macOS

### DIFF
--- a/src/base/image_reader.cc
+++ b/src/base/image_reader.cc
@@ -54,6 +54,8 @@ ImageReader::ImageReader(const ImageReaderOptions& options, Database* database)
   // Ensure trailing slash, so that we can build the correct image name.
   options_.image_path =
       EnsureTrailingSlash(StringReplace(options_.image_path, "\\", "/"));
+  options_.mask_path =
+      EnsureTrailingSlash(StringReplace(options_.mask_path, "\\", "/"));
 
   // Get a list of all files in the image path, sorted by image name.
   if (options_.image_list.empty()) {
@@ -140,7 +142,7 @@ ImageReader::Status ImageReader::Next(Camera* camera, Image* image,
   if (mask && !options_.mask_path.empty()) {
     const std::string mask_path =
         JoinPaths(options_.mask_path,
-                  GetRelativePath(options_.image_path, image_path) + ".png");
+                  image->Name() + ".png");
     if (ExistsFile(mask_path) && !mask->Read(mask_path, false)) {
       // NOTE: Maybe introduce a separate error type MASK_ERROR?
       return Status::BITMAP_ERROR;

--- a/src/util/misc.cc
+++ b/src/util/misc.cc
@@ -134,45 +134,6 @@ std::string GetParentDir(const std::string& path) {
   return boost::filesystem::path(path).parent_path().string();
 }
 
-std::string GetRelativePath(const std::string& from, const std::string& to) {
-  // This implementation is adapted from:
-  // https://stackoverflow.com/questions/10167382
-  // A native implementation in boost::filesystem is only available starting
-  // from boost version 1.60.
-  using namespace boost::filesystem;
-
-  path from_path = canonical(path(from));
-  path to_path = canonical(path(to));
-
-  // Start at the root path and while they are the same then do nothing then
-  // when they first diverge take the entire from path, swap it with '..'
-  // segments, and then append the remainder of the to path.
-  path::const_iterator from_iter = from_path.begin();
-  path::const_iterator to_iter = to_path.begin();
-
-  // Loop through both while they are the same to find nearest common directory
-  while (from_iter != from_path.end() && to_iter != to_path.end() &&
-         (*to_iter) == (*from_iter)) {
-    ++to_iter;
-    ++from_iter;
-  }
-
-  // Replace from path segments with '..' (from => nearest common directory)
-  path rel_path;
-  while (from_iter != from_path.end()) {
-    rel_path /= "..";
-    ++from_iter;
-  }
-
-  // Append the remainder of the to path (nearest common directory => to)
-  while (to_iter != to_path.end()) {
-    rel_path /= *to_iter;
-    ++to_iter;
-  }
-
-  return rel_path.string();
-}
-
 std::vector<std::string> GetFileList(const std::string& path) {
   std::vector<std::string> file_list;
   for (auto it = boost::filesystem::directory_iterator(path);

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -85,10 +85,6 @@ std::string GetPathBaseName(const std::string& path);
 // Get the path of the parent directory for the given path.
 std::string GetParentDir(const std::string& path);
 
-// Get the relative path between from and to. Both the from and to paths must
-// exist.
-std::string GetRelativePath(const std::string& from, const std::string& to);
-
 // Join multiple paths into one path.
 template <typename... T>
 std::string JoinPaths(T const&... paths);


### PR DESCRIPTION
OS: macOS 12.5.1
COLMAP version: 3.8

I experienced the problem that my image masks where not used during feature extraction. Debugging of the mask loading process showed that function `GetRelativePath(options_.image_path, image_path)` had a faulty behaviour:

- Inputs (example):
   - options_.image_path: /users/buesma/colmap-ws/images/
   - image_path: /users/buesma/colmap-ws/images/cam1/image0001
- Retval (expected): cam1/image0001
- Retval (actual): ../cam1/image0001

This could be related to issues of the BOOST filesystem library with paths with trailing slashs under macOS (probably related boostorg/filesystem#76). The wrong path lead to `ExistsFile(mask_path)`returning `False`, and therefore to not loading the image mask.

As `options_.image_path` is fully contained in `image_path`, the (for macOS) faulty function for computation of relative paths is not needed at all. In fact, the relative path is already computed with simple string operations  for `image->Name()` (see line 105).

Independent of this problem, `mask_path` was not processed the same way as `image_path`, before being assigned to `options`. This could have led to issues in the future.
