### PR TITLE
Observation manager needs to check if image_id exists before query operations

### DIFF
--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -78,7 +78,7 @@ ObservationManager::ObservationManager(
         kNumPoint3DVisibilityPyramidLevels, camera.width, camera.height);
     image_stat.num_correspondences_have_point3D.resize(image.NumPoints2D(), 0);
     image_stat.num_visible_points3D = 0;
-    if (correspondence_graph_) {
+    if (correspondence_graph_ && correspondence_graph_->ExistsImage(id_image.first)) {
       image_stat.num_observations =
           correspondence_graph_->NumObservationsForImage(id_image.first);
       image_stat.num_correspondences =

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -78,7 +78,8 @@ ObservationManager::ObservationManager(
         kNumPoint3DVisibilityPyramidLevels, camera.width, camera.height);
     image_stat.num_correspondences_have_point3D.resize(image.NumPoints2D(), 0);
     image_stat.num_visible_points3D = 0;
-    if (correspondence_graph_ && correspondence_graph_->ExistsImage(id_image.first)) {
+    if (correspondence_graph_ &&
+        correspondence_graph_->ExistsImage(id_image.first)) {
       image_stat.num_observations =
           correspondence_graph_->NumObservationsForImage(id_image.first);
       image_stat.num_correspondences =


### PR DESCRIPTION
This potential bug was discovered when I tried to use `colmap point_triangulator` command to perform 3d reconstruction with known camera poses, following [this guide](https://colmap.github.io/faq.html#reconstruct-sparse-dense-model-from-known-camera-poses)

I think the issue is the following: 
* user-provided images.txt with known poses can include all images in a dataset.
* However for database cache creation (database_cache.cc line 145), some of the images may be skipped due to lack of connections.
* The combination of the above two _may_ create a discrepancy in this usecase.

The error message I had is:
```
==============================================================================
Loading model
==============================================================================
I0812 12:24:24.535923 202389 incremental_mapper.cc:225] Loading database
I0812 12:24:24.537750 202389 database_cache.cc:65] Loading cameras...
I0812 12:24:24.537819 202389 database_cache.cc:75]  5 in 0.000s
I0812 12:24:24.537863 202389 database_cache.cc:83] Loading matches...
I0812 12:24:24.557704 202389 database_cache.cc:89]  4663 in 0.020s
I0812 12:24:24.557758 202389 database_cache.cc:105] Loading images...
I0812 12:24:24.638643 202389 database_cache.cc:155]  355 in 0.081s (connected 354)
I0812 12:24:24.638706 202389 database_cache.cc:166] Building correspondence graph...
I0812 12:24:24.796042 202389 database_cache.cc:195]  in 0.157s (ignored 0)
I0812 12:24:24.796790 202389 timer.cc:91] Elapsed time: 0.004 [minutes]
terminate called after throwing an instance of 'std::out_of_range'
  what():  _Map_base::at
*** Aborted at 1723490664 (unix time) try "date -d @1723490664" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x3e800031695) received by PID 202389 (TID 0x7c34fcd3a000) from PID 202389; stack trace: ***
    @     0x7c3542786046 (unknown)
    @     0x7c351f042520 (unknown)
    @     0x7c351f0969fc pthread_kill
    @     0x7c351f042476 raise
    @     0x7c351f0287f3 abort
    @     0x7c351f4a2b9e (unknown)
    @     0x7c351f4ae20c (unknown)
    @     0x7c351f4ae277 std::terminate()
    @     0x7c351f4ae4d8 __cxa_throw
    @     0x7c351f4a54a0 std::__throw_out_of_range()
    @     0x5a2c07386c92 colmap::ObservationManager::ObservationManager()
    @     0x5a2c07379b86 colmap::IncrementalMapper::BeginReconstruction()
    @     0x5a2c073051bb colmap::IncrementalMapperController::TriangulateReconstruction()
    @     0x5a2c07229510 colmap::RunPointTriangulatorImpl()
    @     0x5a2c07229b11 colmap::RunPointTriangulator()
    @     0x5a2c0720bd68 main
    @     0x7c351f029d90 (unknown)
    @     0x7c351f029e40 __libc_start_main
    @     0x5a2c072128d5 _start
Aborted (core dumped)
```
Through debugging the issue is pinned at line 83 `observation_manager.cc`

Adding a check fixed the problem I had.

Any thoughts?