### PR TITLE
Add missing Boost::graph import

### DIFF
--- a/cmake/CMakeConfig.cmake.in
+++ b/cmake/CMakeConfig.cmake.in
@@ -76,6 +76,7 @@ if(COLMAP_FIND_QUIETLY)
                  program_options
                  filesystem
                  system
+                 graph
                  unit_test_framework
                  QUIET)
 
@@ -101,6 +102,7 @@ else()
                  program_options
                  filesystem
                  system
+                 graph
                  unit_test_framework
                  REQUIRED)
 
@@ -184,6 +186,7 @@ if(UNIX)
         ${Boost_FILESYSTEM_LIBRARY}
         ${Boost_PROGRAM_OPTIONS_LIBRARY}
         ${Boost_SYSTEM_LIBRARY}
+        ${Boost_GRAPH_LIBRARY}
         pthread)
 endif()
 


### PR DESCRIPTION
Breaking changes introduced by https://github.com/colmap/colmap/pull/2016 and https://github.com/colmap/colmap/pull/2017.