### PR TITLE
Add missing "include <memory>" needed for unique_ptr

### DIFF
--- a/src/colmap/image/line.cc
+++ b/src/colmap/image/line.cc
@@ -27,8 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <memory>
-
 #include "colmap/image/line.h"
 
 #include "colmap/util/logging.h"
@@ -36,6 +34,8 @@
 extern "C" {
 #include "thirdparty/LSD/lsd.h"
 }
+
+#include <memory>
 
 namespace colmap {
 namespace {

--- a/src/colmap/image/line.cc
+++ b/src/colmap/image/line.cc
@@ -27,6 +27,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <memory>
+
 #include "colmap/image/line.h"
 
 #include "colmap/util/logging.h"

--- a/src/colmap/mvs/workspace.h
+++ b/src/colmap/mvs/workspace.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "colmap/mvs/consistency_graph.h"
 #include "colmap/mvs/depth_map.h"
 #include "colmap/mvs/model.h"

--- a/src/colmap/mvs/workspace.h
+++ b/src/colmap/mvs/workspace.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "colmap/mvs/consistency_graph.h"
 #include "colmap/mvs/depth_map.h"
 #include "colmap/mvs/model.h"
@@ -38,6 +36,8 @@
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/cache.h"
 #include "colmap/util/misc.h"
+
+#include <memory>
 
 namespace colmap {
 namespace mvs {


### PR DESCRIPTION
Fix:
```
/home/conda/feedstock_root/build_artifacts/colmap_1704738145804/work/src/colmap/image/line.cc: In function 'std::vector<colmap::LineSegment> colmap::DetectLineSegments(const colmap::Bitmap&, double)': /home/conda/feedstock_root/build_artifacts/colmap_1704738145804/work/src/colmap/image/line.cc:63:8: error: 'unique_ptr' is not a member of 'std'
   63 |   std::unique_ptr<double, RawDeleter> segments_data(
      |        ^~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/colmap_1704738145804/work/src/colmap/image/line.cc:36:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
```