### PR TITLE
Align with the convention of ceres doc on SqrtInformation.

### DIFF
--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -48,7 +48,7 @@ using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
 using EigenMatrix6d = Eigen::Matrix<double, 6, 6>;
 
 inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
-  return covariance.inverse().llt().matrixL();
+  return covariance.inverse().llt().matrixL().transpose();
 }
 
 // Standard bundle adjustment cost function for variable
@@ -385,7 +385,7 @@ struct AbsolutePoseErrorCostFunction {
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
     residuals.applyOnTheLeft(
-        sqrt_information_cam_.transpose().template cast<T>());
+        sqrt_information_cam_.template cast<T>());
     return true;
   }
 
@@ -446,7 +446,7 @@ struct MetricRelativePoseErrorCostFunction {
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
     residuals.applyOnTheLeft(
-        sqrt_information_j_.transpose().template cast<T>());
+        sqrt_information_j_.template cast<T>());
     return true;
   }
 

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -384,8 +384,7 @@ struct AbsolutePoseErrorCostFunction {
                                 world_from_cam_.translation.cast<T>();
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(
-        sqrt_information_cam_.template cast<T>());
+    residuals.applyOnTheLeft(sqrt_information_cam_.template cast<T>());
     return true;
   }
 
@@ -445,8 +444,7 @@ struct MetricRelativePoseErrorCostFunction {
         EigenVector3Map<T>(j_from_world_t) + j_from_i_q * i_from_jw_t;
 
     Eigen::Map<Eigen::Matrix<T, 6, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(
-        sqrt_information_j_.template cast<T>());
+    residuals.applyOnTheLeft(sqrt_information_j_.template cast<T>());
     return true;
   }
 


### PR DESCRIPTION
[Minor] Align with the S_{-1/2}f(x) in the ceres doc here http://ceres-solver.org/nnls_covariance.html. Move ``.transpose()`` into the SqrtInformation matrix. 