### PR TITLE
Avoid unnecessary copies of data

### DIFF
--- a/src/base/database_cache.h
+++ b/src/base/database_cache.h
@@ -77,8 +77,8 @@ class DatabaseCache {
   inline const class CorrespondenceGraph& CorrespondenceGraph() const;
 
   // Manually add data to cache.
-  void AddCamera(const class Camera& camera);
-  void AddImage(const class Image& image);
+  void AddCamera(class Camera camera);
+  void AddImage(class Image image);
 
   // Load cameras, images, features, and matches from database.
   //

--- a/src/base/point3d.h
+++ b/src/base/point3d.h
@@ -73,7 +73,7 @@ class Point3D {
 
   inline const class Track& Track() const;
   inline class Track& Track();
-  inline void SetTrack(const class Track& track);
+  inline void SetTrack(class Track track);
 
  private:
   // The 3D position of the point.
@@ -131,7 +131,7 @@ class Track& Point3D::Track() {
   return track_;
 }
 
-void Point3D::SetTrack(const class Track& track) { track_ = track; }
+void Point3D::SetTrack(class Track track) { track_ = std::move(track); }
 
 }  // namespace colmap
 

--- a/src/base/reconstruction.h
+++ b/src/base/reconstruction.h
@@ -129,14 +129,14 @@ class Reconstruction {
 
   // Add new camera. There is only one camera per image, while multiple images
   // might be taken by the same camera.
-  void AddCamera(const class Camera& camera);
+  void AddCamera(class Camera camera);
 
   // Add new image.
-  void AddImage(const class Image& image);
+  void AddImage(class Image image);
 
   // Add new 3D object, and return its unique ID.
   point3D_t AddPoint3D(
-      const Eigen::Vector3d& xyz, const Track& track,
+      const Eigen::Vector3d& xyz, Track track,
       const Eigen::Vector3ub& color = Eigen::Vector3ub::Zero());
 
   // Add observation to existing 3D point.

--- a/src/base/track.h
+++ b/src/base/track.h
@@ -59,7 +59,7 @@ class Track {
   // Access all elements.
   inline const std::vector<TrackElement>& Elements() const;
   inline std::vector<TrackElement>& Elements();
-  inline void SetElements(const std::vector<TrackElement>& elements);
+  inline void SetElements(std::vector<TrackElement> elements);
 
   // Access specific elements.
   inline const TrackElement& Element(const size_t idx) const;
@@ -96,8 +96,8 @@ const std::vector<TrackElement>& Track::Elements() const { return elements_; }
 
 std::vector<TrackElement>& Track::Elements() { return elements_; }
 
-void Track::SetElements(const std::vector<TrackElement>& elements) {
-  elements_ = elements;
+void Track::SetElements(std::vector<TrackElement> elements) {
+  elements_ = std::move(elements);
 }
 
 // Access specific elements.

--- a/src/sfm/incremental_mapper.cc
+++ b/src/sfm/incremental_mapper.cc
@@ -334,7 +334,7 @@ bool IncrementalMapper::RegisterInitialImagePair(const Options& options,
         HasPointPositiveDepth(proj_matrix2, xyz)) {
       track.Element(0).point2D_idx = corr.point2D_idx1;
       track.Element(1).point2D_idx = corr.point2D_idx2;
-      reconstruction_->AddPoint3D(xyz, track);
+      reconstruction_->AddPoint3D(xyz, std::move(track));
     }
   }
 

--- a/src/sfm/incremental_triangulator.cc
+++ b/src/sfm/incremental_triangulator.cc
@@ -221,7 +221,8 @@ size_t IncrementalTriangulator::CompleteImage(const Options& options,
       }
     }
 
-    const point3D_t point3D_id = reconstruction_->AddPoint3D(xyz, track);
+    const point3D_t point3D_id =
+        reconstruction_->AddPoint3D(xyz, std::move(track));
     modified_point3D_ids_.insert(point3D_id);
   }
 
@@ -531,15 +532,17 @@ size_t IncrementalTriangulator::Create(
   }
 
   // Add estimated point to reconstruction.
-  const point3D_t point3D_id = reconstruction_->AddPoint3D(xyz, track);
+  const size_t track_length = track.Length();
+  const point3D_t point3D_id =
+      reconstruction_->AddPoint3D(xyz, std::move(track));
   modified_point3D_ids_.insert(point3D_id);
 
   const size_t kMinRecursiveTrackLength = 3;
-  if (create_corrs_data.size() - track.Length() >= kMinRecursiveTrackLength) {
-    return track.Length() + Create(options, create_corrs_data);
+  if (create_corrs_data.size() - track_length >= kMinRecursiveTrackLength) {
+    return track_length + Create(options, create_corrs_data);
   }
 
-  return track.Length();
+  return track_length;
 }
 
 size_t IncrementalTriangulator::Continue(


### PR DESCRIPTION
Better usage of move semantics to avoid unnecessary and expensive copy of data.