### PR TITLE
Implement transitive matcher with pair generator + tests

### DIFF
--- a/src/colmap/controllers/feature_matching.h
+++ b/src/colmap/controllers/feature_matching.h
@@ -108,9 +108,9 @@ std::unique_ptr<Thread> CreateSpatialFeatureMatcher(
     const std::string& database_path);
 
 // Match transitive image pairs in a database with existing feature matches.
-// This matcher transitively closes loops. For example, if image pairs A-B and
-// B-C match but A-C has not been matched, then this matcher attempts to match
-// A-C. This procedure is performed for multiple iterations.
+// This matcher transitively closes loops/triplets. For example, if image pairs
+// A-B and B-C match but A-C has not been matched, then this matcher attempts to
+// match A-C. This procedure is performed for multiple iterations.
 std::unique_ptr<Thread> CreateTransitiveFeatureMatcher(
     const TransitiveMatchingOptions& options,
     const SiftMatchingOptions& matching_options,

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -103,6 +103,12 @@ void FeatureMatcherCache::Setup() {
           });
 }
 
+void FeatureMatcherCache::AccessDatabase(
+    const std::function<void(const Database& database)>& func) {
+  std::lock_guard<std::mutex> lock(database_mutex_);
+  func(*database_);
+}
+
 const Camera& FeatureMatcherCache::GetCamera(const camera_t camera_id) const {
   return cameras_cache_.at(camera_id);
 }

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -78,6 +78,11 @@ class FeatureMatcherCache {
 
   void Setup();
 
+  // Executes a function that accesses the database. This function is thread
+  // safe and ensures that only one function can access the database at a time.
+  void AccessDatabase(
+      const std::function<void(const Database& database)>& func);
+
   const Camera& GetCamera(camera_t camera_id) const;
   const Image& GetImage(image_t image_id) const;
   const PosePrior& GetPosePrior(image_t image_id) const;

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -643,6 +643,102 @@ SpatialPairGenerator::ReadPositionPriorData(const FeatureMatcherCache& cache) {
   return position_matrix;
 }
 
+TransitivePairGenerator::TransitivePairGenerator(
+    const TransitiveMatchingOptions& options,
+    const std::shared_ptr<FeatureMatcherCache>& cache)
+    : options_(options), cache_(cache) {
+  THROW_CHECK(options.Check());
+}
+
+TransitivePairGenerator::TransitivePairGenerator(
+    const TransitiveMatchingOptions& options,
+    const std::shared_ptr<Database>& database)
+    : TransitivePairGenerator(
+          options,
+          std::make_shared<FeatureMatcherCache>(CacheSize(options),
+                                                THROW_CHECK_NOTNULL(database),
+                                                /*do_setup=*/true)) {}
+
+void TransitivePairGenerator::Reset() {
+  current_iteration_ = 0;
+  current_batch_idx_ = 0;
+  image_pairs_.clear();
+  image_pair_ids_.clear();
+}
+
+bool TransitivePairGenerator::HasFinished() const {
+  return current_iteration_ >= options_.num_iterations && image_pairs_.empty();
+}
+
+std::vector<std::pair<image_t, image_t>> TransitivePairGenerator::Next() {
+  if (!image_pairs_.empty()) {
+    current_batch_idx_++;
+    std::vector<std::pair<image_t, image_t>> batch;
+    while (!image_pairs_.empty() &&
+           static_cast<int>(batch.size()) < options_.batch_size) {
+      batch.push_back(image_pairs_.back());
+      image_pairs_.pop_back();
+    }
+    LOG(INFO) << StringPrintf(
+        "Matching batch [%d/%d]", current_batch_idx_, current_num_batches_);
+    return batch;
+  }
+
+  if (current_iteration_ >= options_.num_iterations) {
+    return {};
+  }
+
+  current_batch_idx_ = 0;
+  current_num_batches_ = 0;
+  current_iteration_++;
+
+  LOG(INFO) << StringPrintf(
+      "Iteration [%d/%d]", current_iteration_, options_.num_iterations);
+
+  std::vector<std::pair<image_t, image_t>> existing_image_pairs;
+  std::vector<int> existing_num_inliers;
+  cache_->AccessDatabase([this, &existing_image_pairs, &existing_num_inliers](
+                             const Database& database) {
+    database.ReadTwoViewGeometryNumInliers(&existing_image_pairs,
+                                           &existing_num_inliers);
+  });
+
+  std::unordered_map<image_t, std::vector<image_t>> adjacency;
+  for (const auto& image_pair : existing_image_pairs) {
+    adjacency[image_pair.first].push_back(image_pair.second);
+    adjacency[image_pair.second].push_back(image_pair.first);
+    image_pair_ids_.insert(
+        Database::ImagePairToPairId(image_pair.first, image_pair.second));
+  }
+
+  for (const auto& image : adjacency) {
+    const auto image_id1 = image.first;
+    for (const auto& image_id2 : image.second) {
+      const auto it = adjacency.find(image_id2);
+      if (it == adjacency.end()) {
+        continue;
+      }
+      for (const auto& image_id3 : it->second) {
+        if (image_id1 == image_id3) {
+          continue;
+        }
+        const auto image_pair_id =
+            Database::ImagePairToPairId(image_id1, image_id3);
+        if (image_pair_ids_.count(image_pair_id) != 0) {
+          continue;
+        }
+        image_pairs_.emplace_back(image_id1, image_id3);
+        image_pair_ids_.insert(image_pair_id);
+      }
+    }
+  }
+
+  current_num_batches_ =
+      std::ceil(static_cast<double>(image_pairs_.size()) / options_.batch_size);
+
+  return Next();
+}
+
 ImportedPairGenerator::ImportedPairGenerator(
     const ImagePairsMatchingOptions& options,
     const std::shared_ptr<FeatureMatcherCache>& cache)

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -697,11 +697,11 @@ std::vector<std::pair<image_t, image_t>> TransitivePairGenerator::Next() {
 
   std::vector<std::pair<image_t, image_t>> existing_image_pairs;
   std::vector<int> existing_num_inliers;
-  cache_->AccessDatabase([this, &existing_image_pairs, &existing_num_inliers](
-                             const Database& database) {
-    database.ReadTwoViewGeometryNumInliers(&existing_image_pairs,
-                                           &existing_num_inliers);
-  });
+  cache_->AccessDatabase(
+      [&existing_image_pairs, &existing_num_inliers](const Database& database) {
+        database.ReadTwoViewGeometryNumInliers(&existing_image_pairs,
+                                               &existing_num_inliers);
+      });
 
   std::unordered_map<image_t, std::vector<image_t>> adjacency;
   for (const auto& image_pair : existing_image_pairs) {

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -310,6 +310,35 @@ class SpatialPairGenerator : public PairGenerator {
   int knn_ = 0;
 };
 
+class TransitivePairGenerator : public PairGenerator {
+ public:
+  using PairOptions = TransitiveMatchingOptions;
+  static size_t CacheSize(const TransitiveMatchingOptions& options) {
+    return 2 * options.batch_size;
+  }
+
+  TransitivePairGenerator(const TransitiveMatchingOptions& options,
+                          const std::shared_ptr<FeatureMatcherCache>& cache);
+
+  TransitivePairGenerator(const TransitiveMatchingOptions& options,
+                          const std::shared_ptr<Database>& database);
+
+  void Reset() override;
+
+  bool HasFinished() const override;
+
+  std::vector<std::pair<image_t, image_t>> Next() override;
+
+ private:
+  const TransitiveMatchingOptions options_;
+  const std::shared_ptr<FeatureMatcherCache> cache_;
+  int current_iteration_ = 0;
+  int current_batch_idx_ = 0;
+  int current_num_batches_ = 0;
+  std::vector<std::pair<image_t, image_t>> image_pairs_;
+  std::unordered_set<image_pair_t> image_pair_ids_;
+};
+
 class ImportedPairGenerator : public PairGenerator {
  public:
   using PairOptions = ImagePairsMatchingOptions;


### PR DESCRIPTION
Consistently implements transitive matching through pair generation interface. This allows to implement tests against the pair generation. No change in behavior.