### PR TITLE
Simplify the low-level triangulation API

### DIFF
--- a/src/colmap/estimators/triangulation.h
+++ b/src/colmap/estimators/triangulation.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/geometry/rigid3.h"
 #include "colmap/math/math.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/scene/camera.h"
@@ -137,11 +138,11 @@ struct EstimateTriangulationOptions {
 // Robustly estimate 3D point from observations in multiple views using RANSAC
 // and a subsequent non-linear refinement using all inliers. Returns true
 // if the estimated number of inliers has more than two views.
-bool EstimateTriangulation(
-    const EstimateTriangulationOptions& options,
-    const std::vector<TriangulationEstimator::PointData>& point_data,
-    const std::vector<TriangulationEstimator::PoseData>& pose_data,
-    std::vector<char>* inlier_mask,
-    Eigen::Vector3d* xyz);
+bool EstimateTriangulation(const EstimateTriangulationOptions& options,
+                           const std::vector<Eigen::Vector2d>& points,
+                           const std::vector<Rigid3d const*>& cams_from_world,
+                           const std::vector<Camera const*>& cameras,
+                           std::vector<char>* inlier_mask,
+                           Eigen::Vector3d* xyz);
 
 }  // namespace colmap

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -37,7 +37,7 @@ namespace colmap {
 namespace {
 
 bool TriangulateTrack(
-    EstimateTriangulationOptions& tri_options,
+    const EstimateTriangulationOptions& options,
     const std::vector<IncrementalTriangulator::CorrData>& corrs_data,
     std::vector<char>& inlier_mask,
     Eigen::Vector3d& xyz) {
@@ -55,13 +55,14 @@ bool TriangulateTrack(
   }
 
   // Enforce exhaustive sampling for small track lengths.
+  EstimateTriangulationOptions options_(options);
   const size_t kExhaustiveSamplingThreshold = 15;
   if (points.size() <= kExhaustiveSamplingThreshold) {
-    tri_options.ransac_options.min_num_trials = NChooseK(points.size(), 2);
+    options_.ransac_options.min_num_trials = NChooseK(points.size(), 2);
   }
 
   return EstimateTriangulation(
-      tri_options, points, cams_from_world, cameras, &inlier_mask, &xyz);
+      options_, points, cams_from_world, cameras, &inlier_mask, &xyz);
 }
 
 }  // namespace

--- a/src/pycolmap/estimators/triangulation.h
+++ b/src/pycolmap/estimators/triangulation.h
@@ -16,7 +16,7 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-py::dict PyEstimateTriangulation(
+py::object PyEstimateTriangulation(
     const std::vector<TriangulationEstimator::PointData>& point_data,
     const std::vector<Image>& images,
     const std::vector<Camera>& cameras,

--- a/src/pycolmap/estimators/triangulation.h
+++ b/src/pycolmap/estimators/triangulation.h
@@ -81,7 +81,7 @@ void BindTriangulationEstimator(py::module& m) {
         "point_data"_a,
         "images"_a,
         "cameras"_a,
-        "opions"_a = triangulation_options,
+        "options"_a = triangulation_options,
         "Robustly estimate 3D point from observations in multiple views using "
         "RANSAC");
 }


### PR DESCRIPTION
- Simplify the interface of `EstimateTriangulation` to ease its Python bindings
- Abstract duplicated code in the `IncrementalTriangulator`