### PR TITLE
cmake: add testing.cc to colmap_util only if TESTS_ENABLED=ON

### DIFF
--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -41,7 +41,6 @@ COLMAP_ADD_LIBRARY(
         ply.h ply.cc
         sqlite3_utils.h
         string.h string.cc
-        testing.h testing.cc
         threading.h threading.cc
         timer.h timer.cc
         types.h
@@ -55,6 +54,13 @@ COLMAP_ADD_LIBRARY(
         Qt5::OpenGL
         SQLite::SQLite3
 )
+if(TESTS_ENABLED)
+    target_sources(
+        colmap_util
+        PRIVATE
+            testing.h testing.cc
+    )
+endif()
 
 if(CUDA_ENABLED)
     COLMAP_ADD_LIBRARY(


### PR DESCRIPTION
Conditionally add the files `testing.h` and `testing.cc` to the library target `colmap_util` only if `TESTS_ENABLED=ON`.

Otherwise one needs the `gtest/gtest.h` header available, for example by installing the Debian package `libgtest-dev`, even though no tests are actually built.

Using the `target_sources()` function (Introduced with CMake 3.1`) to conditionally add the two testing files to the util target.

https://cmake.org/cmake/help/latest/command/target_sources.html

Fixes: https://github.com/colmap/colmap/issues/2101