### PR TITLE
Add missing ClearModifiedPoints3D

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -803,6 +803,7 @@ void IncrementalMapper::IterativeGlobalRefinement(
       break;
     }
   }
+  ClearModifiedPoints3D();
 }
 
 size_t IncrementalMapper::FilterImages(const Options& options) {


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/2582. Should make no difference in the default `IncrementalPipeline` because `IterativeGlobalRefinement` comes right after `IterativeLocalRefinement` but it could save some compute in a custom pipeline.