### PR TITLE
database_merger: add 'Panoptic Studio' mode

### DIFF
--- a/src/base/database.h
+++ b/src/base/database.h
@@ -224,7 +224,7 @@ class Database {
 
   // Merge two databases into a single, new database.
   static void Merge(const Database& database1, const Database& database2,
-                    Database* merged_database);
+                    Database* merged_database, const bool panoptic_studio = false);
 
  private:
   friend class DatabaseTransaction;

--- a/src/exe/database.cc
+++ b/src/exe/database.cc
@@ -92,11 +92,13 @@ int RunDatabaseMerger(int argc, char** argv) {
   std::string database_path1;
   std::string database_path2;
   std::string merged_database_path;
+  bool panoptic_studio = false;
 
   OptionManager options;
   options.AddRequiredOption("database_path1", &database_path1);
   options.AddRequiredOption("database_path2", &database_path2);
   options.AddRequiredOption("merged_database_path", &merged_database_path);
+  options.AddDefaultOption("panoptic_studio", &panoptic_studio, "Do feature matches merging as in 'Panoptic Studio' paper, Section 3.4");
   options.Parse(argc, argv);
 
   if (ExistsFile(merged_database_path)) {
@@ -107,7 +109,7 @@ int RunDatabaseMerger(int argc, char** argv) {
   Database database1(database_path1);
   Database database2(database_path2);
   Database merged_database(merged_database_path);
-  Database::Merge(database1, database2, &merged_database);
+  Database::Merge(database1, database2, &merged_database, panoptic_studio);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I'm not very familiar with Multi-View Stereo, but I think this is a correct reimplementation of what is described in Section 3.4 of the [Panoptic Studio](https://www.cs.cmu.edu/~hanbyulj/panoptic-studio/) paper.

Here's an example synthetic result where the same multi-view camera rig captures three scenes each containing a textured cube in a different configuration:
![image](https://user-images.githubusercontent.com/1090150/227820415-8b0426cb-a46e-493e-a214-274f8c859de6.png)

This result seems to agree with what is shown in the author's [tutorial video](https://youtu.be/wmQF3XKvL8s?t=2958):
![image](https://user-images.githubusercontent.com/1090150/227820710-3f46ccd6-b55d-4cb9-bf5b-8f10bd43defc.png)

