### PR TITLE
print RMS reprojection error in solver summary

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -862,12 +862,12 @@ void PrintSolverSummary(const ceres::Solver::Summary& summary,
 
   log << std::right << std::setw(16) << "Initial cost : ";
   log << std::right << std::setprecision(6)
-      << std::sqrt(summary.initial_cost / summary.num_residuals_reduced)
+      << std::sqrt(2 * summary.initial_cost / summary.num_residuals_reduced)
       << " [px]\n";
 
   log << std::right << std::setw(16) << "Final cost : ";
   log << std::right << std::setprecision(6)
-      << std::sqrt(summary.final_cost / summary.num_residuals_reduced)
+      << std::sqrt(2 * summary.final_cost / summary.num_residuals_reduced)
       << " [px]\n";
 
   log << std::right << std::setw(16) << "Termination : ";


### PR DESCRIPTION
According to ceres e.g. here https://github.com/ceres-solver/ceres-solver/blob/ea4400cd57f17699077ec8905b503b9320aa1d6d/internal/ceres/solver_test.cc#L334 the cost in the summary is 0.5 * sum of squared residuals.