### PR TITLE
Clean up dependencies

### DIFF
--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -127,6 +127,11 @@ COLMAP_ADD_TEST(
     LINK_LIBS colmap_estimators
 )
 COLMAP_ADD_TEST(
+    NAME similarity_transform_test
+    SRCS similarity_transform_test.cc
+    LINK_LIBS colmap_estimators
+)
+COLMAP_ADD_TEST(
     NAME translation_transform_test
     SRCS translation_transform_test.cc
     LINK_LIBS colmap_estimators

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -61,6 +61,7 @@ COLMAP_ADD_LIBRARY(
         colmap_sensor
         colmap_image
         colmap_scene
+        colmap_optim
         Eigen3::Eigen
         Ceres::ceres
 )

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -74,7 +74,7 @@ struct ReconstructionAlignmentEstimator {
     }
 
     Sim3d tgt_from_src;
-    if (tgt_from_src.Estimate(proj_centers1, proj_centers2)) {
+    if (EstimateSim3d(proj_centers1, proj_centers2, tgt_from_src)) {
       return {tgt_from_src};
     }
 

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -32,7 +32,6 @@
 #include "colmap/estimators/coordinate_frame.h"
 
 #include "colmap/geometry/gps.h"
-#include "colmap/scene/projection.h"
 
 #include <gtest/gtest.h>
 

--- a/src/colmap/estimators/essential_matrix_test.cc
+++ b/src/colmap/estimators/essential_matrix_test.cc
@@ -35,7 +35,6 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/math/random.h"
 #include "colmap/optim/ransac.h"
-#include "colmap/scene/projection.h"
 #include "colmap/sensor/models.h"
 
 #include <Eigen/Core>

--- a/src/colmap/estimators/generalized_absolute_pose.cc
+++ b/src/colmap/estimators/generalized_absolute_pose.cc
@@ -33,7 +33,6 @@
 
 #include "colmap/estimators/generalized_absolute_pose_coeffs.h"
 #include "colmap/math/polynomial.h"
-#include "colmap/scene/projection.h"
 #include "colmap/util/logging.h"
 
 #include <array>

--- a/src/colmap/estimators/generalized_absolute_pose_test.cc
+++ b/src/colmap/estimators/generalized_absolute_pose_test.cc
@@ -34,7 +34,6 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/optim/ransac.h"
-#include "colmap/scene/projection.h"
 
 #include <array>
 

--- a/src/colmap/estimators/generalized_relative_pose.cc
+++ b/src/colmap/estimators/generalized_relative_pose.cc
@@ -35,7 +35,6 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/triangulation.h"
 #include "colmap/math/random.h"
-#include "colmap/scene/projection.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Dense>

--- a/src/colmap/estimators/generalized_relative_pose_test.cc
+++ b/src/colmap/estimators/generalized_relative_pose_test.cc
@@ -34,7 +34,6 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/optim/loransac.h"
-#include "colmap/scene/projection.h"
 
 #include <array>
 

--- a/src/colmap/estimators/homography_matrix.cc
+++ b/src/colmap/estimators/homography_matrix.cc
@@ -32,7 +32,6 @@
 #include "colmap/estimators/homography_matrix.h"
 
 #include "colmap/estimators/utils.h"
-#include "colmap/scene/projection.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include "colmap/geometry/sim3.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 
@@ -89,6 +90,19 @@ class SimilarityTransformEstimator {
                         const M_t& matrix,
                         std::vector<double>* residuals);
 };
+
+inline bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
+                          const std::vector<Eigen::Vector3d>& tgt,
+                          Sim3d& tgt_from_src) {
+  const auto results =
+      SimilarityTransformEstimator<3, true>().Estimate(src, tgt);
+  if (results.empty()) {
+    return false;
+  }
+  CHECK_EQ(results.size(), 1);
+  tgt_from_src = Sim3d::FromMatrix(results[0]);
+  return true;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -31,7 +31,6 @@
 
 #pragma once
 
-#include "colmap/scene/projection.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -34,8 +34,6 @@
 #include "colmap/geometry/sim3.h"
 #include "colmap/math/random.h"
 
-#include <fstream>
-
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -29,37 +29,47 @@
 //
 // Author: Johannes L. Schoenberger (jsch-at-demuc-dot-de)
 
-#include "colmap/geometry/sim3.h"
+#include "colmap/estimators/similarity_transform.h"
 
-#include "colmap/util/logging.h"
+#include "colmap/geometry/sim3.h"
+#include "colmap/math/random.h"
 
 #include <fstream>
 
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
 namespace colmap {
 
-void Sim3d::ToFile(const std::string& path) const {
-  std::ofstream file(path, std::ios::trunc);
-  CHECK(file.good()) << path;
-  // Ensure that we don't loose any precision by storing in text.
-  file.precision(17);
-  file << scale << " " << rotation.w() << " " << rotation.x() << " "
-       << rotation.y() << " " << rotation.z() << " " << translation.x() << " "
-       << translation.y() << " " << translation.z() << std::endl;
+void TestEstimateSim3dWithNumCoords(const size_t num_coords) {
+  const Sim3d gt_tgt_from_src(RandomUniformReal<double>(0.1, 10),
+                              Eigen::Quaterniond::UnitRandom(),
+                              Eigen::Vector3d::Random());
+
+  std::vector<Eigen::Vector3d> src;
+  std::vector<Eigen::Vector3d> dst;
+  for (size_t i = 0; i < num_coords; ++i) {
+    src.emplace_back(i, i + 2, i * i);
+    dst.push_back(gt_tgt_from_src * src.back());
+  }
+
+  Sim3d tgt_from_src;
+  EXPECT_TRUE(EstimateSim3d(src, dst, tgt_from_src));
+  EXPECT_NEAR(gt_tgt_from_src.scale, tgt_from_src.scale, 1e-6);
+  EXPECT_LT(gt_tgt_from_src.rotation.angularDistance(tgt_from_src.rotation),
+            1e-6);
+  EXPECT_LT((gt_tgt_from_src.translation - tgt_from_src.translation).norm(),
+            1e-6);
 }
 
-Sim3d Sim3d::FromFile(const std::string& path) {
-  std::ifstream file(path);
-  CHECK(file.good()) << path;
-  Sim3d t;
-  file >> t.scale;
-  file >> t.rotation.w();
-  file >> t.rotation.x();
-  file >> t.rotation.y();
-  file >> t.rotation.z();
-  file >> t.translation(0);
-  file >> t.translation(1);
-  file >> t.translation(2);
-  return t;
+TEST(Sim3d, EstimateMinimal) { TestEstimateSim3dWithNumCoords(3); }
+
+TEST(Sim3d, EstimateOverDetermined) { TestEstimateSim3dWithNumCoords(100); }
+
+TEST(Sim3d, EstimateDegenerate) {
+  std::vector<Eigen::Vector3d> invalid_src_dst(3, Eigen::Vector3d::Zero());
+  Sim3d tgt_from_src;
+  EXPECT_FALSE(EstimateSim3d(invalid_src_dst, invalid_src_dst, tgt_from_src));
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -43,7 +43,6 @@
 #include "colmap/optim/loransac.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/scene/camera.h"
-#include "colmap/scene/projection.h"
 
 #include <unordered_set>
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -35,6 +35,7 @@
 #include "colmap/controllers/bundle_adjustment.h"
 #include "colmap/controllers/hierarchical_mapper.h"
 #include "colmap/controllers/option_manager.h"
+#include "colmap/estimators/similarity_transform.h"
 #include "colmap/exe/gui.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/misc.h"
@@ -282,8 +283,8 @@ int RunMapper(int argc, char** argv) {
             reconstruction->Image(image_id).ProjectionCenter());
       }
       Sim3d orig_from_new;
-      orig_from_new.Estimate(new_fixed_image_positions,
-                             orig_fixed_image_positions);
+      EstimateSim3d(
+          new_fixed_image_positions, orig_fixed_image_positions, orig_from_new);
       reconstruction->Transform(orig_from_new);
     }
 

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -45,8 +45,6 @@ COLMAP_ADD_LIBRARY(
         colmap_util
         colmap_math
         Eigen3::Eigen
-    PRIVATE_LINK_LIBS
-        colmap_estimators
 )
 
 COLMAP_ADD_TEST(

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -46,7 +46,7 @@ COLMAP_ADD_LIBRARY(
         colmap_math
         Eigen3::Eigen
     PRIVATE_LINK_LIBS
-        colmap_optim
+        colmap_estimators
 )
 
 COLMAP_ADD_TEST(

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -32,7 +32,6 @@
 #include "colmap/geometry/essential_matrix.h"
 
 #include "colmap/geometry/pose.h"
-#include "colmap/scene/projection.h"
 
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -32,7 +32,6 @@
 #include "colmap/geometry/pose.h"
 
 #include "colmap/math/math.h"
-#include "colmap/scene/projection.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/geometry/sim3.cc
+++ b/src/colmap/geometry/sim3.cc
@@ -32,8 +32,6 @@
 #include "colmap/geometry/sim3.h"
 
 #include "colmap/estimators/similarity_transform.h"
-#include "colmap/geometry/pose.h"
-#include "colmap/scene/projection.h"
 
 #include <fstream>
 

--- a/src/colmap/geometry/sim3.h
+++ b/src/colmap/geometry/sim3.h
@@ -69,10 +69,6 @@ struct Sim3d {
     return t;
   }
 
-  // Estimate tgtFromSrc transform. Return true if successful.
-  bool Estimate(const std::vector<Eigen::Vector3d>& src,
-                const std::vector<Eigen::Vector3d>& tgt);
-
   // Read from or write to text file without loss of precision.
   void ToFile(const std::string& path) const;
   static Sim3d FromFile(const std::string& path);

--- a/src/colmap/geometry/sim3_test.cc
+++ b/src/colmap/geometry/sim3_test.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/geometry/sim3.h"
 
-#include "colmap/geometry/pose.h"
 #include "colmap/math/random.h"
 #include "colmap/util/testing.h"
 
@@ -141,34 +140,6 @@ TEST(Sim3d, Compose) {
   const Eigen::Vector3d x_in_c = c_from_b * x_in_b;
   const Eigen::Vector3d x_in_d = d_from_c * x_in_c;
   EXPECT_LT((d_from_a * x_in_a - x_in_d).norm(), 1e-6);
-}
-
-void TestEstimationWithNumCoords(const size_t num_coords) {
-  const Sim3d gt_tgt_from_src = TestSim3d();
-
-  std::vector<Eigen::Vector3d> src;
-  std::vector<Eigen::Vector3d> dst;
-  for (size_t i = 0; i < num_coords; ++i) {
-    src.emplace_back(i, i + 2, i * i);
-    dst.push_back(gt_tgt_from_src * src.back());
-  }
-
-  Sim3d tgt_from_src;
-  EXPECT_TRUE(tgt_from_src.Estimate(src, dst));
-  EXPECT_NEAR(gt_tgt_from_src.scale, tgt_from_src.scale, 1e-6);
-  EXPECT_LT(gt_tgt_from_src.rotation.angularDistance(tgt_from_src.rotation),
-            1e-6);
-  EXPECT_LT((gt_tgt_from_src.translation - tgt_from_src.translation).norm(),
-            1e-6);
-}
-
-TEST(Sim3d, EstimateMinimal) { TestEstimationWithNumCoords(3); }
-
-TEST(Sim3d, EstimateOverDetermined) { TestEstimationWithNumCoords(100); }
-
-TEST(Sim3d, EstimateDegenerate) {
-  std::vector<Eigen::Vector3d> invalid_src_dst(3, Eigen::Vector3d::Zero());
-  EXPECT_FALSE(Sim3d().Estimate(invalid_src_dst, invalid_src_dst));
 }
 
 TEST(Sim3d, ToFromFile) {

--- a/src/colmap/retrieval/CMakeLists.txt
+++ b/src/colmap/retrieval/CMakeLists.txt
@@ -49,6 +49,7 @@ COLMAP_ADD_LIBRARY(
     PRIVATE_LINK_LIBS
         colmap_math
         colmap_estimators
+        colmap_optim
 )
 
 COLMAP_ADD_TEST(

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -34,7 +34,6 @@
 #include "colmap/geometry/gps.h"
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/triangulation.h"
-#include "colmap/optim/loransac.h"
 #include "colmap/scene/database_cache.h"
 #include "colmap/scene/projection.h"
 #include "colmap/sensor/bitmap.h"


### PR DESCRIPTION
Nasty dependency cycle:
```
  "colmap_estimators" of type STATIC_LIBRARY
    depends on "colmap_geometry" (weak)
    depends on "colmap_image" (weak)
    depends on "colmap_scene" (weak)
  "colmap_geometry" of type STATIC_LIBRARY
    depends on "colmap_estimators" (weak)
    depends on "colmap_image" (weak)
    depends on "colmap_scene" (weak)
  "colmap_image" of type STATIC_LIBRARY
    depends on "colmap_scene" (weak)
    depends on "colmap_geometry" (weak)
    depends on "colmap_estimators" (weak)
  "colmap_scene" of type STATIC_LIBRARY
    depends on "colmap_geometry" (weak)
    depends on "colmap_estimators" (weak)
    depends on "colmap_image" (weak)
```
Options:
1. Move `SimilarityTransform` to geometry
2. Move `Sim3d::Estimate` to `similarity_transform.h`

In the end I went for 2.