### PR TITLE
Use FindCUDAToolkit when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,11 @@ endif()
 
 set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)
-    find_package(CUDA ${CUDA_MIN_VERSION} QUIET)
+    if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+	find_package(CUDA ${CUDA_MIN_VERSION} QUIET)
+    else()
+	find_package(CUDAToolkit ${CUDA_MIN_VERSION} QUIET)
+    endif()
 endif()
 
 if(GUI_ENABLED)


### PR DESCRIPTION
Using find_package resulted in missing CUDA::cudart, CUDA::cublas, etc, from my machine.
WSL Ubuntu 20, CMake 3.24, CUDA 12.

Using find_package(CUDAToolkit) solved this issue. Also, FindCUDA is departed since CMake 3.10!

Have not tested this in other machines and new to using CUDA, so maybe this might be a wrong approach to this problem...

references:
https://cmake.org/cmake/help/latest/module/FindCUDA.html
https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html