### PR TITLE
Propagate glog version compile definition to dependents

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -20,11 +20,6 @@ find_package(LZ4 ${COLMAP_FIND_TYPE})
 find_package(Metis ${COLMAP_FIND_TYPE})
 
 find_package(Glog ${COLMAP_FIND_TYPE})
-if(DEFINED glog_VERSION_MAJOR)
-  # Older versions of glog don't export version variables.
-  add_definitions("-DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}")
-  add_definitions("-DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}")
-endif()
 
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
 

--- a/cmake/FindGlog.cmake
+++ b/cmake/FindGlog.cmake
@@ -52,6 +52,11 @@ if(TARGET glog::glog)
     set(GLOG_FOUND TRUE)
     message(STATUS "Found Glog")
     message(STATUS "  Target : glog::glog")
+    target_compile_definitions(glog::glog
+        INTERFACE
+            -DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}
+            -DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}
+    )
 else()
     # Older versions of glog don't come with a find_package config.
     # Fall back to custom logic to find the library and remap to imported target.

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -63,6 +63,15 @@ if(TESTS_ENABLED)
     )
 endif()
 
+if(DEFINED glog_VERSION_MAJOR)
+    # Older versions of glog don't export version variables.
+    target_compile_definitions(colmap_util
+        PUBLIC
+            -DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}
+            -DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}
+    )
+endif()
+
 if(GUI_ENABLED)
     target_link_libraries(colmap_util PUBLIC Qt5::Core Qt5::OpenGL OpenGL::GL)
 endif()

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -63,15 +63,6 @@ if(TESTS_ENABLED)
     )
 endif()
 
-if(DEFINED glog_VERSION_MAJOR)
-    # Older versions of glog don't export version variables.
-    target_compile_definitions(colmap_util
-        PUBLIC
-            -DGLOG_VERSION_MAJOR=${glog_VERSION_MAJOR}
-            -DGLOG_VERSION_MINOR=${glog_VERSION_MINOR}
-    )
-endif()
-
 if(GUI_ENABLED)
     target_link_libraries(colmap_util PUBLIC Qt5::Core Qt5::OpenGL OpenGL::GL)
 endif()


### PR DESCRIPTION
This will correctly propagate the definitions to other projects consuming colmap as a library.