### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 ################################################################################
 
 set(COLMAP_FIND_QUIETLY FALSE)
+set(CMAKE_CUDA_ARCHITECTURES "native")  # Set the desired CUDA architecture(s)
 include(cmake/FindDependencies.cmake)
 
 ################################################################################


### PR DESCRIPTION
When installing colmap on deep learning cluster, I found that the colmap needs to know some GPU architecture parameter. When using native, it auto find and configures to the current GPU data.