### PR TITLE
Define vcpkg binary cache source inline

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -82,7 +82,8 @@ jobs:
           echo "CIBW_CONFIG_SETTINGS_MACOS=${CONFIG_SETTINGS}" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          # !!!PLEASE!!! be nice and don't use this cache for your own purposes. This is only meant for CI purposes in this repository.
+          VCPKG_BINARY_SOURCES="clear;x-azblob,https://colmap.blob.core.windows.net/github-actions-cache,sp=r&st=2024-12-10T17:29:32Z&se=2030-12-31T01:29:32Z&spr=https&sv=2022-11-02&sr=c&sig=bWydkilTMjRn3LHKTxLgdWrFpV4h%2Finzoe9QCOcPpYQ%3D,read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
@@ -112,7 +113,8 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=${CIBW_REPAIR_WHEEL_COMMAND}" >> "${env:GITHUB_ENV}"
 
           # vcpkg binary caching
-          $VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          # !!!PLEASE!!! be nice and don't use this cache for your own purposes. This is only meant for CI purposes in this repository.
+          $VCPKG_BINARY_SOURCES = "clear;x-azblob,https://colmap.blob.core.windows.net/github-actions-cache,sp=r&st=2024-12-10T17:29:32Z&se=2030-12-31T01:29:32Z&spr=https&sv=2022-11-02&sr=c&sig=bWydkilTMjRn3LHKTxLgdWrFpV4h%2Finzoe9QCOcPpYQ%3D,read"
           if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}") {
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"
@@ -145,7 +147,8 @@ jobs:
           echo "CCACHE_BASEDIR=/project" >> "$GITHUB_ENV"
 
           # vcpkg binary caching
-          VCPKG_BINARY_SOURCES="clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          # !!!PLEASE!!! be nice and don't use this cache for your own purposes. This is only meant for CI purposes in this repository.
+          VCPKG_BINARY_SOURCES="clear;x-azblob,https://colmap.blob.core.windows.net/github-actions-cache,sp=r&st=2024-12-10T17:29:32Z&se=2030-12-31T01:29:32Z&spr=https&sv=2022-11-02&sr=c&sig=bWydkilTMjRn3LHKTxLgdWrFpV4h%2Finzoe9QCOcPpYQ%3D,read"
           if [ -z "${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}" ]; then
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             VCPKG_BINARY_SOURCES="${VCPKG_BINARY_SOURCES};x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,18 +49,21 @@ jobs:
       
       # We define the vcpkg binary sources using separate variables for read and
       # write operations:
-      # * Read sources are defined as action environment variables. These can be
-      #   read by pull requests from forks.
+      # * Read sources are defined as inline. These can be read by anyone and,
+      #   in particular, pull requests from forks. Unfortunately, we cannot
+      #   define these as action environment variables. See:
+      #   https://github.com/orgs/community/discussions/44322
       # * Write sources are defined as action secret variables. These cannot be
       #   read by pull requests from forks but only from pull requests from
       #   within the target repository (i.e., created by a repository owner).
-      # This protects us from malicious actors accessing our secrets and gaining
-      # write access to our binary cache. For more information, see:
-      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+      #   This protects us from malicious actors accessing our secrets and
+      #   gaining write access to our binary cache. For more information, see:
+      #   https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
       - name: Setup vcpkg binary cache
         shell: pwsh
         run: |
-          $VCPKG_BINARY_SOURCES = "clear;x-azblob,${{ vars.VCPKG_BINARY_CACHE_AZBLOB_URL_READ }},${{ vars.VCPKG_BINARY_CACHE_AZBLOB_SAS_READ }},read"
+          # !!!PLEASE!!! be nice and don't use this cache for your own purposes. This is only meant for CI purposes in this repository.
+          $VCPKG_BINARY_SOURCES = "clear;x-azblob,https://colmap.blob.core.windows.net/github-actions-cache,sp=r&st=2024-12-10T17:29:32Z&se=2030-12-31T01:29:32Z&spr=https&sv=2022-11-02&sr=c&sig=bWydkilTMjRn3LHKTxLgdWrFpV4h%2Finzoe9QCOcPpYQ%3D,read"
           if ("${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }}") {
             # The secrets are only accessible in runs triggered from within the target repository and not forks.
             $VCPKG_BINARY_SOURCES += ";x-azblob,${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_URL }},${{ secrets.VCPKG_BINARY_CACHE_AZBLOB_SAS }},write"


### PR DESCRIPTION
The Github documentation on this topic is very fuzzy. Unfortunately, it turns out that even action env variables are not readable by forks. See: https://github.com/orgs/community/discussions/44322. The only option is to define the variable directly in the action definition.