### PR TITLE
Expose exe as libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ set(COLMAP_EXPORT_LIBS
     # Internal.
     colmap_controllers
     colmap_estimators
+    colmap_exe
     colmap_feature
     colmap_geometry
     colmap_image

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -227,7 +227,7 @@ vcpkg, first run `./vcpkg integrate install` and then configure COLMAP as::
     mkdir build
     cd build
     cmake .. -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
-    cmake --build . --config release --target colmap_exe --parallel 24
+    cmake --build . --config release --target colmap_main --parallel 24
 
 Alternatively, you can also use the Python build script. Please follow the
 instructions in the next section, but VCPKG is now the recommended approach.

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -48,11 +48,21 @@ if(GUI_ENABLED)
     )
 endif()
 
-COLMAP_ADD_EXECUTABLE(
+COLMAP_ADD_LIBRARY(
     NAME colmap_exe
     SRCS
         feature.h feature.cc
         sfm.h sfm.cc
+    PUBLIC_LINK_LIBS
+        colmap_controllers
+        colmap_scene
+)
+
+COLMAP_ADD_EXECUTABLE(
+    NAME colmap_main
+    SRCS
+        feature.cc
+        sfm.cc
         colmap.cc
         database.cc
         feature.cc
@@ -69,4 +79,4 @@ COLMAP_ADD_EXECUTABLE(
         colmap_util
         ${OPTIONAL_LIBS}
 )
-set_target_properties(colmap_exe PROPERTIES OUTPUT_NAME colmap)
+set_target_properties(colmap_main PROPERTIES OUTPUT_NAME colmap)

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -53,9 +53,14 @@ COLMAP_ADD_LIBRARY(
     SRCS
         feature.h feature.cc
         sfm.h sfm.cc
+        model.h model.cc
     PUBLIC_LINK_LIBS
         colmap_controllers
+        colmap_estimators
+        colmap_geometry
+        colmap_optim
         colmap_scene
+        colmap_util
 )
 
 COLMAP_ADD_EXECUTABLE(

--- a/src/colmap/exe/feature.cc
+++ b/src/colmap/exe/feature.cc
@@ -41,7 +41,6 @@
 #include "colmap/util/opengl_utils.h"
 
 namespace colmap {
-namespace {
 
 bool VerifyCameraParams(const std::string& camera_model,
                         const std::string& params) {
@@ -72,8 +71,6 @@ bool VerifySiftGPUParams(const bool use_gpu) {
 #endif
   return true;
 }
-
-}  // namespace
 
 void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
                                             CameraMode mode) {

--- a/src/colmap/exe/feature.cc
+++ b/src/colmap/exe/feature.cc
@@ -62,7 +62,7 @@ bool VerifyCameraParams(const std::string& camera_model,
 }
 
 bool VerifySiftGPUParams(const bool use_gpu) {
-#if defined(COLMAP_GPU_ENABLED)
+#if !defined(COLMAP_GPU_ENABLED)
   if (use_gpu) {
     std::cerr << "ERROR: Cannot use Sift GPU without CUDA or OpenGL support; "
                  "set SiftExtraction.use_gpu or SiftMatching.use_gpu to false."

--- a/src/colmap/exe/feature.h
+++ b/src/colmap/exe/feature.h
@@ -71,7 +71,7 @@ enum class CameraMode { AUTO = 0, SINGLE = 1, PER_FOLDER = 2, PER_IMAGE = 3 };
 void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
                                             CameraMode mode);
 
-bool VerifySiftGPUParams(const bool use_gpu);
+bool VerifySiftGPUParams(bool use_gpu);
 
 bool VerifyCameraParams(const std::string& camera_model,
                         const std::string& params);

--- a/src/colmap/exe/feature.h
+++ b/src/colmap/exe/feature.h
@@ -71,6 +71,11 @@ enum class CameraMode { AUTO = 0, SINGLE = 1, PER_FOLDER = 2, PER_IMAGE = 3 };
 void UpdateImageReaderOptionsFromCameraMode(ImageReaderOptions& options,
                                             CameraMode mode);
 
+bool VerifySiftGPUParams(const bool use_gpu);
+
+bool VerifyCameraParams(const std::string& camera_model,
+                        const std::string& params);
+
 int RunFeatureExtractor(int argc, char** argv);
 int RunFeatureImporter(int argc, char** argv);
 int RunExhaustiveMatcher(int argc, char** argv);

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -508,14 +508,47 @@ int RunModelComparer(int argc, char** argv) {
 
   Reconstruction reconstruction1;
   reconstruction1.Read(input_path1);
+  Reconstruction reconstruction2;
+  reconstruction2.Read(input_path2);
+  std::vector<ImageAlignmentError> errors;
+  Sim3d rec2_from_rec1;
+  bool success = CompareModels(reconstruction1,
+                               reconstruction2,
+                               alignment_error,
+                               min_inlier_observations,
+                               max_reproj_error,
+                               max_proj_center_error,
+                               errors,
+                               rec2_from_rec1);
+  if (!success) {
+    return EXIT_FAILURE;
+  }
+  if (!output_path.empty()) {
+    const std::string errors_path = JoinPaths(output_path, "errors.csv");
+    WriteComparisonErrorsCSV(errors_path, errors);
+    const std::string summary_path =
+        JoinPaths(output_path, "errors_summary.txt");
+    std::ofstream file(summary_path, std::ios::trunc);
+    CHECK(file.is_open()) << summary_path;
+    PrintComparisonSummary(file, errors);
+  }
+  return EXIT_SUCCESS;
+}
+
+int CompareModels(const Reconstruction& reconstruction1,
+                  const Reconstruction& reconstruction2,
+                  const std::string& alignment_error,
+                  const double min_inlier_observations,
+                  const double max_reproj_error,
+                  const double max_proj_center_error,
+                  std::vector<ImageAlignmentError>& errors,
+                  Sim3d& rec2_from_rec1) {
   PrintHeading1("Reconstruction 1");
   std::cout << StringPrintf("Images: %d", reconstruction1.NumRegImages())
             << std::endl;
   std::cout << StringPrintf("Points: %d", reconstruction1.NumPoints3D())
             << std::endl;
 
-  Reconstruction reconstruction2;
-  reconstruction2.Read(input_path2);
   PrintHeading1("Reconstruction 2");
   std::cout << StringPrintf("Images: %d", reconstruction2.NumRegImages())
             << std::endl;
@@ -528,7 +561,6 @@ int RunModelComparer(int argc, char** argv) {
   std::cout << StringPrintf("Common images: %d", common_image_ids.size())
             << std::endl;
 
-  Sim3d new_from_old_world;
   bool success = false;
   if (alignment_error == "reprojection") {
     success = AlignReconstructions(
@@ -536,42 +568,33 @@ int RunModelComparer(int argc, char** argv) {
         reconstruction2,
         /*min_inlier_observations=*/min_inlier_observations,
         /*max_reproj_error=*/max_reproj_error,
-        &new_from_old_world);
+        &rec2_from_rec1);
   } else if (alignment_error == "proj_center") {
     success =
         AlignReconstructions(reconstruction1,
                              reconstruction2,
                              /*max_proj_center_error=*/max_proj_center_error,
-                             &new_from_old_world);
+                             &rec2_from_rec1);
   } else {
     std::cout << "ERROR: Invalid alignment_error specified." << std::endl;
-    return EXIT_FAILURE;
+    return false;
   }
 
   if (!success) {
     std::cout << "=> Reconstruction alignment failed" << std::endl;
-    return EXIT_FAILURE;
+    return false;
   }
 
   std::cout << "Computed alignment transform:" << std::endl
-            << new_from_old_world.ToMatrix() << std::endl;
+            << rec2_from_rec1.ToMatrix() << std::endl;
 
-  const std::vector<ImageAlignmentError> errors = ComputeImageAlignmentError(
-      reconstruction1, reconstruction2, new_from_old_world);
+  errors = ComputeImageAlignmentError(
+      reconstruction1, reconstruction2, rec2_from_rec1);
 
   PrintHeading2("Image alignment error summary");
   PrintComparisonSummary(std::cout, errors);
-  if (!output_path.empty()) {
-    const std::string errors_path = JoinPaths(output_path, "errors.csv");
-    WriteComparisonErrorsCSV(errors_path, errors);
-    const std::string summary_path =
-        JoinPaths(output_path, "errors_summary.txt");
-    std::ofstream file(summary_path, std::ios::trunc);
-    CHECK(file.is_open()) << summary_path;
-    PrintComparisonSummary(file, errors);
-  }
 
-  return EXIT_SUCCESS;
+  return true;
 }
 
 int RunModelConverter(int argc, char** argv) {

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -535,14 +535,14 @@ int RunModelComparer(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
-int CompareModels(const Reconstruction& reconstruction1,
-                  const Reconstruction& reconstruction2,
-                  const std::string& alignment_error,
-                  const double min_inlier_observations,
-                  const double max_reproj_error,
-                  const double max_proj_center_error,
-                  std::vector<ImageAlignmentError>& errors,
-                  Sim3d& rec2_from_rec1) {
+bool CompareModels(const Reconstruction& reconstruction1,
+                   const Reconstruction& reconstruction2,
+                   const std::string& alignment_error,
+                   const double min_inlier_observations,
+                   const double max_reproj_error,
+                   const double max_proj_center_error,
+                   std::vector<ImageAlignmentError>& errors,
+                   Sim3d& rec2_from_rec1) {
   PrintHeading1("Reconstruction 1");
   std::cout << StringPrintf("Images: %d", reconstruction1.NumRegImages())
             << std::endl;

--- a/src/colmap/exe/model.h
+++ b/src/colmap/exe/model.h
@@ -29,7 +29,22 @@
 //
 // Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
 
+#pragma once
+
+#include "colmap/estimators/alignment.h"
+#include "colmap/geometry/sim3.h"
+#include "colmap/scene/reconstruction.h"
+
 namespace colmap {
+
+int CompareModels(const Reconstruction& reconstruction1,
+                  const Reconstruction& reconstruction2,
+                  const std::string& alignment_error,
+                  double min_inlier_observations,
+                  double max_reproj_error,
+                  double max_proj_center_error,
+                  std::vector<ImageAlignmentError>& errors,
+                  Sim3d& rec2_from_rec1);
 
 int RunModelAligner(int argc, char** argv);
 int RunModelAnalyzer(int argc, char** argv);

--- a/src/colmap/exe/model.h
+++ b/src/colmap/exe/model.h
@@ -37,14 +37,14 @@
 
 namespace colmap {
 
-int CompareModels(const Reconstruction& reconstruction1,
-                  const Reconstruction& reconstruction2,
-                  const std::string& alignment_error,
-                  double min_inlier_observations,
-                  double max_reproj_error,
-                  double max_proj_center_error,
-                  std::vector<ImageAlignmentError>& errors,
-                  Sim3d& rec2_from_rec1);
+bool CompareModels(const Reconstruction& reconstruction1,
+                   const Reconstruction& reconstruction2,
+                   const std::string& alignment_error,
+                   double min_inlier_observations,
+                   double max_reproj_error,
+                   double max_proj_center_error,
+                   std::vector<ImageAlignmentError>& errors,
+                   Sim3d& rec2_from_rec1);
 
 int RunModelAligner(int argc, char** argv);
 int RunModelAnalyzer(int argc, char** argv);


### PR DESCRIPTION
- Rename the executable target `colmap_exe` -> `colmap_main`.
- Add lib target `colmap_exe` to expose some internals of exe/{feature,sfm} for pycolmap - done in https://github.com/colmap/colmap/pull/1368 but the target was deleted in a recent commit.
- Expose the internals of RunModelComparer