### PR TITLE
Stop setting C++ standard flags manually

### DIFF
--- a/src/colmap/CMakeLists.txt
+++ b/src/colmap/CMakeLists.txt
@@ -36,16 +36,6 @@ if(IS_MSVC)
 elseif(IS_GNU OR IS_CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-    # We want c++14 mainly for supporting latest dependencies, but older GCC
-    # versions in combination with CUDA do not yet support it. In the worst
-    # case, this will lead to compile errors and there is not much we can
-    # do on the COLMAP side.
-    if(CUDA_ENABLED AND
-       IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    endif()
 endif()
 
 if(CUDA_ENABLED)

--- a/src/thirdparty/PoissonRecon/CMakeLists.txt
+++ b/src/thirdparty/PoissonRecon/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT IS_MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -ffast-math -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -ffast-math")
 endif()
 
 add_definitions("-DRELEASE")


### PR DESCRIPTION
Commit 717d069 does now enforce C++14 in any case.

@ahojnnes This is basically a revert of commit 3a2ae37 and commit 2bc8182.

If compilation with compilers not supporting C++14 might still work, removing the `CMAKE_CXX_STANDARD_REQUIRED` added in commit 717d069 would automatically downgrade to the highest C++ version supported by the compiler.