### PR TITLE
Separate read and write SAS tokens for vcpkg binary cache

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -82,7 +82,11 @@ jobs:
           echo "CIBW_CONFIG_SETTINGS_MACOS=${CONFIG_SETTINGS}" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},readwrite"
+          VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
+            # The secrets are only accessible in runs triggered from within the target repository and not forks.
+            VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+          fi
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "$GITHUB_ENV"
 
       - name: Set env (Windows)
@@ -108,7 +112,11 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=${CIBW_REPAIR_WHEEL_COMMAND}" >> "${env:GITHUB_ENV}"
 
           # vcpkg binary caching
-          $VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},readwrite"
+          $VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}") {
+            # The secrets are only accessible in runs triggered from within the target repository and not forks.
+            $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+          }
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "${env:GITHUB_ENV}"
 
       - name: Set env (Linux)
@@ -137,7 +145,11 @@ jobs:
           echo "CCACHE_BASEDIR=/project" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},readwrite"
+          VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
+            # The secrets are only accessible in runs triggered from within the target repository and not forks.
+            VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+          fi
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "$GITHUB_ENV"
 
           CIBW_ENVIRONMENT_PASS_LINUX="VCPKG_TARGET_TRIPLET VCPKG_INSTALLATION_ROOT CMAKE_TOOLCHAIN_FILE VCPKG_BINARY_SOURCES CONTAINER_COMPILER_CACHE_DIR CCACHE_DIR CCACHE_BASEDIR"

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -145,7 +145,7 @@ jobs:
           echo "CCACHE_BASEDIR=/project" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -85,7 +85,7 @@ jobs:
           VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
-            VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+            VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
           fi
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "$GITHUB_ENV"
 
@@ -148,7 +148,7 @@ jobs:
           VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
-            VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+            VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
           fi
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -82,7 +82,7 @@ jobs:
           echo "CIBW_CONFIG_SETTINGS_MACOS=${CONFIG_SETTINGS}" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,20 +43,29 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/compiler-cache/ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
       VCPKG_COMMIT_ID: 10b7a178346f3f0abef60cecd5130e295afd8da4
-      VCPKG_BINARY_SOURCES: "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
 
     steps:
       - uses: actions/checkout@v4
-
+      
+      # We define the vcpkg binary sources using separate variables for read and
+      # write operations:
+      # * Read sources are defined as action environment variables. These can be
+      #   read by pull requests from forks.
+      # * Write sources are defined as action secret variables. These cannot be
+      #   read by pull requests from forks but only from pull requests from
+      #   within the target repository (i.e., created buy a repository owner).
+      # This protects us from malicious actors accessing our secrets and gaining
+      # write access to our binary cache. For more information, see:
+      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
       - name: Setup vcpkg binary cache
         shell: pwsh
         run: |
-          $VCPKG_BINARY_SOURCES = "VCPKG_BINARY_SOURCES=clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          $VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
           if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}") {
+            # The secrets are only accessible in runs triggered from within the target repository and not forks.
             $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
           }
-          echo "${VCPKG_BINARY_SOURCES}"
-          echo "${VCPKG_BINARY_SOURCES}" >> "${env:GITHUB_ENV}"
+          echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "${env:GITHUB_ENV}"
 
       - name: Compiler cache
         uses: actions/cache@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,7 +52,7 @@ jobs:
         shell: pwsh
         run: |
           $VCPKG_BINARY_SOURCES = "VCPKG_BINARY_SOURCES=clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
-          if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" != "") {
+          if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}") {
             $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
           }
           echo "${VCPKG_BINARY_SOURCES}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,10 +43,20 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/compiler-cache/ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
       VCPKG_COMMIT_ID: 10b7a178346f3f0abef60cecd5130e295afd8da4
-      VCPKG_BINARY_SOURCES: "clear;x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},readwrite"
+      VCPKG_BINARY_SOURCES: "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup vcpkg binary cache
+        shell: pwsh
+        run: |
+          $VCPKG_BINARY_SOURCES = "VCPKG_BINARY_SOURCES=clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" != "") {
+            $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
+          }
+          echo "${VCPKG_BINARY_SOURCES}"
+          echo "${VCPKG_BINARY_SOURCES}" >> "${env:GITHUB_ENV}"
 
       - name: Compiler cache
         uses: actions/cache@v4
@@ -61,11 +71,9 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path "${{ env.CCACHE_DIR }}"
           echo "${{ env.COMPILER_CACHE_DIR }}/bin" | Out-File -Encoding utf8 -Append -FilePath $env:GITHUB_PATH
-
           if (Test-Path -PathType Leaf "${{ env.COMPILER_CACHE_DIR }}/bin/ccache.exe") {
             exit
           }
-
           .github/workflows/install-ccache.ps1 -Destination "${{ env.COMPILER_CACHE_DIR }}/bin"
 
       - name: Install CUDA

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,7 +53,7 @@ jobs:
       #   read by pull requests from forks.
       # * Write sources are defined as action secret variables. These cannot be
       #   read by pull requests from forks but only from pull requests from
-      #   within the target repository (i.e., created buy a repository owner).
+      #   within the target repository (i.e., created by a repository owner).
       # This protects us from malicious actors accessing our secrets and gaining
       # write access to our binary cache. For more information, see:
       # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/


### PR DESCRIPTION
Currently, PR from forks cannot run our CI pipeline, because secrets are not accessible for PRs originating from forks. See e.g. https://github.com/colmap/colmap/pull/3024. This PR fixes the issue by letting PRs from forks read but not write to the cache.