### PR TITLE
Faster covariance computation for small blocks

### DIFF
--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -585,6 +585,8 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   Eigen::MatrixXd L_dense = L;
   L_matrix_variables_inv_ = L_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
+  LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
+               "inverted.";
   return true;
 }
 
@@ -677,6 +679,8 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   Eigen::MatrixXd L_poses_dense = L_poses;
   L_matrix_poses_inv_ = L_poses_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
+  LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
+               "inverted.";
   return true;
 }
 

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -218,6 +218,39 @@ bool BundleAdjustmentCovarianceEstimatorBase::HasValidFullCovariance() const {
   return cov_variables_.size() != 0;
 }
 
+double BundleAdjustmentCovarianceEstimatorBase::GetPoseCovarianceByIndex(
+    int row, int col) const {
+  THROW_CHECK(HasValidPoseCovariance());
+  return cov_poses_(row, col);
+}
+
+Eigen::MatrixXd
+BundleAdjustmentCovarianceEstimatorBase::GetPoseCovarianceBlockOperation(
+    int row_start,
+    int col_start,
+    int row_block_size,
+    int col_block_size) const {
+  THROW_CHECK(HasValidPoseCovariance());
+  return cov_poses_.block(row_start, col_start, row_block_size, col_block_size);
+}
+
+double BundleAdjustmentCovarianceEstimatorBase::GetCovarianceByIndex(
+    int row, int col) const {
+  THROW_CHECK(HasValidFullCovariance());
+  return cov_variables_(row, col);
+}
+
+Eigen::MatrixXd
+BundleAdjustmentCovarianceEstimatorBase::GetCovarianceBlockOperation(
+    int row_start,
+    int col_start,
+    int row_block_size,
+    int col_block_size) const {
+  THROW_CHECK(HasValidFullCovariance());
+  return cov_variables_.block(
+      row_start, col_start, row_block_size, col_block_size);
+}
+
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance()
     const {
   THROW_CHECK(HasValidPoseCovariance());
@@ -227,17 +260,16 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance()
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     image_t image_id) const {
   THROW_CHECK(HasReconstruction());
-  THROW_CHECK(HasValidPoseCovariance());
   THROW_CHECK(HasPose(image_id));
   int index = GetPoseIndex(image_id);
   int num_params_pose = GetPoseTangentSize(image_id);
-  return cov_poses_.block(index, index, num_params_pose, num_params_pose);
+  return GetPoseCovarianceBlockOperation(
+      index, index, num_params_pose, num_params_pose);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     const std::vector<image_t>& image_ids) const {
   THROW_CHECK(HasReconstruction());
-  THROW_CHECK(HasValidPoseCovariance());
   std::vector<int> indices;
   for (const auto& image_id : image_ids) {
     THROW_CHECK(HasPose(image_id));
@@ -251,7 +283,7 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
   Eigen::MatrixXd output(n_indices, n_indices);
   for (size_t i = 0; i < n_indices; ++i) {
     for (size_t j = 0; j < n_indices; ++j) {
-      output(i, j) = cov_poses_(indices[i], indices[j]);
+      output(i, j) = GetPoseCovarianceByIndex(indices[i], indices[j]);
     }
   }
   return output;
@@ -260,28 +292,26 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     image_t image_id1, image_t image_id2) const {
   THROW_CHECK(HasReconstruction());
-  THROW_CHECK(HasValidPoseCovariance());
   THROW_CHECK(HasPose(image_id1));
   THROW_CHECK(HasPose(image_id2));
   int index1 = GetPoseIndex(image_id1);
   int num_params_pose1 = GetPoseTangentSize(image_id1);
   int index2 = GetPoseIndex(image_id2);
   int num_params_pose2 = GetPoseTangentSize(image_id2);
-  return cov_poses_.block(index1, index2, num_params_pose1, num_params_pose2);
+  return GetPoseCovarianceBlockOperation(
+      index1, index2, num_params_pose1, num_params_pose2);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     double* params) const {
-  THROW_CHECK(HasValidPoseCovariance());
   THROW_CHECK(HasPoseBlock(params));
   int index = GetBlockIndex(params);
   int num_params = GetBlockTangentSize(params);
-  return cov_poses_.block(index, index, num_params, num_params);
+  return GetPoseCovarianceBlockOperation(index, index, num_params, num_params);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     const std::vector<double*>& blocks) const {
-  THROW_CHECK(HasValidPoseCovariance());
   std::vector<int> indices;
   for (const double* block : blocks) {
     THROW_CHECK(HasPoseBlock(block));
@@ -295,7 +325,7 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
   Eigen::MatrixXd output(n_indices, n_indices);
   for (size_t i = 0; i < n_indices; ++i) {
     for (size_t j = 0; j < n_indices; ++j) {
-      output(i, j) = cov_poses_(indices[i], indices[j]);
+      output(i, j) = GetPoseCovarianceByIndex(indices[i], indices[j]);
     }
   }
   return output;
@@ -303,28 +333,26 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     double* params1, double* params2) const {
-  THROW_CHECK(HasValidPoseCovariance());
   THROW_CHECK(HasPoseBlock(params1));
   THROW_CHECK(HasPoseBlock(params2));
   int index1 = GetBlockIndex(params1);
   int num_params_block1 = GetBlockTangentSize(params1);
   int index2 = GetBlockIndex(params2);
   int num_params_block2 = GetBlockTangentSize(params2);
-  return cov_poses_.block(index1, index2, num_params_block1, num_params_block2);
+  return GetPoseCovarianceBlockOperation(
+      index1, index2, num_params_block1, num_params_block2);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetCovariance(
     double* params) const {
-  THROW_CHECK(HasValidFullCovariance());
   THROW_CHECK(HasBlock(params));
   int index = GetBlockIndex(params);
   int num_params = GetBlockTangentSize(params);
-  return cov_variables_.block(index, index, num_params, num_params);
+  return GetCovarianceBlockOperation(index, index, num_params, num_params);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetCovariance(
     const std::vector<double*>& blocks) const {
-  THROW_CHECK(HasValidFullCovariance());
   std::vector<int> indices;
   for (const double* block : blocks) {
     THROW_CHECK(HasBlock(block));
@@ -338,7 +366,7 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetCovariance(
   Eigen::MatrixXd output(n_indices, n_indices);
   for (size_t i = 0; i < n_indices; ++i) {
     for (size_t j = 0; j < n_indices; ++j) {
-      output(i, j) = cov_variables_(indices[i], indices[j]);
+      output(i, j) = GetCovarianceByIndex(indices[i], indices[j]);
     }
   }
   return output;
@@ -346,14 +374,13 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetCovariance(
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetCovariance(
     double* params1, double* params2) const {
-  THROW_CHECK(HasValidFullCovariance());
   THROW_CHECK(HasBlock(params1));
   THROW_CHECK(HasBlock(params2));
   int index1 = GetBlockIndex(params1);
   int num_params_block1 = GetBlockTangentSize(params1);
   int index2 = GetBlockIndex(params2);
   int num_params_block2 = GetBlockTangentSize(params2);
-  return cov_variables_.block(
+  return GetCovarianceBlockOperation(
       index1, index2, num_params_block1, num_params_block2);
 }
 
@@ -452,7 +479,78 @@ bool BundleAdjustmentCovarianceEstimator::HasValidSchurComplement() const {
   return S_matrix_.size() != 0;
 }
 
-bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
+bool BundleAdjustmentCovarianceEstimator::HasValidPoseFactorization() const {
+  return L_matrix_poses_inv_.size() != 0;
+}
+
+double BundleAdjustmentCovarianceEstimator::GetPoseCovarianceByIndex(
+    int row, int col) const {
+  THROW_CHECK(HasValidPoseCovariance() || HasValidPoseFactorization());
+  if (HasValidPoseCovariance())
+    return cov_poses_(row, col);
+  else
+    return L_matrix_poses_inv_.col(row).dot(L_matrix_poses_inv_.col(col));
+}
+
+Eigen::MatrixXd
+BundleAdjustmentCovarianceEstimator::GetPoseCovarianceBlockOperation(
+    int row_start,
+    int col_start,
+    int row_block_size,
+    int col_block_size) const {
+  THROW_CHECK(HasValidPoseCovariance() || HasValidPoseFactorization());
+  if (HasValidPoseCovariance()) {
+    return cov_poses_.block(
+        row_start, col_start, row_block_size, col_block_size);
+  }
+  // HasValidPoseRefactorization() == True
+  Eigen::MatrixXd output(row_block_size, col_block_size);
+  for (int row = 0; row < row_block_size; ++row) {
+    for (int col = 0; col < col_block_size; ++col) {
+      output(row, col) = L_matrix_poses_inv_.col(row_start + row)
+                             .dot(L_matrix_poses_inv_.col(col_start + col));
+    }
+  }
+  return output;
+}
+
+bool BundleAdjustmentCovarianceEstimator::HasValidFullFactorization() const {
+  return L_matrix_variables_inv_.size() != 0;
+}
+
+double BundleAdjustmentCovarianceEstimator::GetCovarianceByIndex(
+    int row, int col) const {
+  THROW_CHECK(HasValidFullCovariance() || HasValidFullFactorization());
+  if (HasValidFullCovariance())
+    return cov_variables_(row, col);
+  else
+    return L_matrix_variables_inv_.col(row).dot(
+        L_matrix_variables_inv_.col(col));
+}
+
+Eigen::MatrixXd
+BundleAdjustmentCovarianceEstimator::GetCovarianceBlockOperation(
+    int row_start,
+    int col_start,
+    int row_block_size,
+    int col_block_size) const {
+  THROW_CHECK(HasValidFullCovariance() || HasValidFullFactorization());
+  if (HasValidFullCovariance()) {
+    return cov_variables_.block(
+        row_start, col_start, row_block_size, col_block_size);
+  }
+  // HasValidRefactorization() == True
+  Eigen::MatrixXd output(row_block_size, col_block_size);
+  for (int row = 0; row < row_block_size; ++row) {
+    for (int col = 0; col < col_block_size; ++col) {
+      output(row, col) = L_matrix_variables_inv_.col(row_start + row)
+                             .dot(L_matrix_variables_inv_.col(col_start + col));
+    }
+  }
+  return output;
+}
+
+bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   if (!HasValidSchurComplement()) {
     ComputeSchurComplement();
   }
@@ -460,6 +558,8 @@ bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
       "Inverting Schur complement for all variables except for 3D points (n = "
       "%d)",
       num_params_poses_ + num_params_other_variables_);
+  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+                            num_params_poses_ + num_params_other_variables_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
   int rank = 0;
   for (int i = 0; i < S_matrix_.rows(); ++i) {
@@ -474,11 +574,109 @@ bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
         rank);
     return false;
   }
+  LOG(INFO) << "Finish sparse Cholesky decomposition.";
+  // construct the inverse of the L_matrix
+  Eigen::SparseMatrix<double> L = ldltOfS.matrixL();
+  for (int i = 0; i < S_matrix_.rows(); ++i) {
+    for (int k = L.outerIndexPtr()[i]; k < L.outerIndexPtr()[i + 1]; ++k) {
+      L.valuePtr()[i] *= sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.));
+    }
+  }
+  Eigen::MatrixXd L_dense = L;
+  L_matrix_variables_inv_ = L_dense.triangularView<Eigen::Lower>().solve(
+      Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
+  return true;
+}
+
+bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
+  if (!HasValidSchurComplement()) {
+    ComputeSchurComplement();
+  }
+  LOG(INFO) << StringPrintf(
+      "Inverting Schur complement for all variables except for 3D points (n = "
+      "%d)",
+      num_params_poses_ + num_params_other_variables_);
+  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+                            num_params_poses_ + num_params_other_variables_);
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
+  int rank = 0;
+  for (int i = 0; i < S_matrix_.rows(); ++i) {
+    if (ldltOfS.vectorD().coeff(i) != 0.0) rank++;
+  }
+  if (rank < S_matrix_.rows()) {
+    LOG(INFO) << StringPrintf(
+        "Unable to compute covariance. The Schur complement on all variables "
+        "(except for 3D points) is rank deficient. Number of columns: %d, "
+        "rank: %d.",
+        S_matrix_.rows(),
+        rank);
+    return false;
+  }
+  LOG(INFO) << "Finish sparse Cholesky decomposition.";
   Eigen::SparseMatrix<double> I(S_matrix_.rows(), S_matrix_.cols());
   I.setIdentity();
   Eigen::SparseMatrix<double> S_inv = ldltOfS.solve(I);
   cov_variables_ = S_inv;  // convert to dense matrix
   cov_poses_ = cov_variables_.block(0, 0, num_params_poses_, num_params_poses_);
+  return true;
+}
+
+bool BundleAdjustmentCovarianceEstimator::Factorize() {
+  if (!HasValidSchurComplement()) {
+    ComputeSchurComplement();
+  }
+  // Schur elimination on other variables
+  LOG(INFO) << StringPrintf("Schur elimination on other variables (n = %d)",
+                            num_params_other_variables_);
+  Eigen::SparseMatrix<double> S_aa =
+      S_matrix_.block(0, 0, num_params_poses_, num_params_poses_);
+  Eigen::SparseMatrix<double> S_ab = S_matrix_.block(
+      0, num_params_poses_, num_params_poses_, num_params_other_variables_);
+  Eigen::SparseMatrix<double> S_ba = S_ab.transpose();
+  Eigen::SparseMatrix<double> S_bb =
+      S_matrix_.block(num_params_poses_,
+                      num_params_poses_,
+                      num_params_other_variables_,
+                      num_params_other_variables_);
+  for (int i = 0; i < S_bb.rows(); ++i) {
+    if (S_bb.coeff(i, i) == 0.0)
+      S_bb.coeffRef(i, i) = lambda_;
+    else
+      S_bb.coeffRef(i, i) += lambda_;
+  }
+  Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> lltOfS_bb(S_bb);
+  Eigen::SparseMatrix<double> S_poses = S_aa - S_ab * lltOfS_bb.solve(S_ba);
+
+  // Compute pose covariance
+  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+                            num_params_poses_);
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
+  int rank = 0;
+  for (int i = 0; i < S_poses.rows(); ++i) {
+    if (ldltOfS_poses.vectorD().coeff(i) != 0.0) rank++;
+  }
+  if (rank < S_poses.rows()) {
+    LOG(INFO) << StringPrintf(
+        "Unable to compute covariance. The Schur complement on pose parameters "
+        "is rank deficient. Number of columns: %d, rank: %d. This is likely "
+        "due to the poses being underconstrained with Gauge ambiguity.",
+        S_poses.rows(),
+        rank);
+    return false;
+  }
+  LOG(INFO) << "Finish sparse Cholesky decomposition.";
+  // construct the inverse of the L_matrix
+  Eigen::SparseMatrix<double> L_poses = ldltOfS_poses.matrixL();
+  for (int i = 0; i < L_poses.rows(); ++i) {
+    for (int k = L_poses.outerIndexPtr()[i]; k < L_poses.outerIndexPtr()[i + 1];
+         ++k) {
+      L_poses.valuePtr()[k] *=
+          sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.));
+    }
+  }
+  Eigen::MatrixXd L_poses_dense = L_poses;
+  L_matrix_poses_inv_ = L_poses_dense.triangularView<Eigen::Lower>().solve(
+      Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
   return true;
 }
 
@@ -510,6 +708,8 @@ bool BundleAdjustmentCovarianceEstimator::Compute() {
   Eigen::SparseMatrix<double> S_poses = S_aa - S_ab * lltOfS_bb.solve(S_ba);
 
   // Compute pose covariance
+  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+                            num_params_poses_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
   int rank = 0;
   for (int i = 0; i < S_poses.rows(); ++i) {
@@ -524,6 +724,7 @@ bool BundleAdjustmentCovarianceEstimator::Compute() {
         rank);
     return false;
   }
+  LOG(INFO) << "Finish sparse Cholesky decomposition.";
   Eigen::SparseMatrix<double> I(S_poses.rows(), S_poses.cols());
   I.setIdentity();
   Eigen::SparseMatrix<double> S_poses_inv = ldltOfS_poses.solve(I);
@@ -554,7 +755,7 @@ bool EstimatePoseCovariance(
     double lambda) {
   BundleAdjustmentCovarianceEstimator estimator(
       problem, reconstruction, lambda);
-  if (!estimator.Compute()) return false;
+  if (!estimator.Factorize()) return false;
   image_id_to_covar.clear();
   for (const auto& image : reconstruction->Images()) {
     image_t image_id = image.first;

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -558,7 +558,7 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
       "Inverting Schur complement for all variables except for 3D points (n = "
       "%d)",
       num_params_poses_ + num_params_other_variables_);
-  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+  LOG(INFO) << StringPrintf("Start sparse Cholesky decomposition (n = %d)",
                             num_params_poses_ + num_params_other_variables_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
   int rank = 0;
@@ -596,7 +596,7 @@ bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
       "Inverting Schur complement for all variables except for 3D points (n = "
       "%d)",
       num_params_poses_ + num_params_other_variables_);
-  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+  LOG(INFO) << StringPrintf("Start sparse Cholesky decomposition (n = %d)",
                             num_params_poses_ + num_params_other_variables_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
   int rank = 0;
@@ -648,7 +648,7 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   Eigen::SparseMatrix<double> S_poses = S_aa - S_ab * lltOfS_bb.solve(S_ba);
 
   // Compute pose covariance
-  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+  LOG(INFO) << StringPrintf("Start sparse Cholesky decomposition (n = %d)",
                             num_params_poses_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
   int rank = 0;
@@ -708,7 +708,7 @@ bool BundleAdjustmentCovarianceEstimator::Compute() {
   Eigen::SparseMatrix<double> S_poses = S_aa - S_ab * lltOfS_bb.solve(S_ba);
 
   // Compute pose covariance
-  LOG(INFO) << StringPrintf("Start sparse Choleskey decomposition (n = %d)",
+  LOG(INFO) << StringPrintf("Start sparse Cholesky decomposition (n = %d)",
                             num_params_poses_);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
   int rank = 0;

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -503,7 +503,7 @@ BundleAdjustmentCovarianceEstimator::GetPoseCovarianceBlockOperation(
     return cov_poses_.block(
         row_start, col_start, row_block_size, col_block_size);
   }
-  // HasValidPoseRefactorization() == True
+  // HasValidPoseRefactorization() == true
   Eigen::MatrixXd output(row_block_size, col_block_size);
   for (int row = 0; row < row_block_size; ++row) {
     for (int col = 0; col < col_block_size; ++col) {
@@ -539,7 +539,7 @@ BundleAdjustmentCovarianceEstimator::GetCovarianceBlockOperation(
     return cov_variables_.block(
         row_start, col_start, row_block_size, col_block_size);
   }
-  // HasValidRefactorization() == True
+  // HasValidRefactorization() == true
   Eigen::MatrixXd output(row_block_size, col_block_size);
   for (int row = 0; row < row_block_size; ++row) {
     for (int col = 0; col < col_block_size; ++col) {

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -104,6 +104,19 @@ class BundleAdjustmentCovarianceEstimatorBase {
   bool HasValidFullCovariance() const;
 
  protected:
+  // indexing the covariance matrix
+  virtual double GetCovarianceByIndex(int row, int col) const;
+  virtual Eigen::MatrixXd GetCovarianceBlockOperation(int row_start,
+                                                      int col_start,
+                                                      int row_block_size,
+                                                      int col_block_size) const;
+  virtual double GetPoseCovarianceByIndex(int row, int col) const;
+  virtual Eigen::MatrixXd GetPoseCovarianceBlockOperation(
+      int row_start,
+      int col_start,
+      int row_block_size,
+      int col_block_size) const;
+
   // blocks parsed from reconstruction (initialized at construction)
   std::vector<const double*> pose_blocks_;
   int num_params_poses_ = 0;
@@ -176,7 +189,27 @@ class BundleAdjustmentCovarianceEstimator
   bool ComputeFull() override;
   bool Compute() override;
 
+  // factorization
+  bool FactorizeFull();
+  bool Factorize();
+  bool HasValidFullFactorization() const;
+  bool HasValidPoseFactorization() const;
+
  private:
+  // indexing the covariance matrix
+  double GetCovarianceByIndex(int row, int col) const override;
+  Eigen::MatrixXd GetCovarianceBlockOperation(
+      int row_start,
+      int col_start,
+      int row_block_size,
+      int col_block_size) const override;
+  double GetPoseCovarianceByIndex(int row, int col) const override;
+  Eigen::MatrixXd GetPoseCovarianceBlockOperation(
+      int row_start,
+      int col_start,
+      int row_block_size,
+      int col_block_size) const override;
+
   // The Schur complement for all parameters (except for 3D points) after Schur
   // elimination
   Eigen::SparseMatrix<double> S_matrix_;
@@ -188,6 +221,10 @@ class BundleAdjustmentCovarianceEstimator
   // 3D points
   void ComputeSchurComplement();
   bool HasValidSchurComplement() const;
+
+  // The inverse of L matrix after Cholesky factorization
+  Eigen::MatrixXd L_matrix_variables_inv_;
+  Eigen::MatrixXd L_matrix_poses_inv_;
 };
 
 // The covariance for each image is in the order [R, t] with both of them

--- a/src/pycolmap/estimators/covariance.cc
+++ b/src/pycolmap/estimators/covariance.cc
@@ -191,5 +191,12 @@ void BindCovarianceEstimator(py::module& m) {
            py::arg("problem"),
            py::arg("pose_blocks"),
            py::arg("point_blocks"),
-           py::arg("lambda") = 1e-8);
+           py::arg("lambda") = 1e-8)
+      .def("factorize_full",
+           &BundleAdjustmentCovarianceEstimator::FactorizeFull)
+      .def("factorize", &BundleAdjustmentCovarianceEstimator::Factorize)
+      .def("has_valid_full_factorization",
+           &BundleAdjustmentCovarianceEstimator::HasValidFullFactorization)
+      .def("has_valid_pose_factorization",
+           &BundleAdjustmentCovarianceEstimator::HasValidPoseFactorization);
 }


### PR DESCRIPTION
This PR includes faster covariance computation for small blocks, as a follow up for https://github.com/colmap/colmap/pull/2610. This is achieved by storing the inversion of the triangular matrix L from sparse Cholesky rather than storing the full covariance matrix. 

This brings ~5x constant speed up on the computation of per-image pose covariance while the asymptotic complexity is still cubic (as in the table below, the sparse cholesky operation is already cubic).

Below are some benchmark timing results for per-pose covariance estimation. Control points were used to fix the Gauge ambiguity.

| # images   | # pose parameters | sparse cholesky (in both methods)  | full time before from https://github.com/colmap/colmap/pull/2610 | full time in this PR | 
| -------- | -------- | -------- | -------- | -------- |
| 400 | 2400 | 1.9s | 13.3s | 3.8s |
| 600 | 3600 | 6.9s | 52.9s | 13.4s |
| 800 | 4800 | 16.9s | 147.8s | 31.9s |
| 1200 | 7200 | 56.6s | 487.4s | 105.7s |
| 1800 | 10800 | 189.1s | 1644.7s | 374.6s |

The asymptotic complexity is O(n^3) with a very stable constant so one can estimate the time needed for larger reconstruction using the numbers from this table. The time may vary a bit depending on the level of connection (shared 3D points across images) in the reconstruction. Same unit tests from https://github.com/colmap/colmap/pull/2610 were done here to verify the correctness.

To be able to use this feature in Python one just needs to substitute ``estimator.compute()`` into ``estimator.factorize()`` for the colmap estimator ``pycolmap.BundleAdjustmentCovarianceEstimator``. Note that the method ``Compute()`` is still preferred if one wants the full covariance matrix (``n_parameters`` by ``n_parameters`` ).