### PR TITLE
Disable -march=native flags in poselib

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -61,6 +61,7 @@ if(FETCH_POSELIB)
         ${_fetch_content_declare_args}
     )
     message(STATUS "Configuring PoseLib...")
+    set(MARCH_NATIVE OFF)
     FetchContent_MakeAvailable(poselib)
     message(STATUS "Configuring PoseLib... done")
 else()


### PR DESCRIPTION
Otherwise, the binaries are not redistributable across different machines. If users want to squeeze out more performance on a specific machine, they can add the flags easily during CMake configuration time.