### PR TITLE
Fixed a crash due to inconsistent undistortion

### DIFF
--- a/src/base/undistortion.cc
+++ b/src/base/undistortion.cc
@@ -954,7 +954,10 @@ void UndistortImage(const UndistortCameraOptions& options,
 void UndistortReconstruction(const UndistortCameraOptions& options,
                              Reconstruction* reconstruction) {
   const auto distorted_cameras = reconstruction->Cameras();
-  for (auto& camera : distorted_cameras) {
+  for (const auto& camera : distorted_cameras) {
+    if (camera.second.IsUndistorted()) {
+      continue;
+    }
     reconstruction->Camera(camera.first) =
         UndistortCamera(options, camera.second);
   }


### PR DESCRIPTION
When distortion coefficients are really small but not zero, IsUndistorted() may return true, but undistorted image size may still be different from the original image size. In this situation the mismatch between the image size in the model and the actual image size causes the patch match stereo step to crash. This change skips camera undistortion when the coefficients are very small, which makes it consistent with image undistortion and fixes the crash.