### PR TITLE
Fix CUDA_ENABLED macro in new bundle adjustment code

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -346,7 +346,7 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
-    !defined(CERES_NO_CUDSS) && defined(CUDA_ENABLED)
+    !defined(CERES_NO_CUDSS) && defined(COLMAP_CUDA_ENABLED)
     if (options_.use_gpu) {
       const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
       THROW_CHECK_GT(gpu_indices.size(), 0);


### PR DESCRIPTION
I think that the macro CUDA_ENABLED should be COLMAP_CUDA_ENABLED instead, in the new bundle adjustment code that directs Ceres to use the GPU.