### PR TITLE
Add use_cache in fusion options GUI

### DIFF
--- a/src/ui/dense_reconstruction_widget.cc
+++ b/src/ui/dense_reconstruction_widget.cc
@@ -116,8 +116,7 @@ class FusionOptionsTab : public OptionsWidget {
     AddOptionDouble(&options->stereo_fusion->cache_size,
                     "cache_size [gigabytes]", 0,
                     std::numeric_limits<double>::max(), 0.1, 1);
-    AddOptionBool(&options->stereo_fusion->use_cache,
-                    "use_cache");
+    AddOptionBool(&options->stereo_fusion->use_cache, "use_cache");
   }
 };
 

--- a/src/ui/dense_reconstruction_widget.cc
+++ b/src/ui/dense_reconstruction_widget.cc
@@ -116,6 +116,8 @@ class FusionOptionsTab : public OptionsWidget {
     AddOptionDouble(&options->stereo_fusion->cache_size,
                     "cache_size [gigabytes]", 0,
                     std::numeric_limits<double>::max(), 0.1, 1);
+    AddOptionBool(&options->stereo_fusion->use_cache,
+                    "use_cache");
   }
 };
 


### PR DESCRIPTION
Adds use_cache option in stereo_fusion options GUI (previously only available through command line interface)