### PR TITLE
Consistent interface and various improvements for pycolmap/estimators

### DIFF
--- a/src/pycolmap/estimators/alignment.cc
+++ b/src/pycolmap/estimators/alignment.cc
@@ -92,14 +92,14 @@ void BindAlignmentEstimator(py::module& m) {
   m.def(
       "align_reconstruction_to_locations",
       [](const Reconstruction& src,
-         const std::vector<std::string>& image_names,
-         const std::vector<Eigen::Vector3d>& locations,
+         const std::vector<std::string>& tgt_image_names,
+         const std::vector<Eigen::Vector3d>& tgt_locations,
          const int min_common_images,
          const RANSACOptions& ransac_options) -> py::typing::Optional<Sim3d> {
         Sim3d locations_from_src;
         if (!AlignReconstructionToLocations(src,
-                                            image_names,
-                                            locations,
+                                            tgt_image_names,
+                                            tgt_locations,
                                             min_common_images,
                                             ransac_options,
                                             &locations_from_src)) {
@@ -108,8 +108,8 @@ void BindAlignmentEstimator(py::module& m) {
         return py::cast(locations_from_src);
       },
       "src"_a,
-      "image_names"_a,
-      "locations"_a,
+      "tgt_image_names"_a,
+      "tgt_locations"_a,
       "min_common_points"_a,
       "ransac_options"_a);
 

--- a/src/pycolmap/estimators/essential_matrix.cc
+++ b/src/pycolmap/estimators/essential_matrix.cc
@@ -7,6 +7,7 @@
 #include "colmap/scene/camera.h"
 #include "colmap/util/logging.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/pybind11_extension.h"
 #include "pycolmap/utils.h"
 
@@ -21,77 +22,76 @@ namespace py = pybind11;
 py::typing::Optional<py::dict> PyEstimateAndDecomposeEssentialMatrix(
     const std::vector<Eigen::Vector2d>& points2D1,
     const std::vector<Eigen::Vector2d>& points2D2,
-    Camera& camera1,
-    Camera& camera2,
+    const Camera& camera1,
+    const Camera& camera2,
     const RANSACOptions& options) {
   py::gil_scoped_release release;
+
   THROW_CHECK_EQ(points2D1.size(), points2D2.size());
-  std::vector<Eigen::Vector2d> world_points2D1;
-  for (size_t idx = 0; idx < points2D1.size(); ++idx) {
-    world_points2D1.push_back(camera1.CamFromImg(points2D1[idx]));
-  }
-  std::vector<Eigen::Vector2d> world_points2D2;
-  for (size_t idx = 0; idx < points2D2.size(); ++idx) {
-    world_points2D2.push_back(camera2.CamFromImg(points2D2[idx]));
+  const size_t num_points2D = points2D1.size();
+
+  std::vector<Eigen::Vector2d> cam_points2D1(num_points2D);
+  std::vector<Eigen::Vector2d> cam_points2D2(num_points2D);
+  for (size_t point2D_idx = 0; point2D_idx < num_points2D; ++point2D_idx) {
+    cam_points2D1[point2D_idx] = camera1.CamFromImg(points2D1[point2D_idx]);
+    cam_points2D2[point2D_idx] = camera2.CamFromImg(points2D2[point2D_idx]);
   }
 
   const double max_error_px = options.max_error;
-  const double max_error = 0.5 * (max_error_px / camera1.MeanFocalLength() +
-                                  max_error_px / camera2.MeanFocalLength());
   RANSACOptions ransac_options(options);
-  ransac_options.max_error = max_error;
+  ransac_options.max_error = 0.5 * (max_error_px / camera1.MeanFocalLength() +
+                                    max_error_px / camera2.MeanFocalLength());
 
   LORANSAC<EssentialMatrixFivePointEstimator, EssentialMatrixFivePointEstimator>
       ransac(ransac_options);
 
   // Essential matrix estimation.
-  const auto report = ransac.Estimate(world_points2D1, world_points2D2);
+  const auto report = ransac.Estimate(cam_points2D1, cam_points2D2);
 
   if (!report.success) {
     py::gil_scoped_acquire acquire;
     return py::none();
   }
 
-  // Recover data from report.
-  const Eigen::Matrix3d E = report.model;
-  const size_t num_inliers = report.support.num_inliers;
-  const auto& inlier_mask = report.inlier_mask;
-
   // Pose from essential matrix.
-  std::vector<Eigen::Vector2d> inlier_world_points2D1;
-  std::vector<Eigen::Vector2d> inlier_world_points2D2;
-
-  for (size_t idx = 0; idx < inlier_mask.size(); ++idx) {
-    if (inlier_mask[idx]) {
-      inlier_world_points2D1.push_back(world_points2D1[idx]);
-      inlier_world_points2D2.push_back(world_points2D2[idx]);
+  std::vector<Eigen::Vector2d> inlier_cam_points2D1;
+  inlier_cam_points2D1.reserve(inlier_cam_points2D1.size());
+  std::vector<Eigen::Vector2d> inlier_cam_points2D2;
+  inlier_cam_points2D1.reserve(inlier_cam_points2D2.size());
+  for (size_t point2D_idx = 0; point2D_idx < num_points2D; ++point2D_idx) {
+    if (report.inlier_mask[point2D_idx]) {
+      inlier_cam_points2D1.push_back(cam_points2D1[point2D_idx]);
+      inlier_cam_points2D2.push_back(cam_points2D2[point2D_idx]);
     }
   }
 
   Rigid3d cam2_from_cam1;
-  std::vector<Eigen::Vector3d> points3D;
-  PoseFromEssentialMatrix(E,
-                          inlier_world_points2D1,
-                          inlier_world_points2D2,
+  std::vector<Eigen::Vector3d> inlier_points3D;
+  PoseFromEssentialMatrix(report.model,
+                          inlier_cam_points2D1,
+                          inlier_cam_points2D2,
                           &cam2_from_cam1,
-                          &points3D);
+                          &inlier_points3D);
 
   py::gil_scoped_acquire acquire;
-  return py::dict("E"_a = E,
+  return py::dict("E"_a = report.model,
                   "cam2_from_cam1"_a = cam2_from_cam1,
-                  "num_inliers"_a = num_inliers,
-                  "inliers"_a = ToPythonMask(inlier_mask));
+                  "num_inliers"_a = report.support.num_inliers,
+                  "inlier_mask"_a = ToPythonMask(report.inlier_mask),
+                  "inlier_points3D"_a = inlier_points3D);
 }
 
 void BindEssentialMatrixEstimator(py::module& m) {
-  auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
+  auto ransac_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
-  m.def("essential_matrix_estimation",
+  m.def("estimate_essential_matrix",
         &PyEstimateAndDecomposeEssentialMatrix,
         "points2D1"_a,
         "points2D2"_a,
         "camera1"_a,
         "camera2"_a,
-        py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-        "LORANSAC + 5-point algorithm.");
+        py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
+        "Robustly estimate essential matrix with LO-RANSAC and decompose it "
+        "using the cheirality check.");
+  DefDeprecation(m, "essential_matrix_estimation", "estimate_essential_matrix");
 }

--- a/src/pycolmap/estimators/fundamental_matrix.cc
+++ b/src/pycolmap/estimators/fundamental_matrix.cc
@@ -5,6 +5,7 @@
 #include "colmap/scene/camera.h"
 #include "colmap/util/logging.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/pybind11_extension.h"
 #include "pycolmap/utils.h"
 
@@ -31,19 +32,20 @@ py::typing::Optional<py::dict> PyEstimateFundamentalMatrix(
     return py::none();
   }
 
-  const Eigen::Matrix3d F = report.model;
-  return py::dict("F"_a = F,
+  return py::dict("F"_a = report.model,
                   "num_inliers"_a = report.support.num_inliers,
-                  "inliers"_a = ToPythonMask(report.inlier_mask));
+                  "inlier_mask"_a = ToPythonMask(report.inlier_mask));
 }
 
 void BindFundamentalMatrixEstimator(py::module& m) {
-  auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
+  auto ransac_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
   m.def("fundamental_matrix_estimation",
         &PyEstimateFundamentalMatrix,
         "points2D1"_a,
         "points2D2"_a,
-        py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-        "LORANSAC + 7-point algorithm.");
+        py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
+        "Robustly estimate fundamental matrix with LO-RANSAC.");
+  DefDeprecation(
+      m, "fundamental_matrix_estimation", "estimate_fundamental_matrix");
 }

--- a/src/pycolmap/estimators/homography_matrix.cc
+++ b/src/pycolmap/estimators/homography_matrix.cc
@@ -4,6 +4,7 @@
 #include "colmap/optim/loransac.h"
 #include "colmap/util/logging.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/pybind11_extension.h"
 #include "pycolmap/utils.h"
 
@@ -21,26 +22,27 @@ py::typing::Optional<py::dict> PyEstimateHomographyMatrix(
     const RANSACOptions& options) {
   py::gil_scoped_release release;
   THROW_CHECK_EQ(points2D1.size(), points2D2.size());
-  LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
+  LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> ransac(
       options);
-  const auto report = H_ransac.Estimate(points2D1, points2D2);
+  const auto report = ransac.Estimate(points2D1, points2D2);
   py::gil_scoped_acquire acquire;
   if (!report.success) {
     return py::none();
   }
-  const Eigen::Matrix3d H = report.model;
-  return py::dict("H"_a = H,
+  return py::dict("H"_a = report.model,
                   "num_inliers"_a = report.support.num_inliers,
-                  "inliers"_a = ToPythonMask(report.inlier_mask));
+                  "inlier_mask"_a = ToPythonMask(report.inlier_mask));
 }
 
 void BindHomographyMatrixEstimator(py::module& m) {
   auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
-  m.def("homography_matrix_estimation",
+  m.def("estimate_homography_matrix",
         &PyEstimateHomographyMatrix,
         "points2D1"_a,
         "points2D2"_a,
         py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-        "LORANSAC + 4-point DLT algorithm.");
+        "Robustly estimate homography matrix using LO-RANSAC.");
+  DefDeprecation(
+      m, "homography_matrix_estimation", "estimate_homography_matrix");
 }

--- a/src/pycolmap/estimators/similarity_transform.cc
+++ b/src/pycolmap/estimators/similarity_transform.cc
@@ -16,7 +16,7 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindSimilarityTransformEstimator(py::module& m) {
-  auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
+  auto ransac_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
   m.def(
       "estimate_sim3d",
@@ -33,9 +33,9 @@ void BindSimilarityTransformEstimator(py::module& m) {
           return py::none();
         }
       },
-      "points3D_src"_a,
-      "points3D_tgt"_a,
-      "Estimate the 3D similarity transform tgt_T_src.");
+      "src"_a,
+      "tgt"_a,
+      "Estimate the 3D similarity transform tgt_from_src.");
 
   m.def(
       "estimate_sim3d_robust",
@@ -54,8 +54,9 @@ void BindSimilarityTransformEstimator(py::module& m) {
                         "num_inliers"_a = report.support.num_inliers,
                         "inliers"_a = ToPythonMask(report.inlier_mask));
       },
-      "points3D_src"_a,
-      "points3D_tgt"_a,
-      py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-      "Estimate the 3D similarity transform in a robust way with LORANSAC.");
+      "src"_a,
+      "tgt"_a,
+      py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
+      "Robustly estimate the 3D similarity transform tgt_from_src using "
+      "LO-RANSAC.");
 }

--- a/src/pycolmap/estimators/similarity_transform.cc
+++ b/src/pycolmap/estimators/similarity_transform.cc
@@ -52,7 +52,7 @@ void BindSimilarityTransformEstimator(py::module& m) {
         }
         return py::dict("tgt_from_src"_a = Sim3d::FromMatrix(report.model),
                         "num_inliers"_a = report.support.num_inliers,
-                        "inliers"_a = ToPythonMask(report.inlier_mask));
+                        "inlier_mask"_a = ToPythonMask(report.inlier_mask));
       },
       "src"_a,
       "tgt"_a,

--- a/src/pycolmap/estimators/triangulation.cc
+++ b/src/pycolmap/estimators/triangulation.cc
@@ -66,5 +66,5 @@ void BindTriangulationEstimator(py::module& m) {
                   EstimateTriangulationOptions(),
                   "EstimateTriangulationOptions()"),
         "Robustly estimate 3D point from observations in multiple views using "
-        "RANSAC");
+        "LO-RANSAC");
 }

--- a/src/pycolmap/estimators/two_view_geometry.cc
+++ b/src/pycolmap/estimators/two_view_geometry.cc
@@ -112,7 +112,7 @@ void BindTwoViewGeometryEstimator(py::module& m) {
         "geometry"_a);
 
   m.def(
-      "squared_sampson_error",
+      "compute_squared_sampson_error",
       [](const std::vector<Eigen::Vector2d>& points1,
          const std::vector<Eigen::Vector2d>& points2,
          const Eigen::Matrix3d& E) {
@@ -126,4 +126,5 @@ void BindTwoViewGeometryEstimator(py::module& m) {
       "Calculate the squared Sampson error for a given essential or "
       "fundamental matrix.",
       py::call_guard<py::gil_scoped_release>());
+  DefDeprecation(m, "squared_sampson_error", "compute_squared_sampson_error");
 }

--- a/src/pycolmap/helpers.h
+++ b/src/pycolmap/helpers.h
@@ -28,7 +28,7 @@ const Eigen::IOFormat vec_fmt(Eigen::StreamPrecision,
                               ", ");
 
 template <typename T>
-T pyStringToEnum(const py::enum_<T>& enm, const std::string& value) {
+T PyStringToEnum(const py::enum_<T>& enm, const std::string& value) {
   const auto values = enm.attr("__members__").template cast<py::dict>();
   const auto str_val = py::str(value);
   if (!values.contains(str_val)) {
@@ -41,7 +41,7 @@ T pyStringToEnum(const py::enum_<T>& enm, const std::string& value) {
 template <typename T>
 void AddStringToEnumConstructor(py::enum_<T>& enm) {
   enm.def(py::init([enm](const std::string& value) {
-    return pyStringToEnum(enm, py::str(value));  // str constructor
+    return PyStringToEnum(enm, py::str(value));  // str constructor
   }));
   py::implicitly_convertible<std::string, T>();
 }
@@ -405,4 +405,19 @@ inline bool IsPyceresAvailable() {
     return false;
   }
   return true;
+}
+
+template <typename Parent>
+inline void DefDeprecation(Parent& parent,
+                           const std::string& old_name,
+                           const std::string& new_name) {
+  parent.def(old_name.c_str(),
+             [parent, old_name, new_name](const py::args& args,
+                                          const py::kwargs& kwargs) {
+               std::ostringstream warning;
+               warning << old_name << "() is deprecated, use " << new_name
+                       << "() instead.";
+               PyErr_WarnEx(PyExc_DeprecationWarning, warning.str().c_str(), 1);
+               return parent.attr(new_name.c_str())(*args, **kwargs);
+             });
 }


### PR DESCRIPTION
With a best effort of raising deprecation warnings for  renamed function names. For example:
```
>>> pycolmap.essential_matrix_estimation()
<stdin>:1: DeprecationWarning: essential_matrix_estimation() is deprecated, use estimate_essential_matrix() instead.
...
```
Other modules follow in separate PRs.