### PR TITLE
Filter unused two_view_geometry

### DIFF
--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -568,12 +568,22 @@ TwoViewGeometry Database::ReadTwoViewGeometry(const image_t image_id1,
 
 void Database::ReadTwoViewGeometries(
     std::vector<image_pair_t>* image_pair_ids,
-    std::vector<TwoViewGeometry>* two_view_geometries) const {
+    std::vector<TwoViewGeometry>* two_view_geometries,
+    const std::unordered_set<image_t>* image_ids) const {
   int rc;
   while ((rc = SQLITE3_CALL(sqlite3_step(
               sql_stmt_read_two_view_geometries_))) == SQLITE_ROW) {
     const image_pair_t pair_id = static_cast<image_pair_t>(
         sqlite3_column_int64(sql_stmt_read_two_view_geometries_, 0));
+
+    if (image_ids != nullptr) {
+      const auto image_pair = PairIdToImagePair(pair_id);
+      if (image_ids->count(image_pair.first) == 0 &&
+          image_ids->count(image_pair.second) == 0) {
+        continue;
+      }
+    }
+
     image_pair_ids->push_back(pair_id);
 
     TwoViewGeometry two_view_geometry;

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -38,6 +38,7 @@
 
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <Eigen/Core>
@@ -165,7 +166,8 @@ class Database {
                                       image_t image_id2) const;
   void ReadTwoViewGeometries(
       std::vector<image_pair_t>* image_pair_ids,
-      std::vector<TwoViewGeometry>* two_view_geometries) const;
+      std::vector<TwoViewGeometry>* two_view_geometries,
+      const std::unordered_set<image_t>* image_ids = nullptr) const;
 
   // Read all image pairs that have an entry in the `NumVerifiedImagePairs`
   // table with at least one inlier match and their number of inlier matches.


### PR DESCRIPTION
This PR improves the performance of DatabaseCache in certain scenarios by filtering out unused two_veiw_geometry. For example, the user only wants to process some of the images in the entire dataset.