### PR TITLE
Add new and missing options to automatic reconstructor

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -153,13 +153,17 @@ void AutomaticReconstructionController::Run() {
     return;
   }
 
-  RunFeatureExtraction();
+  if (options_.extraction) {
+    RunFeatureExtraction();
+  }
 
   if (IsStopped()) {
     return;
   }
 
-  RunFeatureMatching();
+  if (options_.matching) {
+    RunFeatureMatching();
+  }
 
   if (IsStopped()) {
     return;

--- a/src/colmap/controllers/automatic_reconstruction.h
+++ b/src/colmap/controllers/automatic_reconstruction.h
@@ -76,6 +76,12 @@ class AutomaticReconstructionController : public Thread {
     // Initial camera params for all images.
     std::string camera_params;
 
+    // Whether to perform feature extraction.
+    bool extraction = true;
+
+    // Whether to perform feature matching.
+    bool matching = true;
+
     // Whether to perform sparse mapping.
     bool sparse = true;
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -84,8 +84,12 @@ int RunAutomaticReconstructor(int argc, char** argv) {
                            &reconstruction_options.camera_model);
   options.AddDefaultOption("single_camera",
                            &reconstruction_options.single_camera);
+  options.AddDefaultOption("single_camera_per_folder",
+                           &reconstruction_options.single_camera_per_folder);
   options.AddDefaultOption("camera_params",
                            &reconstruction_options.camera_params);
+  options.AddDefaultOption("extraction", &reconstruction_options.extraction);
+  options.AddDefaultOption("matching", &reconstruction_options.matching);
   options.AddDefaultOption("sparse", &reconstruction_options.sparse);
   options.AddDefaultOption("dense", &reconstruction_options.dense);
   options.AddDefaultOption("mesher", &mesher, "{poisson, delaunay}");


### PR DESCRIPTION
* Adds missing single_camera_per_folder option.
* Allows optional feature extraction/matching.