### PR TITLE
Added a virtual destructor to Sampler

### DIFF
--- a/src/colmap/optim/sampler.h
+++ b/src/colmap/optim/sampler.h
@@ -44,6 +44,7 @@ class Sampler {
  public:
   Sampler() = default;
   explicit Sampler(const size_t num_samples);
+  virtual ~Sampler() = default;
 
   // Initialize the sampler, before calling the `Sample` method.
   virtual void Initialize(const size_t total_num_samples) = 0;


### PR DESCRIPTION
Any superclass that has virtual methods should also have a virtual destructor, otherwise there's a risk of undefined behavior (if an object of a subclass is deleted through a pointer to the superclass).