### PR TITLE
Branch prediction for THROW_CHECK_NOTNULL

### DIFF
--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -199,7 +199,7 @@ using LogMessageFatalThrowDefault = LogMessageFatalThrow<std::invalid_argument>;
 
 template <typename T>
 T ThrowCheckNotNull(const char* file, int line, const char* names, T&& t) {
-  if (t == nullptr) {
+  if (GOOGLE_PREDICT_FALSE(t == nullptr)) {
     LogMessageFatalThrowDefault(file, line).stream() << names;
   }
   return std::forward<T>(t);


### PR DESCRIPTION
Uses __builtin_expect() under the hood. Other THROW_CHECK macros already have it because they use the glog macros under the hood.