### PR TITLE
Fix model_cropper not resetting image.num_points3D of cropped_rec

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -452,8 +452,8 @@ Reconstruction Reconstruction::Crop(
   for (const auto& image : images_) {
     auto new_image = image.second;
     new_image.SetRegistered(false);
-    for (auto& point2D : new_image.Points2D()) {
-      point2D.point3D_id = kInvalidPoint3DId;
+    for (point2D_t pid = 0; pid < new_image.NumPoints2D(); ++pid) {
+      new_image.ResetPoint3DForPoint2D(pid);
     }
     cropped_reconstruction.AddImage(std::move(new_image));
   }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -452,8 +452,9 @@ Reconstruction Reconstruction::Crop(
   for (const auto& image : images_) {
     auto new_image = image.second;
     new_image.SetRegistered(false);
-    for (point2D_t pid = 0; pid < new_image.NumPoints2D(); ++pid) {
-      new_image.ResetPoint3DForPoint2D(pid);
+    const auto num_points2D = new_image.NumPoints2D();
+    for (point2D_t point2D_idx = 0; point2D_idx < num_points2D; ++point2D_idx) {
+      new_image.ResetPoint3DForPoint2D(point2D_idx);
     }
     cropped_reconstruction.AddImage(std::move(new_image));
   }


### PR DESCRIPTION
While investigating the model_splitter issue for the current revision 1f95f3ee74fdbc020ef2dca190ec56958ea5f9e1 described in https://github.com/colmap/colmap/issues/2096 I found a code regression introduced with commit https://github.com/colmap/colmap/commit/67029ad21205fac3d149e06000c1e20bf4be1b80

This affects model_cropper and model_splitter tools.

As the previous implementation used the Image::ResetPoint3DForPoint2D method inside the loop, the num_points3D member was reset to 0 correctly.

https://github.com/colmap/colmap/blob/1f95f3ee74fdbc020ef2dca190ec56958ea5f9e1/src/colmap/scene/image.cc#L97-L103

When directly assigning the kInvalidPoint3DId value, new_image keeps the value of the source num_points3D representing an incorrect state of the newly created cropped_reconstruction and finally leads to a failing check at https://github.com/colmap/colmap/blob/1f95f3ee74fdbc020ef2dca190ec56958ea5f9e1/src/colmap/scene/reconstruction.cc#L184

Fixing this by adding the call to Image::ResetPoint3DForPoint2D inside the loop again as it was first implemented in https://github.com/colmap/colmap/commit/99c7904c4a3c99c17d80fee1d8b57ed7fe5d3753.


<details>
<summary>Debugger screenshots:</summary>

Current Revision 1f95f3ee74fdbc020ef2dca190ec56958ea5f9e1 :

![colmap_crop_debug_faulty](https://github.com/colmap/colmap/assets/38115976/3c399a17-8ea4-4d02-ad53-ed0475eb3504)

Old implementation:
![colmap_crop_debug_pre_change](https://github.com/colmap/colmap/assets/38115976/db4de923-26ad-4595-b9f2-8df42514a20a)

</details>