### PR TITLE
Improvements to deprecated pycolmap members

### DIFF
--- a/src/pycolmap/estimators/fundamental_matrix.cc
+++ b/src/pycolmap/estimators/fundamental_matrix.cc
@@ -40,7 +40,7 @@ py::typing::Optional<py::dict> PyEstimateFundamentalMatrix(
 void BindFundamentalMatrixEstimator(py::module& m) {
   auto ransac_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
-  m.def("fundamental_matrix_estimation",
+  m.def("estimate_fundamental_matrix",
         &PyEstimateFundamentalMatrix,
         "points2D1"_a,
         "points2D2"_a,

--- a/src/pycolmap/helpers.h
+++ b/src/pycolmap/helpers.h
@@ -414,6 +414,8 @@ inline void DefDeprecation(
     std::string old_name,
     std::string new_name,
     std::optional<std::string> custom_warning = std::nullopt) {
+  const std::string doc =
+      StringPrintf("Deprecated, use ``%s`` instead.", new_name.c_str());
   parent.def(
       old_name.c_str(),
       [parent,
@@ -430,5 +432,6 @@ inline void DefDeprecation(
           PyErr_WarnEx(PyExc_DeprecationWarning, warning.str().c_str(), 1);
         }
         return parent.attr(new_name.c_str())(*args, **kwargs);
-      });
+      },
+      doc.c_str());
 }


### PR DESCRIPTION
- https://github.com/colmap/colmap/pull/2923 missed to rename `fundamental_matrix_estimation` to `estimate_fundamental_matrix`
- Display the deprecation in the doc
<img width="698" alt="Screenshot 2024-11-22 at 11 09 12" src="https://github.com/user-attachments/assets/2b51c830-2428-4ce6-8398-b6e923332005">
