### PR TITLE
Add CUDA-based dense BA solver

### DIFF
--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -119,6 +119,8 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
   options.loss_function_scale = 1.0;
   options.loss_function_type =
       BundleAdjustmentOptions::LossFunctionType::SOFT_L1;
+  options.use_gpu = ba_use_gpu;
+  options.gpu_index = ba_gpu_index;
   return options;
 }
 

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -114,8 +114,8 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
   options.refine_focal_length = ba_refine_focal_length;
   options.refine_principal_point = ba_refine_principal_point;
   options.refine_extra_params = ba_refine_extra_params;
-  options.min_num_residuals_for_multi_threading =
-      ba_min_num_residuals_for_multi_threading;
+  options.min_num_residuals_for_cpu_multi_threading =
+      ba_min_num_residuals_for_cpu_multi_threading;
   options.loss_function_scale = 1.0;
   options.loss_function_type =
       BundleAdjustmentOptions::LossFunctionType::SOFT_L1;
@@ -146,8 +146,8 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
   options.refine_focal_length = ba_refine_focal_length;
   options.refine_principal_point = ba_refine_principal_point;
   options.refine_extra_params = ba_refine_extra_params;
-  options.min_num_residuals_for_multi_threading =
-      ba_min_num_residuals_for_multi_threading;
+  options.min_num_residuals_for_cpu_multi_threading =
+      ba_min_num_residuals_for_cpu_multi_threading;
   options.loss_function_type =
       BundleAdjustmentOptions::LossFunctionType::TRIVIAL;
   options.use_gpu = ba_use_gpu;

--- a/src/colmap/controllers/incremental_mapper.h
+++ b/src/colmap/controllers/incremental_mapper.h
@@ -86,7 +86,7 @@ struct IncrementalPipelineOptions {
 
   // The minimum number of residuals per bundle adjustment problem to
   // enable multi-threading solving of the problems.
-  int ba_min_num_residuals_for_multi_threading = 50000;
+  int ba_min_num_residuals_for_cpu_multi_threading = 50000;
 
   // The number of images to optimize in local bundle adjustment.
   int ba_local_num_images = 6;

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -474,15 +474,23 @@ void OptionManager::AddBundleAdjustmentOptions() {
                               &bundle_adjustment->use_gpu);
   AddAndRegisterDefaultOption("BundleAdjustment.gpu_index",
                               &bundle_adjustment->gpu_index);
+  AddAndRegisterDefaultOption("BundleAdjustment.min_num_images_gpu_solver",
+                              &bundle_adjustment->min_num_images_gpu_solver);
   AddAndRegisterDefaultOption(
-      "BundleAdjustment.min_num_residuals_for_multi_threading",
-      &bundle_adjustment->min_num_residuals_for_multi_threading);
+      "BundleAdjustment.min_num_residuals_for_cpu_multi_threading",
+      &bundle_adjustment->min_num_residuals_for_cpu_multi_threading);
   AddAndRegisterDefaultOption(
-      "BundleAdjustment.max_num_images_direct_dense_solver",
-      &bundle_adjustment->max_num_images_direct_dense_solver);
+      "BundleAdjustment.max_num_images_direct_dense_cpu_solver",
+      &bundle_adjustment->max_num_images_direct_dense_cpu_solver);
   AddAndRegisterDefaultOption(
-      "BundleAdjustment.max_num_images_direct_sparse_solver",
-      &bundle_adjustment->max_num_images_direct_sparse_solver);
+      "BundleAdjustment.max_num_images_direct_sparse_cpu_solver",
+      &bundle_adjustment->max_num_images_direct_sparse_cpu_solver);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.max_num_images_direct_dense_gpu_solver",
+      &bundle_adjustment->max_num_images_direct_dense_gpu_solver);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.max_num_images_direct_sparse_gpu_solver",
+      &bundle_adjustment->max_num_images_direct_sparse_gpu_solver);
 }
 
 void OptionManager::AddMapperOptions() {
@@ -519,9 +527,6 @@ void OptionManager::AddMapperOptions() {
                               &mapper->ba_refine_principal_point);
   AddAndRegisterDefaultOption("Mapper.ba_refine_extra_params",
                               &mapper->ba_refine_extra_params);
-  AddAndRegisterDefaultOption(
-      "Mapper.ba_min_num_residuals_for_multi_threading",
-      &mapper->ba_min_num_residuals_for_multi_threading);
   AddAndRegisterDefaultOption("Mapper.ba_local_num_images",
                               &mapper->ba_local_num_images);
   AddAndRegisterDefaultOption("Mapper.ba_local_function_tolerance",
@@ -550,6 +555,9 @@ void OptionManager::AddMapperOptions() {
                               &mapper->ba_local_max_refinement_change);
   AddAndRegisterDefaultOption("Mapper.ba_use_gpu", &mapper->ba_use_gpu);
   AddAndRegisterDefaultOption("Mapper.ba_gpu_index", &mapper->ba_gpu_index);
+  AddAndRegisterDefaultOption(
+      "Mapper.ba_min_num_residuals_for_cpu_multi_threading",
+      &mapper->ba_min_num_residuals_for_cpu_multi_threading);
   AddAndRegisterDefaultOption("Mapper.snapshot_path", &mapper->snapshot_path);
   AddAndRegisterDefaultOption("Mapper.snapshot_images_freq",
                               &mapper->snapshot_images_freq);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -65,8 +65,10 @@ ceres::LossFunction* BundleAdjustmentOptions::CreateLossFunction() const {
 
 bool BundleAdjustmentOptions::Check() const {
   CHECK_OPTION_GE(loss_function_scale, 0);
-  CHECK_OPTION_LT(max_num_images_direct_dense_solver,
-                  max_num_images_direct_sparse_solver);
+  CHECK_OPTION_LT(max_num_images_direct_dense_cpu_solver,
+                  max_num_images_direct_sparse_cpu_solver);
+  CHECK_OPTION_LT(max_num_images_direct_dense_gpu_solver,
+                  max_num_images_direct_sparse_gpu_solver);
   return true;
 }
 
@@ -337,21 +339,41 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
     solver_options.logging_type = ceres::LoggingType::PER_MINIMIZER_ITERATION;
   }
 
+  const int num_images = config_.NumImages();
   const bool has_sparse =
       solver_options.sparse_linear_algebra_library_type != ceres::NO_SPARSE;
 
-  const int num_images = config_.NumImages();
-  if (num_images <= options_.max_num_images_direct_dense_solver) {
+  int max_num_images_direct_dense_solver =
+      options_.max_num_images_direct_dense_cpu_solver;
+  int max_num_images_direct_sparse_solver =
+      options_.max_num_images_direct_sparse_cpu_solver;
+#if (CERES_VERSION_MAJOR >= 3 ||                                \
+     (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
+    !defined(CERES_NO_CUDSS) && defined(COLMAP_CUDA_ENABLED)
+  if (options_.use_gpu && num_images >= options_.min_num_images_gpu_solver) {
+    const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
+    THROW_CHECK_GT(gpu_indices.size(), 0);
+    SetBestCudaDevice(gpu_indices[0]);
+    solver_options.dense_linear_algebra_library_type = ceres::CUDA;
+    solver_options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+    max_num_images_direct_dense_solver =
+        options_.max_num_images_direct_dense_gpu_solver;
+    max_num_images_direct_sparse_solver =
+        options_.max_num_images_direct_sparse_gpu_solver;
+  }
+#endif
+
+  if (num_images <= max_num_images_direct_dense_solver) {
     solver_options.linear_solver_type = ceres::DENSE_SCHUR;
-  } else if (num_images <= options_.max_num_images_direct_sparse_solver &&
-             has_sparse) {
+  } else if (has_sparse && num_images <= max_num_images_direct_sparse_solver) {
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
   } else {  // Indirect sparse (preconditioned CG) solver.
     solver_options.linear_solver_type = ceres::ITERATIVE_SCHUR;
     solver_options.preconditioner_type = ceres::SCHUR_JACOBI;
   }
 
-  if (problem.NumResiduals() < options_.min_num_residuals_for_multi_threading) {
+  if (problem.NumResiduals() <
+      options_.min_num_residuals_for_cpu_multi_threading) {
     solver_options.num_threads = 1;
 #if CERES_VERSION_MAJOR < 2
     solver_options.num_linear_solver_threads = 1;
@@ -364,18 +386,6 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
         GetEffectiveNumThreads(solver_options.num_linear_solver_threads);
 #endif  // CERES_VERSION_MAJOR
   }
-
-#if (CERES_VERSION_MAJOR >= 3 ||                                \
-     (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
-    !defined(CERES_NO_CUDSS) && defined(COLMAP_CUDA_ENABLED)
-  if (options_.use_gpu) {
-    const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
-    THROW_CHECK_GT(gpu_indices.size(), 0);
-    SetBestCudaDevice(gpu_indices[0]);
-    solver_options.dense_linear_algebra_library_type = ceres::CUDA;
-    solver_options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
-  }
-#endif
 
   std::string solver_error;
   THROW_CHECK(solver_options.IsValid(&solver_error)) << solver_error;

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -64,19 +64,27 @@ struct BundleAdjustmentOptions {
   // Whether to print a final summary.
   bool print_summary = true;
 
-  // Whether to use Ceres' CUDA sparse linear algebra library, if available.
+  // Whether to use Ceres' CUDA linear algebra library, if available.
   bool use_gpu = false;
   std::string gpu_index = "-1";
 
-  // Minimum number of residuals to enable multi-threading. Note that
-  // single-threaded is typically better for small bundle adjustment problems
-  // due to the overhead of threading.
-  int min_num_residuals_for_multi_threading = 50000;
+  // Heuristic threshold to switch from CPU to GPU based solvers.
+  // Typically, the GPU is faster for large problems but the overhead of
+  // transferring memory from the CPU to the GPU leads to better CPU performance
+  // for small problems. This depends on the specific problem and hardware.
+  int min_num_images_gpu_solver = 50;
+
+  // Heuristic threshold on the minimum number of residuals to enable
+  // multi-threading. Note that single-threaded is typically better for small
+  // bundle adjustment problems due to the overhead of threading.
+  int min_num_residuals_for_cpu_multi_threading = 50000;
 
   // Heuristic thresholds to switch between direct, sparse, and iterative
   // solvers. These thresholds may not be optimal for all types of problems.
-  int max_num_images_direct_dense_solver = 50;
-  int max_num_images_direct_sparse_solver = 1000;
+  int max_num_images_direct_dense_cpu_solver = 50;
+  int max_num_images_direct_sparse_cpu_solver = 1000;
+  int max_num_images_direct_dense_gpu_solver = 200;
+  int max_num_images_direct_sparse_gpu_solver = 4000;
 
   // Ceres-Solver options.
   ceres::Solver::Options solver_options;

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -67,6 +67,22 @@ void BindBundleAdjuster(py::module& m) {
           .def_readwrite("min_num_images_gpu_solver",
                          &BAOpts::min_num_images_gpu_solver,
                          "Minimum number of images to use the GPU solver.")
+          .def_readwrite("max_num_images_direct_dense_cpu_solver",
+                         &BAOpts::max_num_images_direct_dense_cpu_solver,
+                         "Threshold to switch between direct, sparse, and "
+                         "iterative solvers.")
+          .def_readwrite("max_num_images_direct_sparse_cpu_solver",
+                         &BAOpts::max_num_images_direct_sparse_cpu_solver,
+                         "Threshold to switch between direct, sparse, and "
+                         "iterative solvers.")
+          .def_readwrite("max_num_images_direct_dense_gpu_solver",
+                         &BAOpts::max_num_images_direct_dense_gpu_solver,
+                         "Threshold to switch between direct, sparse, and "
+                         "iterative solvers.")
+          .def_readwrite("max_num_images_direct_sparse_gpu_solver",
+                         &BAOpts::max_num_images_direct_sparse_gpu_solver,
+                         "Threshold to switch between direct, sparse, and "
+                         "iterative solvers.")
           .def_readwrite(
               "solver_options",
               &BAOpts::solver_options,

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -51,18 +51,27 @@ void BindBundleAdjuster(py::module& m) {
           .def_readwrite("print_summary",
                          &BAOpts::print_summary,
                          "Whether to print a final summary.")
-          .def_readwrite("min_num_residuals_for_multi_threading",
-                         &BAOpts::min_num_residuals_for_multi_threading,
-                         "Minimum number of residuals to enable "
-                         "multi-threading. Note that "
-                         "single-threaded is typically better for small bundle "
-                         "adjustment problems "
-                         "due to the overhead of threading. ")
+          .def_readwrite("use_gpu",
+                         &BAOpts::use_gpu,
+                         "Whether to use Ceres' CUDA linear algebra library, "
+                         "if available.")
+          .def_readwrite("gpu_index",
+                         &BAOpts::gpu_index,
+                         "Which GPU to use for solving the problem.")
+          .def_readwrite(
+              "min_num_residuals_for_cpu_multi_threading",
+              &BAOpts::min_num_residuals_for_cpu_multi_threading,
+              "Minimum number of residuals to enable multi-threading. Note "
+              "that single-threaded is typically better for small bundle "
+              "adjustment problems due to the overhead of threading.")
+          .def_readwrite("min_num_images_gpu_solver",
+                         &BAOpts::min_num_images_gpu_solver,
+                         "Minimum number of images to use the GPU solver.")
           .def_readwrite(
               "solver_options",
               &BAOpts::solver_options,
               "Ceres-Solver options. To be able to use this feature "
-              "one needs to install pyceres and import it beforehand. ");
+              "one needs to install pyceres and import it beforehand.");
   MakeDataclass(PyBundleAdjustmentOptions);
 
   using BACfg = BundleAdjustmentConfig;

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -86,8 +86,8 @@ void BindIncrementalPipeline(py::module& m) {
           &Opts::ba_refine_extra_params,
           "Which intrinsic parameters to optimize during the reconstruction.")
       .def_readwrite(
-          "ba_min_num_residuals_for_multi_threading",
-          &Opts::ba_min_num_residuals_for_multi_threading,
+          "ba_min_num_residuals_for_cpu_multi_threading",
+          &Opts::ba_min_num_residuals_for_cpu_multi_threading,
           "The minimum number of residuals per bundle adjustment problem to "
           "enable multi-threading solving of the problems.")
       .def_readwrite(


### PR DESCRIPTION
* Adds support for using Ceres' CUDA based dense solver for BA.
* Adds some initial heuristic thresholds to switch between CPU and GPU based solvers.
* GPU-based solvers are still disabled by default and require explicit enabling through e.g. `--Mapper.ba_use_gpu` or `--BundleAdjustment.use_gpu`.
* The heuristic thresholds would benefit from a more sophisticated tuning based on CPU/GPU capability. Not sure if feasible.