### PR TITLE
Pr/remove all sources target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ src/colmap/util/version.cc
 .vscode
 .vs
 .DS_Store
+.cache
 build*/
 install-debug/
 install-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,47 +243,47 @@ COLMAP_ADD_SOURCE_DIR(src/thirdparty/PoissonRecon THIRDPARTY_POISSON_RECON_SRCS 
 COLMAP_ADD_SOURCE_DIR(src/thirdparty/SiftGPU THIRDPARTY_SIFT_GPU_SRCS *.h *.cpp *.cu)
 COLMAP_ADD_SOURCE_DIR(src/thirdparty/VLFeat THIRDPARTY_VLFEAT_SRCS *.h *.c *.tc)
 
-# Add all of the source files to a regular library target, as using a custom
-# target does not allow us to set its C++ include directories (and thus
-# intellisense can't find any of the included files).
-set(ALL_SRCS
-    ${CONTROLLERS_SRCS}
-    ${ESTIMATORS_SRCS}
-    ${EXE_SRCS}
-    ${FEATURE_SRCS}
-    ${GEOMETRY_SRCS}
-    ${IMAGE_SRCS}
-    ${MATH_SRCS}
-    ${MVS_SRCS}
-    ${OPTIM_SRCS}
-    ${RETRIEVAL_SRCS}
-    ${SCENE_SRCS}
-    ${SENSOR_SRCS}
-    ${SFM_SRCS}
-    ${TOOLS_SRCS}
-    ${UI_SRCS}
-    ${UTIL_SRCS}
-    ${THIRDPARTY_POISSON_RECON_SRCS}
-    ${THIRDPARTY_SIFT_GPU_SRCS}
-    ${THIRDPARTY_VLFEAT_SRCS}
-)
+# # Add all of the source files to a regular library target, as using a custom
+# # target does not allow us to set its C++ include directories (and thus
+# # intellisense can't find any of the included files).
+# set(ALL_SRCS
+#     ${CONTROLLERS_SRCS}
+#     ${ESTIMATORS_SRCS}
+#     ${EXE_SRCS}
+#     ${FEATURE_SRCS}
+#     ${GEOMETRY_SRCS}
+#     ${IMAGE_SRCS}
+#     ${MATH_SRCS}
+#     ${MVS_SRCS}
+#     ${OPTIM_SRCS}
+#     ${RETRIEVAL_SRCS}
+#     ${SCENE_SRCS}
+#     ${SENSOR_SRCS}
+#     ${SFM_SRCS}
+#     ${TOOLS_SRCS}
+#     ${UI_SRCS}
+#     ${UTIL_SRCS}
+#     ${THIRDPARTY_POISSON_RECON_SRCS}
+#     ${THIRDPARTY_SIFT_GPU_SRCS}
+#     ${THIRDPARTY_VLFEAT_SRCS}
+# )
 
-if(LSD_ENABLED)
-    list(APPEND ALL_SRCS
-        ${THIRDPARTY_LSD_SRCS}
-    )
-endif()
+# if(LSD_ENABLED)
+#     list(APPEND ALL_SRCS
+#         ${THIRDPARTY_LSD_SRCS}
+#     )
+# endif()
 
-add_library(
-    ${COLMAP_SRC_ROOT_FOLDER}
-    ${ALL_SRCS}
-)
+# add_library(
+#     ${COLMAP_SRC_ROOT_FOLDER}
+#     ${ALL_SRCS}
+# )
 
-# Prevent the library from being compiled automatically.
-set_target_properties(
-    ${COLMAP_SRC_ROOT_FOLDER} PROPERTIES
-    EXCLUDE_FROM_ALL 1
-    EXCLUDE_FROM_DEFAULT_BUILD 1)
+# # Prevent the library from being compiled automatically.
+# set_target_properties(
+#     ${COLMAP_SRC_ROOT_FOLDER} PROPERTIES
+#     EXCLUDE_FROM_ALL 1
+#     EXCLUDE_FROM_DEFAULT_BUILD 1)
 
 
 ################################################################################


### PR DESCRIPTION
1. ignore .cache path, which used by clangd for index caching.
2. comment out `COLMAP_SRC_ROOT_FOLDER` target since it's not compilable, missing linking target and would mess up static checks with vcpkg managed dependencies. relating to #1093 