### PR TITLE
Fix abseil that ceres 2.3.0 depends on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(CCACHE_ENABLED "Whether to enable compiler caching, if available" ON)
 option(CGAL_ENABLED "Whether to enable the CGAL library" ON)
 option(LSD_ENABLED "Whether to enable the LSD library" ON)
 option(UNINSTALL_ENABLED "Whether to create a target to 'uninstall' colmap" ON)
+option(ABSL_ENABLED "Whether to enable abseil, if ceres 2.3.0 is available" OFF)
 
 # Propagate options to vcpkg manifest.
 if(TESTS_ENABLED)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -35,6 +35,17 @@ find_package(Glew ${COLMAP_FIND_TYPE})
 
 find_package(Git)
 
+if(ABSL_ENABLED)
+    find_package(absl ${COLMAP_FIND_TYPE})
+    message("-- Found abseil version ${absl_VERSION}: ${absl_DIR}")
+    # For some reason unknown to me having the version number in the
+    # find_package call fails. So we check for he minimum version
+    # manually.
+    if(absl_VERSION VERSION_LESS 20240116)
+      message(FATAL_ERROR "The version of abseil installed on the system is " ${absl_VERSION} " need at least 20240116")
+    endif()    
+endif()
+
 find_package(Ceres ${COLMAP_FIND_TYPE})
 if(NOT TARGET Ceres::ceres)
     # Older Ceres versions don't come with an imported interface target.


### PR DESCRIPTION
When building colmap using ceres 2.3.0 (ceres master branch), the cmake output log is as follows:
```
CMake Error at D:/xxx1/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Found package configuration file:

    D:/xxx2/lib/cmake/Ceres/CeresConfig.cmake

  but it set Ceres_FOUND to FALSE so package "Ceres" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing: absl::log
  absl::check absl::fixed_array

Call Stack (most recent call first):
  cmake/FindDependencies.cmake:49 (find_package)
  CMakeLists.txt:106 (include)


-- Configuring incomplete, errors occurred!
```

This PR fixes the issue by adding an option called ABSL_ENABLED.
When building colmap with ceres 2.3.0, turn on ABSL_ENABLED.