### PR TITLE
Suppress CMP0167 warning for FindBoost under CMake 3.30 or newer

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -4,6 +4,10 @@ else()
     set(COLMAP_FIND_TYPE REQUIRED)
 endif()
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
+    cmake_policy(SET CMP0167 NEW)
+endif()
+
 find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
              graph
              program_options


### PR DESCRIPTION
Supersedes https://github.com/colmap/colmap/pull/2848