### PR TITLE
Add cost functions to pycolmap

### DIFF
--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -480,16 +480,16 @@ class IsotropicNoiseCostFunctionWrapper {
     THROW_CHECK_GT(stddev, 0.0);
     ceres::CostFunction* cost_function =
         CostFunction::Create(std::forward<Args>(args)...);
-#if CERES_VERSION_MAJOR < 2
+    const double scale = 1.0 / stddev;
     std::vector<ceres::CostFunction*> conditioners(
+#if CERES_VERSION_MAJOR < 2
         cost_function->num_residuals());
     // Ceres <2.0 does not allow reuse the same conditioner multiple times.
     for (size_t i = 0; i < conditioners.size(); ++i) {
-      conditioners.push_back(new LinearCostFunction(1.0 / stddev));
+      conditioners.push_back(new LinearCostFunction(scale));
     }
 #else
-    std::vector<ceres::CostFunction*> conditioners(
-        cost_function->num_residuals(), new LinearCostFunction(1.0 / stddev));
+        cost_function->num_residuals(), new LinearCostFunction(scale));
 #endif
     return new ceres::ConditionedCostFunction(
         cost_function, conditioners, ceres::TAKE_OWNERSHIP);

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -36,6 +36,7 @@
 
 #include <Eigen/Core>
 #include <ceres/ceres.h>
+#include <ceres/conditioned_cost_function.h>
 #include <ceres/rotation.h>
 
 namespace colmap {
@@ -450,7 +451,7 @@ struct MetricRelativePoseErrorCostFunction {
 
 class LinearCostFunction : public ceres::CostFunction {
  public:
-  LinearCostFunction(const double s) : s_(s) {
+  explicit LinearCostFunction(const double s) : s_(s) {
     set_num_residuals(1);
     mutable_parameter_block_sizes()->push_back(1);
   }

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -485,7 +485,7 @@ class IsotropicNoiseCostFunctionWrapper {
     std::vector<ceres::CostFunction*> conditioners(
 #if CERES_VERSION_MAJOR < 2
         cost_function->num_residuals());
-    // Ceres <2.0 does not allow reuse the same conditioner multiple times.
+    // Ceres <2.0 does not allow reusing the same conditioner multiple times.
     for (size_t i = 0; i < conditioners.size(); ++i) {
       conditioners[i] = new LinearCostFunction(scale);
     }

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -452,7 +452,7 @@ struct MetricRelativePoseErrorCostFunction {
 // A cost function that wraps another one and whiten its residuals with an
 // isotropic covariance, i.e. assuming that the variance is identical in and
 // independent between each dimension of the residual.
-template <class CostFunction, typename... Args>
+template <class CostFunction>
 class IsotropicNoiseCostFunctionWrapper {
   class LinearCostFunction : public ceres::CostFunction {
    public:
@@ -476,7 +476,8 @@ class IsotropicNoiseCostFunctionWrapper {
   };
 
  public:
-  static ceres::CostFunction* Create(Args&&... args, const double stddev) {
+  template <typename... Args>
+  static ceres::CostFunction* Create(const double stddev, Args&&... args) {
     THROW_CHECK_GT(stddev, 0.0);
     ceres::CostFunction* cost_function =
         CostFunction::Create(std::forward<Args>(args)...);

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -486,7 +486,7 @@ class IsotropicNoiseCostFunctionWrapper {
         cost_function->num_residuals());
     // Ceres <2.0 does not allow reuse the same conditioner multiple times.
     for (size_t i = 0; i < conditioners.size(); ++i) {
-      conditioners.push_back(new LinearCostFunction(scale));
+      conditioners[i] = new LinearCostFunction(scale);
     }
 #else
         cost_function->num_residuals(), new LinearCostFunction(scale));

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -40,9 +40,9 @@ namespace colmap {
 namespace {
 
 TEST(BundleAdjustment, AbsolutePose) {
+  using CostFunction = ReprojErrorCostFunction<SimplePinholeCameraModel>;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      ReprojErrorCostFunction<SimplePinholeCameraModel>::Create(
-          Eigen::Vector2d::Zero()));
+      CostFunction::Create(Eigen::Vector2d::Zero()));
   double cam_from_world_rotation[4] = {0, 0, 0, 1};
   double cam_from_world_translation[3] = {0, 0, 0};
   double point3D[3] = {0, 0, 1};
@@ -72,9 +72,8 @@ TEST(BundleAdjustment, AbsolutePose) {
   EXPECT_EQ(residuals[1], 2);
 
   std::unique_ptr<ceres::CostFunction> cost_function_with_noise(
-      IsotropicNoiseCostFunctionWrapper<
-          ReprojErrorCostFunction<SimplePinholeCameraModel>,
-          const Eigen::Vector2d>::Create(Eigen::Vector2d::Zero(), 2.0));
+      IsotropicNoiseCostFunctionWrapper<CostFunction>::Create(
+          2.0, Eigen::Vector2d::Zero()));
   EXPECT_TRUE(
       cost_function_with_noise->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], -1);

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -70,6 +70,15 @@ TEST(BundleAdjustment, AbsolutePose) {
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], -2);
   EXPECT_EQ(residuals[1], 2);
+
+  std::unique_ptr<ceres::CostFunction> cost_function_with_noise(
+      IsotropicNoiseCostFunctionWrapper<
+          ReprojErrorCostFunction<SimplePinholeCameraModel>,
+          const Eigen::Vector2d>::Create(Eigen::Vector2d::Zero(), 2.0));
+  EXPECT_TRUE(
+      cost_function_with_noise->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], -1);
+  EXPECT_EQ(residuals[1], 1);
 }
 
 TEST(BundleAdjustment, ConstantPoseAbsolutePose) {

--- a/src/pycolmap/estimators/bindings.h
+++ b/src/pycolmap/estimators/bindings.h
@@ -2,6 +2,7 @@
 
 #include "pycolmap/estimators/absolute_pose.h"
 #include "pycolmap/estimators/alignment.h"
+#include "pycolmap/estimators/cost_functions.h"
 #include "pycolmap/estimators/essential_matrix.h"
 #include "pycolmap/estimators/fundamental_matrix.h"
 #include "pycolmap/estimators/generalized_absolute_pose.h"
@@ -16,6 +17,7 @@ namespace py = pybind11;
 void BindEstimators(py::module& m) {
   BindAbsolutePoseEstimator(m);
   BindAlignmentEstimator(m);
+  BindCostFunctions(m);
   BindEssentialMatrixEstimator(m);
   BindFundamentalMatrixEstimator(m);
   BindGeneralizedAbsolutePoseEstimator(m);

--- a/src/pycolmap/estimators/cost_functions.h
+++ b/src/pycolmap/estimators/cost_functions.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "colmap/estimators/cost_functions.h"
+#include "colmap/geometry/rigid3.h"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+template <typename CameraModel>
+using ReprojErrorCostFunctionWithNoise =
+    IsotropicNoiseCostFunctionWrapper<ReprojErrorCostFunction<CameraModel>,
+                                      const Eigen::Vector2d&>;
+
+template <typename CameraModel>
+using ReprojErrorConstantPoseCostFunctionWithNoise =
+    IsotropicNoiseCostFunctionWrapper<
+        ReprojErrorConstantPoseCostFunction<CameraModel>,
+        const Rigid3d&,
+        const Eigen::Vector2d&>;
+
+template <typename CameraModel>
+using ReprojErrorConstantPoint3DCostFunctionWithNoise =
+    IsotropicNoiseCostFunctionWrapper<
+        ReprojErrorConstantPoint3DCostFunction<CameraModel>,
+        const Eigen::Vector2d&,
+        const Eigen::Vector3d&>;
+
+template <typename CameraModel>
+using RigReprojErrorCostFunctionWithNoise =
+    IsotropicNoiseCostFunctionWrapper<RigReprojErrorCostFunction<CameraModel>,
+                                      const Eigen::Vector2d&>;
+
+template <typename CameraModel>
+using RigReprojErrorConstantRigCostFunctionWithNoise =
+    IsotropicNoiseCostFunctionWrapper<
+        RigReprojErrorConstantRigCostFunction<CameraModel>,
+        const Rigid3d&,
+        const Eigen::Vector2d&>;
+
+void BindCostFunctions(py::module& m_parent) {
+  py::module_ m = m_parent.def_submodule("cost_functions");
+
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorCostFunction, const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D"_a);
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorCostFunctionWithNoise,
+                            const Eigen::Vector2d&,
+                            const double>,
+        "camera_model_id"_a,
+        "point2D"_a,
+        "stddev"_a);
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorConstantPoseCostFunction,
+                            const Rigid3d&,
+                            const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "cam_from_world"_a,
+        "point2D"_a);
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorConstantPoseCostFunctionWithNoise,
+                            const Rigid3d&,
+                            const Eigen::Vector2d&,
+                            const double>,
+        "camera_model_id"_a,
+        "cam_from_world"_a,
+        "point2D"_a,
+        "stddev"_a);
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunction,
+                            const Eigen::Vector2d&,
+                            const Eigen::Vector3d&>,
+        "camera_model_id"_a,
+        "point2D"_a,
+        "point3D"_a);
+  m.def("ReprojErrorCost",
+        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunctionWithNoise,
+                            const Eigen::Vector2d&,
+                            const Eigen::Vector3d&,
+                            const double>,
+        "camera_model_id"_a,
+        "point2D"_a,
+        "point3D"_a,
+        "stddev"_a);
+
+  m.def("RigReprojErrorCost",
+        &CameraCostFunction<RigReprojErrorCostFunction, const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D"_a);
+  m.def("RigReprojErrorCost",
+        &CameraCostFunction<RigReprojErrorCostFunctionWithNoise,
+                            const Eigen::Vector2d&,
+                            const double>,
+        "camera_model_id"_a,
+        "point2D"_a,
+        "stddev"_a);
+  m.def("RigReprojErrorCost",
+        &CameraCostFunction<RigReprojErrorConstantRigCostFunction,
+                            const Rigid3d&,
+                            const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "cam_from_rig"_a,
+        "point2D"_a);
+  m.def("RigReprojErrorCost",
+        &CameraCostFunction<RigReprojErrorConstantRigCostFunctionWithNoise,
+                            const Rigid3d&,
+                            const Eigen::Vector2d&,
+                            const double>,
+        "camera_model_id"_a,
+        "cam_from_rig"_a,
+        "point2D"_a,
+        "stddev"_a);
+
+  m.def("SampsonErrorCost",
+        &SampsonErrorCostFunction::Create,
+        "point2D1"_a,
+        "point2D2"_a);
+
+  m.def("AbsolutePoseErrorCost",
+        &AbsolutePoseErrorCostFunction::Create,
+        "cam_from_world"_a,
+        "covariance_cam"_a);
+  m.def("MetricRelativePoseErrorCost",
+        &MetricRelativePoseErrorCostFunction::Create,
+        "i_from_j"_a,
+        "covariance_j"_a);
+}

--- a/src/pycolmap/estimators/cost_functions.h
+++ b/src/pycolmap/estimators/cost_functions.h
@@ -12,34 +12,26 @@ namespace py = pybind11;
 
 template <typename CameraModel>
 using ReprojErrorCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<ReprojErrorCostFunction<CameraModel>,
-                                      const Eigen::Vector2d&>;
+    IsotropicNoiseCostFunctionWrapper<ReprojErrorCostFunction<CameraModel>>;
 
 template <typename CameraModel>
 using ReprojErrorConstantPoseCostFunctionWithNoise =
     IsotropicNoiseCostFunctionWrapper<
-        ReprojErrorConstantPoseCostFunction<CameraModel>,
-        const Rigid3d&,
-        const Eigen::Vector2d&>;
+        ReprojErrorConstantPoseCostFunction<CameraModel>>;
 
 template <typename CameraModel>
 using ReprojErrorConstantPoint3DCostFunctionWithNoise =
     IsotropicNoiseCostFunctionWrapper<
-        ReprojErrorConstantPoint3DCostFunction<CameraModel>,
-        const Eigen::Vector2d&,
-        const Eigen::Vector3d&>;
+        ReprojErrorConstantPoint3DCostFunction<CameraModel>>;
 
 template <typename CameraModel>
 using RigReprojErrorCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<RigReprojErrorCostFunction<CameraModel>,
-                                      const Eigen::Vector2d&>;
+    IsotropicNoiseCostFunctionWrapper<RigReprojErrorCostFunction<CameraModel>>;
 
 template <typename CameraModel>
 using RigReprojErrorConstantRigCostFunctionWithNoise =
     IsotropicNoiseCostFunctionWrapper<
-        RigReprojErrorConstantRigCostFunction<CameraModel>,
-        const Rigid3d&,
-        const Eigen::Vector2d&>;
+        RigReprojErrorConstantRigCostFunction<CameraModel>>;
 
 void BindCostFunctions(py::module& m_parent) {
   py::module_ m = m_parent.def_submodule("cost_functions");
@@ -50,11 +42,11 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a);
   m.def("ReprojErrorCost",
         &CameraCostFunction<ReprojErrorCostFunctionWithNoise,
-                            const Eigen::Vector2d&,
-                            const double>,
+                            const double,
+                            const Eigen::Vector2d&>,
         "camera_model_id"_a,
-        "point2D"_a,
-        "stddev"_a);
+        "stddev"_a,
+        "point2D"_a);
   m.def("ReprojErrorCost",
         &CameraCostFunction<ReprojErrorConstantPoseCostFunction,
                             const Rigid3d&,
@@ -64,13 +56,13 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a);
   m.def("ReprojErrorCost",
         &CameraCostFunction<ReprojErrorConstantPoseCostFunctionWithNoise,
+                            const double,
                             const Rigid3d&,
-                            const Eigen::Vector2d&,
-                            const double>,
+                            const Eigen::Vector2d&>,
         "camera_model_id"_a,
+        "stddev"_a,
         "cam_from_world"_a,
-        "point2D"_a,
-        "stddev"_a);
+        "point2D"_a);
   m.def("ReprojErrorCost",
         &CameraCostFunction<ReprojErrorConstantPoint3DCostFunction,
                             const Eigen::Vector2d&,
@@ -80,13 +72,13 @@ void BindCostFunctions(py::module& m_parent) {
         "point3D"_a);
   m.def("ReprojErrorCost",
         &CameraCostFunction<ReprojErrorConstantPoint3DCostFunctionWithNoise,
+                            const double,
                             const Eigen::Vector2d&,
-                            const Eigen::Vector3d&,
-                            const double>,
+                            const Eigen::Vector3d&>,
         "camera_model_id"_a,
+        "stddev"_a,
         "point2D"_a,
-        "point3D"_a,
-        "stddev"_a);
+        "point3D"_a);
 
   m.def("RigReprojErrorCost",
         &CameraCostFunction<RigReprojErrorCostFunction, const Eigen::Vector2d&>,
@@ -94,11 +86,11 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a);
   m.def("RigReprojErrorCost",
         &CameraCostFunction<RigReprojErrorCostFunctionWithNoise,
-                            const Eigen::Vector2d&,
-                            const double>,
+                            const double,
+                            const Eigen::Vector2d&>,
         "camera_model_id"_a,
-        "point2D"_a,
-        "stddev"_a);
+        "stddev"_a,
+        "point2D"_a);
   m.def("RigReprojErrorCost",
         &CameraCostFunction<RigReprojErrorConstantRigCostFunction,
                             const Rigid3d&,
@@ -108,13 +100,13 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a);
   m.def("RigReprojErrorCost",
         &CameraCostFunction<RigReprojErrorConstantRigCostFunctionWithNoise,
+                            const double,
                             const Rigid3d&,
-                            const Eigen::Vector2d&,
-                            const double>,
+                            const Eigen::Vector2d&>,
         "camera_model_id"_a,
+        "stddev"_a,
         "cam_from_rig"_a,
-        "point2D"_a,
-        "stddev"_a);
+        "point2D"_a);
 
   m.def("SampsonErrorCost",
         &SampsonErrorCostFunction::Create,


### PR DESCRIPTION
- Introduces a new `IsotropicNoiseCostFunctionWrapper` to scale the BA cost functions with the covariance of the detection noise - this was needed in LaMAR to optimize camera with very different resolution and will be useful in COLMAP in the future.
  - I haven't figured out how to efficiently support a full anisotropic covariance matrix. We don't need it for now so I'll give it a try another time.
- Examples of usage of the pycolmap bindings for BA and PGO: https://github.com/cvg/pyceres/tree/main/examples
- If `pyceres` is not installed, calling any of these function will result in an error - we don't want to make it a hard dependency yet