### PR TITLE
Recover custom Eigen std::vector allocator for Eigen <3.4 support

### DIFF
--- a/src/colmap/estimators/absolute_pose.cc
+++ b/src/colmap/estimators/absolute_pose.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/utils.h"
 #include "colmap/math/polynomial.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <array>

--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -34,6 +34,7 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/math/random.h"
 #include "colmap/optim/ransac.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/estimators/affine_transform.cc
+++ b/src/colmap/estimators/affine_transform.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/affine_transform.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/SVD>

--- a/src/colmap/estimators/affine_transform.h
+++ b/src/colmap/estimators/affine_transform.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/affine_transform_test.cc
+++ b/src/colmap/estimators/affine_transform_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/estimators/affine_transform.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
 

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -31,6 +31,7 @@
 
 #include "colmap/scene/camera_rig.h"
 #include "colmap/scene/reconstruction.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <memory>
 #include <unordered_set>

--- a/src/colmap/estimators/coordinate_frame.h
+++ b/src/colmap/estimators/coordinate_frame.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/scene/reconstruction.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <ceres/ceres.h>

--- a/src/colmap/estimators/essential_matrix.cc
+++ b/src/colmap/estimators/essential_matrix.cc
@@ -32,6 +32,7 @@
 #include "colmap/estimators/utils.h"
 #include "colmap/math/math.h"
 #include "colmap/math/polynomial.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <complex>

--- a/src/colmap/estimators/essential_matrix.h
+++ b/src/colmap/estimators/essential_matrix.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/essential_matrix_test.cc
+++ b/src/colmap/estimators/essential_matrix_test.cc
@@ -34,6 +34,7 @@
 #include "colmap/math/random.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/estimators/fundamental_matrix.cc
+++ b/src/colmap/estimators/fundamental_matrix.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/utils.h"
 #include "colmap/math/polynomial.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <cfloat>

--- a/src/colmap/estimators/fundamental_matrix.h
+++ b/src/colmap/estimators/fundamental_matrix.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/estimators/homography_matrix.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/generalized_absolute_pose.h
+++ b/src/colmap/estimators/generalized_absolute_pose.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/generalized_absolute_pose_coeffs.h
+++ b/src/colmap/estimators/generalized_absolute_pose_coeffs.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Core>
 
 namespace colmap {

--- a/src/colmap/estimators/generalized_absolute_pose_test.cc
+++ b/src/colmap/estimators/generalized_absolute_pose_test.cc
@@ -32,6 +32,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/optim/ransac.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <array>
 

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -39,6 +39,7 @@
 #include "colmap/optim/support_measurement.h"
 #include "colmap/scene/camera.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/misc.h"
 
 #include <Eigen/Core>

--- a/src/colmap/estimators/generalized_pose.h
+++ b/src/colmap/estimators/generalized_pose.h
@@ -33,6 +33,7 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/scene/camera.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <vector>
 

--- a/src/colmap/estimators/generalized_relative_pose.cc
+++ b/src/colmap/estimators/generalized_relative_pose.cc
@@ -33,6 +33,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/triangulation.h"
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Dense>

--- a/src/colmap/estimators/generalized_relative_pose.h
+++ b/src/colmap/estimators/generalized_relative_pose.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/homography_matrix.cc
+++ b/src/colmap/estimators/homography_matrix.cc
@@ -30,6 +30,7 @@
 #include "colmap/estimators/homography_matrix.h"
 
 #include "colmap/estimators/utils.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/estimators/homography_matrix.h
+++ b/src/colmap/estimators/homography_matrix.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/homography_matrix_test.cc
+++ b/src/colmap/estimators/homography_matrix_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/estimators/homography_matrix.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>

--- a/src/colmap/estimators/pose.h
+++ b/src/colmap/estimators/pose.h
@@ -33,6 +33,7 @@
 #include "colmap/optim/loransac.h"
 #include "colmap/scene/camera.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/threading.h"
 #include "colmap/util/types.h"

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/sim3.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/sim3.h"
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/estimators/translation_transform.h
+++ b/src/colmap/estimators/translation_transform.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 

--- a/src/colmap/estimators/translation_transform_test.cc
+++ b/src/colmap/estimators/translation_transform_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/math/random.h"
 #include "colmap/optim/ransac.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/estimators/triangulation.cc
+++ b/src/colmap/estimators/triangulation.cc
@@ -35,6 +35,7 @@
 #include "colmap/optim/combination_sampler.h"
 #include "colmap/optim/loransac.h"
 #include "colmap/scene/projection.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/estimators/triangulation.h
+++ b/src/colmap/estimators/triangulation.h
@@ -32,6 +32,7 @@
 #include "colmap/math/math.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/scene/camera.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/utils.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -43,6 +43,8 @@
 #include <GL/glew.h>
 #endif  // COLMAP_GUI_ENABLED
 #endif  // COLMAP_GPU_ENABLED
+#include "colmap/util/eigen_alignment.h"
+
 #include "thirdparty/VLFeat/covdet.h"
 #include "thirdparty/VLFeat/sift.h"
 

--- a/src/colmap/feature/types.h
+++ b/src/colmap/feature/types.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/geometry/essential_matrix.h"
 
 #include "colmap/geometry/pose.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>

--- a/src/colmap/geometry/gps.h
+++ b/src/colmap/geometry/gps.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/homography_matrix.cc
+++ b/src/colmap/geometry/homography_matrix.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/pose.h"
 #include "colmap/math/math.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <array>

--- a/src/colmap/geometry/homography_matrix.h
+++ b/src/colmap/geometry/homography_matrix.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/homography_matrix_test.cc
+++ b/src/colmap/geometry/homography_matrix_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/geometry/homography_matrix.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <cmath>
 
 #include <Eigen/Geometry>

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/triangulation.h"
 #include "colmap/math/matrix.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Eigenvalues>
 

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/rigid3.h"
 #include "colmap/geometry/sim3.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/geometry/pose.h"
 
 #include "colmap/math/math.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/geometry/sim3.h
+++ b/src/colmap/geometry/sim3.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/sim3_test.cc
+++ b/src/colmap/geometry/sim3_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/geometry/sim3.h"
 
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/testing.h"
 
 #include <fstream>

--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/essential_matrix.h"
 #include "colmap/geometry/pose.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Dense>
 

--- a/src/colmap/geometry/triangulation.h
+++ b/src/colmap/geometry/triangulation.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/math/math.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/triangulation_test.cc
+++ b/src/colmap/geometry/triangulation_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/geometry/triangulation.h"
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/image/line.h
+++ b/src/colmap/image/line.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/sensor/bitmap.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 

--- a/src/colmap/image/warp.cc
+++ b/src/colmap/image/warp.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/image/warp.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include "thirdparty/VLFeat/imopv.h"

--- a/src/colmap/math/matrix.h
+++ b/src/colmap/math/matrix.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/QR>

--- a/src/colmap/math/polynomial.cc
+++ b/src/colmap/math/polynomial.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/math/polynomial.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Eigenvalues>

--- a/src/colmap/math/polynomial.h
+++ b/src/colmap/math/polynomial.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Core>
 
 namespace colmap {

--- a/src/colmap/mvs/consistency_graph.h
+++ b/src/colmap/mvs/consistency_graph.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <string>

--- a/src/colmap/mvs/fusion.cc
+++ b/src/colmap/mvs/fusion.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/mvs/fusion.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/misc.h"
 
 #include <Eigen/Geometry>

--- a/src/colmap/mvs/fusion.h
+++ b/src/colmap/mvs/fusion.h
@@ -37,6 +37,7 @@
 #include "colmap/mvs/normal_map.h"
 #include "colmap/mvs/workspace.h"
 #include "colmap/util/cache.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/ply.h"
 #include "colmap/util/threading.h"
 

--- a/src/colmap/mvs/image.cc
+++ b/src/colmap/mvs/image.cc
@@ -30,6 +30,7 @@
 #include "colmap/mvs/image.h"
 
 #include "colmap/scene/projection.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Core>

--- a/src/colmap/optim/least_absolute_deviations.cc
+++ b/src/colmap/optim/least_absolute_deviations.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/optim/least_absolute_deviations.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/SparseCholesky>
 
 namespace colmap {

--- a/src/colmap/optim/least_absolute_deviations.h
+++ b/src/colmap/optim/least_absolute_deviations.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Core>

--- a/src/colmap/optim/least_absolute_deviations_test.cc
+++ b/src/colmap/optim/least_absolute_deviations_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/optim/least_absolute_deviations.h"
 
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/src/colmap/optim/loransac_test.cc
+++ b/src/colmap/optim/loransac_test.cc
@@ -33,6 +33,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/sim3.h"
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/colmap/optim/ransac_test.cc
+++ b/src/colmap/optim/ransac_test.cc
@@ -33,6 +33,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/sim3.h"
 #include "colmap/math/random.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/colmap/retrieval/geometry.h
+++ b/src/colmap/retrieval/geometry.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <vector>
 
 #include <Eigen/Core>

--- a/src/colmap/retrieval/geometry_test.cc
+++ b/src/colmap/retrieval/geometry_test.cc
@@ -31,6 +31,8 @@
 #define BOOST_TEST_MODULE "retrieval/geometry"
 #include "colmap/retrieval/geometry.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <iostream>
 
 #include <Eigen/Dense>

--- a/src/colmap/retrieval/inverted_file.h
+++ b/src/colmap/retrieval/inverted_file.h
@@ -33,6 +33,7 @@
 #include "colmap/retrieval/geometry.h"
 #include "colmap/retrieval/inverted_file_entry.h"
 #include "colmap/retrieval/utils.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <algorithm>

--- a/src/colmap/retrieval/inverted_index.h
+++ b/src/colmap/retrieval/inverted_index.h
@@ -31,6 +31,7 @@
 
 #include "colmap/math/random.h"
 #include "colmap/retrieval/inverted_file.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <algorithm>
 #include <bitset>

--- a/src/colmap/retrieval/visual_index.h
+++ b/src/colmap/retrieval/visual_index.h
@@ -34,6 +34,7 @@
 #include "colmap/retrieval/inverted_file.h"
 #include "colmap/retrieval/inverted_index.h"
 #include "colmap/retrieval/vote_and_verify.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/endian.h"
 #include "colmap/util/logging.h"
 

--- a/src/colmap/retrieval/vote_and_verify.cc
+++ b/src/colmap/retrieval/vote_and_verify.cc
@@ -32,6 +32,7 @@
 #include "colmap/estimators/affine_transform.h"
 #include "colmap/math/math.h"
 #include "colmap/optim/ransac.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <array>

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -33,6 +33,7 @@
 #include "colmap/scene/camera.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/two_view_geometry.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <mutex>

--- a/src/colmap/scene/database_cache.h
+++ b/src/colmap/scene/database_cache.h
@@ -34,6 +34,7 @@
 #include "colmap/scene/database.h"
 #include "colmap/scene/image.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <memory>

--- a/src/colmap/scene/database_test.cc
+++ b/src/colmap/scene/database_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/scene/database.h"
 
 #include "colmap/geometry/pose.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <thread>
 

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -34,6 +34,7 @@
 #include "colmap/scene/camera.h"
 #include "colmap/scene/point2d.h"
 #include "colmap/scene/visibility_pyramid.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 

--- a/src/colmap/scene/point2d.h
+++ b/src/colmap/scene/point2d.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <Eigen/Core>

--- a/src/colmap/scene/point3d.h
+++ b/src/colmap/scene/point3d.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/scene/track.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 

--- a/src/colmap/scene/projection.h
+++ b/src/colmap/scene/projection.h
@@ -31,6 +31,7 @@
 
 #include "colmap/geometry/rigid3.h"
 #include "colmap/scene/camera.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <limits>
 #include <vector>

--- a/src/colmap/scene/projection_test.cc
+++ b/src/colmap/scene/projection_test.cc
@@ -32,6 +32,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/math/math.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -36,6 +36,7 @@
 #include "colmap/scene/point2d.h"
 #include "colmap/scene/point3d.h"
 #include "colmap/scene/track.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <memory>

--- a/src/colmap/scene/reconstruction_manager_test.cc
+++ b/src/colmap/scene/reconstruction_manager_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/scene/reconstruction_manager.h"
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
 

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -33,6 +33,7 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/math/random.h"
 #include "colmap/scene/projection.h"
+#include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Geometry>
 

--- a/src/colmap/scene/visibility_pyramid.h
+++ b/src/colmap/scene/visibility_pyramid.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <vector>
 
 #include <Eigen/Core>

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <array>

--- a/src/colmap/ui/colormaps.h
+++ b/src/colmap/ui/colormaps.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/scene/reconstruction.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <Eigen/Core>

--- a/src/colmap/ui/qt_utils.h
+++ b/src/colmap/ui/qt_utils.h
@@ -31,6 +31,7 @@
 
 #include "colmap/feature/types.h"
 #include "colmap/sensor/bitmap.h"
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
 #include <QtCore>

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -34,6 +34,7 @@ COLMAP_ADD_LIBRARY(
     NAME colmap_util
     SRCS
         cache.h
+        eigen_alignment.h
         logging.h logging.cc
         misc.h misc.cc
         opengl_utils.h opengl_utils.cc

--- a/src/colmap/util/eigen_alignment.h
+++ b/src/colmap/util/eigen_alignment.h
@@ -29,9 +29,7 @@
 
 #pragma once
 
-#include "colmap/util/eigen_alignment.h"
-
-#include <Eigen/src/Core/util/Macros.h>
+#include <Eigen/Core>
 
 #ifdef _MSVC_LANG
 #define CPP_VERSION _MSVC_LANG
@@ -41,13 +39,10 @@
 
 #if !EIGEN_VERSION_AT_LEAST(3, 4, 0) || CPP_VERSION < 201703L
 
-#include "colmap/util/eigen_alignment.h"
-
 #include <initializer_list>
 #include <memory>
 #include <vector>
 
-#include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
 

--- a/src/colmap/util/eigen_alignment.h
+++ b/src/colmap/util/eigen_alignment.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/util/eigen_alignment.h"
+#include <Eigen/src/Core/util/Macros.h>
+
+#ifdef _MSVC_LANG
+#define CPP_VERSION _MSVC_LANG
+#else
+#define CPP_VERSION __cplusplus
+#endif
+
+#if !EIGEN_VERSION_AT_LEAST(3, 4, 0) || CPP_VERSION < 201703L
+
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include "colmap/util/eigen_alignment.h"
+#include <Eigen/Core>
+#include "colmap/util/eigen_alignment.h"
+#include <Eigen/Geometry>
+#include "colmap/util/eigen_alignment.h"
+#include <Eigen/StdVector>
+
+#ifndef EIGEN_ALIGNED_ALLOCATOR
+#define EIGEN_ALIGNED_ALLOCATOR Eigen::aligned_allocator
+#endif
+
+// Equivalent to EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION but with support for
+// initializer lists, which is a C++11 feature and not supported by the Eigen.
+// The initializer list extension is inspired by Theia and StackOverflow code.
+#define EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(...)                 \
+  namespace std {                                                          \
+  template <>                                                              \
+  class vector<__VA_ARGS__, std::allocator<__VA_ARGS__>>                   \
+      : public vector<__VA_ARGS__, EIGEN_ALIGNED_ALLOCATOR<__VA_ARGS__>> { \
+    typedef vector<__VA_ARGS__, EIGEN_ALIGNED_ALLOCATOR<__VA_ARGS__>>      \
+        vector_base;                                                       \
+                                                                           \
+   public:                                                                 \
+    typedef __VA_ARGS__ value_type;                                        \
+    typedef vector_base::allocator_type allocator_type;                    \
+    typedef vector_base::size_type size_type;                              \
+    typedef vector_base::iterator iterator;                                \
+    explicit vector(const allocator_type& a = allocator_type())            \
+        : vector_base(a) {}                                                \
+    template <typename InputIterator>                                      \
+    vector(InputIterator first,                                            \
+           InputIterator last,                                             \
+           const allocator_type& a = allocator_type())                     \
+        : vector_base(first, last, a) {}                                   \
+    vector(const vector& c) : vector_base(c) {}                            \
+    explicit vector(size_type num, const value_type& val = value_type())   \
+        : vector_base(num, val) {}                                         \
+    vector(iterator start, iterator end) : vector_base(start, end) {}      \
+    vector& operator=(const vector& x) {                                   \
+      vector_base::operator=(x);                                           \
+      return *this;                                                        \
+    }                                                                      \
+    vector(initializer_list<__VA_ARGS__> list)                             \
+        : vector_base(list.begin(), list.end()) {}                         \
+  };                                                                       \
+  }  // namespace std
+
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Vector2d)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Vector4d)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Vector4f)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix2d)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix2f)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix4d)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix4f)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Affine3d)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Affine3f)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Quaterniond)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Quaternionf)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix<float, 3, 4>)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION_CUSTOM(Eigen::Matrix<double, 3, 4>)
+
+#endif
+
+#undef CPP_VERSION

--- a/src/colmap/util/eigen_alignment.h
+++ b/src/colmap/util/eigen_alignment.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/src/Core/util/Macros.h>
 
 #ifdef _MSVC_LANG
@@ -40,15 +41,14 @@
 
 #if !EIGEN_VERSION_AT_LEAST(3, 4, 0) || CPP_VERSION < 201703L
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <initializer_list>
 #include <memory>
 #include <vector>
 
-#include "colmap/util/eigen_alignment.h"
 #include <Eigen/Core>
-#include "colmap/util/eigen_alignment.h"
 #include <Eigen/Geometry>
-#include "colmap/util/eigen_alignment.h"
 #include <Eigen/StdVector>
 
 #ifndef EIGEN_ALIGNED_ALLOCATOR

--- a/src/colmap/util/ply.cc
+++ b/src/colmap/util/ply.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/util/ply.h"
 
+#include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/misc.h"
 

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -54,6 +54,8 @@ typedef unsigned __int64 uint64_t;
 // NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define NON_MOVABLE(class_name) class_name(class_name&&) = delete;
 
+#include "colmap/util/eigen_alignment.h"
+
 #include <Eigen/Core>
 
 namespace Eigen {


### PR DESCRIPTION
Removing the custom allocators degrades performance for Eigen <3.4, which is still the default under Ubuntu 20.04. This should recover more efficient SIMD instructions on these platforms.