### PR TITLE
Expose UpdatePoint3DErrors to pycolmap

### DIFF
--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -183,6 +183,7 @@ void BindReconstruction(py::module& m) {
            "other"_a,
            "Find images that are both present in this and the given "
            "reconstruction.")
+      .def("update_point_3d_errors", &Reconstruction::UpdatePoint3DErrors)
       .def("compute_num_observations", &Reconstruction::ComputeNumObservations)
       .def("compute_mean_track_length", &Reconstruction::ComputeMeanTrackLength)
       .def("compute_mean_observations_per_reg_image",


### PR DESCRIPTION
I'm working on a SLAM system, and writing the results in colmap format using pycolmap. Computing reprojection error is trivial, but it would be nice of pycolmap can do it as well.