### PR TITLE
Cleanup of remaining pycolmap interfaces

### DIFF
--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -1,4 +1,3 @@
-#include "colmap/geometry/essential_matrix.h"
 #include "colmap/geometry/gps.h"
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/rigid3.h"
@@ -19,11 +18,10 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-void BindHomographyGeometry(py::module& m);
+void BindHomographyMatrixGeometry(py::module& m);
+void BindEssentialMatrixGeometry(py::module& m);
 
 void BindGeometry(py::module& m) {
-  BindHomographyGeometry(m);
-
   py::class_ext_<Eigen::Quaterniond> PyRotation3d(m, "Rotation3d");
   PyRotation3d.def(py::init([]() { return Eigen::Quaterniond::Identity(); }))
       .def(py::init<const Eigen::Vector4d&>(),
@@ -85,7 +83,6 @@ void BindGeometry(py::module& m) {
       .def_readwrite("translation", &Rigid3d::translation)
       .def("matrix", &Rigid3d::ToMatrix)
       .def("adjoint", &Rigid3d::Adjoint)
-      .def("essential_matrix", &EssentialMatrixFromPose)
       .def(py::self * Rigid3d())
       .def(py::self * Eigen::Vector3d())
       .def("__mul__",
@@ -162,4 +159,7 @@ void BindGeometry(py::module& m) {
       .def("is_valid", &PosePrior::IsValid)
       .def("is_covariance_valid", &PosePrior::IsCovarianceValid);
   MakeDataclass(PyPosePrior);
+
+  BindHomographyMatrixGeometry(m);
+  BindEssentialMatrixGeometry(m);
 }

--- a/src/pycolmap/geometry/essential_matrix.cc
+++ b/src/pycolmap/geometry/essential_matrix.cc
@@ -1,0 +1,20 @@
+#include "colmap/geometry/essential_matrix.h"
+
+#include "colmap/util/logging.h"
+
+#include "pycolmap/pybind11_extension.h"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+void BindEssentialMatrixGeometry(py::module& m) {
+  m.def("essential_matrix_from_pose",
+        &EssentialMatrixFromPose,
+        "cam2_from_cam1"_a,
+        "Construct essential matrix from relative pose.");
+}

--- a/src/pycolmap/geometry/homography_matrix.cc
+++ b/src/pycolmap/geometry/homography_matrix.cc
@@ -2,6 +2,7 @@
 
 #include "colmap/util/logging.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/pybind11_extension.h"
 
 #include <pybind11/eigen.h>
@@ -30,13 +31,15 @@ py::dict PyPoseFromHomographyMatrix(
                   "points3D"_a = points3D);
 }
 
-void BindHomographyGeometry(py::module& m) {
-  m.def("homography_decomposition",
+void BindHomographyMatrixGeometry(py::module& m) {
+  m.def("pose_from_homography_matrix",
         &PyPoseFromHomographyMatrix,
         "H"_a,
         "K1"_a,
         "K2"_a,
         "points1"_a,
         "points2"_a,
-        "Analytical Homography Decomposition.");
+        "Recover the most probable pose from the given homography matrix using "
+        "the cheirality check.");
+  DefDeprecation(m, "homography_decomposition", "pose_from_homography_matrix");
 }

--- a/src/pycolmap/pipeline/match_features.cc
+++ b/src/pycolmap/pipeline/match_features.cc
@@ -70,36 +70,6 @@ void verify_matches(const std::string& database_path,
 }
 
 void BindMatchFeatures(py::module& m) {
-  using SMOpts = SiftMatchingOptions;
-  auto PySiftMatchingOptions =
-      py::class_<SMOpts>(m, "SiftMatchingOptions")
-          .def(py::init<>())
-          .def_readwrite("num_threads", &SMOpts::num_threads)
-          .def_readwrite("gpu_index",
-                         &SMOpts::gpu_index,
-                         "Index of the GPU used for feature matching. For "
-                         "multi-GPU matching, "
-                         "you should separate multiple GPU indices by comma, "
-                         "e.g., \"0,1,2,3\".")
-          .def_readwrite(
-              "max_ratio",
-              &SMOpts::max_ratio,
-              "Maximum distance ratio between first and second best match.")
-          .def_readwrite("max_distance",
-                         &SMOpts::max_distance,
-                         "Maximum distance to best match.")
-          .def_readwrite("cross_check",
-                         &SMOpts::cross_check,
-                         "Whether to enable cross checking in matching.")
-          .def_readwrite("max_num_matches",
-                         &SMOpts::max_num_matches,
-                         "Maximum number of matches.")
-          .def_readwrite("guided_matching",
-                         &SMOpts::guided_matching,
-                         "Whether to perform guided matching, if geometric "
-                         "verification succeeds.");
-  MakeDataclass(PySiftMatchingOptions);
-
   using EMOpts = ExhaustiveMatchingOptions;
   auto PyExhaustiveMatchingOptions =
       py::class_<ExhaustiveMatchingOptions>(m, "ExhaustiveMatchingOptions")


### PR DESCRIPTION
For Sift, I want to move to a consistent set of options, where we use the C++ ones as the default. We'll issue a deprecation warning:
```
>>> import pycolmap
>>> pycolmap.Sift(pycolmap.SiftExtractionOptions())
I20241120 09:56:59.974107 202499 sift.cc:727] Creating SIFT CPU feature extractor
<pycolmap._core.Sift object at 0x106511230>
>>> pycolmap.Sift()
<stdin>:1: DeprecationWarning: No SIFT extraction options specified. Setting them to peak_threshold=0.01, first_octave=0, max_image_size=7000 for backwards compatibility. If you want to keep the settings, explicitly pass them, because the defaults will change in the next major release.
I20241120 09:57:04.519587 202499 sift.cc:727] Creating SIFT CPU feature extractor
<pycolmap._core.Sift object at 0x106325630>
```