### PR TITLE
Restore GLEW include

### DIFF
--- a/src/colmap/feature/CMakeLists.txt
+++ b/src/colmap/feature/CMakeLists.txt
@@ -51,6 +51,9 @@ COLMAP_ADD_LIBRARY(
 )
 if(GPU_ENABLED)
     target_link_libraries(colmap_feature PRIVATE colmap_sift_gpu)
+    if(NOT GUI_ENABLED)
+        target_link_libraries(colmap_feature PRIVATE GLEW::GLEW)
+    endif()
 endif()
 
 COLMAP_ADD_TEST(

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -40,6 +40,10 @@
 
 #if defined(COLMAP_GPU_ENABLED)
 #include "thirdparty/SiftGPU/SiftGPU.h"
+#if !defined(COLMAP_GUI_ENABLED)
+// GLEW symbols are already defined by Qt.
+#include <GL/glew.h>
+#endif  // COLMAP_GUI_ENABLED
 #endif  // COLMAP_GPU_ENABLED
 #include "thirdparty/VLFeat/covdet.h"
 #include "thirdparty/VLFeat/sift.h"


### PR DESCRIPTION
Since https://github.com/colmap/colmap/pull/2176, building with `CUDA_ENABLED=ON GUI_ENABLED=OFF` fails due to undfined `GL_*` symbols:
https://github.com/colmap/colmap/blob/e7014366d750ba5a7e05956bc16617af84588cbd/src/colmap/feature/sift.cc#L652-L656