### PR TITLE
Subproblem partitioning with BFS to support covariance estimation for extremely large-scale problem 

### DIFF
--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -49,6 +49,7 @@ COLMAP_ADD_LIBRARY(
         generalized_relative_pose.h generalized_relative_pose.cc
         homography_matrix.h homography_matrix.cc
         pose.h pose.cc
+        problem_partitioner.h problem_partitioner.cc
         generalized_pose.h generalized_pose.cc
         similarity_transform.h
         translation_transform.h

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -41,7 +41,8 @@ BundleAdjustmentCovarianceEstimatorBase::
     : problem_(THROW_CHECK_NOTNULL(problem)),
       reconstruction_(THROW_CHECK_NOTNULL(reconstruction)) {
   partitioner_ = std::make_unique<ProblemPartitioner>(problem, reconstruction);
-  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  partitioner_->GetBlocks(
+      &pose_blocks_, &other_variables_blocks_, &point_blocks_);
   SetUpBlockSizes();
 }
 
@@ -51,16 +52,18 @@ BundleAdjustmentCovarianceEstimatorBase::
         const std::vector<const double*>& pose_blocks,
         const std::vector<const double*>& point_blocks)
     : problem_(THROW_CHECK_NOTNULL(problem)) {
-
-  partitioner_ = std::make_unique<ProblemPartitioner>(problem, pose_blocks, point_blocks);
-  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  partitioner_ =
+      std::make_unique<ProblemPartitioner>(problem, pose_blocks, point_blocks);
+  partitioner_->GetBlocks(
+      &pose_blocks_, &other_variables_blocks_, &point_blocks_);
   SetUpBlockSizes();
 }
 
 void BundleAdjustmentCovarianceEstimatorBase::SetPoseBlocks(
     const std::vector<const double*>& pose_blocks) {
   partitioner_->SetPoseBlocks(pose_blocks);
-  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  partitioner_->GetBlocks(
+      &pose_blocks_, &other_variables_blocks_, &point_blocks_);
   SetUpBlockSizes();
 }
 
@@ -69,17 +72,18 @@ void BundleAdjustmentCovarianceEstimatorBase::SetUpBlockSizes() {
   num_params_other_variables_ = 0;
   num_params_points_ = 0;
   map_block_to_index_.clear();
-  for (const double* block: pose_blocks_) {
+  for (const double* block : pose_blocks_) {
     int block_size = ParameterBlockTangentSize(problem_, block);
     map_block_to_index_.emplace(block, num_params_poses_);
     num_params_poses_ += block_size;
   }
-  for (const double* block: other_variables_blocks_) {
+  for (const double* block : other_variables_blocks_) {
     int block_size = ParameterBlockTangentSize(problem_, block);
-    map_block_to_index_.emplace(block, num_params_poses_ + num_params_other_variables_);
+    map_block_to_index_.emplace(
+        block, num_params_poses_ + num_params_other_variables_);
     num_params_other_variables_ += block_size;
   }
-  for (const double* block: point_blocks_) {
+  for (const double* block : point_blocks_) {
     int block_size = ParameterBlockTangentSize(problem_, block);
     num_params_points_ += block_size;
   }
@@ -189,11 +193,13 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
   std::vector<double*> blocks;
   for (const auto& image_id : image_ids) {
     THROW_CHECK(HasPose(image_id));
-    const double* qvec =
-      reconstruction_->Image(image_id).CamFromWorld().rotation.coeffs().data();
+    const double* qvec = reconstruction_->Image(image_id)
+                             .CamFromWorld()
+                             .rotation.coeffs()
+                             .data();
     blocks.push_back(const_cast<double*>(qvec));
     const double* tvec =
-      reconstruction_->Image(image_id).CamFromWorld().translation.data();
+        reconstruction_->Image(image_id).CamFromWorld().translation.data();
     blocks.push_back(const_cast<double*>(tvec));
   }
   return GetPoseCovariance(blocks);
@@ -208,10 +214,10 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
   // image_id1
   THROW_CHECK(HasPose(image_id1));
   const double* qvec_1 =
-    reconstruction_->Image(image_id1).CamFromWorld().rotation.coeffs().data();
+      reconstruction_->Image(image_id1).CamFromWorld().rotation.coeffs().data();
   blocks1.push_back(const_cast<double*>(qvec_1));
   const double* tvec_1 =
-    reconstruction_->Image(image_id1).CamFromWorld().translation.data();
+      reconstruction_->Image(image_id1).CamFromWorld().translation.data();
   blocks1.push_back(const_cast<double*>(tvec_1));
   for (const double* block : blocks1) {
     int index = GetBlockIndex(block);
@@ -224,10 +230,10 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
   // image_id2
   THROW_CHECK(HasPose(image_id2));
   const double* qvec_2 =
-    reconstruction_->Image(image_id2).CamFromWorld().rotation.coeffs().data();
+      reconstruction_->Image(image_id2).CamFromWorld().rotation.coeffs().data();
   blocks2.push_back(const_cast<double*>(qvec_2));
   const double* tvec_2 =
-    reconstruction_->Image(image_id2).CamFromWorld().translation.data();
+      reconstruction_->Image(image_id2).CamFromWorld().translation.data();
   blocks2.push_back(const_cast<double*>(tvec_2));
   for (const double* block : blocks2) {
     int index = GetBlockIndex(block);

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -40,44 +40,9 @@ BundleAdjustmentCovarianceEstimatorBase::
                                             Reconstruction* reconstruction)
     : problem_(THROW_CHECK_NOTNULL(problem)),
       reconstruction_(THROW_CHECK_NOTNULL(reconstruction)) {
-  // Parse parameter blocks for poses
-  pose_blocks_.clear();
-  num_params_poses_ = 0;
-  for (const auto& image : reconstruction_->Images()) {
-    const double* qvec = image.second.CamFromWorld().rotation.coeffs().data();
-    if (problem_->HasParameterBlock(qvec) &&
-        !problem_->IsParameterBlockConstant(const_cast<double*>(qvec))) {
-      int num_params_qvec = ParameterBlockTangentSize(problem_, qvec);
-      pose_blocks_.push_back(qvec);
-      map_block_to_index_.emplace(qvec, num_params_poses_);
-      num_params_poses_ += num_params_qvec;
-    }
-
-    const double* tvec = image.second.CamFromWorld().translation.data();
-    if (problem_->HasParameterBlock(tvec) &&
-        !problem_->IsParameterBlockConstant(const_cast<double*>(tvec))) {
-      int num_params_tvec = ParameterBlockTangentSize(problem_, tvec);
-      pose_blocks_.push_back(tvec);
-      map_block_to_index_.emplace(tvec, num_params_poses_);
-      num_params_poses_ += num_params_tvec;
-    }
-  }
-
-  // Parse parameter blocks for 3D points
-  point_blocks_.clear();
-  num_params_points_ = 0;
-  for (const auto& point3D : reconstruction_->Points3D()) {
-    const double* point3D_ptr = point3D.second.xyz.data();
-    if (problem_->HasParameterBlock(point3D_ptr) &&
-        !problem_->IsParameterBlockConstant(const_cast<double*>(point3D_ptr))) {
-      int num_params_point = ParameterBlockTangentSize(problem_, point3D_ptr);
-      point_blocks_.push_back(point3D_ptr);
-      num_params_points_ += num_params_point;
-    }
-  }
-
-  // Parse parameter blocks for other variables
-  SetUpOtherVariablesBlocks();
+  partitioner_ = std::make_unique<ProblemPartitioner>(problem, reconstruction);
+  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  SetUpBlockSizes();
 }
 
 BundleAdjustmentCovarianceEstimatorBase::
@@ -86,71 +51,37 @@ BundleAdjustmentCovarianceEstimatorBase::
         const std::vector<const double*>& pose_blocks,
         const std::vector<const double*>& point_blocks)
     : problem_(THROW_CHECK_NOTNULL(problem)) {
-  // Parse parameter blocks for 3D points
-  point_blocks_.clear();
-  num_params_points_ = 0;
-  for (const double* block : point_blocks) {
-    THROW_CHECK(
-        problem_->HasParameterBlock(block) &&
-        !problem_->IsParameterBlockConstant(const_cast<double*>(block)));
-    int num_params_point = ParameterBlockTangentSize(problem_, block);
-    point_blocks_.push_back(block);
-    num_params_points_ += num_params_point;
-  }
 
-  // Parse parameter blocks for poses
-  SetPoseBlocks(pose_blocks);
+  partitioner_ = std::make_unique<ProblemPartitioner>(problem, pose_blocks, point_blocks);
+  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  SetUpBlockSizes();
 }
 
 void BundleAdjustmentCovarianceEstimatorBase::SetPoseBlocks(
     const std::vector<const double*>& pose_blocks) {
-  // Reset block indexing map
-  map_block_to_index_.clear();
-
-  // Parse parameter blocks for poses
-  pose_blocks_.clear();
-  num_params_poses_ = 0;
-  for (const double* block : pose_blocks) {
-    THROW_CHECK(
-        problem_->HasParameterBlock(block) &&
-        !problem_->IsParameterBlockConstant(const_cast<double*>(block)));
-
-    int num_params_block = ParameterBlockTangentSize(problem_, block);
-    pose_blocks_.push_back(block);
-    map_block_to_index_.emplace(block, num_params_poses_);
-    num_params_poses_ += num_params_block;
-  }
-
-  // Parse parameter blocks for other variables
-  SetUpOtherVariablesBlocks();
+  partitioner_->SetPoseBlocks(pose_blocks);
+  partitioner_->GetBlocks(&pose_blocks_, &other_variables_blocks_, &point_blocks_);
+  SetUpBlockSizes();
 }
 
-void BundleAdjustmentCovarianceEstimatorBase::SetUpOtherVariablesBlocks() {
-  // Construct a set for excluding pose and point parameter blocks
-  std::set<const double*> pose_and_point_parameter_blocks;
-  for (const double* block : pose_blocks_)
-    pose_and_point_parameter_blocks.insert(block);
-  for (const double* block : point_blocks_)
-    pose_and_point_parameter_blocks.insert(block);
-
-  // Parse parameter blocks for other variables
-  other_variables_blocks_.clear();
+void BundleAdjustmentCovarianceEstimatorBase::SetUpBlockSizes() {
+  num_params_poses_ = 0;
   num_params_other_variables_ = 0;
-  std::vector<double*> all_parameter_blocks;
-  problem_->GetParameterBlocks(&all_parameter_blocks);
-  for (double* block : all_parameter_blocks) {
-    if (problem_->IsParameterBlockConstant(block)) continue;
-    // check if the current parameter block is in either the pose or point
-    // parameter blocks
-    if (pose_and_point_parameter_blocks.find(block) !=
-        pose_and_point_parameter_blocks.end()) {
-      continue;
-    }
-    other_variables_blocks_.push_back(block);
-    map_block_to_index_.emplace(
-        block, num_params_poses_ + num_params_other_variables_);
-    int num_params_block = ParameterBlockTangentSize(problem_, block);
-    num_params_other_variables_ += num_params_block;
+  num_params_points_ = 0;
+  map_block_to_index_.clear();
+  for (const double* block: pose_blocks_) {
+    int block_size = ParameterBlockTangentSize(problem_, block);
+    map_block_to_index_.emplace(block, num_params_poses_);
+    num_params_poses_ += block_size;
+  }
+  for (const double* block: other_variables_blocks_) {
+    int block_size = ParameterBlockTangentSize(problem_, block);
+    map_block_to_index_.emplace(block, num_params_poses_ + num_params_other_variables_);
+    num_params_other_variables_ += block_size;
+  }
+  for (const double* block: point_blocks_) {
+    int block_size = ParameterBlockTangentSize(problem_, block);
+    num_params_points_ += block_size;
   }
 }
 
@@ -189,25 +120,6 @@ int BundleAdjustmentCovarianceEstimatorBase::GetBlockTangentSize(
     const double* params) const {
   THROW_CHECK(HasBlock(params));
   return ParameterBlockTangentSize(problem_, params);
-}
-
-int BundleAdjustmentCovarianceEstimatorBase::GetPoseIndex(
-    image_t image_id) const {
-  THROW_CHECK(HasReconstruction());
-  const double* qvec =
-      reconstruction_->Image(image_id).CamFromWorld().rotation.coeffs().data();
-  return GetBlockIndex(qvec);
-}
-
-int BundleAdjustmentCovarianceEstimatorBase::GetPoseTangentSize(
-    image_t image_id) const {
-  THROW_CHECK(HasReconstruction());
-  THROW_CHECK(HasPose(image_id));
-  const double* qvec =
-      reconstruction_->Image(image_id).CamFromWorld().rotation.coeffs().data();
-  const double* tvec =
-      reconstruction_->Image(image_id).CamFromWorld().translation.data();
-  return GetBlockTangentSize(qvec) + GetBlockTangentSize(tvec);
 }
 
 bool BundleAdjustmentCovarianceEstimatorBase::HasValidPoseCovariance() const {
@@ -261,45 +173,76 @@ Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     image_t image_id) const {
   THROW_CHECK(HasReconstruction());
   THROW_CHECK(HasPose(image_id));
-  int index = GetPoseIndex(image_id);
-  int num_params_pose = GetPoseTangentSize(image_id);
-  return GetPoseCovarianceBlockOperation(
-      index, index, num_params_pose, num_params_pose);
+  std::vector<double*> blocks;
+  const double* qvec =
+      reconstruction_->Image(image_id).CamFromWorld().rotation.coeffs().data();
+  blocks.push_back(const_cast<double*>(qvec));
+  const double* tvec =
+      reconstruction_->Image(image_id).CamFromWorld().translation.data();
+  blocks.push_back(const_cast<double*>(tvec));
+  return GetPoseCovariance(blocks);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     const std::vector<image_t>& image_ids) const {
   THROW_CHECK(HasReconstruction());
-  std::vector<int> indices;
+  std::vector<double*> blocks;
   for (const auto& image_id : image_ids) {
     THROW_CHECK(HasPose(image_id));
-    int index = GetPoseIndex(image_id);
-    int num_params_pose = GetPoseTangentSize(image_id);
-    for (int i = 0; i < num_params_pose; ++i) {
-      indices.push_back(index + i);
-    }
+    const double* qvec =
+      reconstruction_->Image(image_id).CamFromWorld().rotation.coeffs().data();
+    blocks.push_back(const_cast<double*>(qvec));
+    const double* tvec =
+      reconstruction_->Image(image_id).CamFromWorld().translation.data();
+    blocks.push_back(const_cast<double*>(tvec));
   }
-  size_t n_indices = indices.size();
-  Eigen::MatrixXd output(n_indices, n_indices);
-  for (size_t i = 0; i < n_indices; ++i) {
-    for (size_t j = 0; j < n_indices; ++j) {
-      output(i, j) = GetPoseCovarianceByIndex(indices[i], indices[j]);
-    }
-  }
-  return output;
+  return GetPoseCovariance(blocks);
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(
     image_t image_id1, image_t image_id2) const {
   THROW_CHECK(HasReconstruction());
+  std::vector<double*> blocks1, blocks2;
+  std::vector<int> indices1, indices2;
+
+  // image_id1
   THROW_CHECK(HasPose(image_id1));
+  const double* qvec_1 =
+    reconstruction_->Image(image_id1).CamFromWorld().rotation.coeffs().data();
+  blocks1.push_back(const_cast<double*>(qvec_1));
+  const double* tvec_1 =
+    reconstruction_->Image(image_id1).CamFromWorld().translation.data();
+  blocks1.push_back(const_cast<double*>(tvec_1));
+  for (const double* block : blocks1) {
+    int index = GetBlockIndex(block);
+    int num_params_pose = GetBlockTangentSize(block);
+    for (int i = 0; i < num_params_pose; ++i) {
+      indices1.push_back(index + i);
+    }
+  }
+
+  // image_id2
   THROW_CHECK(HasPose(image_id2));
-  int index1 = GetPoseIndex(image_id1);
-  int num_params_pose1 = GetPoseTangentSize(image_id1);
-  int index2 = GetPoseIndex(image_id2);
-  int num_params_pose2 = GetPoseTangentSize(image_id2);
-  return GetPoseCovarianceBlockOperation(
-      index1, index2, num_params_pose1, num_params_pose2);
+  const double* qvec_2 =
+    reconstruction_->Image(image_id2).CamFromWorld().rotation.coeffs().data();
+  blocks2.push_back(const_cast<double*>(qvec_2));
+  const double* tvec_2 =
+    reconstruction_->Image(image_id2).CamFromWorld().translation.data();
+  blocks2.push_back(const_cast<double*>(tvec_2));
+  for (const double* block : blocks2) {
+    int index = GetBlockIndex(block);
+    int num_params_pose = GetBlockTangentSize(block);
+    for (int i = 0; i < num_params_pose; ++i) {
+      indices2.push_back(index + i);
+    }
+  }
+  Eigen::MatrixXd output(indices1.size(), indices2.size());
+  for (size_t i = 0; i < indices1.size(); ++i) {
+    for (size_t j = 0; j < indices2.size(); ++j) {
+      output(i, j) = GetPoseCovarianceByIndex(indices1[i], indices2[j]);
+    }
+  }
+  return output;
 }
 
 Eigen::MatrixXd BundleAdjustmentCovarianceEstimatorBase::GetPoseCovariance(

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -77,6 +77,30 @@ void BundleAdjustmentCovarianceEstimatorBase::UseSubproblemFromSubsetPoseBlocks(
   SetUpBlockSizes();
 }
 
+void BundleAdjustmentCovarianceEstimatorBase::UseSubproblemFromSubsetImages(
+    const std::vector<image_t>& subset_image_ids) {
+  THROW_CHECK(HasReconstruction());
+  std::vector<const double*> blocks;
+  for (const auto& image_id : subset_image_ids) {
+    const double* qvec = reconstruction_->Image(image_id)
+                             .CamFromWorld()
+                             .rotation.coeffs()
+                             .data();
+    if (problem_->HasParameterBlock(qvec) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(qvec))) {
+      blocks.push_back(qvec);
+    }
+
+    const double* tvec =
+        reconstruction_->Image(image_id).CamFromWorld().translation.data();
+    if (problem_->HasParameterBlock(tvec) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(tvec))) {
+      blocks.push_back(tvec);
+    }
+  }
+  UseSubproblemFromSubsetPoseBlocks(blocks);
+}
+
 void BundleAdjustmentCovarianceEstimatorBase::SetUpBlockSizes() {
   num_params_poses_ = 0;
   num_params_other_variables_ = 0;

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -62,14 +62,16 @@ class BundleAdjustmentCovarianceEstimatorBase {
   // reconstruction. e.g., the rig setup.
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
-  // Focus on a subproblem described by a subset of
-  // the original pose blocks. The subproblem include all constraints that
-  // connects with the subset pose blocks without passing the complementary set
-  // w.r.t the full pose blocks, with the boundary fixed. This is particularly
-  // useful for covariance estimation for very large-scale bundle adjustment
-  // problem, e.g., > 10k images.
+  // Focus on a subproblem described by a subset of the original pose blocks (or
+  // image ids). The subproblem include all constraints that connects with the
+  // subset pose blocks without passing the complementary set w.r.t the full
+  // pose blocks, with the boundary fixed. This is particularly useful for
+  // covariance estimation for very large-scale bundle adjustment problem, e.g.,
+  // > 10k images.
   void UseSubproblemFromSubsetPoseBlocks(
       const std::vector<const double*>& subset_pose_blocks);
+  void UseSubproblemFromSubsetImages(
+      const std::vector<image_t>& subset_image_ids);
 
   // Compute covariance for all parameters (except for 3D points).
   // Store the full matrix at cov_variables_ and the subblock copy at

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -58,7 +58,8 @@ class BundleAdjustmentCovarianceEstimatorBase {
   virtual ~BundleAdjustmentCovarianceEstimatorBase() = default;
 
   // Manually set pose blocks that are interested while keeping the point blocks
-  // unchanged
+  // unchanged. Needed for the cases where the poses does not fully come from
+  // reconstruction. e.g., the rig setup.
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   // Compute covariance for all parameters (except for 3D points).

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -62,6 +62,15 @@ class BundleAdjustmentCovarianceEstimatorBase {
   // reconstruction. e.g., the rig setup.
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
+  // Focus on a subproblem described by a subset of
+  // the original pose blocks. The subproblem include all constraints that
+  // connects with the subset pose blocks without passing the complementary set
+  // w.r.t the full pose blocks, with the boundary fixed. This is particularly
+  // useful for covariance estimation for very large-scale bundle adjustment
+  // problem, e.g., > 10k images.
+  void UseSubproblemFromSubsetPoseBlocks(
+      const std::vector<const double*>& subset_pose_blocks);
+
   // Compute covariance for all parameters (except for 3D points).
   // Store the full matrix at cov_variables_ and the subblock copy at
   // cov_poses_;
@@ -131,6 +140,9 @@ class BundleAdjustmentCovarianceEstimatorBase {
   // get the starting index of the parameter block in the matrix
   // orders: [pose_blocks, other_variables_blocks, point_blocks]
   std::map<const double*, int> map_block_to_index_;
+
+  // residual block ids used in the subproblem. If empty, use all the residuals
+  std::vector<ceres::ResidualBlockId> residual_block_ids_;
 
   int GetBlockIndex(const double* params) const;
   int GetBlockTangentSize(const double* params) const;

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/problem_partitioner.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/scene/reconstruction.h"
 
@@ -56,7 +57,7 @@ class BundleAdjustmentCovarianceEstimatorBase {
       const std::vector<const double*>& point_blocks);
   virtual ~BundleAdjustmentCovarianceEstimatorBase() = default;
 
-  // Manually set pose blocks that are interested
+  // Manually set pose blocks that are interested while keeping the point blocks unchanged
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   // Compute covariance for all parameters (except for 3D points).
@@ -131,8 +132,6 @@ class BundleAdjustmentCovarianceEstimatorBase {
 
   int GetBlockIndex(const double* params) const;
   int GetBlockTangentSize(const double* params) const;
-  int GetPoseIndex(image_t image_id) const;
-  int GetPoseTangentSize(image_t image_id) const;
 
   // covariance for all parameters (except for 3D points)
   Eigen::MatrixXd cov_variables_;
@@ -147,8 +146,9 @@ class BundleAdjustmentCovarianceEstimatorBase {
   Reconstruction* reconstruction_ = nullptr;
 
  private:
-  // set up parameter blocks
-  void SetUpOtherVariablesBlocks();
+  std::unique_ptr<ProblemPartitioner> partitioner_;
+  // Set up block sizes and number of parameters for the existing parameter blocks
+  void SetUpBlockSizes();
 };
 
 class BundleAdjustmentCovarianceEstimatorCeresBackend

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -57,7 +57,8 @@ class BundleAdjustmentCovarianceEstimatorBase {
       const std::vector<const double*>& point_blocks);
   virtual ~BundleAdjustmentCovarianceEstimatorBase() = default;
 
-  // Manually set pose blocks that are interested while keeping the point blocks unchanged
+  // Manually set pose blocks that are interested while keeping the point blocks
+  // unchanged
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   // Compute covariance for all parameters (except for 3D points).
@@ -147,7 +148,8 @@ class BundleAdjustmentCovarianceEstimatorBase {
 
  private:
   std::unique_ptr<ProblemPartitioner> partitioner_;
-  // Set up block sizes and number of parameters for the existing parameter blocks
+  // Set up block sizes and number of parameters for the existing parameter
+  // blocks
   void SetUpBlockSizes();
 };
 

--- a/src/colmap/estimators/problem_partitioner.cc
+++ b/src/colmap/estimators/problem_partitioner.cc
@@ -1,0 +1,249 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/estimators/problem_partitioner.h"
+
+#include <queue>
+
+namespace colmap {
+
+ProblemPartitioner::BipartiteGraph::BipartiteGraph() {}
+
+ProblemPartitioner::BipartiteGraph::BipartiteGraph(ceres::Problem* problem) {
+  std::vector<ceres::ResidualBlockId> residual_block_ids;
+  problem->GetResidualBlocks(&residual_block_ids);
+  for (const auto& residual_block_id : residual_block_ids) {
+    std::vector<double*> param_blocks;
+    problem->GetParameterBlocksForResidualBlock(residual_block_id,
+                                                 &param_blocks);
+
+    for (auto& param_block : param_blocks) {
+      AddEdge(param_block, residual_block_id);
+    }
+  }
+}
+
+void ProblemPartitioner::BipartiteGraph::AddEdge(double* param_block,
+             ceres::ResidualBlockId residual_block_id) {
+  param_to_residual[param_block].push_back(residual_block_id);
+  residual_to_param[residual_block_id].push_back(param_block);
+}
+
+std::vector<ceres::ResidualBlockId> ProblemPartitioner::BipartiteGraph::GetResidualBlocks(
+    double* param_block) const {
+  return param_to_residual.at(param_block);
+}
+
+std::vector<double*> ProblemPartitioner::BipartiteGraph::GetParameterBlocks(
+    ceres::ResidualBlockId residual_block_id) const {
+  return residual_to_param.at(residual_block_id);
+}
+
+ProblemPartitioner::ProblemPartitioner() {}
+
+ProblemPartitioner::ProblemPartitioner(ceres::Problem* problem,
+                                       Reconstruction* reconstruction) {
+  problem_ = problem;
+  graph_ = std::make_unique<BipartiteGraph>(problem);
+
+  // Parse parameter blocks for poses
+  for (const auto& [image_id, image]: reconstruction->Images()) {
+    const double* qvec = image.CamFromWorld().rotation.coeffs().data();
+    if (problem_->HasParameterBlock(qvec) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(qvec))) {
+      pose_blocks_.insert(const_cast<double*>(qvec));
+    }
+    const double* tvec = image.CamFromWorld().translation.data();
+    if (problem_->HasParameterBlock(tvec) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(tvec))) {
+      pose_blocks_.insert(const_cast<double*>(tvec));
+    }
+  }
+
+  // Parse parameter blocks for 3D points
+  for (const auto& [point3D_id, point3D]: reconstruction->Points3D()) {
+    const double* point3D_ptr = point3D.xyz.data();
+    if (problem_->HasParameterBlock(point3D_ptr) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(point3D_ptr))) {
+      point_blocks_.insert(const_cast<double*>(point3D_ptr));
+    }
+  } 
+  // Parse parameter blocks for other variables
+  SetUpOtherVariablesBlocks();
+}
+
+
+ProblemPartitioner::ProblemPartitioner(
+    ceres::Problem* problem, const std::vector<const double*>& pose_blocks, const std::vector<const double*>& point_blocks) {
+  problem_ = problem;
+  graph_ = std::make_unique<BipartiteGraph>(problem);
+
+  // Set parameter blocks for poses
+  for (auto it = pose_blocks.begin(); it != pose_blocks.end(); ++it) {
+    if (problem->HasParameterBlock(*it) &&
+        !problem->IsParameterBlockConstant(const_cast<double*>(*it))) {
+      pose_blocks_.insert(const_cast<double*>(*it));
+    }
+  }
+
+  // Set parameter blocks for 3D Points 
+  for (auto it = point_blocks.begin(); it != point_blocks.end(); ++it)
+  {
+    if (problem->HasParameterBlock(*it) &&
+        !problem->IsParameterBlockConstant(const_cast<double*>(*it))) {
+      point_blocks_.insert(const_cast<double*>(*it));
+    }
+  }
+
+  // Parse parameter blocks for other variables
+  SetUpOtherVariablesBlocks();
+}
+
+
+void ProblemPartitioner::SetPoseBlocks(
+    const std::vector<const double*>& pose_blocks) {
+  // Parse parameter blocks for poses
+  pose_blocks_.clear();
+  for (const double* block : pose_blocks) {
+    THROW_CHECK(
+        problem_->HasParameterBlock(block) &&
+        !problem_->IsParameterBlockConstant(const_cast<double*>(block)));
+    pose_blocks_.insert(const_cast<double*>(block));
+  }
+
+  // Parse parameter blocks for other variables
+  SetUpOtherVariablesBlocks();
+}
+
+
+void ProblemPartitioner::SetUpOtherVariablesBlocks() {
+  // Parse parameter blocks for other variables
+  other_variables_blocks_.clear();
+  std::vector<double*> all_parameter_blocks;
+  problem_->GetParameterBlocks(&all_parameter_blocks);
+  for (double* block : all_parameter_blocks) {
+    if (problem_->IsParameterBlockConstant(block)) continue;
+    // check if the current parameter block is in either the pose or point
+    if (pose_blocks_.find(block) != pose_blocks_.end()) {
+      continue;
+    }
+    if (point_blocks_.find(block) != point_blocks_.end()) {
+      continue;
+    }
+    other_variables_blocks_.insert(block);
+  }
+}
+
+void ProblemPartitioner::GetBlocks(std::vector<const double*>* pose_blocks, 
+    std::vector<const double*>* other_variables_blocks,
+    std::vector<const double*>* point_blocks) const {
+  pose_blocks->clear();
+  for (double* block: pose_blocks_) {
+    pose_blocks->push_back(block);
+  }
+  other_variables_blocks->clear();
+  for (double* block: other_variables_blocks_) {
+    other_variables_blocks->push_back(block);
+  }
+  point_blocks->clear();
+  for (double* block: point_blocks_) {
+    point_blocks->push_back(block);
+  }
+}
+
+
+void ProblemPartitioner::GetBlocksForSubproblem(
+    const std::vector<const double*>& subproblem_pose_blocks,
+    std::vector<const double*>* subproblem_other_variables_blocks,
+    std::vector<const double*>* subproblem_point_blocks,
+    std::unordered_set<ceres::ResidualBlockId>* residual_block_ids) const {
+  // Reset
+  subproblem_other_variables_blocks->clear();
+  subproblem_point_blocks->clear();
+  residual_block_ids->clear();
+
+  // Construct irrelevant pose blocks
+  std::unordered_set<double*> relevant_pose_blocks;
+  for (const auto& param : subproblem_pose_blocks) {
+    THROW_CHECK(problem_->HasParameterBlock(param));
+    THROW_CHECK(!problem_->IsParameterBlockConstant(const_cast<double*>(param)));
+    relevant_pose_blocks.insert(const_cast<double*>(param));
+  }
+  std::unordered_set<double*> irrelevant_pose_blocks;
+  for (double* param: pose_blocks_) {
+    if (relevant_pose_blocks.find(param) != relevant_pose_blocks.end())
+      continue;
+    irrelevant_pose_blocks.insert(param);
+  }
+
+  // Customizd BFS: Traverse all residuals from the relevant pose blocks but stop at irrelevant pose blocks
+  std::queue<double*> bfs_queue;
+  std::unordered_set<double*> param_visited;
+  for (const auto& param : subproblem_pose_blocks) {
+    bfs_queue.push(const_cast<double*>(param));
+    param_visited.insert(const_cast<double*>(param));
+  }
+  while (!bfs_queue.empty()) {
+    double* current_param = bfs_queue.front();
+    bfs_queue.pop();
+    for (auto& residual_block_id : graph_->GetResidualBlocks(current_param)) {
+      // check if the residual block exists
+      if (residual_block_ids->find(residual_block_id) !=
+          residual_block_ids->end())
+        continue;
+      // skip if the residual block links to irrelevant poses
+      bool flag = true;
+      for (auto& param_block : graph_->GetParameterBlocks(residual_block_id)) {
+        if (irrelevant_pose_blocks.find(param_block) !=
+            irrelevant_pose_blocks.end()) {
+          flag = false;
+          break;
+        }
+      }
+      if (!flag) continue;
+      // insert residual blocks
+      residual_block_ids->insert(residual_block_id);
+      for (auto& param_block : graph_->GetParameterBlocks(residual_block_id)) {
+        // check if visited
+        if (param_visited.find(param_block) != param_visited.end()) continue;
+        // non-pose parameter update bfs and subproblem parameter blocks
+        bfs_queue.push(param_block);
+        param_visited.insert(param_block);
+        if (point_blocks_.find(param_block) != point_blocks_.end()) {
+          subproblem_point_blocks->push_back(param_block);
+        }
+        else {
+          subproblem_other_variables_blocks->push_back(param_block);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/problem_partitioner.h
+++ b/src/colmap/estimators/problem_partitioner.h
@@ -49,7 +49,7 @@ class ProblemPartitioner {
                      const std::vector<const double*>& point_blocks);
   // Manually set pose blocks that are interested while keeping the point blocks
   // unchanged. Needed for the cases where the poses does not fully come from
-  // reconstruction. e.g., the rig setup.
+  // reconstruction, e.g., the rig setup.
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   void GetBlocks(std::vector<const double*>* pose_blocks,
@@ -58,14 +58,15 @@ class ProblemPartitioner {
 
   // Get parameter blocks and residual blocks for a subproblem with a subset of
   // the original pose blocks. The subproblem include all constraints that
-  // connects with the subset pose blocks without passing the complementary set.
-  // This is particularly useful for covariance estimation for very large-scale
-  // bundle adjustment problem with > 10k images.
+  // connects with the subset pose blocks without passing the complementary set
+  // w.r.t. the full pose blocks. This is particularly useful for covariance
+  // estimation for very large-scale bundle adjustment problem, e.g., > 10k
+  // images.
   void GetBlocksForSubproblem(
-      const std::vector<const double*>& subproblem_pose_blocks,
+      const std::vector<const double*>& subset_pose_blocks,
       std::vector<const double*>* subproblem_other_variables_blocks,
       std::vector<const double*>* subproblem_point_blocks,
-      std::unordered_set<ceres::ResidualBlockId>* residual_block_ids) const;
+      std::vector<ceres::ResidualBlockId>* residual_block_ids) const;
 
  private:
   struct BipartiteGraph {

--- a/src/colmap/estimators/problem_partitioner.h
+++ b/src/colmap/estimators/problem_partitioner.h
@@ -30,13 +30,16 @@
 #pragma once
 
 #include "colmap/scene/reconstruction.h"
+
 #include <ceres/ceres.h>
 
 namespace colmap {
 
-// Problem partitioner for bundle adjustment (or extended) problem, useful for covariance estimation.
-// The ceres problem is partitioned into three blocks: pose blocks, point blocks (can be used for Schur elimination), and other variable blocks. 
-// One can also get parameter and residual blocks for a subproblem of the original problem with a subset of the original pose blocks.
+// Problem partitioner for bundle adjustment (or extended) problem, useful for
+// covariance estimation. The ceres problem is partitioned into three blocks:
+// pose blocks, point blocks (can be used for Schur elimination), and other
+// variable blocks. One can also get parameter and residual blocks for a
+// subproblem of the original problem with a subset of the original pose blocks.
 class ProblemPartitioner {
  public:
   ProblemPartitioner();
@@ -44,15 +47,21 @@ class ProblemPartitioner {
   ProblemPartitioner(ceres::Problem* problem,
                      const std::vector<const double*>& pose_blocks,
                      const std::vector<const double*>& point_blocks);
-  // Manually set pose blocks that are interested while keeping the point blocks unchanged
+  // Manually set pose blocks that are interested while keeping the point blocks
+  // unchanged
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   void GetBlocks(std::vector<const double*>* pose_blocks,
-      std::vector<const double*>* other_variables_blocks,
-      std::vector<const double*>* point_blocks) const;
+                 std::vector<const double*>* other_variables_blocks,
+                 std::vector<const double*>* point_blocks) const;
 
-  // Get parameter blocks and residual blocks for a subproblem with a subset of the original pose blocks. The subproblem include all constraints that connects with the subset pose blocks without passing the complementary set. This is particularly useful for covariance estimation for very large-scale bundle adjustment problem with > 10k images.
-  void GetBlocksForSubproblem(const std::vector<const double*>& subproblem_pose_blocks,
+  // Get parameter blocks and residual blocks for a subproblem with a subset of
+  // the original pose blocks. The subproblem include all constraints that
+  // connects with the subset pose blocks without passing the complementary set.
+  // This is particularly useful for covariance estimation for very large-scale
+  // bundle adjustment problem with > 10k images.
+  void GetBlocksForSubproblem(
+      const std::vector<const double*>& subproblem_pose_blocks,
       std::vector<const double*>* subproblem_other_variables_blocks,
       std::vector<const double*>* subproblem_point_blocks,
       std::unordered_set<ceres::ResidualBlockId>* residual_block_ids) const;
@@ -62,15 +71,14 @@ class ProblemPartitioner {
     BipartiteGraph();
     BipartiteGraph(ceres::Problem* problem);
 
-    void AddEdge(double* param_block,
-                 ceres::ResidualBlockId residual_block_id);
-    
+    void AddEdge(double* param_block, ceres::ResidualBlockId residual_block_id);
+
     std::vector<ceres::ResidualBlockId> GetResidualBlocks(
         double* param_block) const;
 
     std::vector<double*> GetParameterBlocks(
         ceres::ResidualBlockId residual_block_id) const;
-   
+
     std::unordered_map<double*, std::vector<ceres::ResidualBlockId>>
         param_to_residual;
     std::unordered_map<ceres::ResidualBlockId, std::vector<double*>>
@@ -82,7 +90,7 @@ class ProblemPartitioner {
 
   // The bipartite between param blocks and residuals
   std::unique_ptr<BipartiteGraph> graph_;
-  
+
   // All the parameter blocks
   std::unordered_set<double*> pose_blocks_;
   std::unordered_set<double*> other_variables_blocks_;

--- a/src/colmap/estimators/problem_partitioner.h
+++ b/src/colmap/estimators/problem_partitioner.h
@@ -48,7 +48,8 @@ class ProblemPartitioner {
                      const std::vector<const double*>& pose_blocks,
                      const std::vector<const double*>& point_blocks);
   // Manually set pose blocks that are interested while keeping the point blocks
-  // unchanged
+  // unchanged. Needed for the cases where the poses does not fully come from
+  // reconstruction. e.g., the rig setup.
   void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
 
   void GetBlocks(std::vector<const double*>* pose_blocks,

--- a/src/colmap/estimators/problem_partitioner.h
+++ b/src/colmap/estimators/problem_partitioner.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/scene/reconstruction.h"
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+// Problem partitioner for bundle adjustment (or extended) problem, useful for covariance estimation.
+// The ceres problem is partitioned into three blocks: pose blocks, point blocks (can be used for Schur elimination), and other variable blocks. 
+// One can also get parameter and residual blocks for a subproblem of the original problem with a subset of the original pose blocks.
+class ProblemPartitioner {
+ public:
+  ProblemPartitioner();
+  ProblemPartitioner(ceres::Problem* problem, Reconstruction* reconstruction);
+  ProblemPartitioner(ceres::Problem* problem,
+                     const std::vector<const double*>& pose_blocks,
+                     const std::vector<const double*>& point_blocks);
+  // Manually set pose blocks that are interested while keeping the point blocks unchanged
+  void SetPoseBlocks(const std::vector<const double*>& pose_blocks);
+
+  void GetBlocks(std::vector<const double*>* pose_blocks,
+      std::vector<const double*>* other_variables_blocks,
+      std::vector<const double*>* point_blocks) const;
+
+  // Get parameter blocks and residual blocks for a subproblem with a subset of the original pose blocks. The subproblem include all constraints that connects with the subset pose blocks without passing the complementary set. This is particularly useful for covariance estimation for very large-scale bundle adjustment problem with > 10k images.
+  void GetBlocksForSubproblem(const std::vector<const double*>& subproblem_pose_blocks,
+      std::vector<const double*>* subproblem_other_variables_blocks,
+      std::vector<const double*>* subproblem_point_blocks,
+      std::unordered_set<ceres::ResidualBlockId>* residual_block_ids) const;
+
+ private:
+  struct BipartiteGraph {
+    BipartiteGraph();
+    BipartiteGraph(ceres::Problem* problem);
+
+    void AddEdge(double* param_block,
+                 ceres::ResidualBlockId residual_block_id);
+    
+    std::vector<ceres::ResidualBlockId> GetResidualBlocks(
+        double* param_block) const;
+
+    std::vector<double*> GetParameterBlocks(
+        ceres::ResidualBlockId residual_block_id) const;
+   
+    std::unordered_map<double*, std::vector<ceres::ResidualBlockId>>
+        param_to_residual;
+    std::unordered_map<ceres::ResidualBlockId, std::vector<double*>>
+        residual_to_param;
+  };
+
+  // The address of the problem
+  ceres::Problem* problem_;
+
+  // The bipartite between param blocks and residuals
+  std::unique_ptr<BipartiteGraph> graph_;
+  
+  // All the parameter blocks
+  std::unordered_set<double*> pose_blocks_;
+  std::unordered_set<double*> other_variables_blocks_;
+  std::unordered_set<double*> point_blocks_;
+  void SetUpOtherVariablesBlocks();
+};
+
+}  // namespace colmap

--- a/src/pycolmap/estimators/covariance.cc
+++ b/src/pycolmap/estimators/covariance.cc
@@ -73,6 +73,9 @@ void BindCovarianceEstimator(py::module& m) {
             return self.UseSubproblemFromSubsetPoseBlocks(blocks);
           },
           py::arg("subset_pose_blocks"))
+      .def("use_subproblem_from_subset_images",
+           &EstimatorBase::UseSubproblemFromSubsetImages,
+           py::arg("subset_image_ids"))
       .def("has_block", &EstimatorBase::HasBlock, py::arg("parameter_block"))
       .def("has_pose_block",
            &EstimatorBase::HasPoseBlock,

--- a/src/pycolmap/estimators/covariance.cc
+++ b/src/pycolmap/estimators/covariance.cc
@@ -65,6 +65,14 @@ void BindCovarianceEstimator(py::module& m) {
             return self.SetPoseBlocks(blocks);
           },
           py::arg("pose_blocks"))
+      .def(
+          "use_subproblem_from_subset_pose_blocks",
+          [](EstimatorBase& self, std::vector<py::array_t<double>>& pyarrays) {
+            std::vector<const double*> blocks =
+                ConvertListOfPyArraysToConstPointers(pyarrays);
+            return self.UseSubproblemFromSubsetPoseBlocks(blocks);
+          },
+          py::arg("subset_pose_blocks"))
       .def("has_block", &EstimatorBase::HasBlock, py::arg("parameter_block"))
       .def("has_pose_block",
            &EstimatorBase::HasPoseBlock,


### PR DESCRIPTION
- Abstract the logic of parameter block partitioning in ``ProblemPartitioner``
- Support covariance estimation with subproblem specified either by 1) a list of subset pose parameter blocks. 2) a list of subset image ids. If used only the subproblem is considered in covariance estimation, with all the other pose parameter blocks treated as fixed at the boundary.

This will make estimation of pose covariance for ultra large scale problem feasible with a reasonable selection of subset pose blocks.  One can do covariance estimation in sliding window manner spatially with this update. 