### PR TITLE
Exclude DetectLineSegments if LSD is disabled

### DIFF
--- a/src/colmap/image/line.h
+++ b/src/colmap/image/line.h
@@ -47,9 +47,11 @@ enum class LineSegmentOrientation {
   UNDEFINED = 0,
 };
 
+#ifdef COLMAP_LSD_ENABLED
 // Detect line segments in the given bitmap image.
 std::vector<LineSegment> DetectLineSegments(const Bitmap& bitmap,
                                             double min_length = 3);
+#endif
 
 // Classify line segments into horizontal/vertical.
 std::vector<LineSegmentOrientation> ClassifyLineSegmentOrientations(

--- a/src/colmap/image/line_test.cc
+++ b/src/colmap/image/line_test.cc
@@ -34,6 +34,7 @@
 namespace colmap {
 namespace {
 
+#ifdef COLMAP_LSD_ENABLED
 TEST(DetectLineSegments, Nominal) {
   Bitmap bitmap;
   bitmap.Allocate(100, 100, false);
@@ -77,6 +78,7 @@ TEST(ClassifyLineSegmentOrientations, Nominal) {
   EXPECT_TRUE(orientations[4] == LineSegmentOrientation::UNDEFINED);
   EXPECT_TRUE(orientations[5] == LineSegmentOrientation::UNDEFINED);
 }
+#endif
 
 }  // namespace
 }  // namespace colmap


### PR DESCRIPTION
We could alternatively exclude colmap/image/line altogether.