### PR TITLE
Incremental model refiner for DetectorFreeSfM

### DIFF
--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -538,10 +538,12 @@ void IncrementalMapperController::Reconstruct(
 }
 
 void IncrementalMapperController::TriangulateReconstruction(
-    const std::shared_ptr<Reconstruction>& reconstruction) {
+    const std::shared_ptr<Reconstruction>& reconstruction,
+    const std::unordered_set<image_t> fixed_image_ids) {
   THROW_CHECK(LoadDatabase());
   IncrementalMapper mapper(database_cache_);
   mapper.BeginReconstruction(reconstruction);
+  mapper.SetFixedImageIds(fixed_image_ids);
 
   LOG(INFO) << "Iterative triangulation";
   const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -543,8 +543,10 @@ void IncrementalMapperController::TriangulateReconstruction(
   THROW_CHECK(LoadDatabase());
   IncrementalMapper mapper(database_cache_);
   mapper.BeginReconstruction(reconstruction);
-  mapper.SetFixedImageIds(fixed_image_ids);
-
+  
+  if (!fixed_image_ids.empty()) {
+    mapper.SetFixedImageIds(fixed_image_ids);
+  }
   LOG(INFO) << "Iterative triangulation";
   const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
   for (size_t i = 0; i < reg_image_ids.size(); ++i) {

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -163,7 +163,8 @@ class IncrementalMapperController : public BaseController {
   void Run();
 
   void TriangulateReconstruction(
-      const std::shared_ptr<Reconstruction>& reconstruction);
+      const std::shared_ptr<Reconstruction>& reconstruction,
+      std::unordered_set<image_t> fixed_image_ids = {});
 
   bool LoadDatabase();
 

--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -113,6 +113,8 @@ int main(int argc, char** argv) {
   commands.emplace_back("image_undistorter", &colmap::RunImageUndistorter);
   commands.emplace_back("image_undistorter_standalone",
                         &colmap::RunImageUndistorterStandalone);
+  commands.emplace_back("incremental_model_refiner",
+                        &colmap::RunIncrementalModelRefiner);
   commands.emplace_back("mapper", &colmap::RunMapper);
   commands.emplace_back("matches_importer", &colmap::RunMatchesImporter);
   commands.emplace_back("model_aligner", &colmap::RunModelAligner);

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -46,6 +46,7 @@ void RunPointTriangulatorImpl(
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);
 int RunColorExtractor(int argc, char** argv);
+int RunIncrementalModelRefiner(int argc, char** argv);
 int RunMapper(int argc, char** argv);
 int RunHierarchicalMapper(int argc, char** argv);
 int RunPointFiltering(int argc, char** argv);

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -109,7 +109,6 @@ IncrementalMapper::IncrementalMapper(
       num_shared_reg_images_(0) {}
 
 void IncrementalMapper::SetFixedImageIds(std::unordered_set<image_t> image_ids) {
-
   existing_image_ids_ = image_ids;
 }
 

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -108,6 +108,11 @@ IncrementalMapper::IncrementalMapper(
       num_total_reg_images_(0),
       num_shared_reg_images_(0) {}
 
+void IncrementalMapper::SetFixedImageIds(std::unordered_set<image_t> image_ids) {
+
+  existing_image_ids_ = image_ids;
+}
+
 void IncrementalMapper::BeginReconstruction(
     const std::shared_ptr<class Reconstruction>& reconstruction) {
   THROW_CHECK(reconstruction_ == nullptr);

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -145,6 +145,10 @@ class IncrementalMapper {
   explicit IncrementalMapper(
       std::shared_ptr<const DatabaseCache> database_cache);
 
+  // Set existing_image_ids_ to a custom list of images
+  // This will be overridden in at the beginning of TriangulateReconstruction in BeginReconstruction
+  void SetFixedImageIds(std::unordered_set<image_t> image_ids);
+
   // Prepare the mapper for a new reconstruction, which might have existing
   // registered images (in which case `RegisterNextImage` must be called) or
   // which is empty (in which case `RegisterInitialImagePair` must be called).

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -146,7 +146,7 @@ class IncrementalMapper {
       std::shared_ptr<const DatabaseCache> database_cache);
 
   // Set existing_image_ids_ to a custom list of images
-  // This will be overridden in at the beginning of TriangulateReconstruction in BeginReconstruction
+  // This will be used at the beginning of TriangulateReconstruction
   void SetFixedImageIds(std::unordered_set<image_t> image_ids);
 
   // Prepare the mapper for a new reconstruction, which might have existing


### PR DESCRIPTION
This feature helps refine cameras and models.

- Adds an optional parameter to TriangulateReconstruction for the fixed image ids
- Adds a setter function and call it after BeginReconstruction.

Do I need to add tests/python bindings?

Based on https://github.com/colmap/colmap/pull/2145 and https://github.com/hxy-123/colmap
