### PR TITLE
Check clang formatting in the CI

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '14'
+        check-path: 'src/colmap'

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -385,9 +385,10 @@ int RunPointTriangulator(int argc, char** argv) {
       "clear_points",
       &clear_points,
       "Whether to clear all existing points and observations");
-  options.AddDefaultOption(
-      "refine_intrinsics", &refine_intrinsics,
-      "Whether to refine the intrinsics of the cameras (fixing the principal point)");
+  options.AddDefaultOption("refine_intrinsics",
+                           &refine_intrinsics,
+                           "Whether to refine the intrinsics of the cameras "
+                           "(fixing the principal point)");
   options.AddMapperOptions();
   options.Parse(argc, argv);
 

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -42,7 +42,8 @@ int RunPointTriangulatorImpl(
     const std::string& image_path,
     const std::string& output_path,
     const IncrementalMapperOptions& mapper_options,
-    bool clear_points, bool refine_intrinsics);
+    bool clear_points,
+    bool refine_intrinsics);
 
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -1457,7 +1457,7 @@ std::unique_ptr<FeatureMatcher> CreateSiftFeatureMatcher(
     return SiftGPUFeatureMatcher::Create(options);
 #else
     return nullptr;
-#endif // COLMAP_GPU_ENABLED
+#endif  // COLMAP_GPU_ENABLED
   } else {
     return SiftCPUFeatureMatcher::Create(options);
   }


### PR DESCRIPTION
Alternatively, we could automatically run clang-format on each PR using https://pre-commit.ci/ and https://github.com/pre-commit/mirrors-clang-format.