### PR TITLE
Improve interface for ReadWriteBinaryBlob and add tests

### DIFF
--- a/src/colmap/mvs/consistency_graph.cc
+++ b/src/colmap/mvs/consistency_graph.cc
@@ -110,7 +110,7 @@ void ConsistencyGraph::Write(const std::string& path) const {
   std::fstream binary_file(path,
                            std::ios::out | std::ios::binary | std::ios::app);
   THROW_CHECK_FILE_OPEN(binary_file, path);
-  WriteBinaryLittleEndian<int>(&binary_file, data_);
+  WriteBinaryLittleEndian<int>(&binary_file, {data_.data(), data_.size()});
   binary_file.close();
 }
 

--- a/src/colmap/mvs/mat.cc
+++ b/src/colmap/mvs/mat.cc
@@ -60,7 +60,7 @@ void Mat<float>::Write(const std::string& path) const {
   std::ofstream file(path, std::ios::binary);
   THROW_CHECK_FILE_OPEN(file, path);
   file << width_ << "&" << height_ << "&" << depth_ << "&";
-  WriteBinaryLittleEndian<float>(&file, data_);
+  WriteBinaryLittleEndian<float>(&file, {data_.data(), data_.size()});
   file.close();
 }
 

--- a/src/colmap/util/endian.h
+++ b/src/colmap/util/endian.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include "colmap/util/types.h"
+
 #include <algorithm>
 #include <iostream>
 #include <vector>
@@ -65,7 +67,7 @@ void ReadBinaryLittleEndian(std::istream* stream, std::vector<T>* data);
 template <typename T>
 void WriteBinaryLittleEndian(std::ostream* stream, const T& data);
 template <typename T>
-void WriteBinaryLittleEndian(std::ostream* stream, const std::vector<T>& data);
+void WriteBinaryLittleEndian(std::ostream* stream, const span<const T>& data);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation
@@ -136,7 +138,7 @@ void WriteBinaryLittleEndian(std::ostream* stream, const T& data) {
 }
 
 template <typename T>
-void WriteBinaryLittleEndian(std::ostream* stream, const std::vector<T>& data) {
+void WriteBinaryLittleEndian(std::ostream* stream, const span<const T>& data) {
   for (const auto& elem : data) {
     WriteBinaryLittleEndian<T>(stream, elem);
   }

--- a/src/colmap/util/endian_test.cc
+++ b/src/colmap/util/endian_test.cc
@@ -153,7 +153,8 @@ void TestIntReadWriteBinaryLittleEndian() {
     std::generate(orig_vector.begin(), orig_vector.end(), [&]() {
       return distribution(prng);
     });
-    WriteBinaryLittleEndian<T>(&file_vector, orig_vector);
+    WriteBinaryLittleEndian<T>(&file_vector,
+                               {orig_vector.data(), orig_vector.size()});
     std::vector<T> read_vector(orig_vector.size());
     ReadBinaryLittleEndian<T>(&file_vector, &read_vector);
     for (size_t i = 0; i < orig_vector.size(); ++i) {
@@ -179,7 +180,8 @@ void TestFloatReadWriteBinaryLittleEndian() {
     std::generate(orig_vector.begin(), orig_vector.end(), [&]() {
       return distribution(prng);
     });
-    WriteBinaryLittleEndian<T>(&file_vector, orig_vector);
+    WriteBinaryLittleEndian<T>(&file_vector,
+                               {orig_vector.data(), orig_vector.size()});
     std::vector<T> read_vector(orig_vector.size());
     ReadBinaryLittleEndian<T>(&file_vector, &read_vector);
     for (size_t i = 0; i < orig_vector.size(); ++i) {

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -188,6 +188,22 @@ size_t GetFileSize(const std::string& path) {
   return file.tellg();
 }
 
+void ReadBinaryBlob(const std::string& path, std::vector<char>* data) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  THROW_CHECK_FILE_OPEN(file, path);
+  file.seekg(0, std::ios::end);
+  const size_t num_bytes = file.tellg();
+  data->resize(num_bytes);
+  file.seekg(0, std::ios::beg);
+  file.read(data->data(), num_bytes);
+}
+
+void WriteBinaryBlob(const std::string& path, const span<const char>& data) {
+  std::ofstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  file.write(data.begin(), data.size());
+}
+
 std::vector<std::string> ReadTextFileLines(const std::string& path) {
   std::ifstream file(path);
   THROW_CHECK_FILE_OPEN(file, path);

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -31,6 +31,7 @@
 
 #include "colmap/util/endian.h"
 #include "colmap/util/logging.h"
+#include "colmap/util/types.h"
 
 #include <filesystem>
 #include <fstream>
@@ -117,12 +118,10 @@ std::vector<std::string> GetRecursiveDirList(const std::string& path);
 size_t GetFileSize(const std::string& path);
 
 // Read contiguous binary blob from file.
-template <typename T>
-void ReadBinaryBlob(const std::string& path, std::vector<T>* data);
+void ReadBinaryBlob(const std::string& path, std::vector<char>* data);
 
 // Write contiguous binary blob to file.
-template <typename T>
-void WriteBinaryBlob(const std::string& path, const std::vector<T>& data);
+void WriteBinaryBlob(const std::string& path, const span<const char>& data);
 
 // Read each line of a text file into a separate element. Empty lines are
 // ignored and leading/trailing whitespace is removed.
@@ -138,25 +137,6 @@ std::string JoinPaths(T const&... paths) {
   int unpack[]{0, (result = result / std::filesystem::path(paths), 0)...};
   static_cast<void>(unpack);
   return result.string();
-}
-
-template <typename T>
-void ReadBinaryBlob(const std::string& path, std::vector<T>* data) {
-  std::ifstream file(path, std::ios::binary | std::ios::ate);
-  THROW_CHECK_FILE_OPEN(file, path);
-  file.seekg(0, std::ios::end);
-  const size_t num_bytes = file.tellg();
-  THROW_CHECK_EQ(num_bytes % sizeof(T), 0);
-  data->resize(num_bytes / sizeof(T));
-  file.seekg(0, std::ios::beg);
-  ReadBinaryLittleEndian<T>(&file, data);
-}
-
-template <typename T>
-void WriteBinaryBlob(const std::string& path, const std::vector<T>& data) {
-  std::ofstream file(path, std::ios::binary);
-  THROW_CHECK_FILE_OPEN(file, path);
-  WriteBinaryLittleEndian<T>(&file, data);
 }
 
 }  // namespace colmap

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/util/file.h"
 
+#include "colmap/util/testing.h"
+
 #include <cstring>
 
 #include <gtest/gtest.h>
@@ -136,6 +138,22 @@ TEST(JoinPaths, Nominal) {
   EXPECT_EQ(JoinPaths("/test1", "/test2"), "/test2");
   EXPECT_EQ(JoinPaths("/test1", "/test2/"), "/test2/");
   EXPECT_EQ(JoinPaths("/test1", "/test2/", "test3.ext"), "/test2/test3.ext");
+}
+
+TEST(ReadWriteBinaryBlob, Nominal) {
+  const std::string file_path = CreateTestDir() + "/test.bin";
+  const int kNumBytes = 123;
+  std::vector<char> data(kNumBytes);
+  for (int i = 0; i < kNumBytes; ++i) {
+    data[i] = (i * 100 + 4 + i) % 256;
+  }
+
+  WriteBinaryBlob(file_path, {data.data(), data.size()});
+
+  std::vector<char> read_data;
+  ReadBinaryBlob(file_path, &read_data);
+
+  EXPECT_EQ(read_data, data);
 }
 
 }  // namespace


### PR DESCRIPTION
Several changes in this PR:
* Improved interface for WriteBinaryBlob now takes spans to allow for more generic inputs.
* Little/big endian doesn't really make sense for generic binary data. The data should already be in consistent format before being converted into raw bytes.
* Added missing unit tests.