### PR TITLE
Initialize glog in pycolmap only if not already done

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -20,6 +20,8 @@ find_package(LZ4 ${COLMAP_FIND_TYPE})
 find_package(Metis ${COLMAP_FIND_TYPE})
 
 find_package(Glog ${COLMAP_FIND_TYPE})
+add_definitions("-DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}")
+add_definitions("-DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}")
 
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
 

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -22,6 +22,7 @@ find_package(Metis ${COLMAP_FIND_TYPE})
 find_package(Glog ${COLMAP_FIND_TYPE})
 add_definitions("-DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}")
 add_definitions("-DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}")
+message(STATUS "GLOG versions: ${glog_VERSION} ${glog_VERSION_MAJOR} ${glog_VERSION_MINOR}")
 
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
 

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -20,9 +20,11 @@ find_package(LZ4 ${COLMAP_FIND_TYPE})
 find_package(Metis ${COLMAP_FIND_TYPE})
 
 find_package(Glog ${COLMAP_FIND_TYPE})
-add_definitions("-DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}")
-add_definitions("-DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}")
-message(STATUS "GLOG versions: ${glog_VERSION} ${glog_VERSION_MAJOR} ${glog_VERSION_MINOR}")
+if(DEFINED glog_VERSION_MAJOR)
+  # Older versions of glog don't export version variables.
+  add_definitions("-DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}")
+  add_definitions("-DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}")
+endif()
 
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
 

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -156,7 +156,7 @@ class LogMessageFatalThrow : public google::LogMessage {
         prefix_(__MakeExceptionPrefix(file, line)){};
   LogMessageFatalThrow(const char* file,
                        int line,
-#if GLOG_VERSION_MAJOR >= 0 && GLOG_VERSION_MINOR >= 7
+#if GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 7
                        const google::logging::internal::CheckOpString& result)
 #else
                        const google::CheckOpString& result)

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -156,7 +156,11 @@ class LogMessageFatalThrow : public google::LogMessage {
         prefix_(__MakeExceptionPrefix(file, line)){};
   LogMessageFatalThrow(const char* file,
                        int line,
+#if GLOG_VERSION_MAJOR >= 0 && GLOG_VERSION_MINOR >= 7
+                       const google::logging::internal::CheckOpString& result)
+#else
                        const google::CheckOpString& result)
+#endif
       : google::LogMessage(file, line, google::GLOG_ERROR, &message_),
         prefix_(__MakeExceptionPrefix(file, line)) {
     stream() << "Check failed: " << (*result.str_) << " ";

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -156,7 +156,8 @@ class LogMessageFatalThrow : public google::LogMessage {
         prefix_(__MakeExceptionPrefix(file, line)){};
   LogMessageFatalThrow(const char* file,
                        int line,
-#if GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 7
+#if defined(GLOG_VERSION_MAJOR) && \
+    (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 7)
                        const google::logging::internal::CheckOpString& result)
 #else
                        const google::CheckOpString& result)

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -85,7 +85,8 @@ void BindLogging(py::module& m) {
       .value("FATAL", Logging::LogSeverity::GLOG_FATAL)
       .export_values();
 
-#if GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6
+#if defined(GLOG_VERSION_MAJOR) && \
+    (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6)
   if (!google::IsGoogleLoggingInitialized())
 #endif
   {

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -38,7 +38,7 @@ std::pair<std::string, int> GetPythonCallFrame() {
 }
 
 void BindLogging(py::module& m) {
-  py::class_<Logging> PyLogging(m, "logging");
+  py::class_<Logging> PyLogging(m, "logging", py::module_local());
   PyLogging.def_readwrite_static("minloglevel", &FLAGS_minloglevel)
       .def_readwrite_static("stderrthreshold", &FLAGS_stderrthreshold)
       .def_readwrite_static("log_dir", &FLAGS_log_dir)
@@ -84,8 +84,11 @@ void BindLogging(py::module& m) {
       .value("ERROR", Logging::LogSeverity::GLOG_ERROR)
       .value("FATAL", Logging::LogSeverity::GLOG_FATAL)
       .export_values();
-  google::InitGoogleLogging("");
-  google::InstallFailureSignalHandler();
+
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("");
+    google::InstallFailureSignalHandler();
+  }
   FLAGS_alsologtostderr = true;
 }
 

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -85,7 +85,7 @@ void BindLogging(py::module& m) {
       .value("FATAL", Logging::LogSeverity::GLOG_FATAL)
       .export_values();
 
-#if GLOG_VERSION_MAJOR >= 0 && GLOG_VERSION_MINOR >= 6
+#if GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6
   if (!google::IsGoogleLoggingInitialized())
 #endif
   {

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -85,7 +85,10 @@ void BindLogging(py::module& m) {
       .value("FATAL", Logging::LogSeverity::GLOG_FATAL)
       .export_values();
 
-  if (!google::IsGoogleLoggingInitialized()) {
+#if GLOG_VERSION_MAJOR >= 0 && GLOG_VERSION_MINOR >= 6
+  if (!google::IsGoogleLoggingInitialized())
+#endif
+  {
     google::InitGoogleLogging("");
     google::InstallFailureSignalHandler();
   }


### PR DESCRIPTION
- Context: multiple libraries might initialize glog, e.g. pyceres and pycolmap. Initializing glog twice causes a fatal error
- Add a fix for glog >=0.6.0. There exists a (hacky) workaround for 0.4.0 but not for 0.5.0.
- This PR also adds support for glog 0.7.0