### PR TITLE
Modernized bundle adjustment interface

### DIFF
--- a/pycolmap/examples/custom_bundle_adjustment.py
+++ b/pycolmap/examples/custom_bundle_adjustment.py
@@ -7,7 +7,7 @@ pyceres is needed as a dependency for this file.
 
 import copy
 
-import pyceres # noqa F401
+import pyceres  # noqa F401
 
 import pycolmap
 from pycolmap import logging

--- a/pycolmap/examples/custom_bundle_adjustment.py
+++ b/pycolmap/examples/custom_bundle_adjustment.py
@@ -7,7 +7,7 @@ pyceres is needed as a dependency for this file.
 
 import copy
 
-import pyceres
+import pyceres # noqa F401
 
 import pycolmap
 from pycolmap import logging

--- a/pycolmap/examples/custom_bundle_adjustment.py
+++ b/pycolmap/examples/custom_bundle_adjustment.py
@@ -13,198 +13,17 @@ import pycolmap
 from pycolmap import logging
 
 
-class PyBundleAdjuster:
-    # Python implementation of COLMAP bundle adjuster with pyceres
-    def __init__(
-        self,
-        options: pycolmap.BundleAdjustmentOptions,
-        config: pycolmap.BundleAdjustmentConfig,
-    ):
-        self.options = options
-        self.config = config
-        self.problem = pyceres.Problem()
-        self.summary = pyceres.SolverSummary()
-        self.camera_ids = set()
-        self.point3D_num_observations = dict()
-
-    def solve(self, reconstruction: pycolmap.Reconstruction):
-        loss = self.options.create_loss_function()
-        self.set_up_problem(reconstruction, loss)
-        if self.problem.num_residuals() == 0:
-            return False
-        solver_options = self.set_up_solver_options(
-            self.problem, self.options.solver_options
-        )
-        pyceres.solve(solver_options, self.problem, self.summary)
-        return True
-
-    def set_up_problem(
-        self,
-        reconstruction: pycolmap.Reconstruction,
-        loss: pyceres.LossFunction,
-    ):
-        assert reconstruction is not None
-        self.problem = pyceres.Problem()
-        for image_id in self.config.image_ids:
-            self.add_image_to_problem(image_id, reconstruction, loss)
-        for point3D_id in self.config.variable_point3D_ids:
-            self.add_point_to_problem(point3D_id, reconstruction, loss)
-        for point3D_id in self.config.constant_point3D_ids:
-            self.add_point_to_problem(point3D_id, reconstruction, loss)
-        self.parameterize_cameras(reconstruction)
-        self.parameterize_points(reconstruction)
-        return self.problem
-
-    def set_up_solver_options(
-        self, problem: pyceres.Problem, solver_options: pyceres.SolverOptions
-    ):
-        bundle_adjuster = pycolmap.BundleAdjuster(self.options, self.config)
-        return bundle_adjuster.set_up_solver_options(problem, solver_options)
-
-    def add_image_to_problem(
-        self,
-        image_id: int,
-        reconstruction: pycolmap.Reconstruction,
-        loss: pyceres.LossFunction,
-    ):
-        image = reconstruction.images[image_id]
-        pose = image.cam_from_world
-        camera = reconstruction.cameras[image.camera_id]
-        constant_cam_pose = (
-            not self.options.refine_extrinsics
-        ) or self.config.has_constant_cam_pose(image.image_id)
-        num_observations = 0
-        for point2D in image.points2D:
-            if not point2D.has_point3D():
-                continue
-            num_observations += 1
-            if point2D.point3D_id not in self.point3D_num_observations:
-                self.point3D_num_observations[point2D.point3D_id] = 0
-            self.point3D_num_observations[point2D.point3D_id] += 1
-            point3D = reconstruction.points3D[point2D.point3D_id]
-            assert point3D.track.length() > 1
-            if constant_cam_pose:
-                cost = pycolmap.cost_functions.ReprojErrorCost(
-                    camera.model, pose, point2D.xy
-                )
-                self.problem.add_residual_block(
-                    cost, loss, [point3D.xyz, camera.params]
-                )
-            else:
-                cost = pycolmap.cost_functions.ReprojErrorCost(
-                    camera.model, point2D.xy
-                )
-                self.problem.add_residual_block(
-                    cost,
-                    loss,
-                    [
-                        pose.rotation.quat,
-                        pose.translation,
-                        point3D.xyz,
-                        camera.params,
-                    ],
-                )
-        if num_observations > 0:
-            self.camera_ids.add(image.camera_id)
-            # Set pose parameterization
-            if not constant_cam_pose:
-                self.problem.set_manifold(
-                    pose.rotation.quat, pyceres.QuaternionManifold()
-                )
-                if self.config.has_constant_cam_positions(image_id):
-                    constant_position_idxs = self.config.constant_cam_positions(
-                        image_id
-                    )
-                    self.problem.set_manifold(
-                        pose.translation,
-                        pyceres.SubsetManifold(3, constant_position_idxs),
-                    )
-
-    def add_point_to_problem(
-        self,
-        point3D_id: int,
-        reconstruction: pycolmap.Reconstruction,
-        loss: pyceres.LossFunction,
-    ):
-        point3D = reconstruction.points3D[point3D_id]
-        if point3D_id in self.point3D_num_observations:
-            if (
-                self.point3D_num_observations[point3D_id]
-                == point3D.track.length()
-            ):
-                return
-        else:
-            self.point3D_num_observations[point3D_id] = 0
-        for track_el in point3D.track.elements:
-            if self.config.has_image(track_el.image_id):
-                continue
-            self.point3D_num_observations[point3D_id] += 1
-            image = reconstruction.images[track_el.image_id]
-            camera = reconstruction.cameras[image.camera_id]
-            point2D = image.point2D(track_el.point2D_idx)
-            if image.camera_id not in self.camera_ids:
-                self.camera_ids.add(image.camera_id)
-                self.config.set_constant_cam_intrinsics(image.camera_id)
-            cost = pycolmap.cost_functions.ReprojErrorCost(
-                camera.model, image.cam_from_world, point2D.xy
-            )
-            self.problem.add_residual_block(
-                cost, loss, [point3D.xyz, camera.params]
-            )
-
-    def parameterize_cameras(self, reconstruction: pycolmap.Reconstruction):
-        constant_camera = (
-            (not self.options.refine_focal_length)
-            and (not self.options.refine_principal_point)
-            and (not self.options.refine_extra_params)
-        )
-        for camera_id in self.camera_ids:
-            camera = reconstruction.cameras[camera_id]
-            if constant_camera or self.config.has_constant_cam_intrinsics(
-                camera_id
-            ):
-                self.problem.set_parameter_block_constant(camera.params)
-                continue
-            const_camera_params = []
-            if not self.options.refine_focal_length:
-                const_camera_params.extend(camera.focal_length_idxs())
-            if not self.options.refine_principal_point:
-                const_camera_params.extend(camera.principal_point_idxs())
-            if not self.options.refine_extra_params:
-                const_camera_params.extend(camera.extra_point_idxs())
-            if len(const_camera_params) > 0:
-                self.problem.set_manifold(
-                    camera.params,
-                    pyceres.SubsetManifold(
-                        len(camera.params), const_camera_params
-                    ),
-                )
-
-    def parameterize_points(self, reconstruction: pycolmap.Reconstruction):
-        for (
-            point3D_id,
-            num_observations,
-        ) in self.point3D_num_observations.items():
-            point3D = reconstruction.points3D[point3D_id]
-            if point3D.track.length() > num_observations:
-                self.problem.set_parameter_block_constant(point3D.xyz)
-        for point3D_id in self.config.constant_point3D_ids:
-            point3D = reconstruction.points3D[point3D_id]
-            self.problem.set_parameter_block_constant(point3D.xyz)
-
-
 def solve_bundle_adjustment(reconstruction, ba_options, ba_config):
-    bundle_adjuster = pycolmap.BundleAdjuster(ba_options, ba_config)
-    # alternative equivalent python-based bundle adjustment (slower):
-    # bundle_adjuster = PyBundleAdjuster(ba_options, ba_config)
-    bundle_adjuster.set_up_problem(
-        reconstruction, ba_options.create_loss_function()
+    bundle_adjuster = pycolmap.create_default_bundle_adjuster(
+        ba_options, ba_config, reconstruction
     )
-    solver_options = bundle_adjuster.set_up_solver_options(
-        bundle_adjuster.problem, ba_options.solver_options
-    )
-    summary = pyceres.SolverSummary()
-    pyceres.solve(solver_options, bundle_adjuster.problem, summary)
+    summary = bundle_adjuster.solve()
+    # Alternatively, you can customize the existing problem or options as:
+    # solver_options = ba_options.create_solver_options(
+    #     ba_config, bundle_adjuster.problem
+    # )
+    # summary = pyceres.SolverSummary()
+    # pyceres.solve(solver_options, bundle_adjuster.problem, summary)
     return summary
 
 
@@ -240,11 +59,14 @@ def adjust_global_bundle(mapper, mapper_options, ba_options):
                 ba_config.set_constant_cam_pose(image_id)
 
     # Fix 7-DOFs of the bundle adjustment problem
-    ba_config.set_constant_cam_pose(reg_image_ids[0])
+    reg_image_ids_it = iter(reg_image_ids)
+    first_reg_image_id = next(reg_image_ids_it)
+    second_reg_image_id = next(reg_image_ids_it)
+    ba_config.set_constant_cam_pose(first_reg_image_id)
     if (not mapper_options.fix_existing_images) or (
-        reg_image_ids[1] not in mapper.existing_image_ids
+        second_reg_image_id not in mapper.existing_image_ids
     ):
-        ba_config.set_constant_cam_positions(reg_image_ids[1], [0])
+        ba_config.set_constant_cam_positions(second_reg_image_id, [0])
 
     # Run bundle adjustment
     summary = solve_bundle_adjustment(reconstruction, ba_options_tmp, ba_config)

--- a/pycolmap/examples/custom_bundle_adjustment.py
+++ b/pycolmap/examples/custom_bundle_adjustment.py
@@ -7,8 +7,6 @@ pyceres is needed as a dependency for this file.
 
 import copy
 
-import pyceres
-
 import pycolmap
 from pycolmap import logging
 

--- a/pycolmap/examples/custom_bundle_adjustment.py
+++ b/pycolmap/examples/custom_bundle_adjustment.py
@@ -7,6 +7,8 @@ pyceres is needed as a dependency for this file.
 
 import copy
 
+import pyceres
+
 import pycolmap
 from pycolmap import logging
 

--- a/pycolmap/examples/custom_incremental_mapping.py
+++ b/pycolmap/examples/custom_incremental_mapping.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import custom_bundle_adjustment
 import enlighten
+
 import pycolmap
 from pycolmap import logging
 

--- a/pycolmap/examples/custom_incremental_mapping.py
+++ b/pycolmap/examples/custom_incremental_mapping.py
@@ -6,12 +6,10 @@ import argparse
 import time
 from pathlib import Path
 
+import custom_bundle_adjustment
 import enlighten
-
 import pycolmap
 from pycolmap import logging
-
-import custom_bundle_adjustment
 
 
 def extract_colors(image_path, image_id, reconstruction):

--- a/pycolmap/examples/custom_incremental_mapping.py
+++ b/pycolmap/examples/custom_incremental_mapping.py
@@ -6,11 +6,12 @@ import time
 import argparse
 from pathlib import Path
 
-import custom_bundle_adjustment
 import enlighten
 
 import pycolmap
 from pycolmap import logging
+
+import custom_bundle_adjustment
 
 
 def extract_colors(image_path, image_id, reconstruction):

--- a/pycolmap/examples/custom_incremental_mapping.py
+++ b/pycolmap/examples/custom_incremental_mapping.py
@@ -3,6 +3,7 @@ Python reimplementation of the C++ incremental mapper with equivalent logic.
 """
 
 import time
+import argparse
 from pathlib import Path
 
 import custom_bundle_adjustment
@@ -319,3 +320,22 @@ def main(
     for i in range(reconstruction_manager.size()):
         reconstructions[i] = reconstruction_manager.get(i)
     return reconstructions
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--database_path", required=True)
+    parser.add_argument("--image_path", required=True)
+    parser.add_argument("--input_path", default=None)
+    parser.add_argument("--output_path", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(
+        database_path=Path(args.database_path),
+        image_path=Path(args.image_path),
+        input_path=Path(args.input_path) if args.input_path else None,
+        output_path=Path(args.output_path),
+    )

--- a/pycolmap/examples/custom_incremental_mapping.py
+++ b/pycolmap/examples/custom_incremental_mapping.py
@@ -2,8 +2,8 @@
 Python reimplementation of the C++ incremental mapper with equivalent logic.
 """
 
-import time
 import argparse
+import time
 from pathlib import Path
 
 import enlighten

--- a/scripts/format/python.sh
+++ b/scripts/format/python.sh
@@ -22,5 +22,5 @@ num_files=$(echo $all_files | wc -w)
 echo "Formatting ${num_files} files"
 
 # shellcheck disable=SC2086
-ruff format --config ${root_folder}/ruff.toml ${all_files} --fix
+ruff format --config ${root_folder}/ruff.toml ${all_files}
 ruff check --config ${root_folder}/ruff.toml ${all_files}

--- a/scripts/format/python.sh
+++ b/scripts/format/python.sh
@@ -22,5 +22,5 @@ num_files=$(echo $all_files | wc -w)
 echo "Formatting ${num_files} files"
 
 # shellcheck disable=SC2086
-ruff format --config ${root_folder}/ruff.toml ${all_files}
+ruff format --config ${root_folder}/ruff.toml ${all_files} --fix
 ruff check --config ${root_folder}/ruff.toml ${all_files}

--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -96,8 +96,9 @@ void BundleAdjustmentController::Run() {
   ba_config.SetConstantCamPositions(*(++reg_image_ids_it), {0});  // 2nd image
 
   // Run bundle adjustment.
-  BundleAdjuster bundle_adjuster(ba_options, ba_config);
-  bundle_adjuster.Solve(reconstruction_.get());
+  std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateDefaultBundleAdjuster(
+      std::move(ba_options), std::move(ba_config), *reconstruction_);
+  bundle_adjuster->Solve();
 
   run_timer.PrintMinutes();
 }

--- a/src/colmap/estimators/alignment.h
+++ b/src/colmap/estimators/alignment.h
@@ -43,6 +43,7 @@ bool AlignReconstructionToLocations(
     const RANSACOptions& ransac_options,
     Sim3d* tgt_from_src);
 
+// TODO: Needs a unit test.
 bool AlignReconstructionToPosePriors(
     const Reconstruction& src_reconstruction,
     const std::unordered_map<image_t, PosePrior>& tgt_pose_priors,

--- a/src/colmap/estimators/alignment.h
+++ b/src/colmap/estimators/alignment.h
@@ -36,12 +36,18 @@
 namespace colmap {
 
 bool AlignReconstructionToLocations(
-    const Reconstruction& reconstruction,
-    const std::vector<std::string>& image_names,
-    const std::vector<Eigen::Vector3d>& locations,
+    const Reconstruction& src_reconstruction,
+    const std::vector<std::string>& tgt_image_names,
+    const std::vector<Eigen::Vector3d>& tgt_image_locations,
     int min_common_images,
     const RANSACOptions& ransac_options,
-    Sim3d* tform);
+    Sim3d* tgt_from_src);
+
+bool AlignReconstructionToPosePriors(
+    const Reconstruction& src_reconstruction,
+    const std::unordered_map<image_t, PosePrior>& tgt_pose_priors,
+    const RANSACOptions& ransac_options,
+    Sim3d* tgt_from_src);
 
 // Robustly compute alignment between reconstructions by finding images that
 // are registered in both reconstructions. The alignment is then estimated

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -290,13 +290,13 @@ ceres::Solver::Options BundleAdjustmentOptions::CreateSolverOptions(
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
     !defined(CERES_NO_CUDA)
-  if (options.use_gpu && num_images >= min_num_images_gpu_solver) {
+  if (use_gpu && num_images >= min_num_images_gpu_solver) {
     cuda_solver_enabled = true;
     custom_solver_options.dense_linear_algebra_library_type = ceres::CUDA;
     max_num_images_direct_dense_solver = max_num_images_direct_dense_gpu_solver;
   }
 #else
-  if (options.use_gpu) {
+  if (use_gpu) {
     LOG_FIRST_N(WARNING, 1)
         << "Requested to use GPU for bundle adjustment, but Ceres was "
            "compiled without CUDA support. Falling back to CPU-based dense "
@@ -307,7 +307,7 @@ ceres::Solver::Options BundleAdjustmentOptions::CreateSolverOptions(
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 3)) && \
     !defined(CERES_NO_CUDSS)
-  if (options.use_gpu && num_images >= min_num_images_gpu_solver) {
+  if (use_gpu && num_images >= min_num_images_gpu_solver) {
     cuda_solver_enabled = true;
     custom_solver_options.sparse_linear_algebra_library_type =
         ceres::CUDA_SPARSE;
@@ -315,7 +315,7 @@ ceres::Solver::Options BundleAdjustmentOptions::CreateSolverOptions(
         max_num_images_direct_sparse_gpu_solver;
   }
 #else
-  if (options.use_gpu) {
+  if (use_gpu) {
     LOG_FIRST_N(WARNING, 1)
         << "Requested to use GPU for bundle adjustment, but Ceres was "
            "compiled without cuDSS support. Falling back to CPU-based sparse "
@@ -324,7 +324,7 @@ ceres::Solver::Options BundleAdjustmentOptions::CreateSolverOptions(
 #endif
 
   if (cuda_solver_enabled) {
-    const std::vector<int> gpu_indices = CSVToVector<int>(options.gpu_index);
+    const std::vector<int> gpu_indices = CSVToVector<int>(gpu_index);
     THROW_CHECK_GT(gpu_indices.size(), 0);
     SetBestCudaDevice(gpu_indices[0]);
   }

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -421,7 +421,7 @@ void ParameterizeCameras(const BundleAdjustmentOptions& options,
 
 void ParameterizePoints(
     const BundleAdjustmentConfig& config,
-    const std::unordered_map<point3D_t, size_t> point3D_num_observations,
+    const std::unordered_map<point3D_t, size_t>& point3D_num_observations,
     Reconstruction& reconstruction,
     ceres::Problem& problem) {
   for (const auto& [point3D_id, num_observations] : point3D_num_observations) {
@@ -1084,7 +1084,7 @@ std::unique_ptr<BundleAdjuster> CreateRigBundleAdjuster(
     Reconstruction& reconstruction,
     std::vector<CameraRig>& camera_rigs) {
   return std::make_unique<RigBundleAdjuster>(std::move(options),
-                                             std::move(rig_options),
+                                             rig_options,
                                              std::move(config),
                                              reconstruction,
                                              camera_rigs);
@@ -1097,7 +1097,7 @@ std::unique_ptr<BundleAdjuster> CreatePosePriorBundleAdjuster(
     std::unordered_map<image_t, PosePrior> pose_priors,
     Reconstruction& reconstruction) {
   return std::make_unique<PosePriorBundleAdjuster>(std::move(options),
-                                                   std::move(prior_options),
+                                                   prior_options,
                                                    std::move(config),
                                                    std::move(pose_priors),
                                                    reconstruction);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -32,8 +32,6 @@
 #include "colmap/estimators/alignment.h"
 #include "colmap/estimators/cost_functions.h"
 #include "colmap/estimators/manifold.h"
-#include "colmap/estimators/similarity_transform.h"
-#include "colmap/optim/loransac.h"
 #include "colmap/scene/projection.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/cuda.h"
@@ -264,35 +262,10 @@ void BundleAdjustmentConfig::RemoveConstantPoint(const point3D_t point3D_id) {
   constant_point3D_ids_.erase(point3D_id);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// BundleAdjuster
-////////////////////////////////////////////////////////////////////////////////
-
-BundleAdjuster::BundleAdjuster(const BundleAdjustmentOptions& options,
-                               const BundleAdjustmentConfig& config)
-    : options_(options), config_(config) {
+BundleAdjuster::BundleAdjuster(BundleAdjustmentOptions options,
+                               BundleAdjustmentConfig config)
+    : options_(std::move(options)), config_(std::move(config)) {
   THROW_CHECK(options_.Check());
-}
-
-bool BundleAdjuster::Solve(Reconstruction* reconstruction) {
-  loss_function_ =
-      std::unique_ptr<ceres::LossFunction>(options_.CreateLossFunction());
-  SetUpProblem(reconstruction, loss_function_.get());
-
-  if (problem_->NumResiduals() == 0) {
-    return false;
-  }
-
-  ceres::Solver::Options solver_options =
-      SetUpSolverOptions(*problem_, options_.solver_options);
-
-  ceres::Solve(solver_options, problem_.get(), &summary_);
-
-  if (options_.print_summary || VLOG_IS_ON(1)) {
-    PrintSolverSummary(summary_, "Bundle adjustment report");
-  }
-
-  return true;
 }
 
 const BundleAdjustmentOptions& BundleAdjuster::Options() const {
@@ -301,55 +274,26 @@ const BundleAdjustmentOptions& BundleAdjuster::Options() const {
 
 const BundleAdjustmentConfig& BundleAdjuster::Config() const { return config_; }
 
-std::shared_ptr<ceres::Problem> BundleAdjuster::Problem() { return problem_; }
+namespace {
 
-const ceres::Solver::Summary& BundleAdjuster::Summary() const {
-  return summary_;
-}
-
-void BundleAdjuster::SetUpProblem(Reconstruction* reconstruction,
-                                  ceres::LossFunction* loss_function) {
-  THROW_CHECK_NOTNULL(reconstruction);
-
-  // Initialize an empty problem
-  ceres::Problem::Options problem_options;
-  problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_ = std::make_shared<ceres::Problem>(problem_options);
-
-  // Set up problem
-  // Warning: AddPointsToProblem assumes that AddImageToProblem is called first.
-  // Do not change order of instructions!
-  for (const image_t image_id : config_.Images()) {
-    AddImageToProblem(image_id, reconstruction, loss_function);
-  }
-  for (const auto point3D_id : config_.VariablePoints()) {
-    AddPointToProblem(point3D_id, reconstruction, loss_function);
-  }
-  for (const auto point3D_id : config_.ConstantPoints()) {
-    AddPointToProblem(point3D_id, reconstruction, loss_function);
-  }
-
-  ParameterizeCameras(reconstruction);
-  ParameterizePoints(reconstruction);
-}
-
-ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
-    const ceres::Problem& problem,
-    const ceres::Solver::Options& input_solver_options) const {
-  ceres::Solver::Options solver_options = input_solver_options;
+ceres::Solver::Options CreateSolverOptions(
+    const BundleAdjustmentOptions& options,
+    const BundleAdjustmentConfig& config,
+    const ceres::Problem& problem) {
+  ceres::Solver::Options solver_options = options.solver_options;
   if (VLOG_IS_ON(2)) {
     solver_options.minimizer_progress_to_stdout = true;
     solver_options.logging_type = ceres::LoggingType::PER_MINIMIZER_ITERATION;
   }
 
-  const int num_images = config_.NumImages();
+  const int num_images = config.NumImages();
   const bool has_sparse =
       solver_options.sparse_linear_algebra_library_type != ceres::NO_SPARSE;
 
   int max_num_images_direct_dense_solver =
-      options_.max_num_images_direct_dense_cpu_solver;
+      options.max_num_images_direct_dense_cpu_solver;
   int max_num_images_direct_sparse_solver =
-      options_.max_num_images_direct_sparse_cpu_solver;
+      options.max_num_images_direct_sparse_cpu_solver;
 
 #ifdef COLMAP_CUDA_ENABLED
   bool cuda_solver_enabled = false;
@@ -357,14 +301,14 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
     !defined(CERES_NO_CUDA)
-  if (options_.use_gpu && num_images >= options_.min_num_images_gpu_solver) {
+  if (options.use_gpu && num_images >= options.min_num_images_gpu_solver) {
     cuda_solver_enabled = true;
     solver_options.dense_linear_algebra_library_type = ceres::CUDA;
     max_num_images_direct_dense_solver =
-        options_.max_num_images_direct_dense_gpu_solver;
+        options.max_num_images_direct_dense_gpu_solver;
   }
 #else
-  if (options_.use_gpu) {
+  if (options.use_gpu) {
     LOG_FIRST_N(WARNING, 1)
         << "Requested to use GPU for bundle adjustment, but Ceres was "
            "compiled without CUDA support. Falling back to CPU-based dense "
@@ -375,14 +319,14 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 3)) && \
     !defined(CERES_NO_CUDSS)
-  if (options_.use_gpu && num_images >= options_.min_num_images_gpu_solver) {
+  if (options.use_gpu && num_images >= options.min_num_images_gpu_solver) {
     cuda_solver_enabled = true;
     solver_options.sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
     max_num_images_direct_sparse_solver =
-        options_.max_num_images_direct_sparse_gpu_solver;
+        options.max_num_images_direct_sparse_gpu_solver;
   }
 #else
-  if (options_.use_gpu) {
+  if (options.use_gpu) {
     LOG_FIRST_N(WARNING, 1)
         << "Requested to use GPU for bundle adjustment, but Ceres was "
            "compiled without cuDSS support. Falling back to CPU-based sparse "
@@ -391,15 +335,16 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
 #endif
 
   if (cuda_solver_enabled) {
-    const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
+    const std::vector<int> gpu_indices = CSVToVector<int>(options.gpu_index);
     THROW_CHECK_GT(gpu_indices.size(), 0);
     SetBestCudaDevice(gpu_indices[0]);
   }
 #else
-  if (options_.use_gpu) {
+  if (options.use_gpu) {
     LOG_FIRST_N(WARNING, 1)
         << "Requested to use GPU for bundle adjustment, but COLMAP was "
-           "compiled without CUDA support. Falling back to CPU-based solvers.";
+           "compiled without CUDA support. Falling back to CPU-based "
+           "solvers.";
   }
 #endif  // COLMAP_CUDA_ENABLED
 
@@ -413,7 +358,7 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
   }
 
   if (problem.NumResiduals() <
-      options_.min_num_residuals_for_cpu_multi_threading) {
+      options.min_num_residuals_for_cpu_multi_threading) {
     solver_options.num_threads = 1;
 #if CERES_VERSION_MAJOR < 2
     solver_options.num_linear_solver_threads = 1;
@@ -432,141 +377,33 @@ ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(
   return solver_options;
 }
 
-void BundleAdjuster::AddImageToProblem(const image_t image_id,
-                                       Reconstruction* reconstruction,
-                                       ceres::LossFunction* loss_function) {
-  Image& image = reconstruction->Image(image_id);
-  Camera& camera = *image.CameraPtr();
+void ParameterizeCameras(const BundleAdjustmentOptions& options,
+                         const BundleAdjustmentConfig& config,
+                         const std::unordered_set<camera_t>& camera_ids,
+                         Reconstruction& reconstruction,
+                         ceres::Problem& problem) {
+  const bool constant_camera = !options.refine_focal_length &&
+                               !options.refine_principal_point &&
+                               !options.refine_extra_params;
+  for (const camera_t camera_id : camera_ids) {
+    Camera& camera = reconstruction.Camera(camera_id);
 
-  // CostFunction assumes unit quaternions.
-  THROW_CHECK(image.HasPose());
-  image.CamFromWorld().rotation.normalize();
-
-  double* cam_from_world_rotation =
-      image.CamFromWorld().rotation.coeffs().data();
-  double* cam_from_world_translation = image.CamFromWorld().translation.data();
-  double* camera_params = camera.params.data();
-
-  const bool constant_cam_pose =
-      !options_.refine_extrinsics || config_.HasConstantCamPose(image_id);
-
-  // Add residuals to bundle adjustment problem.
-  size_t num_observations = 0;
-  for (const Point2D& point2D : image.Points2D()) {
-    if (!point2D.HasPoint3D()) {
-      continue;
-    }
-
-    num_observations += 1;
-    point3D_num_observations_[point2D.point3D_id] += 1;
-
-    Point3D& point3D = reconstruction->Point3D(point2D.point3D_id);
-    assert(point3D.track.Length() > 1);
-
-    if (constant_cam_pose) {
-      problem_->AddResidualBlock(
-          CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
-              camera.model_id, point2D.xy, image.CamFromWorld()),
-          loss_function,
-          point3D.xyz.data(),
-          camera_params);
-    } else {
-      problem_->AddResidualBlock(
-          CreateCameraCostFunction<ReprojErrorCostFunctor>(camera.model_id,
-                                                           point2D.xy),
-          loss_function,
-          cam_from_world_rotation,
-          cam_from_world_translation,
-          point3D.xyz.data(),
-          camera_params);
-    }
-  }
-
-  if (num_observations > 0) {
-    camera_ids_.insert(image.CameraId());
-
-    // Set pose parameterization.
-    if (!constant_cam_pose) {
-      SetQuaternionManifold(problem_.get(), cam_from_world_rotation);
-      if (config_.HasConstantCamPositions(image_id)) {
-        const std::vector<int>& constant_position_idxs =
-            config_.ConstantCamPositions(image_id);
-        SetSubsetManifold(3,
-                          constant_position_idxs,
-                          problem_.get(),
-                          cam_from_world_translation);
-      }
-    }
-  }
-}
-
-void BundleAdjuster::AddPointToProblem(const point3D_t point3D_id,
-                                       Reconstruction* reconstruction,
-                                       ceres::LossFunction* loss_function) {
-  Point3D& point3D = reconstruction->Point3D(point3D_id);
-
-  // Is 3D point already fully contained in the problem? I.e. its entire track
-  // is contained in `variable_image_ids`, `constant_image_ids`,
-  // `constant_x_image_ids`.
-  if (point3D_num_observations_[point3D_id] == point3D.track.Length()) {
-    return;
-  }
-
-  for (const auto& track_el : point3D.track.Elements()) {
-    // Skip observations that were already added in `FillImages`.
-    if (config_.HasImage(track_el.image_id)) {
-      continue;
-    }
-
-    point3D_num_observations_[point3D_id] += 1;
-
-    Image& image = reconstruction->Image(track_el.image_id);
-    Camera& camera = *image.CameraPtr();
-    const Point2D& point2D = image.Point2D(track_el.point2D_idx);
-
-    // CostFunction assumes unit quaternions.
-    image.CamFromWorld().rotation.normalize();
-
-    // We do not want to refine the camera of images that are not
-    // part of `constant_image_ids_`, `constant_image_ids_`,
-    // `constant_x_image_ids_`.
-    if (camera_ids_.count(image.CameraId()) == 0) {
-      camera_ids_.insert(image.CameraId());
-      config_.SetConstantCamIntrinsics(image.CameraId());
-    }
-    problem_->AddResidualBlock(
-        CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
-            camera.model_id, point2D.xy, image.CamFromWorld()),
-        loss_function,
-        point3D.xyz.data(),
-        camera.params.data());
-  }
-}
-
-void BundleAdjuster::ParameterizeCameras(Reconstruction* reconstruction) {
-  const bool constant_camera = !options_.refine_focal_length &&
-                               !options_.refine_principal_point &&
-                               !options_.refine_extra_params;
-  for (const camera_t camera_id : camera_ids_) {
-    Camera& camera = reconstruction->Camera(camera_id);
-
-    if (constant_camera || config_.HasConstantCamIntrinsics(camera_id)) {
-      problem_->SetParameterBlockConstant(camera.params.data());
-      continue;
+    if (constant_camera || config.HasConstantCamIntrinsics(camera_id)) {
+      problem.SetParameterBlockConstant(camera.params.data());
     } else {
       std::vector<int> const_camera_params;
 
-      if (!options_.refine_focal_length) {
+      if (!options.refine_focal_length) {
         const span<const size_t> params_idxs = camera.FocalLengthIdxs();
         const_camera_params.insert(
             const_camera_params.end(), params_idxs.begin(), params_idxs.end());
       }
-      if (!options_.refine_principal_point) {
+      if (!options.refine_principal_point) {
         const span<const size_t> params_idxs = camera.PrincipalPointIdxs();
         const_camera_params.insert(
             const_camera_params.end(), params_idxs.begin(), params_idxs.end());
       }
-      if (!options_.refine_extra_params) {
+      if (!options.refine_extra_params) {
         const span<const size_t> params_idxs = camera.ExtraParamsIdxs();
         const_camera_params.insert(
             const_camera_params.end(), params_idxs.begin(), params_idxs.end());
@@ -575,526 +412,699 @@ void BundleAdjuster::ParameterizeCameras(Reconstruction* reconstruction) {
       if (const_camera_params.size() > 0) {
         SetSubsetManifold(static_cast<int>(camera.params.size()),
                           const_camera_params,
-                          problem_.get(),
+                          &problem,
                           camera.params.data());
       }
     }
   }
 }
 
-void BundleAdjuster::ParameterizePoints(Reconstruction* reconstruction) {
-  for (const auto elem : point3D_num_observations_) {
-    Point3D& point3D = reconstruction->Point3D(elem.first);
-    if (point3D.track.Length() > elem.second) {
-      problem_->SetParameterBlockConstant(point3D.xyz.data());
+void ParameterizePoints(
+    const BundleAdjustmentConfig& config,
+    const std::unordered_map<point3D_t, size_t> point3D_num_observations,
+    Reconstruction& reconstruction,
+    ceres::Problem& problem) {
+  for (const auto& [point3D_id, num_observations] : point3D_num_observations) {
+    Point3D& point3D = reconstruction.Point3D(point3D_id);
+    if (point3D.track.Length() > num_observations) {
+      problem.SetParameterBlockConstant(point3D.xyz.data());
     }
   }
 
-  for (const point3D_t point3D_id : config_.ConstantPoints()) {
-    Point3D& point3D = reconstruction->Point3D(point3D_id);
-    problem_->SetParameterBlockConstant(point3D.xyz.data());
+  for (const point3D_t point3D_id : config.ConstantPoints()) {
+    Point3D& point3D = reconstruction.Point3D(point3D_id);
+    problem.SetParameterBlockConstant(point3D.xyz.data());
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// RigBundleAdjuster
-////////////////////////////////////////////////////////////////////////////////
+class DefaultBundleAdjuster : public BundleAdjuster {
+ public:
+  DefaultBundleAdjuster(BundleAdjustmentOptions options,
+                        BundleAdjustmentConfig config,
+                        Reconstruction& reconstruction)
+      : BundleAdjuster(std::move(options), std::move(config)),
+        loss_function_(std::unique_ptr<ceres::LossFunction>(
+            options_.CreateLossFunction())) {
+    ceres::Problem::Options problem_options;
+    problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+    problem_ = std::make_shared<ceres::Problem>(problem_options);
 
-RigBundleAdjuster::RigBundleAdjuster(const BundleAdjustmentOptions& options,
-                                     const Options& rig_options,
-                                     const BundleAdjustmentConfig& config)
-    : BundleAdjuster(options, config), rig_options_(rig_options) {}
-
-bool RigBundleAdjuster::Solve(Reconstruction* reconstruction,
-                              std::vector<CameraRig>* camera_rigs) {
-  loss_function_ =
-      std::unique_ptr<ceres::LossFunction>(options_.CreateLossFunction());
-  SetUpProblem(reconstruction, camera_rigs, loss_function_.get());
-
-  if (problem_->NumResiduals() == 0) {
-    return false;
-  }
-
-  ceres::Solver::Options solver_options =
-      SetUpSolverOptions(*problem_, options_.solver_options);
-
-  ceres::Solve(solver_options, problem_.get(), &summary_);
-
-  if (options_.print_summary || VLOG_IS_ON(1)) {
-    PrintSolverSummary(summary_, "Rig Bundle adjustment report");
-  }
-
-  TearDown(reconstruction, *camera_rigs);
-
-  return true;
-}
-
-void RigBundleAdjuster::SetUpProblem(Reconstruction* reconstruction,
-                                     std::vector<CameraRig>* camera_rigs,
-                                     ceres::LossFunction* loss_function) {
-  THROW_CHECK_NOTNULL(reconstruction);
-  THROW_CHECK_NOTNULL(camera_rigs);
-  THROW_CHECK(!problem_)
-      << "Cannot set up problem from the same BundleAdjuster multiple times";
-
-  // Check the validity of the provided camera rigs.
-  std::unordered_set<camera_t> rig_camera_ids;
-  for (auto& camera_rig : *camera_rigs) {
-    camera_rig.Check(*reconstruction);
-    for (const auto& camera_id : camera_rig.GetCameraIds()) {
-      THROW_CHECK_EQ(rig_camera_ids.count(camera_id), 0)
-          << "Camera must not be part of multiple camera rigs";
-      rig_camera_ids.insert(camera_id);
+    // Set up problem
+    // Warning: AddPointsToProblem assumes that AddImageToProblem is called
+    // first. Do not change order of instructions!
+    for (const image_t image_id : config_.Images()) {
+      AddImageToProblem(image_id, reconstruction);
+    }
+    for (const auto point3D_id : config_.VariablePoints()) {
+      AddPointToProblem(point3D_id, reconstruction);
+    }
+    for (const auto point3D_id : config_.ConstantPoints()) {
+      AddPointToProblem(point3D_id, reconstruction);
     }
 
-    for (const auto& snapshot : camera_rig.Snapshots()) {
-      for (const auto& image_id : snapshot) {
-        THROW_CHECK_EQ(image_id_to_camera_rig_.count(image_id), 0)
-            << "Image must not be part of multiple camera rigs";
-        image_id_to_camera_rig_.emplace(image_id, &camera_rig);
-      }
+    ParameterizeCameras(
+        options_, config_, camera_ids_, reconstruction, *problem_);
+    ParameterizePoints(
+        config_, point3D_num_observations_, reconstruction, *problem_);
+  }
+
+  ceres::Solver::Summary Solve() override {
+    ceres::Solver::Summary summary;
+    if (problem_->NumResiduals() == 0) {
+      return summary;
     }
+
+    const ceres::Solver::Options solver_options =
+        CreateSolverOptions(options_, config_, *problem_);
+
+    ceres::Solve(solver_options, problem_.get(), &summary);
+
+    if (options_.print_summary || VLOG_IS_ON(1)) {
+      PrintSolverSummary(summary, "Bundle adjustment report");
+    }
+
+    return summary;
   }
 
-  // Initialize an empty problem
-  ceres::Problem::Options problem_options;
-  problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_ = std::make_shared<ceres::Problem>(problem_options);
+  std::shared_ptr<ceres::Problem>& Problem() override { return problem_; }
 
-  // Set up problem
-  ComputeCameraRigPoses(*reconstruction, *camera_rigs);
+  void AddImageToProblem(const image_t image_id,
+                         Reconstruction& reconstruction) {
+    Image& image = reconstruction.Image(image_id);
+    Camera& camera = *image.CameraPtr();
 
-  for (const image_t image_id : config_.Images()) {
-    AddImageToProblem(image_id, reconstruction, camera_rigs, loss_function);
-  }
-  for (const auto point3D_id : config_.VariablePoints()) {
-    AddPointToProblem(point3D_id, reconstruction, loss_function);
-  }
-  for (const auto point3D_id : config_.ConstantPoints()) {
-    AddPointToProblem(point3D_id, reconstruction, loss_function);
-  }
-
-  ParameterizeCameras(reconstruction);
-  ParameterizePoints(reconstruction);
-  ParameterizeCameraRigs(reconstruction);
-}
-
-void RigBundleAdjuster::TearDown(Reconstruction* reconstruction,
-                                 const std::vector<CameraRig>& camera_rigs) {
-  for (const auto& elem : image_id_to_camera_rig_) {
-    const auto image_id = elem.first;
-    const auto& camera_rig = *elem.second;
-    auto& image = reconstruction->Image(image_id);
-    image.CamFromWorld() = camera_rig.CamFromRig(image.CameraId()) *
-                           (*image_id_to_rig_from_world_.at(image_id));
-  }
-}
-
-void RigBundleAdjuster::AddImageToProblem(const image_t image_id,
-                                          Reconstruction* reconstruction,
-                                          std::vector<CameraRig>* camera_rigs,
-                                          ceres::LossFunction* loss_function) {
-  const double max_squared_reproj_error =
-      rig_options_.max_reproj_error * rig_options_.max_reproj_error;
-
-  Image& image = reconstruction->Image(image_id);
-  Camera& camera = *image.CameraPtr();
-
-  const bool constant_cam_pose = config_.HasConstantCamPose(image_id);
-  const bool constant_cam_position = config_.HasConstantCamPositions(image_id);
-
-  double* camera_params = camera.params.data();
-  double* cam_from_rig_rotation = nullptr;
-  double* cam_from_rig_translation = nullptr;
-  double* rig_from_world_rotation = nullptr;
-  double* rig_from_world_translation = nullptr;
-  CameraRig* camera_rig = nullptr;
-  Eigen::Matrix3x4d cam_from_world_mat = Eigen::Matrix3x4d::Zero();
-
-  if (image_id_to_camera_rig_.count(image_id) > 0) {
-    THROW_CHECK(!constant_cam_pose)
-        << "Images contained in a camera rig must not have constant pose";
-    THROW_CHECK(!constant_cam_position)
-        << "Images contained in a camera rig must not have constant tvec";
-    camera_rig = image_id_to_camera_rig_.at(image_id);
-    Rigid3d& rig_from_world = *image_id_to_rig_from_world_.at(image_id);
-    rig_from_world_rotation = rig_from_world.rotation.coeffs().data();
-    rig_from_world_translation = rig_from_world.translation.data();
-    Rigid3d& cam_from_rig = camera_rig->CamFromRig(image.CameraId());
-    cam_from_rig_rotation = cam_from_rig.rotation.coeffs().data();
-    cam_from_rig_translation = cam_from_rig.translation.data();
-    cam_from_world_mat = (cam_from_rig * rig_from_world).ToMatrix();
-  } else {
     // CostFunction assumes unit quaternions.
     image.CamFromWorld().rotation.normalize();
-    cam_from_rig_rotation = image.CamFromWorld().rotation.coeffs().data();
-    cam_from_rig_translation = image.CamFromWorld().translation.data();
-  }
 
-  // Collect cameras for final parameterization.
-  THROW_CHECK(image.HasCameraId());
-  camera_ids_.insert(image.CameraId());
+    double* cam_from_world_rotation =
+        image.CamFromWorld().rotation.coeffs().data();
+    double* cam_from_world_translation =
+        image.CamFromWorld().translation.data();
+    double* camera_params = camera.params.data();
 
-  // The number of added observations for the current image.
-  size_t num_observations = 0;
+    const bool constant_cam_pose =
+        !options_.refine_extrinsics || config_.HasConstantCamPose(image_id);
 
-  // Add residuals to bundle adjustment problem.
-  for (const Point2D& point2D : image.Points2D()) {
-    if (!point2D.HasPoint3D()) {
-      continue;
-    }
+    // Add residuals to bundle adjustment problem.
+    size_t num_observations = 0;
+    for (const Point2D& point2D : image.Points2D()) {
+      if (!point2D.HasPoint3D()) {
+        continue;
+      }
 
-    Point3D& point3D = reconstruction->Point3D(point2D.point3D_id);
-    assert(point3D.track.Length() > 1);
+      num_observations += 1;
+      point3D_num_observations_[point2D.point3D_id] += 1;
 
-    if (camera_rig != nullptr &&
-        CalculateSquaredReprojectionError(
-            point2D.xy, point3D.xyz, cam_from_world_mat, camera) >
-            max_squared_reproj_error) {
-      continue;
-    }
+      Point3D& point3D = reconstruction.Point3D(point2D.point3D_id);
+      assert(point3D.track.Length() > 1);
 
-    num_observations += 1;
-    point3D_num_observations_[point2D.point3D_id] += 1;
-
-    if (camera_rig == nullptr) {
       if (constant_cam_pose) {
         problem_->AddResidualBlock(
             CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
                 camera.model_id, point2D.xy, image.CamFromWorld()),
-            loss_function,
+            loss_function_.get(),
             point3D.xyz.data(),
             camera_params);
       } else {
         problem_->AddResidualBlock(
             CreateCameraCostFunction<ReprojErrorCostFunctor>(camera.model_id,
                                                              point2D.xy),
-            loss_function,
-            cam_from_rig_rotation,     // rig == world
-            cam_from_rig_translation,  // rig == world
+            loss_function_.get(),
+            cam_from_world_rotation,
+            cam_from_world_translation,
             point3D.xyz.data(),
             camera_params);
       }
-    } else {
-      problem_->AddResidualBlock(
-          CreateCameraCostFunction<RigReprojErrorCostFunctor>(camera.model_id,
-                                                              point2D.xy),
-          loss_function,
-          cam_from_rig_rotation,
-          cam_from_rig_translation,
-          rig_from_world_rotation,
-          rig_from_world_translation,
-          point3D.xyz.data(),
-          camera_params);
-    }
-  }
-
-  if (num_observations > 0) {
-    parameterized_quats_.insert(cam_from_rig_rotation);
-
-    if (camera_rig != nullptr) {
-      parameterized_quats_.insert(rig_from_world_rotation);
-
-      // Set the relative pose of the camera constant if relative pose
-      // refinement is disabled or if it is the reference camera to avoid over-
-      // parameterization of the camera pose.
-      if (!rig_options_.refine_relative_poses ||
-          image.CameraId() == camera_rig->RefCameraId()) {
-        problem_->SetParameterBlockConstant(cam_from_rig_rotation);
-        problem_->SetParameterBlockConstant(cam_from_rig_translation);
-      }
     }
 
-    // Set pose parameterization.
-    if (!constant_cam_pose && constant_cam_position) {
-      const std::vector<int>& constant_position_idxs =
-          config_.ConstantCamPositions(image_id);
-      SetSubsetManifold(
-          3, constant_position_idxs, problem_.get(), cam_from_rig_translation);
-    }
-  }
-}
-
-void RigBundleAdjuster::AddPointToProblem(const point3D_t point3D_id,
-                                          Reconstruction* reconstruction,
-                                          ceres::LossFunction* loss_function) {
-  Point3D& point3D = reconstruction->Point3D(point3D_id);
-
-  // Is 3D point already fully contained in the problem? I.e. its entire track
-  // is contained in `variable_image_ids`, `constant_image_ids`,
-  // `constant_x_image_ids`.
-  if (point3D_num_observations_[point3D_id] == point3D.track.Length()) {
-    return;
-  }
-
-  for (const auto& track_el : point3D.track.Elements()) {
-    // Skip observations that were already added in `AddImageToProblem`.
-    if (config_.HasImage(track_el.image_id)) {
-      continue;
-    }
-
-    point3D_num_observations_[point3D_id] += 1;
-
-    Image& image = reconstruction->Image(track_el.image_id);
-    Camera& camera = *image.CameraPtr();
-    const Point2D& point2D = image.Point2D(track_el.point2D_idx);
-
-    // We do not want to refine the camera of images that are not
-    // part of `constant_image_ids_`, `constant_image_ids_`,
-    // `constant_x_image_ids_`.
-    if (camera_ids_.count(image.CameraId()) == 0) {
+    if (num_observations > 0) {
       camera_ids_.insert(image.CameraId());
-      config_.SetConstantCamIntrinsics(image.CameraId());
-    }
 
-    problem_->AddResidualBlock(
-        CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
-            camera.model_id, point2D.xy, image.CamFromWorld()),
-        loss_function,
-        point3D.xyz.data(),
-        camera.params.data());
-  }
-}
-
-void RigBundleAdjuster::ComputeCameraRigPoses(
-    const Reconstruction& reconstruction,
-    const std::vector<CameraRig>& camera_rigs) {
-  rigs_from_world_.reserve(camera_rigs.size());
-  for (const auto& camera_rig : camera_rigs) {
-    rigs_from_world_.emplace_back();
-    auto& rig_from_world = rigs_from_world_.back();
-    const size_t num_snapshots = camera_rig.NumSnapshots();
-    rig_from_world.resize(num_snapshots);
-    for (size_t snapshot_idx = 0; snapshot_idx < num_snapshots;
-         ++snapshot_idx) {
-      rig_from_world[snapshot_idx] =
-          camera_rig.ComputeRigFromWorld(snapshot_idx, reconstruction);
-      for (const auto image_id : camera_rig.Snapshots()[snapshot_idx]) {
-        image_id_to_rig_from_world_.emplace(image_id,
-                                            &rig_from_world[snapshot_idx]);
+      // Set pose parameterization.
+      if (!constant_cam_pose) {
+        SetQuaternionManifold(problem_.get(), cam_from_world_rotation);
+        if (config_.HasConstantCamPositions(image_id)) {
+          const std::vector<int>& constant_position_idxs =
+              config_.ConstantCamPositions(image_id);
+          SetSubsetManifold(3,
+                            constant_position_idxs,
+                            problem_.get(),
+                            cam_from_world_translation);
+        }
       }
     }
   }
-}
 
-void RigBundleAdjuster::ParameterizeCameraRigs(Reconstruction* reconstruction) {
-  for (double* cam_from_rig_rotation : parameterized_quats_) {
-    SetQuaternionManifold(problem_.get(), cam_from_rig_rotation);
-  }
-}
+  void AddPointToProblem(const point3D_t point3D_id,
+                         Reconstruction& reconstruction) {
+    Point3D& point3D = reconstruction.Point3D(point3D_id);
 
-////////////////////////////////////////////////////////////////////////////////
-// PosePriorBundleAdjuster
-////////////////////////////////////////////////////////////////////////////////
+    // Is 3D point already fully contained in the problem? I.e. its entire track
+    // is contained in `variable_image_ids`, `constant_image_ids`,
+    // `constant_x_image_ids`.
+    if (point3D_num_observations_[point3D_id] == point3D.track.Length()) {
+      return;
+    }
 
-PosePriorBundleAdjuster::PosePriorBundleAdjuster(
-    const BundleAdjustmentOptions& options,
-    const Options& prior_options,
-    const BundleAdjustmentConfig& config,
-    const std::unordered_map<image_t, PosePrior>& image_id_to_pose_prior)
-    : BundleAdjuster(options, config),
-      prior_options_(prior_options),
-      image_id_to_pose_prior_(image_id_to_pose_prior) {
-  SetRansacMaxErrorFromPriorsCovariance();
-}
+    for (const auto& track_el : point3D.track.Elements()) {
+      // Skip observations that were already added in `FillImages`.
+      if (config_.HasImage(track_el.image_id)) {
+        continue;
+      }
 
-bool PosePriorBundleAdjuster::Solve(Reconstruction* reconstruction) {
-  loss_function_ =
-      std::unique_ptr<ceres::LossFunction>(options_.CreateLossFunction());
+      point3D_num_observations_[point3D_id] += 1;
 
-  if (prior_options_.use_robust_loss_on_prior_position) {
-    prior_loss_function_ = std::make_unique<ceres::CauchyLoss>(
-        prior_options_.prior_position_loss_scale);
-  }
+      Image& image = reconstruction.Image(track_el.image_id);
+      Camera& camera = *image.CameraPtr();
+      const Point2D& point2D = image.Point2D(track_el.point2D_idx);
 
-  // Initialize images' position w.r.t. priors with a rigid sim3D alignment
-  use_prior_position_ = Sim3DAlignment(reconstruction);
+      // CostFunction assumes unit quaternions.
+      image.CamFromWorld().rotation.normalize();
 
-  // Fix 7-DOFs of BA problem if not enough valid pose priors
-  if (!use_prior_position_) {
-    auto reg_image_ids_it = reconstruction->RegImageIds().begin();
-    config_.SetConstantCamPose(*reg_image_ids_it);
-    config_.SetConstantCamPositions(*(++reg_image_ids_it), {0});
-  }
-
-  // Normalize the reconstruction to avoid any numerical instability BUT do not
-  // transform priors as they will be transformed when added to ceres::Problem
-  normalized_from_metric_ = reconstruction->Normalize(/*fixed_scale=*/true);
-
-  SetUpProblem(
-      reconstruction, loss_function_.get(), prior_loss_function_.get());
-
-  if (problem_->NumResiduals() == 0) {
-    return false;
+      // We do not want to refine the camera of images that are not
+      // part of `constant_image_ids_`, `constant_image_ids_`,
+      // `constant_x_image_ids_`.
+      if (camera_ids_.count(image.CameraId()) == 0) {
+        camera_ids_.insert(image.CameraId());
+        config_.SetConstantCamIntrinsics(image.CameraId());
+      }
+      problem_->AddResidualBlock(
+          CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
+              camera.model_id, point2D.xy, image.CamFromWorld()),
+          loss_function_.get(),
+          point3D.xyz.data(),
+          camera.params.data());
+    }
   }
 
-  ceres::Solver::Options solver_options =
-      SetUpSolverOptions(*problem_, options_.solver_options);
+ private:
+  std::shared_ptr<ceres::Problem> problem_;
+  std::unique_ptr<ceres::LossFunction> loss_function_;
 
-  ceres::Solve(solver_options, problem_.get(), &summary_);
+  std::unordered_set<camera_t> camera_ids_;
+  std::unordered_map<point3D_t, size_t> point3D_num_observations_;
+};
 
-  // Transform back the reconstruction to its coordinate system state
-  reconstruction->Transform(Inverse(normalized_from_metric_));
+class RigBundleAdjuster : public BundleAdjuster {
+ public:
+  RigBundleAdjuster(BundleAdjustmentOptions options,
+                    RigBundleAdjustmentOptions rig_options,
+                    BundleAdjustmentConfig config,
+                    Reconstruction& reconstruction,
+                    std::vector<CameraRig>& camera_rigs)
+      : BundleAdjuster(std::move(options), std::move(config)),
+        rig_options_(rig_options),
+        reconstruction_(reconstruction),
+        loss_function_(std::unique_ptr<ceres::LossFunction>(
+            options_.CreateLossFunction())) {
+    // Check the validity of the provided camera rigs.
+    std::unordered_set<camera_t> rig_camera_ids;
+    for (CameraRig& camera_rig : camera_rigs) {
+      camera_rig.Check(reconstruction);
+      for (const auto& camera_id : camera_rig.GetCameraIds()) {
+        THROW_CHECK_EQ(rig_camera_ids.count(camera_id), 0)
+            << "Camera must not be part of multiple camera rigs";
+        rig_camera_ids.insert(camera_id);
+      }
 
-  if (options_.print_summary || VLOG_IS_ON(1)) {
-    PrintSolverSummary(summary_, "Pose Prior Bundle adjustment report");
-  }
+      for (const auto& snapshot : camera_rig.Snapshots()) {
+        for (const auto& image_id : snapshot) {
+          THROW_CHECK_EQ(image_id_to_camera_rig_.count(image_id), 0)
+              << "Image must not be part of multiple camera rigs";
+          image_id_to_camera_rig_.emplace(image_id, &camera_rig);
+        }
+      }
+    }
 
-  return true;
-}
+    ceres::Problem::Options problem_options;
+    problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+    problem_ = std::make_shared<ceres::Problem>(problem_options);
 
-void PosePriorBundleAdjuster::SetUpProblem(
-    Reconstruction* reconstruction,
-    ceres::LossFunction* loss_function,
-    ceres::LossFunction* prior_loss_function) {
-  // Set up problem
-  // Warning: SetUpProblem must be called before AddPosePriorToProblem()
-  // Do not change order of instructions!
-  BundleAdjuster::SetUpProblem(reconstruction, loss_function_.get());
+    ExtractRigsFromWorld(reconstruction, camera_rigs);
 
-  if (use_prior_position_) {
     for (const image_t image_id : config_.Images()) {
-      const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
-      if (pose_prior_it != image_id_to_pose_prior_.end()) {
-        AddPosePriorToProblem(image_id,
-                              pose_prior_it->second,
-                              reconstruction,
-                              prior_loss_function_.get());
+      AddImageToProblem(image_id, reconstruction);
+    }
+    for (const auto point3D_id : config_.VariablePoints()) {
+      AddPointToProblem(point3D_id, reconstruction);
+    }
+    for (const auto point3D_id : config_.ConstantPoints()) {
+      AddPointToProblem(point3D_id, reconstruction);
+    }
+
+    ParameterizeCameras(
+        options_, config_, camera_ids_, reconstruction, *problem_);
+    ParameterizeCameraRigs();
+    ParameterizePoints(
+        config_, point3D_num_observations_, reconstruction, *problem_);
+  }
+
+  ceres::Solver::Summary Solve() override {
+    ceres::Solver::Summary summary;
+    if (problem_->NumResiduals() == 0) {
+      return summary;
+    }
+
+    const ceres::Solver::Options solver_options =
+        CreateSolverOptions(options_, config_, *problem_);
+
+    ceres::Solve(solver_options, problem_.get(), &summary);
+
+    if (options_.print_summary || VLOG_IS_ON(1)) {
+      PrintSolverSummary(summary, "Rig Bundle adjustment report");
+    }
+
+    ComputeCamsFromWorld();
+
+    return summary;
+  }
+
+  std::shared_ptr<ceres::Problem>& Problem() override { return problem_; }
+
+  void AddImageToProblem(const image_t image_id,
+                         Reconstruction& reconstruction) {
+    const double max_squared_reproj_error =
+        rig_options_.max_reproj_error * rig_options_.max_reproj_error;
+
+    Image& image = reconstruction.Image(image_id);
+    Camera& camera = *image.CameraPtr();
+
+    const bool constant_cam_pose = config_.HasConstantCamPose(image_id);
+    const bool constant_cam_position =
+        config_.HasConstantCamPositions(image_id);
+
+    double* camera_params = camera.params.data();
+    double* cam_from_rig_rotation = nullptr;
+    double* cam_from_rig_translation = nullptr;
+    double* rig_from_world_rotation = nullptr;
+    double* rig_from_world_translation = nullptr;
+    CameraRig* camera_rig = nullptr;
+    Eigen::Matrix3x4d cam_from_world_mat = Eigen::Matrix3x4d::Zero();
+
+    if (image_id_to_camera_rig_.count(image_id) > 0) {
+      THROW_CHECK(!constant_cam_pose)
+          << "Images contained in a camera rig must not have constant pose";
+      THROW_CHECK(!constant_cam_position)
+          << "Images contained in a camera rig must not have constant tvec";
+      camera_rig = image_id_to_camera_rig_.at(image_id);
+      Rigid3d& rig_from_world = *image_id_to_rig_from_world_.at(image_id);
+      rig_from_world_rotation = rig_from_world.rotation.coeffs().data();
+      rig_from_world_translation = rig_from_world.translation.data();
+      Rigid3d& cam_from_rig = camera_rig->CamFromRig(image.CameraId());
+      cam_from_rig_rotation = cam_from_rig.rotation.coeffs().data();
+      cam_from_rig_translation = cam_from_rig.translation.data();
+      cam_from_world_mat = (cam_from_rig * rig_from_world).ToMatrix();
+    } else {
+      // CostFunction assumes unit quaternions.
+      image.CamFromWorld().rotation.normalize();
+      cam_from_rig_rotation = image.CamFromWorld().rotation.coeffs().data();
+      cam_from_rig_translation = image.CamFromWorld().translation.data();
+    }
+
+    // Collect cameras for final parameterization.
+    THROW_CHECK(image.HasCameraId());
+    camera_ids_.insert(image.CameraId());
+
+    // The number of added observations for the current image.
+    size_t num_observations = 0;
+
+    // Add residuals to bundle adjustment problem.
+    for (const Point2D& point2D : image.Points2D()) {
+      if (!point2D.HasPoint3D()) {
+        continue;
+      }
+
+      Point3D& point3D = reconstruction.Point3D(point2D.point3D_id);
+      assert(point3D.track.Length() > 1);
+
+      if (camera_rig != nullptr &&
+          CalculateSquaredReprojectionError(
+              point2D.xy, point3D.xyz, cam_from_world_mat, camera) >
+              max_squared_reproj_error) {
+        continue;
+      }
+
+      num_observations += 1;
+      point3D_num_observations_[point2D.point3D_id] += 1;
+
+      if (camera_rig == nullptr) {
+        if (constant_cam_pose) {
+          problem_->AddResidualBlock(
+              CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
+                  camera.model_id, point2D.xy, image.CamFromWorld()),
+              loss_function_.get(),
+              point3D.xyz.data(),
+              camera_params);
+        } else {
+          problem_->AddResidualBlock(
+              CreateCameraCostFunction<ReprojErrorCostFunctor>(camera.model_id,
+                                                               point2D.xy),
+              loss_function_.get(),
+              cam_from_rig_rotation,     // rig == world
+              cam_from_rig_translation,  // rig == world
+              point3D.xyz.data(),
+              camera_params);
+        }
+      } else {
+        problem_->AddResidualBlock(
+            CreateCameraCostFunction<RigReprojErrorCostFunctor>(camera.model_id,
+                                                                point2D.xy),
+            loss_function_.get(),
+            cam_from_rig_rotation,
+            cam_from_rig_translation,
+            rig_from_world_rotation,
+            rig_from_world_translation,
+            point3D.xyz.data(),
+            camera_params);
+      }
+    }
+
+    if (num_observations > 0) {
+      parameterized_cams_from_rig_rotations_.insert(cam_from_rig_rotation);
+
+      if (camera_rig != nullptr) {
+        parameterized_cams_from_rig_rotations_.insert(rig_from_world_rotation);
+
+        // Set the relative pose of the camera constant if relative pose
+        // refinement is disabled or if it is the reference camera to avoid
+        // over- parameterization of the camera pose.
+        if (!rig_options_.refine_relative_poses ||
+            image.CameraId() == camera_rig->RefCameraId()) {
+          problem_->SetParameterBlockConstant(cam_from_rig_rotation);
+          problem_->SetParameterBlockConstant(cam_from_rig_translation);
+        }
+      }
+
+      // Set pose parameterization.
+      if (!constant_cam_pose && constant_cam_position) {
+        const std::vector<int>& constant_position_idxs =
+            config_.ConstantCamPositions(image_id);
+        SetSubsetManifold(3,
+                          constant_position_idxs,
+                          problem_.get(),
+                          cam_from_rig_translation);
       }
     }
   }
-}
 
-void PosePriorBundleAdjuster::AddPosePriorToProblem(
-    image_t image_id,
-    const PosePrior& prior,
-    Reconstruction* reconstruction,
-    ceres::LossFunction* prior_loss_function) {
-  if (!prior.IsValid() || !prior.IsCovarianceValid()) {
-    LOG(ERROR) << "Could not add prior for image #" << image_id;
-    return;
-  }
-  Image& image = reconstruction->Image(image_id);
-  THROW_CHECK(image.HasPose());
-  double* cam_from_world_translation = image.CamFromWorld().translation.data();
+  void AddPointToProblem(const point3D_t point3D_id,
+                         Reconstruction& reconstruction) {
+    Point3D& point3D = reconstruction.Point3D(point3D_id);
 
-  // If image has not been added to the problem do not use it
-  if (!problem_->HasParameterBlock(cam_from_world_translation)) {
-    return;
-  }
+    // Is 3D point already fully contained in the problem? I.e. its entire track
+    // is contained in `variable_image_ids`, `constant_image_ids`,
+    // `constant_x_image_ids`.
+    if (point3D_num_observations_[point3D_id] == point3D.track.Length()) {
+      return;
+    }
 
-  // image.CamFromWorld().rotation is already normalized in AddImageToProblem()
-  double* cam_from_world_rotation =
-      image.CamFromWorld().rotation.coeffs().data();
+    for (const auto& track_el : point3D.track.Elements()) {
+      // Skip observations that were already added in `AddImageToProblem`.
+      if (config_.HasImage(track_el.image_id)) {
+        continue;
+      }
 
-  problem_->AddResidualBlock(
-      CovarianceWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
-          Create(prior.position_covariance,
-                 normalized_from_metric_ * prior.position),
-      prior_loss_function,
-      cam_from_world_rotation,
-      cam_from_world_translation);
-}
+      point3D_num_observations_[point3D_id] += 1;
 
-bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
-  // Compute initial squared error between position priors & current images
-  // projection center and prepare data for RANSAC-based sim3 alignment
-  std::vector<double> vini_err2_wrt_prior;
-  std::vector<Eigen::Vector3d> v_src, v_tgt;
-  vini_err2_wrt_prior.reserve(NumPosePriors());
-  v_src.reserve(NumPosePriors());
-  v_tgt.reserve(NumPosePriors());
+      Image& image = reconstruction.Image(track_el.image_id);
+      Camera& camera = *image.CameraPtr();
+      const Point2D& point2D = image.Point2D(track_el.point2D_idx);
 
-  for (const image_t image_id : reconstruction->RegImageIds()) {
-    const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
-    if (pose_prior_it != image_id_to_pose_prior_.end() &&
-        pose_prior_it->second.IsValid()) {
-      const auto& image = reconstruction->Image(image_id);
-      v_src.push_back(image.ProjectionCenter());
-      v_tgt.push_back(pose_prior_it->second.position);
-      vini_err2_wrt_prior.push_back(
-          (v_src.back() - v_tgt.back()).squaredNorm());
+      // We do not want to refine the camera of images that are not
+      // part of `constant_image_ids_`, `constant_image_ids_`,
+      // `constant_x_image_ids_`.
+      if (camera_ids_.count(image.CameraId()) == 0) {
+        camera_ids_.insert(image.CameraId());
+        config_.SetConstantCamIntrinsics(image.CameraId());
+      }
+
+      problem_->AddResidualBlock(
+          CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor>(
+              camera.model_id, point2D.xy, image.CamFromWorld()),
+          loss_function_.get(),
+          point3D.xyz.data(),
+          camera.params.data());
     }
   }
 
-  if (v_src.size() < 3) {
-    LOG(WARNING)
-        << "Not enough valid pose priors for PosePrior based alignment!";
-    return false;
+  void ExtractRigsFromWorld(const Reconstruction& reconstruction,
+                            const std::vector<CameraRig>& camera_rigs) {
+    rigs_from_world_.reserve(camera_rigs.size());
+    for (const auto& camera_rig : camera_rigs) {
+      rigs_from_world_.emplace_back();
+      auto& rig_from_world = rigs_from_world_.back();
+      const size_t num_snapshots = camera_rig.NumSnapshots();
+      rig_from_world.resize(num_snapshots);
+      for (size_t snapshot_idx = 0; snapshot_idx < num_snapshots;
+           ++snapshot_idx) {
+        rig_from_world[snapshot_idx] =
+            camera_rig.ComputeRigFromWorld(snapshot_idx, reconstruction);
+        for (const auto image_id : camera_rig.Snapshots()[snapshot_idx]) {
+          image_id_to_rig_from_world_.emplace(image_id,
+                                              &rig_from_world[snapshot_idx]);
+        }
+      }
+    }
   }
 
-  VLOG(2) << "Initial alignment error w.r.t. prior position:\n"
-          << "  - rmse:   " << std::sqrt(Mean(vini_err2_wrt_prior)) << " m\n"
-          << "  - median: " << std::sqrt(Median(vini_err2_wrt_prior)) << " m\n";
+  void ComputeCamsFromWorld() {
+    for (const auto& [image_id, camera_rig] : image_id_to_camera_rig_) {
+      Image& image = reconstruction_.Image(image_id);
+      image.CamFromWorld() = camera_rig->CamFromRig(image.CameraId()) *
+                             (*image_id_to_rig_from_world_.at(image_id));
+    }
+  }
 
-  Sim3d sim3_tform;
-  bool success = false;
+  void ParameterizeCameraRigs() {
+    for (double* cam_from_rig_rotation :
+         parameterized_cams_from_rig_rotations_) {
+      SetQuaternionManifold(problem_.get(), cam_from_rig_rotation);
+    }
+  }
 
-  // Apply RANSAC-based Sim3 Alignment if ransac_max_error is set
-  if (prior_options_.ransac_max_error > 0.) {
+ private:
+  const RigBundleAdjustmentOptions rig_options_;
+
+  Reconstruction& reconstruction_;
+
+  std::shared_ptr<ceres::Problem> problem_;
+  std::unique_ptr<ceres::LossFunction> loss_function_;
+
+  std::unordered_set<camera_t> camera_ids_;
+  std::unordered_map<point3D_t, size_t> point3D_num_observations_;
+
+  // Mapping from images to camera rigs.
+  std::unordered_map<image_t, CameraRig*> image_id_to_camera_rig_;
+  std::unordered_map<image_t, Rigid3d*> image_id_to_rig_from_world_;
+
+  // For each camera rig, the absolute camera rig poses for all snapshots.
+  std::vector<std::vector<Rigid3d>> rigs_from_world_;
+
+  // The Quaternions added to the problem, used to set the local
+  // parameterization once after setting up the problem.
+  std::unordered_set<double*> parameterized_cams_from_rig_rotations_;
+};
+
+class PosePriorBundleAdjuster : public BundleAdjuster {
+ public:
+  PosePriorBundleAdjuster(BundleAdjustmentOptions options,
+                          PosePriorBundleAdjustmentOptions prior_options,
+                          BundleAdjustmentConfig config,
+                          std::unordered_map<image_t, PosePrior> pose_priors,
+                          Reconstruction& reconstruction)
+      : BundleAdjuster(std::move(options), std::move(config)),
+        prior_options_(prior_options),
+        pose_priors_(std::move(pose_priors)),
+        reconstruction_(reconstruction) {
+    const bool use_prior_position = AlignReconstruction();
+
+    // Fix 7-DOFs of BA problem if not enough valid pose priors.
+    if (!use_prior_position) {
+      auto reg_image_ids_it = reconstruction_.RegImageIds().begin();
+      config_.SetConstantCamPose(*reg_image_ids_it);
+      config_.SetConstantCamPositions(*(++reg_image_ids_it), {0});
+    }
+
+    default_bundle_adjuster_ = std::make_unique<DefaultBundleAdjuster>(
+        options_, config_, reconstruction);
+
+    if (use_prior_position) {
+      // Normalize the reconstruction to avoid any numerical instability but do
+      // not transform priors as they will be transformed when added to
+      // ceres::Problem.
+      normalized_from_metric_ = reconstruction_.Normalize(/*fixed_scale=*/true);
+
+      if (prior_options_.use_robust_loss_on_prior_position) {
+        THROW_CHECK_EQ(default_bundle_adjuster_->Problem()
+                           ->options()
+                           .loss_function_ownership,
+                       ceres::DO_NOT_TAKE_OWNERSHIP);
+        prior_loss_function_ = std::make_unique<ceres::CauchyLoss>(
+            prior_options_.prior_position_loss_scale);
+      }
+
+      for (const image_t image_id : config_.Images()) {
+        const auto pose_prior_it = pose_priors_.find(image_id);
+        if (pose_prior_it != pose_priors_.end()) {
+          AddPosePriorToProblem(
+              image_id, pose_prior_it->second, reconstruction);
+        }
+      }
+    }
+  }
+
+  ceres::Solver::Summary Solve() override {
+    ceres::Solver::Summary summary;
+    std::shared_ptr<ceres::Problem> problem =
+        default_bundle_adjuster_->Problem();
+    if (problem->NumResiduals() == 0) {
+      return summary;
+    }
+
+    const ceres::Solver::Options solver_options =
+        CreateSolverOptions(options_, config_, *problem);
+
+    ceres::Solve(solver_options, problem.get(), &summary);
+
+    reconstruction_.Transform(Inverse(normalized_from_metric_));
+
+    if (options_.print_summary || VLOG_IS_ON(1)) {
+      PrintSolverSummary(summary, "Pose Prior Bundle adjustment report");
+    }
+
+    return summary;
+  }
+
+  std::shared_ptr<ceres::Problem>& Problem() override {
+    return default_bundle_adjuster_->Problem();
+  }
+
+  void AddPosePriorToProblem(image_t image_id,
+                             const PosePrior& prior,
+                             Reconstruction& reconstruction) {
+    if (!prior.IsValid() || !prior.IsCovarianceValid()) {
+      LOG(ERROR) << "Could not add prior for image #" << image_id;
+      return;
+    }
+
+    std::shared_ptr<ceres::Problem> problem =
+        default_bundle_adjuster_->Problem();
+
+    Image& image = reconstruction.Image(image_id);
+    THROW_CHECK(image.HasPose());
+
+    double* cam_from_world_translation =
+        image.CamFromWorld().translation.data();
+    if (!problem->HasParameterBlock(cam_from_world_translation)) {
+      return;
+    }
+
+    // image.CamFromWorld().rotation is already normalized in
+    // AddImageToProblem()
+    double* cam_from_world_rotation =
+        image.CamFromWorld().rotation.coeffs().data();
+
+    problem->AddResidualBlock(
+        CovarianceWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
+            Create(prior.position_covariance,
+                   normalized_from_metric_ * prior.position),
+        prior_loss_function_.get(),
+        cam_from_world_rotation,
+        cam_from_world_translation);
+  }
+
+  bool AlignReconstruction() {
     RANSACOptions ransac_options;
-    ransac_options.max_error = prior_options_.ransac_max_error;
-
-    LORANSAC<SimilarityTransformEstimator<3, true>,
-             SimilarityTransformEstimator<3, true>>
-        ransac(ransac_options);
-
-    const auto report = ransac.Estimate(v_src, v_tgt);
-
-    if (report.success) {
-      // Apply sim3 transform
-      sim3_tform = Sim3d::FromMatrix(report.model);
-      success = true;
-    }
-  } else {
-    success = EstimateSim3d(v_src, v_tgt, sim3_tform);
-  }
-
-  if (success) {
-    reconstruction->Transform(sim3_tform);
-  } else {
-    LOG(WARNING) << "Sim3 alignment w.r.t. prior position failed!";
-  }
-
-  if (VLOG_IS_ON(2) && success) {
-    std::vector<double> verr2_wrt_prior;
-    verr2_wrt_prior.reserve(vini_err2_wrt_prior.size());
-    for (const image_t image_id : reconstruction->RegImageIds()) {
-      const auto pose_prior_it = image_id_to_pose_prior_.find(image_id);
-      if (pose_prior_it != image_id_to_pose_prior_.end() &&
-          pose_prior_it->second.IsValid()) {
-        const auto& image = reconstruction->Image(image_id);
-        verr2_wrt_prior.push_back(
-            (image.ProjectionCenter() - pose_prior_it->second.position)
-                .squaredNorm());
+    ransac_options.max_error = -1;
+    size_t num_covs = 0;
+    Eigen::Vector3d avg_cov = Eigen::Vector3d::Zero();
+    for (const auto& [_, pose_prior] : pose_priors_) {
+      if (pose_prior.IsCovarianceValid()) {
+        avg_cov += pose_prior.position_covariance.diagonal();
+        ++num_covs;
       }
     }
+    if (num_covs > 0) {
+      ransac_options.max_error = (3. * (avg_cov / num_covs).cwiseSqrt()).norm();
+    }
 
-    VLOG(2) << "Rigid Sim3 alignment w.r.t. prior position:\n"
-            << "  - scale : " << sim3_tform.scale << "\n"
-            << "  - trans : " << sim3_tform.translation.transpose() << "\n";
+    Sim3d metric_from_orig;
+    const bool success = AlignReconstructionToPosePriors(
+        reconstruction_, pose_priors_, ransac_options, &metric_from_orig);
 
-    VLOG(2) << "Sim3 alignment error w.r.t. prior position:\n"
-            << "  - rmse:   " << std::sqrt(Mean(verr2_wrt_prior)) << " m\n"
-            << "  - median: " << std::sqrt(Median(verr2_wrt_prior)) << " m\n";
+    if (success) {
+      reconstruction_.Transform(metric_from_orig);
+    } else {
+      LOG(WARNING) << "Alignment w.r.t. prior positions failed";
+    }
+
+    if (VLOG_IS_ON(2) && success) {
+      std::vector<double> verr2_wrt_prior;
+      verr2_wrt_prior.reserve(reconstruction_.NumRegImages());
+      for (const image_t image_id : reconstruction_.RegImageIds()) {
+        const auto pose_prior_it = pose_priors_.find(image_id);
+        if (pose_prior_it != pose_priors_.end() &&
+            pose_prior_it->second.IsValid()) {
+          const auto& image = reconstruction_.Image(image_id);
+          verr2_wrt_prior.push_back(
+              (image.ProjectionCenter() - pose_prior_it->second.position)
+                  .squaredNorm());
+        }
+      }
+
+      VLOG(2) << "Alignment error w.r.t. prior positions:\n"
+              << "  - rmse:   " << std::sqrt(Mean(verr2_wrt_prior)) << "\n"
+              << "  - median: " << std::sqrt(Median(verr2_wrt_prior)) << "\n";
+    }
+
+    return success;
   }
 
-  return success;
+ private:
+  const PosePriorBundleAdjustmentOptions prior_options_;
+  const std::unordered_map<image_t, PosePrior> pose_priors_;
+  Reconstruction& reconstruction_;
+
+  std::unique_ptr<DefaultBundleAdjuster> default_bundle_adjuster_;
+  std::unique_ptr<ceres::LossFunction> prior_loss_function_;
+
+  Sim3d normalized_from_metric_;
+};
+
+}  // namespace
+
+std::unique_ptr<BundleAdjuster> CreateDefaultBundleAdjuster(
+    BundleAdjustmentOptions options,
+    BundleAdjustmentConfig config,
+    Reconstruction& reconstruction) {
+  return std::make_unique<DefaultBundleAdjuster>(
+      std::move(options), std::move(config), reconstruction);
 }
 
-void PosePriorBundleAdjuster::SetRansacMaxErrorFromPriorsCovariance() {
-  std::size_t nb_cov = 0;
-  Eigen::Vector3d avg_cov = Eigen::Vector3d::Zero();
-  for (const auto& [_, pose_prior] : image_id_to_pose_prior_) {
-    if (pose_prior.IsCovarianceValid()) {
-      avg_cov += pose_prior.position_covariance.diagonal();
-      ++nb_cov;
-    }
-  }
-  if (!avg_cov.isZero()) {
-    prior_options_.ransac_max_error =
-        (3. * (avg_cov / nb_cov).cwiseSqrt()).norm();
-  }
+std::unique_ptr<BundleAdjuster> CreateRigBundleAdjuster(
+    BundleAdjustmentOptions options,
+    RigBundleAdjustmentOptions rig_options,
+    BundleAdjustmentConfig config,
+    Reconstruction& reconstruction,
+    std::vector<CameraRig>& camera_rigs) {
+  return std::make_unique<RigBundleAdjuster>(std::move(options),
+                                             std::move(rig_options),
+                                             std::move(config),
+                                             reconstruction,
+                                             camera_rigs);
+}
+
+std::unique_ptr<BundleAdjuster> CreatePosePriorBundleAdjuster(
+    BundleAdjustmentOptions options,
+    PosePriorBundleAdjustmentOptions prior_options,
+    BundleAdjustmentConfig config,
+    std::unordered_map<image_t, PosePrior> pose_priors,
+    Reconstruction& reconstruction) {
+  return std::make_unique<PosePriorBundleAdjuster>(std::move(options),
+                                                   std::move(prior_options),
+                                                   std::move(config),
+                                                   std::move(pose_priors),
+                                                   reconstruction);
 }
 
 void PrintSolverSummary(const ceres::Solver::Summary& summary,

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -935,10 +935,6 @@ class PosePriorBundleAdjuster : public BundleAdjuster {
       normalized_from_metric_ = reconstruction_.Normalize(/*fixed_scale=*/true);
 
       if (prior_options_.use_robust_loss_on_prior_position) {
-        THROW_CHECK_EQ(default_bundle_adjuster_->Problem()
-                           ->options()
-                           .loss_function_ownership,
-                       ceres::DO_NOT_TAKE_OWNERSHIP);
         prior_loss_function_ = std::make_unique<ceres::CauchyLoss>(
             prior_options_.prior_position_loss_scale);
       }

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -195,7 +195,7 @@ void GenerateReconstruction(const size_t num_images,
   }
 }
 
-TEST(BundleAdjustment, ConfigNumObservations) {
+TEST(DefaultBundleAdjuster, ConfigNumObservations) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
 
@@ -218,7 +218,7 @@ TEST(BundleAdjustment, ConfigNumObservations) {
   EXPECT_EQ(config.NumResiduals(reconstruction), 800);
 }
 
-TEST(BundleAdjustment, TwoView) {
+TEST(DefaultBundleAdjuster, TwoView) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -230,10 +230,10 @@ TEST(BundleAdjustment, TwoView) {
   config.SetConstantCamPositions(1, {0});
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -254,7 +254,7 @@ TEST(BundleAdjustment, TwoView) {
   }
 }
 
-TEST(BundleAdjustment, TwoViewConstantCamera) {
+TEST(DefaultBundleAdjuster, TwoViewConstantCamera) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -267,10 +267,10 @@ TEST(BundleAdjustment, TwoViewConstantCamera) {
   config.SetConstantCamIntrinsics(0);
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -290,7 +290,7 @@ TEST(BundleAdjustment, TwoViewConstantCamera) {
   }
 }
 
-TEST(BundleAdjustment, PartiallyContainedTracks) {
+TEST(DefaultBundleAdjuster, PartiallyContainedTracks) {
   Reconstruction reconstruction;
   GenerateReconstruction(3, 100, &reconstruction);
   const auto variable_point3D_id =
@@ -306,10 +306,10 @@ TEST(BundleAdjustment, PartiallyContainedTracks) {
   config.SetConstantCamPose(1);
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -337,7 +337,7 @@ TEST(BundleAdjustment, PartiallyContainedTracks) {
   }
 }
 
-TEST(BundleAdjustment, PartiallyContainedTracksForceToOptimizePoint) {
+TEST(DefaultBundleAdjuster, PartiallyContainedTracksForceToOptimizePoint) {
   Reconstruction reconstruction;
   GenerateReconstruction(3, 100, &reconstruction);
   const point3D_t variable_point3D_id =
@@ -359,10 +359,10 @@ TEST(BundleAdjustment, PartiallyContainedTracksForceToOptimizePoint) {
   config.AddConstantPoint(add_constant_point3D_id);
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   // + 2 residuals in 3rd image for added variable 3D point
@@ -394,7 +394,7 @@ TEST(BundleAdjustment, PartiallyContainedTracksForceToOptimizePoint) {
   }
 }
 
-TEST(BundleAdjustment, ConstantPoints) {
+TEST(DefaultBundleAdjuster, ConstantPoints) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -411,10 +411,10 @@ TEST(BundleAdjustment, ConstantPoints) {
   config.AddConstantPoint(constant_point3D_id2);
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -440,7 +440,7 @@ TEST(BundleAdjustment, ConstantPoints) {
   }
 }
 
-TEST(BundleAdjustment, VariableImage) {
+TEST(DefaultBundleAdjuster, VariableImage) {
   Reconstruction reconstruction;
   GenerateReconstruction(3, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -453,10 +453,10 @@ TEST(BundleAdjustment, VariableImage) {
   config.SetConstantCamPositions(1, {0});
 
   BundleAdjustmentOptions options;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 3 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 600);
@@ -481,7 +481,7 @@ TEST(BundleAdjustment, VariableImage) {
   }
 }
 
-TEST(BundleAdjustment, ConstantFocalLength) {
+TEST(DefaultBundleAdjuster, ConstantFocalLength) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -494,10 +494,10 @@ TEST(BundleAdjustment, ConstantFocalLength) {
 
   BundleAdjustmentOptions options;
   options.refine_focal_length = false;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 3 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -532,7 +532,7 @@ TEST(BundleAdjustment, ConstantFocalLength) {
   }
 }
 
-TEST(BundleAdjustment, VariablePrincipalPoint) {
+TEST(DefaultBundleAdjuster, VariablePrincipalPoint) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -545,10 +545,10 @@ TEST(BundleAdjustment, VariablePrincipalPoint) {
 
   BundleAdjustmentOptions options;
   options.refine_principal_point = true;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 3 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -595,7 +595,7 @@ TEST(BundleAdjustment, VariablePrincipalPoint) {
   }
 }
 
-TEST(BundleAdjustment, ConstantExtraParam) {
+TEST(DefaultBundleAdjuster, ConstantExtraParam) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -608,10 +608,10 @@ TEST(BundleAdjustment, ConstantExtraParam) {
 
   BundleAdjustmentOptions options;
   options.refine_extra_params = false;
-  BundleAdjuster bundle_adjuster(options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 3 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -646,7 +646,7 @@ TEST(BundleAdjustment, ConstantExtraParam) {
   }
 }
 
-TEST(BundleAdjustment, RigTwoView) {
+TEST(RigBundleAdjuster, TwoView) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, 100, &reconstruction);
   const auto orig_reconstruction = reconstruction;
@@ -664,11 +664,11 @@ TEST(BundleAdjustment, RigTwoView) {
   const auto orig_camera_rigs = camera_rigs;
 
   BundleAdjustmentOptions options;
-  RigBundleAdjuster::Options rig_options;
-  RigBundleAdjuster bundle_adjuster(options, rig_options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction, &camera_rigs));
-
-  const auto summary = bundle_adjuster.Summary();
+  RigBundleAdjustmentOptions rig_options;
+  std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateRigBundleAdjuster(
+      options, rig_options, config, reconstruction, camera_rigs);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 400);
@@ -693,7 +693,7 @@ TEST(BundleAdjustment, RigTwoView) {
   }
 }
 
-TEST(BundleAdjustment, RigFourView) {
+TEST(RigBundleAdjuster, FourView) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
   reconstruction.Image(2).ResetCameraPtr();
@@ -720,11 +720,11 @@ TEST(BundleAdjustment, RigFourView) {
   const auto orig_camera_rigs = camera_rigs;
 
   BundleAdjustmentOptions options;
-  RigBundleAdjuster::Options rig_options;
-  RigBundleAdjuster bundle_adjuster(options, rig_options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction, &camera_rigs));
-
-  const auto summary = bundle_adjuster.Summary();
+  RigBundleAdjustmentOptions rig_options;
+  std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateRigBundleAdjuster(
+      options, rig_options, config, reconstruction, camera_rigs);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 800);
@@ -749,7 +749,7 @@ TEST(BundleAdjustment, RigFourView) {
   }
 }
 
-TEST(BundleAdjustment, ConstantRigFourView) {
+TEST(RigBundleAdjuster, ConstantFourView) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
   reconstruction.Image(2).ResetCameraPtr();
@@ -776,12 +776,12 @@ TEST(BundleAdjustment, ConstantRigFourView) {
   const auto orig_camera_rigs = camera_rigs;
 
   BundleAdjustmentOptions options;
-  RigBundleAdjuster::Options rig_options;
+  RigBundleAdjustmentOptions rig_options;
   rig_options.refine_relative_poses = false;
-  RigBundleAdjuster bundle_adjuster(options, rig_options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction, &camera_rigs));
-
-  const auto summary = bundle_adjuster.Summary();
+  std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateRigBundleAdjuster(
+      options, rig_options, config, reconstruction, camera_rigs);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 800);
@@ -805,7 +805,7 @@ TEST(BundleAdjustment, ConstantRigFourView) {
   }
 }
 
-TEST(BundleAdjustment, RigFourViewPartial) {
+TEST(RigBundleAdjuster, FourViewPartial) {
   Reconstruction reconstruction;
   GenerateReconstruction(4, 100, &reconstruction);
   reconstruction.Image(2).ResetCameraPtr();
@@ -832,11 +832,11 @@ TEST(BundleAdjustment, RigFourViewPartial) {
   const auto orig_camera_rigs = camera_rigs;
 
   BundleAdjustmentOptions options;
-  RigBundleAdjuster::Options rig_options;
-  RigBundleAdjuster bundle_adjuster(options, rig_options, config);
-  ASSERT_TRUE(bundle_adjuster.Solve(&reconstruction, &camera_rigs));
-
-  const auto summary = bundle_adjuster.Summary();
+  RigBundleAdjustmentOptions rig_options;
+  std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateRigBundleAdjuster(
+      options, rig_options, config, reconstruction, camera_rigs);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary.termination_type, ceres::FAILURE);
 
   // 100 points, 2 images, 2 residuals per point per image
   EXPECT_EQ(summary.num_residuals_reduced, 800);

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -835,7 +835,7 @@ int RunRigBundleAdjuster(int argc, char** argv) {
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster =
       CreateRigBundleAdjuster(std::move(ba_options),
-                              std::move(rig_ba_options),
+                              rig_ba_options,
                               std::move(config),
                               reconstruction,
                               camera_rigs);

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -795,7 +795,7 @@ int RunRigBundleAdjuster(int argc, char** argv) {
   std::string rig_config_path;
   bool estimate_rig_relative_poses = true;
 
-  RigBundleAdjuster::Options rig_ba_options;
+  RigBundleAdjustmentOptions rig_ba_options;
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
@@ -832,8 +832,14 @@ int RunRigBundleAdjuster(int argc, char** argv) {
   PrintHeading1("Rig bundle adjustment");
 
   BundleAdjustmentOptions ba_options = *options.bundle_adjustment;
-  RigBundleAdjuster bundle_adjuster(ba_options, rig_ba_options, config);
-  THROW_CHECK(bundle_adjuster.Solve(&reconstruction, &camera_rigs));
+
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateRigBundleAdjuster(std::move(ba_options),
+                              std::move(rig_ba_options),
+                              std::move(config),
+                              reconstruction,
+                              camera_rigs);
+  THROW_CHECK_NE(bundle_adjuster->Solve().termination_type, ceres::FAILURE);
 
   reconstruction.Write(output_path);
 

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -647,11 +647,12 @@ IncrementalMapper::AdjustLocalBundle(
     }
 
     // Adjust the local bundle.
-    BundleAdjuster bundle_adjuster(ba_options, ba_config);
-    bundle_adjuster.Solve(reconstruction_.get());
+    std::unique_ptr<BundleAdjuster> bundle_adjuster =
+        CreateDefaultBundleAdjuster(
+            std::move(ba_options), std::move(ba_config), *reconstruction_);
+    const ceres::Solver::Summary summary = bundle_adjuster->Solve();
 
-    report.num_adjusted_observations =
-        bundle_adjuster.Summary().num_residuals / 2;
+    report.num_adjusted_observations = summary.num_residuals / 2;
 
     // Merge refined tracks with other existing points.
     report.num_merged_observations =
@@ -696,15 +697,15 @@ bool IncrementalMapper::AdjustGlobalBundle(
                                              "registered for global "
                                              "bundle-adjustment";
 
-  BundleAdjustmentOptions ba_options_tmp = ba_options;
+  BundleAdjustmentOptions custom_ba_options = ba_options;
   // Use stricter convergence criteria for first registered images.
   const size_t kMinNumRegImagesForFastBA = 10;
   if (reg_image_ids.size() < kMinNumRegImagesForFastBA) {
-    ba_options_tmp.solver_options.function_tolerance /= 10;
-    ba_options_tmp.solver_options.gradient_tolerance /= 10;
-    ba_options_tmp.solver_options.parameter_tolerance /= 10;
-    ba_options_tmp.solver_options.max_num_iterations *= 2;
-    ba_options_tmp.solver_options.max_linear_solver_iterations = 200;
+    custom_ba_options.solver_options.function_tolerance /= 10;
+    custom_ba_options.solver_options.gradient_tolerance /= 10;
+    custom_ba_options.solver_options.parameter_tolerance /= 10;
+    custom_ba_options.solver_options.max_num_iterations *= 2;
+    custom_ba_options.solver_options.max_linear_solver_iterations = 200;
   }
 
   // Avoid degeneracies in bundle adjustment.
@@ -729,6 +730,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
   const bool use_prior_position =
       options.use_prior_position && reg_image_ids.size() > 2;
 
+  std::unique_ptr<BundleAdjuster> bundle_adjuster;
   if (!use_prior_position) {
     // Fix 7-DOFs of the bundle adjustment problem.
     auto reg_image_ids_it = reg_image_ids.begin();
@@ -738,19 +740,22 @@ bool IncrementalMapper::AdjustGlobalBundle(
       ba_config.SetConstantCamPositions(*reg_image_ids_it, {0});  // 2nd image
     }
 
-    // Run bundle adjustment.
-    BundleAdjuster bundle_adjuster(ba_options_tmp, ba_config);
-    return bundle_adjuster.Solve(reconstruction_.get());
+    bundle_adjuster = CreateDefaultBundleAdjuster(
+        std::move(custom_ba_options), std::move(ba_config), *reconstruction_);
   } else {
-    PosePriorBundleAdjuster prior_bundle_adjuster(
-        ba_options_tmp,
-        PosePriorBundleAdjuster::Options(
-            options.use_robust_loss_on_prior_position,
-            options.prior_position_loss_scale),
-        ba_config,
-        database_cache_->PosePriors());
-    return prior_bundle_adjuster.Solve(reconstruction_.get());
+    PosePriorBundleAdjustmentOptions prior_options;
+    prior_options.use_robust_loss_on_prior_position =
+        options.use_robust_loss_on_prior_position;
+    prior_options.prior_position_loss_scale = options.prior_position_loss_scale;
+    bundle_adjuster =
+        CreatePosePriorBundleAdjuster(std::move(custom_ba_options),
+                                      std::move(prior_options),
+                                      std::move(ba_config),
+                                      database_cache_->PosePriors(),
+                                      *reconstruction_);
   }
+
+  return bundle_adjuster->Solve().termination_type != ceres::FAILURE;
 }
 
 void IncrementalMapper::IterativeLocalRefinement(
@@ -760,10 +765,13 @@ void IncrementalMapper::IterativeLocalRefinement(
     const BundleAdjustmentOptions& ba_options,
     const IncrementalTriangulator::Options& tri_options,
     const image_t image_id) {
-  BundleAdjustmentOptions ba_options_tmp = ba_options;
+  BundleAdjustmentOptions custom_ba_options = ba_options;
   for (int i = 0; i < max_num_refinements; ++i) {
-    const auto report = AdjustLocalBundle(
-        options, ba_options_tmp, tri_options, image_id, GetModifiedPoints3D());
+    const auto report = AdjustLocalBundle(options,
+                                          custom_ba_options,
+                                          tri_options,
+                                          image_id,
+                                          GetModifiedPoints3D());
     VLOG(1) << "=> Merged observations: " << report.num_merged_observations;
     VLOG(1) << "=> Completed observations: "
             << report.num_completed_observations;
@@ -780,7 +788,7 @@ void IncrementalMapper::IterativeLocalRefinement(
       break;
     }
     // Only use robust cost function for first iteration.
-    ba_options_tmp.loss_function_type =
+    custom_ba_options.loss_function_type =
         BundleAdjustmentOptions::LossFunctionType::TRIVIAL;
   }
   ClearModifiedPoints3D();

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -649,7 +649,7 @@ IncrementalMapper::AdjustLocalBundle(
     // Adjust the local bundle.
     std::unique_ptr<BundleAdjuster> bundle_adjuster =
         CreateDefaultBundleAdjuster(
-            std::move(ba_options), std::move(ba_config), *reconstruction_);
+            ba_options, std::move(ba_config), *reconstruction_);
     const ceres::Solver::Summary summary = bundle_adjuster->Solve();
 
     report.num_adjusted_observations = summary.num_residuals / 2;
@@ -749,7 +749,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
     prior_options.prior_position_loss_scale = options.prior_position_loss_scale;
     bundle_adjuster =
         CreatePosePriorBundleAdjuster(std::move(custom_ba_options),
-                                      std::move(prior_options),
+                                      prior_options,
                                       std::move(ba_config),
                                       database_cache_->PosePriors(),
                                       *reconstruction_);

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -15,6 +15,58 @@ namespace py = pybind11;
 void BindBundleAdjuster(py::module& m) {
   IsPyceresAvailable();  // Try to import pyceres to populate the docstrings.
 
+  using BACfg = BundleAdjustmentConfig;
+  py::class_<BACfg> PyBundleAdjustmentConfig(m, "BundleAdjustmentConfig");
+  PyBundleAdjustmentConfig.def(py::init<>())
+      .def("num_images", &BACfg::NumImages)
+      .def("num_points", &BACfg::NumPoints)
+      .def("num_constant_cam_intrinsics", &BACfg::NumConstantCamIntrinsics)
+      .def("num_constant_cam_poses", &BACfg::NumConstantCamPoses)
+      .def("num_constant_cam_positions", &BACfg::NumConstantCamPositions)
+      .def("num_variable_points", &BACfg::NumVariablePoints)
+      .def("num_constant_points", &BACfg::NumConstantPoints)
+      .def("num_residuals", &BACfg::NumResiduals, "reconstruction"_a)
+      .def("add_image", &BACfg::AddImage, "image_id"_a)
+      .def("has_image", &BACfg::HasImage, "image_id"_a)
+      .def("remove_image", &BACfg::RemoveImage, "image_id"_a)
+      .def("set_constant_cam_intrinsics",
+           &BACfg::SetConstantCamIntrinsics,
+           "camera_id"_a)
+      .def("set_variable_cam_intrinsics",
+           &BACfg::SetVariableCamIntrinsics,
+           "camera_id"_a)
+      .def("has_constant_cam_intrinsics",
+           &BACfg::HasConstantCamIntrinsics,
+           "camera_id"_a)
+      .def("set_constant_cam_pose", &BACfg::SetConstantCamPose, "image_id"_a)
+      .def("set_variable_cam_pose", &BACfg::SetVariableCamPose, "image_id"_a)
+      .def("has_constant_cam_pose", &BACfg::HasConstantCamPose, "image_id"_a)
+      .def("set_constant_cam_positions",
+           &BACfg::SetConstantCamPositions,
+           "image_id"_a,
+           "idxs"_a)
+      .def("remove_variable_cam_positions",
+           &BACfg::RemoveConstantCamPositions,
+           "image_id"_a)
+      .def("has_constant_cam_positions",
+           &BACfg::HasConstantCamPositions,
+           "image_id"_a)
+      .def("add_variable_point", &BACfg::AddVariablePoint, "point3D_id"_a)
+      .def("add_constant_point", &BACfg::AddConstantPoint, "point3D_id"_a)
+      .def("has_point", &BACfg::HasPoint, "point3D_id"_a)
+      .def("has_variable_point", &BACfg::HasVariablePoint, "point3D_id"_a)
+      .def("has_constant_point", &BACfg::HasConstantPoint, "point3D_id"_a)
+      .def("remove_variable_point", &BACfg::RemoveVariablePoint, "point3D_id"_a)
+      .def("remove_constant_point", &BACfg::RemoveConstantPoint, "point3D_id"_a)
+      .def_property_readonly("constant_intrinsics", &BACfg::ConstantIntrinsics)
+      .def_property_readonly("image_ids", &BACfg::Images)
+      .def_property_readonly("variable_point3D_ids", &BACfg::VariablePoints)
+      .def_property_readonly("constant_point3D_ids", &BACfg::ConstantPoints)
+      .def_property_readonly("constant_cam_poses", &BACfg::ConstantCamPoses)
+      .def(
+          "constant_cam_positions", &BACfg::ConstantCamPositions, "image_id"_a);
+  MakeDataclass(PyBundleAdjustmentConfig);
+
   using BAOpts = BundleAdjustmentOptions;
   auto PyBALossFunctionType =
       py::enum_<BAOpts::LossFunctionType>(m, "LossFunctionType")
@@ -27,6 +79,10 @@ void BindBundleAdjuster(py::module& m) {
       py::class_<BAOpts>(m, "BundleAdjustmentOptions")
           .def(py::init<>())
           .def("create_loss_function", &BAOpts::CreateLossFunction)
+          .def("create_solver_options",
+               &BAOpts::CreateSolverOptions,
+               "config"_a,
+               "problem"_a)
           .def_readwrite("loss_function_type",
                          &BAOpts::loss_function_type,
                          "Loss function types: Trivial (non-robust) and Cauchy "
@@ -104,58 +160,6 @@ void BindBundleAdjuster(py::module& m) {
                          &PosePriorBAOpts::ransac_max_error,
                          "Maximum RANSAC error for Sim3 alignment.");
   MakeDataclass(PyPosePriorBundleAdjustmentOptions);
-
-  using BACfg = BundleAdjustmentConfig;
-  py::class_<BACfg> PyBundleAdjustmentConfig(m, "BundleAdjustmentConfig");
-  PyBundleAdjustmentConfig.def(py::init<>())
-      .def("num_images", &BACfg::NumImages)
-      .def("num_points", &BACfg::NumPoints)
-      .def("num_constant_cam_intrinsics", &BACfg::NumConstantCamIntrinsics)
-      .def("num_constant_cam_poses", &BACfg::NumConstantCamPoses)
-      .def("num_constant_cam_positions", &BACfg::NumConstantCamPositions)
-      .def("num_variable_points", &BACfg::NumVariablePoints)
-      .def("num_constant_points", &BACfg::NumConstantPoints)
-      .def("num_residuals", &BACfg::NumResiduals, "reconstruction"_a)
-      .def("add_image", &BACfg::AddImage, "image_id"_a)
-      .def("has_image", &BACfg::HasImage, "image_id"_a)
-      .def("remove_image", &BACfg::RemoveImage, "image_id"_a)
-      .def("set_constant_cam_intrinsics",
-           &BACfg::SetConstantCamIntrinsics,
-           "camera_id"_a)
-      .def("set_variable_cam_intrinsics",
-           &BACfg::SetVariableCamIntrinsics,
-           "camera_id"_a)
-      .def("has_constant_cam_intrinsics",
-           &BACfg::HasConstantCamIntrinsics,
-           "camera_id"_a)
-      .def("set_constant_cam_pose", &BACfg::SetConstantCamPose, "image_id"_a)
-      .def("set_variable_cam_pose", &BACfg::SetVariableCamPose, "image_id"_a)
-      .def("has_constant_cam_pose", &BACfg::HasConstantCamPose, "image_id"_a)
-      .def("set_constant_cam_positions",
-           &BACfg::SetConstantCamPositions,
-           "image_id"_a,
-           "idxs"_a)
-      .def("remove_variable_cam_positions",
-           &BACfg::RemoveConstantCamPositions,
-           "image_id"_a)
-      .def("has_constant_cam_positions",
-           &BACfg::HasConstantCamPositions,
-           "image_id"_a)
-      .def("add_variable_point", &BACfg::AddVariablePoint, "point3D_id"_a)
-      .def("add_constant_point", &BACfg::AddConstantPoint, "point3D_id"_a)
-      .def("has_point", &BACfg::HasPoint, "point3D_id"_a)
-      .def("has_variable_point", &BACfg::HasVariablePoint, "point3D_id"_a)
-      .def("has_constant_point", &BACfg::HasConstantPoint, "point3D_id"_a)
-      .def("remove_variable_point", &BACfg::RemoveVariablePoint, "point3D_id"_a)
-      .def("remove_constant_point", &BACfg::RemoveConstantPoint, "point3D_id"_a)
-      .def_property_readonly("constant_intrinsics", &BACfg::ConstantIntrinsics)
-      .def_property_readonly("image_ids", &BACfg::Images)
-      .def_property_readonly("variable_point3D_ids", &BACfg::VariablePoints)
-      .def_property_readonly("constant_point3D_ids", &BACfg::ConstantPoints)
-      .def_property_readonly("constant_cam_poses", &BACfg::ConstantCamPoses)
-      .def(
-          "constant_cam_positions", &BACfg::ConstantCamPositions, "image_id"_a);
-  MakeDataclass(PyBundleAdjustmentConfig);
 
   class PyBundleAdjuster : public BundleAdjuster {
    public:


### PR DESCRIPTION
* Defines a single consistent abstract interface for bundle adjustment.
* Reuses functionality between different bundle adjusters using composition rather than inheritance.
* Extracts the pose prior alignment to the alignment module. Ideally needs tests but this remains a TODO.
* The problem setup is now performed when the bundle adjuster is created and, as such, disentangled from the solving of the problem. This renders the current awkward SetUpProblem unnecessary.
* The idea later is then to pass a bundle adjuster object to a simplified covariance estimation interface.