### PR TITLE
Link against the release version dependencies when building with vcpkg

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -226,7 +226,7 @@ vcpkg, first run `./vcpkg integrate install` (under Windows use pwsh and
     cd path/to/colmap
     mkdir build
     cd build
-    cmake .. -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+    cmake .. -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
     cmake --build . --config release --target colmap --parallel 24
 
 


### PR DESCRIPTION
When CMAKE_BUILD_TYPE is not specified, cmake links the debug version of the dependencies(not all) by default.
Maybe it's a problem with vcpkg。

CMakeCache.txt without specifying building type.

```
//Path to a library.
BLAS_openblas_LIBRARY:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/openblas.lib

//Build the testing tree.
BUILD_TESTING:BOOL=OFF

//Activate the debug messages of the script FindBoost
Boost_DEBUG:BOOL=OFF

//Boost filesystem library (debug)
Boost_FILESYSTEM_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_filesystem-vc140-mt-gd.lib

//Boost filesystem library (release)
Boost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_filesystem-vc140-mt.lib

//Boost graph library (debug)
Boost_GRAPH_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_graph-vc140-mt-gd.lib

//Boost graph library (release)
Boost_GRAPH_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_graph-vc140-mt.lib

//Path to a file.
Boost_INCLUDE_DIR:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/include

//Boost library directory DEBUG
Boost_LIBRARY_DIR_DEBUG:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib

//Boost library directory RELEASE
Boost_LIBRARY_DIR_RELEASE:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib

//Boost program_options library (debug)
Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_program_options-vc140-mt-gd.lib

//Boost program_options library (release)
Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_program_options-vc140-mt.lib

//Boost system library (debug)
Boost_SYSTEM_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_system-vc140-mt-gd.lib

//Boost system library (release)
Boost_SYSTEM_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_system-vc140-mt.lib
```

CMakeCache.txt specifying building type.

```
//Path to a library.
BLAS_openblas_LIBRARY:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/openblas.lib

//Build the testing tree.
BUILD_TESTING:BOOL=OFF

//Activate the debug messages of the script FindBoost
Boost_DEBUG:BOOL=OFF

//Boost filesystem library (debug)
Boost_FILESYSTEM_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_filesystem-vc140-mt-gd.lib

//Boost filesystem library (release)
Boost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_filesystem-vc140-mt.lib

//Boost graph library (debug)
Boost_GRAPH_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_graph-vc140-mt-gd.lib

//Boost graph library (release)
Boost_GRAPH_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_graph-vc140-mt.lib

//Path to a file.
Boost_INCLUDE_DIR:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/include

//Boost library directory DEBUG
Boost_LIBRARY_DIR_DEBUG:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib

//Boost library directory RELEASE
Boost_LIBRARY_DIR_RELEASE:PATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib

//Boost program_options library (debug)
Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_program_options-vc140-mt-gd.lib

//Boost program_options library (release)
Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_program_options-vc140-mt.lib

//Boost system library (debug)
Boost_SYSTEM_LIBRARY_DEBUG:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/debug/lib/boost_system-vc140-mt-gd.lib

//Boost system library (release)
Boost_SYSTEM_LIBRARY_RELEASE:FILEPATH=F:/Libs/vcpkg/vcpkg/installed/x64-windows/lib/boost_system-vc140-mt.lib
```
