### PR TITLE
Fix 'std::out_of_range' error when using hierarchical_mapper

### DIFF
--- a/src/colmap/controllers/hierarchical_mapper.cc
+++ b/src/colmap/controllers/hierarchical_mapper.cc
@@ -226,9 +226,11 @@ void HierarchicalMapperController::Run() {
   // Merge clusters
   //////////////////////////////////////////////////////////////////////////////
 
-  PrintHeading1("Merging clusters");
+  if (leaf_clusters.size() > 1) {
+    PrintHeading1("Merging clusters");
 
-  MergeClusters(*scene_clustering.GetRootCluster(), &reconstruction_managers);
+    MergeClusters(*scene_clustering.GetRootCluster(), &reconstruction_managers);
+  }
 
   THROW_CHECK_EQ(reconstruction_managers.size(), 1);
   THROW_CHECK_GT(


### PR DESCRIPTION
Fix a bug described here:
https://github.com/colmap/colmap/issues/2525#issue-2251904473