### PR TITLE
Improve bindings of Database

### DIFF
--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -734,14 +734,15 @@ void Database::WriteMatches(const image_t image_id1,
 
 void Database::WriteMatches(const image_t image_id1,
                             const image_t image_id2,
-                            FeatureMatchesBlob blob) const {
+                            const FeatureMatchesBlob& blob) const {
   const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
   SQLITE3_CALL(sqlite3_bind_int64(sql_stmt_write_matches_, 1, pair_id));
 
   // Important: the swapped data must live until the query is executed.
   if (SwapImagePair(image_id1, image_id2)) {
-    SwapFeatureMatchesBlob(&blob);
-    WriteDynamicMatrixBlob(sql_stmt_write_matches_, blob, 2);
+    FeatureMatchesBlob swapped_blob = blob;
+    SwapFeatureMatchesBlob(&swapped_blob);
+    WriteDynamicMatrixBlob(sql_stmt_write_matches_, swapped_blob, 2);
   } else {
     WriteDynamicMatrixBlob(sql_stmt_write_matches_, blob, 2);
   }

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -618,12 +618,10 @@ void Database::ReadTwoViewGeometryNumInliers(
 
   while (SQLITE3_CALL(sqlite3_step(
              sql_stmt_read_two_view_geometry_num_inliers_)) == SQLITE_ROW) {
-    image_t image_id1;
-    image_t image_id2;
     const image_pair_t pair_id = static_cast<image_pair_t>(
         sqlite3_column_int64(sql_stmt_read_two_view_geometry_num_inliers_, 0));
-    PairIdToImagePair(pair_id, &image_id1, &image_id2);
-    image_pairs->emplace_back(image_id1, image_id2);
+    const auto image_pair = PairIdToImagePair(pair_id);
+    image_pairs->emplace_back(image_pair.first, image_pair.second);
 
     const int rows = static_cast<int>(
         sqlite3_column_int64(sql_stmt_read_two_view_geometry_num_inliers_, 1));
@@ -986,21 +984,19 @@ void Database::Merge(const Database& database1,
   // Merge the matches.
 
   for (const auto& matches : database1.ReadAllMatches()) {
-    image_t image_id1, image_id2;
-    Database::PairIdToImagePair(matches.first, &image_id1, &image_id2);
+    const auto image_pair = Database::PairIdToImagePair(matches.first);
 
-    const image_t new_image_id1 = new_image_ids1.at(image_id1);
-    const image_t new_image_id2 = new_image_ids1.at(image_id2);
+    const image_t new_image_id1 = new_image_ids1.at(image_pair.first);
+    const image_t new_image_id2 = new_image_ids1.at(image_pair.second);
 
     merged_database->WriteMatches(new_image_id1, new_image_id2, matches.second);
   }
 
   for (const auto& matches : database2.ReadAllMatches()) {
-    image_t image_id1, image_id2;
-    Database::PairIdToImagePair(matches.first, &image_id1, &image_id2);
+    const auto image_pair = Database::PairIdToImagePair(matches.first);
 
-    const image_t new_image_id1 = new_image_ids2.at(image_id1);
-    const image_t new_image_id2 = new_image_ids2.at(image_id2);
+    const image_t new_image_id1 = new_image_ids2.at(image_pair.first);
+    const image_t new_image_id2 = new_image_ids2.at(image_pair.second);
 
     merged_database->WriteMatches(new_image_id1, new_image_id2, matches.second);
   }
@@ -1013,11 +1009,10 @@ void Database::Merge(const Database& database1,
     database1.ReadTwoViewGeometries(&image_pair_ids, &two_view_geometries);
 
     for (size_t i = 0; i < two_view_geometries.size(); ++i) {
-      image_t image_id1, image_id2;
-      Database::PairIdToImagePair(image_pair_ids[i], &image_id1, &image_id2);
+      const auto image_pair = Database::PairIdToImagePair(image_pair_ids[i]);
 
-      const image_t new_image_id1 = new_image_ids1.at(image_id1);
-      const image_t new_image_id2 = new_image_ids1.at(image_id2);
+      const image_t new_image_id1 = new_image_ids1.at(image_pair.first);
+      const image_t new_image_id2 = new_image_ids1.at(image_pair.second);
 
       merged_database->WriteTwoViewGeometry(
           new_image_id1, new_image_id2, two_view_geometries[i]);
@@ -1030,11 +1025,10 @@ void Database::Merge(const Database& database1,
     database2.ReadTwoViewGeometries(&image_pair_ids, &two_view_geometries);
 
     for (size_t i = 0; i < two_view_geometries.size(); ++i) {
-      image_t image_id1, image_id2;
-      Database::PairIdToImagePair(image_pair_ids[i], &image_id1, &image_id2);
+      const auto image_pair = Database::PairIdToImagePair(image_pair_ids[i]);
 
-      const image_t new_image_id1 = new_image_ids2.at(image_id1);
-      const image_t new_image_id2 = new_image_ids2.at(image_id2);
+      const image_t new_image_id1 = new_image_ids2.at(image_pair.first);
+      const image_t new_image_id2 = new_image_ids2.at(image_pair.second);
 
       merged_database->WriteTwoViewGeometry(
           new_image_id1, new_image_id2, two_view_geometries[i]);

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -458,7 +458,7 @@ FeatureKeypointsBlob Database::ReadKeypointsBlob(const image_t image_id) const {
   SQLITE3_CALL(sqlite3_bind_int64(sql_stmt_read_keypoints_, 1, image_id));
 
   const int rc = SQLITE3_CALL(sqlite3_step(sql_stmt_read_keypoints_));
-  const FeatureKeypointsBlob blob = ReadDynamicMatrixBlob<FeatureKeypointsBlob>(
+  FeatureKeypointsBlob blob = ReadDynamicMatrixBlob<FeatureKeypointsBlob>(
       sql_stmt_read_keypoints_, rc, 0);
 
   SQLITE3_CALL(sqlite3_reset(sql_stmt_read_keypoints_));
@@ -729,7 +729,7 @@ void Database::WriteDescriptors(const image_t image_id,
 void Database::WriteMatches(const image_t image_id1,
                             const image_t image_id2,
                             const FeatureMatches& matches) const {
-  WriteMatches(image_id1, image_id2, std::move(FeatureMatchesToBlob(matches)));
+  WriteMatches(image_id1, image_id2, FeatureMatchesToBlob(matches));
 }
 
 void Database::WriteMatches(const image_t image_id1,

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -194,7 +194,7 @@ class Database {
                     const FeatureMatches& matches) const;
   void WriteMatches(image_t image_id1,
                     image_t image_id2,
-                    FeatureMatchesBlob blob) const;
+                    const FeatureMatchesBlob& blob) const;
   void WriteTwoViewGeometry(image_t image_id1,
                             image_t image_id2,
                             const TwoViewGeometry& two_view_geometry) const;

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -134,9 +134,8 @@ class Database {
   inline static image_pair_t ImagePairToPairId(image_t image_id1,
                                                image_t image_id2);
 
-  inline static void PairIdToImagePair(image_pair_t pair_id,
-                                       image_t* image_id1,
-                                       image_t* image_id2);
+  inline static std::pair<image_t, image_t> PairIdToImagePair(
+      image_pair_t pair_id);
 
   // Return true if image pairs should be swapped. Used to enforce a specific
   // image order to generate unique image pair identifiers independent of the
@@ -383,13 +382,14 @@ image_pair_t Database::ImagePairToPairId(const image_t image_id1,
   }
 }
 
-void Database::PairIdToImagePair(const image_pair_t pair_id,
-                                 image_t* image_id1,
-                                 image_t* image_id2) {
-  *image_id2 = static_cast<image_t>(pair_id % kMaxNumImages);
-  *image_id1 = static_cast<image_t>((pair_id - *image_id2) / kMaxNumImages);
-  THROW_CHECK_LT(*image_id1, kMaxNumImages);
-  THROW_CHECK_LT(*image_id2, kMaxNumImages);
+std::pair<image_t, image_t> Database::PairIdToImagePair(
+    const image_pair_t pair_id) {
+  const image_t image_id2 = static_cast<image_t>(pair_id % kMaxNumImages);
+  const image_t image_id1 =
+      static_cast<image_t>((pair_id - image_id2) / kMaxNumImages);
+  THROW_CHECK_LT(image_id1, kMaxNumImages);
+  THROW_CHECK_LT(image_id2, kMaxNumImages);
+  return std::make_pair(std::move(image_id1), std::move(image_id2));
 }
 
 // Return true if image pairs should be swapped. Used to enforce a specific

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -389,7 +389,7 @@ std::pair<image_t, image_t> Database::PairIdToImagePair(
       static_cast<image_t>((pair_id - image_id2) / kMaxNumImages);
   THROW_CHECK_LT(image_id1, kMaxNumImages);
   THROW_CHECK_LT(image_id2, kMaxNumImages);
-  return std::make_pair(std::move(image_id1), std::move(image_id2));
+  return std::make_pair(image_id1, image_id2);
 }
 
 // Return true if image pairs should be swapped. Used to enforce a specific

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -45,6 +45,13 @@
 
 namespace colmap {
 
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+    FeatureKeypointsBlob;
+typedef Eigen::Matrix<uint8_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+    FeatureDescriptorsBlob;
+typedef Eigen::Matrix<point2D_t, Eigen::Dynamic, 2, Eigen::RowMajor>
+    FeatureMatchesBlob;
+
 // Database class to read and write images, features, cameras, matches, etc.
 // from a SQLite database. The class is not thread-safe and must not be accessed
 // concurrently. The class is optimized for single-thread speed and for optimal
@@ -146,9 +153,12 @@ class Database {
   Image ReadImageWithName(const std::string& name) const;
   std::vector<Image> ReadAllImages() const;
 
+  FeatureKeypointsBlob ReadKeypointsBlob(image_t image_id) const;
   FeatureKeypoints ReadKeypoints(image_t image_id) const;
   FeatureDescriptors ReadDescriptors(image_t image_id) const;
 
+  FeatureMatchesBlob ReadMatchesBlob(image_t image_id1,
+                                     image_t image_id2) const;
   FeatureMatches ReadMatches(image_t image_id1, image_t image_id2) const;
   std::vector<std::pair<image_pair_t, FeatureMatches>> ReadAllMatches() const;
 
@@ -177,11 +187,15 @@ class Database {
   // `image_id1` and `image_id2` does not matter.
   void WriteKeypoints(image_t image_id,
                       const FeatureKeypoints& keypoints) const;
+  void WriteKeypoints(image_t image_id, const FeatureKeypointsBlob& blob) const;
   void WriteDescriptors(image_t image_id,
                         const FeatureDescriptors& descriptors) const;
   void WriteMatches(image_t image_id1,
                     image_t image_id2,
                     const FeatureMatches& matches) const;
+  void WriteMatches(image_t image_id1,
+                    image_t image_id2,
+                    FeatureMatchesBlob blob) const;
   void WriteTwoViewGeometry(image_t image_id1,
                             image_t image_id2,
                             const TwoViewGeometry& two_view_geometry) const;

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -119,7 +119,8 @@ std::shared_ptr<DatabaseCache> DatabaseCache::Create(
       if (UseInlierMatchesCheck(two_view_geometries[i])) {
         image_t image_id1;
         image_t image_id2;
-        Database::PairIdToImagePair(image_pair_ids[i], &image_id1, &image_id2);
+        std::tie(image_id1, image_id2) =
+            Database::PairIdToImagePair(image_pair_ids[i]);
         if (image_ids.count(image_id1) > 0 && image_ids.count(image_id2) > 0) {
           connected_image_ids.insert(image_id1);
           connected_image_ids.insert(image_id2);
@@ -165,7 +166,8 @@ std::shared_ptr<DatabaseCache> DatabaseCache::Create(
     if (UseInlierMatchesCheck(two_view_geometries[i])) {
       image_t image_id1;
       image_t image_id2;
-      Database::PairIdToImagePair(image_pair_ids[i], &image_id1, &image_id2);
+      std::tie(image_id1, image_id2) =
+          Database::PairIdToImagePair(image_pair_ids[i]);
       if (image_ids.count(image_id1) > 0 && image_ids.count(image_id2) > 0) {
         cache->correspondence_graph_->AddCorrespondences(
             image_id1, image_id2, two_view_geometries[i].inlier_matches);

--- a/src/colmap/scene/database_test.cc
+++ b/src/colmap/scene/database_test.cc
@@ -95,7 +95,7 @@ TEST(Database, ImagePairToPairId) {
       const image_pair_t pair_id = Database::ImagePairToPairId(i, j);
       image_t image_id1;
       image_t image_id2;
-      Database::PairIdToImagePair(pair_id, &image_id1, &image_id2);
+      std::tie(image_id1, image_id2) = Database::PairIdToImagePair(pair_id);
       if (i < j) {
         EXPECT_EQ(i, image_id1);
         EXPECT_EQ(j, image_id2);

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -102,12 +102,10 @@ void SynthesizeChainedMatches(Reconstruction* reconstruction,
   }
 
   for (auto& two_view_geometry : two_view_geometries) {
-    image_t image_id1;
-    image_t image_id2;
-    Database::PairIdToImagePair(
-        two_view_geometry.first, &image_id1, &image_id2);
-    const auto& image1 = reconstruction->Image(image_id1);
-    const auto& image2 = reconstruction->Image(image_id2);
+    const auto image_pair =
+        Database::PairIdToImagePair(two_view_geometry.first);
+    const auto& image1 = reconstruction->Image(image_pair.first);
+    const auto& image2 = reconstruction->Image(image_pair.second);
     two_view_geometry.second.config = TwoViewGeometry::CALIBRATED;
     const Rigid3d cam2_from_cam1 =
         image2.CamFromWorld() * Inverse(image1.CamFromWorld());

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -323,7 +323,8 @@ size_t IncrementalTriangulator::Retriangulate(const Options& options) {
 
     image_t image_id1;
     image_t image_id2;
-    Database::PairIdToImagePair(image_pair.first, &image_id1, &image_id2);
+    std::tie(image_id1, image_id2) =
+        Database::PairIdToImagePair(image_pair.first);
 
     const Image& image1 = reconstruction_->Image(image_id1);
     if (!image1.IsRegistered()) {

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -149,11 +149,11 @@ class LogMessageFatalThrow : public google::LogMessage {
  public:
   LogMessageFatalThrow(const char* file, int line)
       : google::LogMessage(file, line, google::GLOG_ERROR, &message_),
-        prefix_(__MakeExceptionPrefix(file, line)){};
+        prefix_(__MakeExceptionPrefix(file, line)) {}
   LogMessageFatalThrow(const char* file, int line, std::string* message)
       : google::LogMessage(file, line, google::GLOG_ERROR, message),
         message_(*message),
-        prefix_(__MakeExceptionPrefix(file, line)){};
+        prefix_(__MakeExceptionPrefix(file, line)) {}
   LogMessageFatalThrow(const char* file,
                        int line,
 #if defined(GLOG_VERSION_MAJOR) && \
@@ -168,7 +168,7 @@ class LogMessageFatalThrow : public google::LogMessage {
     // On LOG(FATAL) glog does not bother cleaning up CheckOpString
     // so we do it here.
     delete result.str_;
-  };
+  }
   ~LogMessageFatalThrow() noexcept(false) {
     Flush();
 #if defined(__cpp_lib_uncaught_exceptions) && \
@@ -180,7 +180,7 @@ class LogMessageFatalThrow : public google::LogMessage {
     {
       throw T(prefix_ + message_);
     }
-  };
+  }
 
  private:
   std::string message_;

--- a/src/pycolmap/scene/database.h
+++ b/src/pycolmap/scene/database.h
@@ -10,33 +10,122 @@ namespace py = pybind11;
 
 void BindDatabase(py::module& m) {
   py::class_<Database> PyDatabase(m, "Database");
-  PyDatabase.def(py::init<const std::string&>(), "path"_a)
+  PyDatabase.def(py::init<>())
+      .def(py::init<const std::string&>(), "path"_a)
       .def("open", &Database::Open, "path"_a)
       .def("close", &Database::Close)
       .def_property_readonly("num_cameras", &Database::NumCameras)
       .def_property_readonly("num_images", &Database::NumImages)
       .def_property_readonly("num_keypoints", &Database::NumKeypoints)
-      .def_property_readonly("num_keypoints_for_image",
-                             &Database::NumKeypointsForImage)
+      .def("num_keypoints_for_image",
+           &Database::NumKeypointsForImage,
+           "image_id"_a)
       .def_property_readonly("num_descriptors", &Database::NumDescriptors)
-      .def_property_readonly("num_descriptors_for_image",
-                             &Database::NumDescriptorsForImage)
+      .def("num_descriptors_for_image",
+           &Database::NumDescriptorsForImage,
+           "image_id"_a)
       .def_property_readonly("num_matches", &Database::NumMatches)
       .def_property_readonly("num_inlier_matches", &Database::NumInlierMatches)
       .def_property_readonly("num_matched_image_pairs",
                              &Database::NumMatchedImagePairs)
       .def_property_readonly("num_verified_image_pairs",
                              &Database::NumVerifiedImagePairs)
-      .def("image_pair_to_pair_id", &Database::ImagePairToPairId)
-      .def("pair_id_to_image_pair", &Database::PairIdToImagePair)
-      .def("read_camera", &Database::ReadCamera)
+      .def_static("image_pair_to_pair_id",
+                  &Database::ImagePairToPairId,
+                  "image_id1"_a,
+                  "image_id2"_a)
+      .def_static(
+          "pair_id_to_image_pair",
+          [](const image_pair_t pair_id) {
+            image_t image_id1, image_id2;
+            Database::PairIdToImagePair(pair_id, &image_id1, &image_id2);
+            return std::make_pair(image_id1, image_id2);
+          },
+          "pair_id"_a)
+      .def_static("swap_image_pair",
+                  &Database::SwapImagePair,
+                  "image_id1"_a,
+                  "image_id2"_a)
+      .def("read_camera", &Database::ReadCamera, "camera_id"_a)
       .def("read_all_cameras", &Database::ReadAllCameras)
-      .def("read_image", &Database::ReadImage)
-      .def("read_image_with_name", &Database::ReadImageWithName)
+      .def("read_image", &Database::ReadImage, "image_id"_a)
+      .def("read_image_with_name", &Database::ReadImageWithName, "name"_a)
       .def("read_all_images", &Database::ReadAllImages)
-      .def("read_two_view_geometry", &Database::ReadTwoViewGeometry)
-      .def("write_camera", &Database::WriteCamera)
-      .def("write_image", &Database::WriteImage);
+      .def("read_keypoints", &Database::ReadKeypointsBlob, "image_id"_a)
+      .def("read_descriptors", &Database::ReadDescriptors, "image_id"_a)
+      .def("read_matches",
+           &Database::ReadMatchesBlob,
+           "image_id1"_a,
+           "image_id2"_a)
+      // TODO: ReadAllMatches
+      .def("read_two_view_geometry",
+           &Database::ReadTwoViewGeometry,
+           "image_id1"_a,
+           "image_id2"_a)
+      .def("read_two_view_geometries",
+           [](const Database& self) {
+             std::vector<image_pair_t> image_pair_ids;
+             std::vector<TwoViewGeometry> two_view_geometries;
+             self.ReadTwoViewGeometries(&image_pair_ids, &two_view_geometries);
+             return std::make_pair(image_pair_ids, two_view_geometries);
+           })
+      .def("read_two_view_geometry_num_inliers",
+           [](const Database& self) {
+             std::vector<std::pair<image_t, image_t>> image_pair_ids;
+             std::vector<int> num_inliers;
+             self.ReadTwoViewGeometryNumInliers(&image_pair_ids, &num_inliers);
+             return std::make_pair(image_pair_ids, num_inliers);
+           })
+      .def("write_camera",
+           &Database::WriteCamera,
+           "camera"_a,
+           "use_camera_id"_a = false)
+      .def("write_image",
+           &Database::WriteImage,
+           "image"_a,
+           "use_image_id"_a = false)
+      .def("write_keypoints",
+           py::overload_cast<image_t, const FeatureKeypointsBlob&>(
+               &Database::WriteKeypoints, py::const_),
+           "image_id"_a,
+           "keypoints"_a)
+      .def("write_descriptors",
+           &Database::WriteDescriptors,
+           "image_id"_a,
+           "descriptors"_a)
+      .def("write_matches",
+           py::overload_cast<image_t, image_t, FeatureMatchesBlob>(
+               &Database::WriteMatches, py::const_),
+           "image_id1"_a,
+           "image_id2"_a,
+           "matches"_a)
+      .def("write_two_view_geometry",
+           &Database::WriteTwoViewGeometry,
+           "image_id1"_a,
+           "image_id2"_a,
+           "two_view_geometry"_a)
+      .def("update_camera", &Database::UpdateCamera, "camera"_a)
+      .def("update_image", &Database::UpdateImage, "image"_a)
+      .def("delete_matches",
+           &Database::DeleteMatches,
+           "image_id1"_a,
+           "image_id2"_a)
+      .def("delete_inlier_matches",
+           &Database::DeleteInlierMatches,
+           "image_id1"_a,
+           "image_id2"_a)
+      .def("clear_all_tables", &Database::ClearAllTables)
+      .def("clear_cameras", &Database::ClearCameras)
+      .def("clear_images", &Database::ClearImages)
+      .def("clear_descriptors", &Database::ClearDescriptors)
+      .def("clear_keypoints", &Database::ClearKeypoints)
+      .def("clear_matches", &Database::ClearMatches)
+      .def("clear_two_view_geometries", &Database::ClearTwoViewGeometries)
+      .def_static("merge",
+                  &Database::Merge,
+                  "database1"_a,
+                  "database2"_a,
+                  "merged_database"_a);
 
   py::class_<DatabaseTransaction>(m, "DatabaseTransaction")
       .def(py::init<Database*>(), "database"_a);

--- a/src/pycolmap/scene/database.h
+++ b/src/pycolmap/scene/database.h
@@ -104,7 +104,7 @@ void BindDatabase(py::module& m) {
            "image_id"_a,
            "descriptors"_a)
       .def("write_matches",
-           py::overload_cast<image_t, image_t, FeatureMatchesBlob>(
+           py::overload_cast<image_t, image_t, const FeatureMatchesBlob&>(
                &Database::WriteMatches, py::const_),
            "image_id1"_a,
            "image_id2"_a,

--- a/src/pycolmap/scene/database.h
+++ b/src/pycolmap/scene/database.h
@@ -11,7 +11,7 @@ namespace py = pybind11;
 class DatabaseTransactionWrapper {
  public:
   explicit DatabaseTransactionWrapper(Database* database)
-      : database_(database){};
+      : database_(database) {}
 
   void enter() {
     transaction_ = std::make_unique<DatabaseTransaction>(database_);

--- a/src/pycolmap/scene/database.h
+++ b/src/pycolmap/scene/database.h
@@ -51,13 +51,7 @@ void BindDatabase(py::module& m) {
                   "image_id1"_a,
                   "image_id2"_a)
       .def_static(
-          "pair_id_to_image_pair",
-          [](const image_pair_t pair_id) {
-            image_t image_id1, image_id2;
-            Database::PairIdToImagePair(pair_id, &image_id1, &image_id2);
-            return std::make_pair(image_id1, image_id2);
-          },
-          "pair_id"_a)
+          "pair_id_to_image_pair", &Database::PairIdToImagePair, "pair_id"_a)
       .def_static("swap_image_pair",
                   &Database::SwapImagePair,
                   "image_id1"_a,

--- a/src/pycolmap/scene/database.h
+++ b/src/pycolmap/scene/database.h
@@ -59,7 +59,7 @@ void BindDatabase(py::module& m) {
       .def("read_camera", &Database::ReadCamera, "camera_id"_a)
       .def("read_all_cameras", &Database::ReadAllCameras)
       .def("read_image", &Database::ReadImage, "image_id"_a)
-      .def("read_image_with_name", &Database::ReadImageWithName, "name"_a)
+      .def("read_image", &Database::ReadImageWithName, "name"_a)
       .def("read_all_images", &Database::ReadAllImages)
       .def("read_keypoints", &Database::ReadKeypointsBlob, "image_id"_a)
       .def("read_descriptors", &Database::ReadDescriptors, "image_id"_a)


### PR DESCRIPTION
Related to this PR: `FeatureKeypoint`/`FeatureKeypoints` and `FeatureMatch`/`FeatureMatches` are not Python-friendly, would it be OK to replace all their occurrences with their blob counterparts? NxD matrices are directly translated to numpy arrays. This would simplify the COLMAP code as well and also make it cleaner to support non-affine features.