### PR TITLE
Add missing openmp flags in retrieval for flann parallelization

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -52,7 +52,7 @@ if(TESTS_ENABLED)
     find_package(GTest ${COLMAP_FIND_TYPE})
 endif()
 
-if(OPENMP_ENABLED)
+if(OPENMP_ENABLED AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "ClangTidy")
     find_package(OpenMP QUIET)
 endif()
 

--- a/src/colmap/retrieval/CMakeLists.txt
+++ b/src/colmap/retrieval/CMakeLists.txt
@@ -50,6 +50,9 @@ COLMAP_ADD_LIBRARY(
         colmap_estimators
         colmap_optim
 )
+if(OPENMP_FOUND)
+    target_link_libraries(colmap_retrieval PUBLIC OpenMP::OpenMP_CXX)
+endif()
 
 COLMAP_ADD_TEST(
     NAME geometry_test


### PR DESCRIPTION
Fixes: https://github.com/colmap/colmap/issues/2977