### PR TITLE
Use analytical Jacobian in IterativeUndistortion. Add trust region

### DIFF
--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -691,7 +691,7 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
 
     // Update
     Eigen::Vector2d step_x = J.partialPivLu().solve(x + dx - x0);
-    double radius = std::max(x.norm() * kRelStepRadius, kStepRadius);
+    const double radius = std::max(x.norm() * kRelStepRadius, kStepRadius);
     if (step_x.norm() > radius) {
       step_x *= (radius / step_x.norm());
     }

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -686,7 +686,7 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
     CameraModel::Distortion(
         params_jet, x_jet[0], x_jet[1], &dx_jet[0], &dx_jet[1]);
     dx[0] = dx_jet[0].a;
-    dx[1] = dx_jet[0].a;
+    dx[1] = dx_jet[1].a;
     J(0, 0) = dx_jet[0].v[0];
     J(0, 1) = dx_jet[0].v[1];
     J(1, 0) = dx_jet[1].v[0];

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -665,10 +665,6 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
   const Eigen::Vector2d x0(*u, *v);
   Eigen::Vector2d x(*u, *v);
   Eigen::Vector2d dx;
-  Eigen::Vector2d dx_0b;
-  Eigen::Vector2d dx_0f;
-  Eigen::Vector2d dx_1b;
-  Eigen::Vector2d dx_1f;
 
   ceres::Jet<double, 2> params_jet[CameraModel::num_extra_params];
   for (size_t i = 0; i < CameraModel::num_extra_params; ++i) {
@@ -676,7 +672,6 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
   }
   for (size_t i = 0; i < kNumIterations; ++i) {
     // Get Jacobian
-    CameraModel::Distortion(params, x(0), x(1), &dx(0), &dx(1));
     ceres::Jet<double, 2> x_jet[2];
     x_jet[0] = ceres::Jet<double, 2>(x(0));
     x_jet[1] = ceres::Jet<double, 2>(x(1));
@@ -687,10 +682,10 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
         params_jet, x_jet[0], x_jet[1], &dx_jet[0], &dx_jet[1]);
     dx[0] = dx_jet[0].a;
     dx[1] = dx_jet[1].a;
-    J(0, 0) = dx_jet[0].v[0];
+    J(0, 0) = dx_jet[0].v[0] + 1;
     J(0, 1) = dx_jet[0].v[1];
     J(1, 0) = dx_jet[1].v[0];
-    J(1, 1) = dx_jet[1].v[1];
+    J(1, 1) = dx_jet[1].v[1] + 1;
 
     // Update
     const Eigen::Vector2d step_x = J.partialPivLu().solve(x + dx - x0);

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -657,11 +657,11 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
                                                          double* v) {
   // Parameters for Newton iteration. 100 iterations should be enough for
   // complex camera models with higher order terms.
-  const size_t kNumIterations = 100;
-  const double kMaxStepNorm = 1e-10;
+  constexpr size_t kNumIterations = 100;
+  constexpr double kMaxStepNorm = 1e-10;
   // Trust region: step_x.norm() <= max(x.norm() * kRelStepRadius, kStepRadius)
-  const double kRelStepRadius = 0.1;
-  const double kStepRadius = 0.1;
+  constexpr double kRelStepRadius = 0.1;
+  constexpr double kStepRadius = 0.1;
 
   Eigen::Matrix2d J;
   const Eigen::Vector2d x0(*u, *v);
@@ -691,9 +691,12 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
 
     // Update
     Eigen::Vector2d step_x = J.partialPivLu().solve(x + dx - x0);
-    const double radius = std::max(x.norm() * kRelStepRadius, kStepRadius);
-    if (step_x.norm() > radius) {
-      step_x *= (radius / step_x.norm());
+    const double radius_sqr =
+        std::max(x.squaredNorm() * kRelStepRadius * kRelStepRadius,
+                 kStepRadius * kStepRadius);
+    const double step_x_norm_sqr = step_x.squaredNorm();
+    if (step_x_norm_sqr > radius_sqr) {
+      step_x *= std::sqrt(radius_sqr / step_x_norm_sqr);
     }
     x -= step_x;
     if (step_x.squaredNorm() < kMaxStepNorm) {

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -679,7 +679,7 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
     CameraModel::Distortion(params, x(0), x(1), &dx(0), &dx(1));
     ceres::Jet<double, 2> x_jet[2];
     x_jet[0] = ceres::Jet<double, 2>(x(0));
-    x_jet[1] = ceres::Jet<double, 2>(x(0));
+    x_jet[1] = ceres::Jet<double, 2>(x(1));
     x_jet[0].v[0] = 1.0;
     x_jet[1].v[1] = 1.0;
     ceres::Jet<double, 2> dx_jet[2];

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -675,10 +675,8 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const double* params,
   for (size_t i = 0; i < kNumIterations; ++i) {
     // Get Jacobian
     ceres::Jet<double, 2> x_jet[2];
-    x_jet[0] = ceres::Jet<double, 2>(x(0));
-    x_jet[1] = ceres::Jet<double, 2>(x(1));
-    x_jet[0].v[0] = 1.0;
-    x_jet[1].v[1] = 1.0;
+    x_jet[0] = ceres::Jet<double, 2>(x(0), 0);
+    x_jet[1] = ceres::Jet<double, 2>(x(1), 1);
     ceres::Jet<double, 2> dx_jet[2];
     CameraModel::Distortion(
         params_jet, x_jet[0], x_jet[1], &dx_jet[0], &dx_jet[1]);

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -667,20 +667,28 @@ void BaseCameraModel<CameraModel>::IterativeUndistortion(const T* params,
   Eigen::Vector2d dx_1b;
   Eigen::Vector2d dx_1f;
 
+  ceres::Jet<double, 2> params_jet[CameraModel::num_extra_params];
+  for (size_t i = 0; i < CameraModel::num_extra_params; ++i) {
+    params_jet[i] = ceres::Jet<double, 2>(params[i], 0., 0.);
+  }
   for (size_t i = 0; i < kNumIterations; ++i) {
     const double step0 = std::max(std::numeric_limits<double>::epsilon(),
                                   std::abs(kRelStepSize * x(0)));
     const double step1 = std::max(std::numeric_limits<double>::epsilon(),
                                   std::abs(kRelStepSize * x(1)));
+    // Get Jacobian
     CameraModel::Distortion(params, x(0), x(1), &dx(0), &dx(1));
-    CameraModel::Distortion(params, x(0) - step0, x(1), &dx_0b(0), &dx_0b(1));
-    CameraModel::Distortion(params, x(0) + step0, x(1), &dx_0f(0), &dx_0f(1));
-    CameraModel::Distortion(params, x(0), x(1) - step1, &dx_1b(0), &dx_1b(1));
-    CameraModel::Distortion(params, x(0), x(1) + step1, &dx_1f(0), &dx_1f(1));
-    J(0, 0) = 1 + (dx_0f(0) - dx_0b(0)) / (2 * step0);
-    J(0, 1) = (dx_1f(0) - dx_1b(0)) / (2 * step1);
-    J(1, 0) = (dx_0f(1) - dx_0b(1)) / (2 * step0);
-    J(1, 1) = 1 + (dx_1f(1) - dx_1b(1)) / (2 * step1);
+    ceres::Jet<double, 2> x_jet[2];
+    x_jet[0] = ceres::Jet<double, 2>(x(0), 1.0, 0.0);
+    x_jet[1] = ceres::Jet<double, 2>(x(0), 0.0, 1.0);
+    ceres::Jet<double, 2> dx_jet[2];
+    CameraModel::Distortion(params_jet, x_jet(0), x_jet(1), &dx_jet(0), &dx_jet(1));
+    dx(0) = dx_jet(0).a;
+    dx(1) = dx_jet(0).a;
+    J(0, 0) = dx_jet(0).v[0];
+    J(0, 1) = dx_jet(0).v[1];
+    J(1, 0) = dx_jet(1).v[0];
+    J(1, 1) = dx_jet(1).v[1];
     const Eigen::Vector2d step_x = J.partialPivLu().solve(x + dx - x0);
     x -= step_x;
     if (step_x.squaredNorm() < kMaxStepNorm) {


### PR DESCRIPTION
Attempt on https://github.com/colmap/colmap/issues/2802 (improvement but did not manage to fully fix as discussed in the post below)

Remove templating of CamFromImg as it is never used in the optimization (and is tricky to be used in the optimization due to the unrolling in IterativeUndistortion). 

Use Jet from ceres to enable analytical Jacobian in the IterativeUndistortion. 
