### PR TITLE
Provide reasonable defaults for some estimator options

### DIFF
--- a/src/colmap/estimators/pose.h
+++ b/src/colmap/estimators/pose.h
@@ -66,6 +66,15 @@ struct AbsolutePoseEstimationOptions {
   // Options used for P3P RANSAC.
   RANSACOptions ransac_options;
 
+  AbsolutePoseEstimationOptions() {
+    ransac_options.max_error = 12.0;
+    // Use high confidence to avoid preemptive termination of P3P RANSAC
+    // - too early termination may lead to bad registration.
+    ransac_options.min_num_trials = 100;
+    ransac_options.max_num_trials = 10000;
+    ransac_options.confidence = 0.99999;
+  }
+
   void Check() const {
     THROW_CHECK_GT(num_focal_length_samples, 0);
     THROW_CHECK_GT(min_focal_length_ratio, 0);
@@ -86,10 +95,10 @@ struct AbsolutePoseRefinementOptions {
   double loss_function_scale = 1.0;
 
   // Whether to refine the focal length parameter group.
-  bool refine_focal_length = true;
+  bool refine_focal_length = false;
 
   // Whether to refine the extra parameter group.
-  bool refine_extra_params = true;
+  bool refine_extra_params = false;
 
   // Whether to print final summary.
   bool print_summary = false;

--- a/src/colmap/estimators/triangulation.h
+++ b/src/colmap/estimators/triangulation.h
@@ -129,6 +129,13 @@ struct EstimateTriangulationOptions {
   // RANSAC options for TriangulationEstimator.
   RANSACOptions ransac_options;
 
+  EstimateTriangulationOptions() {
+    ransac_options.max_error = DegToRad(2.0);
+    ransac_options.confidence = 0.9999;
+    ransac_options.min_inlier_ratio = 0.02;
+    ransac_options.max_num_trials = 10000;
+  }
+
   void Check() const {
     THROW_CHECK_GE(min_tri_angle, 0.0);
     ransac_options.Check();

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -444,11 +444,6 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
   abs_pose_options.ransac_options.max_error = options.abs_pose_max_error;
   abs_pose_options.ransac_options.min_inlier_ratio =
       options.abs_pose_min_inlier_ratio;
-  // Use high confidence to avoid preemptive termination of P3P RANSAC
-  // - too early termination may lead to bad registration.
-  abs_pose_options.ransac_options.min_num_trials = 100;
-  abs_pose_options.ransac_options.max_num_trials = 10000;
-  abs_pose_options.ransac_options.confidence = 0.99999;
 
   AbsolutePoseRefinementOptions abs_pose_refinement_options;
   if (num_reg_images_per_camera_[image.CameraId()] > 0) {

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -180,9 +180,6 @@ size_t IncrementalTriangulator::CompleteImage(const Options& options,
   tri_options.residual_type =
       TriangulationEstimator::ResidualType::REPROJECTION_ERROR;
   tri_options.ransac_options.max_error = options.complete_max_reproj_error;
-  tri_options.ransac_options.confidence = 0.9999;
-  tri_options.ransac_options.min_inlier_ratio = 0.02;
-  tri_options.ransac_options.max_num_trials = 10000;
 
   // Correspondence data for reference observation in given image. We iterate
   // over all observations of the image and each observation once becomes
@@ -508,9 +505,6 @@ size_t IncrementalTriangulator::Create(
       TriangulationEstimator::ResidualType::ANGULAR_ERROR;
   tri_options.ransac_options.max_error =
       DegToRad(options.create_max_angle_error);
-  tri_options.ransac_options.confidence = 0.9999;
-  tri_options.ransac_options.min_inlier_ratio = 0.02;
-  tri_options.ransac_options.max_num_trials = 10000;
 
   // Estimate triangulation.
   Eigen::Vector3d xyz;

--- a/src/pycolmap/estimators/absolute_pose.cc
+++ b/src/pycolmap/estimators/absolute_pose.cc
@@ -87,15 +87,7 @@ void BindAbsolutePoseEstimator(py::module& m) {
   auto PyRANSACOptions = m.attr("RANSACOptions");
   py::class_<AbsolutePoseEstimationOptions> PyEstimationOptions(
       m, "AbsolutePoseEstimationOptions");
-  PyEstimationOptions
-      .def(py::init<>([PyRANSACOptions]() {
-        AbsolutePoseEstimationOptions options;
-        options.estimate_focal_length = false;
-        // init through Python to obtain the new defaults defined in __init__
-        options.ransac_options = PyRANSACOptions().cast<RANSACOptions>();
-        options.ransac_options.max_error = 12.0;
-        return options;
-      }))
+  PyEstimationOptions.def(py::init<>())
       .def_readwrite("estimate_focal_length",
                      &AbsolutePoseEstimationOptions::estimate_focal_length)
       .def_readwrite("num_focal_length_samples",
@@ -106,18 +98,10 @@ void BindAbsolutePoseEstimator(py::module& m) {
                      &AbsolutePoseEstimationOptions::max_focal_length_ratio)
       .def_readwrite("ransac", &AbsolutePoseEstimationOptions::ransac_options);
   MakeDataclass(PyEstimationOptions);
-  auto est_options =
-      PyEstimationOptions().cast<AbsolutePoseEstimationOptions>();
 
   py::class_<AbsolutePoseRefinementOptions> PyRefinementOptions(
       m, "AbsolutePoseRefinementOptions");
-  PyRefinementOptions
-      .def(py::init<>([]() {
-        AbsolutePoseRefinementOptions options;
-        options.refine_focal_length = false;
-        options.refine_extra_params = false;
-        return options;
-      }))
+  PyRefinementOptions.def(py::init<>())
       .def_readwrite("gradient_tolerance",
                      &AbsolutePoseRefinementOptions::gradient_tolerance)
       .def_readwrite("max_num_iterations",
@@ -131,31 +115,30 @@ void BindAbsolutePoseEstimator(py::module& m) {
       .def_readwrite("print_summary",
                      &AbsolutePoseRefinementOptions::print_summary);
   MakeDataclass(PyRefinementOptions);
-  auto ref_options =
-      PyRefinementOptions().cast<AbsolutePoseRefinementOptions>();
 
-  m.def(
-      "absolute_pose_estimation",
-      &PyEstimateAndRefineAbsolutePose,
-      "points2D"_a,
-      "points3D"_a,
-      "camera"_a,
-      py::arg_v(
-          "estimation_options", est_options, "AbsolutePoseEstimationOptions()"),
-      py::arg_v(
-          "refinement_options", ref_options, "AbsolutePoseRefinementOptions()"),
-      "return_covariance"_a = false,
-      "Absolute pose estimation with non-linear refinement.");
+  m.def("absolute_pose_estimation",
+        &PyEstimateAndRefineAbsolutePose,
+        "points2D"_a,
+        "points3D"_a,
+        "camera"_a,
+        py::arg_v("estimation_options",
+                  AbsolutePoseEstimationOptions(),
+                  "AbsolutePoseEstimationOptions()"),
+        py::arg_v("refinement_options",
+                  AbsolutePoseRefinementOptions(),
+                  "AbsolutePoseRefinementOptions()"),
+        "return_covariance"_a = false,
+        "Absolute pose estimation with non-linear refinement.");
 
-  m.def(
-      "pose_refinement",
-      &PyRefineAbsolutePose,
-      "cam_from_world"_a,
-      "points2D"_a,
-      "points3D"_a,
-      "inlier_mask"_a,
-      "camera"_a,
-      py::arg_v(
-          "refinement_options", ref_options, "AbsolutePoseRefinementOptions()"),
-      "Non-linear refinement of absolute pose.");
+  m.def("pose_refinement",
+        &PyRefineAbsolutePose,
+        "cam_from_world"_a,
+        "points2D"_a,
+        "points3D"_a,
+        "inlier_mask"_a,
+        "camera"_a,
+        py::arg_v("refinement_options",
+                  AbsolutePoseRefinementOptions(),
+                  "AbsolutePoseRefinementOptions()"),
+        "Non-linear refinement of absolute pose.");
 }

--- a/src/pycolmap/estimators/generalized_absolute_pose.cc
+++ b/src/pycolmap/estimators/generalized_absolute_pose.cc
@@ -67,10 +67,6 @@ py::typing::Optional<py::dict> PyEstimateAndRefineGeneralizedAbsolutePose(
 }
 
 void BindGeneralizedAbsolutePoseEstimator(py::module& m) {
-  auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
-  auto ref_options = m.attr("AbsolutePoseRefinementOptions")()
-                         .cast<AbsolutePoseRefinementOptions>();
-
   m.def(
       "rig_absolute_pose_estimation",
       &PyEstimateAndRefineGeneralizedAbsolutePose,
@@ -79,9 +75,12 @@ void BindGeneralizedAbsolutePoseEstimator(py::module& m) {
       "camera_idxs"_a,
       "cams_from_rig"_a,
       "cameras"_a,
-      py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-      py::arg_v(
-          "refinement_options", ref_options, "AbsolutePoseRefinementOptions()"),
+      py::arg_v("estimation_options",
+                AbsolutePoseEstimationOptions().ransac_options,
+                "AbsolutePoseEstimationOptions().ransac"),
+      py::arg_v("refinement_options",
+                AbsolutePoseRefinementOptions(),
+                "AbsolutePoseRefinementOptions()"),
       "return_covariance"_a = false,
       "Absolute pose estimation with non-linear refinement for a multi-camera "
       "rig.");

--- a/src/pycolmap/estimators/triangulation.cc
+++ b/src/pycolmap/estimators/triangulation.cc
@@ -48,13 +48,7 @@ void BindTriangulationEstimator(py::module& m) {
 
   using Options = EstimateTriangulationOptions;
   py::class_<Options> PyTriangulationOptions(m, "EstimateTriangulationOptions");
-  PyTriangulationOptions
-      .def(py::init<>([PyRANSACOptions]() {
-        Options options;
-        // init through Python to obtain the new defaults defined in  __init__
-        options.ransac_options = PyRANSACOptions().cast<RANSACOptions>();
-        return options;
-      }))
+  PyTriangulationOptions.def(py::init<>())
       .def_readwrite("min_tri_angle",
                      &Options::min_tri_angle,
                      "Minimum triangulation angle in radians.")

--- a/src/pycolmap/estimators/triangulation.cc
+++ b/src/pycolmap/estimators/triangulation.cc
@@ -59,8 +59,8 @@ void BindTriangulationEstimator(py::module& m) {
 
   m.def("estimate_triangulation",
         &PyEstimateTriangulation,
-        "point_data"_a,
-        "images"_a,
+        "points"_a,
+        "cams_from_world"_a,
         "cameras"_a,
         py::arg_v("options",
                   EstimateTriangulationOptions(),


### PR DESCRIPTION
https://github.com/colmap/colmap/pull/2721 inadvertently broke the default options for `pycolmap.estimate_triangulation`, which I then realized were completely wrong. To fix this, I think that `EstimateTriangulationOptions` and `AbsolutePose{Estimation,Refinement}Options` should provide sensible defaults instead of, as we have been doing it so far, monkey-patching some values in Python. This PR doesn't change the default behavior of COLMAP and only slightly affects PyCOLMAP's `estimate_triangulation`/`absolute_pose_estimation`/`rig_absolute_pose_estimation` to be consistent with the corresponding COLMAP options.