### PR TITLE
Avoid dependent inputs in IncrementalMapperImpl

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -116,9 +116,9 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
                                              image_t& image_id2) {
   return IncrementalMapperImpl::FindInitialImagePair(
       options,
-      database_cache_,
-      reconstruction_,
-      obs_manager_,
+      *database_cache_,
+      *reconstruction_,
+      *obs_manager_,
       reg_stats_.init_num_reg_trials,
       reg_stats_.num_registrations,
       reg_stats_.init_image_pairs,
@@ -129,8 +129,8 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
 
 std::vector<image_t> IncrementalMapper::FindNextImages(const Options& options) {
   return IncrementalMapperImpl::FindNextImages(options,
-                                               reconstruction_,
-                                               obs_manager_,
+                                               *reconstruction_,
+                                               *obs_manager_,
                                                filtered_images_,
                                                reg_stats_.num_reg_trials);
 }
@@ -782,7 +782,7 @@ void IncrementalMapper::ClearModifiedPoints3D() {
 std::vector<image_t> IncrementalMapper::FindLocalBundle(
     const Options& options, const image_t image_id) const {
   return IncrementalMapperImpl::FindLocalBundle(
-      options, image_id, reconstruction_);
+      options, image_id, *reconstruction_);
 }
 
 void IncrementalMapper::RegisterImageEvent(const image_t image_id) {
@@ -822,7 +822,7 @@ bool IncrementalMapper::EstimateInitialTwoViewGeometry(
     const image_t image_id2,
     TwoViewGeometry& two_view_geometry) {
   return IncrementalMapperImpl::EstimateInitialTwoViewGeometry(
-      options, database_cache_, image_id1, image_id2, two_view_geometry);
+      options, *database_cache_, image_id1, image_id2, two_view_geometry);
 }
 
 }  // namespace colmap

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -118,7 +118,6 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
       options,
       *database_cache_,
       *reconstruction_,
-      *obs_manager_,
       reg_stats_.init_num_reg_trials,
       reg_stats_.num_registrations,
       reg_stats_.init_image_pairs,
@@ -128,11 +127,8 @@ bool IncrementalMapper::FindInitialImagePair(const Options& options,
 }
 
 std::vector<image_t> IncrementalMapper::FindNextImages(const Options& options) {
-  return IncrementalMapperImpl::FindNextImages(options,
-                                               *reconstruction_,
-                                               *obs_manager_,
-                                               filtered_images_,
-                                               reg_stats_.num_reg_trials);
+  return IncrementalMapperImpl::FindNextImages(
+      options, *obs_manager_, filtered_images_, reg_stats_.num_reg_trials);
 }
 
 void IncrementalMapper::RegisterInitialImagePair(

--- a/src/colmap/sfm/incremental_mapper_impl.cc
+++ b/src/colmap/sfm/incremental_mapper_impl.cc
@@ -78,8 +78,8 @@ float RankNextImageMinUncertainty(const image_t image_id,
 
 std::vector<image_t> IncrementalMapperImpl::FindFirstInitialImage(
     const IncrementalMapper::Options& options,
-    const std::shared_ptr<class Reconstruction>& reconstruction,
-    const std::shared_ptr<class ObservationManager>& obs_manager,
+    const Reconstruction& reconstruction,
+    const ObservationManager& obs_manager,
     const std::unordered_map<image_t, size_t>& init_num_reg_trials,
     const std::unordered_map<image_t, size_t>& num_registrations) {
   // Struct to hold meta-data for ranking images.
@@ -95,10 +95,10 @@ std::vector<image_t> IncrementalMapperImpl::FindFirstInitialImage(
   // Collect information of all not yet registered images with
   // correspondences.
   std::vector<ImageInfo> image_infos;
-  image_infos.reserve(reconstruction->NumImages());
-  for (const auto& image : reconstruction->Images()) {
+  image_infos.reserve(reconstruction.NumImages());
+  for (const auto& image : reconstruction.Images()) {
     // Only images with correspondences can be registered.
-    if (obs_manager->NumCorrespondences(image.first) == 0) {
+    if (obs_manager.NumCorrespondences(image.first) == 0) {
       continue;
     }
 
@@ -120,7 +120,7 @@ std::vector<image_t> IncrementalMapperImpl::FindFirstInitialImage(
     image_info.image_id = image.first;
     image_info.prior_focal_length = camera.has_prior_focal_length;
     image_info.num_correspondences =
-        obs_manager->NumCorrespondences(image.first);
+        obs_manager.NumCorrespondences(image.first);
     image_infos.push_back(image_info);
   }
 
@@ -154,14 +154,14 @@ std::vector<image_t> IncrementalMapperImpl::FindFirstInitialImage(
 std::vector<image_t> IncrementalMapperImpl::FindSecondInitialImage(
     const IncrementalMapper::Options& options,
     image_t image_id1,
-    const std::shared_ptr<const DatabaseCache>& database_cache,
-    const std::shared_ptr<class Reconstruction>& reconstruction,
+    const DatabaseCache& database_cache,
+    const Reconstruction& reconstruction,
     const std::unordered_map<image_t, size_t>& num_registrations) {
   const std::shared_ptr<const CorrespondenceGraph> correspondence_graph =
-      database_cache->CorrespondenceGraph();
+      database_cache.CorrespondenceGraph();
   // Collect images that are connected to the first seed image and have
   // not been registered before in other reconstructions.
-  const class Image& image1 = reconstruction->Image(image_id1);
+  const class Image& image1 = reconstruction.Image(image_id1);
   std::unordered_map<image_t, point2D_t> num_correspondences;
   for (point2D_t point2D_idx = 0; point2D_idx < image1.NumPoints2D();
        ++point2D_idx) {
@@ -187,10 +187,10 @@ std::vector<image_t> IncrementalMapperImpl::FindSecondInitialImage(
 
   // Compose image information in a compact form for sorting.
   std::vector<ImageInfo> image_infos;
-  image_infos.reserve(reconstruction->NumImages());
+  image_infos.reserve(reconstruction.NumImages());
   for (const auto elem : num_correspondences) {
     if (elem.second >= init_min_num_inliers) {
-      const Image& image = reconstruction->Image(elem.first);
+      const Image& image = reconstruction.Image(elem.first);
       const Camera& camera = *image.CameraPtr();
       ImageInfo image_info;
       image_info.image_id = elem.first;
@@ -229,9 +229,9 @@ std::vector<image_t> IncrementalMapperImpl::FindSecondInitialImage(
 
 bool IncrementalMapperImpl::FindInitialImagePair(
     const IncrementalMapper::Options& options,
-    const std::shared_ptr<const DatabaseCache>& database_cache,
-    const std::shared_ptr<class Reconstruction>& reconstruction,
-    const std::shared_ptr<class ObservationManager>& obs_manager,
+    const DatabaseCache& database_cache,
+    const Reconstruction& reconstruction,
+    const ObservationManager& obs_manager,
     const std::unordered_map<image_t, size_t>& init_num_reg_trials,
     const std::unordered_map<image_t, size_t>& num_registrations,
     std::unordered_set<image_pair_t>& init_image_pairs,
@@ -243,13 +243,13 @@ bool IncrementalMapperImpl::FindInitialImagePair(
   std::vector<image_t> image_ids1;
   if (image_id1 != kInvalidImageId && image_id2 == kInvalidImageId) {
     // Only image_id1 provided.
-    if (!database_cache->ExistsImage(image_id1)) {
+    if (!database_cache.ExistsImage(image_id1)) {
       return false;
     }
     image_ids1.push_back(image_id1);
   } else if (image_id1 == kInvalidImageId && image_id2 != kInvalidImageId) {
     // Only image_id2 provided.
-    if (!database_cache->ExistsImage(image_id2)) {
+    if (!database_cache.ExistsImage(image_id2)) {
       return false;
     }
     image_ids1.push_back(image_id2);
@@ -307,11 +307,10 @@ bool IncrementalMapperImpl::FindInitialImagePair(
 
 std::vector<image_t> IncrementalMapperImpl::FindNextImages(
     const IncrementalMapper::Options& options,
-    const std::shared_ptr<class Reconstruction>& reconstruction,
-    const std::shared_ptr<class ObservationManager>& obs_manager,
+    const Reconstruction& reconstruction,
+    const ObservationManager& obs_manager,
     const std::unordered_set<image_t>& filtered_images,
     std::unordered_map<image_t, size_t>& m_num_reg_trials) {
-  THROW_CHECK_NOTNULL(reconstruction);
   THROW_CHECK(options.Check());
 
   std::function<float(image_t, const class ObservationManager&)>
@@ -334,14 +333,14 @@ std::vector<image_t> IncrementalMapperImpl::FindNextImages(
   std::vector<std::pair<image_t, float>> other_image_ranks;
 
   // Append images that have not failed to register before.
-  for (const auto& image : reconstruction->Images()) {
+  for (const auto& image : reconstruction.Images()) {
     // Skip images that are already registered.
     if (image.second.HasPose()) {
       continue;
     }
 
     // Only consider images with a sufficient number of visible points.
-    if (obs_manager->NumVisiblePoints3D(image.first) <
+    if (obs_manager.NumVisiblePoints3D(image.first) <
         static_cast<size_t>(options.abs_pose_min_num_inliers)) {
       continue;
     }
@@ -354,7 +353,7 @@ std::vector<image_t> IncrementalMapperImpl::FindNextImages(
 
     // If image has been filtered or failed to register, place it in the
     // second bucket and prefer images that have not been tried before.
-    const float rank = rank_image_func(image.first, *obs_manager);
+    const float rank = rank_image_func(image.first, obs_manager);
     if (filtered_images.count(image.first) == 0 && num_reg_trials == 0) {
       image_ranks.emplace_back(image.first, rank);
     } else {
@@ -372,10 +371,10 @@ std::vector<image_t> IncrementalMapperImpl::FindNextImages(
 std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
     const IncrementalMapper::Options& options,
     image_t image_id,
-    const std::shared_ptr<class Reconstruction>& reconstruction) {
+    const Reconstruction& reconstruction) {
   THROW_CHECK(options.Check());
 
-  const Image& image = reconstruction->Image(image_id);
+  const Image& image = reconstruction.Image(image_id);
   THROW_CHECK(image.HasPose());
 
   // Extract all images that have at least one 3D point with the query image
@@ -389,7 +388,7 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
   for (const Point2D& point2D : image.Points2D()) {
     if (point2D.HasPoint3D()) {
       point3D_ids.insert(point2D.point3D_id);
-      const Point3D& point3D = reconstruction->Point3D(point2D.point3D_id);
+      const Point3D& point3D = reconstruction.Point3D(point2D.point3D_id);
       for (const TrackElement& track_el : point3D.track.Elements()) {
         if (track_el.image_id != image_id) {
           shared_observations[track_el.image_id] += 1;
@@ -474,8 +473,8 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
         continue;
       }
 
-      const auto& overlapping_image = reconstruction->Image(
-          overlapping_images[overlapping_image_idx].first);
+      const auto& overlapping_image =
+          reconstruction.Image(overlapping_images[overlapping_image_idx].first);
       const Eigen::Vector3d overlapping_proj_center =
           overlapping_image.ProjectionCenter();
 
@@ -488,7 +487,7 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
         for (const Point2D& point2D : overlapping_image.Points2D()) {
           if (point2D.HasPoint3D() && point3D_ids.count(point2D.point3D_id)) {
             shared_points3D.push_back(
-                reconstruction->Point3D(point2D.point3D_id).xyz);
+                reconstruction.Point3D(point2D.point3D_id).xyz);
           }
         }
 
@@ -543,18 +542,18 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
 
 bool IncrementalMapperImpl::EstimateInitialTwoViewGeometry(
     const IncrementalMapper::Options& options,
-    const std::shared_ptr<const DatabaseCache>& database_cache,
+    const DatabaseCache& database_cache,
     const image_t image_id1,
     const image_t image_id2,
     TwoViewGeometry& two_view_geometry) {
-  const Image& image1 = database_cache->Image(image_id1);
-  const Camera& camera1 = database_cache->Camera(image1.CameraId());
+  const Image& image1 = database_cache.Image(image_id1);
+  const Camera& camera1 = database_cache.Camera(image1.CameraId());
 
-  const Image& image2 = database_cache->Image(image_id2);
-  const Camera& camera2 = database_cache->Camera(image2.CameraId());
+  const Image& image2 = database_cache.Image(image_id2);
+  const Camera& camera2 = database_cache.Camera(image2.CameraId());
 
   const FeatureMatches matches =
-      database_cache->CorrespondenceGraph()->FindCorrespondencesBetweenImages(
+      database_cache.CorrespondenceGraph()->FindCorrespondencesBetweenImages(
           image_id1, image_id2);
 
   std::vector<Eigen::Vector2d> points1;

--- a/src/colmap/sfm/incremental_mapper_impl.h
+++ b/src/colmap/sfm/incremental_mapper_impl.h
@@ -45,8 +45,8 @@ class IncrementalMapperImpl {
   // returned list is ordered such that most suitable images are in the front.
   static std::vector<image_t> FindFirstInitialImage(
       const IncrementalMapper::Options& options,
-      const std::shared_ptr<class Reconstruction>& reconstruction,
-      const std::shared_ptr<class ObservationManager>& obs_manager,
+      const Reconstruction& reconstruction,
+      const ObservationManager& obs_manager,
       const std::unordered_map<image_t, size_t>& init_num_reg_trials,
       const std::unordered_map<image_t, size_t>& num_registrations);
 
@@ -57,16 +57,16 @@ class IncrementalMapperImpl {
   static std::vector<image_t> FindSecondInitialImage(
       const IncrementalMapper::Options& options,
       image_t image_id1,
-      const std::shared_ptr<const DatabaseCache>& database_cache,
-      const std::shared_ptr<class Reconstruction>& reconstruction,
+      const DatabaseCache& database_cache,
+      const Reconstruction& reconstruction,
       const std::unordered_map<image_t, size_t>& num_registrations);
 
   // Implement IncrementalMapper::FindInitialImagePair
   static bool FindInitialImagePair(
       const IncrementalMapper::Options& options,
-      const std::shared_ptr<const DatabaseCache>& database_cache,
-      const std::shared_ptr<class Reconstruction>& reconstruction,
-      const std::shared_ptr<class ObservationManager>& obs_manager,
+      const DatabaseCache& database_cache,
+      const Reconstruction& reconstruction,
+      const ObservationManager& obs_manager,
       const std::unordered_map<image_t, size_t>& init_num_reg_trials,
       const std::unordered_map<image_t, size_t>& num_registrations,
       std::unordered_set<image_pair_t>& init_image_pairs,
@@ -77,8 +77,8 @@ class IncrementalMapperImpl {
   // Implement IncrementalMapper::FindNextImages
   static std::vector<image_t> FindNextImages(
       const IncrementalMapper::Options& options,
-      const std::shared_ptr<class Reconstruction>& reconstruction,
-      const std::shared_ptr<class ObservationManager>& obs_manager,
+      const Reconstruction& reconstruction,
+      const ObservationManager& obs_manager,
       const std::unordered_set<image_t>& filtered_images,
       std::unordered_map<image_t, size_t>& m_num_reg_trials);
 
@@ -86,12 +86,12 @@ class IncrementalMapperImpl {
   static std::vector<image_t> FindLocalBundle(
       const IncrementalMapper::Options& options,
       image_t image_id,
-      const std::shared_ptr<class Reconstruction>& reconstruction);
+      const Reconstruction& reconstruction);
 
   // Implement IncrementalMapper::EstimateInitialTwoViewGeometry
   static bool EstimateInitialTwoViewGeometry(
       const IncrementalMapper::Options& options,
-      const std::shared_ptr<const DatabaseCache>& database_cache,
+      const DatabaseCache& database_cache,
       image_t image_id1,
       image_t image_id2,
       TwoViewGeometry& two_view_geometry);

--- a/src/colmap/sfm/incremental_mapper_impl.h
+++ b/src/colmap/sfm/incremental_mapper_impl.h
@@ -45,8 +45,8 @@ class IncrementalMapperImpl {
   // returned list is ordered such that most suitable images are in the front.
   static std::vector<image_t> FindFirstInitialImage(
       const IncrementalMapper::Options& options,
+      const CorrespondenceGraph& correspondence_graph,
       const Reconstruction& reconstruction,
-      const ObservationManager& obs_manager,
       const std::unordered_map<image_t, size_t>& init_num_reg_trials,
       const std::unordered_map<image_t, size_t>& num_registrations);
 
@@ -57,7 +57,7 @@ class IncrementalMapperImpl {
   static std::vector<image_t> FindSecondInitialImage(
       const IncrementalMapper::Options& options,
       image_t image_id1,
-      const DatabaseCache& database_cache,
+      const CorrespondenceGraph& correspondence_graph,
       const Reconstruction& reconstruction,
       const std::unordered_map<image_t, size_t>& num_registrations);
 
@@ -66,7 +66,6 @@ class IncrementalMapperImpl {
       const IncrementalMapper::Options& options,
       const DatabaseCache& database_cache,
       const Reconstruction& reconstruction,
-      const ObservationManager& obs_manager,
       const std::unordered_map<image_t, size_t>& init_num_reg_trials,
       const std::unordered_map<image_t, size_t>& num_registrations,
       std::unordered_set<image_pair_t>& init_image_pairs,
@@ -77,7 +76,6 @@ class IncrementalMapperImpl {
   // Implement IncrementalMapper::FindNextImages
   static std::vector<image_t> FindNextImages(
       const IncrementalMapper::Options& options,
-      const Reconstruction& reconstruction,
       const ObservationManager& obs_manager,
       const std::unordered_set<image_t>& filtered_images,
       std::unordered_map<image_t, size_t>& m_num_reg_trials);

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -53,7 +53,7 @@ bool MergeAndFilterReconstructions(const double max_reproj_error,
 const int ObservationManager::kNumPoint3DVisibilityPyramidLevels = 6;
 
 ObservationManager::ObservationManager(
-    Reconstruction& reconstruction,
+    class Reconstruction& reconstruction,
     std::shared_ptr<const CorrespondenceGraph> correspondence_graph)
     : reconstruction_(reconstruction),
       correspondence_graph_(std::move(correspondence_graph)) {

--- a/src/colmap/sfm/observation_manager.h
+++ b/src/colmap/sfm/observation_manager.h
@@ -50,9 +50,12 @@ class ObservationManager {
     size_t num_total_corrs = 0;
   };
 
-  explicit ObservationManager(Reconstruction& reconstruction,
+  explicit ObservationManager(class Reconstruction& reconstruction,
                               std::shared_ptr<const CorrespondenceGraph>
                                   correspondence_graph = nullptr);
+
+  inline const class Reconstruction& Reconstruction() const;
+  inline class Reconstruction& Reconstruction();
 
   inline const std::unordered_map<image_pair_t, ImagePairStat>& ImagePairs()
       const;
@@ -179,7 +182,7 @@ class ObservationManager {
     VisibilityPyramid point3D_visibility_pyramid;
   };
 
-  Reconstruction& reconstruction_;
+  class Reconstruction& reconstruction_;
   const std::shared_ptr<const CorrespondenceGraph> correspondence_graph_;
   std::unordered_map<image_pair_t, ImagePairStat> image_pair_stats_;
   std::unordered_map<image_t, ImageStat> image_stats_;
@@ -187,6 +190,14 @@ class ObservationManager {
 
 std::ostream& operator<<(std::ostream& stream,
                          const ObservationManager& obs_manager);
+
+const class Reconstruction& ObservationManager::Reconstruction() const {
+  return reconstruction_;
+}
+
+class Reconstruction& ObservationManager::Reconstruction() {
+  return reconstruction_;
+}
 
 const std::unordered_map<image_pair_t, ObservationManager::ImagePairStat>&
 ObservationManager::ImagePairs() const {


### PR DESCRIPTION
As mentioned in https://github.com/colmap/colmap/pull/3042, there are some dependencies in the graph that we need to take care of to avoid inconsistency, notably:
* ``ObservationManager`` and ``DatabaseCache`` shares a same ``CorrespondenceGraph`` object, so should not be listed as input together to a static method
* ``ObservationManager`` has a reference to the ``Reconstruction`` object, so should not be listed as input together with a ``Reconstruction`` object to a static method

This PR contains the updates as follows:
* use const ref rather than smart pointers as input in the algorithm class
* use ``NumCorrespondencesForImage`` from ``CorrespondenceGraph`` rather than ``ObservationManager`` to avoid dependent input
* add getter for the ``Reconstruction`` object to the ``ObservationManager`` class to avoid dependent input. 