### PR TITLE
Speed up snapshot construct in RigBundleAdjuster

### DIFF
--- a/src/colmap/base/camera_rig.cc
+++ b/src/colmap/base/camera_rig.cc
@@ -181,6 +181,7 @@ bool CameraRig::ComputeRelativePoses(const Reconstruction& reconstruction) {
       const auto& image = reconstruction.Image(image_id);
       if (image.CameraId() == ref_camera_id_) {
         ref_image = &image;
+        break;
       }
     }
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -643,6 +643,7 @@ std::vector<CameraRig> ReadCameraRigConfig(const std::string& rig_config_path,
         const auto& image = reconstruction.Image(image_id);
         if (image.CameraId() == camera_rig.RefCameraId()) {
           has_ref_camera = true;
+          break;
         }
       }
 


### PR DESCRIPTION
1. Too many loops for snapshot setup in ReadCameraRigConfig, could break if ref camera found.
2. the same for another palce in ComputeRelativePoses function , could break if ref camera found, although there is only one ref image.
