### PR TITLE
fix LORANSAC::Estimate compilation error when build with visual studio C++ 17

### DIFF
--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -89,7 +89,7 @@ template <typename Estimator,
           typename LocalEstimator,
           typename SupportMeasurer,
           typename Sampler>
-typename LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Report
+typename RANSAC<Estimator, SupportMeasurer, Sampler>::Report
 LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
     const std::vector<typename Estimator::X_t>& X,
     const std::vector<typename Estimator::Y_t>& Y) {


### PR DESCRIPTION
when build latest master branch of GLOMAP on windows with visual studio 2017, I found this compilation error, and found that colmap is using C++14 , but glomap is using C++17, which cause this problem.
