### PR TITLE
More informative exception if invalid access of image/camera/point3D

### DIFF
--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -266,28 +266,46 @@ size_t Reconstruction::NumRegImages() const { return reg_image_ids_.size(); }
 size_t Reconstruction::NumPoints3D() const { return points3D_.size(); }
 
 const struct Camera& Reconstruction::Camera(const camera_t camera_id) const {
-  return cameras_.at(camera_id);
+  try {
+    return cameras_.at(camera_id);
+  } catch (const std::out_of_range& e) {
+    throw std::invalid_argument(
+        StringPrintf("Camera with ID %d does not exist", camera_id));
+  }
 }
 
 const class Image& Reconstruction::Image(const image_t image_id) const {
-  return images_.at(image_id);
+  try {
+    return images_.at(image_id);
+  } catch (const std::out_of_range& e) {
+    throw std::invalid_argument(
+        StringPrintf("Image with ID %d does not exist", image_id));
+  }
 }
 
 const struct Point3D& Reconstruction::Point3D(
     const point3D_t point3D_id) const {
-  return points3D_.at(point3D_id);
+  try {
+    return points3D_.at(point3D_id);
+  } catch (const std::out_of_range& e) {
+    throw std::invalid_argument(
+        StringPrintf("Point3D with ID %d does not exist", point3D_id));
+  }
 }
 
 struct Camera& Reconstruction::Camera(const camera_t camera_id) {
-  return cameras_.at(camera_id);
+  return const_cast<class Camera&>(
+      const_cast<const Reconstruction*>(this)->Camera(camera_id));
 }
 
 class Image& Reconstruction::Image(const image_t image_id) {
-  return images_.at(image_id);
+  return const_cast<class Image&>(
+      const_cast<const Reconstruction*>(this)->Image(image_id));
 }
 
 struct Point3D& Reconstruction::Point3D(const point3D_t point3D_id) {
-  return points3D_.at(point3D_id);
+  return const_cast<class Point3D&>(
+      const_cast<const Reconstruction*>(this)->Point3D(point3D_id));
 }
 
 const std::unordered_map<camera_t, Camera>& Reconstruction::Cameras() const {

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -269,7 +269,7 @@ const struct Camera& Reconstruction::Camera(const camera_t camera_id) const {
   try {
     return cameras_.at(camera_id);
   } catch (const std::out_of_range& e) {
-    throw std::invalid_argument(
+    throw std::out_of_range(
         StringPrintf("Camera with ID %d does not exist", camera_id));
   }
 }
@@ -278,7 +278,7 @@ const class Image& Reconstruction::Image(const image_t image_id) const {
   try {
     return images_.at(image_id);
   } catch (const std::out_of_range& e) {
-    throw std::invalid_argument(
+    throw std::out_of_range(
         StringPrintf("Image with ID %d does not exist", image_id));
   }
 }
@@ -288,7 +288,7 @@ const struct Point3D& Reconstruction::Point3D(
   try {
     return points3D_.at(point3D_id);
   } catch (const std::out_of_range& e) {
-    throw std::invalid_argument(
+    throw std::out_of_range(
         StringPrintf("Point3D with ID %d does not exist", point3D_id));
   }
 }

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -294,7 +294,7 @@ const struct Point3D& Reconstruction::Point3D(
 }
 
 struct Camera& Reconstruction::Camera(const camera_t camera_id) {
-  return const_cast<class Camera&>(
+  return const_cast<struct Camera&>(
       const_cast<const Reconstruction*>(this)->Camera(camera_id));
 }
 
@@ -304,7 +304,7 @@ class Image& Reconstruction::Image(const image_t image_id) {
 }
 
 struct Point3D& Reconstruction::Point3D(const point3D_t point3D_id) {
-  return const_cast<class Point3D&>(
+  return const_cast<struct Point3D&>(
       const_cast<const Reconstruction*>(this)->Point3D(point3D_id));
 }
 

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -294,18 +294,30 @@ const struct Point3D& Reconstruction::Point3D(
 }
 
 struct Camera& Reconstruction::Camera(const camera_t camera_id) {
-  return const_cast<struct Camera&>(
-      const_cast<const Reconstruction*>(this)->Camera(camera_id));
+  try {
+    return cameras_.at(camera_id);
+  } catch (const std::out_of_range& e) {
+    throw std::out_of_range(
+        StringPrintf("Camera with ID %d does not exist", camera_id));
+  }
 }
 
 class Image& Reconstruction::Image(const image_t image_id) {
-  return const_cast<class Image&>(
-      const_cast<const Reconstruction*>(this)->Image(image_id));
+  try {
+    return images_.at(image_id);
+  } catch (const std::out_of_range& e) {
+    throw std::out_of_range(
+        StringPrintf("Image with ID %d does not exist", image_id));
+  }
 }
 
 struct Point3D& Reconstruction::Point3D(const point3D_t point3D_id) {
-  return const_cast<struct Point3D&>(
-      const_cast<const Reconstruction*>(this)->Point3D(point3D_id));
+  try {
+    return points3D_.at(point3D_id);
+  } catch (const std::out_of_range& e) {
+    throw std::out_of_range(
+        StringPrintf("Point3D with ID %d does not exist", point3D_id));
+  }
 }
 
 const std::unordered_map<camera_t, Camera>& Reconstruction::Cameras() const {


### PR DESCRIPTION
- Calling `reconstruction.Image(image_id)` for a nonexistent image ID raises an exception with the uninformative message `_Map_base::at`. This is especially confusing for Python users. This PR makes the exception message more informative.
- This PR also shares the implementations of the const and non-const getters, as suggested here: https://stackoverflow.com/a/856839 Does it still make sense to keep these implementations inlined?