### PR TITLE
Introduce gmock Eigen matrix matchers

### DIFF
--- a/src/colmap/geometry/gps_test.cc
+++ b/src/colmap/geometry/gps_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/geometry/gps.h"
 
+#include "colmap/util/eigen_matchers.h"
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -53,7 +55,7 @@ TEST(GPS, EllToXYZGRS80) {
   const auto xyz = gps_tform.EllToXYZ(ell);
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(xyz[i].isApprox(ref_xyz[i], 1e-8));
+    EXPECT_THAT(xyz[i], EigenMatrixNear(ref_xyz[i], 1e-8));
   }
 }
 
@@ -76,7 +78,7 @@ TEST(GPS, EllToXYZWGS84) {
   const auto xyz = gps_tform.EllToXYZ(ell);
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(xyz[i].isApprox(ref_xyz[i], 1e-8));
+    EXPECT_THAT(xyz[i], EigenMatrixNear(ref_xyz[i], 1e-8));
   }
 }
 
@@ -99,7 +101,7 @@ TEST(GPS, XYZToEll_GRS80) {
   const auto ell = gps_tform.XYZToEll(xyz);
 
   for (size_t i = 0; i < xyz.size(); ++i) {
-    EXPECT_TRUE(ell[i].isApprox(ref_ell[i], 1e-5));
+    EXPECT_THAT(ell[i], EigenMatrixNear(ref_ell[i], 1e-5));
   }
 }
 
@@ -122,7 +124,7 @@ TEST(GPS, XYZToEll_WGS84) {
   const auto ell = gps_tform.XYZToEll(xyz);
 
   for (size_t i = 0; i < xyz.size(); ++i) {
-    EXPECT_TRUE(ell[i].isApprox(ref_ell[i], 1e-5));
+    EXPECT_THAT(ell[i], EigenMatrixNear(ref_ell[i], 1e-5));
   }
 }
 
@@ -139,7 +141,7 @@ TEST(GPS, XYZToEllToXYZ_GRS80) {
   const auto xyz2 = gps_tform.EllToXYZ(ell);
 
   for (size_t i = 0; i < xyz.size(); ++i) {
-    EXPECT_TRUE(xyz[i].isApprox(xyz2[i], 1e-5));
+    EXPECT_THAT(xyz[i], EigenMatrixNear(xyz2[i], 1e-5));
   }
 }
 
@@ -156,7 +158,7 @@ TEST(GPS, XYZToEllToXYZ_WGS84) {
   const auto xyz2 = gps_tform.EllToXYZ(ell);
 
   for (size_t i = 0; i < xyz.size(); ++i) {
-    EXPECT_TRUE(xyz[i].isApprox(xyz2[i], 1e-5));
+    EXPECT_THAT(xyz[i], EigenMatrixNear(xyz2[i], 1e-5));
   }
 }
 
@@ -186,7 +188,7 @@ TEST(GPS, EllToENUWGS84) {
   const auto enu = gps_tform.EllToENU(ell, ori_ell(0), ori_ell(1));
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(enu[i].isApprox(ref_enu[i], 1e-8));
+    EXPECT_THAT(enu[i], EigenMatrixNear(ref_enu[i], 1e-8));
   }
 }
 
@@ -218,7 +220,7 @@ TEST(GPS, XYZToENU) {
   const auto enu = gps_tform.XYZToENU(xyz, ori_ell(0), ori_ell(1));
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(enu[i].isApprox(ref_enu[i], 1e-8));
+    EXPECT_THAT(enu[i], EigenMatrixNear(ref_enu[i], 1e-8));
   }
 }
 
@@ -254,7 +256,7 @@ TEST(GPS, ENUToEllWGS84) {
   const auto ell = gps_tform.ENUToEll(enu, lat0, lon0, alt0);
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(ell[i].isApprox(ref_ell[i], 1e-5));
+    EXPECT_THAT(ell[i], EigenMatrixNear(ref_ell[i], 1e-5));
   }
 }
 
@@ -286,7 +288,7 @@ TEST(GPS, ENUToXYZ) {
   const auto xyz = gps_tform.ENUToXYZ(enu, lat0, lon0, alt0);
 
   for (size_t i = 0; i < ell.size(); ++i) {
-    EXPECT_TRUE(xyz[i].isApprox(ref_xyz[i], 1e-8));
+    EXPECT_THAT(xyz[i], EigenMatrixNear(ref_xyz[i], 1e-8));
   }
 }
 

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/image/undistortion.h"
 
 #include "colmap/geometry/pose.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <gtest/gtest.h>
 
@@ -241,16 +242,16 @@ TEST(RectifyStereoCameras, Nominal) {
   Eigen::Matrix3d H1_ref;
   H1_ref << -0.202759, -0.815848, -0.897034, 0.416329, 0.733069, -0.199657,
       0.910839, -0.175408, 0.942638;
-  EXPECT_TRUE(H1.isApprox(H1_ref.transpose(), 1e-5));
+  EXPECT_THAT(H1, EigenMatrixNear<Eigen::Matrix3d>(H1_ref.transpose(), 1e-5));
 
   Eigen::Matrix3d H2_ref;
   H2_ref << -0.082173, -1.01288, -0.698868, 0.301854, 0.472844, -0.465336,
       0.963533, 0.292411, 1.12528;
-  EXPECT_TRUE(H2.isApprox(H2_ref.transpose(), 1e-5));
+  EXPECT_THAT(H2, EigenMatrixNear<Eigen::Matrix3d>(H2_ref.transpose(), 1e-5));
 
   Eigen::Matrix4d Q_ref;
   Q_ref << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -2.67261, -0.5, -0.5, 1, 0;
-  EXPECT_TRUE(Q.isApprox(Q_ref, 1e-5));
+  EXPECT_THAT(Q, EigenMatrixNear(Q_ref, 1e-5));
 }
 
 }  // namespace

--- a/src/colmap/math/polynomial_test.cc
+++ b/src/colmap/math/polynomial_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/math/polynomial.h"
 
+#include "colmap/util/eigen_matchers.h"
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -84,7 +86,8 @@ TEST(FindQuadraticPolynomialRootsReal, Nominal) {
   Eigen::VectorXd imag;
   Eigen::Vector3d coeffs(3, -2, -4);
   EXPECT_TRUE(FindQuadraticPolynomialRoots(coeffs, &real, &imag));
-  EXPECT_TRUE(real.isApprox(Eigen::Vector2d(-0.868517092, 1.535183758), 1e-6));
+  EXPECT_THAT(
+      real, EigenMatrixNear(Eigen::Vector2d(-0.868517092, 1.535183758), 1e-6));
   EXPECT_EQ(imag, Eigen::Vector2d(0, 0));
   EXPECT_NEAR(
       EvaluatePolynomial(coeffs, std::complex<double>(real(0), imag(0))).real(),
@@ -102,10 +105,14 @@ TEST(FindQuadraticPolynomialRootsComplex, Nominal) {
   const Eigen::Vector3d coeffs(
       0.276025076998578, 0.679702676853675, 0.655098003973841);
   EXPECT_TRUE(FindQuadraticPolynomialRoots(coeffs, &real, &imag));
-  EXPECT_TRUE(real.isApprox(
-      Eigen::Vector2d(-1.231233560813707, -1.231233560813707), 1e-6));
-  EXPECT_TRUE(imag.isApprox(
-      Eigen::Vector2d(0.925954520440279, -0.925954520440279), 1e-6));
+  EXPECT_THAT(
+      real,
+      EigenMatrixNear(Eigen::Vector2d(-1.231233560813707, -1.231233560813707),
+                      1e-6));
+  EXPECT_THAT(
+      imag,
+      EigenMatrixNear(Eigen::Vector2d(0.925954520440279, -0.925954520440279),
+                      1e-6));
   EXPECT_NEAR(
       EvaluatePolynomial(coeffs, std::complex<double>(real(0), imag(0))).real(),
       0.0,
@@ -135,8 +142,10 @@ TEST(FindCubicPolynomialRoots, MultiRoot) {
   EXPECT_EQ(FindCubicPolynomialRoots(coeffs(1), coeffs(2), coeffs(3), &real),
             3);
   std::sort(real.data(), real.data() + real.size());
-  EXPECT_TRUE(real.isApprox(
-      Eigen::Vector3d(-1.4494897427831781, 1, 3.4494897427831783), 1e-6));
+  EXPECT_THAT(
+      real,
+      EigenMatrixNear(
+          Eigen::Vector3d(-1.4494897427831781, 1, 3.4494897427831783), 1e-6));
   for (int i = 0; i < 3; ++i) {
     EXPECT_NEAR(
         EvaluatePolynomial(coeffs, std::complex<double>(real(i), 0)).real(),
@@ -148,7 +157,7 @@ TEST(FindCubicPolynomialRoots, MultiRoot) {
       FindPolynomialRootsDurandKerner(coeffs, &real_durand_kerner, nullptr));
   std::sort(real_durand_kerner.data(),
             real_durand_kerner.data() + real_durand_kerner.size());
-  EXPECT_TRUE(real.isApprox(real_durand_kerner, 1e-4));
+  EXPECT_THAT(real, EigenMatrixNear(real_durand_kerner, 1e-4));
 }
 
 TEST(FindPolynomialRootsDurandKerner, Nominal) {
@@ -160,10 +169,10 @@ TEST(FindPolynomialRootsDurandKerner, Nominal) {
   // Reference values generated with OpenCV/Matlab.
   Eigen::VectorXd ref_real(4);
   ref_real << -0.201826, -0.201826, 0.451826, 0.451826;
-  EXPECT_TRUE(real.isApprox(ref_real, 1e-6));
+  EXPECT_THAT(real, EigenMatrixNear(ref_real, 1e-6));
   Eigen::VectorXd ref_imag(4);
   ref_imag << -0.627696, 0.627696, 0.160867, -0.160867;
-  EXPECT_TRUE(imag.isApprox(ref_imag, 1e-6));
+  EXPECT_THAT(imag, EigenMatrixNear(ref_imag, 1e-6));
 }
 
 TEST(FindPolynomialRootsDurandKernerLinearQuadratic, Nominal) {
@@ -194,10 +203,10 @@ TEST(FindPolynomialRootsCompanionMatrix, Nominal) {
   // Reference values generated with OpenCV/Matlab.
   Eigen::VectorXd ref_real(4);
   ref_real << -0.201826, -0.201826, 0.451826, 0.451826;
-  EXPECT_TRUE(real.isApprox(ref_real, 1e-6));
+  EXPECT_THAT(real, EigenMatrixNear(ref_real, 1e-6));
   Eigen::VectorXd ref_imag(4);
   ref_imag << 0.627696, -0.627696, 0.160867, -0.160867;
-  EXPECT_TRUE(imag.isApprox(ref_imag, 1e-6));
+  EXPECT_THAT(imag, EigenMatrixNear(ref_imag, 1e-6));
 }
 
 TEST(FindPolynomialRootsCompanionMatrixLinearQuadratic, Nominal) {
@@ -228,10 +237,10 @@ TEST(FindPolynomialRootsCompanionMatrixZeroSolution, Nominal) {
   // Reference values generated with Matlab.
   Eigen::VectorXd ref_real(4);
   ref_real << 0.692438, -0.0962191, -0.0962191, 0;
-  EXPECT_TRUE(real.isApprox(ref_real, 1e-6));
+  EXPECT_THAT(real, EigenMatrixNear(ref_real, 1e-6));
   Eigen::VectorXd ref_imag(4);
   ref_imag << 0, 0.651148, -0.651148, 0;
-  EXPECT_TRUE(imag.isApprox(ref_imag, 1e-6));
+  EXPECT_THAT(imag, EigenMatrixNear(ref_imag, 1e-6));
 }
 
 }  // namespace

--- a/src/colmap/optim/least_absolute_deviations_test.cc
+++ b/src/colmap/optim/least_absolute_deviations_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/math/random.h"
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
@@ -58,8 +59,7 @@ TEST(SolveLeastAbsoluteDeviations, OverDetermined) {
   EXPECT_TRUE(SolveLeastAbsoluteDeviations(options, A, b, &x));
 
   // Reference solution obtained with Boyd's Matlab implementation.
-  const Eigen::Vector3d x_ref(0, 0, 1 / 3.0);
-  EXPECT_TRUE(x.isApprox(x_ref));
+  EXPECT_THAT(x, EigenMatrixNear(Eigen::Vector3d(0, 0, 1 / 3.0)));
 
   const Eigen::VectorXd residual = A * x - b;
   EXPECT_LE(residual.norm(), 1e-6);
@@ -85,8 +85,7 @@ TEST(SolveLeastAbsoluteDeviations, WellDetermined) {
   EXPECT_TRUE(SolveLeastAbsoluteDeviations(options, A, b, &x));
 
   // Reference solution obtained with Boyd's Matlab implementation.
-  const Eigen::Vector3d x_ref(0, 0, 1 / 3.0);
-  EXPECT_TRUE(x.isApprox(x_ref));
+  EXPECT_THAT(x, EigenMatrixNear(Eigen::Vector3d(0, 0, 1 / 3.0)));
 
   const Eigen::VectorXd residual = A * x - b;
   EXPECT_LE(residual.norm(), 1e-6);

--- a/src/colmap/retrieval/geometry_test.cc
+++ b/src/colmap/retrieval/geometry_test.cc
@@ -32,6 +32,7 @@
 #include "colmap/retrieval/geometry.h"
 
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <iostream>
 
@@ -59,8 +60,9 @@ TEST(FeatureGeometry, Identity) {
           feature2.orientation = orientation;
           const auto tform_matrix =
               FeatureGeometry::TransformMatrixFromMatch(feature1, feature2);
-          EXPECT_TRUE(
-              tform_matrix.isApprox(Eigen::Matrix<float, 2, 3>::Identity()));
+          EXPECT_THAT(tform_matrix,
+                      EigenMatrixNear(Eigen::Matrix<float, 2, 3>(
+                          Eigen::Matrix<float, 2, 3>::Identity())));
           const auto tform =
               FeatureGeometry::TransformFromMatch(feature1, feature2);
           EXPECT_NEAR(tform.scale, 1, 1e-6);
@@ -85,9 +87,11 @@ TEST(FeatureGeometry, Translation) {
       feature2.orientation = 0;
       const auto tform_matrix =
           FeatureGeometry::TransformMatrixFromMatch(feature1, feature2);
-      EXPECT_TRUE(
-          tform_matrix.leftCols<2>().isApprox(Eigen::Matrix2f::Identity()));
-      EXPECT_TRUE(tform_matrix.rightCols<1>().isApprox(Eigen::Vector2f(x, y)));
+      EXPECT_THAT(
+          tform_matrix.leftCols<2>(),
+          EigenMatrixNear<Eigen::Matrix2f>(Eigen::Matrix2f::Identity()));
+      EXPECT_THAT(tform_matrix.rightCols<1>(),
+                  EigenMatrixNear(Eigen::Vector2f(x, y)));
       const auto tform =
           FeatureGeometry::TransformFromMatch(feature1, feature2);
       EXPECT_NEAR(tform.scale, 1, 1e-6);
@@ -107,9 +111,11 @@ TEST(FeatureGeometry, Scale) {
     feature2.orientation = 0;
     const auto tform_matrix =
         FeatureGeometry::TransformMatrixFromMatch(feature1, feature2);
-    EXPECT_TRUE(tform_matrix.leftCols<2>().isApprox(
-        scale * Eigen::Matrix2f::Identity()));
-    EXPECT_TRUE(tform_matrix.rightCols<1>().isApprox(Eigen::Vector2f(0, 0)));
+    EXPECT_THAT(
+        tform_matrix.leftCols<2>(),
+        EigenMatrixNear<Eigen::Matrix2f>(scale * Eigen::Matrix2f::Identity()));
+    EXPECT_THAT(tform_matrix.rightCols<1>(),
+                EigenMatrixNear(Eigen::Vector2f(0, 0)));
     const auto tform = FeatureGeometry::TransformFromMatch(feature1, feature2);
     EXPECT_NEAR(tform.scale, scale, 1e-6);
     EXPECT_NEAR(tform.angle, 0, 1e-6);
@@ -129,7 +135,8 @@ TEST(FeatureGeometry, Orientation) {
     const auto tform_matrix =
         FeatureGeometry::TransformMatrixFromMatch(feature1, feature2);
     EXPECT_NEAR(tform_matrix.leftCols<2>().determinant(), 1, 1e-5);
-    EXPECT_TRUE(tform_matrix.rightCols<1>().isApprox(Eigen::Vector2f(0, 0)));
+    EXPECT_THAT(tform_matrix.rightCols<1>(),
+                EigenMatrixNear(Eigen::Vector2f(0, 0)));
     const auto tform = FeatureGeometry::TransformFromMatch(feature1, feature2);
     EXPECT_NEAR(tform.scale, 1, 1e-6);
     EXPECT_NEAR(tform.angle, orientation, 1e-6);

--- a/src/colmap/scene/two_view_geometry_test.cc
+++ b/src/colmap/scene/two_view_geometry_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/scene/two_view_geometry.h"
 
 #include "colmap/geometry/pose.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <gtest/gtest.h>
 
@@ -62,13 +63,16 @@ TEST(TwoViewGeometry, Invert) {
 
   two_view_geometry.Invert();
   EXPECT_EQ(two_view_geometry.config, TwoViewGeometry::CALIBRATED);
-  EXPECT_TRUE(two_view_geometry.F.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.E.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.H.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.cam2_from_cam1.rotation.isApprox(
-      Eigen::Quaterniond::Identity()));
-  EXPECT_TRUE(two_view_geometry.cam2_from_cam1.translation.isApprox(
-      Eigen::Vector3d(-0, -1, -2)));
+  EXPECT_THAT(two_view_geometry.F,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.E,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.H,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.cam2_from_cam1.rotation.coeffs(),
+              EigenMatrixNear(Eigen::Quaterniond::Identity().coeffs()));
+  EXPECT_THAT(two_view_geometry.cam2_from_cam1.translation,
+              EigenMatrixNear(Eigen::Vector3d(-0, -1, -2)));
   EXPECT_EQ(two_view_geometry.inlier_matches[0].point2D_idx1, 1);
   EXPECT_EQ(two_view_geometry.inlier_matches[0].point2D_idx2, 0);
   EXPECT_EQ(two_view_geometry.inlier_matches[1].point2D_idx1, 3);
@@ -76,13 +80,16 @@ TEST(TwoViewGeometry, Invert) {
 
   two_view_geometry.Invert();
   EXPECT_EQ(two_view_geometry.config, TwoViewGeometry::CALIBRATED);
-  EXPECT_TRUE(two_view_geometry.F.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.E.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.H.isApprox(Eigen::Matrix3d::Identity()));
-  EXPECT_TRUE(two_view_geometry.cam2_from_cam1.rotation.isApprox(
-      Eigen::Quaterniond::Identity()));
-  EXPECT_TRUE(two_view_geometry.cam2_from_cam1.translation.isApprox(
-      Eigen::Vector3d(0, 1, 2)));
+  EXPECT_THAT(two_view_geometry.F,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.E,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.H,
+              EigenMatrixNear<Eigen::Matrix3d>(Eigen::Matrix3d::Identity()));
+  EXPECT_THAT(two_view_geometry.cam2_from_cam1.rotation.coeffs(),
+              EigenMatrixNear(Eigen::Quaterniond::Identity().coeffs()));
+  EXPECT_THAT(two_view_geometry.cam2_from_cam1.translation,
+              EigenMatrixNear(Eigen::Vector3d(0, 1, 2)));
   EXPECT_EQ(two_view_geometry.inlier_matches[0].point2D_idx1, 0);
   EXPECT_EQ(two_view_geometry.inlier_matches[0].point2D_idx2, 1);
   EXPECT_EQ(two_view_geometry.inlier_matches[1].point2D_idx1, 2);

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -37,6 +37,7 @@ COLMAP_ADD_LIBRARY(
         cache.h
         controller_thread.h
         eigen_alignment.h
+        eigen_matchers.h
         endian.h endian.cc
         enum_to_string.h
         file.h file.cc
@@ -96,6 +97,11 @@ endif()
 COLMAP_ADD_TEST(
     NAME cache_test
     SRCS cache_test.cc
+    LINK_LIBS colmap_util
+)
+COLMAP_ADD_TEST(
+    NAME eigen_matchers_test
+    SRCS eigen_matchers_test.cc
     LINK_LIBS colmap_util
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -37,7 +37,6 @@ COLMAP_ADD_LIBRARY(
         cache.h
         controller_thread.h
         eigen_alignment.h
-        eigen_matchers.h
         endian.h endian.cc
         enum_to_string.h
         file.h file.cc
@@ -64,6 +63,7 @@ if(TESTS_ENABLED)
         colmap_util
         PRIVATE
             testing.h testing.cc
+            eigen_matchers.h
     )
 endif()
 

--- a/src/colmap/util/eigen_matchers.h
+++ b/src/colmap/util/eigen_matchers.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <gmock/gmock.h>
+
+namespace colmap {
+
+template <typename T>
+bool EigenMatrixMatchAndExplainShape(T lhs,
+                                     T rhs,
+                                     testing::MatchResultListener* listener) {
+  if (lhs.rows() != rhs.rows() || lhs.cols() != rhs.cols()) {
+    *listener << " have different shape (" << lhs.rows() << ", " << lhs.cols()
+              << ") vs. (" << rhs.rows() << ", " << rhs.cols() << ")";
+    return false;
+  }
+  return true;
+}
+
+template <typename T>
+class EigenMatrixEqMatcher : public testing::MatcherInterface<T> {
+ public:
+  explicit EigenMatrixEqMatcher(T rhs) : rhs_(std::forward<T>(rhs)) {}
+
+  void DescribeTo(std::ostream* os) const override { *os << rhs_; }
+
+  bool MatchAndExplain(T lhs,
+                       testing::MatchResultListener* listener) const override {
+    if (!EigenMatrixMatchAndExplainShape(lhs, rhs_, listener)) {
+      return false;
+    }
+    return lhs == rhs_;
+  }
+
+ private:
+  const T rhs_;
+};
+
+template <typename T>
+testing::PolymorphicMatcher<EigenMatrixEqMatcher<T>> EigenMatrixEq(T rhs) {
+  return testing::MakePolymorphicMatcher(
+      EigenMatrixEqMatcher<T>(std::forward<T>(rhs)));
+}
+
+template <typename T>
+class EigenMatrixNearMatcher : public testing::MatcherInterface<T> {
+ public:
+  EigenMatrixNearMatcher(T rhs, double tol)
+      : rhs_(std::forward<T>(rhs)), tol_(tol) {}
+
+  void DescribeTo(std::ostream* os) const override { *os << rhs_; }
+
+  bool MatchAndExplain(T lhs,
+                       testing::MatchResultListener* listener) const override {
+    if (!EigenMatrixMatchAndExplainShape(lhs, rhs_, listener)) {
+      return false;
+    }
+    return lhs.isApprox(rhs_, tol_);
+  }
+
+ private:
+  const T rhs_;
+  const double tol_;
+};
+
+template <typename T>
+testing::PolymorphicMatcher<EigenMatrixNearMatcher<T>> EigenMatrixNear(
+    T rhs, double tol = Eigen::NumTraits<double>::dummy_precision()) {
+  return testing::MakePolymorphicMatcher(
+      EigenMatrixNearMatcher<T>(std::forward<T>(rhs), tol));
+}
+
+}  // namespace colmap

--- a/src/colmap/util/eigen_matchers_test.cc
+++ b/src/colmap/util/eigen_matchers_test.cc
@@ -36,6 +36,7 @@ namespace colmap {
 namespace {
 
 struct TestClass {
+  virtual ~TestClass() = default;
   virtual void TestMethod(const Eigen::MatrixXd&) const {}
 };
 

--- a/src/colmap/util/eigen_matchers_test.cc
+++ b/src/colmap/util/eigen_matchers_test.cc
@@ -27,27 +27,35 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "colmap/math/matrix.h"
-
 #include "colmap/util/eigen_matchers.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace colmap {
 namespace {
 
-TEST(DecomposeMatrixRQ, Nominal) {
-  for (int i = 0; i < 10; ++i) {
-    const Eigen::Matrix4d A = Eigen::Matrix4d::Random();
+TEST(EigenMatrix, Eq) {
+  Eigen::MatrixXd x(2, 3);
+  x << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd y = x;
+  EXPECT_THAT(x, EigenMatrixEq(y));
+  y(0, 0) += 1;
+  EXPECT_THAT(x, testing::Not(EigenMatrixEq(y)));
+  y = x.block(0, 0, 2, 2);
+  EXPECT_THAT(x, testing::Not(EigenMatrixEq(y)));
+}
 
-    Eigen::Matrix4d R, Q;
-    DecomposeMatrixRQ(A, &R, &Q);
-
-    EXPECT_TRUE(R.bottomRows(4).isUpperTriangular());
-    EXPECT_TRUE(Q.isUnitary());
-    EXPECT_NEAR(Q.determinant(), 1.0, 1e-6);
-    EXPECT_THAT(A, EigenMatrixNear(Eigen::Matrix4d(R * Q), 1e-6));
-  }
+TEST(EigenMatrix, Near) {
+  Eigen::MatrixXd x(2, 3);
+  x << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd y = x;
+  y(0, 0) += 1e-16;
+  EXPECT_THAT(x, EigenMatrixNear(y, 1e-8));
+  y(0, 0) += 1e-7;
+  EXPECT_THAT(x, testing::Not(EigenMatrixNear(y, 1e-8)));
+  y = x.block(0, 0, 2, 2);
+  EXPECT_THAT(x, testing::Not(EigenMatrixEq(y)));
 }
 
 }  // namespace


### PR DESCRIPTION
Using gmock matchers instead of `a.isApprox(b)` has the advantage of providing more readable output to the user. In case of a test failure, the matrix shape or contents will be printed to the console. Another benefit is that one can embed them into more complex gmock match expressions. This paves the way for better testing some of our interfaces through mocks and fakes.