### PR TITLE
Delete the redundancy install of libmetis-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,7 @@ RUN apt-get update && apt-get install -y \
     libglew-dev \
     qtbase5-dev \
     libqt5opengl5-dev \
-    libcgal-dev \
-    libmetis-dev
+    libcgal-dev
 
 # Build and install ceres solver
 RUN apt-get -y install \


### PR DESCRIPTION
The libmetis-dev  is installed from line 19. Delete the redundancy install of libmetis-dev at line 26.