### PR TITLE
Fix: sequential matcher overlap number should be inclusive

### DIFF
--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -438,7 +438,7 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
 
   const auto image_id1 = image_ids_.at(image_idx_);
   for (int i = 0; i < options_.overlap; ++i) {
-    const size_t image_idx_2 = image_idx_ + i;
+    const size_t image_idx_2 = image_idx_ + i + 1;
     if (image_idx_2 < image_ids_.size()) {
       image_pairs_.emplace_back(image_id1, image_ids_.at(image_idx_2));
       if (options_.quadratic_overlap) {


### PR DESCRIPTION
This bug dates back to commit [
Improve code of feature matchers](https://github.com/colmap/colmap/commit/d2b130bb79c1648d5252acb3081242c74c2c21b2)

According to this doc in `colmap/src/colmap/controllers/feature_matching.h`:

```c++
// Sequentially match images within neighborhood:
//
// +-------------------------------+-----------------------> images[i]
//                      ^          |           ^
//                      |   Current image[i]   |
//                      |          |           |
//                      +----------+-----------+
//                                 |
//                        Match image_i against
//
//                    image_[i - o, i + o]        with o = [1 .. overlap]
//                    image_[i - 2^o, i + 2^o]    (for quadratic overlap)
//
// Sequential order is determined based on the image names in ascending order.
//
// Invoke loop detection if `(i mod loop_detection_period) == 0`, retrieve
// most similar `loop_detection_num_images` images from vocabulary tree,
// and perform matching and verification.
std::unique_ptr<Thread> CreateSequentialFeatureMatcher(
    const SequentialMatchingOptions& options,
    const SiftMatchingOptions& matching_options,
    const TwoViewGeometryOptions& geometry_options,
    const std::string& database_path);
```

As described in the above doc, also intruitively, If we give overlap `3` for sequential matcher, without the `quadratic` option, the image id `100` should be matched to 
`97`, `98`, `99`, and  `101`, `102`, `103`, which incluses `97`, `103`.