### PR TITLE
Customized cost functions should be functors instead

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -436,13 +436,13 @@ void BundleAdjuster::AddImageToProblem(const image_t image_id,
 
     if (constant_cam_pose) {
       problem_->AddResidualBlock(
-          CameraCostFunction<ReprojErrorConstantPoseCostFunction>(
+          CameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
               camera.model_id, image.CamFromWorld(), point2D.xy),
           loss_function,
           point3D.xyz.data(),
           camera_params);
     } else {
-      problem_->AddResidualBlock(CameraCostFunction<ReprojErrorCostFunction>(
+      problem_->AddResidualBlock(CameraCostFunction<ReprojErrorCostFunctor>(
                                      camera.model_id, point2D.xy),
                                  loss_function,
                                  cam_from_world_rotation,
@@ -505,7 +505,7 @@ void BundleAdjuster::AddPointToProblem(const point3D_t point3D_id,
       config_.SetConstantCamIntrinsics(image.CameraId());
     }
     problem_->AddResidualBlock(
-        CameraCostFunction<ReprojErrorConstantPoseCostFunction>(
+        CameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
             camera.model_id, image.CamFromWorld(), point2D.xy),
         loss_function,
         point3D.xyz.data(),
@@ -730,13 +730,13 @@ void RigBundleAdjuster::AddImageToProblem(const image_t image_id,
     if (camera_rig == nullptr) {
       if (constant_cam_pose) {
         problem_->AddResidualBlock(
-            CameraCostFunction<ReprojErrorConstantPoseCostFunction>(
+            CameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
                 camera.model_id, image.CamFromWorld(), point2D.xy),
             loss_function,
             point3D.xyz.data(),
             camera_params);
       } else {
-        problem_->AddResidualBlock(CameraCostFunction<ReprojErrorCostFunction>(
+        problem_->AddResidualBlock(CameraCostFunction<ReprojErrorCostFunctor>(
                                        camera.model_id, point2D.xy),
                                    loss_function,
                                    cam_from_rig_rotation,     // rig == world
@@ -745,7 +745,7 @@ void RigBundleAdjuster::AddImageToProblem(const image_t image_id,
                                    camera_params);
       }
     } else {
-      problem_->AddResidualBlock(CameraCostFunction<RigReprojErrorCostFunction>(
+      problem_->AddResidualBlock(CameraCostFunction<RigReprojErrorCostFunctor>(
                                      camera.model_id, point2D.xy),
                                  loss_function,
                                  cam_from_rig_rotation,
@@ -816,7 +816,7 @@ void RigBundleAdjuster::AddPointToProblem(const point3D_t point3D_id,
     }
 
     problem_->AddResidualBlock(
-        CameraCostFunction<ReprojErrorConstantPoseCostFunction>(
+        CameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
             camera.model_id, image.CamFromWorld(), point2D.xy),
         loss_function,
         point3D.xyz.data(),
@@ -951,7 +951,7 @@ void PosePriorBundleAdjuster::AddPosePriorToProblem(
       image.CamFromWorld().rotation.coeffs().data();
 
   problem_->AddResidualBlock(
-      PositionPriorErrorCostFunction::Create(
+      PositionPriorErrorCostFunctor::Create(
           normalized_from_metric_ * prior.position, prior.position_covariance),
       prior_loss_function,
       cam_from_world_rotation,

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -530,8 +530,8 @@ struct PositionPriorErrorCostFunctor {
 // A cost function that wraps another one and whiten its residuals with an
 // isotropic covariance, i.e. assuming that the variance is identical in and
 // independent between each dimension of the residual.
-template <class CostFunction>
-class IsotropicNoiseCostFunctionWrapper {
+template <class CostFunctor>
+class IsotropicNoiseCostFunctorWrapper {
   class LinearCostFunction : public ceres::CostFunction {
    public:
     explicit LinearCostFunction(const double s) : s_(s) {
@@ -558,7 +558,7 @@ class IsotropicNoiseCostFunctionWrapper {
   static ceres::CostFunction* Create(const double stddev, Args&&... args) {
     THROW_CHECK_GT(stddev, 0.0);
     ceres::CostFunction* cost_function =
-        CostFunction::Create(std::forward<Args>(args)...);
+        CostFunctor::Create(std::forward<Args>(args)...);
     const double scale = 1.0 / stddev;
     std::vector<ceres::CostFunction*> conditioners(
 #if CERES_VERSION_MAJOR < 2
@@ -575,13 +575,13 @@ class IsotropicNoiseCostFunctionWrapper {
   }
 };
 
-template <template <typename> class CostFunction, typename... Args>
+template <template <typename> class CostFunctor, typename... Args>
 ceres::CostFunction* CameraCostFunction(const CameraModelId camera_model_id,
                                         Args&&... args) {
   switch (camera_model_id) {
-#define CAMERA_MODEL_CASE(CameraModel)                                     \
-  case CameraModel::model_id:                                              \
-    return CostFunction<CameraModel>::Create(std::forward<Args>(args)...); \
+#define CAMERA_MODEL_CASE(CameraModel)                                    \
+  case CameraModel::model_id:                                             \
+    return CostFunctor<CameraModel>::Create(std::forward<Args>(args)...); \
     break;
 
     CAMERA_MODEL_SWITCH_CASES

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -54,20 +54,19 @@ inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
 // Standard bundle adjustment cost function for variable
 // camera pose, calibration, and point parameters.
 template <typename CameraModel>
-class ReprojErrorCostFunction {
+class ReprojErrorCostFunctor {
  public:
-  explicit ReprojErrorCostFunction(const Eigen::Vector2d& point2D)
+  explicit ReprojErrorCostFunctor(const Eigen::Vector2d& point2D)
       : observed_x_(point2D(0)), observed_y_(point2D(1)) {}
 
   static ceres::CostFunction* Create(const Eigen::Vector2d& point2D) {
-    return (
-        new ceres::AutoDiffCostFunction<ReprojErrorCostFunction<CameraModel>,
-                                        2,
-                                        4,
-                                        3,
-                                        3,
-                                        CameraModel::num_params>(
-            new ReprojErrorCostFunction(point2D)));
+    return (new ceres::AutoDiffCostFunction<ReprojErrorCostFunctor<CameraModel>,
+                                            2,
+                                            4,
+                                            3,
+                                            3,
+                                            CameraModel::num_params>(
+        new ReprojErrorCostFunctor(point2D)));
   }
 
   template <typename T>
@@ -99,23 +98,23 @@ class ReprojErrorCostFunction {
 // Bundle adjustment cost function for variable
 // camera calibration and point parameters, and fixed camera pose.
 template <typename CameraModel>
-class ReprojErrorConstantPoseCostFunction
-    : public ReprojErrorCostFunction<CameraModel> {
-  using Parent = ReprojErrorCostFunction<CameraModel>;
+class ReprojErrorConstantPoseCostFunctor
+    : public ReprojErrorCostFunctor<CameraModel> {
+  using Parent = ReprojErrorCostFunctor<CameraModel>;
 
  public:
-  ReprojErrorConstantPoseCostFunction(const Rigid3d& cam_from_world,
-                                      const Eigen::Vector2d& point2D)
+  ReprojErrorConstantPoseCostFunctor(const Rigid3d& cam_from_world,
+                                     const Eigen::Vector2d& point2D)
       : Parent(point2D), cam_from_world_(cam_from_world) {}
 
   static ceres::CostFunction* Create(const Rigid3d& cam_from_world,
                                      const Eigen::Vector2d& point2D) {
     return (new ceres::AutoDiffCostFunction<
-            ReprojErrorConstantPoseCostFunction<CameraModel>,
+            ReprojErrorConstantPoseCostFunctor<CameraModel>,
             2,
             3,
             CameraModel::num_params>(
-        new ReprojErrorConstantPoseCostFunction(cam_from_world, point2D)));
+        new ReprojErrorConstantPoseCostFunctor(cam_from_world, point2D)));
   }
 
   template <typename T>
@@ -140,13 +139,13 @@ class ReprojErrorConstantPoseCostFunction
 // Bundle adjustment cost function for variable
 // camera pose and calibration parameters, and fixed point.
 template <typename CameraModel>
-class ReprojErrorConstantPoint3DCostFunction
-    : public ReprojErrorCostFunction<CameraModel> {
-  using Parent = ReprojErrorCostFunction<CameraModel>;
+class ReprojErrorConstantPoint3DCostFunctor
+    : public ReprojErrorCostFunctor<CameraModel> {
+  using Parent = ReprojErrorCostFunctor<CameraModel>;
 
  public:
-  ReprojErrorConstantPoint3DCostFunction(const Eigen::Vector2d& point2D,
-                                         const Eigen::Vector3d& point3D)
+  ReprojErrorConstantPoint3DCostFunctor(const Eigen::Vector2d& point2D,
+                                        const Eigen::Vector3d& point3D)
       : Parent(point2D),
         point3D_x_(point3D(0)),
         point3D_y_(point3D(1)),
@@ -155,12 +154,12 @@ class ReprojErrorConstantPoint3DCostFunction
   static ceres::CostFunction* Create(const Eigen::Vector2d& point2D,
                                      const Eigen::Vector3d& point3D) {
     return (new ceres::AutoDiffCostFunction<
-            ReprojErrorConstantPoint3DCostFunction<CameraModel>,
+            ReprojErrorConstantPoint3DCostFunctor<CameraModel>,
             2,
             4,
             3,
             CameraModel::num_params>(
-        new ReprojErrorConstantPoint3DCostFunction(point2D, point3D)));
+        new ReprojErrorConstantPoint3DCostFunctor(point2D, point3D)));
   }
 
   template <typename T>
@@ -189,14 +188,14 @@ class ReprojErrorConstantPoint3DCostFunction
 // the local system of the camera rig and then into the local system of the
 // camera within the rig.
 template <typename CameraModel>
-class RigReprojErrorCostFunction {
+class RigReprojErrorCostFunctor {
  public:
-  explicit RigReprojErrorCostFunction(const Eigen::Vector2d& point2D)
+  explicit RigReprojErrorCostFunctor(const Eigen::Vector2d& point2D)
       : observed_x_(point2D(0)), observed_y_(point2D(1)) {}
 
   static ceres::CostFunction* Create(const Eigen::Vector2d& point2D) {
     return (
-        new ceres::AutoDiffCostFunction<RigReprojErrorCostFunction<CameraModel>,
+        new ceres::AutoDiffCostFunction<RigReprojErrorCostFunctor<CameraModel>,
                                         2,
                                         4,
                                         3,
@@ -204,7 +203,7 @@ class RigReprojErrorCostFunction {
                                         3,
                                         3,
                                         CameraModel::num_params>(
-            new RigReprojErrorCostFunction(point2D)));
+            new RigReprojErrorCostFunctor(point2D)));
   }
 
   template <typename T>
@@ -240,25 +239,25 @@ class RigReprojErrorCostFunction {
 // Rig bundle adjustment cost function for variable camera pose and camera
 // calibration and point parameters but fixed rig extrinsic poses.
 template <typename CameraModel>
-class RigReprojErrorConstantRigCostFunction
-    : public RigReprojErrorCostFunction<CameraModel> {
-  using Parent = RigReprojErrorCostFunction<CameraModel>;
+class RigReprojErrorConstantRigCostFunctor
+    : public RigReprojErrorCostFunctor<CameraModel> {
+  using Parent = RigReprojErrorCostFunctor<CameraModel>;
 
  public:
-  explicit RigReprojErrorConstantRigCostFunction(const Rigid3d& cam_from_rig,
-                                                 const Eigen::Vector2d& point2D)
+  explicit RigReprojErrorConstantRigCostFunctor(const Rigid3d& cam_from_rig,
+                                                const Eigen::Vector2d& point2D)
       : Parent(point2D), cam_from_rig_(cam_from_rig) {}
 
   static ceres::CostFunction* Create(const Rigid3d& cam_from_rig,
                                      const Eigen::Vector2d& point2D) {
     return (new ceres::AutoDiffCostFunction<
-            RigReprojErrorConstantRigCostFunction<CameraModel>,
+            RigReprojErrorConstantRigCostFunctor<CameraModel>,
             2,
             4,
             3,
             3,
             CameraModel::num_params>(
-        new RigReprojErrorConstantRigCostFunction(cam_from_rig, point2D)));
+        new RigReprojErrorConstantRigCostFunctor(cam_from_rig, point2D)));
   }
 
   template <typename T>
@@ -291,15 +290,15 @@ class RigReprojErrorConstantRigCostFunction
 // pose of the second camera is parameterized by a 3D rotation and a
 // 3D translation with unit norm. `tvec` is therefore over-parameterized as is
 // and should be down-projected using `SphereManifold`.
-class SampsonErrorCostFunction {
+class SampsonErrorCostFunctor {
  public:
-  SampsonErrorCostFunction(const Eigen::Vector2d& x1, const Eigen::Vector2d& x2)
+  SampsonErrorCostFunctor(const Eigen::Vector2d& x1, const Eigen::Vector2d& x2)
       : x1_(x1(0)), y1_(x1(1)), x2_(x2(0)), y2_(x2(1)) {}
 
   static ceres::CostFunction* Create(const Eigen::Vector2d& x1,
                                      const Eigen::Vector2d& x2) {
-    return (new ceres::AutoDiffCostFunction<SampsonErrorCostFunction, 1, 4, 3>(
-        new SampsonErrorCostFunction(x1, x2)));
+    return (new ceres::AutoDiffCostFunction<SampsonErrorCostFunctor, 1, 4, 3>(
+        new SampsonErrorCostFunctor(x1, x2)));
   }
 
   template <typename T>
@@ -354,18 +353,18 @@ inline void EigenQuaternionToAngleAxis(const T* eigen_quaternion,
 // splitting SE(3) into SO(3) x R^3. The 6x6 covariance matrix is defined in the
 // reference frame of the camera. Its first and last three components correspond
 // to the rotation and translation errors, respectively.
-struct AbsolutePoseErrorCostFunction {
+struct AbsolutePoseErrorCostFunctor {
  public:
-  AbsolutePoseErrorCostFunction(const Rigid3d& cam_from_world,
-                                const EigenMatrix6d& covariance_cam)
+  AbsolutePoseErrorCostFunctor(const Rigid3d& cam_from_world,
+                               const EigenMatrix6d& covariance_cam)
       : world_from_cam_(Inverse(cam_from_world)),
         sqrt_information_cam_(SqrtInformation(covariance_cam)) {}
 
   static ceres::CostFunction* Create(const Rigid3d& cam_from_world,
                                      const EigenMatrix6d& covariance_cam) {
     return (
-        new ceres::AutoDiffCostFunction<AbsolutePoseErrorCostFunction, 6, 4, 3>(
-            new AbsolutePoseErrorCostFunction(cam_from_world, covariance_cam)));
+        new ceres::AutoDiffCostFunction<AbsolutePoseErrorCostFunctor, 6, 4, 3>(
+            new AbsolutePoseErrorCostFunctor(cam_from_world, covariance_cam)));
   }
 
   template <typename T>
@@ -405,22 +404,22 @@ struct AbsolutePoseErrorCostFunction {
 // Thus η_j = log(j_T_w·i_T_w⁻¹·i_T_j)
 // Rotation term: ΔR = log(j_R_w·i_R_w⁻¹·i_R_j)
 // Translation term: Δt = j_t_w + j_R_w·i_R_w⁻¹·(i_t_j -i_t_w)
-struct MetricRelativePoseErrorCostFunction {
+struct MetricRelativePoseErrorCostFunctor {
  public:
-  MetricRelativePoseErrorCostFunction(const Rigid3d& i_from_j,
-                                      const EigenMatrix6d& covariance_j)
+  MetricRelativePoseErrorCostFunctor(const Rigid3d& i_from_j,
+                                     const EigenMatrix6d& covariance_j)
       : i_from_j_(i_from_j),
         sqrt_information_j_(SqrtInformation(covariance_j)) {}
 
   static ceres::CostFunction* Create(const Rigid3d& i_from_j,
                                      const EigenMatrix6d& covariance_j) {
-    return (new ceres::AutoDiffCostFunction<MetricRelativePoseErrorCostFunction,
+    return (new ceres::AutoDiffCostFunction<MetricRelativePoseErrorCostFunctor,
                                             6,
                                             4,
                                             3,
                                             4,
                                             3>(
-        new MetricRelativePoseErrorCostFunction(i_from_j, covariance_j)));
+        new MetricRelativePoseErrorCostFunctor(i_from_j, covariance_j)));
   }
 
   template <typename T>
@@ -457,10 +456,10 @@ struct MetricRelativePoseErrorCostFunction {
 // covariance. Convention is similar to colmap::Sim3d
 // residual = scale_b_from_a * R_b_from_a * point_in_a + t_b_from_a -
 // ref_point_in_b
-struct Point3dAlignmentCostFunction {
+struct Point3dAlignmentCostFunctor {
  public:
-  Point3dAlignmentCostFunction(const Eigen::Vector3d& ref_point,
-                               const Eigen::Matrix3d& covariance_point)
+  Point3dAlignmentCostFunctor(const Eigen::Vector3d& ref_point,
+                              const Eigen::Matrix3d& covariance_point)
       : ref_point_(ref_point),
         sqrt_information_point_(SqrtInformation(covariance_point)) {}
 
@@ -468,8 +467,8 @@ struct Point3dAlignmentCostFunction {
                                      const Eigen::Matrix3d& covariance_point) {
     return (
         new ceres::
-            AutoDiffCostFunction<Point3dAlignmentCostFunction, 3, 3, 4, 3, 1>(
-                new Point3dAlignmentCostFunction(ref_point, covariance_point)));
+            AutoDiffCostFunction<Point3dAlignmentCostFunctor, 3, 3, 4, 3, 1>(
+                new Point3dAlignmentCostFunctor(ref_point, covariance_point)));
   }
 
   template <typename T>
@@ -494,9 +493,9 @@ struct Point3dAlignmentCostFunction {
 };
 
 // 3-DoF error on the cam to world position.
-struct PositionPriorErrorCostFunction {
+struct PositionPriorErrorCostFunctor {
  public:
-  PositionPriorErrorCostFunction(
+  PositionPriorErrorCostFunctor(
       const Eigen::Vector3d& world_from_cam_position_prior,
       const Eigen::Matrix3d& covariance)
       : world_from_cam_position_prior_(world_from_cam_position_prior),
@@ -505,10 +504,10 @@ struct PositionPriorErrorCostFunction {
   static ceres::CostFunction* Create(
       const Eigen::Vector3d& world_from_cam_position_prior,
       const Eigen::Matrix3d& covariance) {
-    return (new ceres::
-                AutoDiffCostFunction<PositionPriorErrorCostFunction, 3, 4, 3>(
-                    new PositionPriorErrorCostFunction(
-                        world_from_cam_position_prior, covariance)));
+    return (
+        new ceres::AutoDiffCostFunction<PositionPriorErrorCostFunctor, 3, 4, 3>(
+            new PositionPriorErrorCostFunctor(world_from_cam_position_prior,
+                                              covariance)));
   }
 
   template <typename T>

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -42,7 +42,7 @@ namespace colmap {
 namespace {
 
 TEST(BundleAdjustment, AbsolutePose) {
-  using CostFunction = ReprojErrorCostFunction<SimplePinholeCameraModel>;
+  using CostFunction = ReprojErrorCostFunctor<SimplePinholeCameraModel>;
   std::unique_ptr<ceres::CostFunction> cost_function(
       CostFunction::Create(Eigen::Vector2d::Zero()));
   double cam_from_world_rotation[4] = {0, 0, 0, 1};
@@ -85,7 +85,7 @@ TEST(BundleAdjustment, AbsolutePose) {
 TEST(BundleAdjustment, ConstantPoseAbsolutePose) {
   Rigid3d cam_from_world;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      ReprojErrorConstantPoseCostFunction<SimplePinholeCameraModel>::Create(
+      ReprojErrorConstantPoseCostFunctor<SimplePinholeCameraModel>::Create(
           cam_from_world, Eigen::Vector2d::Zero()));
   double point3D[3] = {0, 0, 1};
   double camera_params[3] = {1, 0, 0};
@@ -125,8 +125,8 @@ TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
 
   {
     std::unique_ptr<ceres::CostFunction> cost_function(
-        ReprojErrorConstantPoint3DCostFunction<
-            SimplePinholeCameraModel>::Create(point2D, point3D));
+        ReprojErrorConstantPoint3DCostFunctor<SimplePinholeCameraModel>::Create(
+            point2D, point3D));
     EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
     EXPECT_EQ(residuals[0], 0);
     EXPECT_EQ(residuals[1], 0);
@@ -135,8 +135,8 @@ TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
   {
     point3D[1] = 1;
     std::unique_ptr<ceres::CostFunction> cost_function(
-        ReprojErrorConstantPoint3DCostFunction<
-            SimplePinholeCameraModel>::Create(point2D, point3D));
+        ReprojErrorConstantPoint3DCostFunctor<SimplePinholeCameraModel>::Create(
+            point2D, point3D));
     EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
     EXPECT_EQ(residuals[0], 0);
     EXPECT_EQ(residuals[1], 1);
@@ -145,8 +145,8 @@ TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
   {
     camera_params[0] = 2;
     std::unique_ptr<ceres::CostFunction> cost_function(
-        ReprojErrorConstantPoint3DCostFunction<
-            SimplePinholeCameraModel>::Create(point2D, point3D));
+        ReprojErrorConstantPoint3DCostFunctor<SimplePinholeCameraModel>::Create(
+            point2D, point3D));
     EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
     EXPECT_EQ(residuals[0], 0);
     EXPECT_EQ(residuals[1], 2);
@@ -155,8 +155,8 @@ TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
   {
     point3D[0] = -1;
     std::unique_ptr<ceres::CostFunction> cost_function(
-        ReprojErrorConstantPoint3DCostFunction<
-            SimplePinholeCameraModel>::Create(point2D, point3D));
+        ReprojErrorConstantPoint3DCostFunctor<SimplePinholeCameraModel>::Create(
+            point2D, point3D));
     EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
     EXPECT_EQ(residuals[0], -2);
     EXPECT_EQ(residuals[1], 2);
@@ -165,7 +165,7 @@ TEST(BundleAdjustment, ConstantPoint3DAbsolutePose) {
 
 TEST(BundleAdjustment, Rig) {
   std::unique_ptr<ceres::CostFunction> cost_function(
-      RigReprojErrorCostFunction<SimplePinholeCameraModel>::Create(
+      RigReprojErrorCostFunctor<SimplePinholeCameraModel>::Create(
           Eigen::Vector2d::Zero()));
   double cam_from_rig_rotation[4] = {0, 0, 0, 1};
   double cam_from_rig_translation[3] = {0, 0, -1};
@@ -204,7 +204,7 @@ TEST(BundleAdjustment, ConstantRig) {
   Rigid3d cam_from_rig;
   cam_from_rig.translation << 0, 0, -1;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      RigReprojErrorConstantRigCostFunction<SimplePinholeCameraModel>::Create(
+      RigReprojErrorConstantRigCostFunctor<SimplePinholeCameraModel>::Create(
           cam_from_rig, Eigen::Vector2d::Zero()));
 
   double rig_from_world_rotation[4] = {0, 0, 0, 1};
@@ -238,8 +238,8 @@ TEST(BundleAdjustment, ConstantRig) {
 
 TEST(BundleAdjustment, RelativePose) {
   std::unique_ptr<ceres::CostFunction> cost_function(
-      SampsonErrorCostFunction::Create(Eigen::Vector2d(0, 0),
-                                       Eigen::Vector2d(0, 0)));
+      SampsonErrorCostFunctor::Create(Eigen::Vector2d(0, 0),
+                                      Eigen::Vector2d(0, 0)));
   double cam_from_world_rotation[4] = {1, 0, 0, 0};
   double cam_from_world_translation[3] = {0, 1, 0};
   double residuals[1];
@@ -248,13 +248,13 @@ TEST(BundleAdjustment, RelativePose) {
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], 0);
 
-  cost_function.reset(SampsonErrorCostFunction::Create(Eigen::Vector2d(0, 0),
-                                                       Eigen::Vector2d(1, 0)));
+  cost_function.reset(SampsonErrorCostFunctor::Create(Eigen::Vector2d(0, 0),
+                                                      Eigen::Vector2d(1, 0)));
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], 0.5);
 
-  cost_function.reset(SampsonErrorCostFunction::Create(Eigen::Vector2d(0, 0),
-                                                       Eigen::Vector2d(1, 1)));
+  cost_function.reset(SampsonErrorCostFunctor::Create(Eigen::Vector2d(0, 0),
+                                                      Eigen::Vector2d(1, 1)));
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], 0.5);
 }
@@ -264,8 +264,7 @@ TEST(PoseGraphOptimization, AbsolutePose) {
   EigenMatrix6d covariance_cam = EigenMatrix6d::Identity();
   covariance_cam(5, 5) = 4;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      AbsolutePoseErrorCostFunction::Create(mes_cam_from_world,
-                                            covariance_cam));
+      AbsolutePoseErrorCostFunctor::Create(mes_cam_from_world, covariance_cam));
 
   double cam_from_world_rotation[4] = {0, 0, 0, 1};
   double cam_from_world_translation[3] = {0, 0, 0};
@@ -311,7 +310,7 @@ TEST(PoseGraphOptimization, RelativePose) {
   EigenMatrix6d covariance_j = EigenMatrix6d::Identity();
   covariance_j(5, 5) = 4;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      MetricRelativePoseErrorCostFunction::Create(i_from_j, covariance_j));
+      MetricRelativePoseErrorCostFunctor::Create(i_from_j, covariance_j));
 
   double i_from_world_rotation[4] = {0, 0, 0, 1};
   double i_from_world_translation[3] = {0, 0, 0};
@@ -372,7 +371,7 @@ TEST(PoseGraphOptimization, Point3dAlignment) {
   Eigen::Matrix3d covariance_point = Eigen::Matrix3d::Identity();
   covariance_point(2, 2) = 4.;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      Point3dAlignmentCostFunction::Create(ref_point, covariance_point));
+      Point3dAlignmentCostFunctor::Create(ref_point, covariance_point));
   Eigen::Vector3d point(0., 0., 0.);
   const double* parameters[4] = {point.data(),
                                  tform.rotation.coeffs().data(),

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -42,9 +42,9 @@ namespace colmap {
 namespace {
 
 TEST(BundleAdjustment, AbsolutePose) {
-  using CostFunction = ReprojErrorCostFunctor<SimplePinholeCameraModel>;
+  using CostFunctor = ReprojErrorCostFunctor<SimplePinholeCameraModel>;
   std::unique_ptr<ceres::CostFunction> cost_function(
-      CostFunction::Create(Eigen::Vector2d::Zero()));
+      CostFunctor::Create(Eigen::Vector2d::Zero()));
   double cam_from_world_rotation[4] = {0, 0, 0, 1};
   double cam_from_world_translation[3] = {0, 0, 0};
   double point3D[3] = {0, 0, 1};
@@ -74,7 +74,7 @@ TEST(BundleAdjustment, AbsolutePose) {
   EXPECT_EQ(residuals[1], 2);
 
   std::unique_ptr<ceres::CostFunction> cost_function_with_noise(
-      IsotropicNoiseCostFunctionWrapper<CostFunction>::Create(
+      IsotropicNoiseCostFunctorWrapper<CostFunctor>::Create(
           2.0, Eigen::Vector2d::Zero()));
   EXPECT_TRUE(
       cost_function_with_noise->Evaluate(parameters, residuals, nullptr));

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -200,7 +200,7 @@ bool RefineGeneralizedAbsolutePose(const AbsolutePoseRefinementOptions& options,
     camera_counts[camera_idx] += 1;
 
     problem.AddResidualBlock(
-        CameraCostFunction<RigReprojErrorCostFunction>(
+        CameraCostFunction<RigReprojErrorCostFunctor>(
             cameras->at(camera_idx).model_id, points2D[i]),
         loss_function.get(),
         cams_from_rig_copy[camera_idx].rotation.coeffs().data(),

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -226,7 +226,7 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
       continue;
     }
     problem.AddResidualBlock(
-        CameraCostFunction<ReprojErrorConstantPoint3DCostFunction>(
+        CameraCostFunction<ReprojErrorConstantPoint3DCostFunctor>(
             camera->model_id, points2D[i], points3D[i]),
         loss_function.get(),
         rig_from_world_rotation,
@@ -330,7 +330,7 @@ bool RefineRelativePose(const ceres::Solver::Options& options,
 
   for (size_t i = 0; i < points1.size(); ++i) {
     ceres::CostFunction* cost_function =
-        SampsonErrorCostFunction::Create(points1[i], points2[i]);
+        SampsonErrorCostFunctor::Create(points1[i], points2[i]);
     problem.AddResidualBlock(cost_function,
                              loss_function,
                              cam2_from_cam1_rotation,

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -12,39 +12,39 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 template <typename CameraModel>
-using ReprojErrorCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<ReprojErrorCostFunction<CameraModel>>;
+using ReprojErrorCostFunctorWithNoise =
+    IsotropicNoiseCostFunctorWrapper<ReprojErrorCostFunctor<CameraModel>>;
 
 template <typename CameraModel>
-using ReprojErrorConstantPoseCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<
-        ReprojErrorConstantPoseCostFunction<CameraModel>>;
+using ReprojErrorConstantPoseCostFunctorWithNoise =
+    IsotropicNoiseCostFunctorWrapper<
+        ReprojErrorConstantPoseCostFunctor<CameraModel>>;
 
 template <typename CameraModel>
-using ReprojErrorConstantPoint3DCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<
-        ReprojErrorConstantPoint3DCostFunction<CameraModel>>;
+using ReprojErrorConstantPoint3DCostFunctorWithNoise =
+    IsotropicNoiseCostFunctorWrapper<
+        ReprojErrorConstantPoint3DCostFunctor<CameraModel>>;
 
 template <typename CameraModel>
-using RigReprojErrorCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<RigReprojErrorCostFunction<CameraModel>>;
+using RigReprojErrorCostFunctorWithNoise =
+    IsotropicNoiseCostFunctorWrapper<RigReprojErrorCostFunctor<CameraModel>>;
 
 template <typename CameraModel>
-using RigReprojErrorConstantRigCostFunctionWithNoise =
-    IsotropicNoiseCostFunctionWrapper<
-        RigReprojErrorConstantRigCostFunction<CameraModel>>;
+using RigReprojErrorConstantRigCostFunctorWithNoise =
+    IsotropicNoiseCostFunctorWrapper<
+        RigReprojErrorConstantRigCostFunctor<CameraModel>>;
 
 void BindCostFunctions(py::module& m_parent) {
   py::module_ m = m_parent.def_submodule("cost_functions");
   IsPyceresAvailable();  // Try to import pyceres to populate the docstrings.
 
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorCostFunction, const Eigen::Vector2d&>,
+        &CameraCostFunction<ReprojErrorCostFunctor, const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D"_a,
         "Reprojection error.");
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorCostFunctionWithNoise,
+        &CameraCostFunction<ReprojErrorCostFunctorWithNoise,
                             const double,
                             const Eigen::Vector2d&>,
         "camera_model_id"_a,
@@ -52,7 +52,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error with 2D detection noise.");
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorConstantPoseCostFunction,
+        &CameraCostFunction<ReprojErrorConstantPoseCostFunctor,
                             const Rigid3d&,
                             const Eigen::Vector2d&>,
         "camera_model_id"_a,
@@ -60,7 +60,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error with constant camera pose.");
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorConstantPoseCostFunctionWithNoise,
+        &CameraCostFunction<ReprojErrorConstantPoseCostFunctorWithNoise,
                             const double,
                             const Rigid3d&,
                             const Eigen::Vector2d&>,
@@ -70,7 +70,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error with constant camera pose and 2D detection noise.");
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunction,
+        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunctor,
                             const Eigen::Vector2d&,
                             const Eigen::Vector3d&>,
         "camera_model_id"_a,
@@ -78,7 +78,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point3D"_a,
         "Reprojection error with constant 3D point.");
   m.def("ReprojErrorCost",
-        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunctionWithNoise,
+        &CameraCostFunction<ReprojErrorConstantPoint3DCostFunctorWithNoise,
                             const double,
                             const Eigen::Vector2d&,
                             const Eigen::Vector3d&>,
@@ -89,12 +89,12 @@ void BindCostFunctions(py::module& m_parent) {
         "Reprojection error with constant 3D point and 2D detection noise.");
 
   m.def("RigReprojErrorCost",
-        &CameraCostFunction<RigReprojErrorCostFunction, const Eigen::Vector2d&>,
+        &CameraCostFunction<RigReprojErrorCostFunctor, const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D"_a,
         "Reprojection error for camera rig.");
   m.def("RigReprojErrorCost",
-        &CameraCostFunction<RigReprojErrorCostFunctionWithNoise,
+        &CameraCostFunction<RigReprojErrorCostFunctorWithNoise,
                             const double,
                             const Eigen::Vector2d&>,
         "camera_model_id"_a,
@@ -102,7 +102,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error for camera rig with 2D detection noise.");
   m.def("RigReprojErrorCost",
-        &CameraCostFunction<RigReprojErrorConstantRigCostFunction,
+        &CameraCostFunction<RigReprojErrorConstantRigCostFunctor,
                             const Rigid3d&,
                             const Eigen::Vector2d&>,
         "camera_model_id"_a,
@@ -110,7 +110,7 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error for camera rig with constant cam-from-rig pose.");
   m.def("RigReprojErrorCost",
-        &CameraCostFunction<RigReprojErrorConstantRigCostFunctionWithNoise,
+        &CameraCostFunction<RigReprojErrorConstantRigCostFunctorWithNoise,
                             const double,
                             const Rigid3d&,
                             const Eigen::Vector2d&>,
@@ -122,28 +122,28 @@ void BindCostFunctions(py::module& m_parent) {
         "2D detection noise.");
 
   m.def("SampsonErrorCost",
-        &SampsonErrorCostFunction::Create,
+        &SampsonErrorCostFunctor::Create,
         "point2D1"_a,
         "point2D2"_a,
         "Sampson error for two-view geometry.");
 
   m.def("AbsolutePoseErrorCost",
-        &AbsolutePoseErrorCostFunction::Create,
+        &AbsolutePoseErrorCostFunctor::Create,
         "cam_from_world"_a,
         "covariance_cam"_a,
         "6-DoF error on the absolute pose.");
   m.def("MetricRelativePoseErrorCost",
-        &MetricRelativePoseErrorCostFunction::Create,
+        &MetricRelativePoseErrorCostFunctor::Create,
         "i_from_j"_a,
         "covariance_j"_a,
         "6-DoF error between two absolute poses based on their relative pose.");
   m.def("Point3dAlignmentCost",
-        &Point3dAlignmentCostFunction::Create,
+        &Point3dAlignmentCostFunctor::Create,
         "ref_point"_a,
         "covariance_point"_a,
         "Error between 3D points transformed by a similarity transform.");
   m.def("PositionPriorErrorCost",
-        &PositionPriorErrorCostFunction::Create,
+        &PositionPriorErrorCostFunctor::Create,
         "world_from_cam_position_prior"_a,
         "covariance"_a);
 }


### PR DESCRIPTION
As in the title, rename all the cost functions to cost functors, as in here: https://github.com/ceres-solver/ceres-solver/blob/master/include/ceres/autodiff_cost_function.h#L161. 

Preparatory for the covariance update.