### PR TITLE
Update triangulation.cc

### DIFF
--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -121,7 +121,7 @@ std::vector<Eigen::Vector3d> TriangulateOptimalPoints(
   std::vector<Eigen::Vector3d> points3D(points1.size());
 
   for (size_t i = 0; i < points3D.size(); ++i) {
-    points3D[i] = TriangulatePoint(
+    points3D[i] = TriangulateOptimalPoint(
         cam1_from_world, cam2_from_world, points1[i], points2[i]);
   }
 


### PR DESCRIPTION
The original code's TriangulatePoints and TriangulateOptimalPoints appear to be indistinguishable. Based on the function's purpose, it seems that TriangulateOptimalPoints should probably use TriangulateOptimalPoint instead.