### PR TITLE
Log the name of the file that causes Mat::Read() to checkfail

### DIFF
--- a/src/mvs/mat.h
+++ b/src/mvs/mat.h
@@ -164,9 +164,9 @@ void Mat<T>::Read(const std::string& path) {
   std::streampos pos = text_file.tellg();
   text_file.close();
 
-  CHECK_GT(width_, 0);
-  CHECK_GT(height_, 0);
-  CHECK_GT(depth_, 0);
+  CHECK_GT(width_, 0) << path;
+  CHECK_GT(height_, 0) << path;
+  CHECK_GT(depth_, 0) << path;
   data_.resize(width_ * height_ * depth_);
 
   std::fstream binary_file(path, std::ios::in | std::ios::binary);


### PR DESCRIPTION
Some of the CHECK statements in Mat::Read() do not log the name of the file that triggers them. This can cause crashes that are difficult to debug.