### PR TITLE
Fixed mistake in code comment for OpenCV Fisheye camera

### DIFF
--- a/src/base/camera_models.h
+++ b/src/base/camera_models.h
@@ -250,8 +250,8 @@ struct OpenCVCameraModel : public BaseCameraModel<OpenCVCameraModel> {
 
 // OpenCV fish-eye camera model.
 //
-// Based on the pinhole camera model. Additionally models radial and
-// tangential Distortion (up to 2nd degree of coefficients). Suitable for
+// Based on the pinhole camera model. Additionally models radial distortion
+// (up to 4th degree of coefficients). Suitable for
 // large radial distortions of fish-eye cameras.
 //
 // Parameter list is expected in the following order:


### PR DESCRIPTION
The description of the model was accidentally duplicated from the model above. 