### PR TITLE
Enable reading 16bit/channel (png) images to grayscale

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -579,6 +579,10 @@ bool Bitmap::Read(const std::string& path, const bool as_rgb) {
     FIBITMAP* converted_bitmap = FreeImage_ConvertTo24Bits(handle_.ptr);
     handle_ = FreeImageHandle(converted_bitmap);
   } else if (!IsPtrGrey(handle_.ptr) && !as_rgb) {
+    if (FreeImage_GetBPP(handle_.ptr) != 24) {
+      FIBITMAP* converted_bitmap_24 = FreeImage_ConvertTo24Bits(handle_.ptr);
+      handle_ = FreeImageHandle(converted_bitmap_24);
+    }
     FIBITMAP* converted_bitmap = FreeImage_ConvertToGreyscale(handle_.ptr);
     handle_ = FreeImageHandle(converted_bitmap);
   }


### PR DESCRIPTION
Hello ! I had some issues reading 16bit per channel pngs with the feature extractor. I tracked the issue to [this line](https://github.com/colmap/colmap/blob/ec2180683006fced762994b42fda6df03e140ff7/src/colmap/sensor/bitmap.cc#L582) returning a null pointer. 

Turns out FreeImage cant transform these images directly into grayscale as described [here](https://sourceforge.net/p/freeimage/discussion/36110/thread/a886679e68/). This happens at line 104 in the FreeImage Conversion8.cpp file:

```C++
FIBITMAP * DLL_CALLCONV
FreeImage_ConvertTo8Bits(FIBITMAP *dib) {  // Called by FreeImage_ConvertToGreyscale
	if (!FreeImage_HasPixels(dib)) {
		return NULL;
	}

	const FREE_IMAGE_TYPE image_type = FreeImage_GetImageType(dib);
	if (image_type != FIT_BITMAP && image_type != FIT_UINT16) {   // <----- Here -----
		return NULL;
	}
	...
```

My solution is just transforming the image to 8bits per channel before transforming to grayscale.