### PR TITLE
Expose FindCorrespondences to python

### DIFF
--- a/src/pycolmap/scene/correspondence_graph.h
+++ b/src/pycolmap/scene/correspondence_graph.h
@@ -72,7 +72,18 @@ void BindCorrespondenceGraph(py::module& m) {
             }
             self.AddCorrespondences(image_id1, image_id2, matches);
           })
-      .def("find_correspondences", &CorrespondenceGraph::FindCorrespondences)
+      .def("find_correspondences",
+           [](const CorrespondenceGraph& self,
+              const image_t image_id,
+              const point2D_t point2D_idx) {
+             const auto corr_range =
+               self.FindCorrespondences(image_id, point2D_idx);
+             std::vector<CorrespondenceGraph::Correspondence> correspondences;               
+             for (const auto* corr = corr_range.beg; corr < corr_range.end; ++corr) {
+               corrs.push_back(*corr);
+             }
+             return corrs;
+           })
       .def("extract_correspondences",
            &CorrespondenceGraph::ExtractCorrespondences)
       .def("extract_transitive_correspondences",

--- a/src/pycolmap/scene/correspondence_graph.h
+++ b/src/pycolmap/scene/correspondence_graph.h
@@ -72,6 +72,7 @@ void BindCorrespondenceGraph(py::module& m) {
             }
             self.AddCorrespondences(image_id1, image_id2, matches);
           })
+      .def("find_correspondences", &CorrespondenceGraph::FindCorrespondences)
       .def("extract_correspondences",
            &CorrespondenceGraph::ExtractCorrespondences)
       .def("extract_transitive_correspondences",


### PR DESCRIPTION
This public function was omitted from pycolmap during refactoring.
The simplest commit to restore it.