### PR TITLE
Rename SupperMeasurer::Compare for improved readability

### DIFF
--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -151,7 +151,7 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
       const auto support = support_measurer.Evaluate(residuals, max_residual);
 
       // Do local optimization if better than all previous subsets.
-      if (support_measurer.Compare(support, best_support)) {
+      if (support_measurer.IsLeftBetter(support, best_support)) {
         best_support = support;
         best_model = sample_model;
         best_model_is_local = false;
@@ -187,7 +187,7 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
                   support_measurer.Evaluate(residuals, max_residual);
 
               // Check if locally optimized model is better.
-              if (support_measurer.Compare(local_support, best_support)) {
+              if (support_measurer.IsLeftBetter(local_support, best_support)) {
                 best_support = local_support;
                 best_model = local_model;
                 best_model_is_local = true;

--- a/src/colmap/optim/ransac.h
+++ b/src/colmap/optim/ransac.h
@@ -235,7 +235,7 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
       const auto support = support_measurer.Evaluate(residuals, max_residual);
 
       // Save as best subset if better than all previous subsets.
-      if (support_measurer.Compare(support, best_support)) {
+      if (support_measurer.IsLeftBetter(support, best_support)) {
         best_support = support;
         best_model = sample_model;
 

--- a/src/colmap/optim/support_measurement.cc
+++ b/src/colmap/optim/support_measurement.cc
@@ -51,13 +51,13 @@ InlierSupportMeasurer::Support InlierSupportMeasurer::Evaluate(
   return support;
 }
 
-bool InlierSupportMeasurer::Compare(const Support& support1,
-                                    const Support& support2) {
-  if (support1.num_inliers > support2.num_inliers) {
+bool InlierSupportMeasurer::IsLeftBetter(const Support& left,
+                                         const Support& right) {
+  if (left.num_inliers > right.num_inliers) {
     return true;
   } else {
-    return support1.num_inliers == support2.num_inliers &&
-           support1.residual_sum < support2.residual_sum;
+    return left.num_inliers == right.num_inliers &&
+           left.residual_sum < right.residual_sum;
   }
 }
 
@@ -81,16 +81,16 @@ UniqueInlierSupportMeasurer::Support UniqueInlierSupportMeasurer::Evaluate(
   return support;
 }
 
-bool UniqueInlierSupportMeasurer::Compare(const Support& support1,
-                                          const Support& support2) {
-  if (support1.num_unique_inliers > support2.num_unique_inliers) {
+bool UniqueInlierSupportMeasurer::IsLeftBetter(const Support& left,
+                                               const Support& right) {
+  if (left.num_unique_inliers > right.num_unique_inliers) {
     return true;
-  } else if (support1.num_unique_inliers == support2.num_unique_inliers) {
-    if (support1.num_inliers > support2.num_inliers) {
+  } else if (left.num_unique_inliers == right.num_unique_inliers) {
+    if (left.num_inliers > right.num_inliers) {
       return true;
     } else {
-      return support1.num_inliers == support2.num_inliers &&
-             support1.residual_sum < support2.residual_sum;
+      return left.num_inliers == right.num_inliers &&
+             left.residual_sum < right.residual_sum;
     }
   } else {
     return false;
@@ -115,9 +115,9 @@ MEstimatorSupportMeasurer::Support MEstimatorSupportMeasurer::Evaluate(
   return support;
 }
 
-bool MEstimatorSupportMeasurer::Compare(const Support& support1,
-                                        const Support& support2) {
-  return support1.score < support2.score;
+bool MEstimatorSupportMeasurer::IsLeftBetter(const Support& left,
+                                             const Support& right) {
+  return left.score < right.score;
 }
 
 }  // namespace colmap

--- a/src/colmap/optim/support_measurement.h
+++ b/src/colmap/optim/support_measurement.h
@@ -50,8 +50,8 @@ struct InlierSupportMeasurer {
   // Compute the support of the residuals.
   Support Evaluate(const std::vector<double>& residuals, double max_residual);
 
-  // Compare the two supports and return the better support.
-  bool Compare(const Support& support1, const Support& support2);
+  // Compare the two supports.
+  bool IsLeftBetter(const Support& left, const Support& right);
 };
 
 // Measure the support of a model by counting the number of unique inliers
@@ -79,8 +79,8 @@ struct UniqueInlierSupportMeasurer {
   // Compute the support of the residuals.
   Support Evaluate(const std::vector<double>& residuals, double max_residual);
 
-  // Compare the two supports and return the better support.
-  bool Compare(const Support& support1, const Support& support2);
+  // Compare the two supports.
+  bool IsLeftBetter(const Support& left, const Support& right);
 
  private:
   std::vector<size_t> unique_sample_ids_;
@@ -100,8 +100,8 @@ struct MEstimatorSupportMeasurer {
   // Compute the support of the residuals.
   Support Evaluate(const std::vector<double>& residuals, double max_residual);
 
-  // Compare the two supports and return the better support.
-  bool Compare(const Support& support1, const Support& support2);
+  // Compare the two supports.
+  bool IsLeftBetter(const Support& left, const Support& right);
 };
 
 }  // namespace colmap

--- a/src/colmap/optim/support_measurement_test.cc
+++ b/src/colmap/optim/support_measurement_test.cc
@@ -49,21 +49,21 @@ TEST(InlierSupportMeasurer, Nominal) {
   EXPECT_EQ(support1.residual_sum, 0.0);
   InlierSupportMeasurer::Support support2;
   support2.num_inliers = 2;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum = support1.residual_sum;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.num_inliers = support1.num_inliers;
   support2.residual_sum += 0.01;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum -= 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum -= 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_TRUE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_TRUE(measurer.IsLeftBetter(support2, support1));
 }
 
 TEST(UniqueInlierSupportMeasurer, Nominal) {
@@ -83,35 +83,35 @@ TEST(UniqueInlierSupportMeasurer, Nominal) {
 
   UniqueInlierSupportMeasurer::Support support2;
   support2.num_unique_inliers = support1.num_unique_inliers - 1;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.num_inliers = support1.num_inliers + 1;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.num_inliers = support1.num_inliers;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum = support1.residual_sum - 0.01;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum = support1.residual_sum;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.num_unique_inliers = support1.num_unique_inliers;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.residual_sum = support1.residual_sum - 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_TRUE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_TRUE(measurer.IsLeftBetter(support2, support1));
   support2.num_inliers = support1.num_inliers + 1;
   support2.residual_sum = support1.residual_sum + 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_TRUE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_TRUE(measurer.IsLeftBetter(support2, support1));
   support2.num_unique_inliers = support1.num_unique_inliers + 1;
   support2.num_inliers = support1.num_inliers - 1;
   support2.residual_sum = support1.residual_sum + 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_TRUE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_TRUE(measurer.IsLeftBetter(support2, support1));
 }
 
 TEST(MEstimatorSupportMeasurer, Nominal) {
@@ -124,18 +124,18 @@ TEST(MEstimatorSupportMeasurer, Nominal) {
   EXPECT_EQ(support1.num_inliers, 3);
   EXPECT_EQ(support1.score, 1.0);
   MEstimatorSupportMeasurer::Support support2 = support1;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.num_inliers -= 1;
   support2.score += 0.01;
-  EXPECT_TRUE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_TRUE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.score -= 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_FALSE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_FALSE(measurer.IsLeftBetter(support2, support1));
   support2.score -= 0.01;
-  EXPECT_FALSE(measurer.Compare(support1, support2));
-  EXPECT_TRUE(measurer.Compare(support2, support1));
+  EXPECT_FALSE(measurer.IsLeftBetter(support1, support2));
+  EXPECT_TRUE(measurer.IsLeftBetter(support2, support1));
 }
 
 }  // namespace


### PR DESCRIPTION
No change in behavior.