### PR TITLE
Prevent double initialization of glog for <=0.5

### DIFF
--- a/src/pycolmap/logging.h
+++ b/src/pycolmap/logging.h
@@ -101,6 +101,8 @@ void BindLogging(py::module& m) {
 #if defined(GLOG_VERSION_MAJOR) && \
     (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6)
   if (!google::IsGoogleLoggingInitialized())
+#else
+  if (!py::module_::import("sys").attr("modules").contains("pyceres"))
 #endif
   {
     google::InitGoogleLogging("");


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/2895. We run a similar check in pyceres: https://github.com/cvg/pyceres/pull/59