### PR TITLE
Make sphinx show the pycolmap constructors

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,6 +273,7 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 # Configure how Python API docs are displayed.
+autoclass_content = "both"
 autodoc_member_order = "bysource"
 autodoc_typehints = "both"
 python_maximum_signature_line_length = 120


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/2892:
<img width="658" alt="image" src="https://github.com/user-attachments/assets/35c12cee-352b-44d2-b270-9b607c48de4f">


I will improve the rendering of overloads in a subsequent PR.