### PR TITLE
Fix reconstruction.points3D

### DIFF
--- a/src/pycolmap/scene/point3D.cc
+++ b/src/pycolmap/scene/point3D.cc
@@ -16,9 +16,11 @@
 
 using namespace colmap;
 namespace py = pybind11;
+  
+using Point3DMap = std::unordered_map<point3D_t, Point3D>;
+PYBIND11_MAKE_OPAQUE(Point3DMap);
 
 void BindPoint3D(py::module& m) {
-  using Point3DMap = std::unordered_map<point3D_t, Point3D>;
   py::bind_map<Point3DMap>(m, "MapPoint3DIdToPoint3D")
       .def("__repr__", [](const Point3DMap& self) {
         return "MapPoint3DIdToPoint3D(num_points3D=" +

--- a/src/pycolmap/scene/point3D.cc
+++ b/src/pycolmap/scene/point3D.cc
@@ -16,7 +16,7 @@
 
 using namespace colmap;
 namespace py = pybind11;
-  
+
 using Point3DMap = std::unordered_map<point3D_t, Point3D>;
 PYBIND11_MAKE_OPAQUE(Point3DMap);
 


### PR DESCRIPTION
Need to add ``PYBIND11_MAKE_OPAQUE(Point3DMap)`` in both "reconstruction" and "point3D" to make the conversion correct. Fix for https://github.com/colmap/colmap/pull/2502

cc: @sarlinpe for https://github.com/colmap/colmap/issues/2522