### PR TITLE
Fix cost functions for pose graph optimization

### DIFF
--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -53,9 +53,8 @@ inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
       covariance, Eigen::ComputeThinU | Eigen::ComputeThinV);
   Eigen::MatrixXd U = svd.matrixU();
   Eigen::VectorXd singularValues = svd.singularValues();
-  const double epsilon = 1e-12;
   Eigen::VectorXd invSqrtSingularValues =
-      singularValues.array().max(0.).sqrt().max(epsilon).inverse();
+      singularValues.array().max(0.).sqrt().max(FLT_EPSILON).inverse();
   Eigen::MatrixXd invSqrtSingularValuesDiag =
       invSqrtSingularValues.asDiagonal();
   return U * invSqrtSingularValuesDiag;

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -48,16 +48,7 @@ using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
 using EigenMatrix6d = Eigen::Matrix<double, 6, 6>;
 
 inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
-  // LLT decomposition of Fisher information matrix with SVD
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd(
-      covariance, Eigen::ComputeThinU | Eigen::ComputeThinV);
-  Eigen::MatrixXd U = svd.matrixU();
-  Eigen::VectorXd singularValues = svd.singularValues();
-  Eigen::VectorXd invSqrtSingularValues =
-      singularValues.array().max(0.).sqrt().max(FLT_EPSILON).inverse();
-  Eigen::MatrixXd invSqrtSingularValuesDiag =
-      invSqrtSingularValues.asDiagonal();
-  return U * invSqrtSingularValuesDiag;
+  return covariance.inverse().llt().matrixL();
 }
 
 // Standard bundle adjustment cost function for variable

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -394,7 +394,8 @@ struct AbsolutePoseErrorCostFunction {
                                 world_from_cam_.translation.cast<T>();
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(sqrt_information_cam_.transpose().template cast<T>());
+    residuals.applyOnTheLeft(
+        sqrt_information_cam_.transpose().template cast<T>());
     return true;
   }
 
@@ -454,7 +455,8 @@ struct MetricRelativePoseErrorCostFunction {
         EigenVector3Map<T>(j_from_world_t) + j_from_i_q * i_from_jw_t;
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(sqrt_information_j_.transpose().template cast<T>());
+    residuals.applyOnTheLeft(
+        sqrt_information_j_.transpose().template cast<T>());
     return true;
   }
 

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -47,6 +47,20 @@ template <typename T>
 using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
 using EigenMatrix6d = Eigen::Matrix<double, 6, 6>;
 
+inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
+  // LLT decomposition of Fisher information matrix with SVD
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+      covariance, Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Eigen::MatrixXd U = svd.matrixU();
+  Eigen::VectorXd singularValues = svd.singularValues();
+  const double epsilon = 1e-12;
+  Eigen::VectorXd invSqrtSingularValues =
+      singularValues.array().max(0.).sqrt().max(epsilon).inverse();
+  Eigen::MatrixXd invSqrtSingularValuesDiag =
+      invSqrtSingularValues.asDiagonal();
+  return U * invSqrtSingularValuesDiag;
+}
+
 // Standard bundle adjustment cost function for variable
 // camera pose, calibration, and point parameters.
 template <typename CameraModel>
@@ -355,7 +369,7 @@ struct AbsolutePoseErrorCostFunction {
   AbsolutePoseErrorCostFunction(const Rigid3d& cam_from_world,
                                 const EigenMatrix6d& covariance_cam)
       : world_from_cam_(Inverse(cam_from_world)),
-        sqrt_information_cam_(covariance_cam.inverse().llt().matrixL()) {}
+        sqrt_information_cam_(SqrtInformation(covariance_cam)) {}
 
   static ceres::CostFunction* Create(const Rigid3d& cam_from_world,
                                      const EigenMatrix6d& covariance_cam) {
@@ -380,7 +394,7 @@ struct AbsolutePoseErrorCostFunction {
                                 world_from_cam_.translation.cast<T>();
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(sqrt_information_cam_.template cast<T>());
+    residuals.applyOnTheLeft(sqrt_information_cam_.transpose().template cast<T>());
     return true;
   }
 
@@ -406,7 +420,7 @@ struct MetricRelativePoseErrorCostFunction {
   MetricRelativePoseErrorCostFunction(const Rigid3d& i_from_j,
                                       const EigenMatrix6d& covariance_j)
       : i_from_j_(i_from_j),
-        sqrt_information_j_(covariance_j.inverse().llt().matrixL()) {}
+        sqrt_information_j_(SqrtInformation(covariance_j)) {}
 
   static ceres::CostFunction* Create(const Rigid3d& i_from_j,
                                      const EigenMatrix6d& covariance_j) {
@@ -440,7 +454,7 @@ struct MetricRelativePoseErrorCostFunction {
         EigenVector3Map<T>(j_from_world_t) + j_from_i_q * i_from_jw_t;
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(sqrt_information_j_.template cast<T>());
+    residuals.applyOnTheLeft(sqrt_information_j_.transpose().template cast<T>());
     return true;
   }
 


### PR DESCRIPTION
Just found a long-standing bug from https://github.com/colmap/colmap/pull/2378 in both cost functions in pose graph optimization:

After LLT it should be ``L_matrix.transpose()`` rather than ``L_matrix`` that is left multiplied on the residuals.

Moreover, SVD is faster and more stable compared to ``covariance.inverse().llt()``. I have updated this as well. 