### PR TITLE
Removing clustering_options_ and mapper_options_ in Hierarchical Mapper Controller

### DIFF
--- a/src/colmap/controllers/hierarchical_mapper.h
+++ b/src/colmap/controllers/hierarchical_mapper.h
@@ -77,8 +77,6 @@ class HierarchicalMapperController : public Thread {
   void Run() override;
 
   const Options options_;
-  const SceneClustering::Options clustering_options_;
-  const std::shared_ptr<const IncrementalMapperOptions> mapper_options_;
   std::shared_ptr<ReconstructionManager> reconstruction_manager_;
 };
 


### PR DESCRIPTION
Hi, 

since `clustering_options_` and `mapper_options_` are moved into HierachicalMapperController::Options. They are no longer used, therefore they can be deleted.
