### PR TITLE
Write out options to ini in full precision, relax bundle adjuster convergence

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -966,7 +966,12 @@ void OptionManager::Write(const std::string& path) const {
     }
   }
 
-  boost::property_tree::write_ini(path, pt);
+  std::ofstream file(path);
+  THROW_CHECK_FILE_OPEN(file, path);
+  // Ensure that we don't lose any precision by storing in text.
+  file.precision(17);
+  boost::property_tree::write_ini(file, pt);
+  file.close();
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -74,7 +74,7 @@ struct BundleAdjustmentOptions {
 
   BundleAdjustmentOptions() {
     solver_options.function_tolerance = 0.0;
-    solver_options.gradient_tolerance = 0.0;
+    solver_options.gradient_tolerance = 1e-4;
     solver_options.parameter_tolerance = 0.0;
     solver_options.logging_type = ceres::LoggingType::SILENT;
     solver_options.max_num_iterations = 100;


### PR DESCRIPTION
Addresses https://github.com/colmap/colmap/issues/2703

* Make sure we write out parameters in full precision, so small values do not get truncated to 0.
* Conservatively relax the bundle adjustment convergence thresholds. Before this PR, bundle adjustment would always run for the full iterations because of 0 tolerances.