### PR TITLE
Fix warning C4722

### DIFF
--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -88,6 +88,11 @@ COLMAP_ADD_TEST(
     LINK_LIBS colmap_util
 )
 COLMAP_ADD_TEST(
+    NAME logging_test
+    SRCS logging_test.cc
+    LINK_LIBS colmap_util
+)
+COLMAP_ADD_TEST(
     NAME misc_test
     SRCS misc_test.cc
     LINK_LIBS colmap_util

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -138,6 +138,11 @@ inline std::string __MakeExceptionPrefix(const char* file, int line) {
          std::to_string(line) + "] ";
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4722)
+#endif
+
 template <typename T>
 class LogMessageFatalThrow : public google::LogMessage {
  public:
@@ -167,6 +172,10 @@ class LogMessageFatalThrow : public google::LogMessage {
   std::string message_;
   std::string prefix_;
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 using LogMessageFatalThrowDefault = LogMessageFatalThrow<std::invalid_argument>;
 

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -191,7 +191,7 @@ using LogMessageFatalThrowDefault = LogMessageFatalThrow<std::invalid_argument>;
 template <typename T>
 T ThrowCheckNotNull(const char* file, int line, const char* names, T&& t) {
   if (t == nullptr) {
-    LogMessageFatalThrowDefault(file, line, new std::string(names));
+    LogMessageFatalThrowDefault(file, line).stream() << names;
   }
   return std::forward<T>(t);
 }

--- a/src/colmap/util/logging_test.cc
+++ b/src/colmap/util/logging_test.cc
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/util/logging.h"
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+std::string PrintingFn(const std::string& message) {
+  if (message.empty()) {
+    LOG(FATAL_THROW) << "Error in PrintingFn";
+  }
+  return message;
+}
+
+void ThrowCheck(const bool cond) { THROW_CHECK(cond) << "Error!"; }
+
+void ThrowCheckEqual(const int val) { THROW_CHECK_EQ(val, 1) << "Error!"; }
+
+TEST(ExceptionLogging, Nominal) {
+  EXPECT_NO_THROW(ThrowCheck(true));
+  EXPECT_THROW(ThrowCheck(false), std::invalid_argument);
+  EXPECT_NO_THROW(ThrowCheckEqual(1));
+  EXPECT_THROW(ThrowCheckEqual(0), std::invalid_argument);
+  EXPECT_THROW(THROW_CHECK_NOTNULL(nullptr), std::invalid_argument);
+  EXPECT_THROW({ LOG(FATAL_THROW) << "Error!"; }, std::invalid_argument);
+  EXPECT_THROW({ LOG_FATAL_THROW(std::logic_error) << "Error!"; },
+               std::logic_error);
+}
+
+TEST(ExceptionLogging, Nested) {
+  EXPECT_NO_THROW(PrintingFn("message"));
+  EXPECT_THROW(PrintingFn(""), std::invalid_argument);
+  EXPECT_THROW({ LOG(FATAL_THROW) << "Error: " << PrintingFn("message"); },
+               std::invalid_argument);
+  EXPECT_THROW({ LOG(FATAL_THROW) << "Error: " << PrintingFn(""); },
+               std::invalid_argument);
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/util/sqlite3_utils.h
+++ b/src/colmap/util/sqlite3_utils.h
@@ -50,6 +50,7 @@ inline int SQLite3CallHelper(int result_code,
     default:
       LogMessageFatalThrow<std::runtime_error>(filename.c_str(), line).stream()
           << "SQLite error: " << sqlite3_errstr(result_code);
+      return result_code;
   }
 }
 


### PR DESCRIPTION
Vistual Studio 2022 outputs compiler warning C4722.

`warning C4722: 'colmap::LogMessageFatalThrow<std::invalid_argument>::~LogMessageFatalThrow<std::invalid_argument>': destructor never returns, potential memory leak`

This PR attempts to suppress the C4722 warning. But I'm not sure if this is a good idea.

[Compiler Warning (level 1) C4722](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722?view=msvc-170)
```
'function' : destructor never returns, potential memory leak

The flow of control terminates in a destructor. The thread or the entire program will terminate and allocated resources may not be released. Furthermore, if a destructor will be called for stack unwinding during exception processing, the behavior of executable is undefined.

To resolve, remove the function call that causes the destructor to not return.
```

