### PR TITLE
Fix inconsistent image resizing between CPU/GPU implementations of SIFT

### DIFF
--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -794,8 +794,13 @@ bool CreateSiftGPUExtractor(const SiftExtractionOptions& options,
   sift_gpu_args.push_back("0");
 
   // Fixed maximum image dimension.
+  // Note the max dimension of siftGPU is the maximum dimension of the
+  // first scale in the pyramid(which is the 'first_octave')
+  const double compensation_ratio = options.first_octave < 0 ?
+                              std::pow(2, -options.first_octave) : 1;
   sift_gpu_args.push_back("-maxd");
-  sift_gpu_args.push_back(std::to_string(options.max_image_size * 2));
+  sift_gpu_args.push_back(
+      std::to_string(options.max_image_size * compensation_ratio));
 
   // Keep the highest level features.
   sift_gpu_args.push_back("-tc2");
@@ -854,7 +859,11 @@ bool ExtractSiftFeaturesGPU(const SiftExtractionOptions& options,
   CHECK(bitmap.IsGrey());
   CHECK_NOTNULL(keypoints);
   CHECK_NOTNULL(descriptors);
-  CHECK_EQ(options.max_image_size * 2, sift_gpu->GetMaxDimension());
+
+  const double compensation_ratio = options.first_octave < 0 ?
+                              std::pow(2, -options.first_octave) : 1;
+  CHECK_EQ(options.max_image_size * compensation_ratio,
+           sift_gpu->GetMaxDimension());
 
   CHECK(!options.estimate_affine_shape);
   CHECK(!options.domain_size_pooling);

--- a/src/feature/sift.cc
+++ b/src/feature/sift.cc
@@ -795,7 +795,7 @@ bool CreateSiftGPUExtractor(const SiftExtractionOptions& options,
 
   // Fixed maximum image dimension.
   sift_gpu_args.push_back("-maxd");
-  sift_gpu_args.push_back(std::to_string(options.max_image_size));
+  sift_gpu_args.push_back(std::to_string(options.max_image_size * 2));
 
   // Keep the highest level features.
   sift_gpu_args.push_back("-tc2");
@@ -854,7 +854,7 @@ bool ExtractSiftFeaturesGPU(const SiftExtractionOptions& options,
   CHECK(bitmap.IsGrey());
   CHECK_NOTNULL(keypoints);
   CHECK_NOTNULL(descriptors);
-  CHECK_EQ(options.max_image_size, sift_gpu->GetMaxDimension());
+  CHECK_EQ(options.max_image_size * 2, sift_gpu->GetMaxDimension());
 
   CHECK(!options.estimate_affine_shape);
   CHECK(!options.domain_size_pooling);


### PR DESCRIPTION
**This is an important fix which could improves reconstruction quality in many cases.**

Fix the issue of inconsistent resize behavior between CPU version of SIFT and siftGPU.

The 'max_image_size' is passed to '-maxd' flag of siftGPU. The '-maxd' flag means _maximum working dimension of SIFT algorithm_. The problem is that the _maximum working dimension of SIFT algorithm_ is twice the maximum of the image width/height(The SIFT algorithm first doubles the width and height of its input image).

The issue will cause that many reconstructions which used siftGPU features suffer from potentially lower feature quality and less feature numbers due to unexpected image down-sampling.

Check siftGPU manual for more details.

<img width="601" alt="image" src="https://user-images.githubusercontent.com/44798666/192839302-ec193e28-3952-433e-87c8-d8c6b01802d2.png">
