### PR TITLE
Gracefully handle missing image pose in viewer

### DIFF
--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -87,6 +87,7 @@ class Image {
   // World to camera pose.
   inline const Rigid3d& CamFromWorld() const;
   inline Rigid3d& CamFromWorld();
+  inline const std::optional<Rigid3d>& MaybeCamFromWorld() const;
   inline std::optional<Rigid3d>& MaybeCamFromWorld();
   inline void SetCamFromWorld(const Rigid3d& cam_from_world);
   inline void SetCamFromWorld(const std::optional<Rigid3d>& cam_from_world);
@@ -209,6 +210,10 @@ const Rigid3d& Image::CamFromWorld() const {
 Rigid3d& Image::CamFromWorld() {
   THROW_CHECK(cam_from_world_) << "Image does not have a valid pose.";
   return *cam_from_world_;
+}
+
+const std::optional<Rigid3d>& Image::MaybeCamFromWorld() const {
+  return cam_from_world_;
 }
 
 std::optional<Rigid3d>& Image::MaybeCamFromWorld() { return cam_from_world_; }

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -80,7 +80,7 @@ void BuildImageModel(const Image& image,
   // be in a partial, incorrect state. In rare circumstances, an image may be
   // registered but not yet have a pose. Instead of crashing the viewer, we
   // simply skip the visualization of these images and warn the user.
-  const std::optional<Rigid3d> cam_from_world = image.MaybeCamFromWorld();
+  const std::optional<Rigid3d>& cam_from_world = image.MaybeCamFromWorld();
   if (!cam_from_world) {
     LOG(WARNING) << "Failed to render image " << image.Name()
                  << " but it has no pose.";

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -75,6 +75,18 @@ void BuildImageModel(const Image& image,
                      const Eigen::Vector4f& frame_color,
                      std::vector<TrianglePainter::Data>* triangle_data,
                      std::vector<LinePainter::Data>* line_data) {
+  // Updating the reconstruction in the viewer (e.g., deleting an image or a
+  // point) is not thread-safe when the mapper is running, where some images may
+  // be in a partial, incorrect state. In rare circumstances, an image may be
+  // registered but not yet have a pose. Instead of crashing the viewer, we
+  // simply skip the visualization of these images and warn the user.
+  const std::optional<Rigid3d> cam_from_world = image.MaybeCamFromWorld();
+  if (!cam_from_world) {
+    LOG(WARNING) << "Failed to render image " << image.Name()
+                 << " but it has no pose.";
+    return;
+  }
+
   // Generate camera dimensions in OpenGL (world) coordinate space.
   const float kBaseCameraWidth = 1024.0f;
   const float image_width = image_size * camera.width / kBaseCameraWidth;
@@ -86,23 +98,23 @@ void BuildImageModel(const Image& image,
       static_cast<float>(camera.CamFromImgThreshold(camera_extent));
   const float focal_length = 2.0f * image_extent / camera_extent_normalized;
 
-  const Eigen::Matrix<float, 3, 4> inv_proj_matrix =
-      Inverse(image.CamFromWorld()).ToMatrix().cast<float>();
+  const Eigen::Matrix<float, 3, 4> world_from_cam =
+      Inverse(*cam_from_world).ToMatrix().cast<float>();
 
   // Projection center, top-left, top-right, bottom-right, bottom-left corners.
 
-  const Eigen::Vector3f pc = inv_proj_matrix.rightCols<1>();
+  const Eigen::Vector3f pc = world_from_cam.rightCols<1>();
   const Eigen::Vector3f tl =
-      inv_proj_matrix *
+      world_from_cam *
       Eigen::Vector4f(-image_width, image_height, focal_length, 1);
   const Eigen::Vector3f tr =
-      inv_proj_matrix *
+      world_from_cam *
       Eigen::Vector4f(image_width, image_height, focal_length, 1);
   const Eigen::Vector3f br =
-      inv_proj_matrix *
+      world_from_cam *
       Eigen::Vector4f(image_width, -image_height, focal_length, 1);
   const Eigen::Vector3f bl =
-      inv_proj_matrix *
+      world_from_cam *
       Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
 
   // Image plane as two triangles.

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -80,7 +80,7 @@ void BindImage(py::module& m) {
                     "Name of the image.")
       .def_property(
           "cam_from_world",
-          &Image::MaybeCamFromWorld,
+          py::overload_cast<>(&Image::MaybeCamFromWorld),
           py::overload_cast<const std::optional<Rigid3d>&>(
               &Image::SetCamFromWorld),
           "The pose of the image, defined as the transformation from world to "


### PR DESCRIPTION
Since we changed the behavior to throw an exception on missing image pose, this can cause a crash in the viewer. This case is now handled more gracefully.