### PR TITLE
Simplify IncrementalMapperController

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Setup Ubuntu
         run: |
-          sudo apt-get install -y \
+          sudo apt-get update && sudo apt-get install -y \
             build-essential \
             ninja-build \
             libboost-program-options-dev \

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -263,7 +263,7 @@ IncrementalMapperController::InitializeReconstruction(
   if (!options_->IsInitialPairProvided()) {
     LOG(INFO) << "Finding good initial image pair";
     const bool find_init_success = mapper.FindInitialImagePair(
-        mapper_options, two_view_geometry, &image_id1, &image_id2);
+        mapper_options, two_view_geometry, image_id1, image_id2);
     if (!find_init_success) {
       LOG(INFO) << "=> No good initial image pair found.";
       return Status::NO_INITIAL_PAIR;

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -36,21 +36,21 @@ namespace colmap {
 namespace {
 
 void IterativeGlobalRefinement(const IncrementalMapperOptions& options,
-                               IncrementalMapper* mapper) {
+                               IncrementalMapper& mapper) {
   LOG(INFO) << "Retriangulation and Global bundle adjustment";
-  mapper->IterativeGlobalRefinement(options.ba_global_max_refinements,
-                                    options.ba_global_max_refinement_change,
-                                    options.Mapper(),
-                                    options.GlobalBundleAdjustment(),
-                                    options.Triangulation());
+  mapper.IterativeGlobalRefinement(options.ba_global_max_refinements,
+                                   options.ba_global_max_refinement_change,
+                                   options.Mapper(),
+                                   options.GlobalBundleAdjustment(),
+                                   options.Triangulation());
 }
 
 void ExtractColors(const std::string& image_path,
                    const image_t image_id,
-                   Reconstruction* reconstruction) {
-  if (!reconstruction->ExtractColorsForImage(image_id, image_path)) {
+                   Reconstruction& reconstruction) {
+  if (!reconstruction.ExtractColorsForImage(image_id, image_path)) {
     LOG(WARNING) << StringPrintf("Could not read image %s at path %s.",
-                                 reconstruction->Image(image_id).Name().c_str(),
+                                 reconstruction.Image(image_id).Name().c_str(),
                                  image_path.c_str());
   }
 }
@@ -351,7 +351,7 @@ void IncrementalMapperController::Reconstruct(
       }
 
       if (options_->extract_colors) {
-        ExtractColors(image_path_, image_id1, reconstruction.get());
+        ExtractColors(image_path_, image_id1, *reconstruction);
       }
     }
 
@@ -413,13 +413,13 @@ void IncrementalMapperController::Reconstruct(
                   options_->ba_global_points_ratio * ba_prev_num_points ||
               reconstruction->NumPoints3D() >=
                   options_->ba_global_points_freq + ba_prev_num_points) {
-            IterativeGlobalRefinement(*options_, &mapper);
+            IterativeGlobalRefinement(*options_, mapper);
             ba_prev_num_points = reconstruction->NumPoints3D();
             ba_prev_num_reg_images = reconstruction->NumRegImages();
           }
 
           if (options_->extract_colors) {
-            ExtractColors(image_path_, next_image_id, reconstruction.get());
+            ExtractColors(image_path_, next_image_id, *reconstruction);
           }
 
           if (options_->snapshot_images_freq > 0 &&
@@ -459,7 +459,7 @@ void IncrementalMapperController::Reconstruct(
       if (!reg_next_success && prev_reg_next_success) {
         reg_next_success = true;
         prev_reg_next_success = false;
-        IterativeGlobalRefinement(*options_, &mapper);
+        IterativeGlobalRefinement(*options_, mapper);
       } else {
         prev_reg_next_success = reg_next_success;
       }
@@ -474,7 +474,7 @@ void IncrementalMapperController::Reconstruct(
     if (reconstruction->NumRegImages() >= 2 &&
         reconstruction->NumRegImages() != ba_prev_num_reg_images &&
         reconstruction->NumPoints3D() != ba_prev_num_points) {
-      IterativeGlobalRefinement(*options_, &mapper);
+      IterativeGlobalRefinement(*options_, mapper);
     }
 
     // Remember the total number of registered images before potentially

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -305,6 +305,20 @@ bool IncrementalMapperController::InitializeReconstruction(
   return true;
 }
 
+bool IncrementalMapperController::CheckRunGlobalRefinement(
+    const Reconstruction& reconstruction,
+    const size_t ba_prev_num_reg_images,
+    const size_t ba_prev_num_points) {
+  return reconstruction.NumRegImages() >=
+             options_->ba_global_images_ratio * ba_prev_num_reg_images ||
+         reconstruction.NumRegImages() >=
+             options_->ba_global_images_freq + ba_prev_num_reg_images ||
+         reconstruction.NumPoints3D() >=
+             options_->ba_global_points_ratio * ba_prev_num_points ||
+         reconstruction.NumPoints3D() >=
+             options_->ba_global_points_freq + ba_prev_num_points;
+}
+
 bool IncrementalMapperController::ReconstructSubModel(
     IncrementalMapper& mapper,
     const IncrementalMapper::Options& mapper_options,
@@ -397,14 +411,8 @@ bool IncrementalMapperController::ReconstructSubModel(
                                       options_->Triangulation(),
                                       next_image_id);
 
-      if (reconstruction->NumRegImages() >=
-              options_->ba_global_images_ratio * ba_prev_num_reg_images ||
-          reconstruction->NumRegImages() >=
-              options_->ba_global_images_freq + ba_prev_num_reg_images ||
-          reconstruction->NumPoints3D() >=
-              options_->ba_global_points_ratio * ba_prev_num_points ||
-          reconstruction->NumPoints3D() >=
-              options_->ba_global_points_freq + ba_prev_num_points) {
+      if (CheckRunGlobalRefinement(
+              *reconstruction, ba_prev_num_reg_images, ba_prev_num_points)) {
         IterativeGlobalRefinement(*options_, mapper_options, mapper);
         ba_prev_num_points = reconstruction->NumPoints3D();
         ba_prev_num_reg_images = reconstruction->NumRegImages();

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -250,12 +250,237 @@ bool IncrementalMapperController::LoadDatabase() {
   return true;
 }
 
+bool IncrementalMapperController::ReconstructSubModel(
+    IncrementalMapper& mapper,
+    const IncrementalMapper::Options& mapper_options,
+    const size_t reconstruction_idx) {
+  const bool kIsLastSubModel = true;
+
+  std::shared_ptr<Reconstruction> reconstruction =
+      reconstruction_manager_->Get(reconstruction_idx);
+
+  mapper.BeginReconstruction(reconstruction);
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Register initial pair
+  ////////////////////////////////////////////////////////////////////////////
+
+  if (reconstruction->NumRegImages() == 0) {
+    image_t image_id1 = static_cast<image_t>(options_->init_image_id1);
+    image_t image_id2 = static_cast<image_t>(options_->init_image_id2);
+
+    // Try to find good initial pair.
+    if (options_->init_image_id1 == -1 || options_->init_image_id2 == -1) {
+      LOG(INFO) << "Finding good initial image pair";
+      const bool find_init_success =
+          mapper.FindInitialImagePair(mapper_options, &image_id1, &image_id2);
+      if (!find_init_success) {
+        LOG(INFO) << "=> No good initial image pair found.";
+        mapper.EndReconstruction(/*discard=*/true);
+        reconstruction_manager_->Delete(reconstruction_idx);
+        return kIsLastSubModel;
+      }
+    } else {
+      if (!reconstruction->ExistsImage(image_id1) ||
+          !reconstruction->ExistsImage(image_id2)) {
+        LOG(INFO) << StringPrintf(
+            "=> Initial image pair #%d and #%d do not exist.",
+            image_id1,
+            image_id2);
+        mapper.EndReconstruction(/*discard=*/true);
+        reconstruction_manager_->Delete(reconstruction_idx);
+        return kIsLastSubModel;
+      }
+    }
+
+    LOG(INFO) << StringPrintf(
+        "Initializing with image pair #%d and #%d", image_id1, image_id2);
+    const bool reg_init_success =
+        mapper.RegisterInitialImagePair(mapper_options, image_id1, image_id2);
+    if (!reg_init_success) {
+      LOG(INFO) << "=> Initialization failed - possible solutions:" << std::endl
+                << "     - try to relax the initialization constraints"
+                << std::endl
+                << "     - manually select an initial image pair";
+      mapper.EndReconstruction(/*discard=*/true);
+      reconstruction_manager_->Delete(reconstruction_idx);
+      return kIsLastSubModel;
+    }
+
+    LOG(INFO) << "Global bundle adjustment";
+    mapper.AdjustGlobalBundle(mapper_options,
+                              options_->GlobalBundleAdjustment());
+    mapper.FilterPoints(mapper_options);
+    mapper.FilterImages(mapper_options);
+
+    // Initial image pair failed to register.
+    if (reconstruction->NumRegImages() == 0 ||
+        reconstruction->NumPoints3D() == 0) {
+      mapper.EndReconstruction(/*discard=*/true);
+      reconstruction_manager_->Delete(reconstruction_idx);
+      // If both initial images are manually specified, there is no need for
+      // further initialization trials.
+      return options_->init_image_id1 != -1 && options_->init_image_id2 != -1;
+    }
+
+    if (options_->extract_colors) {
+      ExtractColors(image_path_, image_id1, *reconstruction);
+    }
+  }
+
+  Callback(INITIAL_IMAGE_PAIR_REG_CALLBACK);
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Incremental mapping
+  ////////////////////////////////////////////////////////////////////////////
+
+  size_t snapshot_prev_num_reg_images = reconstruction->NumRegImages();
+  size_t ba_prev_num_reg_images = reconstruction->NumRegImages();
+  size_t ba_prev_num_points = reconstruction->NumPoints3D();
+
+  bool reg_next_success = true;
+  bool prev_reg_next_success = true;
+  while (reg_next_success) {
+    if (CheckIfStopped()) {
+      break;
+    }
+
+    reg_next_success = false;
+
+    const std::vector<image_t> next_images =
+        mapper.FindNextImages(mapper_options);
+
+    if (next_images.empty()) {
+      break;
+    }
+
+    for (size_t reg_trial = 0; reg_trial < next_images.size(); ++reg_trial) {
+      const image_t next_image_id = next_images[reg_trial];
+      const Image& next_image = reconstruction->Image(next_image_id);
+
+      LOG(INFO) << StringPrintf("Registering image #%d (%d)",
+                                next_image_id,
+                                reconstruction->NumRegImages() + 1);
+      LOG(INFO) << StringPrintf("=> Image sees %d / %d points",
+                                next_image.NumVisiblePoints3D(),
+                                next_image.NumObservations());
+
+      reg_next_success =
+          mapper.RegisterNextImage(mapper_options, next_image_id);
+
+      if (reg_next_success) {
+        mapper.TriangulateImage(options_->Triangulation(), next_image_id);
+        mapper.IterativeLocalRefinement(
+            options_->ba_local_max_refinements,
+            options_->ba_local_max_refinement_change,
+            mapper_options,
+            options_->LocalBundleAdjustment(),
+            options_->Triangulation(),
+            next_image_id);
+
+        if (reconstruction->NumRegImages() >=
+                options_->ba_global_images_ratio * ba_prev_num_reg_images ||
+            reconstruction->NumRegImages() >=
+                options_->ba_global_images_freq + ba_prev_num_reg_images ||
+            reconstruction->NumPoints3D() >=
+                options_->ba_global_points_ratio * ba_prev_num_points ||
+            reconstruction->NumPoints3D() >=
+                options_->ba_global_points_freq + ba_prev_num_points) {
+          IterativeGlobalRefinement(*options_, mapper_options, mapper);
+          ba_prev_num_points = reconstruction->NumPoints3D();
+          ba_prev_num_reg_images = reconstruction->NumRegImages();
+        }
+
+        if (options_->extract_colors) {
+          ExtractColors(image_path_, next_image_id, *reconstruction);
+        }
+
+        if (options_->snapshot_images_freq > 0 &&
+            reconstruction->NumRegImages() >=
+                options_->snapshot_images_freq + snapshot_prev_num_reg_images) {
+          snapshot_prev_num_reg_images = reconstruction->NumRegImages();
+          WriteSnapshot(*reconstruction, options_->snapshot_path);
+        }
+
+        Callback(NEXT_IMAGE_REG_CALLBACK);
+
+        break;
+      } else {
+        LOG(INFO) << "=> Could not register, trying another image.";
+
+        // If initial pair fails to continue for some time,
+        // abort and try different initial pair.
+        const size_t kMinNumInitialRegTrials = 30;
+        if (reg_trial >= kMinNumInitialRegTrials &&
+            reconstruction->NumRegImages() <
+                static_cast<size_t>(options_->min_model_size)) {
+          break;
+        }
+      }
+    }
+
+    const size_t max_model_overlap =
+        static_cast<size_t>(options_->max_model_overlap);
+    if (mapper.NumSharedRegImages() >= max_model_overlap) {
+      break;
+    }
+
+    // If no image could be registered, try a single final global iterative
+    // bundle adjustment and try again to register one image. If this fails
+    // once, then exit the incremental mapping.
+    if (!reg_next_success && prev_reg_next_success) {
+      reg_next_success = true;
+      prev_reg_next_success = false;
+      IterativeGlobalRefinement(*options_, mapper_options, mapper);
+    } else {
+      prev_reg_next_success = reg_next_success;
+    }
+  }
+
+  if (CheckIfStopped()) {
+    mapper.EndReconstruction(/*discard=*/false);
+    return kIsLastSubModel;
+  }
+
+  // Only run final global BA, if last incremental BA was not global.
+  if (reconstruction->NumRegImages() >= 2 &&
+      reconstruction->NumRegImages() != ba_prev_num_reg_images &&
+      reconstruction->NumPoints3D() != ba_prev_num_points) {
+    IterativeGlobalRefinement(*options_, mapper_options, mapper);
+  }
+
+  // Remember the total number of registered images before potentially
+  // discarding it below due to small size, so we can out of the main loop,
+  // if all images were registered.
+  const size_t total_num_reg_images = mapper.NumTotalRegImages();
+
+  // If the total number of images is small then do not enforce the minimum
+  // model size so that we can reconstruct small image collections.
+  // Always keep the first reconstruction, independent of size.
+  const size_t min_model_size = std::min<size_t>(
+      0.8 * database_cache_->NumImages(), options_->min_model_size);
+  if ((options_->multiple_models && reconstruction_manager_->Size() > 1 &&
+       reconstruction->NumRegImages() < min_model_size) ||
+      reconstruction->NumRegImages() == 0) {
+    mapper.EndReconstruction(/*discard=*/true);
+    reconstruction_manager_->Delete(reconstruction_idx);
+  } else {
+    mapper.EndReconstruction(/*discard=*/false);
+  }
+
+  Callback(LAST_IMAGE_REG_CALLBACK);
+
+  if (!options_->multiple_models ||
+      reconstruction_manager_->Size() >=
+          static_cast<size_t>(options_->max_num_models) ||
+      total_num_reg_images >= database_cache_->NumImages() - 1) {
+    return kIsLastSubModel;
+  }
+  return !kIsLastSubModel;
+}
+
 void IncrementalMapperController::Reconstruct(
     const IncrementalMapper::Options& mapper_options) {
-  //////////////////////////////////////////////////////////////////////////////
-  // Main loop
-  //////////////////////////////////////////////////////////////////////////////
-
   IncrementalMapper mapper(database_cache_);
 
   // Is there a sub-model before we start the reconstruction? I.e. the user
@@ -268,241 +493,15 @@ void IncrementalMapperController::Reconstruct(
 
   for (int num_trials = 0; num_trials < options_->init_num_trials;
        ++num_trials) {
-    if (CheckIfStopped()) {
-      break;
-    }
-
     size_t reconstruction_idx;
     if (!initial_reconstruction_given || num_trials > 0) {
       reconstruction_idx = reconstruction_manager_->Add();
     } else {
       reconstruction_idx = 0;
     }
-
-    std::shared_ptr<Reconstruction> reconstruction =
-        reconstruction_manager_->Get(reconstruction_idx);
-
-    mapper.BeginReconstruction(reconstruction);
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Register initial pair
-    ////////////////////////////////////////////////////////////////////////////
-
-    if (reconstruction->NumRegImages() == 0) {
-      image_t image_id1 = static_cast<image_t>(options_->init_image_id1);
-      image_t image_id2 = static_cast<image_t>(options_->init_image_id2);
-
-      // Try to find good initial pair.
-      if (options_->init_image_id1 == -1 || options_->init_image_id2 == -1) {
-        LOG(INFO) << "Finding good initial image pair";
-        const bool find_init_success =
-            mapper.FindInitialImagePair(mapper_options, &image_id1, &image_id2);
-        if (!find_init_success) {
-          LOG(INFO) << "=> No good initial image pair found.";
-          mapper.EndReconstruction(/*discard=*/true);
-          reconstruction_manager_->Delete(reconstruction_idx);
-          break;
-        }
-      } else {
-        if (!reconstruction->ExistsImage(image_id1) ||
-            !reconstruction->ExistsImage(image_id2)) {
-          LOG(INFO) << StringPrintf(
-              "=> Initial image pair #%d and #%d do not exist.",
-              image_id1,
-              image_id2);
-          mapper.EndReconstruction(/*discard=*/true);
-          reconstruction_manager_->Delete(reconstruction_idx);
-          return;
-        }
-      }
-
-      LOG(INFO) << StringPrintf(
-          "Initializing with image pair #%d and #%d", image_id1, image_id2);
-      const bool reg_init_success =
-          mapper.RegisterInitialImagePair(mapper_options, image_id1, image_id2);
-      if (!reg_init_success) {
-        LOG(INFO) << "=> Initialization failed - possible solutions:"
-                  << std::endl
-                  << "     - try to relax the initialization constraints"
-                  << std::endl
-                  << "     - manually select an initial image pair";
-        mapper.EndReconstruction(/*discard=*/true);
-        reconstruction_manager_->Delete(reconstruction_idx);
-        break;
-      }
-
-      PrintHeading1("Global bundle adjustment");
-      mapper.AdjustGlobalBundle(mapper_options,
-                                options_->GlobalBundleAdjustment());
-      mapper.FilterPoints(mapper_options);
-      mapper.FilterImages(mapper_options);
-
-      // Initial image pair failed to register.
-      if (reconstruction->NumRegImages() == 0 ||
-          reconstruction->NumPoints3D() == 0) {
-        mapper.EndReconstruction(/*discard=*/true);
-        reconstruction_manager_->Delete(reconstruction_idx);
-        // If both initial images are manually specified, there is no need for
-        // further initialization trials.
-        if (options_->init_image_id1 != -1 && options_->init_image_id2 != -1) {
-          break;
-        } else {
-          continue;
-        }
-      }
-
-      if (options_->extract_colors) {
-        ExtractColors(image_path_, image_id1, *reconstruction);
-      }
-    }
-
-    Callback(INITIAL_IMAGE_PAIR_REG_CALLBACK);
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Incremental mapping
-    ////////////////////////////////////////////////////////////////////////////
-
-    size_t snapshot_prev_num_reg_images = reconstruction->NumRegImages();
-    size_t ba_prev_num_reg_images = reconstruction->NumRegImages();
-    size_t ba_prev_num_points = reconstruction->NumPoints3D();
-
-    bool reg_next_success = true;
-    bool prev_reg_next_success = true;
-    while (reg_next_success) {
-      if (CheckIfStopped()) {
-        break;
-      }
-
-      reg_next_success = false;
-
-      const std::vector<image_t> next_images =
-          mapper.FindNextImages(mapper_options);
-
-      if (next_images.empty()) {
-        break;
-      }
-
-      for (size_t reg_trial = 0; reg_trial < next_images.size(); ++reg_trial) {
-        const image_t next_image_id = next_images[reg_trial];
-        const Image& next_image = reconstruction->Image(next_image_id);
-
-        LOG(INFO) << StringPrintf("Registering image #%d (%d)",
-                                  next_image_id,
-                                  reconstruction->NumRegImages() + 1);
-        LOG(INFO) << StringPrintf("=> Image sees %d / %d points",
-                                  next_image.NumVisiblePoints3D(),
-                                  next_image.NumObservations());
-
-        reg_next_success =
-            mapper.RegisterNextImage(mapper_options, next_image_id);
-
-        if (reg_next_success) {
-          mapper.TriangulateImage(options_->Triangulation(), next_image_id);
-          mapper.IterativeLocalRefinement(
-              options_->ba_local_max_refinements,
-              options_->ba_local_max_refinement_change,
-              mapper_options,
-              options_->LocalBundleAdjustment(),
-              options_->Triangulation(),
-              next_image_id);
-
-          if (reconstruction->NumRegImages() >=
-                  options_->ba_global_images_ratio * ba_prev_num_reg_images ||
-              reconstruction->NumRegImages() >=
-                  options_->ba_global_images_freq + ba_prev_num_reg_images ||
-              reconstruction->NumPoints3D() >=
-                  options_->ba_global_points_ratio * ba_prev_num_points ||
-              reconstruction->NumPoints3D() >=
-                  options_->ba_global_points_freq + ba_prev_num_points) {
-            IterativeGlobalRefinement(*options_, mapper_options, mapper);
-            ba_prev_num_points = reconstruction->NumPoints3D();
-            ba_prev_num_reg_images = reconstruction->NumRegImages();
-          }
-
-          if (options_->extract_colors) {
-            ExtractColors(image_path_, next_image_id, *reconstruction);
-          }
-
-          if (options_->snapshot_images_freq > 0 &&
-              reconstruction->NumRegImages() >=
-                  options_->snapshot_images_freq +
-                      snapshot_prev_num_reg_images) {
-            snapshot_prev_num_reg_images = reconstruction->NumRegImages();
-            WriteSnapshot(*reconstruction, options_->snapshot_path);
-          }
-
-          Callback(NEXT_IMAGE_REG_CALLBACK);
-
-          break;
-        } else {
-          LOG(INFO) << "=> Could not register, trying another image.";
-
-          // If initial pair fails to continue for some time,
-          // abort and try different initial pair.
-          const size_t kMinNumInitialRegTrials = 30;
-          if (reg_trial >= kMinNumInitialRegTrials &&
-              reconstruction->NumRegImages() <
-                  static_cast<size_t>(options_->min_model_size)) {
-            break;
-          }
-        }
-      }
-
-      const size_t max_model_overlap =
-          static_cast<size_t>(options_->max_model_overlap);
-      if (mapper.NumSharedRegImages() >= max_model_overlap) {
-        break;
-      }
-
-      // If no image could be registered, try a single final global iterative
-      // bundle adjustment and try again to register one image. If this fails
-      // once, then exit the incremental mapping.
-      if (!reg_next_success && prev_reg_next_success) {
-        reg_next_success = true;
-        prev_reg_next_success = false;
-        IterativeGlobalRefinement(*options_, mapper_options, mapper);
-      } else {
-        prev_reg_next_success = reg_next_success;
-      }
-    }
-
-    if (CheckIfStopped()) {
-      mapper.EndReconstruction(/*discard=*/false);
-      break;
-    }
-
-    // Only run final global BA, if last incremental BA was not global.
-    if (reconstruction->NumRegImages() >= 2 &&
-        reconstruction->NumRegImages() != ba_prev_num_reg_images &&
-        reconstruction->NumPoints3D() != ba_prev_num_points) {
-      IterativeGlobalRefinement(*options_, mapper_options, mapper);
-    }
-
-    // Remember the total number of registered images before potentially
-    // discarding it below due to small size, so we can out of the main loop,
-    // if all images were registered.
-    const size_t total_num_reg_images = mapper.NumTotalRegImages();
-
-    // If the total number of images is small then do not enforce the minimum
-    // model size so that we can reconstruct small image collections.
-    // Always keep the first reconstruction, independent of size.
-    const size_t min_model_size = std::min<size_t>(
-        0.8 * database_cache_->NumImages(), options_->min_model_size);
-    if ((options_->multiple_models && reconstruction_manager_->Size() > 1 &&
-         reconstruction->NumRegImages() < min_model_size) ||
-        reconstruction->NumRegImages() == 0) {
-      mapper.EndReconstruction(/*discard=*/true);
-      reconstruction_manager_->Delete(reconstruction_idx);
-    } else {
-      mapper.EndReconstruction(/*discard=*/false);
-    }
-
-    Callback(LAST_IMAGE_REG_CALLBACK);
-
-    if (initial_reconstruction_given || !options_->multiple_models ||
-        reconstruction_manager_->Size() >=
-            static_cast<size_t>(options_->max_num_models) ||
-        total_num_reg_images >= database_cache_->NumImages() - 1) {
+    const bool is_last_trial =
+        ReconstructSubModel(mapper, mapper_options, reconstruction_idx);
+    if (initial_reconstruction_given || is_last_trial || CheckIfStopped()) {
       break;
     }
   }

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -135,6 +135,10 @@ struct IncrementalMapperOptions {
   BundleAdjustmentOptions LocalBundleAdjustment() const;
   BundleAdjustmentOptions GlobalBundleAdjustment() const;
 
+  inline bool IsInitialPairProvided() const {
+    return init_image_id1 != -1 && init_image_id2 != -1;
+  }
+
   bool Check() const;
 };
 
@@ -147,6 +151,8 @@ class IncrementalMapperController : public BaseController {
     NEXT_IMAGE_REG_CALLBACK,
     LAST_IMAGE_REG_CALLBACK,
   };
+
+  enum class Status { NO_INITIAL_PAIR, BAD_INITIAL_PAIR, SUCCESS };
 
   IncrementalMapperController(
       std::shared_ptr<const IncrementalMapperOptions> options,
@@ -162,7 +168,7 @@ class IncrementalMapperController : public BaseController {
   bool ReconstructSubModel(IncrementalMapper& mapper,
                            const IncrementalMapper::Options& mapper_options,
                            size_t reconstruction_idx);
-  bool InitializeReconstruction(
+  Status InitializeReconstruction(
       IncrementalMapper& mapper,
       const IncrementalMapper::Options& mapper_options,
       Reconstruction& reconstruction);

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -166,6 +166,9 @@ class IncrementalMapperController : public BaseController {
       IncrementalMapper& mapper,
       const IncrementalMapper::Options& mapper_options,
       Reconstruction& reconstruction);
+  bool CheckRunGlobalRefinement(const Reconstruction& reconstruction,
+                                size_t ba_prev_num_reg_images,
+                                size_t ba_prev_num_points);
 
   const std::shared_ptr<const IncrementalMapperOptions> options_;
   const std::string image_path_;

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -152,7 +152,7 @@ class IncrementalMapperController : public BaseController {
     LAST_IMAGE_REG_CALLBACK,
   };
 
-  enum class Status { NO_INITIAL_PAIR, BAD_INITIAL_PAIR, SUCCESS };
+  enum class Status { NO_INITIAL_PAIR, BAD_INITIAL_PAIR, SUCCESS, INTERRUPTED };
 
   IncrementalMapperController(
       std::shared_ptr<const IncrementalMapperOptions> options,
@@ -165,9 +165,10 @@ class IncrementalMapperController : public BaseController {
  private:
   bool LoadDatabase();
   void Reconstruct(const IncrementalMapper::Options& init_mapper_options);
-  bool ReconstructSubModel(IncrementalMapper& mapper,
-                           const IncrementalMapper::Options& mapper_options,
-                           size_t reconstruction_idx);
+  Status ReconstructSubModel(
+      IncrementalMapper& mapper,
+      const IncrementalMapper::Options& mapper_options,
+      const std::shared_ptr<Reconstruction>& reconstruction);
   Status InitializeReconstruction(
       IncrementalMapper& mapper,
       const IncrementalMapper::Options& mapper_options,

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -159,6 +159,9 @@ class IncrementalMapperController : public BaseController {
  private:
   bool LoadDatabase();
   void Reconstruct(const IncrementalMapper::Options& init_mapper_options);
+  bool ReconstructSubModel(IncrementalMapper& mapper,
+                           const IncrementalMapper::Options& mapper_options,
+                           size_t reconstruction_idx);
 
   const std::shared_ptr<const IncrementalMapperOptions> options_;
   const std::string image_path_;

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -167,14 +167,4 @@ class IncrementalMapperController : public BaseController {
   std::shared_ptr<DatabaseCache> database_cache_;
 };
 
-// Globally filter points and images in mapper.
-size_t FilterPoints(const IncrementalMapperOptions& options,
-                    IncrementalMapper* mapper);
-size_t FilterImages(const IncrementalMapperOptions& options,
-                    IncrementalMapper* mapper);
-
-// Globally complete and merge tracks in mapper.
-size_t CompleteAndMergeTracks(const IncrementalMapperOptions& options,
-                              IncrementalMapper* mapper);
-
 }  // namespace colmap

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -162,6 +162,10 @@ class IncrementalMapperController : public BaseController {
   bool ReconstructSubModel(IncrementalMapper& mapper,
                            const IncrementalMapper::Options& mapper_options,
                            size_t reconstruction_idx);
+  bool InitializeReconstruction(
+      IncrementalMapper& mapper,
+      const IncrementalMapper::Options& mapper_options,
+      Reconstruction& reconstruction);
 
   const std::shared_ptr<const IncrementalMapperOptions> options_;
   const std::string image_path_;

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -419,7 +419,7 @@ int RunPointTriangulatorImpl(
     const std::string& database_path,
     const std::string& image_path,
     const std::string& output_path,
-    const IncrementalMapperOptions& mapper_options,
+    const IncrementalMapperOptions& options,
     const bool clear_points,
     const bool refine_intrinsics) {
   PrintHeading1("Loading database");
@@ -430,12 +430,11 @@ int RunPointTriangulatorImpl(
     Timer timer;
     timer.Start();
     const Database database(database_path);
-    const size_t min_num_matches =
-        static_cast<size_t>(mapper_options.min_num_matches);
+    const size_t min_num_matches = static_cast<size_t>(options.min_num_matches);
     database_cache = DatabaseCache::Create(database,
                                            min_num_matches,
-                                           mapper_options.ignore_watermarks,
-                                           mapper_options.image_names);
+                                           options.ignore_watermarks,
+                                           options.image_names);
 
     if (clear_points) {
       reconstruction->DeleteAllPoints2DAndPoints3D();
@@ -455,8 +454,8 @@ int RunPointTriangulatorImpl(
   // Triangulation
   //////////////////////////////////////////////////////////////////////////////
 
-  const auto tri_options = mapper_options.Triangulation();
-  const auto map_options = mapper_options.Mapper();
+  const auto tri_options = options.Triangulation();
+  const auto mapper_options = options.Mapper();
 
   const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
 
@@ -489,7 +488,7 @@ int RunPointTriangulatorImpl(
   // Bundle adjustment
   //////////////////////////////////////////////////////////////////////////////
 
-  auto ba_options = mapper_options.GlobalBundleAdjustment();
+  auto ba_options = options.GlobalBundleAdjustment();
   ba_options.refine_focal_length = refine_intrinsics;
   ba_options.refine_principal_point = false;
   ba_options.refine_extra_params = refine_intrinsics;
@@ -501,7 +500,7 @@ int RunPointTriangulatorImpl(
     ba_config.AddImage(image_id);
   }
 
-  for (int i = 0; i < mapper_options.ba_global_max_refinements; ++i) {
+  for (int i = 0; i < options.ba_global_max_refinements; ++i) {
     // Avoid degeneracies in bundle adjustment.
     reconstruction->FilterObservationsWithNegativeDepth();
 
@@ -513,11 +512,11 @@ int RunPointTriangulatorImpl(
 
     size_t num_changed_observations = 0;
     num_changed_observations += mapper.CompleteAndMergeTracks(tri_options);
-    num_changed_observations += mapper.FilterPoints(map_options);
+    num_changed_observations += mapper.FilterPoints(mapper_options);
     const double changed =
         static_cast<double>(num_changed_observations) / num_observations;
     LOG(INFO) << StringPrintf("=> Changed observations: %.6f", changed);
-    if (changed < mapper_options.ba_global_max_refinement_change) {
+    if (changed < options.ba_global_max_refinement_change) {
       break;
     }
   }

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -456,6 +456,7 @@ int RunPointTriangulatorImpl(
   //////////////////////////////////////////////////////////////////////////////
 
   const auto tri_options = mapper_options.Triangulation();
+  const auto map_options = mapper_options.Mapper();
 
   const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
 
@@ -482,7 +483,7 @@ int RunPointTriangulatorImpl(
 
   PrintHeading1("Retriangulation");
 
-  CompleteAndMergeTracks(mapper_options, &mapper);
+  mapper.CompleteAndMergeTracks(tri_options);
 
   //////////////////////////////////////////////////////////////////////////////
   // Bundle adjustment
@@ -511,8 +512,8 @@ int RunPointTriangulatorImpl(
     THROW_CHECK(bundle_adjuster.Solve(reconstruction.get()));
 
     size_t num_changed_observations = 0;
-    num_changed_observations += CompleteAndMergeTracks(mapper_options, &mapper);
-    num_changed_observations += FilterPoints(mapper_options, &mapper);
+    num_changed_observations += mapper.CompleteAndMergeTracks(tri_options);
+    num_changed_observations += mapper.FilterPoints(map_options);
     const double changed =
         static_cast<double>(num_changed_observations) / num_observations;
     LOG(INFO) << StringPrintf("=> Changed observations: %.6f", changed);

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -39,7 +39,7 @@ int RunPointTriangulatorImpl(
     const std::string& database_path,
     const std::string& image_path,
     const std::string& output_path,
-    const IncrementalMapperOptions& mapper_options,
+    const IncrementalMapperOptions& options,
     bool clear_points,
     bool refine_intrinsics);
 

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -694,15 +694,15 @@ bool IncrementalMapper::AdjustGlobalBundle(
                                              "registered for global "
                                              "bundle-adjustment";
 
-  BundleAdjustmentOptions ba_options_copy = ba_options;
+  BundleAdjustmentOptions ba_options_tmp = ba_options;
   // Use stricter convergence criteria for first registered images.
   const size_t kMinNumRegImagesForFastBA = 10;
   if (reg_image_ids.size() < kMinNumRegImagesForFastBA) {
-    ba_options_copy.solver_options.function_tolerance /= 10;
-    ba_options_copy.solver_options.gradient_tolerance /= 10;
-    ba_options_copy.solver_options.parameter_tolerance /= 10;
-    ba_options_copy.solver_options.max_num_iterations *= 2;
-    ba_options_copy.solver_options.max_linear_solver_iterations = 200;
+    ba_options_tmp.solver_options.function_tolerance /= 10;
+    ba_options_tmp.solver_options.gradient_tolerance /= 10;
+    ba_options_tmp.solver_options.parameter_tolerance /= 10;
+    ba_options_tmp.solver_options.max_num_iterations *= 2;
+    ba_options_tmp.solver_options.max_linear_solver_iterations = 200;
   }
 
   // Avoid degeneracies in bundle adjustment.
@@ -731,7 +731,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
   }
 
   // Run bundle adjustment.
-  BundleAdjuster bundle_adjuster(ba_options_copy, ba_config);
+  BundleAdjuster bundle_adjuster(ba_options_tmp, ba_config);
   if (!bundle_adjuster.Solve(reconstruction_.get())) {
     return false;
   }
@@ -750,10 +750,10 @@ void IncrementalMapper::IterativeLocalRefinement(
     const BundleAdjustmentOptions& ba_options,
     const IncrementalTriangulator::Options& tri_options,
     const image_t image_id) {
-  BundleAdjustmentOptions ba_options_copy = ba_options;
+  BundleAdjustmentOptions ba_options_tmp = ba_options;
   for (int i = 0; i < max_num_refinements; ++i) {
     const auto report = AdjustLocalBundle(
-        options, ba_options_copy, tri_options, image_id, GetModifiedPoints3D());
+        options, ba_options_tmp, tri_options, image_id, GetModifiedPoints3D());
     VLOG(1) << "=> Merged observations: " << report.num_merged_observations;
     VLOG(1) << "=> Completed observations: "
             << report.num_completed_observations;
@@ -770,7 +770,7 @@ void IncrementalMapper::IterativeLocalRefinement(
       break;
     }
     // Only use robust cost function for first iteration.
-    ba_options_copy.loss_function_type =
+    ba_options_tmp.loss_function_type =
         BundleAdjustmentOptions::LossFunctionType::TRIVIAL;
   }
   ClearModifiedPoints3D();

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -143,23 +143,23 @@ void IncrementalMapper::EndReconstruction(const bool discard) {
 
 bool IncrementalMapper::FindInitialImagePair(const Options& options,
                                              TwoViewGeometry& two_view_geometry,
-                                             image_t* image_id1,
-                                             image_t* image_id2) {
+                                             image_t& image_id1,
+                                             image_t& image_id2) {
   THROW_CHECK(options.Check());
 
   std::vector<image_t> image_ids1;
-  if (*image_id1 != kInvalidImageId && *image_id2 == kInvalidImageId) {
-    // Only *image_id1 provided.
-    if (!database_cache_->ExistsImage(*image_id1)) {
+  if (image_id1 != kInvalidImageId && image_id2 == kInvalidImageId) {
+    // Only image_id1 provided.
+    if (!database_cache_->ExistsImage(image_id1)) {
       return false;
     }
-    image_ids1.push_back(*image_id1);
-  } else if (*image_id1 == kInvalidImageId && *image_id2 != kInvalidImageId) {
-    // Only *image_id2 provided.
-    if (!database_cache_->ExistsImage(*image_id2)) {
+    image_ids1.push_back(image_id1);
+  } else if (image_id1 == kInvalidImageId && image_id2 != kInvalidImageId) {
+    // Only image_id2 provided.
+    if (!database_cache_->ExistsImage(image_id2)) {
       return false;
     }
-    image_ids1.push_back(*image_id2);
+    image_ids1.push_back(image_id2);
   } else {
     // No initial seed image provided.
     image_ids1 = FindFirstInitialImage(options);
@@ -167,16 +167,16 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
 
   // Try to find good initial pair.
   for (size_t i1 = 0; i1 < image_ids1.size(); ++i1) {
-    *image_id1 = image_ids1[i1];
+    image_id1 = image_ids1[i1];
 
     const std::vector<image_t> image_ids2 =
-        FindSecondInitialImage(options, *image_id1);
+        FindSecondInitialImage(options, image_id1);
 
     for (size_t i2 = 0; i2 < image_ids2.size(); ++i2) {
-      *image_id2 = image_ids2[i2];
+      image_id2 = image_ids2[i2];
 
       const image_pair_t pair_id =
-          Database::ImagePairToPairId(*image_id1, *image_id2);
+          Database::ImagePairToPairId(image_id1, image_id2);
 
       // Try every pair only once.
       if (init_image_pairs_.count(pair_id) > 0) {
@@ -186,15 +186,15 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
       init_image_pairs_.insert(pair_id);
 
       if (EstimateInitialTwoViewGeometry(
-              options, two_view_geometry, *image_id1, *image_id2)) {
+              options, two_view_geometry, image_id1, image_id2)) {
         return true;
       }
     }
   }
 
   // No suitable pair found in entire dataset.
-  *image_id1 = kInvalidImageId;
-  *image_id2 = kInvalidImageId;
+  image_id1 = kInvalidImageId;
+  image_id2 = kInvalidImageId;
 
   return false;
 }

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -539,7 +539,12 @@ size_t IncrementalMapper::TriangulateImage(
     const IncrementalTriangulator::Options& tri_options,
     const image_t image_id) {
   THROW_CHECK_NOTNULL(reconstruction_);
-  return triangulator_->TriangulateImage(tri_options, image_id);
+  VLOG(1) << "=> Continued observations: "
+          << reconstruction_->Image(image_id).NumPoints3D();
+  const size_t num_tris =
+      triangulator_->TriangulateImage(tri_options, image_id);
+  VLOG(1) << "=> Added observations: " << num_tris;
+  return num_tris;
 }
 
 size_t IncrementalMapper::Retriangulate(
@@ -558,6 +563,15 @@ size_t IncrementalMapper::MergeTracks(
     const IncrementalTriangulator::Options& tri_options) {
   THROW_CHECK_NOTNULL(reconstruction_);
   return triangulator_->MergeAllTracks(tri_options);
+}
+
+size_t IncrementalMapper::CompleteAndMergeTracks(
+    const IncrementalTriangulator::Options& tri_options) {
+  const size_t num_completed_observations = CompleteTracks(tri_options);
+  VLOG(1) << "=> Completed observations: " << num_completed_observations;
+  const size_t num_merged_observations = MergeTracks(tri_options);
+  VLOG(1) << "=> Merged observations: " << num_merged_observations;
+  return num_completed_observations + num_merged_observations;
 }
 
 IncrementalMapper::LocalBundleAdjustmentReport
@@ -686,6 +700,17 @@ bool IncrementalMapper::AdjustGlobalBundle(
                                              "registered for global "
                                              "bundle-adjustment";
 
+  BundleAdjustmentOptions ba_options_copy = ba_options;
+  // Use stricter convergence criteria for first registered images.
+  const size_t kMinNumRegImagesForFastBA = 10;
+  if (reg_image_ids.size() < kMinNumRegImagesForFastBA) {
+    ba_options_copy.solver_options.function_tolerance /= 10;
+    ba_options_copy.solver_options.gradient_tolerance /= 10;
+    ba_options_copy.solver_options.parameter_tolerance /= 10;
+    ba_options_copy.solver_options.max_num_iterations *= 2;
+    ba_options_copy.solver_options.max_linear_solver_iterations = 200;
+  }
+
   // Avoid degeneracies in bundle adjustment.
   reconstruction_->FilterObservationsWithNegativeDepth();
 
@@ -712,7 +737,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
   }
 
   // Run bundle adjustment.
-  BundleAdjuster bundle_adjuster(ba_options, ba_config);
+  BundleAdjuster bundle_adjuster(ba_options_copy, ba_config);
   if (!bundle_adjuster.Solve(reconstruction_.get())) {
     return false;
   }
@@ -722,6 +747,64 @@ bool IncrementalMapper::AdjustGlobalBundle(
   reconstruction_->Normalize();
 
   return true;
+}
+
+void IncrementalMapper::IterativeLocalRefinement(
+    const int max_num_refinements,
+    const double max_refinement_change,
+    const Options& options,
+    const BundleAdjustmentOptions& ba_options,
+    const IncrementalTriangulator::Options& tri_options,
+    const image_t image_id) {
+  BundleAdjustmentOptions ba_options_copy = ba_options;
+  for (int i = 0; i < max_num_refinements; ++i) {
+    const auto report = AdjustLocalBundle(
+        options, ba_options_copy, tri_options, image_id, GetModifiedPoints3D());
+    VLOG(1) << "=> Merged observations: " << report.num_merged_observations;
+    VLOG(1) << "=> Completed observations: "
+            << report.num_completed_observations;
+    VLOG(1) << "=> Filtered observations: " << report.num_filtered_observations;
+    const double changed =
+        report.num_adjusted_observations == 0
+            ? 0
+            : (report.num_merged_observations +
+               report.num_completed_observations +
+               report.num_filtered_observations) /
+                  static_cast<double>(report.num_adjusted_observations);
+    VLOG(1) << StringPrintf("=> Changed observations: %.6f", changed);
+    if (changed < max_refinement_change) {
+      break;
+    }
+    // Only use robust cost function for first iteration.
+    ba_options_copy.loss_function_type =
+        BundleAdjustmentOptions::LossFunctionType::TRIVIAL;
+  }
+  ClearModifiedPoints3D();
+}
+
+void IncrementalMapper::IterativeGlobalRefinement(
+    const int max_num_refinements,
+    const double max_refinement_change,
+    const Options& options,
+    const BundleAdjustmentOptions& ba_options,
+    const IncrementalTriangulator::Options& tri_options) {
+  CompleteAndMergeTracks(tri_options);
+  VLOG(1) << "=> Retriangulated observations: " << Retriangulate(tri_options);
+  for (int i = 0; i < max_num_refinements; ++i) {
+    const size_t num_observations = reconstruction_->ComputeNumObservations();
+    AdjustGlobalBundle(options, ba_options);
+    size_t num_changed_observations = CompleteAndMergeTracks(tri_options);
+    num_changed_observations += FilterPoints(options);
+    const double changed =
+        num_observations == 0
+            ? 0
+            : static_cast<double>(num_changed_observations) / num_observations;
+    VLOG(1) << StringPrintf("=> Changed observations: %.6f", changed);
+    if (changed < max_refinement_change) {
+      break;
+    }
+  }
+  FilterImages(options);
 }
 
 size_t IncrementalMapper::FilterImages(const Options& options) {
@@ -746,14 +829,18 @@ size_t IncrementalMapper::FilterImages(const Options& options) {
     filtered_images_.insert(image_id);
   }
 
-  return image_ids.size();
+  const size_t num_filtered_images = image_ids.size();
+  VLOG(1) << "=> Filtered images: " << num_filtered_images;
+  return num_filtered_images;
 }
 
 size_t IncrementalMapper::FilterPoints(const Options& options) {
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK(options.Check());
-  return reconstruction_->FilterAllPoints3D(options.filter_max_reproj_error,
-                                            options.filter_min_tri_angle);
+  const size_t num_filtered_observations = reconstruction_->FilterAllPoints3D(
+      options.filter_max_reproj_error, options.filter_min_tri_angle);
+  VLOG(1) << "=> Filtered observations: " << num_filtered_observations;
+  return num_filtered_observations;
 }
 
 const Reconstruction& IncrementalMapper::GetReconstruction() const {

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -160,8 +160,8 @@ class IncrementalMapper {
   // automatically ignores image pairs that failed to register previously.
   bool FindInitialImagePair(const Options& options,
                             TwoViewGeometry& two_view_geometry,
-                            image_t* image_id1,
-                            image_t* image_id2);
+                            image_t& image_id1,
+                            image_t& image_id2);
 
   // Find best next image to register in the incremental reconstruction. The
   // images should be passed to `RegisterNextImage`. This function automatically

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -196,6 +196,10 @@ class IncrementalMapper {
   // the redundancy in subsequent bundle adjustments.
   size_t MergeTracks(const IncrementalTriangulator::Options& tri_options);
 
+  // Globally complete and merge tracks.
+  size_t CompleteAndMergeTracks(
+      const IncrementalTriangulator::Options& tri_options);
+
   // Adjust locally connected images and points of a reference image. In
   // addition, refine the provided 3D points. Only images connected to the
   // reference image are optimized. If the provided 3D points are not locally
@@ -211,6 +215,23 @@ class IncrementalMapper {
   // Global bundle adjustment using Ceres Solver.
   bool AdjustGlobalBundle(const Options& options,
                           const BundleAdjustmentOptions& ba_options);
+
+  // Perform multiple rounds of local bundle adjustment.
+  void IterativeLocalRefinement(
+      int max_num_refinements,
+      double max_refinement_change,
+      const Options& options,
+      const BundleAdjustmentOptions& ba_options,
+      const IncrementalTriangulator::Options& tri_options,
+      image_t image_id);
+
+  // Perform multiple rounds of global bundle adjustment.
+  void IterativeGlobalRefinement(
+      int max_num_refinements,
+      double max_refinement_change,
+      const Options& options,
+      const BundleAdjustmentOptions& ba_options,
+      const IncrementalTriangulator::Options& tri_options);
 
   // Filter images and point observations.
   size_t FilterImages(const Options& options);


### PR DESCRIPTION
Major simplification of `IncrementalMapperController:Reconstruct`. This should make it easier to rewrite it in Python (next step). The logical behavior of the function is unchanged.
cc @B1ueber2y 