### PR TITLE
Bind the estimation of Sim3d

### DIFF
--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -224,18 +224,16 @@ bool AlignReconstructionToLocations(
     return false;
   }
 
-  LORANSAC<SimilarityTransformEstimator<3, true>,
-           SimilarityTransformEstimator<3, true>>
-      ransac(ransac_options);
-
-  const auto report = ransac.Estimate(src, dst);
+  Sim3d tgt_from_src_;
+  const auto report =
+      EstimateSim3dRobust(src, dst, ransac_options, tgt_from_src_);
 
   if (report.support.num_inliers < static_cast<size_t>(min_common_images)) {
     return false;
   }
 
   if (tgt_from_src != nullptr) {
-    *tgt_from_src = Sim3d::FromMatrix(report.model);
+    *tgt_from_src = tgt_from_src_;
   }
 
   return true;
@@ -396,13 +394,8 @@ bool AlignReconstructionsViaPoints(const Reconstruction& src_reconstruction,
   RANSACOptions ransac_options;
   ransac_options.max_error = max_error;
   ransac_options.min_inlier_ratio = min_inlier_ratio;
-  LORANSAC<SimilarityTransformEstimator<3, true>,
-           SimilarityTransformEstimator<3, true>>
-      ransac(ransac_options);
-  const auto report = ransac.Estimate(src_xyz, tgt_xyz);
-  if (report.success) {
-    *tgt_from_src = Sim3d::FromMatrix(report.model);
-  }
+  const auto report =
+      EstimateSim3dRobust(src_xyz, tgt_xyz, ransac_options, *tgt_from_src);
   return report.success;
 }
 

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -266,21 +266,9 @@ bool AlignReconstructionToPosePriors(
   }
 
   if (ransac_options.max_error > 0) {
-    LORANSAC<SimilarityTransformEstimator<3, true>,
-             SimilarityTransformEstimator<3, true>>
-        ransac(ransac_options);
-
-    const auto report = ransac.Estimate(src, tgt);
-
-    if (report.success) {
-      *tgt_from_src = Sim3d::FromMatrix(report.model);
-      return true;
-    }
-  } else {
-    return EstimateSim3d(src, tgt, *tgt_from_src);
+    return EstimateSim3dRobust(src, tgt, ransac_options, *tgt_from_src).success;
   }
-
-  return false;
+  return EstimateSim3d(src, tgt, *tgt_from_src);
 }
 
 bool AlignReconstructionsViaReprojections(

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -1035,17 +1035,8 @@ bool PosePriorBundleAdjuster::Sim3DAlignment(Reconstruction* reconstruction) {
     RANSACOptions ransac_options;
     ransac_options.max_error = prior_options_.ransac_max_error;
 
-    LORANSAC<SimilarityTransformEstimator<3, true>,
-             SimilarityTransformEstimator<3, true>>
-        ransac(ransac_options);
-
-    const auto report = ransac.Estimate(v_src, v_tgt);
-
-    if (report.success) {
-      // Apply sim3 transform
-      sim3_tform = Sim3d::FromMatrix(report.model);
-      success = true;
-    }
+    success =
+        EstimateSim3dRobust(v_src, v_tgt, ransac_options, sim3_tform).success;
   } else {
     success = EstimateSim3d(v_src, v_tgt, sim3_tform);
   }

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -30,6 +30,8 @@
 #pragma once
 
 #include "colmap/geometry/sim3.h"
+#include "colmap/optim/loransac.h"
+#include "colmap/optim/ransac.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
@@ -102,6 +104,22 @@ inline bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
   THROW_CHECK_EQ(models.size(), 1);
   tgt_from_src = Sim3d::FromMatrix(models[0]);
   return true;
+}
+
+template <bool kEstimateScale = true>
+inline typename RANSAC<SimilarityTransformEstimator<3, kEstimateScale>>::Report
+EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
+                    const std::vector<Eigen::Vector3d>& tgt,
+                    const RANSACOptions& options,
+                    Sim3d& tgt_from_src) {
+  LORANSAC<SimilarityTransformEstimator<3, kEstimateScale>,
+           SimilarityTransformEstimator<3, kEstimateScale>>
+      ransac(options);
+  const auto report = ransac.Estimate(src, tgt);
+  if (report.success) {
+    tgt_from_src = Sim3d::FromMatrix(report.model);
+  }
+  return report;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -115,7 +115,7 @@ EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
   LORANSAC<SimilarityTransformEstimator<3, kEstimateScale>,
            SimilarityTransformEstimator<3, kEstimateScale>>
       ransac(options);
-  const auto report = ransac.Estimate(src, tgt);
+  auto report = ransac.Estimate(src, tgt);
   if (report.success) {
     tgt_from_src = Sim3d::FromMatrix(report.model);
   }

--- a/src/colmap/optim/loransac_test.cc
+++ b/src/colmap/optim/loransac_test.cc
@@ -52,56 +52,5 @@ TEST(LORANSAC, Report) {
   EXPECT_EQ(report.inlier_mask.size(), 0);
 }
 
-TEST(LORANSAC, SimilarityTransform) {
-  SetPRNGSeed(0);
-
-  const size_t num_samples = 1000;
-  const size_t num_outliers = 400;
-
-  // Create some arbitrary transformation.
-  const Sim3d expectedTgtFromSrc(
-      2, Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d(100, 10, 10));
-
-  // Generate exact data
-  std::vector<Eigen::Vector3d> src;
-  std::vector<Eigen::Vector3d> tgt;
-  for (size_t i = 0; i < num_samples; ++i) {
-    src.emplace_back(i, std::sqrt(i) + 2, std::sqrt(2 * i + 2));
-    tgt.push_back(expectedTgtFromSrc * src.back());
-  }
-
-  // Add some faulty data.
-  for (size_t i = 0; i < num_outliers; ++i) {
-    tgt[i] = Eigen::Vector3d(RandomUniformReal(-3000.0, -2000.0),
-                             RandomUniformReal(-4000.0, -3000.0),
-                             RandomUniformReal(-5000.0, -4000.0));
-  }
-
-  // Robustly estimate transformation using RANSAC.
-  RANSACOptions options;
-  options.max_error = 10;
-  LORANSAC<SimilarityTransformEstimator<3>, SimilarityTransformEstimator<3>>
-      ransac(options);
-  const auto report = ransac.Estimate(src, tgt);
-
-  EXPECT_TRUE(report.success);
-  EXPECT_GT(report.num_trials, 0);
-
-  // Make sure outliers were detected correctly.
-  EXPECT_EQ(report.support.num_inliers, num_samples - num_outliers);
-  for (size_t i = 0; i < num_samples; ++i) {
-    if (i < num_outliers) {
-      EXPECT_FALSE(report.inlier_mask[i]);
-    } else {
-      EXPECT_TRUE(report.inlier_mask[i]);
-    }
-  }
-
-  // Make sure original transformation is estimated correctly.
-  const double matrix_diff =
-      (expectedTgtFromSrc.ToMatrix() - report.model).norm();
-  EXPECT_LT(matrix_diff, 1e-6);
-}
-
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/estimators/bindings.cc
+++ b/src/pycolmap/estimators/bindings.cc
@@ -12,6 +12,7 @@ void BindFundamentalMatrixEstimator(py::module& m);
 void BindGeneralizedAbsolutePoseEstimator(py::module& m);
 void BindHomographyMatrixEstimator(py::module& m);
 void BindManifold(py::module& m);
+void BindSimilarityTransformEstimator(py::module& m);
 void BindTriangulationEstimator(py::module& m);
 void BindTwoViewGeometryEstimator(py::module& m);
 
@@ -26,6 +27,7 @@ void BindEstimators(py::module& m) {
   BindGeneralizedAbsolutePoseEstimator(m);
   BindHomographyMatrixEstimator(m);
   BindManifold(m);
+  BindSimilarityTransformEstimator(m);
   BindTriangulationEstimator(m);
   BindTwoViewGeometryEstimator(m);
 }

--- a/src/pycolmap/estimators/similarity_transform.cc
+++ b/src/pycolmap/estimators/similarity_transform.cc
@@ -1,0 +1,66 @@
+#include "colmap/estimators/similarity_transform.h"
+
+#include "colmap/math/random.h"
+#include "colmap/optim/loransac.h"
+#include "colmap/util/logging.h"
+
+#include "pycolmap/pybind11_extension.h"
+#include "pycolmap/utils.h"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+py::typing::Optional<py::dict> PyEstimateSim3dRobust(
+    const std::vector<Eigen::Vector3d>& src,
+    const std::vector<Eigen::Vector3d>& tgt,
+    const RANSACOptions& options) {
+  THROW_CHECK_EQ(src.size(), tgt.size());
+  py::gil_scoped_release release;
+  LORANSAC<SimilarityTransformEstimator<3, true>,
+           SimilarityTransformEstimator<3, true>>
+      ransac(options);
+
+  const auto report = ransac.Estimate(src, tgt);
+  py::gil_scoped_acquire acquire;
+  if (!report.success) {
+    return py::none();
+  }
+  return py::dict("tgt_from_src"_a = Sim3d::FromMatrix(report.model),
+                  "num_inliers"_a = report.support.num_inliers,
+                  "inliers"_a = ToPythonMask(report.inlier_mask));
+}
+
+void BindSimilarityTransformEstimator(py::module& m) {
+  auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
+
+  m.def(
+      "estimate_sim3d",
+      [](const std::vector<Eigen::Vector3d>& src,
+         const std::vector<Eigen::Vector3d>& tgt)
+          -> py::typing::Optional<Sim3d> {
+        py::gil_scoped_release release;
+        Sim3d tgt_from_src;
+        const bool success = EstimateSim3d(src, tgt, tgt_from_src);
+        py::gil_scoped_acquire acquire;
+        if (success) {
+          return py::cast(tgt_from_src);
+        } else {
+          return py::none();
+        }
+      },
+      "points3D_src"_a,
+      "points3D_tgt"_a,
+      "Estimate the 3D similarity transform tgt_T_src.");
+
+  m.def("estimate_sim3d_robust",
+        &PyEstimateSim3dRobust,
+        "points3D_src"_a,
+        "points3D_tgt"_a,
+        py::arg_v("estimation_options", est_options, "RANSACOptions()"),
+        "Estimate the 3D similarity transform in a robust way with LORANSAC.");
+}


### PR DESCRIPTION
Test:
```python
import pycolmap
import numpy as np

tgt_from_src = pycolmap.Sim3d(3, np.random.RandomState(0).randn(3), np.arange(3)+1)
n_points = 50
p_src = np.random.RandomState(1).randn(n_points, 3)
p_tgt = tgt_from_src * p_src

tgt_from_src_est = pycolmap.estimate_sim3d(p_src, p_tgt)
print('least-squares:')
print(tgt_from_src)
print(tgt_from_src_est)

inlier_ratio = 0.5
n_inliers = int(inlier_ratio * n_points)
n_outliers = n_points - n_inliers
for i in np.random.RandomState(2).choice(n_points, n_outliers, replace=False):
    p_src[i] = np.random.RandomState(i).randn() * 10
max_error = 0.1
ret = pycolmap.estimate_sim3d_robust(p_src, p_tgt, {"max_error": max_error})
n_inliers_real = np.count_nonzero(np.linalg.norm(p_tgt - tgt_from_src * p_src, axis=1) < max_error)
print('robust:')
print(ret["tgt_from_src"], ret["num_inliers"], n_inliers_real, n_inliers)
```