### PR TITLE
Remove check on Qt version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ if(Qt5_FOUND)
         # Workaround for Qt5 CMake config bug under Ubuntu 20.04: https://gitlab.kitware.com/cmake/cmake/-/issues/16915
         if(TARGET Qt5::Core)
             get_property(core_options TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
-            string(REPLACE "-fPIC" "" new_qt5_core_options ${core_options})
+            string(REPLACE "-fPIC" "" new_qt5_core_options "${core_options}")
             set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_qt5_core_options})
             set_property(TARGET Qt5::Core PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE "ON")
             if(NOT IS_MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ if(Qt5_FOUND)
     if(Qt5_POSITION_INDEPENDENT_CODE)
         set(CMAKE_POSITION_INDEPENDENT_CODE ON)
         # Workaround for Qt5 CMake config bug under Ubuntu 20.04: https://gitlab.kitware.com/cmake/cmake/-/issues/16915
-        if(${Qt5_VERSION} VERSION_EQUAL "5.12.8" AND TARGET Qt5::Core)
+        if(TARGET Qt5::Core)
             get_property(core_options TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
             string(REPLACE "-fPIC" "" new_qt5_core_options ${core_options})
             set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_qt5_core_options})

--- a/cmake/CMakeConfig.cmake.in
+++ b/cmake/CMakeConfig.cmake.in
@@ -76,6 +76,7 @@ if(COLMAP_FIND_QUIETLY)
                  program_options
                  filesystem
                  system
+                 graph
                  unit_test_framework
                  QUIET)
 
@@ -101,6 +102,7 @@ else()
                  program_options
                  filesystem
                  system
+                 graph
                  unit_test_framework
                  REQUIRED)
 
@@ -184,6 +186,7 @@ if(UNIX)
         ${Boost_FILESYSTEM_LIBRARY}
         ${Boost_PROGRAM_OPTIONS_LIBRARY}
         ${Boost_SYSTEM_LIBRARY}
+        ${Boost_GRAPH_LIBRARY}
         pthread)
 endif()
 


### PR DESCRIPTION
I'm on Ubuntu 18.04 and seeing the extra `-fPIC` flag added by Qt 5.9.5, as reported in https://github.com/colmap/colmap/issues/1753 https://github.com/colmap/colmap/issues/1813. Upgrading to cmake 3.26 does not help. I think that it's safer to remove the flag regardless of the Qt version.