### PR TITLE
Expose Reconstruction::SetUp to pycolmap

### DIFF
--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -81,6 +81,8 @@ class Reconstruction {
   inline const struct Point3D& Point3D(point3D_t point3D_id) const;
   inline const ImagePairStat& ImagePair(image_pair_t pair_id) const;
   inline ImagePairStat& ImagePair(image_t image_id1, image_t image_id2);
+  inline void SetImagePair(const image_pair_t pair_id,
+                           const Reconstruction::ImagePairStat& stats);
 
   // Get mutable objects.
   inline struct Camera& Camera(camera_t camera_id);
@@ -375,6 +377,11 @@ struct Point3D& Reconstruction::Point3D(const point3D_t point3D_id) {
 Reconstruction::ImagePairStat& Reconstruction::ImagePair(
     const image_pair_t pair_id) {
   return image_pair_stats_.at(pair_id);
+}
+
+void Reconstruction::SetImagePair(const image_pair_t pair_id,
+                                  const Reconstruction::ImagePairStat& stats) {
+  image_pair_stats_.emplace(pair_id, stats);
 }
 
 Reconstruction::ImagePairStat& Reconstruction::ImagePair(

--- a/src/pycolmap/scene/correspondence_graph.h
+++ b/src/pycolmap/scene/correspondence_graph.h
@@ -56,6 +56,10 @@ void BindCorrespondenceGraph(py::module& m) {
               const image_t image_id2) {
              return self.NumCorrespondencesBetweenImages(image_id1, image_id2);
            })
+      .def("num_correspondences_between_all_images",
+           [](const CorrespondenceGraph& self) {
+             return self.NumCorrespondencesBetweenImages();
+           })
       .def("finalize", &CorrespondenceGraph::Finalize)
       .def("add_image", &CorrespondenceGraph::AddImage)
       .def(

--- a/src/pycolmap/scene/reconstruction.h
+++ b/src/pycolmap/scene/reconstruction.h
@@ -37,6 +37,15 @@ bool ExistsReconstruction(const std::string& path) {
 }
 
 void BindReconstruction(py::module& m) {
+  py::class_ext_<Reconstruction::ImagePairStat,
+                 std::shared_ptr<Reconstruction::ImagePairStat>>(
+      m, "ImagePairStat")
+      .def(py::init<>())
+      .def_readwrite("num_tri_corrs",
+                     &Reconstruction::ImagePairStat::num_tri_corrs)
+      .def_readwrite("num_total_corrs",
+                     &Reconstruction::ImagePairStat::num_total_corrs);
+
   py::class_<Reconstruction, std::shared_ptr<Reconstruction>>(m,
                                                               "Reconstruction")
       .def(py::init<>())
@@ -63,6 +72,9 @@ void BindReconstruction(py::module& m) {
       .def("num_reg_images", &Reconstruction::NumRegImages)
       .def("num_points3D", &Reconstruction::NumPoints3D)
       .def("num_image_pairs", &Reconstruction::NumImagePairs)
+      .def("set_image_pair", &Reconstruction::SetImagePair)
+      .def("image_pair",
+           py::overload_cast<const image_pair_t>(&Reconstruction::ImagePair))
       .def_property_readonly("images",
                              &Reconstruction::Images,
                              py::return_value_policy::reference_internal)
@@ -73,7 +85,7 @@ void BindReconstruction(py::module& m) {
       .def_property_readonly("points3D",
                              &Reconstruction::Points3D,
                              py::return_value_policy::reference_internal)
-      .def("set_up", 
+      .def("set_up",
            &Reconstruction::SetUp,
            "Setup all relevant data structures before reconstruction.")
       .def("point3D_ids", &Reconstruction::Point3DIds)

--- a/src/pycolmap/scene/reconstruction.h
+++ b/src/pycolmap/scene/reconstruction.h
@@ -73,6 +73,9 @@ void BindReconstruction(py::module& m) {
       .def_property_readonly("points3D",
                              &Reconstruction::Points3D,
                              py::return_value_policy::reference_internal)
+      .def("set_up", 
+           &Reconstruction::SetUp,
+           "Setup all relevant data structures before reconstruction.")
       .def("point3D_ids", &Reconstruction::Point3DIds)
       .def("reg_image_ids", &Reconstruction::RegImageIds)
       .def("exists_camera", &Reconstruction::ExistsCamera)


### PR DESCRIPTION
Reconstruction will only do the book keeping correctly (e.g. in functions such as AddPoint3D) if a CorrespondenceGraph is set.