### PR TITLE
Support Adjoint matrix computation for Rigid3d

### DIFF
--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -54,6 +54,17 @@ struct Rigid3d {
     matrix.col(3) = translation;
     return matrix;
   }
+
+  inline Eigen::Matrix6d Adjoint() const {
+    Eigen::Matrix6d adjoint = Eigen::Matrix6d::Zero();
+    Eigen::Matrix3d skew_t;
+    skew_t << 0, -translation(2), translation(1), translation(2), 0, -translation(0), -translation(1), translation(0), 0;
+    Eigen::Matrix3d rot_matrix = rotation.toRotationMatrix();
+    adjoint.block<3, 3>(0, 0) = rot_matrix;
+    adjoint.block<3, 3>(3, 0) = skew_t * rot_matrix;
+    adjoint.block<3, 3>(3, 3) = rot_matrix;
+    return adjoint;
+  }
 };
 
 // Return inverse transform.

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -61,7 +61,8 @@ struct Rigid3d {
     Eigen::Matrix6d adjoint;
     adjoint.block<3, 3>(0, 0) = rotation.toRotationMatrix();
     adjoint.block<3, 3>(0, 3).setZero();
-    adjoint.block<3, 3>(3, 0) = translation.colwise().cross(adjoint.block<3, 3>(0, 0));
+    adjoint.block<3, 3>(3, 0) =
+        adjoint.block<3, 3>(0, 0).colwise().cross(-translation);  // t x R
     adjoint.block<3, 3>(3, 3) = adjoint.block<3, 3>(0, 0);
     return adjoint;
   }

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -55,6 +55,8 @@ struct Rigid3d {
     return matrix;
   }
 
+  // Adjoint matrix to propagate uncertainty on Rigid3d
+  // [Reference] https://gtsam.org/2021/02/23/uncertainties-part3.html
   inline Eigen::Matrix6d Adjoint() const {
     Eigen::Matrix6d adjoint = Eigen::Matrix6d::Zero();
     Eigen::Matrix3d skew_t;

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -60,7 +60,8 @@ struct Rigid3d {
   inline Eigen::Matrix6d Adjoint() const {
     Eigen::Matrix6d adjoint = Eigen::Matrix6d::Zero();
     Eigen::Matrix3d skew_t;
-    skew_t << 0, -translation(2), translation(1), translation(2), 0, -translation(0), -translation(1), translation(0), 0;
+    skew_t << 0, -translation(2), translation(1), translation(2), 0,
+        -translation(0), -translation(1), translation(0), 0;
     Eigen::Matrix3d rot_matrix = rotation.toRotationMatrix();
     adjoint.block<3, 3>(0, 0) = rot_matrix;
     adjoint.block<3, 3>(3, 0) = skew_t * rot_matrix;

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -58,14 +58,11 @@ struct Rigid3d {
   // Adjoint matrix to propagate uncertainty on Rigid3d
   // [Reference] https://gtsam.org/2021/02/23/uncertainties-part3.html
   inline Eigen::Matrix6d Adjoint() const {
-    Eigen::Matrix6d adjoint = Eigen::Matrix6d::Zero();
-    Eigen::Matrix3d skew_t;
-    skew_t << 0, -translation(2), translation(1), translation(2), 0,
-        -translation(0), -translation(1), translation(0), 0;
-    Eigen::Matrix3d rot_matrix = rotation.toRotationMatrix();
-    adjoint.block<3, 3>(0, 0) = rot_matrix;
-    adjoint.block<3, 3>(3, 0) = skew_t * rot_matrix;
-    adjoint.block<3, 3>(3, 3) = rot_matrix;
+    Eigen::Matrix6d adjoint;
+    adjoint.block<3, 3>(0, 0) = rotation.toRotationMatrix();
+    adjoint.block<3, 3>(0, 3).setZero();
+    adjoint.block<3, 3>(3, 0) = translation.colwise().cross(adjoint.block<3, 3>(0, 0));
+    adjoint.block<3, 3>(3, 3) = adjoint.block<3, 3>(0, 0);
     return adjoint;
   }
 };

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -120,10 +120,12 @@ TEST(Rigid3d, Adjoint) {
   const Eigen::Matrix6d A = Eigen::Matrix6d::Random();
   const Eigen::Matrix6d cov_b_from_a = A * A.transpose();
   const Eigen::Matrix6d adjoint_b_from_a = b_from_a.Adjoint();
-  const Eigen::Matrix6d cov_a_from_b = adjoint_b_from_a * cov_b_from_a * adjoint_b_from_a.transpose();
+  const Eigen::Matrix6d cov_a_from_b =
+      adjoint_b_from_a * cov_b_from_a * adjoint_b_from_a.transpose();
   const Rigid3d a_from_b = Inverse(b_from_a);
   const Eigen::Matrix6d adjoint_a_from_b = a_from_b.Adjoint();
-  const Eigen::Matrix6d cov_b_from_a_test = adjoint_a_from_b * cov_a_from_b * adjoint_a_from_b.transpose();
+  const Eigen::Matrix6d cov_b_from_a_test =
+      adjoint_a_from_b * cov_a_from_b * adjoint_a_from_b.transpose();
   EXPECT_LT((cov_b_from_a_test - cov_b_from_a).norm(), 1e-6);
 }
 

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -115,5 +115,17 @@ TEST(Rigid3d, Compose) {
   EXPECT_LT((d_from_a * x_in_a - x_in_d).norm(), 1e-6);
 }
 
+TEST(Rigid3d, Adjoint) {
+  const Rigid3d b_from_a = TestRigid3d();
+  const Eigen::Matrix6d A = Eigen::Matrix6d::Random();
+  const Eigen::Matrix6d cov_b_from_a = A * A.transpose();
+  const Eigen::Matrix6d adjoint_b_from_a = b_from_a.Adjoint();
+  const Eigen::Matrix6d cov_a_from_b = adjoint_b_from_a * cov_b_from_a * adjoint_b_from_a.transpose();
+  const Rigid3d a_from_b = Inverse(b_from_a);
+  const Eigen::Matrix6d adjoint_a_from_b = a_from_b.Adjoint();
+  const Eigen::Matrix6d cov_b_from_a_test = adjoint_a_from_b * cov_a_from_b * adjoint_a_from_b.transpose();
+  EXPECT_LT((cov_b_from_a_test - cov_b_from_a).norm(), 1e-6);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -80,6 +80,7 @@ void BindGeometry(py::module& m) {
       .def_readwrite("rotation", &Rigid3d::rotation)
       .def_readwrite("translation", &Rigid3d::translation)
       .def("matrix", &Rigid3d::ToMatrix)
+      .def("adjoint", &Rigid3d::Adjoint)
       .def("essential_matrix", &EssentialMatrixFromPose)
       .def(py::self * Rigid3d())
       .def(py::self * Eigen::Vector3d())


### PR DESCRIPTION
Reference: 
- https://gtsam.org/2021/02/23/uncertainties-part3.html
- https://github.com/microsoft/lamar-benchmark/blob/fa6f5409364a11d5e59a57cec2ad1d7f9e6a8888/scantools/capture/pose.py#L99

The adjoint matrix is very useful on propagating uncertainty for Rigid3d. 

A unit test is added as well. 