### PR TITLE
Improved and simplified caching in feature matching

### DIFF
--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -53,11 +53,6 @@ FeatureMatcherWorker::FeatureMatcherWorker(
       output_queue_(output_queue) {
   THROW_CHECK(matching_options_.Check());
 
-  prev_keypoints_image_ids_[0] = kInvalidImageId;
-  prev_keypoints_image_ids_[1] = kInvalidImageId;
-  prev_descriptors_image_ids_[0] = kInvalidImageId;
-  prev_descriptors_image_ids_[1] = kInvalidImageId;
-
   if (matching_options_.use_gpu) {
 #if !defined(COLMAP_CUDA_ENABLED)
     opengl_context_ = std::make_unique<OpenGLContextManager>();
@@ -76,6 +71,9 @@ void FeatureMatcherWorker::Run() {
     THROW_CHECK(opengl_context_->MakeCurrent());
 #endif
   }
+
+  matching_options_.cpu_descriptor_index_cache =
+      &cache_->GetFeatureDescriptorIndexCache();
 
   std::unique_ptr<FeatureMatcher> matcher =
       CreateSiftFeatureMatcher(matching_options_);
@@ -102,58 +100,34 @@ void FeatureMatcherWorker::Run() {
         continue;
       }
 
-      auto load_matcher_index_func1 = [this, &data]() {
-        return cache_->GetMatcherIndex(data.image_id1);
-      };
-      auto load_matcher_index_func2 = [this, &data]() {
-        return cache_->GetMatcherIndex(data.image_id2);
-      };
-
       if (matching_options_.guided_matching) {
         matcher->MatchGuided(geometry_options_.ransac_options.max_error,
-                             GetKeypointsPtr(0, data.image_id1),
-                             GetKeypointsPtr(1, data.image_id2),
-                             GetDescriptorsPtr(0, data.image_id1),
-                             GetDescriptorsPtr(1, data.image_id2),
-                             load_matcher_index_func1,
-                             load_matcher_index_func2,
+                             {
+                                 data.image_id1,
+                                 cache_->GetDescriptors(data.image_id1),
+                                 cache_->GetKeypoints(data.image_id1),
+                             },
+                             {
+                                 data.image_id2,
+                                 cache_->GetDescriptors(data.image_id2),
+                                 cache_->GetKeypoints(data.image_id2),
+                             },
                              &data.two_view_geometry);
       } else {
-        matcher->Match(GetDescriptorsPtr(0, data.image_id1),
-                       GetDescriptorsPtr(1, data.image_id2),
-                       load_matcher_index_func1,
-                       load_matcher_index_func2,
-                       &data.matches);
+        matcher->Match(
+            {
+                data.image_id1,
+                cache_->GetDescriptors(data.image_id1),
+            },
+            {
+                data.image_id2,
+                cache_->GetDescriptors(data.image_id2),
+            },
+            &data.matches);
       }
 
       THROW_CHECK(output_queue_->Push(std::move(data)));
     }
-  }
-}
-
-std::shared_ptr<FeatureKeypoints> FeatureMatcherWorker::GetKeypointsPtr(
-    const int index, const image_t image_id) {
-  THROW_CHECK_GE(index, 0);
-  THROW_CHECK_LE(index, 1);
-  if (prev_keypoints_image_ids_[index] == image_id) {
-    return nullptr;
-  } else {
-    prev_keypoints_image_ids_[index] = image_id;
-    prev_keypoints_[index] = cache_->GetKeypoints(image_id);
-    return prev_keypoints_[index];
-  }
-}
-
-std::shared_ptr<FeatureDescriptors> FeatureMatcherWorker::GetDescriptorsPtr(
-    const int index, const image_t image_id) {
-  THROW_CHECK_GE(index, 0);
-  THROW_CHECK_LE(index, 1);
-  if (prev_descriptors_image_ids_[index] == image_id) {
-    return nullptr;
-  } else {
-    prev_descriptors_image_ids_[index] = image_id;
-    prev_descriptors_[index] = cache_->GetDescriptors(image_id);
-    return prev_descriptors_[index];
   }
 }
 

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -102,16 +102,27 @@ void FeatureMatcherWorker::Run() {
         continue;
       }
 
+      auto load_matcher_index_func1 = [this, &data]() {
+        return cache_->GetMatcherIndex(data.image_id1);
+      };
+      auto load_matcher_index_func2 = [this, &data]() {
+        return cache_->GetMatcherIndex(data.image_id2);
+      };
+
       if (matching_options_.guided_matching) {
         matcher->MatchGuided(geometry_options_.ransac_options.max_error,
                              GetKeypointsPtr(0, data.image_id1),
                              GetKeypointsPtr(1, data.image_id2),
                              GetDescriptorsPtr(0, data.image_id1),
                              GetDescriptorsPtr(1, data.image_id2),
+                             load_matcher_index_func1,
+                             load_matcher_index_func2,
                              &data.two_view_geometry);
       } else {
         matcher->Match(GetDescriptorsPtr(0, data.image_id1),
                        GetDescriptorsPtr(1, data.image_id2),
+                       load_matcher_index_func1,
+                       load_matcher_index_func2,
                        &data.matches);
       }
 

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -74,6 +74,7 @@ void FeatureMatcherWorker::Run() {
 
   matching_options_.cpu_descriptor_index_cache =
       &cache_->GetFeatureDescriptorIndexCache();
+  THROW_CHECK_NOTNULL(matching_options_.cpu_descriptor_index_cache);
 
   std::unique_ptr<FeatureMatcher> matcher =
       CreateSiftFeatureMatcher(matching_options_);

--- a/src/colmap/controllers/feature_matching_utils.h
+++ b/src/colmap/controllers/feature_matching_utils.h
@@ -66,11 +66,6 @@ class FeatureMatcherWorker : public Thread {
  private:
   void Run() override;
 
-  std::shared_ptr<FeatureKeypoints> GetKeypointsPtr(int index,
-                                                    image_t image_id);
-  std::shared_ptr<FeatureDescriptors> GetDescriptorsPtr(int index,
-                                                        image_t image_id);
-
   SiftMatchingOptions matching_options_;
   TwoViewGeometryOptions geometry_options_;
   FeatureMatcherCache* cache_;
@@ -78,11 +73,6 @@ class FeatureMatcherWorker : public Thread {
   JobQueue<Output>* output_queue_;
 
   std::unique_ptr<OpenGLContextManager> opengl_context_;
-
-  std::array<image_t, 2> prev_keypoints_image_ids_;
-  std::array<std::shared_ptr<FeatureKeypoints>, 2> prev_keypoints_;
-  std::array<image_t, 2> prev_descriptors_image_ids_;
-  std::array<std::shared_ptr<FeatureDescriptors>, 2> prev_descriptors_;
 };
 
 // Multi-threaded and multi-GPU SIFT feature matcher, which writes the computed

--- a/src/colmap/feature/CMakeLists.txt
+++ b/src/colmap/feature/CMakeLists.txt
@@ -49,6 +49,7 @@ COLMAP_ADD_LIBRARY(
     NAME colmap_feature
     SRCS
         extractor.h
+        index.h index.cc
         matcher.h matcher.cc
         pairing.h pairing.cc
         sift.h sift.cc
@@ -75,6 +76,11 @@ if(GPU_ENABLED)
     endif()
 endif()
 
+COLMAP_ADD_TEST(
+    NAME feature_index_test
+    SRCS index_test.cc
+    LINK_LIBS colmap_feature
+)
 COLMAP_ADD_TEST(
     NAME feature_utils_test
     SRCS utils_test.cc

--- a/src/colmap/feature/CMakeLists.txt
+++ b/src/colmap/feature/CMakeLists.txt
@@ -77,12 +77,12 @@ if(GPU_ENABLED)
 endif()
 
 COLMAP_ADD_TEST(
-    NAME feature_index_test
+    NAME index_test
     SRCS index_test.cc
     LINK_LIBS colmap_feature
 )
 COLMAP_ADD_TEST(
-    NAME feature_utils_test
+    NAME utils_test
     SRCS utils_test.cc
     LINK_LIBS colmap_feature
 )

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -1,0 +1,116 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/feature/matcher.h"
+
+#include <flann/flann.hpp>
+
+namespace colmap {
+namespace {
+
+class FlannFeatureDescriptorIndex : public FeatureDescriptorIndex {
+ public:
+  void Build(const FeatureDescriptors& index_descriptors) override {
+    THROW_CHECK_EQ(index_descriptors.cols(), 128);
+    num_index_descriptors_ = index_descriptors.rows();
+    if (num_index_descriptors_ == 0) {
+      // Flann is not happy when the input has no descriptors.
+      index_ = nullptr;
+      return;
+    }
+    const flann::Matrix<uint8_t> descriptors_matrix(
+        const_cast<uint8_t*>(index_descriptors.data()),
+        num_index_descriptors_,
+        index_descriptors.cols());
+    index_ = std::make_unique<FlannIndexType>(
+        descriptors_matrix, flann::KDTreeIndexParams(kNumTreesInForest));
+    index_->buildIndex();
+  }
+
+  void Search(int num_neighbors,
+              const FeatureDescriptors& query_descriptors,
+              Eigen::RowMajorMatrixXi& indices,
+              Eigen::RowMajorMatrixXi& l2_dists) const override {
+    THROW_CHECK_NOTNULL(index_);
+    THROW_CHECK_EQ(query_descriptors.cols(), 128);
+
+    const int num_query_descriptors = query_descriptors.rows();
+    if (num_query_descriptors == 0) {
+      return;
+    }
+
+    const int num_eff_neighbors =
+        std::min(num_neighbors, num_index_descriptors_);
+
+    indices.resize(num_query_descriptors, num_eff_neighbors);
+    l2_dists.resize(num_query_descriptors, num_eff_neighbors);
+    const flann::Matrix<uint8_t> query_matrix(
+        const_cast<uint8_t*>(query_descriptors.data()),
+        num_query_descriptors,
+        query_descriptors.cols());
+
+    flann::Matrix<int> indices_matrix(
+        indices.data(), num_query_descriptors, num_eff_neighbors);
+    std::vector<float> l2_dist_vector(num_query_descriptors *
+                                      num_eff_neighbors);
+    flann::Matrix<float> l2_dist_matrix(
+        l2_dist_vector.data(), num_query_descriptors, num_eff_neighbors);
+    index_->knnSearch(query_matrix,
+                      indices_matrix,
+                      l2_dist_matrix,
+                      num_eff_neighbors,
+                      flann::SearchParams(kNumLeavesToVisit));
+
+    for (int query_idx = 0; query_idx < num_query_descriptors; ++query_idx) {
+      for (int k = 0; k < num_eff_neighbors; ++k) {
+        l2_dists(query_idx, k) = static_cast<int>(
+            std::round(l2_dist_vector[query_idx * num_eff_neighbors + k]));
+      }
+    }
+  }
+
+ private:
+  // Tuned to produce similar results to brute-force matching. If speed is
+  // important, the parameters can be reduced. The biggest speed improvement can
+  // be gained by reducing the number of leaves.
+  constexpr static int kNumTreesInForest = 4;
+  constexpr static int kNumLeavesToVisit = 128;
+
+  using FlannIndexType = flann::Index<flann::L2<uint8_t>>;
+  std::unique_ptr<FlannIndexType> index_;
+  int num_index_descriptors_ = 0;
+};
+
+}  // namespace
+
+std::unique_ptr<FeatureDescriptorIndex> FeatureDescriptorIndex::Create() {
+  return std::make_unique<FlannFeatureDescriptorIndex>();
+}
+
+}  // namespace colmap

--- a/src/colmap/feature/index.h
+++ b/src/colmap/feature/index.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/feature/types.h"
+#include "colmap/util/types.h"
+
+#include <memory>
+
+namespace colmap {
+
+class FeatureDescriptorIndex {
+ public:
+  virtual ~FeatureDescriptorIndex() = default;
+
+  static std::unique_ptr<FeatureDescriptorIndex> Create();
+
+  virtual void Build(const FeatureDescriptors& descriptors) = 0;
+
+  virtual void Search(int num_neighbors,
+                      const FeatureDescriptors& query_descriptors,
+                      Eigen::RowMajorMatrixXi& indices,
+                      Eigen::RowMajorMatrixXi& l2_dists) const = 0;
+};
+
+}  // namespace colmap

--- a/src/colmap/feature/index_test.cc
+++ b/src/colmap/feature/index_test.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/feature/index.h"
+
+#include "colmap/feature/utils.h"
+#include "colmap/math/random.h"
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+FeatureDescriptors CreateRandomFeatureDescriptors(const size_t num_features) {
+  SetPRNGSeed(0);
+  FeatureDescriptorsFloat descriptors(num_features, 128);
+  for (size_t i = 0; i < num_features; ++i) {
+    for (size_t j = 0; j < 128; ++j) {
+      descriptors(i, j) = std::pow(RandomUniformReal(0.0f, 1.0f), 2);
+    }
+  }
+  L2NormalizeFeatureDescriptors(&descriptors);
+  return FeatureDescriptorsToUnsignedByte(descriptors);
+}
+
+TEST(FeatureDescriptorIndex, Nominal) {
+  const FeatureDescriptors index_descriptors =
+      CreateRandomFeatureDescriptors(100);
+  const FeatureDescriptors& query_descriptors = index_descriptors;
+
+  auto index = FeatureDescriptorIndex::Create();
+  index->Build(index_descriptors);
+
+  Eigen::RowMajorMatrixXi indices;
+  Eigen::RowMajorMatrixXi distances;
+  index->Search(/*num_neighbors=*/1, query_descriptors, indices, distances);
+
+  ASSERT_EQ(indices.rows(), query_descriptors.rows());
+  ASSERT_EQ(indices.cols(), 1);
+  ASSERT_EQ(distances.rows(), query_descriptors.rows());
+  ASSERT_EQ(distances.cols(), 1);
+
+  for (int i = 0; i < query_descriptors.rows(); ++i) {
+    EXPECT_EQ(indices(i, 0), i);
+    EXPECT_EQ(distances(i, 0), 0);
+  }
+
+  index->Search(/*num_neighbors=*/2, query_descriptors, indices, distances);
+  ASSERT_EQ(indices.rows(), query_descriptors.rows());
+  ASSERT_EQ(indices.cols(), 2);
+  ASSERT_EQ(distances.rows(), query_descriptors.rows());
+  ASSERT_EQ(distances.cols(), 2);
+
+  for (int i = 0; i < query_descriptors.rows(); ++i) {
+    EXPECT_EQ(indices(i, 0), i);
+    EXPECT_EQ(distances(i, 0), 0);
+    EXPECT_NE(indices(i, 1), i);
+    EXPECT_EQ(distances(i, 1),
+              (query_descriptors.row(i).cast<int>() -
+               index_descriptors.row(indices(i, 1)).cast<int>())
+                  .squaredNorm());
+  }
+
+  index->Search(/*num_neighbors=*/index_descriptors.rows() + 1,
+                query_descriptors,
+                indices,
+                distances);
+  ASSERT_EQ(indices.rows(), query_descriptors.rows());
+  ASSERT_EQ(indices.cols(), index_descriptors.rows());
+  ASSERT_EQ(distances.rows(), query_descriptors.rows());
+  ASSERT_EQ(distances.cols(), index_descriptors.rows());
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -47,12 +47,6 @@ namespace colmap {
 
 class FeatureMatcher {
  public:
-  // Function to load a feature matcher index. This may be used by some matcher
-  // implementations to speedup feature matching by pre-computing search data
-  // structures.
-  using LoadFeatureDescriptorIndexFunc =
-      std::function<std::shared_ptr<FeatureDescriptorIndex>()>;
-
   virtual ~FeatureMatcher() = default;
 
   struct Image {

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/feature/index.h"
 #include "colmap/feature/types.h"
 #include "colmap/geometry/gps.h"
 #include "colmap/scene/camera.h"
@@ -43,21 +44,6 @@
 #include <unordered_map>
 
 namespace colmap {
-
-class FeatureDescriptorIndex {
- public:
-  virtual ~FeatureDescriptorIndex() = default;
-
-  static std::unique_ptr<FeatureDescriptorIndex> Create();
-
-  virtual void Build(const FeatureDescriptors& descriptors) = 0;
-
-  virtual void Search(const FeatureDescriptors& query_descriptors,
-                      const FeatureDescriptors& index_descriptors,
-                      int num_neighbors,
-                      Eigen::RowMajorMatrixXi* indices,
-                      Eigen::RowMajorMatrixXi* distances) const = 0;
-};
 
 class FeatureMatcher {
  public:

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -134,18 +134,18 @@ class FeatureMatcherCache {
  private:
   const size_t cache_size_;
   const std::shared_ptr<Database> database_;
-  std::mutex mutex_;
+  std::mutex database_mutex_;
   std::unordered_map<camera_t, Camera> cameras_cache_;
   std::unordered_map<image_t, Image> images_cache_;
   std::unordered_map<image_t, PosePrior> pose_priors_cache_;
-  std::unique_ptr<LRUCache<image_t, std::shared_ptr<FeatureKeypoints>>>
+  std::unique_ptr<ThreadSafeLRUCache<image_t, FeatureKeypoints>>
       keypoints_cache_;
-  std::unique_ptr<LRUCache<image_t, std::shared_ptr<FeatureDescriptors>>>
+  std::unique_ptr<ThreadSafeLRUCache<image_t, FeatureDescriptors>>
       descriptors_cache_;
-  std::unique_ptr<LRUCache<image_t, std::shared_ptr<FeatureMatcherIndex>>>
+  std::unique_ptr<ThreadSafeLRUCache<image_t, FeatureMatcherIndex>>
       matcher_index_cache_;
-  std::unique_ptr<LRUCache<image_t, bool>> keypoints_exists_cache_;
-  std::unique_ptr<LRUCache<image_t, bool>> descriptors_exists_cache_;
+  std::unique_ptr<ThreadSafeLRUCache<image_t, bool>> keypoints_exists_cache_;
+  std::unique_ptr<ThreadSafeLRUCache<image_t, bool>> descriptors_exists_cache_;
 };
 
 }  // namespace colmap

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -136,10 +136,9 @@ class FeatureMatcherCache {
       keypoints_cache_;
   std::unique_ptr<ThreadSafeLRUCache<image_t, FeatureDescriptors>>
       descriptors_cache_;
-  std::unique_ptr<ThreadSafeLRUCache<image_t, FeatureDescriptorIndex>>
-      descriptor_index_cache_;
   std::unique_ptr<ThreadSafeLRUCache<image_t, bool>> keypoints_exists_cache_;
   std::unique_ptr<ThreadSafeLRUCache<image_t, bool>> descriptors_exists_cache_;
+  ThreadSafeLRUCache<image_t, FeatureDescriptorIndex> descriptor_index_cache_;
 };
 
 }  // namespace colmap

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -1153,12 +1153,10 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
 
  private:
   const SiftMatchingOptions options_;
-  ThreadSafeLRUCache<image_t, FeatureDescriptorIndex>* index_cache_;
   image_t prev_image_id1_ = kInvalidImageId;
   image_t prev_image_id2_ = kInvalidImageId;
   std::shared_ptr<FeatureDescriptorIndex> index1_;
   std::shared_ptr<FeatureDescriptorIndex> index2_;
-  int omp_num_threads_ = -1;
 };
 
 #if defined(COLMAP_GPU_ENABLED)

--- a/src/colmap/feature/sift.h
+++ b/src/colmap/feature/sift.h
@@ -148,7 +148,11 @@ struct SiftMatchingOptions {
   bool guided_matching = false;
 
   // Whether to use brute-force instead of FLANN based CPU matching.
-  bool brute_force_cpu_matcher = false;
+  bool cpu_brute_force_matcher = false;
+
+  // Cache for reusing descriptor index for feature matching.
+  ThreadSafeLRUCache<image_t, FeatureDescriptorIndex>*
+      cpu_descriptor_index_cache = nullptr;
 
   bool Check() const;
 };

--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -322,7 +322,7 @@ TEST(CreateSiftGPUMatcherCUDA, Nominal) {
 }
 
 struct FeatureDescriptorIndexCacheHelper {
-  FeatureDescriptorIndexCacheHelper(
+  explicit FeatureDescriptorIndexCacheHelper(
       const std::vector<FeatureMatcher::Image>& images)
       : index_cache(100, [this](const image_t image_id) {
           auto index = FeatureDescriptorIndex::Create();

--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -266,14 +266,18 @@ TEST(ExtractSiftFeaturesGPU, Nominal) {
 
 FeatureDescriptors CreateRandomFeatureDescriptors(const size_t num_features) {
   SetPRNGSeed(0);
-  FeatureDescriptorsFloat descriptors(num_features, 128);
+  FeatureDescriptorsFloat descriptors_float =
+      FeatureDescriptorsFloat::Zero(num_features, 128);
+  std::vector<int> dims(128);
+  std::iota(dims.begin(), dims.end(), 0);
   for (size_t i = 0; i < num_features; ++i) {
-    for (size_t j = 0; j < 128; ++j) {
-      descriptors(i, j) = std::pow(RandomUniformReal(0.0f, 1.0f), 2);
+    std::shuffle(dims.begin(), dims.end(), *PRNG);
+    for (size_t j = 0; j < 10; ++j) {
+      descriptors_float(i, dims[j]) = 1.0f;
     }
   }
-  L2NormalizeFeatureDescriptors(&descriptors);
-  return FeatureDescriptorsToUnsignedByte(descriptors);
+  L2NormalizeFeatureDescriptors(&descriptors_float);
+  return FeatureDescriptorsToUnsignedByte(descriptors_float);
 }
 
 void CheckEqualMatches(const FeatureMatches& matches1,
@@ -468,7 +472,7 @@ TEST(SiftCPUFeatureMatcherFlannVsBruteForce, Nominal) {
         match_options, descriptors1.topRows(49), descriptors2);
     EXPECT_EQ(num_matches2, 48);
 
-    match_options.max_ratio = 0.5;
+    match_options.max_ratio = 0.6;
     const size_t num_matches3 =
         TestFlannVsBruteForce(match_options, descriptors1, descriptors2);
     EXPECT_EQ(num_matches3, 49);
@@ -707,7 +711,7 @@ TEST(MatchSiftFeaturesCPUvsGPU, Nominal) {
             TestCPUvsGPU(match_options, descriptors1.topRows(49), descriptors2);
         EXPECT_EQ(num_matches2, 48);
 
-        match_options.max_ratio = 0.5;
+        match_options.max_ratio = 0.6;
         const size_t num_matches3 =
             TestCPUvsGPU(match_options, descriptors1, descriptors2);
         EXPECT_EQ(num_matches3, 49);

--- a/src/colmap/mvs/workspace.h
+++ b/src/colmap/mvs/workspace.h
@@ -122,6 +122,7 @@ class CachedWorkspace : public Workspace {
     CachedImage& operator=(CachedImage&& other) noexcept;
     inline size_t NumBytes() const { return num_bytes; }
     size_t num_bytes = 0;
+    std::mutex mutex;
     std::unique_ptr<Bitmap> bitmap;
     std::unique_ptr<DepthMap> depth_map;
     std::unique_ptr<NormalMap> normal_map;

--- a/src/colmap/util/cache.h
+++ b/src/colmap/util/cache.h
@@ -43,47 +43,35 @@
 namespace colmap {
 
 // Least Recently Used cache implementation. Whenever the cache size is
-// exceeded, the least recently used (by Get and GetMutable) is deleted.
+// exceeded, the least recently used (by Get) is deleted.
 template <typename key_t, typename value_t>
 class LRUCache {
  public:
   using LoadFn = std::function<std::shared_ptr<value_t>(const key_t&)>;
 
   LRUCache(size_t max_num_elems, LoadFn load_fn);
-  virtual ~LRUCache() = default;
 
   // The number of elements in the cache.
-  virtual size_t NumElems() const;
-  virtual size_t MaxNumElems() const;
+  size_t NumElems() const;
+  size_t MaxNumElems() const;
 
   // Check whether the element with the given key exists.
-  virtual bool Exists(const key_t& key) const;
+  bool Exists(const key_t& key) const;
 
   // Get the value of an element either from the cache or compute the new value.
-  virtual std::shared_ptr<value_t> Get(const key_t& key);
-
-  // Manually set the value of an element.
-  virtual void Set(const key_t& key, std::shared_ptr<value_t> value);
+  std::shared_ptr<value_t> Get(const key_t& key);
 
   // Manually evict an element from the cache.
   // Returns true if the element was evicted.
-  virtual bool Evict(const key_t& key) {
-    const auto it = elems_map_.find(key);
-    if (it != elems_map_.end()) {
-      elems_list_.erase(it->second);
-      elems_map_.erase(it);
-      return true;
-    }
-    return false;
-  }
+  bool Evict(const key_t& key);
 
   // Pop least recently used element from cache.
-  virtual void Pop();
+  void Pop();
 
   // Clear all elements from cache.
-  virtual void Clear();
+  void Clear();
 
- protected:
+ private:
   typedef typename std::pair<key_t, std::shared_ptr<value_t>> key_value_pair_t;
   typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
 
@@ -100,65 +88,33 @@ class LRUCache {
   const LoadFn load_fn_;
 };
 
-// Least Recently Used cache implementation that is constrained by a maximum
-// memory limitation of its elements. Whenever the memory limit is exceeded, the
-// least recently used (by Get and GetMutable) is deleted. Each element must
-// implement a `size_t NumBytes()` method that returns its size in memory.
+// Thread-safe Least Recently Used cache implementation.
 template <typename key_t, typename value_t>
-class MemoryConstrainedLRUCache : public LRUCache<key_t, value_t> {
+class ThreadSafeLRUCache {
  public:
-  using typename LRUCache<key_t, value_t>::LoadFn;
+  using LoadFn = std::function<std::shared_ptr<value_t>(const key_t&)>;
 
-  MemoryConstrainedLRUCache(size_t max_num_bytes, LoadFn load_fn);
+  ThreadSafeLRUCache(size_t max_num_elems, LoadFn load_fn);
 
-  size_t NumBytes() const;
-  size_t MaxNumBytes() const;
-  void UpdateNumBytes(const key_t& key);
+  // The number of elements in the cache.
+  size_t NumElems() const;
+  size_t MaxNumElems() const;
 
-  bool Evict(const key_t& key) override {
-    elems_num_bytes_.erase(key);
-    return LRUCache<key_t, value_t>::Evict(key);
-  }
+  // Check whether the element with the given key exists.
+  bool Exists(const key_t& key) const;
 
-  void Set(const key_t& key, std::shared_ptr<value_t> value) override;
-  void Pop() override;
-  void Clear() override;
+  // Get the value of an element either from the cache or compute the new value.
+  std::shared_ptr<value_t> Get(const key_t& key);
 
- private:
-  using typename LRUCache<key_t, value_t>::key_value_pair_t;
-  using typename LRUCache<key_t, value_t>::list_iterator_t;
-  using LRUCache<key_t, value_t>::max_num_elems_;
-  using LRUCache<key_t, value_t>::elems_list_;
-  using LRUCache<key_t, value_t>::elems_map_;
-  using LRUCache<key_t, value_t>::load_fn_;
+  // Manually evict an element from the cache.
+  // Returns true if the element was evicted.
+  bool Evict(const key_t& key);
 
-  const size_t max_num_bytes_;
-  size_t num_bytes_;
-  std::unordered_map<key_t, size_t> elems_num_bytes_;
-};
+  // Pop least recently used element from cache.
+  void Pop();
 
-template <typename key_t, typename value_t>
-class ThreadSafeLRUCache : public LRUCache<key_t, value_t> {
- public:
-  using typename LRUCache<key_t, value_t>::LoadFn;
-
-  ThreadSafeLRUCache(size_t max_num_elems, LoadFn load_fn)
-      : cache_(max_num_elems, std::move(load_fn)) {}
-
-  size_t NumElems() const override;
-  size_t MaxNumElems() const override;
-
-  bool Exists(const key_t& key) const override;
-
-  std::shared_ptr<value_t> Get(const key_t& key) override;
-
-  void Set(const key_t& key, std::shared_ptr<value_t> value) override;
-
-  bool Evict(const key_t& key) override;
-
-  void Pop() override;
-
-  void Clear() override;
+  // Clear all elements from cache.
+  void Clear();
 
  protected:
   struct Entry {
@@ -168,7 +124,64 @@ class ThreadSafeLRUCache : public LRUCache<key_t, value_t> {
     bool is_loading = false;
   };
 
-  std::mutex cache_mutex_;
+  // Function to compute new values if not in the cache.
+  const LoadFn load_fn_;
+
+  mutable std::mutex cache_mutex_;
+  LRUCache<key_t, Entry> cache_;
+};
+
+// Least Recently Used cache implementation that is constrained by a maximum
+// memory limitation of its elements. Whenever the memory limit is exceeded, the
+// least recently used (by Get) is deleted. Each element must implement a
+// `size_t NumBytes()` method that returns its size in memory.
+template <typename key_t, typename value_t>
+class MemoryConstrainedLRUCache {
+ public:
+  using LoadFn = std::function<std::shared_ptr<value_t>(const key_t&)>;
+
+  MemoryConstrainedLRUCache(size_t max_num_bytes, LoadFn load_fn);
+
+  // The size in bytes of the elements in the cache.
+  size_t NumBytes() const;
+  size_t MaxNumBytes() const;
+  void UpdateNumBytes(const key_t& key);
+
+  // The number of elements in the cache.
+  size_t NumElems() const;
+  size_t MaxNumElems() const;
+
+  // Check whether the element with the given key exists.
+  bool Exists(const key_t& key) const;
+
+  // Get the value of an element either from the cache or compute the new value.
+  std::shared_ptr<value_t> Get(const key_t& key);
+
+  // Manually evict an element from the cache.
+  // Returns true if the element was evicted.
+  bool Evict(const key_t& key);
+
+  // Pop least recently used element from cache.
+  void Pop();
+
+  // Clear all elements from cache.
+  void Clear();
+
+ private:
+  typedef typename std::pair<key_t, std::shared_ptr<value_t>> key_value_pair_t;
+  typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
+
+  const size_t max_num_bytes_;
+  size_t num_bytes_;
+
+  // List to keep track of the least-recently-used elements.
+  std::list<key_value_pair_t> elems_list_;
+
+  // Mapping from key to (location in list, num_bytes).
+  std::unordered_map<key_t, std::pair<list_iterator_t, size_t>> elems_map_;
+
+  // Function to compute new values if not in the cache.
+  const LoadFn load_fn_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,28 +214,20 @@ template <typename key_t, typename value_t>
 std::shared_ptr<value_t> LRUCache<key_t, value_t>::Get(const key_t& key) {
   const auto it = elems_map_.find(key);
   if (it == elems_map_.end()) {
-    Set(key, load_fn_(key));
-    return elems_map_[key]->second;
+    auto it = elems_map_.find(key);
+    elems_list_.emplace_front(key, load_fn_(key));
+    if (it != elems_map_.end()) {
+      elems_list_.erase(it->second);
+      elems_map_.erase(it);
+    }
+    it = elems_map_.emplace_hint(it, key, elems_list_.begin());
+    if (elems_map_.size() > max_num_elems_) {
+      Pop();
+    }
+    return it->second->second;
   } else {
     elems_list_.splice(elems_list_.begin(), elems_list_, it->second);
     return it->second->second;
-  }
-}
-
-template <typename key_t, typename value_t>
-void LRUCache<key_t, value_t>::Set(const key_t& key,
-                                   std::shared_ptr<value_t> value) {
-  THROW_CHECK_NOTNULL(value);
-
-  auto it = elems_map_.find(key);
-  elems_list_.emplace_front(key, std::move(value));
-  if (it != elems_map_.end()) {
-    elems_list_.erase(it->second);
-    elems_map_.erase(it);
-  }
-  elems_map_.emplace_hint(it, key, elems_list_.begin());
-  if (elems_map_.size() > max_num_elems_) {
-    Pop();
   }
 }
 
@@ -254,79 +259,33 @@ void LRUCache<key_t, value_t>::Clear() {
 }
 
 template <typename key_t, typename value_t>
-MemoryConstrainedLRUCache<key_t, value_t>::MemoryConstrainedLRUCache(
-    const size_t max_num_bytes, LoadFn load_fn)
-    : LRUCache<key_t, value_t>(std::numeric_limits<size_t>::max(),
-                               std::move(load_fn)),
-      max_num_bytes_(max_num_bytes),
-      num_bytes_(0) {
-  THROW_CHECK_GT(max_num_bytes, 0);
+ThreadSafeLRUCache<key_t, value_t>::ThreadSafeLRUCache(
+    const size_t max_num_elems, LoadFn load_fn)
+    : load_fn_(load_fn), cache_(max_num_elems, [](const key_t&) {
+        return std::make_shared<Entry>();
+      }) {
+  THROW_CHECK_NOTNULL(load_fn_);
 }
 
 template <typename key_t, typename value_t>
-size_t MemoryConstrainedLRUCache<key_t, value_t>::NumBytes() const {
-  return num_bytes_;
+size_t ThreadSafeLRUCache<key_t, value_t>::NumElems() const {
+  // TODO: With C++17, we can use std::shared_lock/mutex.
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return cache_.NumElems();
 }
 
 template <typename key_t, typename value_t>
-size_t MemoryConstrainedLRUCache<key_t, value_t>::MaxNumBytes() const {
-  return max_num_bytes_;
+size_t ThreadSafeLRUCache<key_t, value_t>::MaxNumElems() const {
+  // TODO: With C++17, we can use std::shared_lock/mutex.
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return cache_.MaxNumElems();
 }
 
 template <typename key_t, typename value_t>
-void MemoryConstrainedLRUCache<key_t, value_t>::Set(
-    const key_t& key, std::shared_ptr<value_t> value) {
-  THROW_CHECK_NOTNULL(value);
-
-  const size_t num_bytes = value->NumBytes();
-  auto it = elems_map_.find(key);
-  elems_list_.emplace_front(key, std::move(value));
-  if (it != elems_map_.end()) {
-    elems_list_.erase(it->second);
-    elems_map_.erase(it);
-  }
-  elems_map_[key] = elems_list_.begin();
-
-  num_bytes_ += num_bytes;
-  elems_num_bytes_.emplace(key, num_bytes);
-
-  while (num_bytes_ > max_num_bytes_ && elems_map_.size() > 1) {
-    Pop();
-  }
-}
-
-template <typename key_t, typename value_t>
-void MemoryConstrainedLRUCache<key_t, value_t>::Pop() {
-  if (!elems_list_.empty()) {
-    auto last = elems_list_.end();
-    --last;
-    num_bytes_ -= elems_num_bytes_.at(last->first);
-    THROW_CHECK_GE(num_bytes_, 0);
-    elems_num_bytes_.erase(last->first);
-    elems_map_.erase(last->first);
-    elems_list_.pop_back();
-  }
-}
-
-template <typename key_t, typename value_t>
-void MemoryConstrainedLRUCache<key_t, value_t>::UpdateNumBytes(
-    const key_t& key) {
-  auto& num_bytes = elems_num_bytes_.at(key);
-  num_bytes_ -= num_bytes;
-  THROW_CHECK_GE(num_bytes_, 0);
-  num_bytes = LRUCache<key_t, value_t>::Get(key)->NumBytes();
-  num_bytes_ += num_bytes;
-
-  while (num_bytes_ > max_num_bytes_ && elems_map_.size() > 1) {
-    Pop();
-  }
-}
-
-template <typename key_t, typename value_t>
-void MemoryConstrainedLRUCache<key_t, value_t>::Clear() {
-  LRUCache<key_t, value_t>::Clear();
-  num_bytes_ = 0;
-  elems_num_bytes_.clear();
+bool ThreadSafeLRUCache<key_t, value_t>::Exists(const key_t& key) const {
+  // TODO: With C++17, we can use std::shared_lock/mutex.
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return cache_.Exists(key);
 }
 
 template <typename key_t, typename value_t>
@@ -370,21 +329,119 @@ bool ThreadSafeLRUCache<key_t, value_t>::Evict(const key_t& key) {
 }
 
 template <typename key_t, typename value_t>
+void ThreadSafeLRUCache<key_t, value_t>::Pop() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  return cache_.Pop();
+}
+
+template <typename key_t, typename value_t>
 void ThreadSafeLRUCache<key_t, value_t>::Clear() {
   std::lock_guard<std::mutex> lock(cache_mutex_);
   return cache_.Clear();
 }
 
 template <typename key_t, typename value_t>
-int ThreadSafeLRUCache<key_t, value_t>::NumElems() {
-  std::lock_guard<std::mutex> lock(cache_mutex_);
-  return cache_.NumElems();
+MemoryConstrainedLRUCache<key_t, value_t>::MemoryConstrainedLRUCache(
+    const size_t max_num_bytes, LoadFn load_fn)
+    : max_num_bytes_(max_num_bytes),
+      num_bytes_(0),
+      load_fn_(std::move(load_fn)) {
+  THROW_CHECK_NOTNULL(load_fn_);
+  THROW_CHECK_GT(max_num_bytes, 0);
 }
 
 template <typename key_t, typename value_t>
-int ThreadSafeLRUCache<key_t, value_t>::MaxNumElems() {
-  std::lock_guard<std::mutex> lock(cache_mutex_);
-  return cache_.MaxNumElems();
+size_t MemoryConstrainedLRUCache<key_t, value_t>::NumElems() const {
+  return elems_map_.size();
+}
+
+template <typename key_t, typename value_t>
+size_t MemoryConstrainedLRUCache<key_t, value_t>::NumBytes() const {
+  return num_bytes_;
+}
+
+template <typename key_t, typename value_t>
+size_t MemoryConstrainedLRUCache<key_t, value_t>::MaxNumBytes() const {
+  return max_num_bytes_;
+}
+
+template <typename key_t, typename value_t>
+bool MemoryConstrainedLRUCache<key_t, value_t>::Exists(const key_t& key) const {
+  return elems_map_.find(key) != elems_map_.end();
+}
+
+template <typename key_t, typename value_t>
+std::shared_ptr<value_t> MemoryConstrainedLRUCache<key_t, value_t>::Get(
+    const key_t& key) {
+  const auto it = elems_map_.find(key);
+  if (it == elems_map_.end()) {
+    std::shared_ptr<value_t> value = load_fn_(key);
+    const size_t num_bytes = value->NumBytes();
+    auto it = elems_map_.find(key);
+    elems_list_.emplace_front(key, std::move(value));
+    if (it != elems_map_.end()) {
+      elems_list_.erase(it->second.first);
+      elems_map_.erase(it);
+    }
+    it = elems_map_.emplace_hint(
+        it, key, std::make_pair(elems_list_.begin(), num_bytes));
+
+    num_bytes_ += num_bytes;
+    while (num_bytes_ > max_num_bytes_ && elems_map_.size() > 1) {
+      Pop();
+    }
+
+    return it->second.first->second;
+  } else {
+    elems_list_.splice(elems_list_.begin(), elems_list_, it->second.first);
+    return it->second.first->second;
+  }
+}
+
+template <typename key_t, typename value_t>
+bool MemoryConstrainedLRUCache<key_t, value_t>::Evict(const key_t& key) {
+  const auto it = elems_map_.find(key);
+  if (it != elems_map_.end()) {
+    num_bytes_ -= it->second.second;
+    elems_list_.erase(it->second.first);
+    elems_map_.erase(it);
+    return true;
+  }
+  return false;
+}
+
+template <typename key_t, typename value_t>
+void MemoryConstrainedLRUCache<key_t, value_t>::Pop() {
+  if (!elems_list_.empty()) {
+    auto last = elems_list_.end();
+    --last;
+    const auto it = elems_map_.find(last->first);
+    num_bytes_ -= it->second.second;
+    THROW_CHECK_GE(num_bytes_, 0);
+    elems_map_.erase(it);
+    elems_list_.pop_back();
+  }
+}
+
+template <typename key_t, typename value_t>
+void MemoryConstrainedLRUCache<key_t, value_t>::UpdateNumBytes(
+    const key_t& key) {
+  size_t& num_bytes = elems_map_.at(key).second;
+  num_bytes_ -= num_bytes;
+  THROW_CHECK_GE(num_bytes_, 0);
+  num_bytes = Get(key)->NumBytes();
+  num_bytes_ += num_bytes;
+
+  while (num_bytes_ > max_num_bytes_ && elems_map_.size() > 1) {
+    Pop();
+  }
+}
+
+template <typename key_t, typename value_t>
+void MemoryConstrainedLRUCache<key_t, value_t>::Clear() {
+  elems_list_.clear();
+  elems_map_.clear();
+  num_bytes_ = 0;
 }
 
 }  // namespace colmap

--- a/src/colmap/util/cache_test.cc
+++ b/src/colmap/util/cache_test.cc
@@ -35,64 +35,33 @@ namespace colmap {
 namespace {
 
 TEST(LRUCache, Empty) {
-  LRUCache<int, int> cache(5, [](const int key) { return key; });
+  LRUCache<int, int> cache(
+      5, [](const int key) { return std::make_shared<int>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   EXPECT_EQ(cache.MaxNumElems(), 5);
 }
 
 TEST(LRUCache, Get) {
-  LRUCache<int, int> cache(5, [](const int key) { return key; });
+  LRUCache<int, int> cache(
+      5, [](const int key) { return std::make_shared<int>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i), i);
+    EXPECT_EQ(*cache.Get(i), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
 
-  EXPECT_EQ(cache.Get(5), 5);
+  EXPECT_EQ(*cache.Get(5), 5);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
 
-  EXPECT_EQ(cache.Get(5), 5);
+  EXPECT_EQ(*cache.Get(5), 5);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
 
-  EXPECT_EQ(cache.Get(6), 6);
-  EXPECT_EQ(cache.NumElems(), 5);
-  EXPECT_FALSE(cache.Exists(0));
-  EXPECT_FALSE(cache.Exists(1));
-  EXPECT_TRUE(cache.Exists(6));
-}
-
-TEST(LRUCache, GetMutable) {
-  LRUCache<int, int> cache(5, [](const int key) { return key; });
-  EXPECT_EQ(cache.NumElems(), 0);
-  for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.GetMutable(i), i);
-    EXPECT_EQ(cache.NumElems(), i + 1);
-    EXPECT_TRUE(cache.Exists(i));
-  }
-
-  EXPECT_EQ(cache.GetMutable(5), 5);
-  EXPECT_EQ(cache.NumElems(), 5);
-  EXPECT_FALSE(cache.Exists(0));
-  EXPECT_TRUE(cache.Exists(5));
-
-  EXPECT_EQ(cache.GetMutable(5), 5);
-  EXPECT_EQ(cache.NumElems(), 5);
-  EXPECT_FALSE(cache.Exists(0));
-  EXPECT_TRUE(cache.Exists(5));
-
-  EXPECT_EQ(cache.GetMutable(6), 6);
-  EXPECT_EQ(cache.NumElems(), 5);
-  EXPECT_FALSE(cache.Exists(0));
-  EXPECT_FALSE(cache.Exists(1));
-  EXPECT_TRUE(cache.Exists(6));
-
-  cache.GetMutable(6) = 66;
-  EXPECT_EQ(cache.GetMutable(6), 66);
+  EXPECT_EQ(*cache.Get(6), 6);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_FALSE(cache.Exists(1));
@@ -100,20 +69,21 @@ TEST(LRUCache, GetMutable) {
 }
 
 TEST(LRUCache, Set) {
-  LRUCache<int, int> cache(5, [](const int key) { return -1; });
+  LRUCache<int, int> cache(
+      5, [](const int key) { return std::make_shared<int>(-1); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    cache.Set(i, i);
+    cache.Set(i, std::make_shared<int>(i));
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
 
-  EXPECT_EQ(cache.Get(5), -1);
+  EXPECT_EQ(*cache.Get(5), -1);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
 
-  EXPECT_EQ(cache.Get(6), -1);
+  EXPECT_EQ(*cache.Get(6), -1);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_FALSE(cache.Exists(1));
@@ -121,15 +91,16 @@ TEST(LRUCache, Set) {
 }
 
 TEST(LRUCache, Pop) {
-  LRUCache<int, int> cache(5, [](const int key) { return key; });
+  LRUCache<int, int> cache(
+      5, [](const int key) { return std::make_shared<int>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i), i);
+    EXPECT_EQ(*cache.Get(i), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
 
-  EXPECT_EQ(cache.Get(5), 5);
+  EXPECT_EQ(*cache.Get(5), 5);
   EXPECT_EQ(cache.NumElems(), 5);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
@@ -149,10 +120,11 @@ TEST(LRUCache, Pop) {
 }
 
 TEST(LRUCache, Clear) {
-  LRUCache<int, int> cache(5, [](const int key) { return key; });
+  LRUCache<int, int> cache(
+      5, [](const int key) { return std::make_shared<int>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i), i);
+    EXPECT_EQ(*cache.Get(i), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
@@ -160,7 +132,7 @@ TEST(LRUCache, Clear) {
   cache.Clear();
   EXPECT_EQ(cache.NumElems(), 0);
 
-  EXPECT_EQ(cache.Get(0), 0);
+  EXPECT_EQ(*cache.Get(0), 0);
   EXPECT_EQ(cache.NumElems(), 1);
   EXPECT_TRUE(cache.Exists(0));
 }
@@ -173,7 +145,7 @@ struct SizedElem {
 
 TEST(MemoryConstrainedLRUCache, Empty) {
   MemoryConstrainedLRUCache<int, SizedElem> cache(
-      5, [](const int key) { return SizedElem(key); });
+      5, [](const int key) { return std::make_shared<SizedElem>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   EXPECT_EQ(cache.MaxNumElems(), std::numeric_limits<size_t>::max());
   EXPECT_EQ(cache.NumBytes(), 0);
@@ -182,34 +154,34 @@ TEST(MemoryConstrainedLRUCache, Empty) {
 
 TEST(MemoryConstrainedLRUCache, Get) {
   MemoryConstrainedLRUCache<int, SizedElem> cache(
-      10, [](const int key) { return SizedElem(key); });
+      10, [](const int key) { return std::make_shared<SizedElem>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i).NumBytes(), i);
+    EXPECT_EQ(cache.Get(i)->NumBytes(), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
 
-  EXPECT_EQ(cache.Get(5).NumBytes(), 5);
+  EXPECT_EQ(cache.Get(5)->NumBytes(), 5);
   EXPECT_EQ(cache.NumElems(), 2);
   EXPECT_EQ(cache.NumBytes(), 9);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
 
-  EXPECT_EQ(cache.Get(5).NumBytes(), 5);
+  EXPECT_EQ(cache.Get(5)->NumBytes(), 5);
   EXPECT_EQ(cache.NumElems(), 2);
   EXPECT_EQ(cache.NumBytes(), 9);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_TRUE(cache.Exists(5));
 
-  EXPECT_EQ(cache.Get(6).NumBytes(), 6);
+  EXPECT_EQ(cache.Get(6)->NumBytes(), 6);
   EXPECT_EQ(cache.NumElems(), 1);
   EXPECT_EQ(cache.NumBytes(), 6);
   EXPECT_FALSE(cache.Exists(0));
   EXPECT_FALSE(cache.Exists(1));
   EXPECT_TRUE(cache.Exists(6));
 
-  EXPECT_EQ(cache.Get(1).NumBytes(), 1);
+  EXPECT_EQ(cache.Get(1)->NumBytes(), 1);
   EXPECT_EQ(cache.NumElems(), 2);
   EXPECT_EQ(cache.NumBytes(), 7);
   EXPECT_FALSE(cache.Exists(0));
@@ -219,10 +191,10 @@ TEST(MemoryConstrainedLRUCache, Get) {
 
 TEST(MemoryConstrainedLRUCache, Clear) {
   MemoryConstrainedLRUCache<int, SizedElem> cache(
-      10, [](const int key) { return SizedElem(key); });
+      10, [](const int key) { return std::make_shared<SizedElem>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i).NumBytes(), i);
+    EXPECT_EQ(cache.Get(i)->NumBytes(), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
@@ -231,7 +203,7 @@ TEST(MemoryConstrainedLRUCache, Clear) {
   EXPECT_EQ(cache.NumElems(), 0);
   EXPECT_EQ(cache.NumBytes(), 0);
 
-  EXPECT_EQ(cache.Get(1).NumBytes(), 1);
+  EXPECT_EQ(cache.Get(1)->NumBytes(), 1);
   EXPECT_EQ(cache.NumBytes(), 1);
   EXPECT_EQ(cache.NumElems(), 1);
   EXPECT_TRUE(cache.Exists(1));
@@ -239,34 +211,34 @@ TEST(MemoryConstrainedLRUCache, Clear) {
 
 TEST(MemoryConstrainedLRUCache, UpdateNumBytes) {
   MemoryConstrainedLRUCache<int, SizedElem> cache(
-      50, [](const int key) { return SizedElem(key); });
+      50, [](const int key) { return std::make_shared<SizedElem>(key); });
   EXPECT_EQ(cache.NumElems(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(cache.Get(i).NumBytes(), i);
+    EXPECT_EQ(cache.Get(i)->NumBytes(), i);
     EXPECT_EQ(cache.NumElems(), i + 1);
     EXPECT_TRUE(cache.Exists(i));
   }
 
   EXPECT_EQ(cache.NumBytes(), 10);
 
-  cache.GetMutable(4).num_bytes = 3;
+  cache.Get(4)->num_bytes = 3;
   EXPECT_EQ(cache.NumBytes(), 10);
   cache.UpdateNumBytes(4);
   EXPECT_EQ(cache.NumBytes(), 9);
 
-  cache.GetMutable(2).num_bytes = 3;
+  cache.Get(2)->num_bytes = 3;
   EXPECT_EQ(cache.NumBytes(), 9);
   cache.UpdateNumBytes(2);
   EXPECT_EQ(cache.NumBytes(), 10);
 
-  cache.GetMutable(0).num_bytes = 40;
+  cache.Get(0)->num_bytes = 40;
   EXPECT_EQ(cache.NumBytes(), 10);
   cache.UpdateNumBytes(0);
   EXPECT_EQ(cache.NumBytes(), 50);
 
   cache.Clear();
   EXPECT_EQ(cache.NumBytes(), 0);
-  EXPECT_EQ(cache.Get(2).NumBytes(), 2);
+  EXPECT_EQ(cache.Get(2)->NumBytes(), 2);
   EXPECT_EQ(cache.NumBytes(), 2);
 }
 

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -60,12 +60,13 @@ typedef unsigned __int64 uint64_t;
 
 namespace Eigen {
 
-typedef Eigen::Matrix<float, 3, 4> Matrix3x4f;
-typedef Eigen::Matrix<double, 3, 4> Matrix3x4d;
-typedef Eigen::Matrix<double, 6, 6> Matrix6d;
-typedef Eigen::Matrix<uint8_t, 3, 1> Vector3ub;
-typedef Eigen::Matrix<uint8_t, 4, 1> Vector4ub;
-typedef Eigen::Matrix<double, 6, 1> Vector6d;
+using Matrix3x4f = Matrix<float, 3, 4>;
+using Matrix3x4d = Matrix<double, 3, 4>;
+using Matrix6d = Matrix<double, 6, 6>;
+using Vector3ub = Matrix<uint8_t, 3, 1>;
+using Vector4ub = Matrix<uint8_t, 4, 1>;
+using Vector6d = Matrix<double, 6, 1>;
+using RowMajorMatrixXi = Matrix<int, Dynamic, Dynamic, RowMajor>;
 
 }  // namespace Eigen
 


### PR DESCRIPTION
* Simplifies the caching logic for both CPU and GPU based matching.
* Introduces a new thread-safe LRU cache that allows to efficiently cache the FLANN-based descriptor index for CPU-based matching. As a result, CPU-based matching speed improves by ~20-30%.
* Extracts the FLANN-based descriptor index as a separate interface and adds test coverage.
* Fixes a race-condition in the dense reconstruction workspace cache.