### PR TITLE
Handle unsuccessful image point undistortion

### DIFF
--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -125,7 +125,8 @@ struct Camera {
                              double max_extra_param) const;
 
   // Project point in image plane to world / infinity.
-  inline Eigen::Vector2d CamFromImg(const Eigen::Vector2d& image_point) const;
+  inline std::optional<Eigen::Vector2d> CamFromImg(
+      const Eigen::Vector2d& image_point) const;
 
   // Convert pixel threshold in image plane to camera frame.
   inline double CamFromImgThreshold(double threshold) const;
@@ -243,8 +244,13 @@ bool Camera::HasBogusParams(const double min_focal_length_ratio,
                                    max_extra_param);
 }
 
-Eigen::Vector2d Camera::CamFromImg(const Eigen::Vector2d& image_point) const {
-  return CameraModelCamFromImg(model_id, params, image_point).hnormalized();
+std::optional<Eigen::Vector2d> Camera::CamFromImg(
+    const Eigen::Vector2d& image_point) const {
+  if (const auto cam_point =
+          CameraModelCamFromImg(model_id, params, image_point)) {
+    return cam_point->hnormalized();
+  }
+  return std::nullopt;
 }
 
 double Camera::CamFromImgThreshold(const double threshold) const {

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -268,10 +268,10 @@ TEST(Camera, CamFromImg) {
   Camera camera;
   EXPECT_THROW(camera.CamFromImg(Eigen::Vector2d::Zero()), std::domain_error);
   camera = Camera::CreateFromModelName(1, "SIMPLE_PINHOLE", 1.0, 1, 1);
-  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.0, 0.0))(0), -0.5);
-  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.0, 0.0))(1), -0.5);
-  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.5, 0.5))(0), 0.0);
-  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.5, 0.5))(1), 0.0);
+  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.0, 0.0)).value(),
+            Eigen::Vector2d(-0.5, -0.5));
+  EXPECT_EQ(camera.CamFromImg(Eigen::Vector2d(0.5, 0.5)).value(),
+            Eigen::Vector2d(0.0, 0.0));
 }
 
 TEST(Camera, CamFromImgThreshold) {

--- a/src/colmap/scene/projection.cc
+++ b/src/colmap/scene/projection.cc
@@ -75,16 +75,26 @@ double CalculateAngularError(const Eigen::Vector2d& point2D,
                              const Eigen::Vector3d& point3D,
                              const Rigid3d& cam_from_world,
                              const Camera& camera) {
-  return CalculateNormalizedAngularError(
-      camera.CamFromImg(point2D), point3D, cam_from_world);
+  if (const std::optional<Eigen::Vector2d> point2D_normalized =
+          camera.CamFromImg(point2D)) {
+    return CalculateNormalizedAngularError(
+        *point2D_normalized, point3D, cam_from_world);
+  } else {
+    return M_PI;
+  }
 }
 
 double CalculateAngularError(const Eigen::Vector2d& point2D,
                              const Eigen::Vector3d& point3D,
                              const Eigen::Matrix3x4d& cam_from_world,
                              const Camera& camera) {
-  return CalculateNormalizedAngularError(
-      camera.CamFromImg(point2D), point3D, cam_from_world);
+  if (const std::optional<Eigen::Vector2d> point2D_normalized =
+          camera.CamFromImg(point2D)) {
+    return CalculateNormalizedAngularError(
+        *point2D_normalized, point3D, cam_from_world);
+  } else {
+    return M_PI;
+  }
 }
 
 double CalculateNormalizedAngularError(const Eigen::Vector2d& point2D,

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -83,11 +83,12 @@ void TestCamFromImgToImg(const std::vector<double>& params,
                          const double y0) {
   double u, v, w, x, y;
   CameraModel::CamFromImg(params.data(), x0, y0, &u, &v, &w);
-  const Eigen::Vector3d uvw = CameraModelCamFromImg(
+  const std::optional<Eigen::Vector3d> uvw = CameraModelCamFromImg(
       CameraModel::model_id, params, Eigen::Vector2d(x0, y0));
-  EXPECT_EQ(u, uvw.x());
-  EXPECT_EQ(v, uvw.y());
-  EXPECT_EQ(w, uvw.z());
+  ASSERT_TRUE(uvw.has_value());
+  EXPECT_EQ(u, uvw->x());
+  EXPECT_EQ(v, uvw->y());
+  EXPECT_EQ(w, uvw->z());
   CameraModel::ImgFromCam(params.data(), u, v, w, &x, &y);
   EXPECT_NEAR(x, x0, 1e-6);
   EXPECT_NEAR(y, y0, 1e-6);
@@ -200,11 +201,15 @@ TEST(Radial, Nominal) {
 TEST(OpenCV, Nominal) {
   TestModel<OpenCVCameraModel>(
       {651.123, 655.123, 386.123, 511.123, -0.471, 0.223, -0.001, 0.001});
+  TestModel<OpenCVCameraModel>(
+      {251.123, 255.123, 286.123, 411.123, -0.471, 0.223, -0.01, 0.01});
 }
 
 TEST(OpenCVFisheye, Nominal) {
   TestModel<OpenCVFisheyeCameraModel>(
       {651.123, 655.123, 386.123, 511.123, -0.471, 0.223, -0.001, 0.001});
+  TestModel<OpenCVFisheyeCameraModel>(
+      {251.123, 255.123, 286.123, 411.123, -0.471, 0.223, -0.01, 0.01});
 }
 
 TEST(FullOpenCV, Nominal) {

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -323,13 +323,14 @@ void IncrementalMapper::RegisterInitialImagePair(
   track.Element(0).image_id = image_id1;
   track.Element(1).image_id = image_id2;
   for (const auto& corr : corrs) {
-    const Eigen::Vector2d point2D1 =
+    const std::optional<Eigen::Vector2d> point2D1 =
         camera1.CamFromImg(image1.Point2D(corr.point2D_idx1).xy);
-    const Eigen::Vector2d point2D2 =
+    const std::optional<Eigen::Vector2d> point2D2 =
         camera2.CamFromImg(image2.Point2D(corr.point2D_idx2).xy);
     Eigen::Vector3d xyz;
-    if (TriangulatePoint(
-            cam_from_world1, cam_from_world2, point2D1, point2D2, &xyz) &&
+    if (point2D1 && point2D2 &&
+        TriangulatePoint(
+            cam_from_world1, cam_from_world2, *point2D1, *point2D2, &xyz) &&
         CalculateTriangulationAngle(proj_center1, proj_center2, xyz) >=
             min_tri_angle_rad &&
         HasPointPositiveDepth(cam_from_world1, xyz) &&


### PR DESCRIPTION
When undistortion fails to converge (e.g., see https://github.com/colmap/colmap/issues/2802), we can detect it and then more robustly handle these failures on the callsite. For example, when undistorting images, we now consider such pixels as background pixels instead of arbitrarily warping them. The handling is not super clean in all instances, as implemented in this PR.