### PR TITLE
Implicitly convert iterator to ListPoint2D

### DIFF
--- a/src/pycolmap/scene/bindings.cc
+++ b/src/pycolmap/scene/bindings.cc
@@ -1,3 +1,5 @@
+#include "pycolmap/scene/types.h"
+
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
@@ -24,4 +26,6 @@ void BindScene(py::module& m) {
   BindReconstructionManager(m);
   BindDatabase(m);
   BindDatabaseCache(m);
+
+  py::implicitly_convertible<py::iterable, Point2DVector>();
 }


### PR DESCRIPTION
Fix errors when pass an empty list as a `vector<Point2D>`:
```
    pycolmap.Image(points2D=[])
RuntimeError: instance allocation failed: new instance has no pybind11-registered base types
```
```
    camera.cam_from_img([])
TypeError: cam_from_img(): incompatible function arguments.
```
cc @B1ueber2y 