### PR TITLE
Create requirements.txt for pycolmap examples to document ceres-pyceres version match

### DIFF
--- a/pycolmap/examples/requirements.txt
+++ b/pycolmap/examples/requirements.txt
@@ -1,0 +1,4 @@
+# Note that pyceres must have the same version as the libceres-dev apt package for the 
+# C++ build from source, otherwise there may be pybind issues for the used ceres types.
+pyceres
+enlighten

--- a/pycolmap/examples/requirements.txt
+++ b/pycolmap/examples/requirements.txt
@@ -1,4 +1,4 @@
-# Note that pyceres must have the same version as the libceres-dev apt package for the 
+# Note that pyceres must have the same version as the libceres-dev apt package of the 
 # C++ build from source, otherwise there may be pybind issues for the used ceres types.
 pyceres
 enlighten

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -86,7 +86,8 @@ void BindBundleAdjuster(py::module& m) {
           .def_readwrite("solver_options",
                          &BAOpts::solver_options,
                          "Options for the Ceres solver. Using this member "
-                         "requires having PyCeres installed.");
+                         "requires having PyCeres installed in the same "
+                         "version as libceres-dev.");
   MakeDataclass(PyBundleAdjustmentOptions);
 
   using BACfg = BundleAdjustmentConfig;


### PR DESCRIPTION
Hi, and thanks for your nice repo!

I just installed `pyceres==2.3` (on colmap 3.10), ran the `custom_bundle_adjustment` example, and got the issue that `BundleAdjustmentOptions.solver_options` could not be bound correctly. After aligning versions of ceres and pyceres to both 2.0.0, it worked fine. 

Maybe this is obvious to most people, but the additional documentation I am proposing might save some users some debugging time. If there is a nice way to programmatically enforce matching versions of ceres and pyceres without prescribing the actual version, that would be even better. 

