### PR TITLE
Fix link in camera model documentation

### DIFF
--- a/doc/cameras.rst
+++ b/doc/cameras.rst
@@ -44,4 +44,4 @@ fix the intrinsic parameters during the reconstruction
 
 Please, refer to the camera models header file for information on the parameters
 of the different camera models:
-https://github.com/colmap/colmap/blob/master/src/colmap/camera/models.h
+https://github.com/colmap/colmap/blob/main/src/colmap/sensor/models.h


### PR DESCRIPTION
the header file is now in sensor and not in camera anymore