### PR TITLE
Abstract BaseImage and add raw camera pointer to the Image class

### DIFF
--- a/src/colmap/controllers/feature_extraction.cc
+++ b/src/colmap/controllers/feature_extraction.cc
@@ -87,7 +87,7 @@ struct ImageData {
   ImageReader::Status status = ImageReader::Status::FAILURE;
 
   Camera camera;
-  Image image;
+  BaseImage image;
   PosePrior pose_prior;
   Bitmap bitmap;
   Bitmap mask;
@@ -544,7 +544,7 @@ class FeatureImporterController : public Thread {
 
       // Load image data and possibly save camera to database.
       Camera camera;
-      Image image;
+      BaseImage image;
       PosePrior pose_prior;
       Bitmap bitmap;
       if (image_reader.Next(&camera, &image, &pose_prior, &bitmap, nullptr) !=

--- a/src/colmap/controllers/image_reader.cc
+++ b/src/colmap/controllers/image_reader.cc
@@ -86,7 +86,7 @@ ImageReader::ImageReader(const ImageReaderOptions& options, Database* database)
 }
 
 ImageReader::Status ImageReader::Next(Camera* camera,
-                                      Image* image,
+                                      BaseImage* image,
                                       PosePrior* pose_prior,
                                       Bitmap* bitmap,
                                       Bitmap* mask) {

--- a/src/colmap/controllers/image_reader.h
+++ b/src/colmap/controllers/image_reader.h
@@ -109,7 +109,7 @@ class ImageReader {
   ImageReader(const ImageReaderOptions& options, Database* database);
 
   Status Next(Camera* camera,
-              Image* image,
+              BaseImage* image,
               PosePrior* pose_prior,
               Bitmap* bitmap,
               Bitmap* mask);

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -150,9 +150,8 @@ void GenerateReconstruction(const size_t num_images,
                                   kImageSize);
     reconstruction->AddCamera(camera);
 
-    Image image;
+    Image image(&reconstruction.Camera(camera_id));
     image.SetImageId(image_id);
-    image.SetCameraId(camera_id);
     image.SetName(std::to_string(i));
     image.CamFromWorld() = Rigid3d(
         Eigen::Quaterniond::Identity(),

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -150,7 +150,7 @@ void GenerateReconstruction(const size_t num_images,
                                   kImageSize);
     reconstruction->AddCamera(camera);
 
-    Image image(&reconstruction.Camera(camera_id));
+    Image image(&reconstruction->Camera(camera_id));
     image.SetImageId(image_id);
     image.SetName(std::to_string(i));
     image.CamFromWorld() = Rigid3d(
@@ -692,8 +692,8 @@ TEST(BundleAdjustment, RigTwoView) {
 TEST(BundleAdjustment, RigFourView) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
-  reconstruction.Image(2).SetCameraId(0);
-  reconstruction.Image(3).SetCameraId(1);
+  reconstruction.Image(2).SetCamera(&reconstruction.Camera(0));
+  reconstruction.Image(3).SetCamera(&reconstruction.Camera(1));
   const auto orig_reconstruction = reconstruction;
 
   BundleAdjustmentConfig config;
@@ -744,8 +744,8 @@ TEST(BundleAdjustment, RigFourView) {
 TEST(BundleAdjustment, ConstantRigFourView) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
-  reconstruction.Image(2).SetCameraId(0);
-  reconstruction.Image(3).SetCameraId(1);
+  reconstruction.Image(2).SetCamera(&reconstruction.Camera(0));
+  reconstruction.Image(3).SetCamera(&reconstruction.Camera(1));
   const auto orig_reconstruction = reconstruction;
 
   BundleAdjustmentConfig config;
@@ -796,8 +796,8 @@ TEST(BundleAdjustment, ConstantRigFourView) {
 TEST(BundleAdjustment, RigFourViewPartial) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
-  reconstruction.Image(2).SetCameraId(0);
-  reconstruction.Image(3).SetCameraId(1);
+  reconstruction.Image(2).SetCamera(&reconstruction.Camera(0));
+  reconstruction.Image(3).SetCamera(&reconstruction.Camera(1));
   const auto orig_reconstruction = reconstruction;
 
   BundleAdjustmentConfig config;

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -58,8 +58,12 @@ TEST(CoordinateFrame, AlignToPrincipalPlane) {
   // axis.
   Sim3d tform;
   Reconstruction reconstruction;
+  Camera camera =
+    Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+  reconstruction.AddCamera(camera);
+
   // Setup image with projection center at (1, 0, 0)
-  BaseImage image;
+  Image image(&reconstruction.Camera(camera.camera_id));
   image.SetImageId(1);
   image.SetRegistered(true);
   image.CamFromWorld() =

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -59,7 +59,7 @@ TEST(CoordinateFrame, AlignToPrincipalPlane) {
   Sim3d tform;
   Reconstruction reconstruction;
   Camera camera =
-    Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+      Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
   reconstruction.AddCamera(camera);
 
   // Setup image with projection center at (1, 0, 0)

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -59,7 +59,7 @@ TEST(CoordinateFrame, AlignToPrincipalPlane) {
   Sim3d tform;
   Reconstruction reconstruction;
   // Setup image with projection center at (1, 0, 0)
-  Image image;
+  BaseImage image;
   image.SetImageId(1);
   image.SetRegistered(true);
   image.CamFromWorld() =

--- a/src/colmap/exe/vocab_tree.cc
+++ b/src/colmap/exe/vocab_tree.cc
@@ -52,7 +52,7 @@ FeatureDescriptors LoadRandomDatabaseDescriptors(
   Database database(database_path);
   DatabaseTransaction database_transaction(&database);
 
-  const std::vector<Image> images = database.ReadAllImages();
+  const std::vector<BaseImage> images = database.ReadAllImages();
 
   FeatureDescriptors descriptors;
 
@@ -92,9 +92,9 @@ FeatureDescriptors LoadRandomDatabaseDescriptors(
   return descriptors;
 }
 
-std::vector<Image> ReadVocabTreeRetrievalImageList(const std::string& path,
-                                                   Database* database) {
-  std::vector<Image> images;
+std::vector<BaseImage> ReadVocabTreeRetrievalImageList(const std::string& path,
+                                                       Database* database) {
+  std::vector<BaseImage> images;
   if (path.empty()) {
     images.reserve(database->NumImages());
     for (const auto& image : database->ReadAllImages()) {
@@ -184,7 +184,7 @@ int RunVocabTreeRetriever(int argc, char** argv) {
   const auto query_images =
       (!query_image_list_path.empty() || output_index_path.empty())
           ? ReadVocabTreeRetrievalImageList(query_image_list_path, &database)
-          : std::vector<Image>();
+          : std::vector<BaseImage>();
 
   //////////////////////////////////////////////////////////////////////////////
   // Perform image indexing
@@ -233,7 +233,7 @@ int RunVocabTreeRetriever(int argc, char** argv) {
   // Perform image queries
   //////////////////////////////////////////////////////////////////////////////
 
-  std::unordered_map<image_t, const Image*> image_id_to_image;
+  std::unordered_map<image_t, const BaseImage*> image_id_to_image;
   image_id_to_image.reserve(database_images.size());
   for (const auto& image : database_images) {
     image_id_to_image.emplace(image.ImageId(), &image);

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -48,9 +48,11 @@ void FeatureMatcherCache::Setup() {
     cameras_cache_.emplace(camera.camera_id, std::move(camera));
   }
 
-  std::vector<Image> images = database_->ReadAllImages();
+  std::vector<BaseImage> images = database_->ReadAllImages();
   images_cache_.reserve(images.size());
-  for (Image& image : images) {
+  for (BaseImage& base_image : images) {
+    camera_t camera_id = base_image.CameraId();
+    Image image(base_image, &cameras_cache_[camera_id]);
     images_cache_.emplace(image.ImageId(), std::move(image));
   }
 

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -196,9 +196,8 @@ TEST(UndistortReconstruction, Nominal) {
   reconstruction.AddCamera(camera);
 
   for (image_t image_id = 1; image_id <= kNumImages; ++image_id) {
-    Image image;
+    Image image(&reconstruction.Camera(1));
     image.SetImageId(image_id);
-    image.SetCameraId(1);
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Ones()));

--- a/src/colmap/scene/camera_rig_test.cc
+++ b/src/colmap/scene/camera_rig_test.cc
@@ -130,24 +130,20 @@ TEST(CameraRig, Check) {
   Camera camera2 = Camera::CreateFromModelName(1, "PINHOLE", 1, 1, 1);
   reconstruction.AddCamera(camera2);
 
-  Image image1;
+  Image image1(&reconstruction.Camera(camera1.camera_id));
   image1.SetImageId(0);
-  image1.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image1);
 
-  Image image2;
+  Image image2(&reconstruction.Camera(camera2.camera_id));
   image2.SetImageId(1);
-  image2.SetCameraId(camera2.camera_id);
   reconstruction.AddImage(image2);
 
-  Image image3;
+  Image image3(&reconstruction.Camera(camera1.camera_id));
   image3.SetImageId(2);
-  image3.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image3);
 
-  Image image4;
+  Image image4(&reconstruction.Camera(camera2.camera_id));
   image4.SetImageId(3);
-  image4.SetCameraId(camera2.camera_id);
   reconstruction.AddImage(image4);
 
   camera_rig.SetRefCameraId(0);
@@ -171,14 +167,12 @@ TEST(CameraRig, ComputeRigFromWorldScale) {
   Camera camera2 = Camera::CreateFromModelName(1, "PINHOLE", 1, 1, 1);
   reconstruction.AddCamera(camera2);
 
-  Image image1;
+  Image image1(&reconstruction.Camera(camera1.camera_id));
   image1.SetImageId(0);
-  image1.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image1);
 
-  Image image2;
+  Image image2(&reconstruction.Camera(camera2.camera_id));
   image2.SetImageId(1);
-  image2.SetCameraId(camera2.camera_id);
   image2.CamFromWorld().translation = Eigen::Vector3d(1, 2, 3);
   reconstruction.AddImage(image2);
 
@@ -208,14 +202,12 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   Camera camera2 = Camera::CreateFromModelName(1, "PINHOLE", 1, 1, 1);
   reconstruction.AddCamera(camera2);
 
-  Image image1;
+  Image image1(&reconstruction.Camera(camera1.camera_id));
   image1.SetImageId(0);
-  image1.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image1);
 
-  Image image2;
+  Image image2(&reconstruction.Camera(camera2.camera_id));
   image2.SetImageId(1);
-  image2.SetCameraId(camera2.camera_id);
   image2.CamFromWorld().translation = Eigen::Vector3d(1, 2, 3);
   reconstruction.AddImage(image2);
 
@@ -232,14 +224,12 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   const std::vector<image_t> image_ids2 = {2, 3};
   camera_rig.AddSnapshot(image_ids2);
 
-  Image image3;
+  Image image3(&reconstruction.Camera(camera1.camera_id));
   image3.SetImageId(2);
-  image3.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image3);
 
-  Image image4;
+  Image image4(&reconstruction.Camera(camera2.camera_id));
   image4.SetImageId(3);
-  image4.SetCameraId(camera2.camera_id);
   image4.CamFromWorld().translation = Eigen::Vector3d(2, 4, 6);
   reconstruction.AddImage(image4);
 
@@ -255,9 +245,8 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   const std::vector<image_t> image_ids3 = {4};
   camera_rig.AddSnapshot(image_ids3);
 
-  Image image5;
+  Image image5(&reconstruction.Camera(camera1.camera_id));
   image5.SetImageId(4);
-  image5.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image5);
 
   camera_rig.Check(reconstruction);
@@ -287,14 +276,12 @@ TEST(CameraRig, ComputeRigFromWorld) {
   Camera camera2 = Camera::CreateFromModelName(1, "PINHOLE", 1, 1, 1);
   reconstruction.AddCamera(camera2);
 
-  Image image1;
+  Image image1(&reconstruction.Camera(camera1.camera_id));
   image1.SetImageId(0);
-  image1.SetCameraId(camera1.camera_id);
   reconstruction.AddImage(image1);
 
-  Image image2;
+  Image image2(&reconstruction.Camera(camera2.camera_id));
   image2.SetImageId(1);
-  image2.SetCameraId(camera2.camera_id);
   image2.CamFromWorld().translation = Eigen::Vector3d(3, 3, 3);
   reconstruction.AddImage(image2);
 

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -223,8 +223,8 @@ Camera ReadCameraRow(sqlite3_stmt* sql_stmt) {
   return camera;
 }
 
-Image ReadImageRow(sqlite3_stmt* sql_stmt) {
-  Image image;
+BaseImage ReadImageRow(sqlite3_stmt* sql_stmt) {
+  BaseImage image;
 
   image.SetImageId(static_cast<image_t>(sqlite3_column_int64(sql_stmt, 0)));
   image.SetName(std::string(
@@ -397,10 +397,10 @@ std::vector<Camera> Database::ReadAllCameras() const {
   return cameras;
 }
 
-Image Database::ReadImage(const image_t image_id) const {
+BaseImage Database::ReadImage(const image_t image_id) const {
   SQLITE3_CALL(sqlite3_bind_int64(sql_stmt_read_image_id_, 1, image_id));
 
-  Image image;
+  BaseImage image;
 
   const int rc = SQLITE3_CALL(sqlite3_step(sql_stmt_read_image_id_));
   if (rc == SQLITE_ROW) {
@@ -412,14 +412,14 @@ Image Database::ReadImage(const image_t image_id) const {
   return image;
 }
 
-Image Database::ReadImageWithName(const std::string& name) const {
+BaseImage Database::ReadImageWithName(const std::string& name) const {
   SQLITE3_CALL(sqlite3_bind_text(sql_stmt_read_image_name_,
                                  1,
                                  name.c_str(),
                                  static_cast<int>(name.size()),
                                  SQLITE_STATIC));
 
-  Image image;
+  BaseImage image;
 
   const int rc = SQLITE3_CALL(sqlite3_step(sql_stmt_read_image_name_));
   if (rc == SQLITE_ROW) {
@@ -431,8 +431,8 @@ Image Database::ReadImageWithName(const std::string& name) const {
   return image;
 }
 
-std::vector<Image> Database::ReadAllImages() const {
-  std::vector<Image> images;
+std::vector<BaseImage> Database::ReadAllImages() const {
+  std::vector<BaseImage> images;
   images.reserve(NumImages());
 
   while (SQLITE3_CALL(sqlite3_step(sql_stmt_read_images_)) == SQLITE_ROW) {
@@ -667,7 +667,7 @@ camera_t Database::WriteCamera(const Camera& camera,
   return static_cast<camera_t>(sqlite3_last_insert_rowid(database_));
 }
 
-image_t Database::WriteImage(const Image& image,
+image_t Database::WriteImage(const BaseImage& image,
                              const bool use_image_id) const {
   if (use_image_id) {
     THROW_CHECK(!ExistsImage(image.ImageId())) << "image_id must be unique";
@@ -838,7 +838,7 @@ void Database::UpdateCamera(const Camera& camera) const {
   SQLITE3_CALL(sqlite3_reset(sql_stmt_update_camera_));
 }
 
-void Database::UpdateImage(const Image& image) const {
+void Database::UpdateImage(const BaseImage& image) const {
   SQLITE3_CALL(sqlite3_bind_text(sql_stmt_update_image_,
                                  1,
                                  image.Name().c_str(),

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -153,9 +153,9 @@ class Database {
   Camera ReadCamera(camera_t camera_id) const;
   std::vector<Camera> ReadAllCameras() const;
 
-  Image ReadImage(image_t image_id) const;
-  Image ReadImageWithName(const std::string& name) const;
-  std::vector<Image> ReadAllImages() const;
+  BaseImage ReadImage(image_t image_id) const;
+  BaseImage ReadImageWithName(const std::string& name) const;
+  std::vector<BaseImage> ReadAllImages() const;
 
   PosePrior ReadPosePrior(image_t image_id) const;
 
@@ -186,7 +186,7 @@ class Database {
 
   // Add new image and return its database identifier. If `use_image_id`
   // is false a new identifier is automatically generated.
-  image_t WriteImage(const Image& image, bool use_image_id = false) const;
+  image_t WriteImage(const BaseImage& image, bool use_image_id = false) const;
 
   // Write a new entry in the database. The user is responsible for making sure
   // that the entry does not yet exist. For image pairs, the order of
@@ -213,7 +213,7 @@ class Database {
 
   // Update an existing image in the database. The user is responsible for
   // making sure that the entry already exists.
-  void UpdateImage(const Image& image) const;
+  void UpdateImage(const BaseImage& image) const;
 
   // Delete matches of an image pair.
   void DeleteMatches(image_t image_id1, image_t image_id2) const;

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -107,7 +107,7 @@ std::shared_ptr<DatabaseCache> DatabaseCache::Create(
   std::unordered_set<image_t> image_ids;
 
   {
-    std::vector<class Image> images = database.ReadAllImages();
+    std::vector<BaseImage> images = database.ReadAllImages();
     const size_t num_images = images.size();
 
     // Determines for which images data should be loaded.
@@ -142,7 +142,9 @@ std::shared_ptr<DatabaseCache> DatabaseCache::Create(
     // Load images with correspondences and discard images without
     // correspondences, as those images are useless for SfM.
     cache->images_.reserve(connected_image_ids.size());
-    for (auto& image : images) {
+    for (const auto& base_image : images) {
+      camera_t camera_id = base_image.CameraId();
+      class Image image(base_image, &cache->cameras_[camera_id]);
       const image_t image_id = image.ImageId();
       if (image_ids.count(image_id) > 0 &&
           connected_image_ids.count(image_id) > 0) {

--- a/src/colmap/scene/database_cache_test.cc
+++ b/src/colmap/scene/database_cache_test.cc
@@ -45,10 +45,12 @@ TEST(DatabaseCache, Nominal) {
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, SimplePinholeCameraModel::model_id, 1, 1, 1);
   const camera_t camera_id = database.WriteCamera(camera);
-  Image image1(&camera);
+  BaseImage image1;
   image1.SetName("image1");
-  Image image2(&camera);
+  image1.SetCameraId(camera_id);
+  BaseImage image2;
   image2.SetName("image2");
+  image2.SetCameraId(camera_id);
   const image_t image_id1 = database.WriteImage(image1);
   const image_t image_id2 = database.WriteImage(image2);
   database.WriteKeypoints(image_id1, FeatureKeypoints(10));

--- a/src/colmap/scene/database_cache_test.cc
+++ b/src/colmap/scene/database_cache_test.cc
@@ -45,12 +45,10 @@ TEST(DatabaseCache, Nominal) {
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, SimplePinholeCameraModel::model_id, 1, 1, 1);
   const camera_t camera_id = database.WriteCamera(camera);
-  Image image1;
+  Image image1(&camera);
   image1.SetName("image1");
-  image1.SetCameraId(camera_id);
-  Image image2;
+  Image image2(&camera);
   image2.SetName("image2");
-  image2.SetCameraId(camera_id);
   const image_t image_id1 = database.WriteImage(image1);
   const image_t image_id2 = database.WriteImage(image2);
   database.WriteKeypoints(image_id1, FeatureKeypoints(10));

--- a/src/colmap/scene/database_test.cc
+++ b/src/colmap/scene/database_test.cc
@@ -153,7 +153,7 @@ TEST(Database, Image) {
       kInvalidCameraId, "SIMPLE_PINHOLE", 1.0, 1, 1);
   camera.camera_id = database.WriteCamera(camera);
   EXPECT_EQ(database.NumImages(), 0);
-  Image image;
+  BaseImage image;
   image.SetName("test");
   image.SetCameraId(camera.camera_id);
   image.SetImageId(database.WriteImage(image));
@@ -166,7 +166,7 @@ TEST(Database, Image) {
   read_image = database.ReadImage(image.ImageId());
   EXPECT_EQ(read_image.ImageId(), image.ImageId());
   EXPECT_EQ(read_image.CameraId(), image.CameraId());
-  Image image2 = image;
+  BaseImage image2 = image;
   image2.SetName("test2");
   image2.SetImageId(image.ImageId() + 1);
   database.WriteImage(image2, true);
@@ -182,7 +182,7 @@ TEST(Database, PosePrior) {
   Database database(Database::kInMemoryDatabasePath);
   Camera camera;
   camera.camera_id = database.WriteCamera(camera);
-  Image image;
+  BaseImage image;
   image.SetName("test");
   image.SetCameraId(camera.camera_id);
   image.SetImageId(database.WriteImage(image));
@@ -204,7 +204,7 @@ TEST(Database, Keypoints) {
   Database database(Database::kInMemoryDatabasePath);
   Camera camera;
   camera.camera_id = database.WriteCamera(camera);
-  Image image;
+  BaseImage image;
   image.SetName("test");
   image.SetCameraId(camera.camera_id);
   image.SetImageId(database.WriteImage(image));
@@ -243,7 +243,7 @@ TEST(Database, Descriptors) {
   Database database(Database::kInMemoryDatabasePath);
   Camera camera;
   camera.camera_id = database.WriteCamera(camera);
-  Image image;
+  BaseImage image;
   image.SetName("test");
   image.SetCameraId(camera.camera_id);
   image.SetImageId(database.WriteImage(image));
@@ -426,7 +426,7 @@ TEST(Database, Merge) {
   camera.camera_id = database1.WriteCamera(camera);
   camera.camera_id = database2.WriteCamera(camera);
 
-  Image image;
+  BaseImage image;
   image.SetCameraId(camera.camera_id);
 
   image.SetName("test1");

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -94,9 +94,12 @@ Eigen::Vector3d Image::ViewingDirection() const {
   return cam_from_world_.rotation.toRotationMatrix().row(2);
 }
 
-std::pair<bool, Eigen::Vector2d> Image::ProjectPoint3D(
+std::pair<bool, Eigen::Vector2d> Image::ProjectPoint(
     const Eigen::Vector3d& point3D) const {
+  // The camera pointer has to be existent for this function
   THROW_CHECK(HasCameraPtr());
+
+  // Transform point3D
   const Eigen::Vector3d point3D_in_cam = CamFromWorld() * point3D;
 
   // Check that point is in front of camera.

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -42,7 +42,7 @@ BaseImage::BaseImage()
       num_points3D_(0) {}
 
 Image::Image(struct Camera* camera) : BaseImage(), camera_(camera) {
-  camera_id_ = camera->camera_id;
+  BaseImage::SetCameraId(camera->camera_id);
 }
 
 Image::Image(const Image& image) : camera_(image.Camera()) {
@@ -61,7 +61,7 @@ Image::Image(const BaseImage& base_image, struct Camera* camera)
 void Image::CopyFromBaseImage(const BaseImage& image) {
   SetImageId(image.ImageId());
   SetName(image.Name());
-  camera_id_ = image.CameraId();
+  BaseImage::SetCameraId(image.CameraId());
   SetRegistered(image.IsRegistered());
   num_points3D_ = image.NumPoints3D();
   cam_from_world_ = image.CamFromWorld();

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -45,27 +45,19 @@ Image::Image(struct Camera* camera) : BaseImage(), camera_(camera) {
   BaseImage::SetCameraId(camera->camera_id);
 }
 
-Image::Image(const Image& image) : camera_(image.Camera()) {
-  CopyFromBaseImage(image);
-}
-
 Image::Image(const BaseImage& base_image, struct Camera* camera)
     : camera_(camera) {
   // Check if the camera id matches the one in the base image
   THROW_CHECK_EQ(base_image.CameraId(), camera->camera_id);
 
   // Copy data from the BaseImage instance
-  CopyFromBaseImage(base_image);
-}
-
-void Image::CopyFromBaseImage(const BaseImage& image) {
-  SetImageId(image.ImageId());
-  SetName(image.Name());
-  BaseImage::SetCameraId(image.CameraId());
-  SetRegistered(image.IsRegistered());
-  num_points3D_ = image.NumPoints3D();
-  cam_from_world_ = image.CamFromWorld();
-  SetPoints2D(image.Points2D());
+  SetImageId(base_image.ImageId());
+  SetName(base_image.Name());
+  BaseImage::SetCameraId(base_image.CameraId());
+  SetRegistered(base_image.IsRegistered());
+  num_points3D_ = base_image.NumPoints3D();
+  cam_from_world_ = base_image.CamFromWorld();
+  SetPoints2D(base_image.Points2D());
 }
 
 void BaseImage::SetPoints2D(const std::vector<Eigen::Vector2d>& points) {

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -94,4 +94,18 @@ Eigen::Vector3d Image::ViewingDirection() const {
   return cam_from_world_.rotation.toRotationMatrix().row(2);
 }
 
+std::pair<bool, Eigen::Vector2d> Image::ProjectPoint3D(
+    const Eigen::Vector3d& point3D) const {
+  THROW_CHECK(HasCameraPtr());
+  const Eigen::Vector3d point3D_in_cam = CamFromWorld() * point3D;
+
+  // Check that point is in front of camera.
+  if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
+    return std::make_pair(false, Eigen::Vector2d());
+  }
+
+  return std::make_pair(true,
+                        CameraPtr()->ImgFromCam(point3D_in_cam.hnormalized()));
+}
+
 }  // namespace colmap

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -42,7 +42,7 @@ BaseImage::BaseImage()
       num_points3D_(0) {}
 
 Image::Image(struct Camera* camera) : BaseImage(), camera_(camera) {
-  SetCameraId(camera->camera_id);
+  camera_id_ = camera->camera_id;
 }
 
 Image::Image(const Image& image) : camera_(image.Camera()) {
@@ -61,7 +61,7 @@ Image::Image(const BaseImage& base_image, struct Camera* camera)
 void Image::CopyFromBaseImage(const BaseImage& image) {
   SetImageId(image.ImageId());
   SetName(image.Name());
-  SetCameraId(image.CameraId());
+  camera_id_ = image.CameraId();
   SetRegistered(image.IsRegistered());
   num_points3D_ = image.NumPoints3D();
   cam_from_world_ = image.CamFromWorld();

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -68,8 +68,8 @@ class Image {
   // Check whether identifier of camera has been set.
   inline bool HasCamera() const;
   // [Optional]: Access the shared pointer of the camera
-  inline std::shared_ptr<struct Camera> Camera() const;
-  inline void SetCamera(const std::shared_ptr<struct Camera>& camera);
+  inline std::shared_ptr<struct Camera> CameraPtr() const;
+  inline void SetCameraPtr(const std::shared_ptr<struct Camera>& camera);
   // check whether the camera pointer has been set
   inline bool HasCameraPtr() const;
 
@@ -110,6 +110,11 @@ class Image {
 
   // Extract the viewing direction of the image.
   Eigen::Vector3d ViewingDirection() const;
+
+  // Reproject the 3D point onto the image in pixels (only when the camera
+  // pointer is available) Return false if the 3D point is behind the camera.
+  std::pair<bool, Eigen::Vector2d> ProjectPoint3D(
+      const Eigen::Vector3d& point3D) const;
 
  private:
   // Identifier of the image, if not specified `kInvalidImageId`.
@@ -161,9 +166,11 @@ inline void Image::SetCameraId(const camera_t camera_id) {
 
 inline bool Image::HasCamera() const { return camera_id_ != kInvalidCameraId; }
 
-inline std::shared_ptr<struct Camera> Image::Camera() const { return camera_; }
+inline std::shared_ptr<struct Camera> Image::CameraPtr() const {
+  return camera_;
+}
 
-inline void Image::SetCamera(const std::shared_ptr<struct Camera>& camera) {
+inline void Image::SetCameraPtr(const std::shared_ptr<struct Camera>& camera) {
   THROW_CHECK_NE(camera->camera_id, kInvalidCameraId);
   camera_ = camera;
   camera_id_ = camera->camera_id;

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -113,7 +113,7 @@ class Image {
 
   // Reproject the 3D point onto the image in pixels (only when the camera
   // pointer is available) Return false if the 3D point is behind the camera.
-  std::pair<bool, Eigen::Vector2d> ProjectPoint3D(
+  std::pair<bool, Eigen::Vector2d> ProjectPoint(
       const Eigen::Vector3d& point3D) const;
 
  private:

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -67,6 +67,11 @@ class Image {
   inline void SetCameraId(camera_t camera_id);
   // Check whether identifier of camera has been set.
   inline bool HasCamera() const;
+  // [Optional]: Access the shared pointer of the camera
+  inline std::shared_ptr<struct Camera> Camera() const;
+  inline void SetCamera(const std::shared_ptr<struct Camera>& camera);
+  // check whether the camera pointer has been set
+  inline bool HasCameraPtr() const;
 
   // Check if image is registered.
   inline bool IsRegistered() const;
@@ -116,6 +121,8 @@ class Image {
   // The identifier of the associated camera. Note that multiple images might
   // share the same camera. If not specified `kInvalidCameraId`.
   camera_t camera_id_;
+  // [Optional] the shared pointer of the camera
+  std::shared_ptr<struct Camera> camera_ = nullptr;
 
   // Whether the image is successfully registered in the reconstruction.
   bool registered_;
@@ -153,6 +160,16 @@ inline void Image::SetCameraId(const camera_t camera_id) {
 }
 
 inline bool Image::HasCamera() const { return camera_id_ != kInvalidCameraId; }
+
+inline std::shared_ptr<struct Camera> Image::Camera() const { return camera_; }
+
+inline void Image::SetCamera(const std::shared_ptr<struct Camera>& camera) {
+  THROW_CHECK_NE(camera->camera_id, kInvalidCameraId);
+  camera_ = camera;
+  camera_id_ = camera->camera_id;
+}
+
+inline bool Image::HasCameraPtr() const { return camera_ != nullptr; }
 
 bool Image::IsRegistered() const { return registered_; }
 

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -133,7 +133,7 @@ class BaseImage {
 
 class Image : public BaseImage {
  public:
-  Image(struct Camera* camera);
+  explicit Image(struct Camera* camera);
 
   // Copy constructor
   Image(const Image& image);

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -222,7 +222,7 @@ inline struct Camera* Image::Camera() const { return camera_; }
 
 inline void Image::SetCamera(struct Camera* camera) {
   camera_ = camera;
-  camera_id_ = camera->camera_id;
+  BaseImage::SetCameraId(camera->camera_id);
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -135,9 +135,6 @@ class Image : public BaseImage {
  public:
   explicit Image(struct Camera* camera);
 
-  // Copy constructor
-  Image(const Image& image);
-
   // Initialized from an existing ``BaseImage`` with a raw camera pointer
   Image(const BaseImage& base_image, struct Camera* camera);
 
@@ -158,9 +155,6 @@ class Image : public BaseImage {
  private:
   // The address of the corresponding camera
   struct Camera* camera_;
-
-  // Copy from base image
-  void CopyFromBaseImage(const BaseImage& image);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -147,6 +147,9 @@ class Image : public BaseImage {
   // Switch to different camera address
   inline void SetCamera(struct Camera* camera);
 
+  // Disable ``SetCameraId``
+  void SetCameraId(camera_t camera_id) = delete;
+
   // Reproject the 3D point onto the image in pixels (only when the camera
   // pointer is available) Return false if the 3D point is behind the camera.
   std::pair<bool, Eigen::Vector2d> ProjectPoint(
@@ -219,7 +222,7 @@ inline struct Camera* Image::Camera() const { return camera_; }
 
 inline void Image::SetCamera(struct Camera* camera) {
   camera_ = camera;
-  SetCameraId(camera->camera_id);
+  camera_id_ = camera->camera_id;
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -196,6 +196,7 @@ TEST(Image, ImageConstructor) {
 
 TEST(Image, ImagefromBaseImage) {
   BaseImage base_image;
+  base_image.SetCameraId(1);
   base_image.SetImageId(2);
   base_image.SetName("test1");
   base_image.SetRegistered(true);

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -177,5 +177,47 @@ TEST(Image, ViewingDirection) {
   EXPECT_EQ(image.ViewingDirection(), Eigen::Vector3d(0, 0, 1));
 }
 
+TEST(Image, ImageConstructor) {
+  Camera camera =
+      Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+  Image image(&camera);
+  EXPECT_EQ(image.ImageId(), kInvalidImageId);
+  EXPECT_EQ(image.Name(), "");
+  EXPECT_EQ(image.CameraId(), camera.camera_id);
+  EXPECT_TRUE(image.HasCamera());
+  EXPECT_FALSE(image.IsRegistered());
+  EXPECT_EQ(image.NumPoints2D(), 0);
+  EXPECT_EQ(image.NumPoints3D(), 0);
+  EXPECT_EQ(image.CamFromWorld().rotation.coeffs(),
+            Eigen::Quaterniond::Identity().coeffs());
+  EXPECT_EQ(image.CamFromWorld().translation, Eigen::Vector3d::Zero());
+  EXPECT_EQ(image.Points2D().size(), 0);
+}
+
+TEST(Image, ImagefromBaseImage) {
+  BaseImage base_image;
+  base_image.SetImageId(2);
+  base_image.SetName("test1");
+  base_image.SetRegistered(true);
+  base_image.SetPoints2D(std::vector<Eigen::Vector2d>(10));
+  base_image.SetPoint3DForPoint2D(0, 0);
+  base_image.SetPoint3DForPoint2D(1, 2);
+
+  Camera camera =
+      Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+  Image image(image, &camera);
+  EXPECT_EQ(image.ImageId(), base_image.ImageId());
+  EXPECT_EQ(image.Name(), base_image.Name());
+  EXPECT_EQ(image.CameraId(), base_image.CameraId());
+  EXPECT_TRUE(image.HasCamera());
+  EXPECT_EQ(image.IsRegistered(), base_image.IsRegistered());
+  EXPECT_EQ(image.NumPoints2D(), base_image.NumPoints2D());
+  EXPECT_EQ(image.NumPoints3D(), base_image.NumPoints3D());
+  EXPECT_EQ(image.CamFromWorld().rotation.coeffs(),
+            base_image.CamFromWorld().rotation.coeffs());
+  EXPECT_EQ(image.CamFromWorld().translation,
+            base_image.CamFromWorld().translation);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -35,7 +35,7 @@ namespace colmap {
 namespace {
 
 TEST(Image, Default) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.ImageId(), kInvalidImageId);
   EXPECT_EQ(image.Name(), "");
   EXPECT_EQ(image.CameraId(), kInvalidCameraId);
@@ -50,14 +50,14 @@ TEST(Image, Default) {
 }
 
 TEST(Image, ImageId) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.ImageId(), kInvalidImageId);
   image.SetImageId(1);
   EXPECT_EQ(image.ImageId(), 1);
 }
 
 TEST(Image, Name) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.Name(), "");
   image.SetName("test1");
   EXPECT_EQ(image.Name(), "test1");
@@ -66,14 +66,14 @@ TEST(Image, Name) {
 }
 
 TEST(Image, CameraId) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.CameraId(), kInvalidCameraId);
   image.SetCameraId(1);
   EXPECT_EQ(image.CameraId(), 1);
 }
 
 TEST(Image, Registered) {
-  Image image;
+  BaseImage image;
   EXPECT_FALSE(image.IsRegistered());
   image.SetRegistered(true);
   EXPECT_TRUE(image.IsRegistered());
@@ -82,14 +82,14 @@ TEST(Image, Registered) {
 }
 
 TEST(Image, NumPoints2D) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.NumPoints2D(), 0);
   image.SetPoints2D(std::vector<Eigen::Vector2d>(10));
   EXPECT_EQ(image.NumPoints2D(), 10);
 }
 
 TEST(Image, NumPoints3D) {
-  Image image;
+  BaseImage image;
   image.SetPoints2D(std::vector<Eigen::Vector2d>(10));
   EXPECT_EQ(image.NumPoints3D(), 0);
   image.SetPoint3DForPoint2D(0, 0);
@@ -100,7 +100,7 @@ TEST(Image, NumPoints3D) {
 }
 
 TEST(Image, Points2D) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.Points2D().size(), 0);
   std::vector<Eigen::Vector2d> points2D(10);
   points2D[0] = Eigen::Vector2d(1.0, 2.0);
@@ -112,7 +112,7 @@ TEST(Image, Points2D) {
 }
 
 TEST(Image, Points2DWith3D) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.Points2D().size(), 0);
   std::vector<Point2D> points2D(10);
   points2D[0].xy = Eigen::Vector2d(1.0, 2.0);
@@ -125,7 +125,7 @@ TEST(Image, Points2DWith3D) {
 }
 
 TEST(Image, Points3D) {
-  Image image;
+  BaseImage image;
   image.SetPoints2D(std::vector<Eigen::Vector2d>(2));
   EXPECT_FALSE(image.Point2D(0).HasPoint3D());
   EXPECT_FALSE(image.Point2D(1).HasPoint3D());
@@ -168,12 +168,12 @@ TEST(Image, Points3D) {
 }
 
 TEST(Image, ProjectionCenter) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.ProjectionCenter(), Eigen::Vector3d::Zero());
 }
 
 TEST(Image, ViewingDirection) {
-  Image image;
+  BaseImage image;
   EXPECT_EQ(image.ViewingDirection(), Eigen::Vector3d(0, 0, 1));
 }
 

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -206,7 +206,7 @@ TEST(Image, ImagefromBaseImage) {
 
   Camera camera =
       Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
-  Image image(image, &camera);
+  Image image(base_image, &camera);
   EXPECT_EQ(image.ImageId(), base_image.ImageId());
   EXPECT_EQ(image.Name(), base_image.Name());
   EXPECT_EQ(image.CameraId(), base_image.CameraId());

--- a/src/colmap/scene/projection.cc
+++ b/src/colmap/scene/projection.cc
@@ -40,7 +40,7 @@ double CalculateSquaredReprojectionError(const Eigen::Vector2d& point2D,
                                          const Camera& camera) {
   const Eigen::Vector3d point3D_in_cam = cam_from_world * point3D;
 
-  // Check that point is infront of camera.
+  // Check that point is in front of camera.
   if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
     return std::numeric_limits<double>::max();
   }
@@ -56,7 +56,7 @@ double CalculateSquaredReprojectionError(
     const Camera& camera) {
   const double proj_z = cam_from_world.row(2).dot(point3D.homogeneous());
 
-  // Check that point is infront of camera.
+  // Check that point is in front of camera.
   if (proj_z < std::numeric_limits<double>::epsilon()) {
     return std::numeric_limits<double>::max();
   }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -229,7 +229,6 @@ void Reconstruction::DeleteAllPoints2DAndPoints3D() {
     class Image new_image(image.second.Camera());
     new_image.SetImageId(image.second.ImageId());
     new_image.SetName(image.second.Name());
-    new_image.SetCameraId(image.second.CameraId());
     new_image.SetRegistered(image.second.IsRegistered());
     new_image.CamFromWorld() = image.second.CamFromWorld();
     image.second = std::move(new_image);

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -127,7 +127,7 @@ void Reconstruction::AddImage(class Image image, bool sync_camera_pointer) {
     reg_image_ids_.push_back(image_id);
   }
   if (sync_camera_pointer) {
-    if (!ExistsCamera(image.CameraId()))
+    if (!ExistsCamera(Image(image_id).CameraId()))
       LOG(FATAL_THROW) << "The camera id for the added image needs to be "
                           "existent in the reconstruction if one wants to sync "
                           "the camera pointer with AddImage(image_id, true)";

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -131,7 +131,7 @@ void Reconstruction::AddImage(class Image image, bool sync_camera_pointer) {
       LOG(FATAL_THROW) << "The camera id for the added image needs to be "
                           "existent in the reconstruction if one wants to sync "
                           "the camera pointer with AddImage(image_id, true)";
-    Image(image_id).SetCamera(
+    Image(image_id).SetCameraPtr(
         std::make_shared<struct Camera>(cameras_.at(image.CameraId())));
   }
 }
@@ -731,7 +731,7 @@ void Reconstruction::CreateImageDirs(const std::string& path) const {
 
 void Reconstruction::SyncCameraPointers() {
   for (auto& image : images_) {
-    image.second.SetCamera(
+    image.second.SetCameraPtr(
         std::make_shared<struct Camera>(cameras_.at(image.second.CameraId())));
   }
 }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -131,8 +131,8 @@ void Reconstruction::AddImage(class Image image, bool sync_camera_pointer) {
       LOG(FATAL_THROW) << "The camera id for the added image needs to be "
                           "existent in the reconstruction if one wants to sync "
                           "the camera pointer with AddImage(image_id, true)";
-    Image(image_id).SetCameraPtr(
-        std::make_shared<struct Camera>(cameras_.at(image.CameraId())));
+    Image(image_id).SetCameraPtr(std::make_shared<struct Camera>(
+        cameras_.at(Image(image_id).CameraId())));
   }
 }
 

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -81,6 +81,8 @@ void Reconstruction::Load(const DatabaseCache& database_cache) {
       AddImage(image.second);
     }
   }
+
+  SyncCameraPointers();
 }
 
 void Reconstruction::TearDown() {
@@ -116,13 +118,21 @@ void Reconstruction::AddCamera(struct Camera camera) {
   THROW_CHECK(cameras_.emplace(camera_id, std::move(camera)).second);
 }
 
-void Reconstruction::AddImage(class Image image) {
+void Reconstruction::AddImage(class Image image, bool sync_camera_pointer) {
   const image_t image_id = image.ImageId();
   const bool is_registered = image.IsRegistered();
   THROW_CHECK(images_.emplace(image_id, std::move(image)).second);
   if (is_registered) {
     THROW_CHECK_NE(image_id, kInvalidImageId);
     reg_image_ids_.push_back(image_id);
+  }
+  if (sync_camera_pointer) {
+    if (!ExistsCamera(image.CameraId()))
+      LOG(FATAL_THROW) << "The camera id for the added image needs to be "
+                          "existent in the reconstruction if one wants to sync "
+                          "the camera pointer with AddImage(image_id, true)";
+    Image(image_id).SetCamera(
+        std::make_shared<struct Camera>(cameras_.at(image.CameraId())));
   }
 }
 
@@ -550,6 +560,7 @@ void Reconstruction::ReadText(const std::string& path) {
   ReadCamerasText(*this, JoinPaths(path, "cameras.txt"));
   ReadImagesText(*this, JoinPaths(path, "images.txt"));
   ReadPoints3DText(*this, JoinPaths(path, "points3D.txt"));
+  SyncCameraPointers();
 }
 
 void Reconstruction::ReadBinary(const std::string& path) {
@@ -559,6 +570,7 @@ void Reconstruction::ReadBinary(const std::string& path) {
   ReadCamerasBinary(*this, JoinPaths(path, "cameras.bin"));
   ReadImagesBinary(*this, JoinPaths(path, "images.bin"));
   ReadPoints3DBinary(*this, JoinPaths(path, "points3D.bin"));
+  SyncCameraPointers();
 }
 
 void Reconstruction::WriteText(const std::string& path) const {
@@ -714,6 +726,13 @@ void Reconstruction::CreateImageDirs(const std::string& path) const {
   }
   for (const auto& dir : image_dirs) {
     CreateDirIfNotExists(dir, /*recursive=*/true);
+  }
+}
+
+void Reconstruction::SyncCameraPointers() {
+  for (auto& image : images_) {
+    image.second.SetCamera(
+        std::make_shared<struct Camera>(cameras_.at(image.second.CameraId())));
   }
 }
 

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -116,7 +116,20 @@ void Reconstruction::AddCamera(struct Camera camera) {
   THROW_CHECK(cameras_.emplace(camera_id, std::move(camera)).second);
 }
 
+void Reconstruction::AddImage(BaseImage base_image) {
+  THROW_CHECK(ExistsCamera(base_image.CameraId()));
+  const image_t image_id = base_image.ImageId();
+  const bool is_registered = base_image.IsRegistered();
+  Image image(base_image, &Camera(base_image.CameraId()));
+  THROW_CHECK(images_.emplace(image_id, std::move(image)).second);
+  if (is_registered) {
+    THROW_CHECK_NE(image_id, kInvalidImageId);
+    reg_image_ids_.push_back(image_id);
+  }
+}
+
 void Reconstruction::AddImage(class Image image) {
+  THROW_CHECK(ExistsCamera(image.CameraId()));
   const image_t image_id = image.ImageId();
   const bool is_registered = image.IsRegistered();
   THROW_CHECK(images_.emplace(image_id, std::move(image)).second);

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -120,7 +120,7 @@ void Reconstruction::AddImage(BaseImage base_image) {
   THROW_CHECK(ExistsCamera(base_image.CameraId()));
   const image_t image_id = base_image.ImageId();
   const bool is_registered = base_image.IsRegistered();
-  Image image(base_image, &Camera(base_image.CameraId()));
+  class Image image(base_image, &Camera(base_image.CameraId()));
   THROW_CHECK(images_.emplace(image_id, std::move(image)).second);
   if (is_registered) {
     THROW_CHECK_NE(image_id, kInvalidImageId);

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -81,8 +81,6 @@ void Reconstruction::Load(const DatabaseCache& database_cache) {
       AddImage(image.second);
     }
   }
-
-  SyncCameraPointers();
 }
 
 void Reconstruction::TearDown() {
@@ -118,21 +116,13 @@ void Reconstruction::AddCamera(struct Camera camera) {
   THROW_CHECK(cameras_.emplace(camera_id, std::move(camera)).second);
 }
 
-void Reconstruction::AddImage(class Image image, bool sync_camera_pointer) {
+void Reconstruction::AddImage(class Image image) {
   const image_t image_id = image.ImageId();
   const bool is_registered = image.IsRegistered();
   THROW_CHECK(images_.emplace(image_id, std::move(image)).second);
   if (is_registered) {
     THROW_CHECK_NE(image_id, kInvalidImageId);
     reg_image_ids_.push_back(image_id);
-  }
-  if (sync_camera_pointer) {
-    if (!ExistsCamera(Image(image_id).CameraId()))
-      LOG(FATAL_THROW) << "The camera id for the added image needs to be "
-                          "existent in the reconstruction if one wants to sync "
-                          "the camera pointer with AddImage(image_id, true)";
-    Image(image_id).SetCameraPtr(std::make_shared<struct Camera>(
-        cameras_.at(Image(image_id).CameraId())));
   }
 }
 
@@ -236,7 +226,7 @@ void Reconstruction::DeleteObservation(const image_t image_id,
 void Reconstruction::DeleteAllPoints2DAndPoints3D() {
   points3D_.clear();
   for (auto& image : images_) {
-    class Image new_image;
+    class Image new_image(image.second.Camera());
     new_image.SetImageId(image.second.ImageId());
     new_image.SetName(image.second.Name());
     new_image.SetCameraId(image.second.CameraId());
@@ -560,7 +550,6 @@ void Reconstruction::ReadText(const std::string& path) {
   ReadCamerasText(*this, JoinPaths(path, "cameras.txt"));
   ReadImagesText(*this, JoinPaths(path, "images.txt"));
   ReadPoints3DText(*this, JoinPaths(path, "points3D.txt"));
-  SyncCameraPointers();
 }
 
 void Reconstruction::ReadBinary(const std::string& path) {
@@ -570,7 +559,6 @@ void Reconstruction::ReadBinary(const std::string& path) {
   ReadCamerasBinary(*this, JoinPaths(path, "cameras.bin"));
   ReadImagesBinary(*this, JoinPaths(path, "images.bin"));
   ReadPoints3DBinary(*this, JoinPaths(path, "points3D.bin"));
-  SyncCameraPointers();
 }
 
 void Reconstruction::WriteText(const std::string& path) const {
@@ -726,13 +714,6 @@ void Reconstruction::CreateImageDirs(const std::string& path) const {
   }
   for (const auto& dir : image_dirs) {
     CreateDirIfNotExists(dir, /*recursive=*/true);
-  }
-}
-
-void Reconstruction::SyncCameraPointers() {
-  for (auto& image : images_) {
-    image.second.SetCameraPtr(
-        std::make_shared<struct Camera>(cameras_.at(image.second.CameraId())));
   }
 }
 

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -116,7 +116,7 @@ void Reconstruction::AddCamera(struct Camera camera) {
   THROW_CHECK(cameras_.emplace(camera_id, std::move(camera)).second);
 }
 
-void Reconstruction::AddImage(BaseImage base_image) {
+void Reconstruction::AddImage(const BaseImage& base_image) {
   THROW_CHECK(ExistsCamera(base_image.CameraId()));
   const image_t image_id = base_image.ImageId();
   const bool is_registered = base_image.IsRegistered();

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -103,7 +103,7 @@ class Reconstruction {
   void AddCamera(struct Camera camera);
 
   // Add new image. optionally load camera address in the image
-  void AddImage(class Image image, bool sync_camera_pointer = false);
+  void AddImage(class Image image);
 
   // Add new 3D point with known ID.
   void AddPoint3D(point3D_t point3D_id, struct Point3D point3D);
@@ -235,9 +235,6 @@ class Reconstruction {
 
   // Create all image sub-directories in the given path.
   void CreateImageDirs(const std::string& path) const;
-
-  // Load the camera address for each image
-  void SyncCameraPointers();
 
  private:
   std::tuple<Eigen::Vector3d, Eigen::Vector3d, Eigen::Vector3d>

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -102,7 +102,7 @@ class Reconstruction {
   // might be taken by the same camera.
   void AddCamera(struct Camera camera);
 
-  // Add new image. The corresponding camera needs to be existent in the
+  // Add new image. The corresponding camera needs to exist in the
   // reconstruction before ``AddImage`` is called
   void AddImage(const BaseImage& base_image);
   void AddImage(class Image image);

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -102,7 +102,9 @@ class Reconstruction {
   // might be taken by the same camera.
   void AddCamera(struct Camera camera);
 
-  // Add new image. optionally load camera address in the image
+  // Add new image. The corresponding camera needs to be existent in the
+  // reconstruction before ``AddImage`` is called
+  void AddImage(BaseImage base_image);
   void AddImage(class Image image);
 
   // Add new 3D point with known ID.

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -104,7 +104,7 @@ class Reconstruction {
 
   // Add new image. The corresponding camera needs to be existent in the
   // reconstruction before ``AddImage`` is called
-  void AddImage(BaseImage base_image);
+  void AddImage(const BaseImage& base_image);
   void AddImage(class Image image);
 
   // Add new 3D point with known ID.

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -102,8 +102,8 @@ class Reconstruction {
   // might be taken by the same camera.
   void AddCamera(struct Camera camera);
 
-  // Add new image.
-  void AddImage(class Image image);
+  // Add new image. optionally load camera address in the image
+  void AddImage(class Image image, bool sync_camera_pointer = false);
 
   // Add new 3D point with known ID.
   void AddPoint3D(point3D_t point3D_id, struct Point3D point3D);
@@ -235,6 +235,9 @@ class Reconstruction {
 
   // Create all image sub-directories in the given path.
   void CreateImageDirs(const std::string& path) const;
+
+  // Load the camera address for each image
+  void SyncCameraPointers();
 
  private:
   std::tuple<Eigen::Vector3d, Eigen::Vector3d, Eigen::Vector3d>

--- a/src/colmap/scene/reconstruction_io.h
+++ b/src/colmap/scene/reconstruction_io.h
@@ -37,12 +37,16 @@ namespace colmap {
 
 void ReadCamerasText(Reconstruction& reconstruction, const std::string& path);
 
+// This ``ReadImagesText`` function can only be called with cameras loaded in
+// the reconstruction, e.g., after ``ReadCamerasText`` is called
 void ReadImagesText(Reconstruction& reconstruction, const std::string& path);
 
 void ReadPoints3DText(Reconstruction& reconstruction, const std::string& path);
 
 void ReadCamerasBinary(Reconstruction& reconstruction, const std::string& path);
 
+// This ``ReadImagesBinary`` function can only be called with cameras loaded in
+// the reconstruction, e.g., after ``ReadCamerasBinary`` is called
 void ReadImagesBinary(Reconstruction& reconstruction, const std::string& path);
 
 void ReadPoints3DBinary(Reconstruction& reconstruction,

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -46,7 +46,7 @@ void GenerateReconstruction(const image_t num_images,
   reconstruction->AddCamera(camera);
 
   for (image_t image_id = 1; image_id <= num_images; ++image_id) {
-    Image image(&reconstruction.Camera(camera.camera_id));
+    Image image(&reconstruction->Camera(camera.camera_id));
     image.SetImageId(image_id);
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -80,9 +80,32 @@ TEST(Reconstruction, AddCamera) {
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
 }
 
+TEST(Reconstruction, AddBaseImage) {
+  Reconstruction reconstruction;
+  Camera camera =
+      Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+  reconstruction.AddCamera(camera);
+  BaseImage image;
+  image.SetImageId(1);
+  image.SetCameraId(camera.camera_id);
+  reconstruction.AddImage(image);
+  EXPECT_TRUE(reconstruction.ExistsImage(1));
+  EXPECT_EQ(reconstruction.Image(1).ImageId(), 1);
+  EXPECT_FALSE(reconstruction.Image(1).IsRegistered());
+  EXPECT_EQ(reconstruction.Images().count(1), 1);
+  EXPECT_EQ(reconstruction.Images().size(), 1);
+  EXPECT_EQ(reconstruction.NumCameras(), 0);
+  EXPECT_EQ(reconstruction.NumImages(), 1);
+  EXPECT_EQ(reconstruction.NumRegImages(), 0);
+  EXPECT_EQ(reconstruction.NumPoints3D(), 0);
+}
+
 TEST(Reconstruction, AddImage) {
   Reconstruction reconstruction;
-  BaseImage image;
+  Camera camera =
+      Camera::CreateFromModelId(1, SimplePinholeCameraModel::model_id, 1, 1, 1);
+  reconstruction.AddCamera(camera);
+  Image image(&reconstruction.Camera(camera.camera_id));
   image.SetImageId(1);
   reconstruction.AddImage(image);
   EXPECT_TRUE(reconstruction.ExistsImage(1));

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -94,7 +94,7 @@ TEST(Reconstruction, AddBaseImage) {
   EXPECT_FALSE(reconstruction.Image(1).IsRegistered());
   EXPECT_EQ(reconstruction.Images().count(1), 1);
   EXPECT_EQ(reconstruction.Images().size(), 1);
-  EXPECT_EQ(reconstruction.NumCameras(), 0);
+  EXPECT_EQ(reconstruction.NumCameras(), 1);
   EXPECT_EQ(reconstruction.NumImages(), 1);
   EXPECT_EQ(reconstruction.NumRegImages(), 0);
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
@@ -113,7 +113,7 @@ TEST(Reconstruction, AddImage) {
   EXPECT_FALSE(reconstruction.Image(1).IsRegistered());
   EXPECT_EQ(reconstruction.Images().count(1), 1);
   EXPECT_EQ(reconstruction.Images().size(), 1);
-  EXPECT_EQ(reconstruction.NumCameras(), 0);
+  EXPECT_EQ(reconstruction.NumCameras(), 1);
   EXPECT_EQ(reconstruction.NumImages(), 1);
   EXPECT_EQ(reconstruction.NumRegImages(), 0);
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -46,9 +46,8 @@ void GenerateReconstruction(const image_t num_images,
   reconstruction->AddCamera(camera);
 
   for (image_t image_id = 1; image_id <= num_images; ++image_id) {
-    Image image;
+    Image image(&reconstruction.Camera(camera.camera_id));
     image.SetImageId(image_id);
-    image.SetCameraId(camera.camera_id);
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Zero()));
@@ -83,7 +82,7 @@ TEST(Reconstruction, AddCamera) {
 
 TEST(Reconstruction, AddImage) {
   Reconstruction reconstruction;
-  Image image;
+  BaseImage image;
   image.SetImageId(1);
   reconstruction.AddImage(image);
   EXPECT_TRUE(reconstruction.ExistsImage(1));
@@ -239,7 +238,7 @@ TEST(Reconstruction, Normalize) {
   EXPECT_NEAR(reconstruction.Image(2).CamFromWorld().translation.z(), 0, 1e-6);
   EXPECT_NEAR(reconstruction.Image(3).CamFromWorld().translation.z(), 5, 1e-6);
   reconstruction.Normalize(20);
-  Image image;
+  Image image(reconstruction.Image(1).Camera());
   image.SetImageId(4);
   reconstruction.AddImage(image);
   reconstruction.RegisterImage(4);

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -195,7 +195,10 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
   const int existing_num_images =
       (database == nullptr) ? 0 : database->NumImages();
   for (int image_idx = 0; image_idx < options.num_images; ++image_idx) {
-    Image image;
+    camera_t camera_id = camera_ids[image_idx % options.num_cameras];
+    Camera& camera = reconstruction->Camera(camera_id);
+
+    Image image(&camera);
     image.SetName("image" + std::to_string(existing_num_images + image_idx));
     image.SetCameraId(camera_ids[image_idx % options.num_cameras]);
     // Synthesize image poses with projection centers on sphere with radious 5
@@ -206,8 +209,6 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
         Eigen::Quaterniond::FromTwoVectors(view_dir, Eigen::Vector3d(0, 0, 1));
     image.CamFromWorld().translation =
         image.CamFromWorld().rotation * -proj_center;
-
-    const Camera& camera = reconstruction->Camera(image.CameraId());
 
     std::vector<Point2D> points2D;
     points2D.reserve(options.num_points3D +

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -200,7 +200,6 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
 
     Image image(&camera);
     image.SetName("image" + std::to_string(existing_num_images + image_idx));
-    image.SetCameraId(camera_ids[image_idx % options.num_cameras]);
     // Synthesize image poses with projection centers on sphere with radious 5
     // centered at origin.
     const Eigen::Vector3d view_dir = -Eigen::Vector3d::Random().normalized();

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -44,9 +44,8 @@ void GenerateReconstruction(const image_t num_images,
   reconstruction.AddCamera(camera);
 
   for (image_t image_id = 1; image_id <= num_images; ++image_id) {
-    Image image;
+    Image image(&reconstruction.Camera(camera.camera_id));
     image.SetImageId(image_id);
-    image.SetCameraId(camera.camera_id);
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Zero()));
@@ -216,9 +215,8 @@ TEST(ObservationManager, NumVisiblePoints3D) {
                                                   /*width=*/10,
                                                   /*height=*/10);
   reconstruction.AddCamera(camera);
-  Image image;
+  Image image(&reconstruction.Camera(kCameraId));
   image.SetImageId(kImageId1);
-  image.SetCameraId(kCameraId);
   image.SetPoints2D(std::vector<Eigen::Vector2d>(10));
   reconstruction.AddImage(image);
   image.SetImageId(kImageId2);
@@ -262,9 +260,8 @@ TEST(ObservationManager, Point3DVisibilityScore) {
                                                   /*width=*/4,
                                                   /*height=*/4);
   reconstruction.AddCamera(camera);
-  Image image;
+  Image image(&reconstruction.Camera(kCameraId));
   image.SetImageId(kImageId1);
-  image.SetCameraId(kCameraId);
   std::vector<Eigen::Vector2d> points2D;
   for (size_t i = 0; i < 4; ++i) {
     for (size_t j = 0; j < 4; ++j) {

--- a/src/colmap/ui/colormaps.cc
+++ b/src/colmap/ui/colormaps.cc
@@ -155,7 +155,7 @@ void PointColormapGroundResolution::Prepare(
     const Eigen::Vector3f xyz = point3D.second.xyz.cast<float>();
 
     for (const auto& track_el : point3D.second.track.Elements()) {
-      const auto& image = images[track_el.image_id];
+      const auto& image = images.at(track_el.image_id);
       const float focal_length = focal_lengths[image.CameraId()];
       const float focal_length2 = focal_length * focal_length;
       const Eigen::Vector2f& pp = principal_points[image.CameraId()];

--- a/src/colmap/ui/database_management_widget.cc
+++ b/src/colmap/ui/database_management_widget.cc
@@ -154,7 +154,7 @@ MatchesTab::MatchesTab(QWidget* parent,
   InitializeTable(table_header);
 }
 
-void MatchesTab::Reload(const std::vector<Image>& images,
+void MatchesTab::Reload(const std::vector<BaseImage>& images,
                         const image_t image_id) {
   matches_.clear();
 
@@ -189,7 +189,7 @@ TwoViewGeometriesTab::TwoViewGeometriesTab(QWidget* parent,
   InitializeTable(table_header);
 }
 
-void TwoViewGeometriesTab::Reload(const std::vector<Image>& images,
+void TwoViewGeometriesTab::Reload(const std::vector<BaseImage>& images,
                                   const image_t image_id) {
   matches_.clear();
   configs_.clear();
@@ -245,7 +245,7 @@ OverlappingImagesWidget::OverlappingImagesWidget(QWidget* parent,
   grid->addWidget(close_button, 1, 0, Qt::AlignRight);
 }
 
-void OverlappingImagesWidget::ShowMatches(const std::vector<Image>& images,
+void OverlappingImagesWidget::ShowMatches(const std::vector<BaseImage>& images,
                                           const image_t image_id) {
   parent_->setDisabled(true);
 
@@ -565,7 +565,7 @@ void ImageTab::Clear() {
 }
 
 void ImageTab::itemChanged(QTableWidgetItem* item) {
-  Image& image = images_.at(item->row());
+  BaseImage& image = images_.at(item->row());
   camera_t camera_id = kInvalidCameraId;
 
   switch (item->column()) {

--- a/src/colmap/ui/database_management_widget.h
+++ b/src/colmap/ui/database_management_widget.h
@@ -59,8 +59,8 @@ class TwoViewInfoTab : public QWidget {
   OptionManager* options_;
   Database* database_;
 
-  const Image* image_;
-  std::vector<std::pair<const Image*, FeatureMatches>> matches_;
+  const BaseImage* image_;
+  std::vector<std::pair<const BaseImage*, FeatureMatches>> matches_;
   std::vector<int> configs_;
   std::vector<size_t> sorted_matches_idxs_;
 
@@ -73,7 +73,7 @@ class MatchesTab : public TwoViewInfoTab {
  public:
   MatchesTab(QWidget* parent, OptionManager* options, Database* database);
 
-  void Reload(const std::vector<Image>& images, image_t image_id);
+  void Reload(const std::vector<BaseImage>& images, image_t image_id);
 };
 
 class TwoViewGeometriesTab : public TwoViewInfoTab {
@@ -82,7 +82,7 @@ class TwoViewGeometriesTab : public TwoViewInfoTab {
                        OptionManager* options,
                        Database* database);
 
-  void Reload(const std::vector<Image>& images, image_t image_id);
+  void Reload(const std::vector<BaseImage>& images, image_t image_id);
 };
 
 class OverlappingImagesWidget : public QWidget {
@@ -91,7 +91,7 @@ class OverlappingImagesWidget : public QWidget {
                           OptionManager* options,
                           Database* database);
 
-  void ShowMatches(const std::vector<Image>& images, image_t image_id);
+  void ShowMatches(const std::vector<BaseImage>& images, image_t image_id);
 
  private:
   void closeEvent(QCloseEvent* event);
@@ -152,7 +152,7 @@ class ImageTab : public QWidget {
   OptionManager* options_;
   Database* database_;
 
-  std::vector<Image> images_;
+  std::vector<BaseImage> images_;
 
   QTableWidget* table_widget_;
   QLabel* info_label_;

--- a/src/colmap/ui/match_matrix_widget.cc
+++ b/src/colmap/ui/match_matrix_widget.cc
@@ -44,10 +44,10 @@ void MatchMatrixWidget::Show() {
   }
 
   // Sort the images according to their name.
-  std::vector<Image> images = database.ReadAllImages();
+  std::vector<BaseImage> images = database.ReadAllImages();
   std::sort(images.begin(),
             images.end(),
-            [](const Image& image1, const Image& image2) {
+            [](const BaseImage& image1, const BaseImage& image2) {
               return image1.Name() < image2.Name();
             });
 

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -66,7 +66,7 @@ inline Eigen::Vector4f IndexToRGB(const size_t index) {
   return color;
 }
 
-void BuildImageModel(const Image& image,
+void BuildImageModel(const BaseImage& image,
                      const Camera& camera,
                      const float image_size,
                      const Eigen::Vector4f& plane_color,
@@ -378,7 +378,7 @@ void ModelViewerWidget::ReloadReconstruction() {
 
   images.clear();
   for (const image_t image_id : reg_image_ids) {
-    images[image_id] = reconstruction->Image(image_id);
+    images.at(image_id) = reconstruction->Image(image_id);
   }
 
   statusbar_status_label->setText(
@@ -950,7 +950,7 @@ void ModelViewerWidget::UploadPointData(const bool selection_mode) {
       }
     }
   } else {  // Image selected
-    const auto& selected_image = images[selected_image_id_];
+    const auto& selected_image = images.at(selected_image_id_);
     for (const auto& point3D : points3D) {
       if (point3D.second.error <= options_->render->max_error &&
           point3D.second.track.Length() >= min_track_len) {
@@ -1012,7 +1012,7 @@ void ModelViewerWidget::UploadPointConnectionData() {
 
   // All images in which 3D point is observed.
   for (const auto& track_el : point3D.track.Elements()) {
-    const Image& conn_image = images[track_el.image_id];
+    const Image& conn_image = images.at(track_el.image_id);
     const Eigen::Vector3f conn_proj_center =
         conn_image.ProjectionCenter().cast<float>();
     line.point2 = PointPainter::Data(conn_proj_center(0),
@@ -1038,7 +1038,7 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
   triangle_data.reserve(2 * reg_image_ids.size());
 
   for (const image_t image_id : reg_image_ids) {
-    const Image& image = images[image_id];
+    const Image& image = images.at(image_id);
     const Camera& camera = cameras[image.CameraId()];
 
     Eigen::Vector4f plane_color;
@@ -1118,7 +1118,7 @@ void ModelViewerWidget::UploadImageConnectionData() {
 
     // All connected images to the selected image.
     for (const image_t conn_image_id : conn_image_ids) {
-      const Image& conn_image = images[conn_image_id];
+      const Image& conn_image = images.at(conn_image_id);
       const Eigen::Vector3f conn_proj_center =
           conn_image.ProjectionCenter().cast<float>();
       line.point2 = PointPainter::Data(conn_proj_center(0),
@@ -1148,11 +1148,11 @@ void ModelViewerWidget::UploadMovieGrabberData() {
   triangle_data.reserve(2 * movie_grabber_widget_->views.size());
 
   if (movie_grabber_widget_->views.size() > 0) {
-    const Image& image0 = movie_grabber_widget_->views[0];
+    const BaseImage& image0 = movie_grabber_widget_->views[0];
     Eigen::Vector3f prev_proj_center = image0.ProjectionCenter().cast<float>();
 
     for (size_t i = 1; i < movie_grabber_widget_->views.size(); ++i) {
-      const Image& image = movie_grabber_widget_->views[i];
+      const BaseImage& image = movie_grabber_widget_->views[i];
       const Eigen::Vector3f curr_proj_center =
           image.ProjectionCenter().cast<float>();
       LinePainter::Data path;
@@ -1188,7 +1188,7 @@ void ModelViewerWidget::UploadMovieGrabberData() {
 
     // Build all camera models
     for (size_t i = 0; i < movie_grabber_widget_->views.size(); ++i) {
-      const Image& image = movie_grabber_widget_->views[i];
+      const BaseImage& image = movie_grabber_widget_->views[i];
       Eigen::Vector4f plane_color;
       Eigen::Vector4f frame_color;
       if (i == selected_movie_grabber_view_) {

--- a/src/colmap/ui/movie_grabber_widget.cc
+++ b/src/colmap/ui/movie_grabber_widget.cc
@@ -186,7 +186,7 @@ void MovieGrabberWidget::Assemble() {
       model_viewer_widget_->ModelViewMatrix();
   const float point_size_cached = model_viewer_widget_->PointSize();
   const float image_size_cached = model_viewer_widget_->ImageSize();
-  const std::vector<Image> views_cached = views;
+  const std::vector<BaseImage> views_cached = views;
 
   // Make sure we do not render movie grabber path.
   views.clear();
@@ -291,7 +291,7 @@ void MovieGrabberWidget::UpdateViews() {
 
     const Eigen::Matrix4d model_view_matrix =
         QMatrixToEigen(view_data_.at(item).model_view_matrix).cast<double>();
-    Image image;
+    BaseImage image;
     image.CamFromWorld() =
         Rigid3d(Eigen::Quaterniond(model_view_matrix.topLeftCorner<3, 3>()),
                 model_view_matrix.topRightCorner<3, 1>());

--- a/src/colmap/ui/movie_grabber_widget.h
+++ b/src/colmap/ui/movie_grabber_widget.h
@@ -45,7 +45,7 @@ class MovieGrabberWidget : public QWidget {
   MovieGrabberWidget(QWidget* parent, ModelViewerWidget* model_viewer_widget);
 
   // List of views, used to visualize the movie grabber camera path.
-  std::vector<Image> views;
+  std::vector<BaseImage> views;
 
   struct ViewData {
     QMatrix4x4 model_view_matrix;

--- a/src/colmap/ui/point_viewer_widget.cc
+++ b/src/colmap/ui/point_viewer_widget.cc
@@ -164,7 +164,7 @@ void PointViewerWidget::Show(const point3D_t point3D_id) {
   std::vector<std::pair<TrackElement, std::string>> track_idx_image_name_pairs;
   track_idx_image_name_pairs.reserve(point3D.track.Length());
   for (const auto& track_el : point3D.track.Elements()) {
-    const Image& image = model_viewer_widget_->images[track_el.image_id];
+    const Image& image = model_viewer_widget_->images.at(track_el.image_id);
     track_idx_image_name_pairs.emplace_back(track_el, image.Name());
   }
 
@@ -178,7 +178,8 @@ void PointViewerWidget::Show(const point3D_t point3D_id) {
   // Paint features for each track element.
 
   for (const auto& track_el : track_idx_image_name_pairs) {
-    const Image& image = model_viewer_widget_->images[track_el.first.image_id];
+    const Image& image =
+        model_viewer_widget_->images.at(track_el.first.image_id);
     const Camera& camera = model_viewer_widget_->cameras[image.CameraId()];
     const Point2D& point2D = image.Point2D(track_el.first.point2D_idx);
     const Eigen::Vector2d proj_point2D =

--- a/src/pycolmap/pipeline/images.cc
+++ b/src/pycolmap/pipeline/images.cc
@@ -46,7 +46,7 @@ void ImportImages(const std::string& database_path,
       throw py::error_already_set();
     }
     Camera camera;
-    Image image;
+    BaseImage image;
     PosePrior pose_prior;
     Bitmap bitmap;
     if (image_reader.Next(&camera, &image, &pose_prior, &bitmap, nullptr) !=

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -75,6 +75,10 @@ void BindImage(py::module& m) {
                     &Image::CameraId,
                     &Image::SetCameraId,
                     "Unique identifier of the camera.")
+      .def_property("camera",
+                    &Image::Camera,
+                    &Image::SetCamera,
+                    "The address of the camera")
       .def_property("name",
                     py::overload_cast<>(&Image::Name),
                     &Image::SetName,
@@ -116,6 +120,9 @@ void BindImage(py::module& m) {
       .def("has_camera",
            &Image::HasCamera,
            "Check whether identifier of camera has been set.")
+      .def("has_camera_ptr",
+           &Image::HasCameraPtr,
+           "Check whether the camera address has been set.")
       .def_property("registered",
                     &Image::IsRegistered,
                     &Image::SetRegistered,

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -76,8 +76,8 @@ void BindImage(py::module& m) {
                     &Image::SetCameraId,
                     "Unique identifier of the camera.")
       .def_property("camera",
-                    &Image::Camera,
-                    &Image::SetCamera,
+                    &Image::CameraPtr,
+                    &Image::SetCameraPtr,
                     "The address of the camera")
       .def_property("name",
                     py::overload_cast<>(&Image::Name),
@@ -117,6 +117,16 @@ void BindImage(py::module& m) {
       .def("viewing_direction",
            &Image::ViewingDirection,
            "Extract the viewing direction of the image.")
+      .def(
+          "project_point3d",
+          [](const Image& self, const Eigen::Vector3d& point3D) -> py::object {
+            auto res = self.ProjectPoint3D(point3D);
+            if (res.first)
+              return py::cast(res.second);
+            else
+              return py::none();
+          },
+          "Project 3D point onto the image")
       .def("has_camera",
            &Image::HasCamera,
            "Check whether identifier of camera has been set.")

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -22,9 +22,9 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-std::string PrintImage(const Image& image) {
+std::string PrintBaseImage(const BaseImage& image) {
   std::stringstream ss;
-  ss << "Image(image_id="
+  ss << "BaseImage(image_id="
      << (image.ImageId() != kInvalidImageId ? std::to_string(image.ImageId())
                                             : "Invalid")
      << ", camera_id="
@@ -35,13 +35,26 @@ std::string PrintImage(const Image& image) {
   return ss.str();
 }
 
+std::string PrintImage(const Image& image) {
+  std::stringstream ss;
+  ss << "Image(image_id="
+     << (image.ImageId() != kInvalidImageId ? std::to_string(image.ImageId())
+                                            : "Invalid")
+     << ", camera=Camera(camera_id="
+     << (image.HasCamera() ? std::to_string(image.CameraId()) : "Invalid")
+     << "), name=\"" << image.Name() << "\""
+     << ", triangulated=" << image.NumPoints3D() << "/" << image.NumPoints2D()
+     << ")";
+  return ss.str();
+}
+
 template <typename T>
-std::shared_ptr<Image> MakeImage(const std::string& name,
-                                 const std::vector<T>& points2D,
-                                 const Rigid3d& cam_from_world,
-                                 size_t camera_id,
-                                 image_t image_id) {
-  auto image = std::make_shared<Image>();
+std::shared_ptr<BaseImage> MakeBaseImage(const std::string& name,
+                                         const std::vector<T>& points2D,
+                                         const Rigid3d& cam_from_world,
+                                         size_t camera_id,
+                                         image_t image_id) {
+  auto image = std::make_shared<BaseImage>();
   image->SetName(name);
   image->SetPoints2D(points2D);
   image->CamFromWorld() = cam_from_world;
@@ -52,40 +65,50 @@ std::shared_ptr<Image> MakeImage(const std::string& name,
   return image;
 }
 
+template <typename T>
+std::shared_ptr<Image> MakeImage(Camera* camera,
+                                 const std::string& name,
+                                 const std::vector<T>& points2D,
+                                 const Rigid3d& cam_from_world,
+                                 image_t image_id) {
+  auto image = std::make_shared<Image>(camera);
+  image->SetName(name);
+  image->SetPoints2D(points2D);
+  image->CamFromWorld() = cam_from_world;
+  image->SetImageId(image_id);
+  return image;
+}
+
 void BindImage(py::module& m) {
-  py::class_<Image, std::shared_ptr<Image>> PyImage(m, "Image");
-  PyImage.def(py::init<>())
-      .def(py::init(&MakeImage<Point2D>),
+  py::class_<BaseImage, std::shared_ptr<BaseImage>> PyBaseImage(m, "BaseImage");
+  PyBaseImage.def(py::init<>())
+      .def(py::init(&MakeBaseImage<Point2D>),
            "name"_a = "",
            "points2D"_a = Point2DVector(),
            "cam_from_world"_a = Rigid3d(),
            "camera_id"_a = kInvalidCameraId,
            "id"_a = kInvalidImageId)
-      .def(py::init(&MakeImage<Eigen::Vector2d>),
+      .def(py::init(&MakeBaseImage<Eigen::Vector2d>),
            "name"_a = "",
            "keypoints"_a = std::vector<Eigen::Vector2d>(),
            "cam_from_world"_a = Rigid3d(),
            "camera_id"_a = kInvalidCameraId,
            "id"_a = kInvalidImageId)
       .def_property("image_id",
-                    &Image::ImageId,
-                    &Image::SetImageId,
+                    &BaseImage::ImageId,
+                    &BaseImage::SetImageId,
                     "Unique identifier of image.")
       .def_property("camera_id",
-                    &Image::CameraId,
-                    &Image::SetCameraId,
+                    &BaseImage::CameraId,
+                    &BaseImage::SetCameraId,
                     "Unique identifier of the camera.")
-      .def_property("camera",
-                    &Image::CameraPtr,
-                    &Image::SetCameraPtr,
-                    "The address of the camera")
       .def_property("name",
-                    py::overload_cast<>(&Image::Name),
-                    &Image::SetName,
+                    py::overload_cast<>(&BaseImage::Name),
+                    &BaseImage::SetName,
                     "Name of the image.")
       .def_property(
           "cam_from_world",
-          py::overload_cast<>(&Image::CamFromWorld),
+          py::overload_cast<>(&BaseImage::CamFromWorld),
           [](Image& self, const Rigid3d& cam_from_world) {
             self.CamFromWorld() = cam_from_world;
           },
@@ -93,56 +116,43 @@ void BindImage(py::module& m) {
           "camera space.")
       .def_property(
           "points2D",
-          py::overload_cast<>(&Image::Points2D),
-          py::overload_cast<const Point2DVector&>(&Image::SetPoints2D),
+          py::overload_cast<>(&BaseImage::Points2D),
+          py::overload_cast<const Point2DVector&>(&BaseImage::SetPoints2D),
           "Array of Points2D (=keypoints).")
-      .def("point2D", py::overload_cast<camera_t>(&Image::Point2D))
+      .def("point2D", py::overload_cast<camera_t>(&BaseImage::Point2D))
       .def(
           "set_point3D_for_point2D",
-          &Image::SetPoint3DForPoint2D,
+          &BaseImage::SetPoint3DForPoint2D,
           "point2D_Idx"_a,
           "point3D_id"_a,
           "Set the point as triangulated, i.e. it is part of a 3D point track.")
       .def("reset_point3D_for_point2D",
-           &Image::ResetPoint3DForPoint2D,
+           &BaseImage::ResetPoint3DForPoint2D,
            "Set the point as not triangulated, i.e. it is not part of a 3D "
            "point track")
       .def("has_point3D",
-           &Image::HasPoint3D,
+           &BaseImage::HasPoint3D,
            "Check whether one of the image points is part of the 3D point "
            "track.")
       .def("projection_center",
-           &Image::ProjectionCenter,
+           &BaseImage::ProjectionCenter,
            "Extract the projection center in world space.")
       .def("viewing_direction",
-           &Image::ViewingDirection,
+           &BaseImage::ViewingDirection,
            "Extract the viewing direction of the image.")
-      .def(
-          "project_point",
-          [](const Image& self, const Eigen::Vector3d& point3D) -> py::object {
-            auto res = self.ProjectPoint(point3D);
-            if (res.first)
-              return py::cast(res.second);
-            else
-              return py::none();
-          },
-          "Project 3D point onto the image")
       .def("has_camera",
-           &Image::HasCamera,
+           &BaseImage::HasCamera,
            "Check whether identifier of camera has been set.")
-      .def("has_camera_ptr",
-           &Image::HasCameraPtr,
-           "Check whether the camera address has been set.")
       .def_property("registered",
-                    &Image::IsRegistered,
-                    &Image::SetRegistered,
+                    &BaseImage::IsRegistered,
+                    &BaseImage::SetRegistered,
                     "Whether image is registered in the reconstruction.")
       .def("num_points2D",
-           &Image::NumPoints2D,
+           &BaseImage::NumPoints2D,
            "Get the number of image points (keypoints).")
       .def_property_readonly(
           "num_points3D",
-          &Image::NumPoints3D,
+          &BaseImage::NumPoints3D,
           "Get the number of triangulations, i.e. the number of points that\n"
           "are part of a 3D point track.")
       .def("get_valid_point2D_ids",
@@ -171,8 +181,49 @@ void BindImage(py::module& m) {
 
              return valid_points2D;
            })
+      .def("__repr__", &PrintBaseImage);
+  MakeDataclass(PyBaseImage);
+
+  py::class_<Image, BaseImage, std::shared_ptr<Image>> PyImage(m, "Image");
+  PyImage.def(py::init<const BaseImage&, Camera*>())
+      .def(py::init(&MakeImage<Point2D>),
+           "camera"_a,
+           "name"_a = "",
+           "points2D"_a = Point2DVector(),
+           "cam_from_world"_a = Rigid3d(),
+           "id"_a = kInvalidImageId)
+      .def(py::init(&MakeImage<Eigen::Vector2d>),
+           "camera"_a,
+           "name"_a = "",
+           "keypoints"_a = std::vector<Eigen::Vector2d>(),
+           "cam_from_world"_a = Rigid3d(),
+           "id"_a = kInvalidImageId)
+      .def("cast_to_base", [](Image& self) -> BaseImage { return self; })
+      .def_property(
+          "camera_id",
+          &Image::CameraId,
+          [](Image& self, camera_t camera_id) {
+            LOG(FATAL_THROW)
+                << "Error! The ``camera_id`` property can no longer be "
+                   "directly set in the Image class since it now comes from "
+                   "``image.camera``. Update the ``camera`` property instead.";
+          },
+          "Disable the setter of the camera id.")
+      .def_property("camera",
+                    &Image::Camera,
+                    &Image::SetCamera,
+                    "The address of the camera")
+      .def(
+          "project_point",
+          [](const Image& self, const Eigen::Vector3d& point3D) -> py::object {
+            auto res = self.ProjectPoint(point3D);
+            if (res.first)
+              return py::cast(res.second);
+            else
+              return py::none();
+          },
+          "Project 3D point onto the image")
       .def("__repr__", &PrintImage);
-  MakeDataclass(PyImage);
 
   py::bind_map<ImageMap>(m, "MapImageIdToImage")
       .def("__repr__", [](const ImageMap& self) {

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -118,9 +118,9 @@ void BindImage(py::module& m) {
            &Image::ViewingDirection,
            "Extract the viewing direction of the image.")
       .def(
-          "project_point3d",
+          "project_point",
           [](const Image& self, const Eigen::Vector3d& point3D) -> py::object {
-            auto res = self.ProjectPoint3D(point3D);
+            auto res = self.ProjectPoint(point3D);
             if (res.first)
               return py::cast(res.second);
             else

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -90,7 +90,7 @@ void BindReconstruction(py::module& m) {
            "images\n"
            "might be taken by the same camera.")
       .def("add_image",
-           py::overload_cast<BaseImage>(&Reconstruction::AddImage),
+           py::overload_cast<const BaseImage&>(&Reconstruction::AddImage),
            "base_image"_a,
            "Add a new image.")
       .def("add_image",

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -89,8 +89,11 @@ void BindReconstruction(py::module& m) {
            "Add new camera. There is only one camera per image, while multiple "
            "images\n"
            "might be taken by the same camera.")
-      .def(
-          "add_image", &Reconstruction::AddImage, "image"_a, "Add a new image.")
+      .def("add_image",
+           &Reconstruction::AddImage,
+           "image"_a,
+           "sync_camera_pointer"_a = false,
+           "Add a new image.")
       .def("add_point3D",
            py::overload_cast<const Eigen::Vector3d&,
                              Track,
@@ -202,6 +205,9 @@ void BindReconstruction(py::module& m) {
       .def("create_image_dirs",
            &Reconstruction::CreateImageDirs,
            "Create all image sub-directories in the given path.")
+      .def("sync_camera_pointers",
+           &Reconstruction::SyncCameraPointers,
+           "Load camera address for each image")
       .def(
           "check",
           [](Reconstruction& self) {

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -90,9 +90,12 @@ void BindReconstruction(py::module& m) {
            "images\n"
            "might be taken by the same camera.")
       .def("add_image",
-           &Reconstruction::AddImage,
+           py::overload_cast<BaseImage>(&Reconstruction::AddImage),
+           "base_image"_a,
+           "Add a new image.")
+      .def("add_image",
+           py::overload_cast<Image>(&Reconstruction::AddImage),
            "image"_a,
-           "sync_camera_pointer"_a = false,
            "Add a new image.")
       .def("add_point3D",
            py::overload_cast<const Eigen::Vector3d&,
@@ -205,9 +208,6 @@ void BindReconstruction(py::module& m) {
       .def("create_image_dirs",
            &Reconstruction::CreateImageDirs,
            "Create all image sub-directories in the given path.")
-      .def("sync_camera_pointers",
-           &Reconstruction::SyncCameraPointers,
-           "Load camera address for each image")
       .def(
           "check",
           [](Reconstruction& self) {


### PR DESCRIPTION
Reopening https://github.com/colmap/colmap/pull/2697.

This PR adds support for directly indexing cameras in the image class with backward compatibility, as one of the steps for enabling better rig design. 

Specifically, the PR is structured as follows:

- Abstract a ``BaseImage`` class similar to the ``Image`` class before, make the ``Image`` class a child class of ``BaseImage`` with a raw camera pointer. 

- Force the raw camera pointer when constructing an ``Image`` object. The ``Image`` object can also be constructed from a ``BaseImage`` object and a camera pointer, with the check that the camera id is consistent. Delete the method ``SetCameraId`` in the ``Image`` class. 

- Adapt the changes across COLMAP. In particular, the use of ``BaseImage`` is kept throughout database and ui, while ``Image`` is used in ``DatabaseCache`` and ``Reconstruction``. In the reconstruction, checks are made to make sure that: 1) images must be read after cameras. 2) ``AddImage`` must be done with the camera present in the reconstruction. Interfaces are kept unchanged. Tests are updated as well.

- As in https://github.com/colmap/colmap/pull/2697, we can add more interesting interfaces on the ``Image`` class (e.g., projecting a 3D point onto pixels), now without the need of any additional checks since the raw camera pointer is required to be initialized at the construction. 

- Update pybind accordingly. Note that only the ``BaseImage`` class can be made a data class since the ``Image`` class does not support IO without the cameras available.

pybind test example:
```
import pycolmap
recon = pycolmap.Reconstruction("./pycolmap/example/sfm/0")
image = recon.images[1]

print(image)
# Image(image_id=1, camera=Camera(camera_id=1), name="0000.png", triangulated=3633/9946)
print(isinstance(image, pycolmap.BaseImage)) # inheritance
# True
print(image.cast_to_base())
# BaseImage(image_id=1, camera_id=1, name="0000.png", triangulated=3633/9946)

print(image.camera) 
# Camera(camera_id=1, model=SIMPLE_RADIAL, width=3072, height=2048, params=[2776.773904, 1536.000000, 1024.000000, -0.003993] (f, cx, cy, k))

print(image.project_point(np.array([0., 0., 0.]))) 
# [-1684.30411175  1236.07593196]

print(image.camera_id)
# 1
image.camera_id = 2
# E20240811 14:02:57.401376 2366510 image.cc:206] Error! The ``camera_id`` property can no longer be directly set in the Image class since it now comes from ``image.camera``. Update the ``camera`` property instead.
*** ValueError: [image.cc:206] Error! The ``camera_id`` property can no longer be directly set in the Image class since it now comes from ``image.camera``. Update the ``camera`` property instead.

image.camera = recon.cameras[2]
print(image.camera_id)
# 2
print(recon.images[1].camera_id)
# 2
```

