### PR TITLE
Fix copying behaviors of Reconstruction regarding camera pointers

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -43,6 +43,18 @@ namespace colmap {
 
 Reconstruction::Reconstruction() : max_point3D_id_(0) {}
 
+Reconstruction::Reconstruction(const Reconstruction& recon)
+    : cameras_(recon.cameras_),
+      images_(recon.images_),
+      points3D_(recon.points3D_),
+      reg_image_ids_(recon.reg_image_ids_),
+      max_point3D_id_(recon.max_point3D_id_) {
+  for (const auto& [image_id, image] : Images()) {
+    Image(image_id).ResetCameraPtr();
+    Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
+  }
+}
+
 std::unordered_set<point3D_t> Reconstruction::Point3DIds() const {
   std::unordered_set<point3D_t> point3D_ids;
   point3D_ids.reserve(points3D_.size());

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -43,28 +43,28 @@ namespace colmap {
 
 Reconstruction::Reconstruction() : max_point3D_id_(0) {}
 
-Reconstruction::Reconstruction(const Reconstruction& recon)
-    : cameras_(recon.cameras_),
-      images_(recon.images_),
-      points3D_(recon.points3D_),
-      reg_image_ids_(recon.reg_image_ids_),
-      max_point3D_id_(recon.max_point3D_id_) {
-  for (const auto& [image_id, image] : Images()) {
-    Image(image_id).ResetCameraPtr();
-    Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
+Reconstruction::Reconstruction(const Reconstruction& other)
+    : cameras_(other.cameras_),
+      images_(other.images_),
+      points3D_(other.points3D_),
+      reg_image_ids_(other.reg_image_ids_),
+      max_point3D_id_(other.max_point3D_id_) {
+  for (auto& [_, image] : images_) {
+    image.ResetCameraPtr();
+    image.SetCameraPtr(&Camera(image.CameraId()));
   }
 }
 
-Reconstruction& Reconstruction::operator=(const Reconstruction& recon) {
-  if (this != &recon) {
-    cameras_ = recon.cameras_;
-    images_ = recon.images_;
-    points3D_ = recon.points3D_;
-    reg_image_ids_ = recon.reg_image_ids_;
-    max_point3D_id_ = recon.max_point3D_id_;
-    for (const auto& [image_id, image] : Images()) {
-      Image(image_id).ResetCameraPtr();
-      Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
+Reconstruction& Reconstruction::operator=(const Reconstruction& other) {
+  if (this != &other) {
+    cameras_ = other.cameras_;
+    images_ = other.images_;
+    points3D_ = other.points3D_;
+    reg_image_ids_ = other.reg_image_ids_;
+    max_point3D_id_ = other.max_point3D_id_;
+    for (auto& [_, image] : images_) {
+      image.ResetCameraPtr();
+      image.SetCameraPtr(&Camera(image.CameraId()));
     }
   }
   return *this;

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -55,6 +55,21 @@ Reconstruction::Reconstruction(const Reconstruction& recon)
   }
 }
 
+Reconstruction& Reconstruction::operator=(const Reconstruction& recon) {
+  if (this != &recon) {
+    cameras_ = recon.cameras_;
+    images_ = recon.images_;
+    points3D_ = recon.points3D_;
+    reg_image_ids_ = recon.reg_image_ids_;
+    max_point3D_id_ = recon.max_point3D_id_;
+    for (const auto& [image_id, image] : Images()) {
+      Image(image_id).ResetCameraPtr();
+      Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
+    }
+  }
+  return *this;
+}
+
 std::unordered_set<point3D_t> Reconstruction::Point3DIds() const {
   std::unordered_set<point3D_t> point3D_ids;
   point3D_ids.reserve(points3D_.size());

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -61,6 +61,7 @@ class Reconstruction {
   Reconstruction();
   // Update the camera pointers for each image at copy constructor.
   Reconstruction(const Reconstruction& recon);
+  Reconstruction& operator=(const Reconstruction& recon);
 
   // Get number of objects.
   inline size_t NumCameras() const;

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -60,7 +60,7 @@ class Reconstruction {
  public:
   Reconstruction();
   // Update the camera pointers for each image at copy constructor.
-  inline Reconstruction(const Reconstruction& recon);
+  Reconstruction(const Reconstruction& recon);
 
   // Get number of objects.
   inline size_t NumCameras() const;
@@ -259,18 +259,6 @@ class Reconstruction {
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation
 ////////////////////////////////////////////////////////////////////////////////
-
-Reconstruction::Reconstruction(const Reconstruction& recon)
-    : cameras_(recon.cameras_),
-      images_(recon.images_),
-      points3D_(recon.points3D_),
-      reg_image_ids_(recon.reg_image_ids_),
-      max_point3D_id_(recon.max_point3D_id_) {
-  for (const auto& [image_id, image] : Images()) {
-    Image(image_id).ResetCameraPtr();
-    Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
-  }
-}
 
 size_t Reconstruction::NumCameras() const { return cameras_.size(); }
 

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -59,6 +59,8 @@ class DatabaseCache;
 class Reconstruction {
  public:
   Reconstruction();
+  // Update the camera pointers for each image at copy constructor.
+  inline Reconstruction(const Reconstruction& recon);
 
   // Get number of objects.
   inline size_t NumCameras() const;
@@ -257,6 +259,18 @@ class Reconstruction {
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation
 ////////////////////////////////////////////////////////////////////////////////
+
+Reconstruction::Reconstruction(const Reconstruction& recon)
+    : cameras_(recon.cameras_),
+      images_(recon.images_),
+      points3D_(recon.points3D_),
+      reg_image_ids_(recon.reg_image_ids_),
+      max_point3D_id_(recon.max_point3D_id_) {
+  for (const auto& [image_id, image] : Images()) {
+    Image(image_id).ResetCameraPtr();
+    Image(image_id).SetCameraPtr(&Camera(image.CameraId()));
+  }
+}
 
 size_t Reconstruction::NumCameras() const { return cameras_.size(); }
 

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -59,9 +59,10 @@ class DatabaseCache;
 class Reconstruction {
  public:
   Reconstruction();
-  // Update the camera pointers for each image at copy constructor.
-  Reconstruction(const Reconstruction& recon);
-  Reconstruction& operator=(const Reconstruction& recon);
+
+  // Copy construct/assign. Updates camera pointers.
+  Reconstruction(const Reconstruction& other);
+  Reconstruction& operator=(const Reconstruction& other);
 
   // Get number of objects.
   inline size_t NumCameras() const;

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -39,6 +39,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
@@ -59,19 +60,19 @@ bool CheckReconstruction(const Reconstruction& reconstruction) {
 bool CompareReconstructions(const Reconstruction& recon1,
                             const Reconstruction& recon2) {
   // compare cameras
-  std::ostream stream1_cameras, stream2_cameras;
+  std::stringstream stream1_cameras, stream2_cameras;
   WriteCamerasText(recon1, stream1_cameras);
   WriteCamerasText(recon2, stream2_cameras);
   if (stream1_cameras.str() != stream2_cameras.str()) return false;
 
   // compare images
-  std::ostream stream1_images, stream2_images;
+  std::stringstream stream1_images, stream2_images;
   WriteImagesText(recon1, stream1_images);
   WriteImagesText(recon2, stream2_images);
   if (stream1_images.str() != stream2_images.str()) return false;
 
   // compare point3ds
-  std::ostream stream1_point3Ds, stream2_point3Ds;
+  std::stringstream stream1_point3Ds, stream2_point3Ds;
   WritePoint3DsText(recon1, stream1_point3Ds);
   WritePoint3DsText(recon2, stream2_point3Ds);
   if (stream1_point3Ds.str() != stream2_point3Ds.str()) return false;

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -138,7 +138,7 @@ TEST(Reconstruction, CopyConstructor) {
   const std::string test_dir = CreateTestDir();
   Reconstruction reconstruction;
   GenerateReconstruction(10, &reconstruction);
-  reconstruction_new = Reconstruction(reconstruction);
+  Reconstruction reconstruction_new = reconstruction;
   EXPECT_TRUE(
       CompareReconstructions(test_dir, reconstruction, reconstruction_new));
 }

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -34,12 +34,12 @@
 #include "colmap/scene/reconstruction_io.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/file.h"
+#include "colmap/util/testing.h"
 
 #include <fstream>
 #include <iostream>
 
-#include "colmap/util/file.h"
-#include "colmap/util/testing.h"
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -98,11 +98,14 @@ bool CompareReconstructions(const std::string& test_dir,
   CreateDirIfNotExists(dir2);
   recon2.WriteBinary(dir2);
 
-  if (!CompareBinaryFiles(JoinPaths(dir1, "cameras.bin"), JoinPaths(dir2, "cameras.bin")))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "cameras.bin"),
+                          JoinPaths(dir2, "cameras.bin")))
     return false;
-  if (!CompareBinaryFiles(JoinPaths(dir1, "images.bin"), JoinPaths(dir2, "images.bin")))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "images.bin"),
+                          JoinPaths(dir2, "images.bin")))
     return false;
-  if (!CompareBinaryFiles(JoinPaths(dir1, "points3D.bin"), JoinPaths(dir2, "points3D.bin")))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "points3D.bin"),
+                          JoinPaths(dir2, "points3D.bin")))
     return false;
   return true;
 }

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -72,10 +72,10 @@ bool CompareReconstructions(const Reconstruction& recon1,
   if (stream1_images.str() != stream2_images.str()) return false;
 
   // compare point3ds
-  std::stringstream stream1_point3Ds, stream2_point3Ds;
-  WritePoint3DsText(recon1, stream1_point3Ds);
-  WritePoint3DsText(recon2, stream2_point3Ds);
-  if (stream1_point3Ds.str() != stream2_point3Ds.str()) return false;
+  std::stringstream stream1_points3D, stream2_points3D;
+  WritePoints3DText(recon1, stream1_points3D);
+  WritePoints3DText(recon2, stream2_points3D);
+  if (stream1_points3D.str() != stream2_points3D.str()) return false;
 
   // success
   return true;
@@ -109,22 +109,18 @@ TEST(Reconstruction, Empty) {
 }
 
 TEST(Reconstruction, CopyConstructor) {
-  const std::string test_dir = CreateTestDir();
   Reconstruction reconstruction;
   GenerateReconstruction(10, &reconstruction);
   Reconstruction reconstruction_new = reconstruction;
-  EXPECT_TRUE(
-      CompareReconstructions(test_dir, reconstruction, reconstruction_new));
+  EXPECT_TRUE(CompareReconstructions(reconstruction, reconstruction_new));
 }
 
 TEST(Reconstruction, CopyAssignment) {
-  const std::string test_dir = CreateTestDir();
   Reconstruction reconstruction;
   GenerateReconstruction(10, &reconstruction);
   Reconstruction reconstruction_new;
   reconstruction_new = reconstruction;
-  EXPECT_TRUE(
-      CompareReconstructions(test_dir, reconstruction, reconstruction_new));
+  EXPECT_TRUE(CompareReconstructions(reconstruction, reconstruction_new));
 }
 
 TEST(Reconstruction, AddCamera) {

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -98,11 +98,11 @@ bool CompareReconstructions(const std::string& test_dir,
   CreateDirIfNotExists(dir2);
   recon2.WriteBinary(dir2);
 
-  if (!CompareBinaryFiles(JoinPaths(dir1, "cameras.bin"), JoinPaths(dir2, "cameras.bin"))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "cameras.bin"), JoinPaths(dir2, "cameras.bin")))
     return false;
-  if (!CompareBinaryFiles(JoinPaths(dir1, "images.bin"), JoinPaths(dir2, "images.bin"))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "images.bin"), JoinPaths(dir2, "images.bin")))
     return false;
-  if (!CompareBinaryFiles(JoinPaths(dir1, "points3D.bin"), JoinPaths(dir2, "points3D.bin"))
+  if (!CompareBinaryFiles(JoinPaths(dir1, "points3D.bin"), JoinPaths(dir2, "points3D.bin")))
     return false;
   return true;
 }

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -121,7 +121,7 @@ TEST(Reconstruction, AssignCopy) {
   synthetic_dataset_options.num_points3D = 21;
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
   Reconstruction reconstruction_copy;
-  reconstruction_copy= reconstruction;
+  reconstruction_copy = reconstruction;
   ExpectEqualReconstructions(reconstruction, reconstruction_copy);
 }
 

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -46,39 +46,33 @@
 namespace colmap {
 namespace {
 
-// Check if all camera pointers are correctly set
-bool CheckReconstruction(const Reconstruction& reconstruction) {
+void ExpectValidCameraPtrs(const Reconstruction& reconstruction) {
   for (const auto& image : reconstruction.Images()) {
-    if (!image.second.HasCameraPtr()) return false;
+    EXPECT_TRUE(image.second.HasCameraPtr());
     auto& camera = reconstruction.Camera(image.second.CameraId());
-    if (image.second.CameraPtr() != &camera) return false;
+    EXPECT_EQ(image.second.CameraPtr(), &camera);
   }
-  return true;
 }
 
-// Compare two reconstructions
-bool CompareReconstructions(const Reconstruction& recon1,
-                            const Reconstruction& recon2) {
+void ExpectEqualReconstructions(const Reconstruction& reconstruction1,
+                                const Reconstruction& reconstruction2) {
   // compare cameras
   std::stringstream stream1_cameras, stream2_cameras;
-  WriteCamerasText(recon1, stream1_cameras);
-  WriteCamerasText(recon2, stream2_cameras);
-  if (stream1_cameras.str() != stream2_cameras.str()) return false;
+  WriteCamerasText(reconstruction1, stream1_cameras);
+  WriteCamerasText(reconstruction2, stream2_cameras);
+  EXPECT_EQ(stream1_cameras.str(), stream2_cameras.str());
 
   // compare images
   std::stringstream stream1_images, stream2_images;
-  WriteImagesText(recon1, stream1_images);
-  WriteImagesText(recon2, stream2_images);
-  if (stream1_images.str() != stream2_images.str()) return false;
+  WriteImagesText(reconstruction1, stream1_images);
+  WriteImagesText(reconstruction2, stream2_images);
+  EXPECT_EQ(stream1_images.str(), stream2_images.str());
 
   // compare point3ds
   std::stringstream stream1_points3D, stream2_points3D;
-  WritePoints3DText(recon1, stream1_points3D);
-  WritePoints3DText(recon2, stream2_points3D);
-  if (stream1_points3D.str() != stream2_points3D.str()) return false;
-
-  // success
-  return true;
+  WritePoints3DText(reconstruction1, stream1_points3D);
+  WritePoints3DText(reconstruction2, stream2_points3D);
+  EXPECT_EQ(stream1_points3D.str(), stream2_points3D.str());
 }
 
 void GenerateReconstruction(const image_t num_images,
@@ -108,19 +102,27 @@ TEST(Reconstruction, Empty) {
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
 }
 
-TEST(Reconstruction, CopyConstructor) {
+TEST(Reconstruction, ConstructCopy) {
   Reconstruction reconstruction;
-  GenerateReconstruction(10, &reconstruction);
-  Reconstruction reconstruction_new = reconstruction;
-  EXPECT_TRUE(CompareReconstructions(reconstruction, reconstruction_new));
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_cameras = 2;
+  synthetic_dataset_options.num_images = 5;
+  synthetic_dataset_options.num_points3D = 21;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  const Reconstruction reconstruction_copy(reconstruction);
+  ExpectEqualReconstructions(reconstruction, reconstruction_copy);
 }
 
-TEST(Reconstruction, CopyAssignment) {
+TEST(Reconstruction, AssignCopy) {
   Reconstruction reconstruction;
-  GenerateReconstruction(10, &reconstruction);
-  Reconstruction reconstruction_new;
-  reconstruction_new = reconstruction;
-  EXPECT_TRUE(CompareReconstructions(reconstruction, reconstruction_new));
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_cameras = 2;
+  synthetic_dataset_options.num_images = 5;
+  synthetic_dataset_options.num_points3D = 21;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  Reconstruction reconstruction_copy;
+  reconstruction_copy= reconstruction;
+  ExpectEqualReconstructions(reconstruction, reconstruction_copy);
 }
 
 TEST(Reconstruction, AddCamera) {
@@ -158,7 +160,7 @@ TEST(Reconstruction, AddImage) {
   EXPECT_EQ(reconstruction.NumImages(), 1);
   EXPECT_EQ(reconstruction.NumRegImages(), 0);
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
-  EXPECT_TRUE(CheckReconstruction(reconstruction));
+  ExpectValidCameraPtrs(reconstruction);
 }
 
 TEST(Reconstruction, AddPoint3D) {
@@ -428,14 +430,14 @@ TEST(Reconstruction, Crop) {
   // Test reconstruction with contents after cropping
   bbox.first = Eigen::Vector3d(0.0, 0.0, 0.0);
   bbox.second = Eigen::Vector3d(0.75, 0.75, 0.75);
-  Reconstruction recon2 = reconstruction.Crop(bbox);
-  EXPECT_EQ(recon2.NumCameras(), 1);
-  EXPECT_EQ(recon2.NumImages(), 3);
-  EXPECT_EQ(recon2.NumRegImages(), 2);
-  EXPECT_EQ(recon2.NumPoints3D(), 3);
-  EXPECT_TRUE(recon2.IsImageRegistered(1));
-  EXPECT_TRUE(recon2.IsImageRegistered(2));
-  EXPECT_FALSE(recon2.IsImageRegistered(3));
+  Reconstruction reconstruction2 = reconstruction.Crop(bbox);
+  EXPECT_EQ(reconstruction2.NumCameras(), 1);
+  EXPECT_EQ(reconstruction2.NumImages(), 3);
+  EXPECT_EQ(reconstruction2.NumRegImages(), 2);
+  EXPECT_EQ(reconstruction2.NumPoints3D(), 3);
+  EXPECT_TRUE(reconstruction2.IsImageRegistered(1));
+  EXPECT_TRUE(reconstruction2.IsImageRegistered(2));
+  EXPECT_FALSE(reconstruction2.IsImageRegistered(3));
 }
 
 TEST(Reconstruction, Transform) {
@@ -566,7 +568,7 @@ TEST(Reconstruction, DeleteAllPoints2DAndPoints3D) {
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
   reconstruction.DeleteAllPoints2DAndPoints3D();
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
-  EXPECT_TRUE(CheckReconstruction(reconstruction));
+  ExpectValidCameraPtrs(reconstruction);
 }
 
 }  // namespace

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -38,8 +38,8 @@
 #include <fstream>
 #include <iostream>
 
-#include "util/file.h"
-#include "util/testing.h"
+#include "colmap/util/file.h"
+#include "colmap/util/testing.h"
 #include <gtest/gtest.h>
 
 namespace colmap {

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -250,9 +250,10 @@ void BindReconstruction(py::module& m) {
            [](const Reconstruction& self, const py::dict&) {
              return Reconstruction(self);
            })
-      .def("__assign__", [](Reconstruction& self, const Reconstruction& recon) {
-          return self = recon;
-      })
+      .def("__assign__",
+           [](Reconstruction& self, const Reconstruction& recon) {
+             return self = recon;
+           })
       .def("__repr__",
            [](const Reconstruction& self) {
              std::stringstream ss;

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -250,10 +250,6 @@ void BindReconstruction(py::module& m) {
            [](const Reconstruction& self, const py::dict&) {
              return Reconstruction(self);
            })
-      .def("__assign__",
-           [](Reconstruction& self, const Reconstruction& recon) {
-             return self = recon;
-           })
       .def("__repr__",
            [](const Reconstruction& self) {
              std::stringstream ss;

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -250,6 +250,9 @@ void BindReconstruction(py::module& m) {
            [](const Reconstruction& self, const py::dict&) {
              return Reconstruction(self);
            })
+      .def("__assign__", [](Reconstruction& self, const Reconstruction& recon) {
+          return self = recon;
+      })
       .def("__repr__",
            [](const Reconstruction& self) {
              std::stringstream ss;

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -44,6 +44,7 @@ void BindReconstruction(py::module& m) {
   py::class_<Reconstruction, std::shared_ptr<Reconstruction>>(m,
                                                               "Reconstruction")
       .def(py::init<>())
+      .def(py::init<const Reconstruction&>())
       .def(py::init([](const std::string& path) {
              auto reconstruction = std::make_shared<Reconstruction>();
              reconstruction->Read(path);


### PR DESCRIPTION
Previous copying behavior is very dangerous after the introduction of camera pointer. 