### PR TITLE
Update reconstruction.cc

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -2068,9 +2068,9 @@ void Reconstruction::ResetTriObservations(const image_t image_id,
         (!is_deleted_point3D || image_id < corr->image_id)) {
       const image_pair_t pair_id =
           Database::ImagePairToPairId(image_id, corr->image_id);
-      image_pair_stats_[pair_id].num_tri_corrs -= 1;
-      CHECK_GE(image_pair_stats_[pair_id].num_tri_corrs, 0)
+      CHECK_GT(image_pair_stats_[pair_id].num_tri_corrs, 0)
           << "The scene graph graph must not contain duplicate matches";
+      image_pair_stats_[pair_id].num_tri_corrs -= 1;
     }
   }
 }


### PR DESCRIPTION
The 'num_tri_corrs' is already of type 'size_t', so the original CHECK here to ensure it's non-negative is redundant. However, considering that a decrement operation is to be performed on 'num_tri_corrs', it is necessary to ensure it is greater than 0 before decrementing.