### PR TITLE
Use the C++ string representation for Python dataclass objects

### DIFF
--- a/src/pycolmap/helpers.h
+++ b/src/pycolmap/helpers.h
@@ -210,7 +210,7 @@ std::string CreateSummary(const T& self, bool write_type) {
   return ss.str();
 }
 
-template <typename T, typename... options>
+template <typename T>
 std::string CreateRepresentation(const T& self) {
   std::stringstream ss;
   auto pyself = py::cast(self);
@@ -241,6 +241,15 @@ std::string CreateRepresentation(const T& self) {
     }
   }
   ss << ")";
+  return ss.str();
+}
+
+template <typename T,
+          typename = std::void_t<decltype(std::declval<std::ostream&>()
+                                          << std::declval<T>())>>
+std::string CreateRepresentation(const T& self) {
+  std::stringstream ss;
+  ss << self;
   return ss.str();
 }
 


### PR DESCRIPTION
https://github.com/colmap/colmap/pull/2842 removed the custom `__repr__` for some objects like `Image`. Pycolmap then falls back to enumerating all the attributes, which is suboptimal - for example for `Image` we don't want to print all 2D points to void bloating the console output. This PR recovers the previous behavior for objects for which `stringstream << obj` is defined.