### PR TITLE
Fix Ceres version test

### DIFF
--- a/src/colmap/base/cost_functions.h
+++ b/src/colmap/base/cost_functions.h
@@ -295,7 +295,8 @@ class RelativePoseCostFunction {
 };
 
 inline void SetQuaternionManifold(ceres::Problem* problem, double* qvec) {
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || \
+   (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
   problem->SetManifold(qvec, new ceres::QuaternionManifold);
 #else
   problem->SetParameterization(qvec, new ceres::QuaternionParameterization);
@@ -306,7 +307,8 @@ inline void SetSubsetManifold(int size,
                               const std::vector<int>& constant_params,
                               ceres::Problem* problem,
                               double* params) {
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || \
+   (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
   problem->SetManifold(params,
                        new ceres::SubsetManifold(size, constant_params));
 #else
@@ -317,7 +319,8 @@ inline void SetSubsetManifold(int size,
 
 template <int size>
 inline void SetSphereManifold(ceres::Problem* problem, double* params) {
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || \
+   (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
   problem->SetManifold(params, new ceres::SphereManifold<size>);
 #else
   problem->SetParameterization(


### PR DESCRIPTION
In #1477, checks of the Ceres version were added to choose between the newer ceres::Manifold or the deprecated ceres::LocalParameterization interface, e.g.:

https://github.com/colmap/colmap/blob/bce8f13727960d9aa4a21bc87524ed11f4706f4f/src/colmap/base/cost_functions.h#L298

However, this test will incorrectly return False for Ceres versions 3.0, 4.0, etc. This PR fixes this bug so that True is returned for all Ceres versions 2.1 and beyond.