### PR TITLE
Allow getters FocalLength{X,Y} for isotropic models

### DIFF
--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -788,13 +788,8 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
   const span<const size_t> focal_length_idxs = camera.FocalLengthIdxs();
   CHECK_LE(focal_length_idxs.size(), 2)
       << "Not more than two focal length parameters supported.";
-  if (focal_length_idxs.size() == 1) {
-    undistorted_camera.SetFocalLengthX(camera.FocalLength());
-    undistorted_camera.SetFocalLengthY(camera.FocalLength());
-  } else if (focal_length_idxs.size() == 2) {
-    undistorted_camera.SetFocalLengthX(camera.FocalLengthX());
-    undistorted_camera.SetFocalLengthY(camera.FocalLengthY());
-  }
+  undistorted_camera.SetFocalLengthX(camera.FocalLengthX());
+  undistorted_camera.SetFocalLengthY(camera.FocalLengthY());
 
   // Copy principal point parameters.
   undistorted_camera.SetPrincipalPointX(camera.PrincipalPointX());

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -160,11 +160,7 @@ double Camera::FocalLengthX() const {
 
 double Camera::FocalLengthY() const {
   const span<const size_t> idxs = FocalLengthIdxs();
-  size_t idx = 1;
-  if (idxs.size() == 1) {
-    idx = 0;
-  }
-  return params[idxs[idx]];
+  return params[idxs[(idxs.size() == 1) ? 0 : 1]];
 }
 
 void Camera::SetFocalLength(const double f) {

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -155,14 +155,16 @@ double Camera::FocalLength() const {
 
 double Camera::FocalLengthX() const {
   const span<const size_t> idxs = FocalLengthIdxs();
-  DCHECK_EQ(idxs.size(), 2);
   return params[idxs[0]];
 }
 
 double Camera::FocalLengthY() const {
   const span<const size_t> idxs = FocalLengthIdxs();
-  DCHECK_EQ(idxs.size(), 2);
-  return params[idxs[1]];
+  size_t idx = 1;
+  if (idxs.size() == 1) {
+    idx = 0;
+  }
+  return params[idxs[idx]];
 }
 
 void Camera::SetFocalLength(const double f) {

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -63,8 +63,12 @@ TEST(Camera, FocalLength) {
   Camera camera = Camera::CreateFromModelId(
       1, SimplePinholeCameraModel::model_id, 1.0, 1, 1);
   EXPECT_EQ(camera.FocalLength(), 1.0);
+  EXPECT_EQ(camera.FocalLengthX(), 1.0);
+  EXPECT_EQ(camera.FocalLengthY(), 1.0);
   camera.SetFocalLength(2.0);
   EXPECT_EQ(camera.FocalLength(), 2.0);
+  EXPECT_EQ(camera.FocalLengthX(), 2.0);
+  EXPECT_EQ(camera.FocalLengthY(), 2.0);
   camera =
       Camera::CreateFromModelId(1, PinholeCameraModel::model_id, 1.0, 1, 1);
   EXPECT_EQ(camera.FocalLengthX(), 1.0);

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -884,14 +884,8 @@ bool Reconstruction::ExportCam(const std::string& path,
       k2 = 1e-10;
     }
 
-    double fx, fy;
-    if (camera.FocalLengthIdxs().size() == 2) {
-      fx = camera.FocalLengthX();
-      fy = camera.FocalLengthY();
-    } else {
-      fx = fy = camera.MeanFocalLength();
-    }
-
+    const double fx = camera.FocalLengthX();
+    const double fy = camera.FocalLengthY();
     double focal_length;
     if (camera.width * fy < camera.height * fx) {
       focal_length = fy / camera.height;


### PR DESCRIPTION
Simplify the higher level logic, especially for Python users (https://github.com/colmap/pycolmap/issues/199).

By the way: what is the rationale for using debug checks `DCHECK_*` instead of `CHECK_*` in `scene/camera.h` getters and setters?