### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/scripts/python/database.py
+++ b/scripts/python/database.py
@@ -201,8 +201,8 @@ class COLMAPDatabase(sqlite3.Connection):
         self,
         name,
         camera_id,
-        prior_q=np.full(4, np.NaN),
-        prior_t=np.full(3, np.NaN),
+        prior_q=np.full(4, np.nan),
+        prior_t=np.full(3, np.nan),
         image_id=None,
     ):
         cursor = self.execute(


### PR DESCRIPTION
AttributeError: `np.NaN` was removed in the NumPy 2.0 release - we should use `np.nan` instead. Originally reported in https://github.com/cvg/Hierarchical-Localization/pull/405
