### PR TITLE
fix: suppress warning about CMP0167 when compile with cmake over 3.30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ option(LSD_ENABLED "Whether to enable the LSD library" ON)
 option(UNINSTALL_ENABLED "Whether to create a target to 'uninstall' colmap" ON)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+    cmake_policy(SET CMP0167 NEW)
+endif()
+
 # Propagate options to vcpkg manifest.
 if(TESTS_ENABLED)
   enable_testing()


### PR DESCRIPTION
CMP1067 is about find_boost module, contents are available [here](https://cmake.org/cmake/help/latest/policy/CMP0167.html).

boost 1.70 was established at Apr 10, 2019, and we should respect the community

Challenges may have of configuring cmake above 3.30, but using boost lib below 1.70. I cannot confirm if this situation can happen, nor can reproduce.

To avoid that challenge, we should set the policy to OLD explicitly align with the default.