### PR TITLE
Install and use newer clang-format from pypi

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -116,9 +116,8 @@ jobs:
             exit 0
           fi
           set +x -euo pipefail
-          sudo apt-get update && sudo apt-get install -y clang-format-14
-          python -m pip install ruff==0.6.7
-          ./scripts/format/clang_format.sh
+          python -m pip install ruff==0.6.7 clang-format==19.1.0
+          ./scripts/format/c++.sh
           ./scripts/format/python.sh
           git diff --name-only
           git diff --exit-code || (echo "Code formatting failed" && exit 1)

--- a/pycolmap/pyproject.toml
+++ b/pycolmap/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "pybind11_stubgen @ git+https://github.com/sarlinpe/pybind11-stubgen@sarlinpe/fix-2024-08",
     "numpy",
     "ruff==0.6.7",
+    "clang-format==19.1.0",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/scripts/format/c++.sh
+++ b/scripts/format/c++.sh
@@ -2,29 +2,9 @@
 
 # This script applies clang-format to the whole repository.
 
-# Find clang-format
-tools='
-  clang-format-8
-  clang-format
-'
-
-clang_format=''
-for tool in ${tools}; do
-    if type -p "${tool}" > /dev/null; then
-        clang_format=$tool
-        break
-    fi
-done
-
-if [ -z "$clang_format" ]; then
-    echo "Could not locate clang-format"
-    exit 1
-fi
-echo "Found clang-format: $(which  ${clang_format})"
-
 # Check version
-version_string=$($clang_format --version | sed -E 's/^.*(\d+\.\d+\.\d+-.*).*$/\1/')
-expected_version_string='14.0.0'
+version_string=$(clang-format --version | sed -E 's/^.*(\d+\.\d+\.\d+-.*).*$/\1/')
+expected_version_string='19.1.0'
 if [[ "$version_string" =~ "$expected_version_string" ]]; then
     echo "clang-format version '$version_string' matches '$expected_version_string'"
 else
@@ -41,5 +21,4 @@ all_files=$( \
 num_files=$(echo $all_files | wc -w)
 echo "Formatting ${num_files} files"
 
-# Run clang-format
-${clang_format} -i $all_files
+clang-format -i $all_files

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -104,10 +104,14 @@
   }
 
 #define CheckVariablePoint(point, orig_point) \
-  { EXPECT_NE((point).xyz, (orig_point).xyz); }
+  {                                           \
+    EXPECT_NE((point).xyz, (orig_point).xyz); \
+  }
 
 #define CheckConstantPoint(point, orig_point) \
-  { EXPECT_EQ((point).xyz, (orig_point).xyz); }
+  {                                           \
+    EXPECT_EQ((point).xyz, (orig_point).xyz); \
+  }
 
 namespace colmap {
 namespace {

--- a/src/colmap/util/logging_test.cc
+++ b/src/colmap/util/logging_test.cc
@@ -52,17 +52,19 @@ TEST(ExceptionLogging, Nominal) {
   EXPECT_THROW(ThrowCheckEqual(0), std::invalid_argument);
   EXPECT_THROW(THROW_CHECK_NOTNULL(nullptr), std::invalid_argument);
   EXPECT_THROW({ LOG(FATAL_THROW) << "Error!"; }, std::invalid_argument);
-  EXPECT_THROW({ LOG_FATAL_THROW(std::logic_error) << "Error!"; },
-               std::logic_error);
+  EXPECT_THROW(
+      { LOG_FATAL_THROW(std::logic_error) << "Error!"; }, std::logic_error);
 }
 
 TEST(ExceptionLogging, Nested) {
   EXPECT_NO_THROW(PrintingFn("message"));
   EXPECT_THROW(PrintingFn(""), std::invalid_argument);
-  EXPECT_THROW({ LOG(FATAL_THROW) << "Error: " << PrintingFn("message"); },
-               std::invalid_argument);
-  EXPECT_THROW({ LOG(FATAL_THROW) << "Error: " << PrintingFn(""); },
-               std::invalid_argument);
+  EXPECT_THROW(
+      { LOG(FATAL_THROW) << "Error: " << PrintingFn("message"); },
+      std::invalid_argument);
+  EXPECT_THROW(
+      { LOG(FATAL_THROW) << "Error: " << PrintingFn(""); },
+      std::invalid_argument);
 }
 
 }  // namespace

--- a/src/pycolmap/pybind11_extension.h
+++ b/src/pycolmap/pybind11_extension.h
@@ -104,12 +104,15 @@ class class_ext_ : public class_<type_, options...> {
   using type = type_;
 
   template <typename C, typename D, typename... Extra>
-  class_ext_& def_readwrite(const char* name, D C::*pm, const Extra&... extra) {
+  class_ext_& def_readwrite(const char* name,
+                            D C::* pm,
+                            const Extra&... extra) {
     static_assert(
         std::is_same<C, type>::value || std::is_base_of<C, type>::value,
         "def_readwrite() requires a class member (or base class member)");
-    cpp_function fget([pm](type&c) -> D& { return c.*pm; }, is_method(*this)),
-        fset([pm](type&c, const D&value) { c.*pm = value; }, is_method(*this));
+    cpp_function fget([pm](type& c) -> D& { return c.*pm; }, is_method(*this)),
+        fset([pm](type& c, const D& value) { c.*pm = value; },
+             is_method(*this));
     this->def_property(
         name, fget, fset, return_value_policy::reference_internal, extra...);
     return *this;


### PR DESCRIPTION
Installing it from pypi makes it easier to rely on a consistent clang-format version on different platforms. It also allows us to use a more recent version.