### PR TITLE
Split Dockerfile in two stages: builder and runtime.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,80 @@
-FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
+ARG UBUNTU_VERSION=22.04
+ARG NVIDIA_CUDA_VERSION=12.3.1
+
+#
+# Docker builder stage.
+#
+FROM nvidia/cuda:${NVIDIA_CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} as builder
 
 ARG COLMAP_GIT_COMMIT=main
-ARG CUDA_ARCHITECTURES=native
+ARG CUDA_ARCHITECTURES=50
 ENV QT_XCB_GL_INTEGRATION=xcb_egl
 
-# Prevent stop building ubuntu at time zone selection.  
+# Prevent stop building ubuntu at time zone selection.
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Prepare and empty machine for building.
-RUN apt-get update && apt-get install -y \
-    git \
-    cmake \
-    ninja-build \
-    build-essential \
-    libboost-program-options-dev \
-    libboost-filesystem-dev \
-    libboost-graph-dev \
-    libboost-system-dev \
-    libeigen3-dev \
-    libflann-dev \
-    libfreeimage-dev \
-    libmetis-dev \
-    libgoogle-glog-dev \
-    libgtest-dev \
-    libsqlite3-dev \
-    libglew-dev \
-    qtbase5-dev \
-    libqt5opengl5-dev \
-    libcgal-dev \
-    libceres-dev
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        git \
+        cmake \
+        ninja-build \
+        build-essential \
+        libboost-program-options-dev \
+        libboost-filesystem-dev \
+        libboost-graph-dev \
+        libboost-system-dev \
+        libeigen3-dev \
+        libflann-dev \
+        libfreeimage-dev \
+        libmetis-dev \
+        libgoogle-glog-dev \
+        libgtest-dev \
+        libsqlite3-dev \
+        libglew-dev \
+        qtbase5-dev \
+        libqt5opengl5-dev \
+        libcgal-dev \
+        libceres-dev
 
 # Build and install COLMAP.
-RUN git clone https://github.com/colmap/colmap.git
-RUN cd colmap && \
+RUN git clone https://github.com/colmap/colmap.git colmap_${COLMAP_GIT_COMMIT}
+RUN cd colmap_${COLMAP_GIT_COMMIT} && \
     git fetch https://github.com/colmap/colmap.git ${COLMAP_GIT_COMMIT} && \
     git checkout FETCH_HEAD && \
     mkdir build && \
     cd build && \
-    cmake .. -GNinja -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} && \
-    ninja && \
+    cmake .. -GNinja -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
+        -DCMAKE_INSTALL_PREFIX=/colmap && \
     ninja install && \
-    cd .. && rm -rf colmap
+    cd .. && rm -rf colmap_${COLMAP_GIT_COMMIT}
+
+# Add the installation directory to the PATH.
+ENV PATH="/colmap/bin:$PATH"
+
+
+#
+# Docker runtime stage.
+#
+FROM nvidia/cuda:${NVIDIA_CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} as runtime
+
+# Minimal dependencies to run colmap binary compiled in the builder stage.
+# Note: this reduces the size of the final image considerably, since all the
+# build dependencies are not needed.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        libboost-filesystem1.74.0 \
+        libboost-program-options1.74.0 \
+        libc6 \
+        libceres2 \
+        libfreeimage3 \
+        libgcc-s1 \
+        libgl1 \
+        libglew2.2 \
+        libgoogle-glog0v5 \
+        libqt5core5a \
+        libqt5gui5 \
+        libqt5widgets5
+
+COPY --from=builder /colmap/bin/colmap /colmap/bin/colmap
+ENV PATH="/colmap/bin:$PATH"


### PR DESCRIPTION
Splitting the Dockerfile in two stages reduces the size of the final image considerably, since all the build dependencies are not needed.

You can still create the tag for the stages separately:
```bash
docker build --target builder -t colmap:builder .
docker build --target runtime -t colmap:runtime .
```
But the default command (without `--target`) is the last stage, so:
```bash
docker build -t colmap:latest .
```
will refer to `--target runtime` because it is the last stage in the Dockerfile.
