### PR TITLE
Add ignore missing files option to geometric patchmatch for PMVS

### DIFF
--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -129,6 +129,7 @@ void WriteCOLMAPCommands(const bool geometric,
   }
   if (geometric) {
     *file << indent << "  --input_type geometric \\" << std::endl;
+    *file << indent << "  --ignore_missing_files true \\" << std::endl;
   } else {
     *file << indent << "  --input_type photometric \\" << std::endl;
   }


### PR DESCRIPTION

If this flag is not included, check fails in https://github.com/colmap/colmap/blob/main/src/colmap/mvs/patch_match.cc#L507. 

It looks for an image that is not in this PMVS option, but in other option. 

With this flag set to true, geometric patchmatch works perfectly fine (after running photometric).