### PR TITLE
Initialize glog in custom gmock main function

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       matrix:
         config: [
-          {
-            os: windows-2019,
-            cmakeBuildType: Release,
-            cudaEnabled: false,
-            testsEnabled: true,
-            exportPackage: false,
-          },
+          # {
+          #   os: windows-2019,
+          #   cmakeBuildType: Release,
+          #   cudaEnabled: false,
+          #   testsEnabled: true,
+          #   exportPackage: false,
+          # },
           {
             os: windows-2022,
             cmakeBuildType: Release,

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       matrix:
         config: [
-          # {
-          #   os: windows-2019,
-          #   cmakeBuildType: Release,
-          #   cudaEnabled: false,
-          #   testsEnabled: true,
-          #   exportPackage: false,
-          # },
+          {
+            os: windows-2019,
+            cmakeBuildType: Release,
+            cudaEnabled: false,
+            testsEnabled: true,
+            exportPackage: false,
+          },
           {
             os: windows-2022,
             cmakeBuildType: Release,

--- a/cmake/CMakeHelper.cmake
+++ b/cmake/CMakeHelper.cmake
@@ -133,9 +133,7 @@ macro(COLMAP_ADD_TEST)
         endif()
         target_link_libraries(${COLMAP_ADD_TEST_NAME}
             ${COLMAP_ADD_TEST_LINK_LIBS}
-            GTest::gtest
-            GTest::gmock
-            GTest::gmock_main)
+            colmap_gtest_main)
         add_test("${FOLDER_NAME}/${COLMAP_ADD_TEST_NAME}" ${COLMAP_ADD_TEST_NAME})
         if(IS_MSVC)
             install(TARGETS ${COLMAP_ADD_TEST_NAME} DESTINATION bin/)

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -203,7 +203,7 @@ TEST(IncrementalPipeline, PriorBasedSfMNoNoise) {
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_cameras = 2;
-  synthetic_dataset_options.num_images = 7;
+  synthetic_dataset_options.num_images = 10;
   synthetic_dataset_options.num_points3D = 100;
   synthetic_dataset_options.point2D_stddev = 0.5;
 
@@ -213,7 +213,6 @@ TEST(IncrementalPipeline, PriorBasedSfMNoNoise) {
 
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
-
   mapper_options->use_prior_position = true;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
@@ -279,8 +278,8 @@ TEST(IncrementalPipeline, GPSPriorBasedSfMWithNoise) {
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_cameras = 2;
-  synthetic_dataset_options.num_images = 17;
-  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.num_images = 10;
+  synthetic_dataset_options.num_points3D = 100;
   synthetic_dataset_options.point2D_stddev = 0.5;
 
   synthetic_dataset_options.use_prior_position = true;

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -697,7 +697,7 @@ std::vector<std::pair<image_t, image_t>> TransitivePairGenerator::Next() {
             database.ReadTwoViewGeometryNumInliers();
       });
 
-  std::unordered_map<image_t, std::vector<image_t>> adjacency;
+  std::map<image_t, std::vector<image_t>> adjacency;
   for (const auto& [pair_id, _] : existing_pair_ids_and_num_inliers) {
     const auto [image_id1, image_id2] = Database::PairIdToImagePair(pair_id);
     adjacency[image_id1].push_back(image_id2);
@@ -721,7 +721,7 @@ std::vector<std::pair<image_t, image_t>> TransitivePairGenerator::Next() {
         if (image_pair_ids_.count(image_pair_id) != 0) {
           continue;
         }
-        image_pairs_.emplace_back(image_id1, image_id3);
+        image_pairs_.emplace_back(std::minmax(image_id1, image_id3));
         image_pair_ids_.insert(image_pair_id);
       }
     }

--- a/src/colmap/feature/pairing_test.cc
+++ b/src/colmap/feature/pairing_test.cc
@@ -294,14 +294,14 @@ TEST(TransitivePairGenerator, Nominal) {
   const auto pairs1 = generator.Next();
   EXPECT_THAT(pairs1,
               testing::UnorderedElementsAre(
-                  std::make_pair(images[2].ImageId(), images[1].ImageId()),
-                  std::make_pair(images[3].ImageId(), images[0].ImageId())));
+                  std::make_pair(images[1].ImageId(), images[2].ImageId()),
+                  std::make_pair(images[0].ImageId(), images[3].ImageId())));
   for (const auto& pair : pairs1) {
     database->WriteTwoViewGeometry(pair.first, pair.second, two_view_geometry);
   }
   EXPECT_THAT(generator.Next(),
               testing::ElementsAre(
-                  std::make_pair(images[3].ImageId(), images[2].ImageId())));
+                  std::make_pair(images[2].ImageId(), images[3].ImageId())));
   EXPECT_TRUE(generator.Next().empty());
   EXPECT_TRUE(generator.HasFinished());
 }

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -247,7 +247,7 @@ bool DatabaseCache::SetupPosePriors() {
   std::vector<Eigen::Vector3d> v_gps_prior;
   v_gps_prior.reserve(NumPosePriors());
 
-  for (const auto& image_id : image_ids_with_prior) {
+  for (const image_t image_id : image_ids_with_prior) {
     const struct PosePrior& pose_prior = PosePrior(image_id);
     if (pose_prior.coordinate_system != PosePrior::CoordinateSystem::WGS84) {
       prior_is_gps = false;
@@ -273,7 +273,7 @@ bool DatabaseCache::SetupPosePriors() {
       struct PosePrior& pose_prior = PosePrior(image_id);
       pose_prior.position = *xyz_prior_it;
       pose_prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
-      xyz_prior_it++;
+      ++xyz_prior_it;
     }
   } else if (!prior_is_gps && !v_gps_prior.empty()) {
     LOG(ERROR)

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -318,7 +318,7 @@ void ReadCamerasBinary(Reconstruction& reconstruction, std::istream& stream) {
 
 void ReadCamerasBinary(Reconstruction& reconstruction,
                        const std::string& path) {
-  std::ifstream file(path);
+  std::ifstream file(path, std::ios::binary);
   THROW_CHECK_FILE_OPEN(file, path);
   ReadCamerasBinary(reconstruction, file);
 }
@@ -382,7 +382,7 @@ void ReadImagesBinary(Reconstruction& reconstruction, std::istream& stream) {
 }
 
 void ReadImagesBinary(Reconstruction& reconstruction, const std::string& path) {
-  std::ifstream file(path);
+  std::ifstream file(path, std::ios::binary);
   THROW_CHECK_FILE_OPEN(file, path);
   ReadImagesBinary(reconstruction, file);
 }
@@ -418,7 +418,7 @@ void ReadPoints3DBinary(Reconstruction& reconstruction, std::istream& stream) {
 
 void ReadPoints3DBinary(Reconstruction& reconstruction,
                         const std::string& path) {
-  std::ifstream file(path);
+  std::ifstream file(path, std::ios::binary);
   THROW_CHECK_FILE_OPEN(file, path);
   ReadPoints3DBinary(reconstruction, file);
 }

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -81,14 +81,16 @@ if(CUDA_ENABLED)
     )
 endif()
 
-COLMAP_ADD_LIBRARY(
-    NAME colmap_gtest_main
-    SRCS
-        gtest_main.cc
-    PUBLIC_LINK_LIBS
-        glog::glog
-        GTest::gmock_main
-)
+if(TESTS_ENABLED)
+    COLMAP_ADD_LIBRARY(
+        NAME colmap_gtest_main
+        SRCS
+            gtest_main.cc
+        PUBLIC_LINK_LIBS
+            glog::glog
+            GTest::gmock_main
+    )
+endif()
 
 COLMAP_ADD_TEST(
     NAME cache_test

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -81,6 +81,15 @@ if(CUDA_ENABLED)
     )
 endif()
 
+COLMAP_ADD_LIBRARY(
+    NAME colmap_gtest_main
+    SRCS
+        gtest_main.cc
+    PUBLIC_LINK_LIBS
+        glog::glog
+        GTest::gmock_main
+)
+
 COLMAP_ADD_TEST(
     NAME cache_test
     SRCS cache_test.cc

--- a/src/colmap/util/gtest_main.cc
+++ b/src/colmap/util/gtest_main.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Without the custom main function introduced in this PR, we get warnings about glog not being initialized, since the default gtest/gmock main functions do not initialize glog.