### PR TITLE
Fix bug in ReconstructionManagerWidget::Update

### DIFF
--- a/src/colmap/ui/reconstruction_manager_widget.cc
+++ b/src/colmap/ui/reconstruction_manager_widget.cc
@@ -81,7 +81,11 @@ void ReconstructionManagerWidget::Update() {
   if (reconstruction_manager_->Size() == 0) {
     setCurrentIndex(0);
   } else {
-    setCurrentIndex(prev_idx);
+    if (prev_idx <= reconstruction_manager_->Size()) {
+      setCurrentIndex(prev_idx);
+    } else {
+      setCurrentIndex(static_cast<int>(reconstruction_manager_->Size()));
+    }
   }
 
   blockSignals(false);


### PR DESCRIPTION
For some datasets with less overlap, small reconstructions will be merged into larger reconstruction or deleted. At this point, colmap may throw an exception if small reconstructions are selected on the ui. This PR attempts to fix this problem.