### PR TITLE
[feature] print verbose information for model analyzer

### DIFF
--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -448,9 +448,11 @@ int RunModelAligner(int argc, char** argv) {
 
 int RunModelAnalyzer(int argc, char** argv) {
   std::string path;
+  bool verbose = false;
 
   OptionManager options;
   options.AddRequiredOption("path", &path);
+  options.AddDefaultOption("verbose", &verbose);
   options.Parse(argc, argv);
 
   Reconstruction reconstruction;
@@ -478,6 +480,26 @@ int RunModelAnalyzer(int argc, char** argv) {
                             reconstruction.ComputeMeanReprojectionError())
             << std::endl;
 
+  // verbose information
+  if (verbose) {
+    PrintHeading2("Cameras");
+    for (const auto& camera : reconstruction.Cameras()) {
+      std::cout << StringPrintf(" - Camera id: %d, Model Name: %s, Params: %s",
+                                camera.first,
+                                camera.second.ModelName().c_str(),
+                                camera.second.ParamsToString().c_str())
+                << std::endl;
+    }
+
+    PrintHeading2("Images");
+    for (const auto& image_id : reconstruction.RegImageIds()) {
+      std::cout << StringPrintf(" - Registerd Image Id: %d, Name: %s",
+                                image_id,
+                                reconstruction.Image(image_id).Name().c_str())
+                << std::endl;
+    }
+  }
+  
   return EXIT_SUCCESS;
 }
 

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -484,7 +484,7 @@ int RunModelAnalyzer(int argc, char** argv) {
   if (verbose) {
     PrintHeading2("Cameras");
     for (const auto& camera : reconstruction.Cameras()) {
-      std::cout << StringPrintf(" - Camera id: %d, Model Name: %s, Params: %s",
+      std::cout << StringPrintf(" - Camera Id: %d, Model Name: %s, Params: %s",
                                 camera.first,
                                 camera.second.ModelName().c_str(),
                                 camera.second.ParamsToString().c_str())
@@ -493,7 +493,7 @@ int RunModelAnalyzer(int argc, char** argv) {
 
     PrintHeading2("Images");
     for (const auto& image_id : reconstruction.RegImageIds()) {
-      std::cout << StringPrintf(" - Registerd Image Id: %d, Name: %s",
+      std::cout << StringPrintf(" - Registered Image Id: %d, Name: %s",
                                 image_id,
                                 reconstruction.Image(image_id).Name().c_str())
                 << std::endl;


### PR DESCRIPTION
When solving the issue, I found the model analyzer didn't print model detail, I add an option to print the detail camera and image information. I think it's useful tooling enhancement.

https://github.com/colmap/colmap/issues/1946
would continue follow up the issue.