### PR TITLE
Add ReprojErrorConstantPoint3DCostFunction to speed up the RefineAbsolutePose function

### DIFF
--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -139,13 +139,13 @@ class ReprojErrorConstantPoseCostFunction {
 template <typename CameraModel>
 class ReprojErrorConstantPoint3DCostFunction {
  public:
-  explicit ReprojErrorConstantPoint3DCostFunction(
-      const Eigen::Vector2d& point2D, const Eigen::Vector3d& point3D)
+  ReprojErrorConstantPoint3DCostFunction(const Eigen::Vector2d& point2D,
+                                         const Eigen::Vector3d& point3D)
       : observed_x_(point2D(0)),
         observed_y_(point2D(1)),
-        point_x_(point3D(0)),
-        point_y_(point3D(1)),
-        point_z_(point3D(2)) {}
+        point3D_x_(point3D(0)),
+        point3D_y_(point3D(1)),
+        point3D_z_(point3D(2)) {}
 
   static ceres::CostFunction* Create(const Eigen::Vector2d& point2D,
                                      const Eigen::Vector3d& point3D) {
@@ -164,9 +164,9 @@ class ReprojErrorConstantPoint3DCostFunction {
                   const T* const camera_params,
                   T* residuals) const {
     Eigen::Matrix<T, 3, 1> point3D;
-    point3D[0] = T(point_x_);
-    point3D[1] = T(point_y_);
-    point3D[2] = T(point_z_);
+    point3D[0] = T(point3D_x_);
+    point3D[1] = T(point3D_y_);
+    point3D[2] = T(point3D_z_);
 
     const Eigen::Matrix<T, 3, 1> point3D_in_cam =
         EigenQuaternionMap<T>(cam_from_world_rotation) * point3D +
@@ -185,9 +185,9 @@ class ReprojErrorConstantPoint3DCostFunction {
  private:
   const double observed_x_;
   const double observed_y_;
-  const double point_x_;
-  const double point_y_;
-  const double point_z_;
+  const double point3D_x_;
+  const double point3D_y_;
+  const double point3D_z_;
 };
 
 // Rig bundle adjustment cost function for variable camera pose and calibration

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -69,7 +69,7 @@ class ReprojErrorCostFunction {
                   const T* const point3D,
                   const T* const camera_params,
                   T* residuals) const {
-    Eigen::Matrix<T, 3, 1> point3D_in_cam =
+    const Eigen::Matrix<T, 3, 1> point3D_in_cam =
         EigenQuaternionMap<T>(cam_from_world_rotation) *
             EigenVector3Map<T>(point3D) +
         EigenVector3Map<T>(cam_from_world_translation);
@@ -114,7 +114,7 @@ class ReprojErrorConstantPoseCostFunction {
   bool operator()(const T* const point3D,
                   const T* const camera_params,
                   T* residuals) const {
-    Eigen::Matrix<T, 3, 1> point3D_in_cam =
+    const Eigen::Matrix<T, 3, 1> point3D_in_cam =
         cam_from_world_.rotation.cast<T>() * EigenVector3Map<T>(point3D) +
         cam_from_world_.translation.cast<T>();
     CameraModel::ImgFromCam(camera_params,
@@ -163,13 +163,13 @@ class ReprojErrorConstantPoint3DCostFunction {
                   const T* const cam_from_world_translation,
                   const T* const camera_params,
                   T* residuals) const {
-    Eigen::Matrix<T, 3, 1> point3d;
-    point3d[0] = T(point_x_);
-    point3d[1] = T(point_y_);
-    point3d[2] = T(point_z_);
+    Eigen::Matrix<T, 3, 1> point3D;
+    point3D[0] = T(point_x_);
+    point3D[1] = T(point_y_);
+    point3D[2] = T(point_z_);
 
-    Eigen::Matrix<T, 3, 1> point3D_in_cam =
-        EigenQuaternionMap<T>(cam_from_world_rotation) * point3d +
+    const Eigen::Matrix<T, 3, 1> point3D_in_cam =
+        EigenQuaternionMap<T>(cam_from_world_rotation) * point3D +
         EigenVector3Map<T>(cam_from_world_translation);
     CameraModel::ImgFromCam(camera_params,
                             point3D_in_cam[0],
@@ -223,7 +223,7 @@ class RigReprojErrorCostFunction {
                   const T* const point3D,
                   const T* const camera_params,
                   T* residuals) const {
-    Eigen::Matrix<T, 3, 1> point3D_in_cam =
+    const Eigen::Matrix<T, 3, 1> point3D_in_cam =
         EigenQuaternionMap<T>(cam_from_rig_rotation) *
             (EigenQuaternionMap<T>(rig_from_world_rotation) *
                  EigenVector3Map<T>(point3D) +

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -71,7 +71,7 @@ TEST(BundleAdjustment, AbsolutePose) {
   EXPECT_EQ(residuals[1], 2);
 }
 
-TEST(BundleAdjustment, ConstantAbsolutePose) {
+TEST(BundleAdjustment, ConstantPoseAbsolutePose) {
   Rigid3d cam_from_world;
   std::unique_ptr<ceres::CostFunction> cost_function(
       ReprojErrorConstantPoseCostFunction<SimplePinholeCameraModel>::Create(
@@ -98,6 +98,58 @@ TEST(BundleAdjustment, ConstantAbsolutePose) {
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], -2);
   EXPECT_EQ(residuals[1], 2);
+}
+
+TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
+  Eigen::Vector2d point2D = Eigen::Vector2d::Zero();
+  Eigen::Vector3d point3D;
+  point3D << 0, 0, 1;
+
+  double cam_from_world_rotation[4] = {0, 0, 0, 1};
+  double cam_from_world_translation[3] = {0, 0, 0};
+  double camera_params[3] = {1, 0, 0};
+  double residuals[2];
+  const double* parameters[3] = {
+      cam_from_world_rotation, cam_from_world_translation, camera_params};
+
+  {
+    std::unique_ptr<ceres::CostFunction> cost_function(
+        ReprojErrorConstantPoint3DCostFunction<
+            SimplePinholeCameraModel>::Create(point2D, point3D));
+    EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+    EXPECT_EQ(residuals[0], 0);
+    EXPECT_EQ(residuals[1], 0);
+  }
+
+  {
+    point3D[1] = 1;
+    std::unique_ptr<ceres::CostFunction> cost_function(
+        ReprojErrorConstantPoint3DCostFunction<
+            SimplePinholeCameraModel>::Create(point2D, point3D));
+    EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+    EXPECT_EQ(residuals[0], 0);
+    EXPECT_EQ(residuals[1], 1);
+  }
+
+  {
+    camera_params[0] = 2;
+    std::unique_ptr<ceres::CostFunction> cost_function(
+        ReprojErrorConstantPoint3DCostFunction<
+            SimplePinholeCameraModel>::Create(point2D, point3D));
+    EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+    EXPECT_EQ(residuals[0], 0);
+    EXPECT_EQ(residuals[1], 2);
+  }
+
+  {
+    point3D[0] = -1;
+    std::unique_ptr<ceres::CostFunction> cost_function(
+        ReprojErrorConstantPoint3DCostFunction<
+            SimplePinholeCameraModel>::Create(point2D, point3D));
+    EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+    EXPECT_EQ(residuals[0], -2);
+    EXPECT_EQ(residuals[1], 2);
+  }
 }
 
 TEST(BundleAdjustment, Rig) {

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -225,8 +225,6 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
   double* rig_from_world_rotation = cam_from_world->rotation.coeffs().data();
   double* rig_from_world_translation = cam_from_world->translation.data();
 
-  std::vector<Eigen::Vector3d> points3D_copy = points3D;
-
   ceres::Problem::Options problem_options;
   problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
   ceres::Problem problem(problem_options);

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -323,10 +323,8 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
   }
 
   if (problem.NumResiduals() > 0 && cam_from_world_cov != nullptr) {
-    ceres::Covariance::Options cov_options;
-    cov_options.algorithm_type = ceres::DENSE_SVD;
-
-    ceres::Covariance covariance(cov_options);
+    ceres::Covariance::Options options;
+    ceres::Covariance covariance(options);
     std::vector<const double*> parameter_blocks = {rig_from_world_rotation,
                                                    rig_from_world_translation};
     if (!covariance.Compute(parameter_blocks, &problem)) {


### PR DESCRIPTION
Add a new costfunction-ReprojErrorConstantPoint3DCostFunction  to speed up the RefineAbsolutePose function.