### PR TITLE
Cross platform usage of monospace font

### DIFF
--- a/src/colmap/ui/log_widget.cc
+++ b/src/colmap/ui/log_widget.cc
@@ -115,7 +115,9 @@ LogWidget::LogWidget(QWidget* parent, const int max_num_blocks) {
   text_box_->setReadOnly(true);
   text_box_->setMaximumBlockCount(max_num_blocks);
   text_box_->setWordWrapMode(QTextOption::NoWrap);
-  text_box_->setFont(QFont("Courier", 10));
+  QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+  font.setPointSize(10);
+  text_box_->setFont(font);
   grid->addWidget(text_box_, 1, 0, 1, 2);
 }
 


### PR DESCRIPTION
Fixes the following warning when Courier is not available on the system. Will use any available monospace/fixed font.
```
qt.qpa.fonts: Populating font family aliases took 122 ms. Replace uses of missing font family "Courier" with one that exists to avoid this cost.
```