### PR TITLE
Use the reference of Rigid3d to reduce memory consumption

### DIFF
--- a/src/colmap/base/cost_functions.h
+++ b/src/colmap/base/cost_functions.h
@@ -129,7 +129,7 @@ class BundleAdjustmentConstantPoseCostFunction {
   }
 
  private:
-  const Rigid3d cam_from_world_;
+  const Rigid3d& cam_from_world_;
   const double observed_x_;
   const double observed_y_;
 };

--- a/src/colmap/base/cost_functions_test.cc
+++ b/src/colmap/base/cost_functions_test.cc
@@ -72,9 +72,10 @@ TEST(BundleAdjustment, AbsolutePose) {
 }
 
 TEST(BundleAdjustment, ConstantAbsolutePose) {
+  Rigid3d cam_from_world;
   std::unique_ptr<ceres::CostFunction> cost_function(
       BundleAdjustmentConstantPoseCostFunction<
-          SimplePinholeCameraModel>::Create(Rigid3d(),
+          SimplePinholeCameraModel>::Create(cam_from_world,
                                             Eigen::Vector2d::Zero()));
   double point3D[3] = {0, 0, 1};
   double camera_params[3] = {1, 0, 0};


### PR DESCRIPTION
Since all points in an image share a pose, we can use the reference of Rigid3d in BundleAdjustmentConstantPoseCostFunction to avoid memory consumption.