### PR TITLE
Setting clear_points to true per default in point_triangulator

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -372,7 +372,7 @@ int RunPointFiltering(int argc, char** argv) {
 int RunPointTriangulator(int argc, char** argv) {
   std::string input_path;
   std::string output_path;
-  bool clear_points = false;
+  bool clear_points = true;
   bool refine_intrinsics = false;
 
   OptionManager options;
@@ -383,7 +383,9 @@ int RunPointTriangulator(int argc, char** argv) {
   options.AddDefaultOption(
       "clear_points",
       &clear_points,
-      "Whether to clear all existing points and observations");
+      "Whether to clear all existing points and observations and recompute "
+      "the image_ids based on matching filenames between the model and the "
+      "database");
   options.AddDefaultOption("refine_intrinsics",
                            &refine_intrinsics,
                            "Whether to refine the intrinsics of the cameras "


### PR DESCRIPTION
Making sure that image_ids between a model and the database are consistent is a pain. The `clear_points` flag takes care of this by assigning the correct image_ids to images (consistent with the database) based on filenames. This makes things much easier for casual users, who don't need to read out the image_ids from the database. I would argue that enabling this by default is the better choice (especially since in many cases, one would re-triangulate from scratch anyways).

The PR sets the default value to true. It also adds a bit of documentation about the behavior described above to the `--help` argument.

If you prefer to keep `clear_points` set to false by default, I would suggest to add another flag that makes recomputing image_ids default behavior.