### PR TITLE
Fix rare deadlock during matching due to concurrent database access

### DIFF
--- a/src/colmap/controllers/feature_matching.cc
+++ b/src/colmap/controllers/feature_matching.cc
@@ -85,7 +85,10 @@ class FeatureMatcherThread : public Thread {
       timer.Start();
       const std::vector<std::pair<image_t, image_t>> image_pairs =
           pair_generator->Next();
-      DatabaseTransaction database_transaction(database_.get());
+      std::unique_ptr<DatabaseTransaction> database_transaction;
+      cache_->AccessDatabase([&database_transaction](Database& database) {
+        database_transaction = std::make_unique<DatabaseTransaction>(&database);
+      });
       matcher_.Match(image_pairs);
       PrintElapsedTime(timer);
     }

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -73,7 +73,7 @@ FeatureMatcherCache::FeatureMatcherCache(
 }
 
 void FeatureMatcherCache::AccessDatabase(
-    const std::function<void(const Database& database)>& func) {
+    const std::function<void(Database& database)>& func) {
   std::lock_guard<std::mutex> lock(database_mutex_);
   func(*database_);
 }

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -77,8 +77,7 @@ class FeatureMatcherCache {
 
   // Executes a function that accesses the database. This function is thread
   // safe and ensures that only one function can access the database at a time.
-  void AccessDatabase(
-      const std::function<void(const Database& database)>& func);
+  void AccessDatabase(const std::function<void(Database& database)>& func);
 
   const Camera& GetCamera(camera_t camera_id);
   const Image& GetImage(image_t image_id);

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -692,7 +692,7 @@ std::vector<std::pair<image_t, image_t>> TransitivePairGenerator::Next() {
 
   std::vector<std::pair<image_pair_t, int>> existing_pair_ids_and_num_inliers;
   cache_->AccessDatabase(
-      [&existing_pair_ids_and_num_inliers](const Database& database) {
+      [&existing_pair_ids_and_num_inliers](Database& database) {
         existing_pair_ids_and_num_inliers =
             database.ReadTwoViewGeometryNumInliers();
       });


### PR DESCRIPTION
It turns out one cannot concurrent read from the database and begin a transaction. This could happen in rare cases during vocabulary tree based matching, as the querying of the vocabulary tree is performed concurrently to the main matching controller thread. In this case, one thread might simultaneously read and begin a transaction. This causes a deadlock if unlucky. With this PR, this cannot happen anymore.