### PR TITLE
Make Image::cam_from_world_ optional

### DIFF
--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -73,9 +73,7 @@ void BundleAdjustmentController::Run() {
   Timer run_timer;
   run_timer.Start();
 
-  const std::vector<image_t>& reg_image_ids = reconstruction_->RegImageIds();
-
-  if (reg_image_ids.size() < 2) {
+  if (reconstruction_->NumRegImages() < 2) {
     LOG(ERROR) << "Need at least two views.";
     return;
   }
@@ -90,11 +88,12 @@ void BundleAdjustmentController::Run() {
 
   // Configure bundle adjustment.
   BundleAdjustmentConfig ba_config;
-  for (const image_t image_id : reg_image_ids) {
+  for (const image_t image_id : reconstruction_->RegImageIds()) {
     ba_config.AddImage(image_id);
   }
-  ba_config.SetConstantCamPose(reg_image_ids[0]);
-  ba_config.SetConstantCamPositions(reg_image_ids[1], {0});
+  auto it_reg_image_ids = reconstruction_->RegImageIds().begin();
+  ba_config.SetConstantCamPose(*it_reg_image_ids);                // 1st image
+  ba_config.SetConstantCamPositions(*(++it_reg_image_ids), {0});  // 2nd image
 
   // Run bundle adjustment.
   BundleAdjuster bundle_adjuster(ba_options, ba_config);

--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -91,9 +91,9 @@ void BundleAdjustmentController::Run() {
   for (const image_t image_id : reconstruction_->RegImageIds()) {
     ba_config.AddImage(image_id);
   }
-  auto it_reg_image_ids = reconstruction_->RegImageIds().begin();
-  ba_config.SetConstantCamPose(*it_reg_image_ids);                // 1st image
-  ba_config.SetConstantCamPositions(*(++it_reg_image_ids), {0});  // 2nd image
+  auto reg_image_ids_it = reconstruction_->RegImageIds().begin();
+  ba_config.SetConstantCamPose(*reg_image_ids_it);                // 1st image
+  ba_config.SetConstantCamPositions(*(++reg_image_ids_it), {0});  // 2nd image
 
   // Run bundle adjustment.
   BundleAdjuster bundle_adjuster(ba_options, ba_config);

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -564,7 +564,7 @@ void IncrementalPipeline::TriangulateReconstruction(
 
   LOG(INFO) << "Iterative triangulation";
   size_t image_idx = 0;
-  for (const image_t& image_id : reconstruction->RegImageIds()) {
+  for (const image_t image_id : reconstruction->RegImageIds()) {
     const auto& image = reconstruction->Image(image_id);
 
     LOG(INFO) << StringPrintf(

--- a/src/colmap/controllers/incremental_mapper.cc
+++ b/src/colmap/controllers/incremental_mapper.cc
@@ -563,12 +563,12 @@ void IncrementalPipeline::TriangulateReconstruction(
   mapper.BeginReconstruction(reconstruction);
 
   LOG(INFO) << "Iterative triangulation";
-  const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
-  for (size_t i = 0; i < reg_image_ids.size(); ++i) {
-    const image_t image_id = reg_image_ids[i];
+  size_t image_idx = 0;
+  for (const image_t& image_id : reconstruction->RegImageIds()) {
     const auto& image = reconstruction->Image(image_id);
 
-    LOG(INFO) << StringPrintf("Triangulating image #%d (%d)", image_id, i);
+    LOG(INFO) << StringPrintf(
+        "Triangulating image #%d (%d)", image_id, image_idx++);
     const size_t num_existing_points3D = image.NumPoints3D();
     LOG(INFO) << "=> Image sees " << num_existing_points3D << " / "
               << mapper.ObservationManager().NumObservations(image_id)

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -435,9 +435,8 @@ bool MergeReconstructions(const double max_reproj_error,
   for (const auto image_id : missing_image_ids) {
     auto src_image = src_reconstruction.Image(image_id);
     src_image.ResetCameraPtr();
-    src_image.SetRegistered(false);
-    src_image.CamFromWorld() =
-        TransformCameraWorld(tgt_from_src, src_image.CamFromWorld());
+    src_image.SetCamFromWorld(
+        TransformCameraWorld(tgt_from_src, src_image.CamFromWorld()));
     if (!tgt_reconstruction.ExistsCamera(src_image.CameraId())) {
       tgt_reconstruction.AddCamera(
           src_reconstruction.Camera(src_image.CameraId()));

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -295,7 +295,7 @@ bool AlignReconstructionsViaProjCenters(
   std::vector<std::string> ref_image_names;
   std::vector<Eigen::Vector3d> ref_proj_centers;
   for (const auto& image : tgt_reconstruction.Images()) {
-    if (image.second.IsRegistered()) {
+    if (image.second.HasPose()) {
       ref_image_names.push_back(image.second.Name());
       ref_proj_centers.push_back(image.second.ProjectionCenter());
     }

--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -126,8 +126,8 @@ TEST(Alignment, MergeReconstructions) {
   Reconstruction tgt_reconstruction = src_reconstruction;
 
   // Remove the camera of the first image from the target reconstruction
-  const std::vector<image_t>& image_ids = tgt_reconstruction.RegImageIds();
-  camera_t camera_id = tgt_reconstruction.Image(image_ids[0]).CameraId();
+  const std::set<image_t> image_ids = tgt_reconstruction.RegImageIds();
+  camera_t camera_id = tgt_reconstruction.Image(*image_ids.begin()).CameraId();
   for (const auto& image_id : image_ids) {
     if (tgt_reconstruction.Image(image_id).CameraId() == camera_id) {
       tgt_reconstruction.DeRegisterImage(image_id);

--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -127,7 +127,8 @@ TEST(Alignment, MergeReconstructions) {
 
   // Remove the camera of the first image from the target reconstruction
   const std::set<image_t> image_ids = tgt_reconstruction.RegImageIds();
-  camera_t camera_id = tgt_reconstruction.Image(*image_ids.begin()).CameraId();
+  const camera_t camera_id =
+      tgt_reconstruction.Image(*image_ids.begin()).CameraId();
   for (const auto& image_id : image_ids) {
     if (tgt_reconstruction.Image(image_id).CameraId() == camera_id) {
       tgt_reconstruction.DeRegisterImage(image_id);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -412,7 +412,7 @@ void BundleAdjuster::AddImageToProblem(const image_t image_id,
   Camera& camera = *image.CameraPtr();
 
   // CostFunction assumes unit quaternions.
-  THROW_CHECK(image.IsRegistered());
+  THROW_CHECK(image.HasPose());
   image.CamFromWorld().rotation.normalize();
 
   double* cam_from_world_rotation =
@@ -945,7 +945,7 @@ void PosePriorBundleAdjuster::AddPosePriorToProblem(
     return;
   }
   Image& image = reconstruction->Image(image_id);
-  THROW_CHECK(image.IsRegistered());
+  THROW_CHECK(image.HasPose());
   double* cam_from_world_translation = image.CamFromWorld().translation.data();
 
   // If image has not been added to the problem do not use it

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -882,9 +882,9 @@ bool PosePriorBundleAdjuster::Solve(Reconstruction* reconstruction) {
 
   // Fix 7-DOFs of BA problem if not enough valid pose priors
   if (!use_prior_position_) {
-    auto it_reg_image_ids = reconstruction->RegImageIds().begin();
-    config_.SetConstantCamPose(*it_reg_image_ids);
-    config_.SetConstantCamPositions(*(++it_reg_image_ids), {0});
+    auto reg_image_ids_it = reconstruction->RegImageIds().begin();
+    config_.SetConstantCamPose(*reg_image_ids_it);
+    config_.SetConstantCamPositions(*(++reg_image_ids_it), {0});
   }
 
   // Normalize the reconstruction to avoid any numerical instability BUT do not

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -1021,7 +1021,11 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
 
   if (success) {
     reconstruction->Transform(sim3_tform);
+  } else {
+    LOG(WARNING) << "Sim3 alignment w.r.t. prior position failed!";
+  }
 
+  if (VLOG_IS_ON(2) && success) {
     std::vector<double> verr2_wrt_prior;
     verr2_wrt_prior.reserve(vini_err2_wrt_prior.size());
     for (const image_t& image_id : reconstruction->RegImageIds()) {
@@ -1042,8 +1046,6 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
     VLOG(2) << "Sim3 alignment error w.r.t. prior position:\n"
             << "  - rmse:   " << std::sqrt(Mean(verr2_wrt_prior)) << " m\n"
             << "  - median: " << std::sqrt(Median(verr2_wrt_prior)) << " m\n";
-  } else {
-    LOG(WARNING) << "Sim3 alignment w.r.t. prior position failed!";
   }
 
   return success;

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -974,7 +974,7 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
   v_src.reserve(NumPosePriors());
   v_tgt.reserve(NumPosePriors());
 
-  for (const image_t& image_id : reconstruction->RegImageIds()) {
+  for (const image_t image_id : reconstruction->RegImageIds()) {
     const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
     if (pose_prior_it != image_id_to_pose_prior_.end() &&
         pose_prior_it->second.IsValid()) {
@@ -1028,7 +1028,7 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
   if (VLOG_IS_ON(2) && success) {
     std::vector<double> verr2_wrt_prior;
     verr2_wrt_prior.reserve(vini_err2_wrt_prior.size());
-    for (const image_t& image_id : reconstruction->RegImageIds()) {
+    for (const image_t image_id : reconstruction->RegImageIds()) {
       const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
       if (pose_prior_it != image_id_to_pose_prior_.end() &&
           pose_prior_it->second.IsValid()) {

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -882,9 +882,9 @@ bool PosePriorBundleAdjuster::Solve(Reconstruction* reconstruction) {
 
   // Fix 7-DOFs of BA problem if not enough valid pose priors
   if (!use_prior_position_) {
-    const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
-    config_.SetConstantCamPose(reg_image_ids[0]);
-    config_.SetConstantCamPositions(reg_image_ids[1], {0});
+    auto it_reg_image_ids = reconstruction->RegImageIds().begin();
+    config_.SetConstantCamPose(*it_reg_image_ids);
+    config_.SetConstantCamPositions(*(++it_reg_image_ids), {0});
   }
 
   // Normalize the reconstruction to avoid any numerical instability BUT do not

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -352,8 +352,9 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
       options_.max_num_images_direct_sparse_cpu_solver;
 
 #ifdef COLMAP_CUDA_ENABLED
-#if (CERES_VERSION_MAJOR >= 3 || \
-     (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2))
+#if (CERES_VERSION_MAJOR >= 3 ||                                \
+     (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
+    !defined(CERES_NO_CUDA)
   if (options_.use_gpu && num_images >= options_.min_num_images_gpu_solver) {
     const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
     THROW_CHECK_GT(gpu_indices.size(), 0);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -412,6 +412,7 @@ void BundleAdjuster::AddImageToProblem(const image_t image_id,
   Camera& camera = *image.CameraPtr();
 
   // CostFunction assumes unit quaternions.
+  THROW_CHECK(image.IsRegistered());
   image.CamFromWorld().rotation.normalize();
 
   double* cam_from_world_rotation =
@@ -922,9 +923,14 @@ void PosePriorBundleAdjuster::SetUpProblem(
   BundleAdjuster::SetUpProblem(reconstruction, loss_function_.get());
 
   if (use_prior_position_) {
-    for (const auto& [image_id, pose_prior] : image_id_to_pose_prior_) {
-      AddPosePriorToProblem(
-          image_id, pose_prior, reconstruction, prior_loss_function_.get());
+    for (const image_t image_id : config_.Images()) {
+      const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
+      if (pose_prior_it != image_id_to_pose_prior_.end()) {
+        AddPosePriorToProblem(image_id,
+                              pose_prior_it->second,
+                              reconstruction,
+                              prior_loss_function_.get());
+      }
     }
   }
 }
@@ -939,7 +945,7 @@ void PosePriorBundleAdjuster::AddPosePriorToProblem(
     return;
   }
   Image& image = reconstruction->Image(image_id);
-
+  THROW_CHECK(image.IsRegistered());
   double* cam_from_world_translation = image.CamFromWorld().translation.data();
 
   // If image has not been added to the problem do not use it
@@ -968,11 +974,13 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
   v_src.reserve(NumPosePriors());
   v_tgt.reserve(NumPosePriors());
 
-  for (const auto& [image_id, pose_prior] : image_id_to_pose_prior_) {
-    if (pose_prior.IsValid()) {
+  for (const image_t& image_id : reconstruction->RegImageIds()) {
+    const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
+    if (pose_prior_it != image_id_to_pose_prior_.end() &&
+        pose_prior_it->second.IsValid()) {
       const auto& image = reconstruction->Image(image_id);
       v_src.push_back(image.ProjectionCenter());
-      v_tgt.push_back(pose_prior.position);
+      v_tgt.push_back(pose_prior_it->second.position);
       vini_err2_wrt_prior.push_back(
           (v_src.back() - v_tgt.back()).squaredNorm());
     }
@@ -1016,11 +1024,14 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
 
     std::vector<double> verr2_wrt_prior;
     verr2_wrt_prior.reserve(vini_err2_wrt_prior.size());
-    for (const auto& [image_id, pose_prior] : image_id_to_pose_prior_) {
-      if (pose_prior.IsValid()) {
+    for (const image_t& image_id : reconstruction->RegImageIds()) {
+      const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
+      if (pose_prior_it != image_id_to_pose_prior_.end() &&
+          pose_prior_it->second.IsValid()) {
         const auto& image = reconstruction->Image(image_id);
         verr2_wrt_prior.push_back(
-            (image.ProjectionCenter() - pose_prior.position).squaredNorm());
+            (image.ProjectionCenter() - pose_prior_it->second.position)
+                .squaredNorm());
       }
     }
 

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -158,11 +158,10 @@ void GenerateReconstruction(const size_t num_images,
     image.SetImageId(image_id);
     image.SetCameraId(camera_id);
     image.SetName(std::to_string(i));
-    image.CamFromWorld() = Rigid3d(
+    image.SetCamFromWorld(Rigid3d(
         Eigen::Quaterniond::Identity(),
         Eigen::Vector3d(
-            RandomUniformReal(-1.0, 1.0), RandomUniformReal(-1.0, 1.0), 10));
-    image.SetRegistered(true);
+            RandomUniformReal(-1.0, 1.0), RandomUniformReal(-1.0, 1.0), 10)));
     reconstruction->AddImage(image);
 
     const Eigen::Matrix3x4d cam_from_world_matrix =

--- a/src/colmap/estimators/coordinate_frame.cc
+++ b/src/colmap/estimators/coordinate_frame.cc
@@ -165,7 +165,7 @@ Eigen::Matrix3d EstimateManhattanWorldFrame(
   std::vector<Eigen::Vector3d> rightward_axes;
   std::vector<Eigen::Vector3d> downward_axes;
   size_t image_idx = 0;
-  for (const image_t& image_id : reconstruction.RegImageIds()) {
+  for (const image_t image_id : reconstruction.RegImageIds()) {
     const auto& image = reconstruction.Image(image_id);
     const auto& camera = *image.CameraPtr();
 

--- a/src/colmap/estimators/coordinate_frame.cc
+++ b/src/colmap/estimators/coordinate_frame.cc
@@ -164,14 +164,14 @@ Eigen::Matrix3d EstimateManhattanWorldFrame(
     const std::string& image_path) {
   std::vector<Eigen::Vector3d> rightward_axes;
   std::vector<Eigen::Vector3d> downward_axes;
-  for (size_t i = 0; i < reconstruction.NumRegImages(); ++i) {
-    const auto image_id = reconstruction.RegImageIds()[i];
+  size_t image_idx = 0;
+  for (const image_t& image_id : reconstruction.RegImageIds()) {
     const auto& image = reconstruction.Image(image_id);
     const auto& camera = *image.CameraPtr();
 
     PrintHeading1(StringPrintf("Processing image %s (%d / %d)",
                                image.Name().c_str(),
-                               i + 1,
+                               ++image_idx,
                                reconstruction.NumRegImages()));
 
     LOG(INFO) << "Reading image...";
@@ -327,7 +327,8 @@ void AlignToPrincipalPlane(Reconstruction* reconstruction, Sim3d* tform) {
   // If camera plane ends up below ground then flip basis vectors.
   const Rigid3d cam0_from_aligned_world = TransformCameraWorld(
       *tform,
-      reconstruction->Image(reconstruction->RegImageIds()[0]).CamFromWorld());
+      reconstruction->Image(*reconstruction->RegImageIds().begin())
+          .CamFromWorld());
   if (Inverse(cam0_from_aligned_world).translation.z() < 0.0) {
     rot_mat << basis.col(0), -basis.col(1), basis.col(0).cross(-basis.col(1));
     rot_mat.transposeInPlace();

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -65,9 +65,8 @@ TEST(CoordinateFrame, AlignToPrincipalPlane) {
   Image image;
   image.SetCameraId(camera.camera_id);
   image.SetImageId(1);
-  image.SetRegistered(true);
-  image.CamFromWorld() =
-      Rigid3d(Eigen::Quaterniond::Identity(), Eigen::Vector3d(-1, 0, 0));
+  image.SetCamFromWorld(
+      Rigid3d(Eigen::Quaterniond::Identity(), Eigen::Vector3d(-1, 0, 0)));
   reconstruction.AddImage(image);
   // Setup 4 points on the Y-Z plane
   const point3D_t p1 =

--- a/src/colmap/exe/image.cc
+++ b/src/colmap/exe/image.cc
@@ -179,7 +179,7 @@ int RunImageFilterer(int argc, char** argv) {
 
   std::vector<image_t> filtered_image_ids;
   for (const auto& [image_id, image] : reconstruction.Images()) {
-    if (image.IsRegistered() && image.NumPoints3D() < min_num_observations) {
+    if (image.HasPose() && image.NumPoints3D() < min_num_observations) {
       filtered_image_ids.push_back(image_id);
     }
   }
@@ -282,7 +282,7 @@ int RunImageRegistrator(int argc, char** argv) {
   const auto mapper_options = options.mapper->Mapper();
 
   for (const auto& image : reconstruction->Images()) {
-    if (image.second.IsRegistered()) {
+    if (image.second.HasPose()) {
       continue;
     }
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -241,7 +241,7 @@ int RunMapper(int argc, char** argv) {
   // frame, as the reconstruction is normalized multiple times for numerical
   // stability.
   std::vector<Eigen::Vector3d> orig_fixed_image_positions;
-  std::vector<image_t> fixed_image_ids;
+  std::set<image_t> fixed_image_ids;
   if (options.mapper->fix_existing_images &&
       reconstruction_manager->Size() > 0) {
     const auto& reconstruction = reconstruction_manager->Get(0);
@@ -418,7 +418,7 @@ int RunPosePriorMapper(int argc, char** argv) {
   // frame, as the reconstruction is normalized multiple times for numerical
   // stability.
   std::vector<Eigen::Vector3d> orig_fixed_image_positions;
-  std::vector<image_t> fixed_image_ids;
+  std::set<image_t> fixed_image_ids;
   if (options.mapper->fix_existing_images &&
       reconstruction_manager->Size() > 0) {
     const auto& reconstruction = reconstruction_manager->Get(0);

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -192,7 +192,7 @@ void COLMAPUndistorter::Run() {
   futures.reserve(reconstruction_.NumRegImages());
   std::vector<image_t> image_ids;
   if (image_ids_.empty()) {
-    for (const image_t& image_id : reconstruction_.RegImageIds()) {
+    for (const image_t image_id : reconstruction_.RegImageIds()) {
       futures.push_back(
           thread_pool.AddTask(&COLMAPUndistorter::Undistort, this, image_id));
       image_ids.push_back(image_id);
@@ -409,7 +409,7 @@ void PMVSUndistorter::WriteVisibilityData() const {
   file << reconstruction_.NumRegImages() << std::endl;
 
   size_t image_idx = 0;
-  for (const image_t& image_id : reconstruction_.RegImageIds()) {
+  for (const image_t image_id : reconstruction_.RegImageIds()) {
     const Image& image = reconstruction_.Image(image_id);
     std::unordered_set<image_t> visible_image_ids;
     for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -202,6 +202,7 @@ TEST(UndistortReconstruction, Nominal) {
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Ones()));
+    image.SetCamFromWorld(Rigid3d());
     reconstruction.AddImage(image);
     reconstruction.RegisterImage(image_id);
   }

--- a/src/colmap/mvs/model.cc
+++ b/src/colmap/mvs/model.cc
@@ -60,7 +60,7 @@ void Model::ReadFromCOLMAP(const std::string& path,
   images.reserve(reconstruction.NumRegImages());
   std::unordered_map<image_t, size_t> image_id_to_idx;
   size_t image_idx = 0;
-  for (const image_t& image_id : reconstruction.RegImageIds()) {
+  for (const image_t image_id : reconstruction.RegImageIds()) {
     const auto& image = reconstruction.Image(image_id);
     const auto& camera = *image.CameraPtr();
 

--- a/src/colmap/mvs/model.cc
+++ b/src/colmap/mvs/model.cc
@@ -59,8 +59,8 @@ void Model::ReadFromCOLMAP(const std::string& path,
 
   images.reserve(reconstruction.NumRegImages());
   std::unordered_map<image_t, size_t> image_id_to_idx;
-  for (size_t i = 0; i < reconstruction.NumRegImages(); ++i) {
-    const auto image_id = reconstruction.RegImageIds()[i];
+  size_t image_idx = 0;
+  for (const image_t& image_id : reconstruction.RegImageIds()) {
     const auto& image = reconstruction.Image(image_id);
     const auto& camera = *image.CameraPtr();
 
@@ -73,9 +73,10 @@ void Model::ReadFromCOLMAP(const std::string& path,
 
     images.emplace_back(
         image_path, camera.width, camera.height, K.data(), R.data(), T.data());
-    image_id_to_idx.emplace(image_id, i);
+    image_id_to_idx.emplace(image_id, image_idx);
     image_names_.push_back(image.Name());
-    image_name_to_idx_.emplace(image.Name(), i);
+    image_name_to_idx_.emplace(image.Name(), image_idx);
+    ++image_idx;
   }
 
   points.reserve(reconstruction.NumPoints3D());

--- a/src/colmap/scene/camera_rig_test.cc
+++ b/src/colmap/scene/camera_rig_test.cc
@@ -174,11 +174,13 @@ TEST(CameraRig, ComputeRigFromWorldScale) {
   Image image1;
   image1.SetImageId(0);
   image1.SetCameraId(camera1.camera_id);
+  image1.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image1);
 
   Image image2;
   image2.SetImageId(1);
   image2.SetCameraId(camera2.camera_id);
+  image2.SetCamFromWorld(Rigid3d());
   image2.CamFromWorld().translation = Eigen::Vector3d(1, 2, 3);
   reconstruction.AddImage(image2);
 
@@ -211,11 +213,13 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   Image image1;
   image1.SetImageId(0);
   image1.SetCameraId(camera1.camera_id);
+  image1.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image1);
 
   Image image2;
   image2.SetImageId(1);
   image2.SetCameraId(camera2.camera_id);
+  image2.SetCamFromWorld(Rigid3d());
   image2.CamFromWorld().translation = Eigen::Vector3d(1, 2, 3);
   reconstruction.AddImage(image2);
 
@@ -235,11 +239,13 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   Image image3;
   image3.SetImageId(2);
   image3.SetCameraId(camera1.camera_id);
+  image3.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image3);
 
   Image image4;
   image4.SetImageId(3);
   image4.SetCameraId(camera2.camera_id);
+  image4.SetCamFromWorld(Rigid3d());
   image4.CamFromWorld().translation = Eigen::Vector3d(2, 4, 6);
   reconstruction.AddImage(image4);
 
@@ -258,6 +264,7 @@ TEST(CameraRig, ComputeCamsFromRigs) {
   Image image5;
   image5.SetImageId(4);
   image5.SetCameraId(camera1.camera_id);
+  image5.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image5);
 
   camera_rig.Check(reconstruction);
@@ -290,11 +297,13 @@ TEST(CameraRig, ComputeRigFromWorld) {
   Image image1;
   image1.SetImageId(0);
   image1.SetCameraId(camera1.camera_id);
+  image1.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image1);
 
   Image image2;
   image2.SetImageId(1);
   image2.SetCameraId(camera2.camera_id);
+  image2.SetCamFromWorld(Rigid3d());
   image2.CamFromWorld().translation = Eigen::Vector3d(3, 3, 3);
   reconstruction.AddImage(image2);
 

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -39,7 +39,6 @@ Image::Image()
       name_(""),
       camera_id_(kInvalidCameraId),
       camera_ptr_(nullptr),
-      registered_(false),
       num_points3D_(0) {}
 
 void Image::SetPoints2D(const std::vector<Eigen::Vector2d>& points) {
@@ -88,17 +87,17 @@ bool Image::HasPoint3D(const point3D_t point3D_id) const {
 }
 
 Eigen::Vector3d Image::ProjectionCenter() const {
-  return cam_from_world_.rotation.inverse() * -cam_from_world_.translation;
+  return CamFromWorld().rotation.inverse() * -CamFromWorld().translation;
 }
 
 Eigen::Vector3d Image::ViewingDirection() const {
-  return cam_from_world_.rotation.toRotationMatrix().row(2);
+  return CamFromWorld().rotation.toRotationMatrix().row(2);
 }
 
 std::pair<bool, Eigen::Vector2d> Image::ProjectPoint(
     const Eigen::Vector3d& point3D) const {
   THROW_CHECK(HasCameraPtr());
-  const Eigen::Vector3d point3D_in_cam = cam_from_world_ * point3D;
+  const Eigen::Vector3d point3D_in_cam = CamFromWorld() * point3D;
   if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
     return {false, Eigen::Vector2d()};
   }

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -77,10 +77,6 @@ class Image {
   inline void ResetCameraPtr();
   inline bool HasCameraPtr() const;
 
-  // Check if image is registered.
-  inline bool IsRegistered() const;
-  inline void DeRegister();
-
   // Get the number of image points.
   inline point2D_t NumPoints2D() const;
 
@@ -94,6 +90,8 @@ class Image {
   inline std::optional<Rigid3d>& MaybeCamFromWorld();
   inline void SetCamFromWorld(const Rigid3d& cam_from_world);
   inline void SetCamFromWorld(const std::optional<Rigid3d>& cam_from_world);
+  inline bool HasPose() const;
+  inline void ResetPose();
 
   // Access the coordinates of image points.
   inline const struct Point2D& Point2D(point2D_t point2D_idx) const;
@@ -192,10 +190,6 @@ void Image::ResetCameraPtr() { camera_ptr_ = nullptr; }
 
 bool Image::HasCameraPtr() const { return camera_ptr_ != nullptr; }
 
-bool Image::IsRegistered() const { return cam_from_world_.has_value(); }
-
-void Image::DeRegister() { cam_from_world_.reset(); }
-
 point2D_t Image::NumPoints2D() const {
   return static_cast<point2D_t>(points2D_.size());
 }
@@ -221,6 +215,10 @@ void Image::SetCamFromWorld(const Rigid3d& cam_from_world) {
 void Image::SetCamFromWorld(const std::optional<Rigid3d>& cam_from_world) {
   cam_from_world_ = cam_from_world;
 }
+
+bool Image::HasPose() const { return cam_from_world_.has_value(); }
+
+void Image::ResetPose() { cam_from_world_.reset(); }
 
 const struct Point2D& Image::Point2D(const point2D_t point2D_idx) const {
   return points2D_.at(point2D_idx);

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -197,12 +197,12 @@ point2D_t Image::NumPoints2D() const {
 point2D_t Image::NumPoints3D() const { return num_points3D_; }
 
 const Rigid3d& Image::CamFromWorld() const {
-  THROW_CHECK(cam_from_world_) << "Image needs to be registered first.";
+  THROW_CHECK(cam_from_world_) << "Image does not have a valid pose.";
   return *cam_from_world_;
 }
 
 Rigid3d& Image::CamFromWorld() {
-  THROW_CHECK(cam_from_world_) << "Image needs to be registered first.";
+  THROW_CHECK(cam_from_world_) << "Image does not have a valid pose.";
   return *cam_from_world_;
 }
 

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -204,12 +204,12 @@ point2D_t Image::NumPoints3D() const { return num_points3D_; }
 
 const Rigid3d& Image::CamFromWorld() const {
   THROW_CHECK(cam_from_world_) << "Image needs to be registered first.";
-  return cam_from_world_.value();
+  return *cam_from_world_;
 }
 
 Rigid3d& Image::CamFromWorld() {
   THROW_CHECK(cam_from_world_) << "Image needs to be registered first.";
-  return cam_from_world_.value();
+  return *cam_from_world_;
 }
 
 std::optional<Rigid3d>& Image::MaybeCamFromWorld() { return cam_from_world_; }

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -44,9 +44,6 @@ TEST(Image, Default) {
   EXPECT_FALSE(image.IsRegistered());
   EXPECT_EQ(image.NumPoints2D(), 0);
   EXPECT_EQ(image.NumPoints3D(), 0);
-  EXPECT_EQ(image.CamFromWorld().rotation.coeffs(),
-            Eigen::Quaterniond::Identity().coeffs());
-  EXPECT_EQ(image.CamFromWorld().translation, Eigen::Vector3d::Zero());
   EXPECT_EQ(image.Points2D().size(), 0);
 }
 
@@ -94,10 +91,15 @@ TEST(Image, CameraPtr) {
 TEST(Image, Registered) {
   Image image;
   EXPECT_FALSE(image.IsRegistered());
-  image.SetRegistered(true);
+  EXPECT_ANY_THROW(image.CamFromWorld());
+  image.SetCamFromWorld(Rigid3d());
   EXPECT_TRUE(image.IsRegistered());
-  image.SetRegistered(false);
+  EXPECT_EQ(image.CamFromWorld().rotation.coeffs(),
+            Eigen::Quaterniond::Identity().coeffs());
+  EXPECT_EQ(image.CamFromWorld().translation, Eigen::Vector3d::Zero());
+  image.DeRegister();
   EXPECT_FALSE(image.IsRegistered());
+  EXPECT_ANY_THROW(image.CamFromWorld());
 }
 
 TEST(Image, NumPoints2D) {
@@ -188,16 +190,19 @@ TEST(Image, Points3D) {
 
 TEST(Image, ProjectionCenter) {
   Image image;
+  image.SetCamFromWorld(Rigid3d());
   EXPECT_EQ(image.ProjectionCenter(), Eigen::Vector3d::Zero());
 }
 
 TEST(Image, ViewingDirection) {
   Image image;
+  image.SetCamFromWorld(Rigid3d());
   EXPECT_EQ(image.ViewingDirection(), Eigen::Vector3d(0, 0, 1));
 }
 
 TEST(Image, ProjectPoint) {
   Image image;
+  image.SetCamFromWorld(Rigid3d());
   Camera camera =
       Camera::CreateFromModelId(1, CameraModelId::kSimplePinhole, 1, 1, 1);
   image.SetCameraId(camera.camera_id);

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -41,7 +41,7 @@ TEST(Image, Default) {
   EXPECT_EQ(image.CameraId(), kInvalidCameraId);
   EXPECT_FALSE(image.HasCameraId());
   EXPECT_FALSE(image.HasCameraPtr());
-  EXPECT_FALSE(image.IsRegistered());
+  EXPECT_FALSE(image.HasPose());
   EXPECT_EQ(image.NumPoints2D(), 0);
   EXPECT_EQ(image.NumPoints3D(), 0);
   EXPECT_EQ(image.Points2D().size(), 0);
@@ -88,17 +88,17 @@ TEST(Image, CameraPtr) {
   EXPECT_ANY_THROW(image.CameraPtr());
 }
 
-TEST(Image, Registered) {
+TEST(Image, SetResetPose) {
   Image image;
-  EXPECT_FALSE(image.IsRegistered());
+  EXPECT_FALSE(image.HasPose());
   EXPECT_ANY_THROW(image.CamFromWorld());
   image.SetCamFromWorld(Rigid3d());
-  EXPECT_TRUE(image.IsRegistered());
+  EXPECT_TRUE(image.HasPose());
   EXPECT_EQ(image.CamFromWorld().rotation.coeffs(),
             Eigen::Quaterniond::Identity().coeffs());
   EXPECT_EQ(image.CamFromWorld().translation, Eigen::Vector3d::Zero());
-  image.DeRegister();
-  EXPECT_FALSE(image.IsRegistered());
+  image.ResetPose();
+  EXPECT_FALSE(image.HasPose());
   EXPECT_ANY_THROW(image.CamFromWorld());
 }
 

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -463,7 +463,7 @@ void Reconstruction::TranscribeImageIdsToDatabase(const Database& database) {
   images_ = std::move(new_images);
 
   std::set<image_t> new_reg_image_ids;
-  for (const image_t& image_id : RegImageIds()) {
+  for (const image_t image_id : RegImageIds()) {
     new_reg_image_ids.insert(old_to_new_image_ids.at(image_id));
   }
   reg_image_ids_ = new_reg_image_ids;

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -87,7 +87,7 @@ void Reconstruction::TearDown() {
   // Remove all not yet registered images.
   std::unordered_set<camera_t> keep_camera_ids;
   for (auto it = images_.begin(); it != images_.end();) {
-    if (it->second.HasPose()) {
+    if (IsImageRegistered(it->first)) {
       keep_camera_ids.insert(it->second.CameraId());
       ++it;
     } else {
@@ -433,7 +433,8 @@ std::vector<std::pair<image_t, image_t>> Reconstruction::FindCommonRegImageIds(
   for (const auto image_id : RegImageIds()) {
     const auto& image = Image(image_id);
     const auto* other_image = other.FindImageWithName(image.Name());
-    if (other_image != nullptr && other_image->HasPose()) {
+    if (other_image != nullptr &&
+        other.IsImageRegistered(other_image->ImageId())) {
       common_reg_image_ids.emplace_back(image_id, other_image->ImageId());
     }
   }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -125,8 +125,9 @@ void Reconstruction::AddImage(class Image image) {
     image.SetCameraPtr(&camera);
   }
   const image_t image_id = image.ImageId();
+  const bool is_registered = image.IsRegistered();
   THROW_CHECK(images_.emplace(image_id, std::move(image)).second);
-  if (image.IsRegistered()) {
+  if (is_registered) {
     THROW_CHECK_NE(image_id, kInvalidImageId);
     RegisterImage(image_id);
   }

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -79,7 +79,7 @@ class Reconstruction {
   // Get reference to all objects.
   inline const std::unordered_map<camera_t, struct Camera>& Cameras() const;
   inline const std::unordered_map<image_t, class Image>& Images() const;
-  inline std::vector<image_t> RegImageIds() const;
+  inline const std::set<image_t>& RegImageIds() const;
   inline const std::unordered_map<point3D_t, struct Point3D>& Points3D() const;
 
   // Identifiers of all 3D points.
@@ -299,8 +299,8 @@ const std::unordered_map<image_t, class Image>& Reconstruction::Images() const {
   return images_;
 }
 
-std::vector<image_t> Reconstruction::RegImageIds() const {
-  return std::vector<image_t>(reg_image_ids_.begin(), reg_image_ids_.end());
+const std::set<image_t>& Reconstruction::RegImageIds() const {
+  return reg_image_ids_;
 }
 
 const std::unordered_map<point3D_t, Point3D>& Reconstruction::Points3D() const {

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -350,7 +350,7 @@ bool Reconstruction::ExistsPoint3D(const point3D_t point3D_id) const {
 }
 
 bool Reconstruction::IsImageRegistered(const image_t image_id) const {
-  return Image(image_id).HasPose();
+  return reg_image_ids_.find(image_id) != reg_image_ids_.end();
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -320,7 +320,7 @@ bool Reconstruction::ExistsPoint3D(const point3D_t point3D_id) const {
 }
 
 bool Reconstruction::IsImageRegistered(const image_t image_id) const {
-  return Image(image_id).IsRegistered();
+  return Image(image_id).HasPose();
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -40,6 +40,7 @@
 #include "colmap/util/types.h"
 
 #include <memory>
+#include <set>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -78,7 +79,7 @@ class Reconstruction {
   // Get reference to all objects.
   inline const std::unordered_map<camera_t, struct Camera>& Cameras() const;
   inline const std::unordered_map<image_t, class Image>& Images() const;
-  inline const std::vector<image_t>& RegImageIds() const;
+  inline std::vector<image_t> RegImageIds() const;
   inline const std::unordered_map<point3D_t, struct Point3D>& Points3D() const;
 
   // Identifiers of all 3D points.
@@ -247,7 +248,7 @@ class Reconstruction {
   std::unordered_map<point3D_t, struct Point3D> points3D_;
 
   // { image_id, ... } where `images_.at(image_id).registered == true`.
-  std::vector<image_t> reg_image_ids_;
+  std::set<image_t> reg_image_ids_;
 
   // Total number of added 3D points, used to generate unique identifiers.
   point3D_t max_point3D_id_;
@@ -298,8 +299,8 @@ const std::unordered_map<image_t, class Image>& Reconstruction::Images() const {
   return images_;
 }
 
-const std::vector<image_t>& Reconstruction::RegImageIds() const {
-  return reg_image_ids_;
+std::vector<image_t> Reconstruction::RegImageIds() const {
+  return std::vector<image_t>(reg_image_ids_.begin(), reg_image_ids_.end());
 }
 
 const std::unordered_map<point3D_t, Point3D>& Reconstruction::Points3D() const {

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -420,7 +420,7 @@ void WriteImagesText(const Reconstruction& reconstruction,
        << reconstruction.ComputeMeanObservationsPerRegImage() << std::endl;
 
   for (const auto& image : reconstruction.Images()) {
-    if (!image.second.IsRegistered()) {
+    if (!image.second.HasPose()) {
       continue;
     }
 
@@ -532,7 +532,7 @@ void WriteImagesBinary(const Reconstruction& reconstruction,
   WriteBinaryLittleEndian<uint64_t>(&file, reconstruction.NumRegImages());
 
   for (const auto& image : reconstruction.Images()) {
-    if (!image.second.IsRegistered()) {
+    if (!image.second.HasPose()) {
       continue;
     }
 
@@ -987,7 +987,7 @@ void ExportVRML(const Reconstruction& reconstruction,
   points.emplace_back(-six / 3.0, +siy / 3.0, six * 1.0 * 2.0);
 
   for (const auto& image : reconstruction.Images()) {
-    if (!image.second.IsRegistered()) {
+    if (!image.second.HasPose()) {
       continue;
     }
 

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -114,8 +114,7 @@ void ReadImagesText(Reconstruction& reconstruction, const std::string& path) {
     class Image image;
     image.SetImageId(image_id);
 
-    image.SetRegistered(true);
-
+    image.SetCamFromWorld(Rigid3d());
     Rigid3d& cam_from_world = image.CamFromWorld();
 
     std::getline(line_stream1, item, ' ');
@@ -293,6 +292,7 @@ void ReadImagesBinary(Reconstruction& reconstruction, const std::string& path) {
 
     image.SetImageId(ReadBinaryLittleEndian<image_t>(&file));
 
+    image.SetCamFromWorld(Rigid3d());
     Rigid3d& cam_from_world = image.CamFromWorld();
     cam_from_world.rotation.w() = ReadBinaryLittleEndian<double>(&file);
     cam_from_world.rotation.x() = ReadBinaryLittleEndian<double>(&file);
@@ -335,7 +335,6 @@ void ReadImagesBinary(Reconstruction& reconstruction, const std::string& path) {
       }
     }
 
-    image.SetRegistered(true);
     reconstruction.AddImage(std::move(image));
   }
 }

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -419,8 +419,8 @@ void WriteImagesText(const Reconstruction& reconstruction,
        << ", mean observations per image: "
        << reconstruction.ComputeMeanObservationsPerRegImage() << std::endl;
 
-  for (const auto& image : reconstruction.Images()) {
-    if (!image.second.HasPose()) {
+  for (const auto& [image_id, image] : reconstruction.Images()) {
+    if (!reconstruction.IsImageRegistered(image_id)) {
       continue;
     }
 
@@ -429,9 +429,9 @@ void WriteImagesText(const Reconstruction& reconstruction,
 
     std::string line_string;
 
-    line << image.first << " ";
+    line << image_id << " ";
 
-    const Rigid3d& cam_from_world = image.second.CamFromWorld();
+    const Rigid3d& cam_from_world = image.CamFromWorld();
     line << cam_from_world.rotation.w() << " ";
     line << cam_from_world.rotation.x() << " ";
     line << cam_from_world.rotation.y() << " ";
@@ -440,16 +440,16 @@ void WriteImagesText(const Reconstruction& reconstruction,
     line << cam_from_world.translation.y() << " ";
     line << cam_from_world.translation.z() << " ";
 
-    line << image.second.CameraId() << " ";
+    line << image.CameraId() << " ";
 
-    line << image.second.Name();
+    line << image.Name();
 
     file << line.str() << std::endl;
 
     line.str("");
     line.clear();
 
-    for (const Point2D& point2D : image.second.Points2D()) {
+    for (const Point2D& point2D : image.Points2D()) {
       line << point2D.xy(0) << " ";
       line << point2D.xy(1) << " ";
       if (point2D.HasPoint3D()) {
@@ -531,14 +531,14 @@ void WriteImagesBinary(const Reconstruction& reconstruction,
 
   WriteBinaryLittleEndian<uint64_t>(&file, reconstruction.NumRegImages());
 
-  for (const auto& image : reconstruction.Images()) {
-    if (!image.second.HasPose()) {
+  for (const auto& [image_id, image] : reconstruction.Images()) {
+    if (!reconstruction.IsImageRegistered(image_id)) {
       continue;
     }
 
-    WriteBinaryLittleEndian<image_t>(&file, image.first);
+    WriteBinaryLittleEndian<image_t>(&file, image_id);
 
-    const Rigid3d& cam_from_world = image.second.CamFromWorld();
+    const Rigid3d& cam_from_world = image.CamFromWorld();
     WriteBinaryLittleEndian<double>(&file, cam_from_world.rotation.w());
     WriteBinaryLittleEndian<double>(&file, cam_from_world.rotation.x());
     WriteBinaryLittleEndian<double>(&file, cam_from_world.rotation.y());
@@ -547,13 +547,13 @@ void WriteImagesBinary(const Reconstruction& reconstruction,
     WriteBinaryLittleEndian<double>(&file, cam_from_world.translation.y());
     WriteBinaryLittleEndian<double>(&file, cam_from_world.translation.z());
 
-    WriteBinaryLittleEndian<camera_t>(&file, image.second.CameraId());
+    WriteBinaryLittleEndian<camera_t>(&file, image.CameraId());
 
-    const std::string name = image.second.Name() + '\0';
+    const std::string name = image.Name() + '\0';
     file.write(name.c_str(), name.size());
 
-    WriteBinaryLittleEndian<uint64_t>(&file, image.second.NumPoints2D());
-    for (const Point2D& point2D : image.second.Points2D()) {
+    WriteBinaryLittleEndian<uint64_t>(&file, image.NumPoints2D());
+    for (const Point2D& point2D : image.Points2D()) {
       WriteBinaryLittleEndian<double>(&file, point2D.xy(0));
       WriteBinaryLittleEndian<double>(&file, point2D.xy(1));
       WriteBinaryLittleEndian<point3D_t>(&file, point2D.point3D_id);
@@ -986,8 +986,8 @@ void ExportVRML(const Reconstruction& reconstruction,
   points.emplace_back(+six / 3.0, +siy / 3.0, six * 1.0 * 2.0);
   points.emplace_back(-six / 3.0, +siy / 3.0, six * 1.0 * 2.0);
 
-  for (const auto& image : reconstruction.Images()) {
-    if (!image.second.HasPose()) {
+  for (const auto& [image_id, image] : reconstruction.Images()) {
+    if (!reconstruction.IsImageRegistered(image_id)) {
       continue;
     }
 
@@ -1009,7 +1009,7 @@ void ExportVRML(const Reconstruction& reconstruction,
 
     // Move camera base model to camera pose.
     const Eigen::Matrix3x4d world_from_cam =
-        Inverse(image.second.CamFromWorld()).ToMatrix();
+        Inverse(image.CamFromWorld()).ToMatrix();
     for (size_t i = 0; i < points.size(); i++) {
       const Eigen::Vector3d point = world_from_cam * points[i].homogeneous();
       images_file << point(0) << " " << point(1) << " " << point(2) << "\n";

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -104,7 +104,7 @@ TEST(Reconstruction, AddImage) {
   reconstruction.AddImage(image);
   EXPECT_TRUE(reconstruction.ExistsImage(1));
   EXPECT_EQ(reconstruction.Image(1).ImageId(), 1);
-  EXPECT_FALSE(reconstruction.Image(1).HasPose());
+  EXPECT_FALSE(reconstruction.IsImageRegistered(1));
   EXPECT_EQ(reconstruction.Images().count(1), 1);
   EXPECT_EQ(reconstruction.Images().size(), 1);
   EXPECT_EQ(reconstruction.NumCameras(), 1);

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -63,7 +63,7 @@ void GenerateReconstruction(const image_t num_images,
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Zero()));
-    image.SetRegistered(true);
+    image.SetCamFromWorld(Rigid3d());
     reconstruction->AddImage(std::move(image));
   }
 }
@@ -233,11 +233,13 @@ TEST(Reconstruction, Normalize) {
   reconstruction.DeRegisterImage(1);
   reconstruction.DeRegisterImage(2);
   reconstruction.DeRegisterImage(3);
-  reconstruction.Normalize(/*fixed_scale=*/false);
-  EXPECT_NEAR(
-      reconstruction.Image(1).CamFromWorld().translation.z(), -10, 1e-6);
-  EXPECT_NEAR(reconstruction.Image(2).CamFromWorld().translation.z(), 0, 1e-6);
-  EXPECT_NEAR(reconstruction.Image(3).CamFromWorld().translation.z(), 10, 1e-6);
+  Sim3d tform = reconstruction.Normalize(/*fixed_scale=*/false);
+  EXPECT_EQ(tform.scale, 1);
+  EXPECT_EQ(tform.rotation.coeffs(), Eigen::Quaterniond::Identity().coeffs());
+  EXPECT_EQ(tform.translation, Eigen::Vector3d::Zero());
+  reconstruction.Image(1).SetCamFromWorld(Rigid3d());
+  reconstruction.Image(2).SetCamFromWorld(Rigid3d());
+  reconstruction.Image(3).SetCamFromWorld(Rigid3d());
   reconstruction.Image(1).CamFromWorld().translation.z() = -20.0;
   reconstruction.Image(2).CamFromWorld().translation.z() = -10.0;
   reconstruction.Image(3).CamFromWorld().translation.z() = 0.0;
@@ -263,7 +265,7 @@ TEST(Reconstruction, Normalize) {
   EXPECT_NEAR(reconstruction.Image(1).CamFromWorld().translation.z(), -5, 1e-6);
   EXPECT_NEAR(reconstruction.Image(2).CamFromWorld().translation.z(), 0, 1e-6);
   EXPECT_NEAR(reconstruction.Image(3).CamFromWorld().translation.z(), 5, 1e-6);
-  const Sim3d tform = reconstruction.Normalize(/*fixed_scale=*/false, 20);
+  tform = reconstruction.Normalize(/*fixed_scale=*/false, 20);
   EXPECT_NEAR(
       reconstruction.Image(1).CamFromWorld().translation.z(), -10, 1e-6);
   EXPECT_NEAR(reconstruction.Image(2).CamFromWorld().translation.z(), 0, 1e-6);
@@ -280,6 +282,7 @@ TEST(Reconstruction, Normalize) {
   Image image;
   image.SetCameraId(reconstruction.Image(1).CameraId());
   image.SetImageId(4);
+  image.SetCamFromWorld(Rigid3d());
   reconstruction.AddImage(image);
   reconstruction.RegisterImage(4);
   image.SetImageId(5);

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -104,7 +104,7 @@ TEST(Reconstruction, AddImage) {
   reconstruction.AddImage(image);
   EXPECT_TRUE(reconstruction.ExistsImage(1));
   EXPECT_EQ(reconstruction.Image(1).ImageId(), 1);
-  EXPECT_FALSE(reconstruction.Image(1).IsRegistered());
+  EXPECT_FALSE(reconstruction.Image(1).HasPose());
   EXPECT_EQ(reconstruction.Images().count(1), 1);
   EXPECT_EQ(reconstruction.Images().size(), 1);
   EXPECT_EQ(reconstruction.NumCameras(), 1);
@@ -212,15 +212,15 @@ TEST(Reconstruction, RegisterImage) {
   Reconstruction reconstruction;
   GenerateReconstruction(1, &reconstruction);
   EXPECT_EQ(reconstruction.NumRegImages(), 1);
-  EXPECT_TRUE(reconstruction.Image(1).IsRegistered());
+  EXPECT_TRUE(reconstruction.Image(1).HasPose());
   EXPECT_TRUE(reconstruction.IsImageRegistered(1));
   reconstruction.RegisterImage(1);
   EXPECT_EQ(reconstruction.NumRegImages(), 1);
-  EXPECT_TRUE(reconstruction.Image(1).IsRegistered());
+  EXPECT_TRUE(reconstruction.Image(1).HasPose());
   EXPECT_TRUE(reconstruction.IsImageRegistered(1));
   reconstruction.DeRegisterImage(1);
   EXPECT_EQ(reconstruction.NumRegImages(), 0);
-  EXPECT_FALSE(reconstruction.Image(1).IsRegistered());
+  EXPECT_FALSE(reconstruction.Image(1).HasPose());
   EXPECT_FALSE(reconstruction.IsImageRegistered(1));
 }
 

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -56,11 +56,11 @@ void AddOutlierMatches(double inlier_ratio,
 void SynthesizeExhaustiveMatches(double inlier_match_ratio,
                                  Reconstruction* reconstruction,
                                  Database* database) {
-  for (const image_t& image_id1 : reconstruction->RegImageIds()) {
+  for (const image_t image_id1 : reconstruction->RegImageIds()) {
     const auto& image1 = reconstruction->Image(image_id1);
     const Eigen::Matrix3d K1 = image1.CameraPtr()->CalibrationMatrix();
     const auto num_points2D1 = image1.NumPoints2D();
-    for (const image_t& image_id2 : reconstruction->RegImageIds()) {
+    for (const image_t image_id2 : reconstruction->RegImageIds()) {
       if (image_id1 == image_id2) {
         break;
       }

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -203,6 +203,7 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
     // centered at origin.
     const Eigen::Vector3d view_dir = -Eigen::Vector3d::Random().normalized();
     const Eigen::Vector3d proj_center = -5 * view_dir;
+    image.SetCamFromWorld(Rigid3d());
     image.CamFromWorld().rotation =
         Eigen::Quaterniond::FromTwoVectors(view_dir, Eigen::Vector3d(0, 0, 1));
     image.CamFromWorld().translation =

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -56,13 +56,15 @@ void AddOutlierMatches(double inlier_ratio,
 void SynthesizeExhaustiveMatches(double inlier_match_ratio,
                                  Reconstruction* reconstruction,
                                  Database* database) {
-  const std::vector<image_t>& reg_image_ids = reconstruction->RegImageIds();
-  for (size_t image_idx1 = 0; image_idx1 < reg_image_ids.size(); ++image_idx1) {
-    const auto& image1 = reconstruction->Image(reg_image_ids[image_idx1]);
+  for (const image_t& image_id1 : reconstruction->RegImageIds()) {
+    const auto& image1 = reconstruction->Image(image_id1);
     const Eigen::Matrix3d K1 = image1.CameraPtr()->CalibrationMatrix();
     const auto num_points2D1 = image1.NumPoints2D();
-    for (size_t image_idx2 = 0; image_idx2 < image_idx1; ++image_idx2) {
-      const auto& image2 = reconstruction->Image(reg_image_ids[image_idx2]);
+    for (const image_t& image_id2 : reconstruction->RegImageIds()) {
+      if (image_id1 == image_id2) {
+        break;
+      }
+      const auto& image2 = reconstruction->Image(image_id2);
       const Eigen::Matrix3d K2 = image2.CameraPtr()->CalibrationMatrix();
       const auto num_points2D2 = image2.NumPoints2D();
 

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -736,11 +736,11 @@ bool IncrementalMapper::AdjustGlobalBundle(
 
   if (!use_prior_position) {
     // Fix 7-DOFs of the bundle adjustment problem.
-    auto it_reg_image_ids = reg_image_ids.begin();
-    ba_config.SetConstantCamPose(*(it_reg_image_ids++));  // 1st image
+    auto reg_image_ids_it = reg_image_ids.begin();
+    ba_config.SetConstantCamPose(*(reg_image_ids_it++));  // 1st image
     if (!options.fix_existing_images ||
-        !existing_image_ids_.count(*it_reg_image_ids)) {
-      ba_config.SetConstantCamPositions(*it_reg_image_ids, {0});  // 2nd image
+        !existing_image_ids_.count(*reg_image_ids_it)) {
+      ba_config.SetConstantCamPositions(*reg_image_ids_it, {0});  // 2nd image
     }
 
     // Run bundle adjustment.

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -292,8 +292,8 @@ void IncrementalMapper::RegisterInitialImagePair(
   // Estimate two-view geometry
   //////////////////////////////////////////////////////////////////////////////
 
-  image1.CamFromWorld() = Rigid3d();
-  image2.CamFromWorld() = two_view_geometry.cam2_from_cam1;
+  image1.SetCamFromWorld(Rigid3d());
+  image2.SetCamFromWorld(two_view_geometry.cam2_from_cam1);
 
   const Eigen::Matrix3x4d cam_from_world1 = image1.CamFromWorld().ToMatrix();
   const Eigen::Matrix3x4d cam_from_world2 = image2.CamFromWorld().ToMatrix();
@@ -482,10 +482,11 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
   size_t num_inliers;
   std::vector<char> inlier_mask;
 
+  Rigid3d cam_from_world;
   if (!EstimateAbsolutePose(abs_pose_options,
                             tri_points2D,
                             tri_points3D,
-                            &image.CamFromWorld(),
+                            &cam_from_world,
                             &camera,
                             &num_inliers,
                             &inlier_mask)) {
@@ -504,7 +505,7 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
                           inlier_mask,
                           tri_points2D,
                           tri_points3D,
-                          &image.CamFromWorld(),
+                          &cam_from_world,
                           &camera)) {
     return false;
   }
@@ -513,6 +514,7 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
   // Continue tracks
   //////////////////////////////////////////////////////////////////////////////
 
+  image.SetCamFromWorld(cam_from_world);
   reconstruction_->RegisterImage(image_id);
   RegisterImageEvent(image_id);
 

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -229,7 +229,7 @@ std::vector<image_t> IncrementalMapper::FindNextImages(const Options& options) {
   // Append images that have not failed to register before.
   for (const auto& image : reconstruction_->Images()) {
     // Skip images that are already registered.
-    if (image.second.IsRegistered()) {
+    if (image.second.HasPose()) {
       continue;
     }
 
@@ -352,8 +352,7 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
   Image& image = reconstruction_->Image(image_id);
   Camera& camera = *image.CameraPtr();
 
-  THROW_CHECK(!image.IsRegistered())
-      << "Image cannot be registered multiple times";
+  THROW_CHECK(!image.HasPose()) << "Image cannot be registered multiple times";
 
   num_reg_trials_[image_id] += 1;
 
@@ -384,7 +383,7 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
         correspondence_graph->FindCorrespondences(image_id, point2D_idx);
     for (const auto* corr = corr_range.beg; corr < corr_range.end; ++corr) {
       const Image& corr_image = reconstruction_->Image(corr->image_id);
-      if (!corr_image.IsRegistered()) {
+      if (!corr_image.HasPose()) {
         continue;
       }
 
@@ -1051,7 +1050,7 @@ std::vector<image_t> IncrementalMapper::FindLocalBundle(
   THROW_CHECK(options.Check());
 
   const Image& image = reconstruction_->Image(image_id);
-  THROW_CHECK(image.IsRegistered());
+  THROW_CHECK(image.HasPose());
 
   // Extract all images that have at least one 3D point with the query image
   // in common, and simultaneously count the number of common 3D points.

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -695,7 +695,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(obs_manager_);
 
-  const std::vector<image_t>& reg_image_ids = reconstruction_->RegImageIds();
+  const std::set<image_t>& reg_image_ids = reconstruction_->RegImageIds();
 
   THROW_CHECK_GE(reg_image_ids.size(), 2) << "At least two images must be "
                                              "registered for global "
@@ -736,10 +736,11 @@ bool IncrementalMapper::AdjustGlobalBundle(
 
   if (!use_prior_position) {
     // Fix 7-DOFs of the bundle adjustment problem.
-    ba_config.SetConstantCamPose(reg_image_ids[0]);
+    auto it_reg_image_ids = reg_image_ids.begin();
+    ba_config.SetConstantCamPose(*(it_reg_image_ids++));  // 1st image
     if (!options.fix_existing_images ||
-        !existing_image_ids_.count(reg_image_ids[1])) {
-      ba_config.SetConstantCamPositions(reg_image_ids[1], {0});
+        !existing_image_ids_.count(*it_reg_image_ids)) {
+      ba_config.SetConstantCamPositions(*it_reg_image_ids, {0});  // 2nd image
     }
 
     // Run bundle adjustment.

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -104,7 +104,7 @@ size_t IncrementalTriangulator::TriangulateImage(const Options& options,
   ClearCaches();
 
   const Image& image = reconstruction_.Image(image_id);
-  if (!image.IsRegistered()) {
+  if (!image.HasPose()) {
     return num_tris;
   }
 
@@ -164,7 +164,7 @@ size_t IncrementalTriangulator::CompleteImage(const Options& options,
   ClearCaches();
 
   const Image& image = reconstruction_.Image(image_id);
-  if (!image.IsRegistered()) {
+  if (!image.HasPose()) {
     return num_tris;
   }
 
@@ -329,12 +329,12 @@ size_t IncrementalTriangulator::Retriangulate(const Options& options) {
         Database::PairIdToImagePair(image_pair.first);
 
     const Image& image1 = reconstruction_.Image(image_id1);
-    if (!image1.IsRegistered()) {
+    if (!image1.HasPose()) {
       continue;
     }
 
     const Image& image2 = reconstruction_.Image(image_id2);
-    if (!image2.IsRegistered()) {
+    if (!image2.HasPose()) {
       continue;
     }
 
@@ -449,7 +449,7 @@ size_t IncrementalTriangulator::Find(const Options& options,
 
   for (const auto& corr : found_corrs_) {
     const Image& corr_image = reconstruction_.Image(corr.image_id);
-    if (!corr_image.IsRegistered()) {
+    if (!corr_image.HasPose()) {
       continue;
     }
 
@@ -597,7 +597,7 @@ size_t IncrementalTriangulator::Merge(const Options& options,
         track_el.image_id, track_el.point2D_idx);
     for (const auto* corr = corr_range.beg; corr < corr_range.end; ++corr) {
       const auto& image = reconstruction_.Image(corr->image_id);
-      if (!image.IsRegistered()) {
+      if (!image.HasPose()) {
         continue;
       }
 
@@ -696,7 +696,7 @@ size_t IncrementalTriangulator::Complete(const Options& options,
           queue_elem.image_id, queue_elem.point2D_idx);
       for (const auto* corr = corr_range.beg; corr < corr_range.end; ++corr) {
         const Image& image = reconstruction_.Image(corr->image_id);
-        if (!image.IsRegistered()) {
+        if (!image.HasPose()) {
           continue;
         }
 

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -141,7 +141,7 @@ void ObservationManager::SetObservationAsTriangulated(
     return;
   }
   const Image& image = reconstruction_.Image(image_id);
-  THROW_CHECK(image.IsRegistered());
+  THROW_CHECK(image.HasPose());
 
   const Point2D& point2D = image.Point2D(point2D_idx);
   THROW_CHECK(point2D.HasPoint3D());
@@ -174,7 +174,7 @@ void ObservationManager::ResetTriObservations(const image_t image_id,
     return;
   }
   const Image& image = reconstruction_.Image(image_id);
-  THROW_CHECK(image.IsRegistered());
+  THROW_CHECK(image.HasPose());
   const Point2D& point2D = image.Point2D(point2D_idx);
   THROW_CHECK(point2D.HasPoint3D());
 

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -50,7 +50,7 @@ void GenerateReconstruction(const image_t num_images,
     image.SetName("image" + std::to_string(image_id));
     image.SetPoints2D(
         std::vector<Eigen::Vector2d>(kNumPoints2D, Eigen::Vector2d::Zero()));
-    image.SetRegistered(true);
+    image.SetCamFromWorld(Rigid3d());
     reconstruction.AddImage(std::move(image));
   }
 }

--- a/src/colmap/ui/image_viewer_widget.cc
+++ b/src/colmap/ui/image_viewer_widget.cc
@@ -353,17 +353,22 @@ void DatabaseImageViewerWidget::ShowImageWithId(const image_t image_id) {
   camera_id_item_->setText(QString::number(image.CameraId()));
   camera_model_item_->setText(QString::fromStdString(camera.ModelName()));
   camera_params_item_->setText(QString::fromStdString(camera.ParamsToString()));
-  rotation_item_->setText(
-      QString::number(image.CamFromWorld().rotation.w()) + ", " +
-      QString::number(image.CamFromWorld().rotation.x()) + ", " +
-      QString::number(image.CamFromWorld().rotation.y()) + ", " +
-      QString::number(image.CamFromWorld().rotation.z()));
-  translation_item_->setText(
-      QString::number(image.CamFromWorld().translation.x()) + ", " +
-      QString::number(image.CamFromWorld().translation.y()) + ", " +
-      QString::number(image.CamFromWorld().translation.z()));
-  dimensions_item_->setText(QString::number(camera.width) + "x" +
-                            QString::number(camera.height));
+  if (image.IsRegistered()) {
+    rotation_item_->setText(
+        QString::number(image.CamFromWorld().rotation.w()) + ", " +
+        QString::number(image.CamFromWorld().rotation.x()) + ", " +
+        QString::number(image.CamFromWorld().rotation.y()) + ", " +
+        QString::number(image.CamFromWorld().rotation.z()));
+    translation_item_->setText(
+        QString::number(image.CamFromWorld().translation.x()) + ", " +
+        QString::number(image.CamFromWorld().translation.y()) + ", " +
+        QString::number(image.CamFromWorld().translation.z()));
+    dimensions_item_->setText(QString::number(camera.width) + "x" +
+                              QString::number(camera.height));
+  } else {
+    rotation_item_->setText("undefined");
+    translation_item_->setText("undefined");
+  }
   num_points2D_item_->setText(QString::number(image.NumPoints2D()));
 
   std::vector<char> tri_mask(image.NumPoints2D());

--- a/src/colmap/ui/image_viewer_widget.cc
+++ b/src/colmap/ui/image_viewer_widget.cc
@@ -353,7 +353,7 @@ void DatabaseImageViewerWidget::ShowImageWithId(const image_t image_id) {
   camera_id_item_->setText(QString::number(image.CameraId()));
   camera_model_item_->setText(QString::fromStdString(camera.ModelName()));
   camera_params_item_->setText(QString::fromStdString(camera.ParamsToString()));
-  if (image.IsRegistered()) {
+  if (image.HasPose()) {
     rotation_item_->setText(
         QString::number(image.CamFromWorld().rotation.w()) + ", " +
         QString::number(image.CamFromWorld().rotation.x()) + ", " +

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -31,6 +31,8 @@
 
 #include "colmap/ui/main_window.h"
 
+#include <set>
+
 #define SELECTION_BUFFER_IMAGE_IDX 0
 #define SELECTION_BUFFER_POINT_IDX 1
 
@@ -374,7 +376,9 @@ void ModelViewerWidget::ReloadReconstruction() {
 
   cameras = reconstruction->Cameras();
   points3D = reconstruction->Points3D();
-  reg_image_ids = reconstruction->RegImageIds();
+  const std::set<image_t> reg_image_ids_set = reconstruction->RegImageIds();
+  reg_image_ids =
+      std::vector<image_t>(reg_image_ids_set.begin(), reg_image_ids_set.end());
 
   images.clear();
   for (const image_t image_id : reg_image_ids) {

--- a/src/colmap/ui/movie_grabber_widget.cc
+++ b/src/colmap/ui/movie_grabber_widget.cc
@@ -292,9 +292,9 @@ void MovieGrabberWidget::UpdateViews() {
     const Eigen::Matrix4d model_view_matrix =
         QMatrixToEigen(view_data_.at(item).model_view_matrix).cast<double>();
     Image image;
-    image.CamFromWorld() =
+    image.SetCamFromWorld(
         Rigid3d(Eigen::Quaterniond(model_view_matrix.topLeftCorner<3, 3>()),
-                model_view_matrix.topRightCorner<3, 1>());
+                model_view_matrix.topRightCorner<3, 1>()));
     views.push_back(image);
   }
 }

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -102,6 +102,9 @@ void BindImage(py::module& m) {
               &Image::SetCamFromWorld),
           "The pose of the image, defined as the transformation from world to "
           "camera space. None if the image is not registered.")
+      .def_property_readonly(
+          "has_pose", &Image::HasPose, "Whether the image has a valid pose.")
+      .def("reset_pose", &Image::ResetPose, "Invalidate the pose of the image.")
       .def_property(
           "points2D",
           py::overload_cast<>(&Image::Points2D),
@@ -152,11 +155,6 @@ void BindImage(py::module& m) {
       .def("reset_camera_ptr",
            &Image::ResetCameraPtr,
            "Make the camera pointer a nullptr.")
-      .def_property_readonly(
-          "registered",
-          &Image::IsRegistered,
-          "Whether the image is registered and has a valid pose.")
-      .def("deregister", &Image::DeRegister, "De-registers the image.")
       .def("num_points2D",
            &Image::NumPoints2D,
            "Get the number of image points (keypoints).")

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -11,6 +11,7 @@
 #include "pycolmap/scene/types.h"
 
 #include <memory>
+#include <optional>
 #include <sstream>
 
 #include <pybind11/eigen.h>
@@ -43,13 +44,13 @@ std::string PrintImage(const Image& image) {
 template <typename T>
 std::shared_ptr<Image> MakeImage(const std::string& name,
                                  const std::vector<T>& points2D,
-                                 const Rigid3d& cam_from_world,
+                                 const std::optional<Rigid3d>& cam_from_world,
                                  size_t camera_id,
                                  image_t image_id) {
   auto image = std::make_shared<Image>();
   image->SetName(name);
   image->SetPoints2D(points2D);
-  image->CamFromWorld() = cam_from_world;
+  image->SetCamFromWorld(cam_from_world);
   if (camera_id != kInvalidCameraId) {
     image->SetCameraId(camera_id);
   }
@@ -63,7 +64,7 @@ void BindImage(py::module& m) {
       .def(py::init(&MakeImage<Point2D>),
            "name"_a = "",
            py::arg_v("points2D", Point2DVector(), "ListPoint2D()"),
-           "cam_from_world"_a = Rigid3d(),
+           "cam_from_world"_a = py::none(),
            "camera_id"_a = kInvalidCameraId,
            "id"_a = kInvalidImageId)
       .def(py::init(&MakeImage<Eigen::Vector2d>),
@@ -96,12 +97,11 @@ void BindImage(py::module& m) {
                     "Name of the image.")
       .def_property(
           "cam_from_world",
-          py::overload_cast<>(&Image::CamFromWorld),
-          [](Image& self, const Rigid3d& cam_from_world) {
-            self.CamFromWorld() = cam_from_world;
-          },
+          &Image::MaybeCamFromWorld,
+          py::overload_cast<const std::optional<Rigid3d>&>(
+              &Image::SetCamFromWorld),
           "The pose of the image, defined as the transformation from world to "
-          "camera space.")
+          "camera space. None if the image is not registered.")
       .def_property(
           "points2D",
           py::overload_cast<>(&Image::Points2D),
@@ -152,10 +152,11 @@ void BindImage(py::module& m) {
       .def("reset_camera_ptr",
            &Image::ResetCameraPtr,
            "Make the camera pointer a nullptr.")
-      .def_property("registered",
-                    &Image::IsRegistered,
-                    &Image::SetRegistered,
-                    "Whether image is registered in the reconstruction.")
+      .def_property_readonly(
+          "registered",
+          &Image::IsRegistered,
+          "Whether the image is registered and has a valid pose.")
+      .def("deregister", &Image::DeRegister, "De-registers the image.")
       .def("num_points2D",
            &Image::NumPoints2D,
            "Get the number of image points (keypoints).")

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -232,7 +232,7 @@ void BindReconstruction(py::module& m) {
                 THROW_CHECK(self.ExistsImage(image_id)) << image_id;
                 THROW_CHECK(self.IsImageRegistered(image_id)) << image_id;
                 const Image& image = self.Image(image_id);
-                THROW_CHECK(image.IsRegistered());
+                THROW_CHECK(image.HasPose());
                 THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);
               }
             }


### PR DESCRIPTION
- `Image::cam_from_world_` becomes optional, making the `registered_` flag unnecessary and greatly simplifying the API (this was a common source of confusion)
- Calling `Image::CamFromWorld` is illegal if the pose hasn't been previously set.
- This helped catch a bug in the `PosePriorBA` - all images (even unregistered ones) were used in the optimization.
- `Reconstruction::RegImageIds` returns a set instead of a vector (and not an unordered set because the order should be deterministic across platforms).