### PR TITLE
Automatically download and cache vocabulary tree

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -290,7 +290,6 @@ new images within this reconstruction, you can follow these steps::
 
     colmap vocab_tree_matcher \
         --database_path $PROJECT_PATH/database.db \
-        --VocabTreeMatching.vocab_tree_path /path/to/vocab-tree.bin \
         --VocabTreeMatching.match_list_path /path/to/image-list.txt
 
     colmap image_registrator \

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -289,15 +289,16 @@ matching modes, that are intended for different input scenarios:
 - **Sequential Matching**: This mode is useful if the images are acquired in
   sequential order, e.g., by a video camera. In this case, consecutive frames
   have visual overlap and there is no need to match all image pairs
-  exhaustively. Instead, consecutively captured images are matched against
-  each other. This matching mode has built-in loop detection based on a
-  vocabulary tree, where every N-th image (`loop_detection_period`) is matched
-  against its visually most similar images (`loop_detection_num_images`). Note
-  that image file names must be ordered sequentially (e.g., `image0001.jpg`,
+  exhaustively. Instead, consecutively captured images are matched against each
+  other. This matching mode has built-in loop detection based on a vocabulary
+  tree, where every N-th image (`loop_detection_period`) is matched against its
+  visually most similar images (`loop_detection_num_images`). Note that image
+  file names must be ordered sequentially (e.g., `image0001.jpg`,
   `image0002.jpg`, etc.). The order in the database is not relevant, since the
   images are explicitly ordered according to their file names. Note that loop
-  detection requires a pre-trained vocabulary tree, that can be downloaded
-  from https://demuc.de/colmap/.
+  detection requires a pre-trained vocabulary tree. A default tree will be
+  automatically downloaded and cached. More trees are available and can be
+  downloaded from https://demuc.de/colmap/.
 
 - **Vocabulary Tree Matching**: In this matching mode [schoenberger16vote]_,
   every image is matched against its visual nearest neighbors using a vocabulary

--- a/src/colmap/controllers/automatic_reconstruction.h
+++ b/src/colmap/controllers/automatic_reconstruction.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
+#include "colmap/retrieval/resources.h"
 #include "colmap/scene/reconstruction_manager.h"
 #include "colmap/util/enum_to_string.h"
 #include "colmap/util/threading.h"
@@ -56,7 +57,7 @@ class AutomaticReconstructionController : public Thread {
     std::string mask_path;
 
     // The path to the vocabulary tree for feature matching.
-    std::string vocab_tree_path = "__download__";
+    std::string vocab_tree_path = kDefaultVocabTreeUri;
 
     // The type of input data used to choose optimal mapper settings.
     DataType data_type = DataType::INDIVIDUAL;

--- a/src/colmap/controllers/automatic_reconstruction.h
+++ b/src/colmap/controllers/automatic_reconstruction.h
@@ -56,7 +56,7 @@ class AutomaticReconstructionController : public Thread {
     std::string mask_path;
 
     // The path to the vocabulary tree for feature matching.
-    std::string vocab_tree_path;
+    std::string vocab_tree_path = "__download__";
 
     // The type of input data used to choose optimal mapper settings.
     DataType data_type = DataType::INDIVIDUAL;

--- a/src/colmap/exe/vocab_tree.cc
+++ b/src/colmap/exe/vocab_tree.cc
@@ -117,7 +117,7 @@ std::vector<Image> ReadVocabTreeRetrievalImageList(const std::string& path,
 }  // namespace
 
 int RunVocabTreeBuilder(int argc, char** argv) {
-  std::string vocab_tree_path;
+  std::string vocab_tree_path = "__download__";
   retrieval::VisualIndex<>::BuildOptions build_options;
   int max_num_images = -1;
 
@@ -152,7 +152,7 @@ int RunVocabTreeBuilder(int argc, char** argv) {
 }
 
 int RunVocabTreeRetriever(int argc, char** argv) {
-  std::string vocab_tree_path;
+  std::string vocab_tree_path = "__download__";
   std::string database_image_list_path;
   std::string query_image_list_path;
   std::string output_index_path;

--- a/src/colmap/exe/vocab_tree.cc
+++ b/src/colmap/exe/vocab_tree.cc
@@ -34,6 +34,7 @@
 #include "colmap/feature/sift.h"
 #include "colmap/feature/utils.h"
 #include "colmap/optim/random_sampler.h"
+#include "colmap/retrieval/resources.h"
 #include "colmap/retrieval/visual_index.h"
 #include "colmap/scene/database.h"
 #include "colmap/util/file.h"
@@ -117,7 +118,7 @@ std::vector<Image> ReadVocabTreeRetrievalImageList(const std::string& path,
 }  // namespace
 
 int RunVocabTreeBuilder(int argc, char** argv) {
-  std::string vocab_tree_path = "__download__";
+  std::string vocab_tree_path = kDefaultVocabTreeUri;
   retrieval::VisualIndex<>::BuildOptions build_options;
   int max_num_images = -1;
 
@@ -152,7 +153,7 @@ int RunVocabTreeBuilder(int argc, char** argv) {
 }
 
 int RunVocabTreeRetriever(int argc, char** argv) {
-  std::string vocab_tree_path = "__download__";
+  std::string vocab_tree_path = kDefaultVocabTreeUri;
   std::string database_image_list_path;
   std::string query_image_list_path;
   std::string output_index_path;

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -65,7 +65,7 @@ struct VocabTreeMatchingOptions {
   int max_num_features = -1;
 
   // Path to the vocabulary tree.
-  std::string vocab_tree_path = "";
+  std::string vocab_tree_path = "__download__";
 
   // Optional path to file with specific image names to match.
   std::string match_list_path = "";
@@ -110,7 +110,7 @@ struct SequentialMatchingOptions {
   int loop_detection_max_num_features = -1;
 
   // Path to the vocabulary tree.
-  std::string vocab_tree_path = "";
+  std::string vocab_tree_path = "__download__";
 
   bool Check() const;
 

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/feature/matcher.h"
+#include "colmap/retrieval/resources.h"
 #include "colmap/retrieval/visual_index.h"
 #include "colmap/scene/database.h"
 #include "colmap/util/threading.h"
@@ -65,7 +66,7 @@ struct VocabTreeMatchingOptions {
   int max_num_features = -1;
 
   // Path to the vocabulary tree.
-  std::string vocab_tree_path = "__download__";
+  std::string vocab_tree_path = kDefaultVocabTreeUri;
 
   // Optional path to file with specific image names to match.
   std::string match_list_path = "";
@@ -110,7 +111,7 @@ struct SequentialMatchingOptions {
   int loop_detection_max_num_features = -1;
 
   // Path to the vocabulary tree.
-  std::string vocab_tree_path = "__download__";
+  std::string vocab_tree_path = kDefaultVocabTreeUri;
 
   bool Check() const;
 

--- a/src/colmap/retrieval/CMakeLists.txt
+++ b/src/colmap/retrieval/CMakeLists.txt
@@ -37,6 +37,7 @@ COLMAP_ADD_LIBRARY(
         inverted_file.h
         inverted_file_entry.h
         inverted_index.h
+        resources.h
         utils.h
         visual_index.h
         vote_and_verify.h vote_and_verify.cc

--- a/src/colmap/retrieval/resources.h
+++ b/src/colmap/retrieval/resources.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+
+namespace colmap {
+
+#ifdef COLMAP_DOWNLOAD_ENABLED
+const static std::string kDefaultVocabTreeUri =
+    "https://github.com/colmap/colmap/releases/download/3.11.1/"
+    "vocab_tree_flickr100K_words256K.bin;"
+    "vocab_tree_flickr100K_words256K.bin;"
+    "d2055600452a531b5b0a62aa5943e1a07195273dc4eeebcf23d3a924d881d53a";
+#else
+const static std::string kDefaultVocabTreeUri = "";
+#endif
+
+}  // namespace colmap

--- a/src/colmap/retrieval/visual_index.h
+++ b/src/colmap/retrieval/visual_index.h
@@ -117,7 +117,7 @@ class VisualIndex {
     int num_threads = kMaxNumThreads;
   };
 
-  struct ReadOptions {
+  struct DownloadOptions {
     std::string vocab_tree_cache_path =
         "$HOME/.cache/colmap/vocab_tree_flickr100K_words256K.bin";
     std::string vocab_tree_url =
@@ -161,7 +161,7 @@ class VisualIndex {
   // Read and write the visual index. This can be done for an index with and
   // without indexed images.
   void Read(const std::string& vocab_tree_path,
-            const ReadOptions& options = {});
+            const DownloadOptions& options = {});
   void Write(const std::string& path);
 
  private:
@@ -571,7 +571,7 @@ void VisualIndex<kDescType, kDescDim, kEmbeddingDim>::Build(
 
 template <typename kDescType, int kDescDim, int kEmbeddingDim>
 void VisualIndex<kDescType, kDescDim, kEmbeddingDim>::Read(
-    const std::string& vocab_tree_path, const ReadOptions& options) {
+    const std::string& vocab_tree_path, const DownloadOptions& options) {
   std::string resolved_path;
   if (vocab_tree_path == "__download__") {
 #ifdef COLMAP_DOWNLOAD_ENABLED

--- a/src/colmap/retrieval/visual_index.h
+++ b/src/colmap/retrieval/visual_index.h
@@ -117,15 +117,6 @@ class VisualIndex {
     int num_threads = kMaxNumThreads;
   };
 
-  struct DownloadOptions {
-    std::string vocab_tree_cache_path =
-        "$HOME/.cache/colmap/vocab_tree_flickr100K_words256K.bin";
-    std::string vocab_tree_url =
-        "https://demuc.de/colmap/vocab_tree_flickr100K_words256K.bin";
-    std::string vocab_tree_sha256 =
-        "d2055600452a531b5b0a62aa5943e1a07195273dc4eeebcf23d3a924d881d53a";
-  };
-
   VisualIndex();
   ~VisualIndex();
 
@@ -160,8 +151,7 @@ class VisualIndex {
 
   // Read and write the visual index. This can be done for an index with and
   // without indexed images.
-  void Read(const std::string& vocab_tree_path,
-            const DownloadOptions& options = {});
+  void Read(const std::string& vocab_tree_path);
   void Write(const std::string& path);
 
  private:
@@ -571,19 +561,8 @@ void VisualIndex<kDescType, kDescDim, kEmbeddingDim>::Build(
 
 template <typename kDescType, int kDescDim, int kEmbeddingDim>
 void VisualIndex<kDescType, kDescDim, kEmbeddingDim>::Read(
-    const std::string& vocab_tree_path, const DownloadOptions& options) {
-  std::string resolved_path;
-  if (vocab_tree_path == "__download__") {
-#ifdef COLMAP_DOWNLOAD_ENABLED
-    resolved_path = SetPathHomeDir(options.vocab_tree_cache_path);
-    DownloadCachedFile(
-        options.vocab_tree_url, options.vocab_tree_sha256, resolved_path);
-#else
-    throw std::invalid_argument("COLMAP was compiled without download support");
-#endif
-  } else {
-    resolved_path = vocab_tree_path;
-  }
+    const std::string& vocab_tree_path) {
+  const std::string resolved_path = MaybeDownloadAndCacheFile(vocab_tree_path);
 
   long int file_offset = 0;
 

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -152,7 +152,7 @@ TEST(VisualIndex, Download) {
   visual_index.Write(vocab_tree_path);
 
   VisualIndexType downloaded_visual_index;
-  VisualIndexType::ReadOptions options;
+  VisualIndexType::DownloadOptions options;
   options.vocab_tree_cache_path = test_dir + "/cached_vocab_tree.bin";
   options.vocab_tree_url =
       "file://" + std::filesystem::absolute(vocab_tree_path).string();

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -140,6 +140,7 @@ TEST(VisualIndex, double_32_16) {
 TEST(VisualIndex, Download) {
   const std::string test_dir = CreateTestDir();
   const std::string vocab_tree_path = test_dir + "/server_vocab_tree.bin";
+  OverwriteCacheDir(test_dir);
 
   typedef VisualIndex<uint8_t, 16, 8> VisualIndexType;
   typename VisualIndexType::DescType descriptors =
@@ -153,15 +154,13 @@ TEST(VisualIndex, Download) {
   visual_index.Write(vocab_tree_path);
 
   VisualIndexType downloaded_visual_index;
-  VisualIndexType::DownloadOptions options;
-  options.vocab_tree_cache_path = test_dir + "/cached_vocab_tree.bin";
-  options.vocab_tree_url =
-      "file://" + std::filesystem::absolute(vocab_tree_path).string();
   std::vector<char> vocab_tree_data;
   ReadBinaryBlob(vocab_tree_path, &vocab_tree_data);
-  options.vocab_tree_sha256 =
+  const std::string vocab_tree_uri =
+      "file://" + std::filesystem::absolute(vocab_tree_path).string() +
+      ";vocab_tree.bin;" +
       ComputeSHA256({vocab_tree_data.data(), vocab_tree_data.size()});
-  downloaded_visual_index.Read("__download__", options);
+  downloaded_visual_index.Read(vocab_tree_uri);
 
   EXPECT_EQ(downloaded_visual_index.NumVisualWords(),
             visual_index.NumVisualWords());

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -148,6 +148,7 @@ TEST(VisualIndex, Download) {
   typename VisualIndexType::BuildOptions build_options;
   build_options.num_visual_words = 5;
   build_options.branching = 5;
+  // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
   visual_index.Build(build_options, descriptors);
   visual_index.Write(vocab_tree_path);
 

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -140,7 +140,7 @@ TEST(VisualIndex, double_32_16) {
 TEST(VisualIndex, Download) {
   const std::string test_dir = CreateTestDir();
   const std::string vocab_tree_path = test_dir + "/server_vocab_tree.bin";
-  OverwriteCacheDir(test_dir);
+  OverwriteDownloadCacheDir(test_dir);
 
   typedef VisualIndex<uint8_t, 16, 8> VisualIndexType;
   typename VisualIndexType::DescType descriptors =

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -377,7 +377,7 @@ std::optional<std::filesystem::path> download_cache_dir_overwrite;
 
 }
 
-std::string DownloadAndCacheFile(std::string uri) {
+std::string DownloadAndCacheFile(const std::string& uri) {
 #ifndef COLMAP_DOWNLOAD_ENABLED
   throw std::invalid_argument("COLMAP was compiled without download support");
 #endif
@@ -423,13 +423,13 @@ std::string DownloadAndCacheFile(std::string uri) {
   return path.string();
 }
 
-std::string MaybeDownloadAndCacheFile(std::string uri) {
+std::string MaybeDownloadAndCacheFile(const std::string& uri) {
   if (!StringStartsWith(uri, "http://") && !StringStartsWith(uri, "https://") &&
       !StringStartsWith(uri, "file://")) {
     return uri;
   }
 
-  return DownloadAndCacheFile(std::move(uri));
+  return DownloadAndCacheFile(uri);
 }
 
 void OverwriteDownloadCacheDir(std::filesystem::path path) {

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -211,12 +211,12 @@ namespace {
 std::optional<std::string> GetEnvSafe(const char* key) {
 #ifdef _MSC_VER
   size_t size = 0;
-  std::getenv_s(&size, nullptr, 0, key);
+  getenv_s(&size, nullptr, 0, key);
   if (size == 0) {
     return std::nullopt;
   }
   std::string value(size, ' ');
-  std::getenv_s(&size, value.data(), size, key);
+  getenv_s(&size, value.data(), size, key);
   return value;
 #else
   // Non-MSVC replacement for std::getenv_s. The safe variant

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -208,7 +208,7 @@ size_t GetFileSize(const std::string& path) {
 
 namespace {
 
-std::optional<std::string> GetEnvSafe(const std::string_view key) {
+std::optional<std::string> GetEnvSafe(const char* key) {
 #ifdef _MSC_VER
   size_t size = 0;
   std::getenv_s(&size, nullptr, 0, key);
@@ -223,13 +223,14 @@ std::optional<std::string> GetEnvSafe(const std::string_view key) {
   // std::getenv_s is not available on all platforms, unfortunately.
   // Stores environment variables as: "key1=value1", "key2=value2", ..., null
   char** env = environ;
+  const std::string_view key_sv(key);
   for (; *env; ++env) {
     const std::string_view key_value(*env);
-    if (key.size() < key_value.size() &&
-        key_value.substr(0, key.size()) == key &&
-        key_value[key.size()] == '=') {
-      return std::string(
-          key_value.substr(key.size() + 1, key_value.size() - key.size() - 1));
+    if (key_sv.size() < key_value.size() &&
+        key_value.substr(0, key_sv.size()) == key_sv &&
+        key_value[key_sv.size()] == '=') {
+      return std::string(key_value.substr(
+          key_sv.size() + 1, key_value.size() - key_sv.size() - 1));
     }
   }
   return std::nullopt;

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -376,7 +376,7 @@ bool DownloadCachedFile(const std::string& url,
   if (std::filesystem::exists(path)) {
     VLOG(2) << "File already downloaded. Skipping download.";
     std::vector<char> blob;
-    ReadBinaryBlob(path, &blob);
+    ReadBinaryBlob(path.string(), &blob);
     THROW_CHECK_EQ(ComputeSHA256({blob.data(), blob.size()}), sha256)
         << "The cached file does not match the expected SHA256";
     return false;
@@ -387,7 +387,7 @@ bool DownloadCachedFile(const std::string& url,
     THROW_CHECK_EQ(ComputeSHA256({blob->data(), blob->size()}), sha256)
         << "The downloaded file does not match the expected SHA256";
     LOG(INFO) << "Caching file at: " << path;
-    WriteBinaryBlob(path, {blob->data(), blob->size()});
+    WriteBinaryBlob(path.string(), {blob->data(), blob->size()});
     return true;
   }
 }

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -146,14 +146,16 @@ std::optional<std::string> DownloadFile(const std::string& url);
 // Computes SHA256 digest for given string.
 std::string ComputeSHA256(const std::string_view& str);
 
-// Downloads file from given URL, if it is not yet cached locally. In both
-// cases, checks the SHA256 digest of the downloaded or cached file. Throws
-// exception if the digest does not match. Returns true in case of download.
-bool DownloadCachedFile(const std::string& url,
-                        const std::string& sha256,
-                        const std::filesystem::path& path);
-
 #endif  // COLMAP_DOWNLOAD_ENABLED
+
+// Downloads file from given URI with the format. The URI can either be a
+// filesystem path or take the format "<url>;<name>;<sha256>" for remotely
+// stored files. In the latter case, the file will be cached under
+// $HOME/.cache/colmap/<sha256>-<name>. File integretiy is checked against the
+// provided SHA256 digest. Throws exception if the digest does not match.
+// Returns the path to the original or the cached file.
+std::string MaybeDownloadAndCacheFile(std::string uri);
+void OverwriteCacheDir(std::filesystem::path path);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -119,6 +119,14 @@ std::vector<std::string> GetRecursiveDirList(const std::string& path);
 // Get the size in bytes of a file.
 size_t GetFileSize(const std::string& path);
 
+// Gets current user's home directory from environment variables.
+// Returns null if it cannot be resolved.
+std::optional<std::filesystem::path> HomeDir();
+
+// Replaces $HOME with the home directory, if it can be resolved from
+// the environment variables. Otherwise leaves the path untouched.
+std::string SetPathHomeDir(std::string path);
+
 // Read contiguous binary blob from file.
 void ReadBinaryBlob(const std::string& path, std::vector<char>* data);
 
@@ -137,6 +145,13 @@ std::optional<std::string> DownloadFile(const std::string& url);
 
 // Computes SHA256 digest for given string.
 std::string ComputeSHA256(const std::string_view& str);
+
+// Downloads file from given URL, if it is not yet cached locally. In both
+// cases, checks the SHA256 digest of the downloaded or cached file. Throws
+// exception if the digest does not match. Returns true in case of download.
+bool DownloadCachedFile(const std::string& url,
+                        const std::string& sha256,
+                        const std::filesystem::path& path);
 
 #endif  // COLMAP_DOWNLOAD_ENABLED
 

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -149,11 +149,11 @@ std::string ComputeSHA256(const std::string_view& str);
 // $HOME/.cache/colmap/<sha256>-<name>. File integrity is checked against the
 // provided SHA256 digest. Throws exception if the digest does not match.
 // Returns the path to the cached file.
-std::string DownloadAndCacheFile(std::string uri);
+std::string DownloadAndCacheFile(const std::string& uri);
 
 // If the given URI is a local filesystem path, returns the input path. If the
 // URI matches the "<url>;<name>;<sha256>" format, calls DownloadAndCacheFile().
-std::string MaybeDownloadAndCacheFile(std::string uri);
+std::string MaybeDownloadAndCacheFile(const std::string& uri);
 
 // Overwrites the default download cache directory at $HOME/.cache/colmap/.
 void OverwriteDownloadCacheDir(std::filesystem::path path);

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -123,10 +123,6 @@ size_t GetFileSize(const std::string& path);
 // Returns null if it cannot be resolved.
 std::optional<std::filesystem::path> HomeDir();
 
-// Replaces $HOME with the home directory, if it can be resolved from
-// the environment variables. Otherwise leaves the path untouched.
-std::string SetPathHomeDir(std::string path);
-
 // Read contiguous binary blob from file.
 void ReadBinaryBlob(const std::string& path, std::vector<char>* data);
 
@@ -148,14 +144,19 @@ std::string ComputeSHA256(const std::string_view& str);
 
 #endif  // COLMAP_DOWNLOAD_ENABLED
 
-// Downloads file from given URI with the format. The URI can either be a
-// filesystem path or take the format "<url>;<name>;<sha256>" for remotely
-// stored files. In the latter case, the file will be cached under
-// $HOME/.cache/colmap/<sha256>-<name>. File integretiy is checked against the
+// Downloads and caches file from given URI. The URI must take the format
+// "<url>;<name>;<sha256>". The file will be cached under
+// $HOME/.cache/colmap/<sha256>-<name>. File integrity is checked against the
 // provided SHA256 digest. Throws exception if the digest does not match.
-// Returns the path to the original or the cached file.
+// Returns the path to the cached file.
+std::string DownloadAndCacheFile(std::string uri);
+
+// If the given URI is a local filesystem path, returns the input path. If the
+// URI matches the "<url>;<name>;<sha256>" format, calls DownloadAndCacheFile().
 std::string MaybeDownloadAndCacheFile(std::string uri);
-void OverwriteCacheDir(std::filesystem::path path);
+
+// Overwrites the default download cache directory at $HOME/.cache/colmap/.
+void OverwriteDownloadCacheDir(std::filesystem::path path);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -202,22 +202,25 @@ TEST(ComputeSHA256, Nominal) {
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
 }
 
-TEST(DownloadCachedFile, Nominal) {
+TEST(MaybeDownloadAndCacheFile, Nominal) {
   const std::string test_dir = CreateTestDir();
-  const std::string server_file_path = test_dir + "/server.bin";
-  const std::string cached_file_path = test_dir + "/cached.bin";
+  OverwriteCacheDir(test_dir);
 
-  std::string data = "123asd<>?";
+  const std::string data = "123asd<>?";
+  const std::string name = "cached.bin";
+  const std::string sha256 =
+      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd";
+  const std::string server_file_path = test_dir + "/server.bin";
+  const std::string cached_file_path = test_dir + "/" + sha256 + "-" + name;
   WriteBinaryBlob(server_file_path, {data.data(), data.size()});
 
-  EXPECT_TRUE(DownloadCachedFile(
-      "file://" + std::filesystem::absolute(server_file_path).string(),
-      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd",
-      cached_file_path));
-  EXPECT_FALSE(DownloadCachedFile(
-      "file://" + std::filesystem::absolute(server_file_path).string(),
-      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd",
-      cached_file_path));
+  const std::string uri = "file://" +
+                          std::filesystem::absolute(server_file_path).string() +
+                          ";" + name + ";" + sha256;
+
+  EXPECT_EQ(MaybeDownloadAndCacheFile(uri), cached_file_path);
+  EXPECT_EQ(MaybeDownloadAndCacheFile(uri), cached_file_path);
+  EXPECT_EQ(MaybeDownloadAndCacheFile(cached_file_path), cached_file_path);
 }
 
 #endif

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -140,6 +140,23 @@ TEST(JoinPaths, Nominal) {
   EXPECT_EQ(JoinPaths("/test1", "/test2/", "test3.ext"), "/test2/test3.ext");
 }
 
+TEST(HomeDir, Nominal) {
+  // Just test that it doesn't crash, since there is no guarantee that it
+  // resolves successfully on a particular machine.
+  const auto home_dir = HomeDir();
+  if (home_dir) {
+    LOG(INFO) << *home_dir;
+  }
+}
+
+TEST(SetPathHomeDir, Nominal) {
+  EXPECT_EQ(SetPathHomeDir(""), "");
+  EXPECT_EQ(SetPathHomeDir("test"), "test");
+  EXPECT_EQ(SetPathHomeDir("test/test"), "test/test");
+  EXPECT_NE(SetPathHomeDir("$HOME/test/test"), "$HOME/test/test");
+  EXPECT_NE(SetPathHomeDir("test/$HOME/test/test"), "test/$HOME/test/test");
+}
+
 TEST(ReadWriteBinaryBlob, Nominal) {
   const std::string file_path = CreateTestDir() + "/test.bin";
   const int kNumBytes = 123;
@@ -183,6 +200,24 @@ TEST(ComputeSHA256, Nominal) {
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
   EXPECT_EQ(ComputeSHA256("hello world"),
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+}
+
+TEST(DownloadCachedFile, Nominal) {
+  const std::string test_dir = CreateTestDir();
+  const std::string server_file_path = test_dir + "/server.bin";
+  const std::string cached_file_path = test_dir + "/cached.bin";
+
+  std::string data = "123asd<>?";
+  WriteBinaryBlob(server_file_path, {data.data(), data.size()});
+
+  EXPECT_TRUE(DownloadCachedFile(
+      "file://" + std::filesystem::absolute(server_file_path).string(),
+      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd",
+      cached_file_path));
+  EXPECT_FALSE(DownloadCachedFile(
+      "file://" + std::filesystem::absolute(server_file_path).string(),
+      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd",
+      cached_file_path));
 }
 
 #endif

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -204,7 +204,7 @@ TEST(MaybeDownloadAndCacheFile, Nominal) {
       "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd";
   const std::string server_file_path = test_dir + "/server.bin";
   const std::string cached_file_path =
-      std::filesystem::path(test_dir) / (sha256 + "-" + name);
+      (std::filesystem::path(test_dir) / (sha256 + "-" + name)).string();
   WriteBinaryBlob(server_file_path, {data.data(), data.size()});
 
   const std::string uri = "file://" +

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -216,28 +216,6 @@ TEST(MaybeDownloadAndCacheFile, Nominal) {
   EXPECT_EQ(MaybeDownloadAndCacheFile(cached_file_path), cached_file_path);
 }
 
-TEST(DownloadAndCacheFile, Nominal) {
-  const std::string test_dir = CreateTestDir();
-  OverwriteDownloadCacheDir(test_dir);
-
-  const std::string data = "123asd<>?";
-  const std::string name = "cached.bin";
-  const std::string sha256 =
-      "2915068022d460a622fb078147aee8d590c0a1bb1907d35fd27cb2f7bdb991dd";
-  const std::string server_file_path = test_dir + "/server.bin";
-  const std::string cached_file_path =
-      std::filesystem::path(test_dir) / (sha256 + "-" + name);
-  WriteBinaryBlob(server_file_path, {data.data(), data.size()});
-
-  const std::string uri = "file://" +
-                          std::filesystem::absolute(server_file_path).string() +
-                          ";" + name + ";" + sha256;
-
-  EXPECT_EQ(DownloadAndCacheFile(uri), cached_file_path);
-  EXPECT_EQ(DownloadAndCacheFile(uri), cached_file_path);
-  EXPECT_EQ(MaybeDownloadAndCacheFile(cached_file_path), cached_file_path);
-}
-
 #endif
 
 }  // namespace


### PR DESCRIPTION
This PR adds automatic download and caching functionality for vocabulary trees. Sample output:
```
$ colmap vocab_tree_matcher --database_path ~/data/south-building/database.db
I20241212 18:17:51.708911 427449 misc.cc:44] 
==============================================================================
Feature matching
==============================================================================
I20241212 18:17:51.724920 427450 sift.cc:1426] Creating SIFT GPU feature matcher
I20241212 18:17:51.755941 427449 pairing.cc:234] Generating image pairs with vocabulary tree...
I20241212 18:17:51.756253 427449 file.cc:356] Downloading file from: https://github.com/colmap/colmap/releases/download/3.11.1/vocab_tree_flickr100K_words256K.bin
I20241212 18:17:56.891381 427449 file.cc:361] Caching file at: "/Users/jsch/.cache/colmap/vocab_tree_flickr100K_words256K.bin"
I20241212 18:17:57.423804 427449 pairing.cc:355] Indexing image [1/128]
...

$ colmap vocab_tree_matcher --database_path ~/data/south-building/database.db
I20241212 18:18:02.601915 427813 misc.cc:44] 
==============================================================================
Feature matching
==============================================================================
I20241212 18:18:02.614478 427814 sift.cc:1426] Creating SIFT GPU feature matcher
I20241212 18:18:02.639487 427813 pairing.cc:234] Generating image pairs with vocabulary tree...
I20241212 18:18:03.135216 427813 pairing.cc:355] Indexing image [1/128]
...
```