### PR TITLE
Remove warning in configure step

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -61,7 +61,7 @@ if(FETCH_POSELIB)
         ${_fetch_content_declare_args}
     )
     message(STATUS "Configuring PoseLib...")
-    set(MARCH_NATIVE OFF)
+    set(MARCH_NATIVE OFF CACHE BOOL "")
     FetchContent_MakeAvailable(poselib)
     message(STATUS "Configuring PoseLib... done")
 else()


### PR DESCRIPTION
The change https://github.com/colmap/colmap/commit/461cd981d10c1ca2c96b6a152342a5b565654f03 results in the following warning in the configure step of CMake 3.27.4:
```
CMake Warning (dev) at build/_deps/poselib-src/CMakeLists.txt:24 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'MARCH_NATIVE'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This PR suppresses the warning.