### PR TITLE
Faster 8-point fundamental matrix estimator

### DIFF
--- a/src/colmap/estimators/fundamental_matrix.cc
+++ b/src/colmap/estimators/fundamental_matrix.cc
@@ -131,6 +131,7 @@ void FundamentalMatrixEightPointEstimator::Estimate(
 
   models->clear();
 
+  // Center and normalize image points for better numerical stability.
   std::vector<X_t> normed_points1;
   std::vector<Y_t> normed_points2;
   Eigen::Matrix3d normed_from_orig1;

--- a/src/colmap/estimators/fundamental_matrix.cc
+++ b/src/colmap/estimators/fundamental_matrix.cc
@@ -126,11 +126,11 @@ void FundamentalMatrixEightPointEstimator::Estimate(
     const std::vector<Y_t>& points2,
     std::vector<M_t>* models) {
   THROW_CHECK_EQ(points1.size(), points2.size());
+  THROW_CHECK_GE(points1.size(), 8);
   THROW_CHECK(models != nullptr);
 
   models->clear();
 
-  // Center and normalize image points for better numerical stability.
   std::vector<X_t> normed_points1;
   std::vector<Y_t> normed_points2;
   Eigen::Matrix3d normed_from_orig1;
@@ -139,30 +139,34 @@ void FundamentalMatrixEightPointEstimator::Estimate(
   CenterAndNormalizeImagePoints(points2, &normed_points2, &normed_from_orig2);
 
   // Setup homogeneous linear equation as x2' * F * x1 = 0.
-  Eigen::Matrix<double, Eigen::Dynamic, 9> cmatrix(points1.size(), 9);
+  Eigen::Matrix<double, 9, Eigen::Dynamic> A(points1.size(), 9);
   for (size_t i = 0; i < points1.size(); ++i) {
-    cmatrix.block<1, 3>(i, 0) = normed_points1[i].homogeneous();
-    cmatrix.block<1, 3>(i, 0) *= normed_points2[i].x();
-    cmatrix.block<1, 3>(i, 3) = normed_points1[i].homogeneous();
-    cmatrix.block<1, 3>(i, 3) *= normed_points2[i].y();
-    cmatrix.block<1, 3>(i, 6) = normed_points1[i].homogeneous();
+    A.col(i) << normed_points2[i].x() * normed_points1[i].homogeneous(),
+        normed_points2[i].y() * normed_points1[i].homogeneous(),
+        normed_points1[i].homogeneous();
   }
 
   // Solve for the nullspace of the constraint matrix.
-  Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> cmatrix_svd(
-      cmatrix, Eigen::ComputeFullV);
-  const Eigen::VectorXd cmatrix_nullspace = cmatrix_svd.matrixV().col(8);
-  const Eigen::Map<const Eigen::Matrix3d> ematrix_t(cmatrix_nullspace.data());
+  Eigen::Matrix3d E;
+  if (points1.size() == 8) {
+    Eigen::Matrix<double, 9, 9> Q = A.householderQr().householderQ();
+    E = Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+        Q.col(8).data());
+  } else {
+    Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> svd(
+        A.transpose(), Eigen::ComputeFullV);
+    E = Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+        svd.matrixV().col(8).data());
+  }
 
   // Enforcing the internal constraint that two singular values must non-zero
   // and one must be zero.
-  Eigen::JacobiSVD<Eigen::Matrix3d> fmatrix_svd(
-      ematrix_t.transpose(), Eigen::ComputeFullU | Eigen::ComputeFullV);
-  Eigen::Vector3d singular_values = fmatrix_svd.singularValues();
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(
+      E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Vector3d singular_values = svd.singularValues();
   singular_values(2) = 0.0;
-  const Eigen::Matrix3d F = fmatrix_svd.matrixU() *
-                            singular_values.asDiagonal() *
-                            fmatrix_svd.matrixV().transpose();
+  const Eigen::Matrix3d F =
+      svd.matrixU() * singular_values.asDiagonal() * svd.matrixV().transpose();
 
   models->resize(1);
   (*models)[0] = normed_from_orig2.transpose() * F * normed_from_orig1;

--- a/src/colmap/estimators/fundamental_matrix_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_test.cc
@@ -308,13 +308,13 @@ TEST_P(FundamentalMatrixEightPointEstimatorTests, NoiseStability) {
     estimator.Estimate(points1, points2, &models);
 
     ExpectAtLeastOneValidModel(
-        estimator, points1, points2, expected_F, models, 1e-3, 1e-4);
+        estimator, points1, points2, expected_F, models, 1e-3, 1e-2);
   }
 }
 
 INSTANTIATE_TEST_SUITE_P(FundamentalMatrixEightPointEstimator,
                          FundamentalMatrixEightPointEstimatorTests,
-                         ::testing::Values(8, 16, 32));
+                         ::testing::Values(8, 64, 1024));
 
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_test.cc
@@ -64,16 +64,31 @@ void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
   }
 }
 
-void ExpectAtLeastOneEqualFundamentalUpToScale(
-    Eigen::Matrix3d& F, std::vector<Eigen::Matrix3d>& Fs) {
-  F /= F(2, 2);
-  for (Eigen::Matrix3d& F_candidate : Fs) {
-    F_candidate /= F_candidate(2, 2);
-    if (F_candidate.isApprox(F, 1e-6)) {
-      return;
+template <typename Estimator>
+void ExpectAtLeastOneValidModel(const Estimator& estimator,
+                                const std::vector<Eigen::Vector2d>& points1,
+                                const std::vector<Eigen::Vector2d>& points2,
+                                Eigen::Matrix3d& expected_F,
+                                std::vector<Eigen::Matrix3d>& models,
+                                double F_eps = 1e-6,
+                                double r_eps = 1e-6) {
+  expected_F /= expected_F(2, 2);
+  for (size_t i = 0; i < models.size(); ++i) {
+    Eigen::Matrix3d F = models[i];
+    F /= F(2, 2);
+    if (!F.isApprox(expected_F, F_eps)) {
+      continue;
     }
+
+    std::vector<double> residuals;
+    estimator.Residuals(points1, points2, F, &residuals);
+    for (size_t j = 0; j < points1.size(); ++j) {
+      EXPECT_LT(residuals[j], r_eps);
+    }
+
+    return;
   }
-  FAIL() << "No fundamental matrix is equal up to scale.";
+  ADD_FAILURE() << "No fundamental matrix is equal up to scale.";
 }
 
 TEST(FundamentalSevenPointEstimator, Reference) {
@@ -152,7 +167,7 @@ TEST(FundamentalSevenPointEstimator, Nominal) {
     std::vector<Eigen::Matrix3d> models;
     estimator.Estimate(points1, points2, &models);
 
-    ExpectAtLeastOneEqualFundamentalUpToScale(expected_F, models);
+    ExpectAtLeastOneValidModel(estimator, points1, points2, expected_F, models);
   }
 }
 
@@ -206,18 +221,18 @@ TEST(FundamentalMatrixEightPointEstimator, Reference) {
   estimator.Estimate(points1, points2, &models);
 
   ASSERT_EQ(models.size(), 1);
-  const auto& F = models[0];
+  const auto& F = models[0] / models[0](2, 2);
 
   // Reference values obtained from Matlab.
-  EXPECT_NEAR(F(0, 0), -0.217859, 1e-5);
-  EXPECT_NEAR(F(0, 1), 0.419282, 1e-5);
-  EXPECT_NEAR(F(0, 2), -0.0343075, 1e-5);
-  EXPECT_NEAR(F(1, 0), -0.0717941, 1e-5);
-  EXPECT_NEAR(F(1, 1), 0.0451643, 1e-5);
-  EXPECT_NEAR(F(1, 2), 0.0216073, 1e-5);
-  EXPECT_NEAR(F(2, 0), 0.248062, 1e-5);
-  EXPECT_NEAR(F(2, 1), -0.429478, 1e-5);
-  EXPECT_NEAR(F(2, 2), 0.0221019, 1e-5);
+  EXPECT_NEAR(F(0, 0), -9.85701, 1e-5);
+  EXPECT_NEAR(F(0, 1), 18.97038, 1e-5);
+  EXPECT_NEAR(F(0, 2), -1.55224, 1e-5);
+  EXPECT_NEAR(F(1, 0), -3.24832, 1e-5);
+  EXPECT_NEAR(F(1, 1), 2.04346, 1e-5);
+  EXPECT_NEAR(F(1, 2), 0.977619, 1e-5);
+  EXPECT_NEAR(F(2, 0), 11.22355, 1e-5);
+  EXPECT_NEAR(F(2, 1), -19.43171, 1e-5);
+  EXPECT_NEAR(F(2, 2), 1, 1e-5);
 }
 
 class FundamentalMatrixEightPointEstimatorTests
@@ -240,7 +255,60 @@ TEST_P(FundamentalMatrixEightPointEstimatorTests, Nominal) {
     std::vector<Eigen::Matrix3d> models;
     estimator.Estimate(points1, points2, &models);
 
-    ExpectAtLeastOneEqualFundamentalUpToScale(expected_F, models);
+    ExpectAtLeastOneValidModel(estimator, points1, points2, expected_F, models);
+  }
+}
+
+TEST_P(FundamentalMatrixEightPointEstimatorTests, NumericalStability) {
+  const size_t kNumPoints = GetParam();
+  constexpr double kCoordinateScale = 1e3;
+  for (size_t k = 0; k < 100; ++k) {
+    Eigen::Matrix3d K = RandomCalibrationMatrix();
+    K(0, 0) *= kCoordinateScale;
+    K(1, 1) *= kCoordinateScale;
+    K(0, 2) *= kCoordinateScale;
+    K(1, 2) *= kCoordinateScale;
+    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                                 Eigen::Vector3d::Random());
+    Eigen::Matrix3d expected_F = FundamentalFromEssentialMatrix(
+        K, EssentialMatrixFromPose(cam2_from_cam1), K);
+    std::vector<Eigen::Vector2d> points1;
+    std::vector<Eigen::Vector2d> points2;
+    RandomEpipolarCorrespondences(
+        cam2_from_cam1, K, kNumPoints, points1, points2);
+
+    FundamentalMatrixEightPointEstimator estimator;
+    std::vector<Eigen::Matrix3d> models;
+    estimator.Estimate(points1, points2, &models);
+
+    ExpectAtLeastOneValidModel(
+        estimator, points1, points2, expected_F, models, 1e-4, 1e-4);
+  }
+}
+
+TEST_P(FundamentalMatrixEightPointEstimatorTests, NoiseStability) {
+  const size_t kNumPoints = GetParam();
+  constexpr double kNoise = 1e-4;
+  for (size_t k = 0; k < 100; ++k) {
+    const Eigen::Matrix3d K = RandomCalibrationMatrix();
+    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                                 Eigen::Vector3d::Random());
+    Eigen::Matrix3d expected_F = FundamentalFromEssentialMatrix(
+        K, EssentialMatrixFromPose(cam2_from_cam1), K);
+    std::vector<Eigen::Vector2d> points1;
+    std::vector<Eigen::Vector2d> points2;
+    RandomEpipolarCorrespondences(
+        cam2_from_cam1, K, kNumPoints, points1, points2);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      points2[i] += Eigen::Vector2d::Random() * kNoise;
+    }
+
+    FundamentalMatrixEightPointEstimator estimator;
+    std::vector<Eigen::Matrix3d> models;
+    estimator.Estimate(points1, points2, &models);
+
+    ExpectAtLeastOneValidModel(
+        estimator, points1, points2, expected_F, models, 1e-3, 1e-4);
   }
 }
 


### PR DESCRIPTION
Minimal 8-point case is ~5 faster. Unchanged performance on over-constrained case. Added some more test coverage.