### PR TITLE
Improve the conditioning of covariance estimation

### DIFF
--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -563,7 +563,7 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
   int rank = 0;
   for (int i = 0; i < S_matrix_.rows(); ++i) {
-    if (ldltOfS.vectorD().coeff(i) > 0.0) rank++;
+    if (ldltOfS.vectorD().coeff(i) != 0.0) rank++;
   }
   if (rank < S_matrix_.rows()) {
     LOG(INFO) << StringPrintf(
@@ -604,7 +604,7 @@ bool BundleAdjustmentCovarianceEstimator::ComputeFull() {
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS(S_matrix_);
   int rank = 0;
   for (int i = 0; i < S_matrix_.rows(); ++i) {
-    if (ldltOfS.vectorD().coeff(i) > 0.0) rank++;
+    if (ldltOfS.vectorD().coeff(i) != 0.0) rank++;
   }
   if (rank < S_matrix_.rows()) {
     LOG(INFO) << StringPrintf(
@@ -656,7 +656,7 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
   int rank = 0;
   for (int i = 0; i < S_poses.rows(); ++i) {
-    if (ldltOfS_poses.vectorD().coeff(i) > 0.0) rank++;
+    if (ldltOfS_poses.vectorD().coeff(i) != 0.0) rank++;
   }
   if (rank < S_poses.rows()) {
     LOG(INFO) << StringPrintf(
@@ -716,7 +716,7 @@ bool BundleAdjustmentCovarianceEstimator::Compute() {
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldltOfS_poses(S_poses);
   int rank = 0;
   for (int i = 0; i < S_poses.rows(); ++i) {
-    if (ldltOfS_poses.vectorD().coeff(i) > 0.0) rank++;
+    if (ldltOfS_poses.vectorD().coeff(i) != 0.0) rank++;
   }
   if (rank < S_poses.rows()) {
     LOG(INFO) << StringPrintf(

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -581,8 +581,10 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   L_matrix_variables_inv_ = L_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
   for (int i = 0; i < S_matrix_.rows(); ++i) {
-    double sqrt_invd = 1.0 / std::max(sqrt(std::max(ldlfOfS.vectorD().coeff(i), 0.0)), 1e-12);
-    L_matrix_variables_inv_.col(i) = L_matrix_variables_inv_.col(i).array() * sqrt_invd;
+    double sqrt_invd =
+        1.0 / std::max(sqrt(std::max(ldlfOfS.vectorD().coeff(i), 0.)), 1e-12);
+    L_matrix_variables_inv_.col(i) =
+        L_matrix_variables_inv_.col(i).array() * sqrt_invd;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
                "inverted.";
@@ -672,7 +674,9 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   L_matrix_poses_inv_ = L_poses_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
   for (int i = 0; i < S_poses_.rows(); ++i) {
-    double sqrt_invd = 1.0 / std::max(sqrt(std::max(ldlfOfS_poses.vectorD().coeff(i), 0.0)), 1e-12);
+    double sqrt_invd =
+        1.0 /
+        std::max(sqrt(std::max(ldlfOfS_poses.vectorD().coeff(i), 0.)), 1e-12);
     L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() * sqrt_invd;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -582,7 +582,7 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
   for (int i = 0; i < S_matrix_.rows(); ++i) {
     double sqrt_d =
-        std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), FLT_MIN);
+        std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), DBL_MIN);
     L_matrix_variables_inv_.col(i) =
         L_matrix_variables_inv_.col(i).array() / sqrt_d;
   }
@@ -675,7 +675,7 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
   for (int i = 0; i < S_poses.rows(); ++i) {
     double sqrt_d =
-        std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), FLT_MIN);
+        std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), DBL_MIN);
     L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -583,8 +583,8 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   for (int i = 0; i < S_matrix_.rows(); ++i) {
     double sqrt_d =
         std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), DBL_MIN);
-    L_matrix_variables_inv_.col(i) =
-        L_matrix_variables_inv_.col(i).array() / sqrt_d;
+    L_matrix_variables_inv_.row(i) =
+        L_matrix_variables_inv_.row(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
                "inverted.";
@@ -676,7 +676,7 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   for (int i = 0; i < S_poses.rows(); ++i) {
     double sqrt_d =
         std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), DBL_MIN);
-    L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() / sqrt_d;
+    L_matrix_poses_inv_.row(i) = L_matrix_poses_inv_.row(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
                "inverted.";

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -582,7 +582,7 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
   for (int i = 0; i < S_matrix_.rows(); ++i) {
     double sqrt_invd =
-        1.0 / std::max(sqrt(std::max(ldlfOfS.vectorD().coeff(i), 0.)), 1e-12);
+        1.0 / std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), 1e-12);
     L_matrix_variables_inv_.col(i) =
         L_matrix_variables_inv_.col(i).array() * sqrt_invd;
   }
@@ -673,10 +673,10 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   Eigen::MatrixXd L_poses_dense = L_poses;
   L_matrix_poses_inv_ = L_poses_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
-  for (int i = 0; i < S_poses_.rows(); ++i) {
+  for (int i = 0; i < S_poses.rows(); ++i) {
     double sqrt_invd =
         1.0 /
-        std::max(sqrt(std::max(ldlfOfS_poses.vectorD().coeff(i), 0.)), 1e-12);
+        std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), 1e-12);
     L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() * sqrt_invd;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -581,10 +581,10 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
   L_matrix_variables_inv_ = L_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
   for (int i = 0; i < S_matrix_.rows(); ++i) {
-    double sqrt_invd =
-        1.0 / std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), 1e-12);
+    double sqrt_d =
+        std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), 1e-12);
     L_matrix_variables_inv_.col(i) =
-        L_matrix_variables_inv_.col(i).array() * sqrt_invd;
+        L_matrix_variables_inv_.col(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
                "inverted.";
@@ -674,10 +674,9 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
   L_matrix_poses_inv_ = L_poses_dense.triangularView<Eigen::Lower>().solve(
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
   for (int i = 0; i < S_poses.rows(); ++i) {
-    double sqrt_invd =
-        1.0 /
+    double sqrt_d =
         std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), 1e-12);
-    L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() * sqrt_invd;
+    L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "
                "inverted.";

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -582,7 +582,7 @@ bool BundleAdjustmentCovarianceEstimator::FactorizeFull() {
       Eigen::MatrixXd::Identity(L_dense.rows(), L_dense.cols()));
   for (int i = 0; i < S_matrix_.rows(); ++i) {
     double sqrt_d =
-        std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), 1e-12);
+        std::max(sqrt(std::max(ldltOfS.vectorD().coeff(i), 0.)), FLT_MIN);
     L_matrix_variables_inv_.col(i) =
         L_matrix_variables_inv_.col(i).array() / sqrt_d;
   }
@@ -675,7 +675,7 @@ bool BundleAdjustmentCovarianceEstimator::Factorize() {
       Eigen::MatrixXd::Identity(L_poses_dense.rows(), L_poses_dense.cols()));
   for (int i = 0; i < S_poses.rows(); ++i) {
     double sqrt_d =
-        std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), 1e-12);
+        std::max(sqrt(std::max(ldltOfS_poses.vectorD().coeff(i), 0.)), FLT_MIN);
     L_matrix_poses_inv_.col(i) = L_matrix_poses_inv_.col(i).array() / sqrt_d;
   }
   LOG(INFO) << "Finish factorization by having the lower triangular matrix L "


### PR DESCRIPTION
This is a very crucial fix. (LD) can be very ill-conditioned on the diagonal, which results in nan at matrix inversion. So we should do inversion only on the L matrix. 