### PR TITLE
Fix table mangled by clang-format

### DIFF
--- a/src/colmap/exe/feature.h
+++ b/src/colmap/exe/feature.h
@@ -38,15 +38,17 @@ namespace colmap {
 // exclusive and unambiguous way. The table below explains the correspondence of
 // each setting with the flags
 //
+// clang-format off
 // -----------------------------------------------------------------------------------
-// |            |                         ImageReaderOptions | | CameraMode |
-// single_camera | single_camera_per_folder | single_camera_per_image |
+// |            |                         ImageReaderOptions                         |
+// | CameraMode | single_camera | single_camera_per_folder | single_camera_per_image |
 // |------------|---------------|--------------------------|-------------------------|
-// | AUTO       | false         | false                    | false | | SINGLE |
-// true          | false                    | false                   | |
-// PER_FOLDER | false         | true                     | false | | PER_IMAGE
-// | false         | false                    | true                    |
+// | AUTO       | false         | false                    | false                   |
+// | SINGLE     | true          | false                    | false                   |
+// | PER_FOLDER | false         | true                     | false                   |
+// | PER_IMAGE  | false         | false                    | true                    |
 // -----------------------------------------------------------------------------------
+// clang-format on
 //
 // Note: When using AUTO mode a camera model will be uniquely identified by the
 // following 5 parameters from EXIF tags:


### PR DESCRIPTION
Noticed a table in exe/feature.h was mangled. Happened when clang-format options where simplified in https://github.com/colmap/colmap/pull/1950.

This reverts it to what it used to look like: https://github.com/colmap/colmap/blob/3947f67243e4924683e14481b4dbb44593950c52/src/colmap/exe/feature.h#L44-L52 and turns off clang-format for those lines.