### PR TITLE
Enable ceres schur specializations in vcpkg build

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,6 +15,7 @@
             "name": "ceres",
             "features": [
                 "lapack",
+                "schur",
                 "suitesparse"
             ]
         },


### PR DESCRIPTION
Unfortunately, vcpkg defaults to not producing schur specializations for ceres. Without them, bundle adjustment is much slower (at the cost of longer compile times and larger binary size).