### PR TITLE
Update Linux install documentation with new branch policy

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -92,7 +92,6 @@ Configure and compile COLMAP::
 
     git clone https://github.com/colmap/colmap.git
     cd colmap
-    git checkout dev
     mkdir build
     cd build
     cmake .. -GNinja


### PR DESCRIPTION
Not sure if this is actually correct, but the `dev` branch doesn't exist anymore, and [this](https://github.com/colmap/colmap/commit/58ba46f81db47e2982545f763698f312d793e9e3) commit seems to suggest that it's formally no longer being used.