### PR TITLE
fix: Add check for data existence when extracting data from CorrespondenceGraph

### DIFF
--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -78,7 +78,7 @@ ObservationManager::ObservationManager(
         kNumPoint3DVisibilityPyramidLevels, camera.width, camera.height);
     image_stat.num_correspondences_have_point3D.resize(image.NumPoints2D(), 0);
     image_stat.num_visible_points3D = 0;
-    if (correspondence_graph_) {
+    if (correspondence_graph_ && correspondence_graph_->ExistsImage(id_image.first)) {
       image_stat.num_observations =
           correspondence_graph_->NumObservationsForImage(id_image.first);
       image_stat.num_correspondences =


### PR DESCRIPTION
The `CorrespondenceGraph` functions `NumObservationsForImage` and `NumCorrespondencesForImage` do not verify if the image ID exists in the correspondence image map, potentially leading to errors.