### PR TITLE
Add a missing include to compile with gcc13

### DIFF
--- a/src/colmap/base/database.cc
+++ b/src/colmap/base/database.cc
@@ -36,6 +36,7 @@
 #include "colmap/util/version.h"
 
 #include <fstream>
+#include <memory>
 
 namespace colmap {
 namespace {


### PR DESCRIPTION
- Add a missing include to compile with gcc13 on Fedora 38