### PR TITLE
fix take the same image for construct pair

### DIFF
--- a/src/feature/matching.cc
+++ b/src/feature/matching.cc
@@ -1041,7 +1041,7 @@ void SequentialFeatureMatcher::RunSequentialMatching(
 
     image_pairs.clear();
     for (int i = 0; i < options_.overlap; ++i) {
-      const size_t image_idx2 = image_idx1 + i;
+      const size_t image_idx2 = image_idx1 + i + 1;
       if (image_idx2 < image_ids.size()) {
         image_pairs.emplace_back(image_id1, image_ids.at(image_idx2));
         if (options_.quadratic_overlap) {


### PR DESCRIPTION
if ```i==0```, then ```image_idx2 is equal image_idx1```, the image pair is redundancy