### PR TITLE
No reconstruction normalization when fix_exisiting_images option is set to true

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -720,7 +720,9 @@ bool IncrementalMapper::AdjustGlobalBundle(
 
   // Normalize scene for numerical stability and
   // to avoid large scale changes in viewer.
-  reconstruction_->Normalize();
+  if (!options.fix_existing_images) {
+    reconstruction_->Normalize();
+  }
 
   return true;
 }


### PR DESCRIPTION
Prevent applying a normalization step to the reconstruction after a Global BA step when the user set existing images as fixed in RunMapper(). 

Should fix issues #2061 #1260