### PR TITLE
Reset CMAKE_MODULE_PATH to previous value

### DIFF
--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -81,3 +81,6 @@ set(CGAL_ENABLED @CGAL_ENABLED@)
 include(${PACKAGE_PREFIX_DIR}/share/colmap/colmap-targets.cmake)
 include(${PACKAGE_PREFIX_DIR}/share/colmap/cmake/FindDependencies.cmake)
 check_required_components(colmap)
+
+# Reset to previous value
+set(CMAKE_MODULE_PATH ${TEMP_CMAKE_MODULE_PATH})


### PR DESCRIPTION
Seems like this line went missing in https://github.com/colmap/colmap/commit/4afd5d986823fea0b629b958fc2bb3e25695c99f