### PR TITLE
Add fix for specifying the correct pycolmap CMake python development …

### DIFF
--- a/pycolmap/CMakeLists.txt
+++ b/pycolmap/CMakeLists.txt
@@ -19,7 +19,12 @@ endif()
 
 find_package(colmap REQUIRED)
 
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+if (CMAKE_VERSION VERSION_LESS 3.18)
+  set(DEV_MODULE Development)
+else()
+  set(DEV_MODULE Development.Module)
+endif()
+find_package(Python REQUIRED COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
 
 find_package(pybind11 2.12.0 REQUIRED)
 


### PR DESCRIPTION
As explained in this [nanobind](https://github.com/wjakob/nanobind/commit/5f6dc9a00ce6e160c5c378967ba9fe4318d9d6eb) commit

The name of ``Development.Module`` component changed across CMake versions. This PR adds this fix to pycolmap. Personally, I ran into this issue while using CMake version 3.16.3