### PR TITLE
Fully encapsulate freeimage in bitmap library

### DIFF
--- a/src/colmap/mvs/fusion.cc
+++ b/src/colmap/mvs/fusion.cc
@@ -354,7 +354,9 @@ void StereoFusion::InitFusedPixelMask(int image_idx,
   if (!options_.mask_path.empty() && ExistsFile(mask_path) &&
       mask.Read(mask_path, false)) {
     BitmapColor<uint8_t> color;
-    mask.Rescale(static_cast<int>(width), static_cast<int>(height), FILTER_BOX);
+    mask.Rescale(static_cast<int>(width),
+                 static_cast<int>(height),
+                 Bitmap::RescaleFilter::kBox);
     for (size_t row = 0; row < height; ++row) {
       for (size_t col = 0; col < width; ++col) {
         mask.GetPixel(col, row, &color);

--- a/src/colmap/sensor/CMakeLists.txt
+++ b/src/colmap/sensor/CMakeLists.txt
@@ -40,10 +40,10 @@ COLMAP_ADD_LIBRARY(
     PUBLIC_LINK_LIBS
         Ceres::ceres
         Eigen3::Eigen
-        freeimage::FreeImage
     PRIVATE_LINK_LIBS
         colmap_util
         colmap_vlfeat
+        freeimage::FreeImage
 )
 
 COLMAP_ADD_TEST(

--- a/src/colmap/sensor/CMakeLists.txt
+++ b/src/colmap/sensor/CMakeLists.txt
@@ -49,7 +49,9 @@ COLMAP_ADD_LIBRARY(
 COLMAP_ADD_TEST(
     NAME bitmap_test
     SRCS bitmap_test.cc
-    LINK_LIBS colmap_sensor
+    LINK_LIBS
+        colmap_sensor
+        freeimage::FreeImage
 )
 COLMAP_ADD_TEST( 
     NAME database_test

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -107,6 +107,9 @@ Bitmap::Bitmap(Bitmap&& other) noexcept : Bitmap() {
   width_ = other.width_;
   height_ = other.height_;
   channels_ = other.channels_;
+  other.width_ = 0;
+  other.height_ = 0;
+  other.channels_ = 0;
 }
 
 Bitmap::Bitmap(FIBITMAP* data) : Bitmap() { SetPtr(data); }
@@ -124,6 +127,9 @@ Bitmap& Bitmap::operator=(Bitmap&& other) noexcept {
     width_ = other.width_;
     height_ = other.height_;
     channels_ = other.channels_;
+    other.width_ = 0;
+    other.height_ = 0;
+    other.channels_ = 0;
   }
   return *this;
 }

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -144,7 +144,7 @@ bool Bitmap::Allocate(const int width, const int height, const bool as_rgb) {
 }
 
 void Bitmap::Deallocate() {
-  handle_ = std::move(FreeImageHandle());
+  handle_ = FreeImageHandle();
   width_ = 0;
   height_ = 0;
   channels_ = 0;

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -133,11 +133,13 @@ bool Bitmap::Allocate(const int width, const int height, const bool as_rgb) {
   height_ = height;
   if (as_rgb) {
     const int kNumBitsPerPixel = 24;
-    handle_.ptr = FreeImage_Allocate(width, height, kNumBitsPerPixel);
+    handle_ =
+        FreeImageHandle(FreeImage_Allocate(width, height, kNumBitsPerPixel));
     channels_ = 3;
   } else {
     const int kNumBitsPerPixel = 8;
-    handle_.ptr = FreeImage_Allocate(width, height, kNumBitsPerPixel);
+    handle_ =
+        FreeImageHandle(FreeImage_Allocate(width, height, kNumBitsPerPixel));
     channels_ = 1;
   }
   return handle_.ptr != nullptr;
@@ -548,7 +550,7 @@ bool Bitmap::Read(const std::string& path, const bool as_rgb) {
     return false;
   }
 
-  handle_.ptr = FreeImage_Load(format, path.c_str());
+  handle_ = FreeImageHandle(FreeImage_Load(format, path.c_str()));
   if (handle_.ptr == nullptr) {
     return false;
   }
@@ -710,6 +712,9 @@ Bitmap::FreeImageHandle::FreeImageHandle(
 Bitmap::FreeImageHandle& Bitmap::FreeImageHandle::operator=(
     Bitmap::FreeImageHandle&& other) noexcept {
   if (this != &other) {
+    if (ptr != nullptr) {
+      FreeImage_Unload(ptr);
+    }
     ptr = other.ptr;
     other.ptr = nullptr;
   }

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <ios>
 #include <limits>
 #include <string>

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -29,23 +29,19 @@
 
 #pragma once
 
+#include "colmap/util/string.h"
+
 #include <algorithm>
 #include <cmath>
 #include <ios>
 #include <limits>
-#include <memory>
 #include <string>
 #include <vector>
 
-#ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <Windows.h>
-#endif
-#include "colmap/util/string.h"
-
-#include <FreeImage.h>
+extern "C" {
+struct FIBITMAP;
+enum FREE_IMAGE_MDMODEL;
+}
 
 namespace colmap {
 
@@ -106,11 +102,11 @@ class Bitmap {
   inline int Channels() const;
 
   // Number of bits per pixel. This is 8 for grey and 24 for RGB image.
-  inline unsigned int BitsPerPixel() const;
+  unsigned int BitsPerPixel() const;
 
   // Scan width of bitmap which differs from the actual image width to achieve
   // 32 bit aligned memory. Also known as pitch or stride.
-  inline unsigned int ScanWidth() const;
+  unsigned int ScanWidth() const;
 
   // Check whether image is grey- or colorscale.
   inline bool IsRGB() const;
@@ -155,17 +151,19 @@ class Bitmap {
 
   // Write image to file. Flags can be used to set e.g. the JPEG quality.
   // Consult the FreeImage documentation for all available flags.
-  bool Write(const std::string& path,
-             FREE_IMAGE_FORMAT format = FIF_UNKNOWN,
-             int flags = 0) const;
+  bool Write(const std::string& path, int flags = 0) const;
 
   // Smooth the image using a Gaussian kernel.
   void Smooth(float sigma_x, float sigma_y);
 
   // Rescale image to the new dimensions.
+  enum class RescaleFilter {
+    kBilinear,
+    kBox,
+  };
   void Rescale(int new_width,
                int new_height,
-               FREE_IMAGE_FILTER filter = FILTER_BILINEAR);
+               RescaleFilter filter = RescaleFilter::kBilinear);
 
   // Clone the image to a new bitmap object.
   Bitmap Clone() const;
@@ -181,15 +179,20 @@ class Bitmap {
                    std::string* result) const;
 
  private:
-  typedef std::unique_ptr<FIBITMAP, decltype(&FreeImage_Unload)> FIBitmapPtr;
+  struct FreeImageHandle {
+    FreeImageHandle();
+    FreeImageHandle(FIBITMAP* ptr);
+    ~FreeImageHandle();
+    FIBITMAP* ptr;
+  };
 
-  void SetPtr(FIBITMAP* data);
+  void SetPtr(FIBITMAP* ptr);
 
-  static bool IsPtrGrey(FIBITMAP* data);
-  static bool IsPtrRGB(FIBITMAP* data);
-  static bool IsPtrSupported(FIBITMAP* data);
+  static bool IsPtrGrey(FIBITMAP* ptr);
+  static bool IsPtrRGB(FIBITMAP* ptr);
+  static bool IsPtrSupported(FIBITMAP* ptr);
 
-  FIBitmapPtr data_;
+  FreeImageHandle handle_;
   int width_;
   int height_;
   int channels_;
@@ -262,20 +265,12 @@ std::ostream& operator<<(std::ostream& output, const BitmapColor<T>& color) {
   return output;
 }
 
-FIBITMAP* Bitmap::Data() { return data_.get(); }
-const FIBITMAP* Bitmap::Data() const { return data_.get(); }
+FIBITMAP* Bitmap::Data() { return handle_.ptr; }
+const FIBITMAP* Bitmap::Data() const { return handle_.ptr; }
 
 int Bitmap::Width() const { return width_; }
 int Bitmap::Height() const { return height_; }
 int Bitmap::Channels() const { return channels_; }
-
-unsigned int Bitmap::BitsPerPixel() const {
-  return FreeImage_GetBPP(data_.get());
-}
-
-unsigned int Bitmap::ScanWidth() const {
-  return FreeImage_GetPitch(data_.get());
-}
 
 bool Bitmap::IsRGB() const { return channels_ == 3; }
 

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -174,7 +174,7 @@ class Bitmap {
  private:
   struct FreeImageHandle {
     FreeImageHandle();
-    FreeImageHandle(FIBITMAP* ptr);
+    explicit FreeImageHandle(FIBITMAP* ptr);
     ~FreeImageHandle();
     FreeImageHandle(FreeImageHandle&&) noexcept;
     FreeImageHandle& operator=(FreeImageHandle&&) noexcept;

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -38,10 +38,7 @@
 #include <string>
 #include <vector>
 
-extern "C" {
 struct FIBITMAP;
-enum FREE_IMAGE_MDMODEL;
-}
 
 namespace colmap {
 
@@ -173,24 +170,19 @@ class Bitmap {
   // Clone metadata from this bitmap object to another target bitmap object.
   void CloneMetadata(Bitmap* target) const;
 
-  // Read specific EXIF tag.
-  bool ReadExifTag(FREE_IMAGE_MDMODEL model,
-                   const std::string& tag_name,
-                   std::string* result) const;
-
  private:
   struct FreeImageHandle {
     FreeImageHandle();
     FreeImageHandle(FIBITMAP* ptr);
     ~FreeImageHandle();
+    FreeImageHandle(FreeImageHandle&&) noexcept;
+    FreeImageHandle& operator=(FreeImageHandle&&) noexcept;
+    FreeImageHandle(const FreeImageHandle&) = delete;
+    FreeImageHandle& operator=(const FreeImageHandle&) = delete;
     FIBITMAP* ptr;
   };
 
   void SetPtr(FIBITMAP* ptr);
-
-  static bool IsPtrGrey(FIBITMAP* ptr);
-  static bool IsPtrRGB(FIBITMAP* ptr);
-  static bool IsPtrSupported(FIBITMAP* ptr);
 
   FreeImageHandle handle_;
   int width_;

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -102,6 +102,38 @@ TEST(Bitmap, Deallocate) {
   EXPECT_FALSE(bitmap.IsGrey());
 }
 
+TEST(Bitmap, MoveConstruct) {
+  Bitmap bitmap;
+  bitmap.Allocate(2, 1, true);
+  const auto* data = bitmap.Data();
+  Bitmap moved_bitmap(std::move(bitmap));
+  EXPECT_EQ(moved_bitmap.Width(), 2);
+  EXPECT_EQ(moved_bitmap.Height(), 1);
+  EXPECT_EQ(moved_bitmap.Channels(), 3);
+  EXPECT_EQ(moved_bitmap.Data(), data);
+  EXPECT_EQ(bitmap.Width(), 0);
+  EXPECT_EQ(bitmap.Height(), 0);
+  EXPECT_EQ(bitmap.Channels(), 0);
+  EXPECT_EQ(bitmap.NumBytes(), 0);
+  EXPECT_EQ(bitmap.Data(), nullptr);
+}
+
+TEST(Bitmap, MoveAssign) {
+  Bitmap bitmap;
+  bitmap.Allocate(2, 1, true);
+  const auto* data = bitmap.Data();
+  Bitmap moved_bitmap = std::move(bitmap);
+  EXPECT_EQ(moved_bitmap.Width(), 2);
+  EXPECT_EQ(moved_bitmap.Height(), 1);
+  EXPECT_EQ(moved_bitmap.Channels(), 3);
+  EXPECT_EQ(moved_bitmap.Data(), data);
+  EXPECT_EQ(bitmap.Width(), 0);
+  EXPECT_EQ(bitmap.Height(), 0);
+  EXPECT_EQ(bitmap.Channels(), 0);
+  EXPECT_EQ(bitmap.NumBytes(), 0);
+  EXPECT_EQ(bitmap.Data(), nullptr);
+}
+
 TEST(Bitmap, BitsPerPixel) {
   Bitmap bitmap;
   bitmap.Allocate(100, 100, true);

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -111,13 +111,13 @@ TEST(Bitmap, MoveConstruct) {
   EXPECT_EQ(moved_bitmap.Height(), 1);
   EXPECT_EQ(moved_bitmap.Channels(), 3);
   EXPECT_EQ(moved_bitmap.Data(), data);
-  // NOLINTBEGIN(bugprone-use-after-move)
+  // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(bitmap.Width(), 0);
   EXPECT_EQ(bitmap.Height(), 0);
   EXPECT_EQ(bitmap.Channels(), 0);
   EXPECT_EQ(bitmap.NumBytes(), 0);
   EXPECT_EQ(bitmap.Data(), nullptr);
-  // NOLINTEND(bugprone-use-after-move)
+  // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 }
 
 TEST(Bitmap, MoveAssign) {
@@ -129,13 +129,13 @@ TEST(Bitmap, MoveAssign) {
   EXPECT_EQ(moved_bitmap.Height(), 1);
   EXPECT_EQ(moved_bitmap.Channels(), 3);
   EXPECT_EQ(moved_bitmap.Data(), data);
-  // NOLINTBEGIN(bugprone-use-after-move)
+  // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(bitmap.Width(), 0);
   EXPECT_EQ(bitmap.Height(), 0);
   EXPECT_EQ(bitmap.Channels(), 0);
   EXPECT_EQ(bitmap.NumBytes(), 0);
   EXPECT_EQ(bitmap.Data(), nullptr);
-  // NOLINTEND(bugprone-use-after-move)
+  // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 }
 
 TEST(Bitmap, BitsPerPixel) {

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/sensor/bitmap.h"
 
+#include <FreeImage.h>
 #include <gtest/gtest.h>
 
 namespace colmap {

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -403,7 +403,10 @@ TEST(Bitmap, ReadWriteAsRGB) {
   EXPECT_TRUE(bitmap.Write(filename));
 
   Bitmap read_bitmap;
-  read_bitmap.Allocate(bitmap.Width(), bitmap.Height(), false);
+
+  // Allocate bitmap with different size to test read overwrites existing data.
+  read_bitmap.Allocate(bitmap.Width() + 1, bitmap.Height() + 2, true);
+
   EXPECT_TRUE(read_bitmap.Read(filename));
   EXPECT_EQ(read_bitmap.Width(), bitmap.Width());
   EXPECT_EQ(read_bitmap.Height(), bitmap.Height());
@@ -437,7 +440,10 @@ TEST(Bitmap, ReadWriteAsGrey) {
   EXPECT_TRUE(bitmap.Write(filename));
 
   Bitmap read_bitmap;
-  read_bitmap.Allocate(bitmap.Width(), bitmap.Height(), true);
+
+  // Allocate bitmap with different size to test read overwrites existing data.
+  read_bitmap.Allocate(bitmap.Width() + 1, bitmap.Height() + 2, true);
+
   EXPECT_TRUE(read_bitmap.Read(filename));
   EXPECT_EQ(read_bitmap.Width(), bitmap.Width());
   EXPECT_EQ(read_bitmap.Height(), bitmap.Height());

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -111,11 +111,13 @@ TEST(Bitmap, MoveConstruct) {
   EXPECT_EQ(moved_bitmap.Height(), 1);
   EXPECT_EQ(moved_bitmap.Channels(), 3);
   EXPECT_EQ(moved_bitmap.Data(), data);
+  // NOLINTBEGIN(bugprone-use-after-move)
   EXPECT_EQ(bitmap.Width(), 0);
   EXPECT_EQ(bitmap.Height(), 0);
   EXPECT_EQ(bitmap.Channels(), 0);
   EXPECT_EQ(bitmap.NumBytes(), 0);
   EXPECT_EQ(bitmap.Data(), nullptr);
+  // NOLINTEND(bugprone-use-after-move)
 }
 
 TEST(Bitmap, MoveAssign) {
@@ -127,11 +129,13 @@ TEST(Bitmap, MoveAssign) {
   EXPECT_EQ(moved_bitmap.Height(), 1);
   EXPECT_EQ(moved_bitmap.Channels(), 3);
   EXPECT_EQ(moved_bitmap.Data(), data);
+  // NOLINTBEGIN(bugprone-use-after-move)
   EXPECT_EQ(bitmap.Width(), 0);
   EXPECT_EQ(bitmap.Height(), 0);
   EXPECT_EQ(bitmap.Channels(), 0);
   EXPECT_EQ(bitmap.NumBytes(), 0);
   EXPECT_EQ(bitmap.Data(), nullptr);
+  // NOLINTEND(bugprone-use-after-move)
 }
 
 TEST(Bitmap, BitsPerPixel) {


### PR DESCRIPTION
This avoids propagating the FreeImage target to other libraries, as it is now defined as a private link library. As a side effect, this circumvents a bug in CMake, as FreeImage defines /EHsc flags as a public compiler flag that is not correctly propagated by CMake to the nvcc.