### PR TITLE
Add support for CUDA sparse BA solver

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -100,10 +100,14 @@ AutomaticReconstructionController::AutomaticReconstructionController(
 
   option_manager_.sift_extraction->use_gpu = options_.use_gpu;
   option_manager_.sift_matching->use_gpu = options_.use_gpu;
+  option_manager_.mapper->ba_use_gpu = options_.use_gpu;
+  option_manager_.bundle_adjustment->use_gpu = options_.use_gpu;
 
   option_manager_.sift_extraction->gpu_index = options_.gpu_index;
   option_manager_.sift_matching->gpu_index = options_.gpu_index;
   option_manager_.patch_match_stereo->gpu_index = options_.gpu_index;
+  option_manager_.mapper->ba_gpu_index = options_.gpu_index;
+  option_manager_.bundle_adjustment->gpu_index = options_.gpu_index;
 
   feature_extractor_ = CreateFeatureExtractorController(
       reader_options, *option_manager_.sift_extraction);

--- a/src/colmap/controllers/automatic_reconstruction.h
+++ b/src/colmap/controllers/automatic_reconstruction.h
@@ -92,12 +92,14 @@ class AutomaticReconstructionController : public Thread {
     // The number of threads to use in all stages.
     int num_threads = -1;
 
-    // Whether to use the GPU in feature extraction and matching.
+    // Whether to use the GPU in feature extraction, feature matching, and
+    // bundle adjustment.
     bool use_gpu = true;
 
-    // Index of the GPU used for GPU stages. For multi-GPU computation,
-    // you should separate multiple GPU indices by comma, e.g., "0,1,2,3".
-    // By default, all GPUs will be used in all stages.
+    // Index of the GPU used for GPU stages. For multi-GPU computation in
+    // feature extraction/matching, you should separate multiple GPU indices by
+    // comma, e.g., "0,1,2,3". For single-GPU stages only the first GPU will be
+    // used. By default, all available GPUs will be used in all stages.
     std::string gpu_index = "-1";
   };
 

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -130,9 +130,12 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
   options.solver_options.parameter_tolerance = 0.0;
   options.solver_options.max_num_iterations = ba_global_max_num_iterations;
   options.solver_options.max_linear_solver_iterations = 100;
-  options.solver_options.logging_type =
-      ceres::LoggingType::PER_MINIMIZER_ITERATION;
-  options.solver_options.minimizer_progress_to_stdout = false;
+  options.solver_options.logging_type = ceres::LoggingType::SILENT;
+  if (VLOG_IS_ON(2)) {
+    options.solver_options.minimizer_progress_to_stdout = true;
+    options.solver_options.logging_type =
+        ceres::LoggingType::PER_MINIMIZER_ITERATION;
+  }
   options.solver_options.num_threads = num_threads;
 #if CERES_VERSION_MAJOR < 2
   options.solver_options.num_linear_solver_threads = num_threads;
@@ -145,6 +148,8 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
       ba_min_num_residuals_for_multi_threading;
   options.loss_function_type =
       BundleAdjustmentOptions::LossFunctionType::TRIVIAL;
+  options.use_gpu = ba_use_gpu;
+  options.gpu_index = ba_gpu_index;
   return options;
 }
 

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -114,6 +114,10 @@ struct IncrementalPipelineOptions {
   int ba_global_max_refinements = 5;
   double ba_global_max_refinement_change = 0.0005;
 
+  // Whether to use Ceres' CUDA sparse linear algebra library, if available.
+  bool ba_use_gpu = false;
+  std::string ba_gpu_index = "-1";
+
   // Path to a folder with reconstruction snapshots during incremental
   // reconstruction. Snapshots will be saved according to the specified
   // frequency of registered images.

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -35,7 +35,6 @@
 
 namespace colmap {
 
-
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct IncrementalPipelineOptions {
   // The minimum number of matches for inlier matches to be considered.

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -35,6 +35,8 @@
 
 namespace colmap {
 
+
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct IncrementalPipelineOptions {
   // The minimum number of matches for inlier matches to be considered.
   int min_num_matches = 15;

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -470,6 +470,19 @@ void OptionManager::AddBundleAdjustmentOptions() {
                               &bundle_adjustment->refine_extra_params);
   AddAndRegisterDefaultOption("BundleAdjustment.refine_extrinsics",
                               &bundle_adjustment->refine_extrinsics);
+  AddAndRegisterDefaultOption("BundleAdjustment.use_gpu",
+                              &bundle_adjustment->use_gpu);
+  AddAndRegisterDefaultOption("BundleAdjustment.gpu_index",
+                              &bundle_adjustment->gpu_index);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.min_num_residuals_for_multi_threading",
+      &bundle_adjustment->min_num_residuals_for_multi_threading);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.max_num_images_direct_dense_solver",
+      &bundle_adjustment->max_num_images_direct_dense_solver);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.max_num_images_direct_sparse_solver",
+      &bundle_adjustment->max_num_images_direct_sparse_solver);
 }
 
 void OptionManager::AddMapperOptions() {
@@ -535,6 +548,8 @@ void OptionManager::AddMapperOptions() {
                               &mapper->ba_local_max_refinements);
   AddAndRegisterDefaultOption("Mapper.ba_local_max_refinement_change",
                               &mapper->ba_local_max_refinement_change);
+  AddAndRegisterDefaultOption("Mapper.ba_use_gpu", &mapper->ba_use_gpu);
+  AddAndRegisterDefaultOption("Mapper.ba_gpu_index", &mapper->ba_gpu_index);
   AddAndRegisterDefaultOption("Mapper.snapshot_path", &mapper->snapshot_path);
   AddAndRegisterDefaultOption("Mapper.snapshot_images_freq",
                               &mapper->snapshot_images_freq);

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -68,6 +68,10 @@ COLMAP_ADD_LIBRARY(
         Ceres::ceres
 )
 
+if(CUDA_ENABLED)
+    target_link_libraries(colmap_estimators PUBLIC colmap_util_cuda)
+endif()
+
 COLMAP_ADD_TEST(
     NAME absolute_pose_test
     SRCS absolute_pose_test.cc

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -346,7 +346,7 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
-    !defined(CERES_NO_CUDSS)
+    !defined(CERES_NO_CUDSS) && defined(CUDA_ENABLED)
     if (options_.use_gpu) {
       const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
       THROW_CHECK_GT(gpu_indices.size(), 0);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -344,7 +344,9 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
   } else if (num_images <= options_.max_num_images_direct_sparse_solver &&
              has_sparse) {
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
-#if !defined(CERES_NO_CUDSS)
+#if (CERES_VERSION_MAJOR >= 3 ||                                \
+     (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
+    !defined(CERES_NO_CUDSS)
     if (options_.use_gpu) {
       const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
       THROW_CHECK_GT(gpu_indices.size(), 0);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -33,6 +33,7 @@
 #include "colmap/estimators/manifold.h"
 #include "colmap/scene/projection.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/cuda.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
 #include "colmap/util/timer.h"
@@ -329,17 +330,28 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
     const ceres::Problem& problem,
     const ceres::Solver::Options& input_solver_options) const {
   ceres::Solver::Options solver_options = input_solver_options;
+  if (VLOG_IS_ON(2)) {
+    solver_options.minimizer_progress_to_stdout = true;
+    solver_options.logging_type = ceres::LoggingType::PER_MINIMIZER_ITERATION;
+  }
+
   const bool has_sparse =
       solver_options.sparse_linear_algebra_library_type != ceres::NO_SPARSE;
 
-  // Empirical choice.
-  const size_t kMaxNumImagesDirectDenseSolver = 50;
-  const size_t kMaxNumImagesDirectSparseSolver = 1000;
-  const size_t num_images = config_.NumImages();
-  if (num_images <= kMaxNumImagesDirectDenseSolver) {
+  const int num_images = config_.NumImages();
+  if (num_images <= options_.max_num_images_direct_dense_solver) {
     solver_options.linear_solver_type = ceres::DENSE_SCHUR;
-  } else if (num_images <= kMaxNumImagesDirectSparseSolver && has_sparse) {
+  } else if (num_images <= options_.max_num_images_direct_sparse_solver &&
+             has_sparse) {
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
+#if !defined(CERES_NO_CUDSS)
+    if (options_.use_gpu) {
+      const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
+      THROW_CHECK_GT(gpu_indices.size(), 0);
+      SetBestCudaDevice(gpu_indices[0]);
+      solver_options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+    }
+#endif
   } else {  // Indirect sparse (preconditioned CG) solver.
     solver_options.linear_solver_type = ceres::ITERATIVE_SCHUR;
     solver_options.preconditioner_type = ceres::SCHUR_JACOBI;
@@ -813,8 +825,12 @@ void RigBundleAdjuster::ParameterizeCameraRigs(Reconstruction* reconstruction) {
 
 void PrintSolverSummary(const ceres::Solver::Summary& summary,
                         const std::string& header) {
+  if (VLOG_IS_ON(3)) {
+    LOG(INFO) << summary.FullReport();
+  }
+
   std::ostringstream log;
-  log << "\n" << header << ":\n";
+  log << header << "\n";
   log << std::right << std::setw(16) << "Residuals : ";
   log << std::left << summary.num_residuals_reduced << "\n";
 

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -64,10 +64,19 @@ struct BundleAdjustmentOptions {
   // Whether to print a final summary.
   bool print_summary = true;
 
+  // Whether to use Ceres' CUDA sparse linear algebra library, if available.
+  bool use_gpu = false;
+  std::string gpu_index = "-1";
+
   // Minimum number of residuals to enable multi-threading. Note that
   // single-threaded is typically better for small bundle adjustment problems
   // due to the overhead of threading.
   int min_num_residuals_for_multi_threading = 50000;
+
+  // Heuristic thresholds to switch between direct, sparse, and iterative
+  // solvers. These thresholds may not be optimal for all types of problems.
+  int max_num_images_direct_dense_solver = 50;
+  int max_num_images_direct_sparse_solver = 1000;
 
   // Ceres-Solver options.
   ceres::Solver::Options solver_options;

--- a/src/colmap/estimators/manifold.h
+++ b/src/colmap/estimators/manifold.h
@@ -98,14 +98,14 @@ class PositiveExponentialManifold : public ceres::Manifold {
   bool Plus(const double* x,
             const double* delta,
             double* x_plus_delta) const override {
-    for (size_t i = 0; i < size_; ++i) {
+    for (int i = 0; i < size_; ++i) {
       x_plus_delta[i] = x[i] * std::exp(delta[i]);
     }
     return true;
   }
 
   bool PlusJacobian(const double* x, double* jacobian) const override {
-    for (size_t i = 0; i < size_; ++i) {
+    for (int i = 0; i < size_; ++i) {
       jacobian[size_ * i + i] = x[i];
     }
     return true;
@@ -149,14 +149,14 @@ class PositiveExponentialParameterization
   bool Plus(const double* x,
             const double* delta,
             double* x_plus_delta) const override {
-    for (size_t i = 0; i < size_; ++i) {
+    for (int i = 0; i < size_; ++i) {
       x_plus_delta[i] = x[i] * std::exp(delta[i]);
     }
     return true;
   }
 
   bool ComputeJacobian(const double* x, double* jacobian) const override {
-    for (size_t i = 0; i < size_; ++i) {
+    for (int i = 0; i < size_; ++i) {
       jacobian[size_ * i + i] = x[i];
     }
     return true;
@@ -168,6 +168,7 @@ class PositiveExponentialParameterization
  private:
   const int size_{};
 };
+
 #endif
 
 template <int size>

--- a/src/colmap/util/cuda.cc
+++ b/src/colmap/util/cuda.cc
@@ -72,6 +72,9 @@ void SetBestCudaDevice(const int gpu_index) {
     }
     std::sort(all_devices.begin(), all_devices.end(), CompareCudaDevice);
     CUDA_SAFE_CALL(cudaChooseDevice(&selected_gpu_index, all_devices.data()));
+    VLOG(2) << "Found " << num_cuda_devices << " CUDA device(s), "
+            << "selected device " << selected_gpu_index << " with name "
+            << all_devices[selected_gpu_index].name;
   }
 
   THROW_CHECK_GE(selected_gpu_index, 0);


### PR DESCRIPTION
This PR implements enhancement: https://github.com/colmap/colmap/issues/2643. It builds upon Ceres' recent CUDA_SPARSE solver type.

Initial experiments show significant runtime improvements. On my machine with an Intel Core i9 10920X and an NVidia RTX 2070, I see a consistent 3x speedup for reconstructions with ~500-5000 images. For smaller problems with ~100 images, the runtime is roughly equivalent. These experiments were done using CUDA 12.5 and cudss 0.3.0.

For now, the feature is disabled by default and requires explicit enabling of the option. This is because no robustness is implemented against situations where the GPU does not have enough memory and some of the thresholds that determine the usage of sparse direct vs. indirect solvers need to be tuned in this new scenario.

