### PR TITLE
Support switching camera directly with camera pointer

### DIFF
--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -181,7 +181,7 @@ inline void Image::SetCameraPtr(struct Camera* camera) {
     THROW_CHECK_EQ(camera->camera_id, camera_id_);
     camera_ptr_ = camera;
   } else {  // switch to new camera
-    camera_id = camera->camera_id;
+    camera_id_ = camera->camera_id;
     camera_ptr_ = camera;
   }
 }

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -177,8 +177,13 @@ inline struct Camera* Image::CameraPtr() const {
 inline void Image::SetCameraPtr(struct Camera* camera) {
   THROW_CHECK_NOTNULL(camera);
   THROW_CHECK_NE(camera->camera_id, kInvalidCameraId);
-  THROW_CHECK_EQ(camera->camera_id, camera_id_);
-  camera_ptr_ = camera;
+  if (!HasCameraPtr()) {
+    THROW_CHECK_EQ(camera->camera_id, camera_id_);
+    camera_ptr_ = camera;
+  } else {  // switch to new camera
+    camera_id = camera->camera_id;
+    camera_ptr_ = camera;
+  }
 }
 
 inline void Image::ResetCameraPtr() { camera_ptr_ = nullptr; }


### PR DESCRIPTION
To switch camera before one needs to first reset camera id and camera pointer and then set both again. This enables direct switching which can be more flexible in both C++ and Python. 