### PR TITLE
Add callbacks by move

### DIFF
--- a/src/colmap/util/base_controller.cc
+++ b/src/colmap/util/base_controller.cc
@@ -35,11 +35,10 @@ namespace colmap {
 
 BaseController::BaseController() {}
 
-void BaseController::AddCallback(const int id,
-                                 const std::function<void()>& func) {
+void BaseController::AddCallback(const int id, std::function<void()> func) {
   CHECK(func);
   CHECK_GT(callbacks_.count(id), 0) << "Callback not registered";
-  callbacks_.at(id).push_back(func);
+  callbacks_.at(id).push_back(std::move(func));
 }
 
 void BaseController::RegisterCallback(const int id) {
@@ -53,8 +52,8 @@ void BaseController::Callback(const int id) const {
   }
 }
 
-void BaseController::SetCheckIfStoppedFunc(const std::function<bool()>& func) {
-  check_if_stopped_fn_ = func;
+void BaseController::SetCheckIfStoppedFunc(std::function<bool()> func) {
+  check_if_stopped_fn_ = std::move(func);
 }
 
 bool BaseController::CheckIfStopped() {

--- a/src/colmap/util/base_controller.h
+++ b/src/colmap/util/base_controller.h
@@ -45,7 +45,7 @@ class BaseController {
   virtual ~BaseController() = default;
 
   // Set callbacks that can be triggered within the main run function.
-  void AddCallback(int id, const std::function<void()>& func);
+  void AddCallback(int id, std::function<void()> func);
 
   // Call back to the function with the specified name, if it exists.
   void Callback(int id) const;
@@ -57,7 +57,7 @@ class BaseController {
   virtual void Run() = 0;
 
   // check if the thread is stopped
-  void SetCheckIfStoppedFunc(const std::function<bool()>& func);
+  void SetCheckIfStoppedFunc(std::function<bool()> func);
   bool CheckIfStopped();
 
  protected:

--- a/src/colmap/util/threading.cc
+++ b/src/colmap/util/threading.cc
@@ -112,10 +112,10 @@ bool Thread::IsFinished() {
   return finished_;
 }
 
-void Thread::AddCallback(const int id, const std::function<void()>& func) {
+void Thread::AddCallback(const int id, std::function<void()> func) {
   THROW_CHECK(func);
   THROW_CHECK_GT(callbacks_.count(id), 0) << "Callback not registered";
-  callbacks_.at(id).push_back(func);
+  callbacks_.at(id).push_back(std::move(func));
 }
 
 void Thread::RegisterCallback(const int id) {

--- a/src/colmap/util/threading.h
+++ b/src/colmap/util/threading.h
@@ -130,7 +130,7 @@ class Thread {
   bool CheckValidSetup();
 
   // Set callbacks that can be triggered within the main run function.
-  void AddCallback(int id, const std::function<void()>& func);
+  void AddCallback(int id, std::function<void()> func);
 
   // Get timing information of the thread, properly accounting for pause times.
   const Timer& GetTimer() const;

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -64,15 +64,16 @@ std::map<size_t, std::shared_ptr<Reconstruction>> IncrementalMapping(
       options_, image_path, database_path, reconstruction_manager);
 
   PyInterrupt py_interrupt(1.0);  // Check for interrupts every second
-  mapper.AddCallback(IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK,
-                     [next_image_callback = std::move(next_image_callback)]() {
-                       if (py_interrupt.Raised()) {
-                         throw py::error_already_set();
-                       }
-                       if (next_image_callback) {
-                         next_image_callback();
-                       }
-                     });
+  mapper.AddCallback(
+      IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK,
+      [&py_interrupt, next_image_callback = std::move(next_image_callback)]() {
+        if (py_interrupt.Raised()) {
+          throw py::error_already_set();
+        }
+        if (next_image_callback) {
+          next_image_callback();
+        }
+      });
   if (initial_image_pair_callback) {
     mapper.AddCallback(IncrementalPipeline::INITIAL_IMAGE_PAIR_REG_CALLBACK,
                        std::move(initial_image_pair_callback));

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -48,8 +48,8 @@ std::map<size_t, std::shared_ptr<Reconstruction>> IncrementalMapping(
     const std::string& output_path,
     const IncrementalPipelineOptions& options,
     const std::string& input_path,
-    const std::function<void()>& initial_image_pair_callback,
-    const std::function<void()>& next_image_callback) {
+    std::function<void()> initial_image_pair_callback,
+    std::function<void()> next_image_callback) {
   THROW_CHECK_FILE_EXISTS(database_path);
   THROW_CHECK_DIR_EXISTS(image_path);
   CreateDirIfNotExists(output_path);
@@ -64,17 +64,18 @@ std::map<size_t, std::shared_ptr<Reconstruction>> IncrementalMapping(
       options_, image_path, database_path, reconstruction_manager);
 
   PyInterrupt py_interrupt(1.0);  // Check for interrupts every second
-  mapper.AddCallback(IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK, [&]() {
-    if (py_interrupt.Raised()) {
-      throw py::error_already_set();
-    }
-    if (next_image_callback) {
-      next_image_callback();
-    }
-  });
+  mapper.AddCallback(IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK,
+                     [next_image_callback = std::move(next_image_callback)]() {
+                       if (py_interrupt.Raised()) {
+                         throw py::error_already_set();
+                       }
+                       if (next_image_callback) {
+                         next_image_callback();
+                       }
+                     });
   if (initial_image_pair_callback) {
     mapper.AddCallback(IncrementalPipeline::INITIAL_IMAGE_PAIR_REG_CALLBACK,
-                       initial_image_pair_callback);
+                       std::move(initial_image_pair_callback));
   }
 
   mapper.Run();


### PR DESCRIPTION
Callable objects can be expensive to copy. This enables the callsite to add callbacks by move. No change of behavior for existing callsites.