### PR TITLE
Support decoding multi-byte characters in Python script

### DIFF
--- a/scripts/python/read_write_model.py
+++ b/scripts/python/read_write_model.py
@@ -261,11 +261,12 @@ def read_images_binary(path_to_model_file):
             qvec = np.array(binary_image_properties[1:5])
             tvec = np.array(binary_image_properties[5:8])
             camera_id = binary_image_properties[8]
-            image_name = ""
+            binary_image_name = b""
             current_char = read_next_bytes(fid, 1, "c")[0]
             while current_char != b"\x00":  # look for the ASCII 0 entry
-                image_name += current_char.decode("utf-8")
+                binary_image_name += current_char
                 current_char = read_next_bytes(fid, 1, "c")[0]
+            image_name = binary_image_name.decode("utf-8")
             num_points2D = read_next_bytes(
                 fid, num_bytes=8, format_char_sequence="Q"
             )[0]


### PR DESCRIPTION
This fixes an issue where read_images_binary() throws an exception when decoding image names with multi-byte characters.

UTF-8 encodes characters using one to four bytes, so decoding byte-by-byte sometimes won't work if a character is encoded with more than one byte. For instance, if a character is encoded using three bytes, all three bytes need to be passed into `.decode("utf-8")` for it to return the proper character. This pull request decodes the entire image name at once to avoid this issue. 