### PR TITLE
Fix little/big endian detection

### DIFF
--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -489,12 +489,13 @@ void IncrementalPipeline::Reconstruct(
     const Status status =
         ReconstructSubModel(mapper, mapper_options, reconstruction);
     switch (status) {
-      case Status::INTERRUPTED:
+      case Status::INTERRUPTED: {
         mapper.EndReconstruction(/*discard=*/false);
         return;
+      }
 
       case Status::NO_INITIAL_PAIR:
-      case Status::BAD_INITIAL_PAIR:
+      case Status::BAD_INITIAL_PAIR: {
         mapper.EndReconstruction(/*discard=*/true);
         reconstruction_manager_->Delete(reconstruction_idx);
         // If both initial images are manually specified, there is no need for
@@ -503,6 +504,7 @@ void IncrementalPipeline::Reconstruct(
           return;
         }
         break;
+      }
 
       case Status::SUCCESS: {
         // Remember the total number of registered images before potentially
@@ -533,7 +535,9 @@ void IncrementalPipeline::Reconstruct(
             total_num_reg_images >= database_cache_->NumImages() - 1) {
           return;
         }
-      } break;
+
+        break;
+      }
 
       default:
         LOG(FATAL_THROW) << "Unknown reconstruction status.";

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -37,6 +37,7 @@ COLMAP_ADD_LIBRARY(
         cache.h
         controller_thread.h
         eigen_alignment.h
+        endian.h endian.cc
         logging.h logging.cc
         misc.h misc.cc
         opengl_utils.h opengl_utils.cc

--- a/src/colmap/util/endian.cc
+++ b/src/colmap/util/endian.cc
@@ -1,0 +1,61 @@
+
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/util/endian.h"
+
+#include "colmap/util/logging.h"
+
+#include <boost/predef/other/endian.h>
+
+namespace colmap {
+
+bool IsLittleEndian() {
+#if BOOST_ENDIAN_LITTLE_BYTE
+  return true;
+#elif BOOST_ENDIAN_LITTLE_WORD
+  // We do not support such exotic architectures.
+  LOG(FATAL) << "Unsupported byte ordering";
+#else
+  return false;
+#endif
+}
+
+bool IsBigEndian() {
+#if BOOST_ENDIAN_BIG_BYTE
+  return true;
+#elif BOOST_ENDIAN_BIG_WORD
+  // We do not support such exotic architectures.
+  LOG(FATAL) << "Unsupported byte ordering";
+#else
+  return false;
+#endif
+}
+
+}  // namespace colmap

--- a/src/colmap/util/endian.h
+++ b/src/colmap/util/endian.h
@@ -79,22 +79,6 @@ T ReverseBytes(const T& data) {
   return data_reversed;
 }
 
-inline bool IsLittleEndian() {
-#ifdef BOOST_BIG_ENDIAN
-  return false;
-#else
-  return true;
-#endif
-}
-
-inline bool IsBigEndian() {
-#ifdef BOOST_BIG_ENDIAN
-  return true;
-#else
-  return false;
-#endif
-}
-
 template <typename T>
 T LittleEndianToNative(const T x) {
   if (IsLittleEndian()) {


### PR DESCRIPTION
This PR fixes two issues:
1. Adds missing boost includes to define the endian macros. Moves the implementation to the .cc file so we don't transitively propagate the boost includes.
2. The boost endian macros have been renamed from `BOOST_*_ENDIAN` to `BOOST_ENDIAN_*_BYTE`.