### PR TITLE
Improvements for reconstruction normalization / bbox / centroid

### DIFF
--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/estimators/coordinate_frame.h"
 
 #include "colmap/geometry/gps.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <gtest/gtest.h>
 
@@ -133,22 +134,26 @@ TEST(CoordinateFrame, AlignToENUPlane) {
   }
   AlignToENUPlane(&reconstruction, &tform, false);
   // Verify final locations of points
-  EXPECT_LE((reconstruction.Point3D(point_ids[0]).xyz -
-             Eigen::Vector3d(3584.8565215, -5561.5336506, 0.0742643))
-                .norm(),
-            1e-6);
-  EXPECT_LE((reconstruction.Point3D(point_ids[1]).xyz -
-             Eigen::Vector3d(-3577.3888622, 5561.6397107, 0.0783761))
-                .norm(),
-            1e-6);
-  EXPECT_LE((reconstruction.Point3D(point_ids[2]).xyz -
-             Eigen::Vector3d(3577.4152111, 5561.6397283, 0.0783613))
-                .norm(),
-            1e-6);
-  EXPECT_LE((reconstruction.Point3D(point_ids[3]).xyz -
-             Eigen::Vector3d(-3584.8301178, -5561.5336683, 0.0742791))
-                .norm(),
-            1e-6);
+  EXPECT_THAT(reconstruction.Point3D(point_ids[0]).xyz,
+              EigenMatrixNear(Eigen::Vector3d(3584.8433196335045,
+                                              -5561.5866894473402,
+                                              -0.0020947810262441635),
+                              1e-6));
+  EXPECT_THAT(reconstruction.Point3D(point_ids[1]).xyz,
+              EigenMatrixNear(Eigen::Vector3d(-3577.4020366631503,
+                                              5561.5866894469982,
+                                              0.0020947791635990143),
+                              1e-6));
+  EXPECT_THAT(reconstruction.Point3D(point_ids[2]).xyz,
+              EigenMatrixNear(Eigen::Vector3d(3577.4020366640707,
+                                              5561.5866894467654,
+                                              0.0020947791635990143),
+                              1e-6));
+  EXPECT_THAT(reconstruction.Point3D(point_ids[3]).xyz,
+              EigenMatrixNear(Eigen::Vector3d(-3584.8433196330498,
+                                              -5561.586689447573,
+                                              -0.0020947810262441635),
+                              1e-6));
 
   // Verify that straight line distance between points is preserved
   for (size_t i = 1; i < points.size(); ++i) {

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -44,27 +44,26 @@
 namespace colmap {
 namespace {
 
-std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>
-ComputeEqualPartsBounds(const Reconstruction& reconstruction,
-                        const Eigen::Vector3i& split) {
-  std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> bounds;
-  const auto bbox = reconstruction.ComputeBoundingBox();
-  const Eigen::Vector3d extent = bbox.second - bbox.first;
+std::vector<Eigen::AlignedBox3d> ComputeEqualPartsBboxes(
+    const Reconstruction& reconstruction, const Eigen::Vector3i& split) {
+  std::vector<Eigen::AlignedBox3d> bboxes;
+  const Eigen::AlignedBox3d bbox = reconstruction.ComputeBoundingBox();
+  const Eigen::Vector3d extent = bbox.diagonal();
   const Eigen::Vector3d offset(
       extent(0) / split(0), extent(1) / split(1), extent(2) / split(2));
 
   for (int k = 0; k < split(2); ++k) {
     for (int j = 0; j < split(1); ++j) {
       for (int i = 0; i < split(0); ++i) {
-        Eigen::Vector3d min_bound(bbox.first(0) + i * offset(0),
-                                  bbox.first(1) + j * offset(1),
-                                  bbox.first(2) + k * offset(2));
-        bounds.emplace_back(min_bound, min_bound + offset);
+        Eigen::Vector3d min(bbox.min().x() + i * offset(0),
+                            bbox.min().z() + j * offset(1),
+                            bbox.min().z() + k * offset(2));
+        bboxes.emplace_back(min, min + offset);
       }
     }
   }
 
-  return bounds;
+  return bboxes;
 }
 
 Eigen::Vector3d TransformLatLonAltToModelCoords(const Sim3d& tform,
@@ -84,9 +83,9 @@ Eigen::Vector3d TransformLatLonAltToModelCoords(const Sim3d& tform,
 }
 
 void WriteBoundingBox(const std::string& reconstruction_path,
-                      const std::pair<Eigen::Vector3d, Eigen::Vector3d>& bounds,
+                      const Eigen::AlignedBox3d& bbox,
                       const std::string& suffix = "") {
-  const Eigen::Vector3d extent = bounds.second - bounds.first;
+  const Eigen::Vector3d extent = bbox.diagonal();
   // write axis-aligned bounding box
   {
     const std::string path =
@@ -96,8 +95,8 @@ void WriteBoundingBox(const std::string& reconstruction_path,
 
     // Ensure that we don't lose any precision by storing in text.
     file.precision(17);
-    file << bounds.first.transpose() << "\n";
-    file << bounds.second.transpose() << "\n";
+    file << bbox.min().transpose() << "\n";
+    file << bbox.max().transpose() << "\n";
   }
   // write oriented bounding box
   {
@@ -108,7 +107,7 @@ void WriteBoundingBox(const std::string& reconstruction_path,
 
     // Ensure that we don't lose any precision by storing in text.
     file.precision(17);
-    const Eigen::Vector3d center = (bounds.first + bounds.second) * 0.5;
+    const Eigen::Vector3d center = (bbox.min() + bbox.max()) * 0.5;
     file << center.transpose() << "\n\n";
     file << "1 0 0\n0 1 0\n0 0 1\n\n";
     file << extent.transpose() << "\n";
@@ -678,7 +677,7 @@ int RunModelCropper(int argc, char** argv) {
   reconstruction.Read(input_path);
 
   PrintHeading2("Calculating boundary coordinates");
-  std::pair<Eigen::Vector3d, Eigen::Vector3d> bounding_box;
+  Eigen::AlignedBox3d bounding_box;
   if (boundary_elements.size() == 6) {
     Sim3d tform;
     if (!gps_transform_path.empty()) {
@@ -686,7 +685,7 @@ int RunModelCropper(int argc, char** argv) {
       is_gps = true;
       tform = Inverse(Sim3d::FromFile(gps_transform_path));
     }
-    bounding_box.first =
+    bounding_box.min() =
         is_gps ? TransformLatLonAltToModelCoords(tform,
                                                  boundary_elements[0],
                                                  boundary_elements[1],
@@ -694,7 +693,7 @@ int RunModelCropper(int argc, char** argv) {
                : Eigen::Vector3d(boundary_elements[0],
                                  boundary_elements[1],
                                  boundary_elements[2]);
-    bounding_box.second =
+    bounding_box.max() =
         is_gps ? TransformLatLonAltToModelCoords(tform,
                                                  boundary_elements[3],
                                                  boundary_elements[4],
@@ -905,9 +904,9 @@ int RunModelSplitter(int argc, char** argv) {
 
   // Create the necessary number of reconstructions based on the split method
   // and get the bounding boxes for each sub-reconstruction
-  PrintHeading2("Computing bound_coords");
+  PrintHeading2("Computing bounding boxes");
   std::vector<std::string> tile_keys;
-  std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> exact_bounds;
+  std::vector<Eigen::AlignedBox3d> exact_bboxes;
   StringToLower(&split_type);
   if (split_type == "tiles") {
     std::ifstream file(split_params);
@@ -915,17 +914,17 @@ int RunModelSplitter(int argc, char** argv) {
 
     double x1, y1, z1, x2, y2, z2;
     std::string tile_key;
-    std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> bounds;
+    std::vector<Eigen::AlignedBox3d> bounds;
     tile_keys.clear();
     file >> tile_key >> x1 >> y1 >> z1 >> x2 >> y2 >> z2;
     while (!file.fail()) {
       tile_keys.push_back(tile_key);
       if (is_gps) {
-        exact_bounds.emplace_back(
+        exact_bboxes.emplace_back(
             TransformLatLonAltToModelCoords(tform, x1, y1, z1),
             TransformLatLonAltToModelCoords(tform, x2, y2, z2));
       } else {
-        exact_bounds.emplace_back(Eigen::Vector3d(x1, y1, z1),
+        exact_bboxes.emplace_back(Eigen::Vector3d(x1, y1, z1),
                                   Eigen::Vector3d(x2, y2, z2));
       }
       file >> tile_key >> x1 >> y1 >> z1 >> x2 >> y2 >> z2;
@@ -939,15 +938,13 @@ int RunModelSplitter(int argc, char** argv) {
       extent(i) = parts[i] * tform.scale;
     }
 
-    const auto bbox = reconstruction.ComputeBoundingBox();
-    const Eigen::Vector3d full_extent = bbox.second - bbox.first;
-    const Eigen::Vector3i split(
-        static_cast<int>(full_extent(0) / extent(0)) + 1,
-        static_cast<int>(full_extent(1) / extent(1)) + 1,
-        static_cast<int>(full_extent(2) / extent(2)) + 1);
+    const Eigen::AlignedBox3d bbox = reconstruction.ComputeBoundingBox();
+    const Eigen::Vector3d full_bbox = bbox.diagonal();
+    const Eigen::Vector3i split(static_cast<int>(full_bbox(0) / extent(0)) + 1,
+                                static_cast<int>(full_bbox(1) / extent(1)) + 1,
+                                static_cast<int>(full_bbox(2) / extent(2)) + 1);
 
-    exact_bounds = ComputeEqualPartsBounds(reconstruction, split);
-
+    exact_bboxes = ComputeEqualPartsBboxes(reconstruction, split);
   } else if (split_type == "parts") {
     auto parts = CSVToVector<int>(split_params);
     Eigen::Vector3i split(1, 1, 1);
@@ -958,36 +955,36 @@ int RunModelSplitter(int argc, char** argv) {
         return EXIT_FAILURE;
       }
     }
-    exact_bounds = ComputeEqualPartsBounds(reconstruction, split);
+    exact_bboxes = ComputeEqualPartsBboxes(reconstruction, split);
   } else {
     LOG(ERROR) << "Invalid split type: " << split_type;
     return EXIT_FAILURE;
   }
 
-  std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> bounds;
-  for (const auto& bbox : exact_bounds) {
-    const Eigen::Vector3d padding =
-        (overlap_ratio * (bbox.second - bbox.first));
-    bounds.emplace_back(bbox.first - padding, bbox.second + padding);
+  std::vector<Eigen::AlignedBox3d> padded_bboxes;
+  for (const auto& bbox : exact_bboxes) {
+    const Eigen::Vector3d padding = overlap_ratio * bbox.diagonal();
+    padded_bboxes.emplace_back(bbox.min() - padding, bbox.max() + padding);
   }
 
   PrintHeading2("Applying split and writing reconstructions");
-  const size_t num_parts = bounds.size();
+  const size_t num_parts = padded_bboxes.size();
   LOG(INFO) << StringPrintf("=> Splitting to %d parts", num_parts);
 
   const bool use_tile_keys = split_type == "tiles";
 
   auto SplitReconstruction = [&](const int idx) {
-    Reconstruction tile_recon = reconstruction.Crop(bounds[idx]);
+    Reconstruction tile_recon = reconstruction.Crop(padded_bboxes[idx]);
     // calculate area covered by model as proportion of box area
-    auto bbox_extent = bounds[idx].second - bounds[idx].first;
-    auto model_bbox = tile_recon.ComputeBoundingBox();
-    auto model_extent = model_bbox.second - model_bbox.first;
-    double area_ratio =
+    const Eigen::Vector3d bbox_extent = padded_bboxes[idx].diagonal();
+    const Eigen::AlignedBox3d model_bbox = tile_recon.ComputeBoundingBox();
+    const Eigen::Vector3d model_extent = model_bbox.diagonal();
+    const double area_ratio =
         (model_extent(0) * model_extent(1)) / (bbox_extent(0) * bbox_extent(1));
-    int tile_num_points = tile_recon.NumPoints3D();
+    const int tile_num_points = tile_recon.NumPoints3D();
 
-    std::string name = use_tile_keys ? tile_keys[idx] : std::to_string(idx);
+    const std::string name =
+        use_tile_keys ? tile_keys[idx] : std::to_string(idx);
     const bool include_tile =
         area_ratio >= min_area_ratio &&       //
         tile_num_points >= min_num_points &&  //
@@ -1004,9 +1001,8 @@ int RunModelSplitter(int argc, char** argv) {
       const std::string reconstruction_path = JoinPaths(output_path, name);
       CreateDirIfNotExists(reconstruction_path);
       tile_recon.Write(reconstruction_path);
-      WriteBoundingBox(reconstruction_path, bounds[idx]);
-      WriteBoundingBox(reconstruction_path, exact_bounds[idx], "_exact");
-
+      WriteBoundingBox(reconstruction_path, padded_bboxes[idx]);
+      WriteBoundingBox(reconstruction_path, exact_bboxes[idx], "_exact");
     } else {
       LOG(INFO) << StringPrintf(
           "Skipping reconstruction %s with %d images, %d points, "

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -58,8 +58,13 @@ COLMAP_ADD_TEST(
     LINK_LIBS colmap_geometry
 )
 COLMAP_ADD_TEST(
-    NAME homography_matrix_utils_test
+    NAME homography_matrix_test
     SRCS homography_matrix_test.cc
+    LINK_LIBS colmap_geometry
+)
+COLMAP_ADD_TEST(
+    NAME normalization_test
+    SRCS normalization_test.cc
     LINK_LIBS colmap_geometry
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -36,6 +36,7 @@ COLMAP_ADD_LIBRARY(
         essential_matrix.h essential_matrix.cc
         gps.h gps.cc
         homography_matrix.h homography_matrix.cc
+        normalization.h normalization.cc
         pose.h pose.cc
         rigid3.h rigid3.cc
         sim3.h sim3.cc

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/geometry/normalization.h"
+
+#include "colmap/util/logging.h"
+
+#include <algorithm>
+
+namespace colmap {
+
+std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
+    double min_percentile,
+    double max_percentile,
+    std::vector<double> coords_x,
+    std::vector<double> coords_y,
+    std::vector<double> coords_z) {
+  THROW_CHECK(!coords_x.empty());
+  THROW_CHECK_EQ(coords_x.size(), coords_y.size());
+  THROW_CHECK_EQ(coords_x.size(), coords_z.size());
+  THROW_CHECK_GE(min_percentile, 0);
+  THROW_CHECK_LE(min_percentile, 1);
+  THROW_CHECK_GE(max_percentile, 0);
+  THROW_CHECK_LE(max_percentile, 1);
+  THROW_CHECK_LE(min_percentile, max_percentile);
+
+  const size_t end_idx = coords_x.size() - 1;
+  const size_t min_idx =
+      std::max(0lu, static_cast<size_t>(std::floor(min_percentile * end_idx)));
+  const size_t max_idx = std::min(
+      end_idx, static_cast<size_t>(std::ceil(max_percentile * end_idx)));
+
+  std::nth_element(
+      coords_x.begin(), coords_x.begin() + min_idx, coords_x.end());
+  std::nth_element(
+      coords_x.begin() + min_idx, coords_x.begin() + max_idx, coords_x.end());
+  std::nth_element(
+      coords_y.begin(), coords_y.begin() + min_idx, coords_y.end());
+  std::nth_element(
+      coords_y.begin() + min_idx, coords_y.begin() + max_idx, coords_y.end());
+  std::nth_element(
+      coords_z.begin(), coords_z.begin() + min_idx, coords_z.end());
+  std::nth_element(
+      coords_z.begin() + min_idx, coords_z.begin() + max_idx, coords_z.end());
+
+  const Eigen::Vector3d bbox_min(
+      coords_x[min_idx], coords_y[min_idx], coords_z[min_idx]);
+  const Eigen::Vector3d bbox_max(
+      coords_x[max_idx], coords_y[max_idx], coords_z[max_idx]);
+
+  Eigen::Vector3d centroid(0, 0, 0);
+  const double normalization = 1.0 / (max_idx - min_idx + 1);
+  for (size_t i = min_idx; i <= max_idx; ++i) {
+    centroid(0) += normalization * coords_x[i];
+    centroid(1) += normalization * coords_y[i];
+    centroid(2) += normalization * coords_z[i];
+  }
+
+  return std::make_pair(Eigen::AlignedBox3d(bbox_min, bbox_max), centroid);
+}
+
+}  // namespace colmap

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -58,16 +58,19 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
 
   std::nth_element(
       coords_x.begin(), coords_x.begin() + min_idx, coords_x.end());
-  std::nth_element(
-      coords_x.begin() + min_idx, coords_x.begin() + max_idx, coords_x.end());
+  std::nth_element(coords_x.begin() + min_idx + 1,
+                   coords_x.begin() + max_idx,
+                   coords_x.end());
   std::nth_element(
       coords_y.begin(), coords_y.begin() + min_idx, coords_y.end());
-  std::nth_element(
-      coords_y.begin() + min_idx, coords_y.begin() + max_idx, coords_y.end());
+  std::nth_element(coords_y.begin() + min_idx + 1,
+                   coords_y.begin() + max_idx,
+                   coords_y.end());
   std::nth_element(
       coords_z.begin(), coords_z.begin() + min_idx, coords_z.end());
-  std::nth_element(
-      coords_z.begin() + min_idx, coords_z.begin() + max_idx, coords_z.end());
+  std::nth_element(coords_z.begin() + min_idx + 1,
+                   coords_z.begin() + max_idx,
+                   coords_z.end());
 
   const Eigen::Vector3d bbox_min(
       coords_x[min_idx], coords_y[min_idx], coords_z[min_idx]);

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -50,11 +50,11 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
   THROW_CHECK_LE(max_percentile, 1);
   THROW_CHECK_LE(min_percentile, max_percentile);
 
-  const size_t end_idx = coords_x.size() - 1;
-  const size_t min_idx = std::min<size_t>(
-      end_idx, static_cast<size_t>(std::floor(min_percentile * end_idx)));
-  const size_t max_idx = std::min<size_t>(
-      end_idx, static_cast<size_t>(std::ceil(max_percentile * end_idx)));
+  const int end_idx = coords_x.size() - 1;
+  const int min_idx = std::min<int>(
+      end_idx, static_cast<int>(std::floor(min_percentile * end_idx)));
+  const int max_idx = std::min<int>(
+      end_idx, static_cast<int>(std::ceil(max_percentile * end_idx)));
 
   std::nth_element(
       coords_x.begin(), coords_x.begin() + min_idx, coords_x.end());
@@ -76,7 +76,7 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
 
   Eigen::Vector3d centroid(0, 0, 0);
   const double normalization = 1.0 / (max_idx - min_idx + 1);
-  for (size_t i = min_idx; i <= max_idx; ++i) {
+  for (int i = min_idx; i <= max_idx; ++i) {
     centroid(0) += normalization * coords_x[i];
     centroid(1) += normalization * coords_y[i];
     centroid(2) += normalization * coords_z[i];

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -50,11 +50,11 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
   THROW_CHECK_LE(max_percentile, 1);
   THROW_CHECK_LE(min_percentile, max_percentile);
 
-  const int end_idx = coords_x.size() - 1;
-  const int min_idx = std::min<int>(
-      end_idx, static_cast<int>(std::floor(min_percentile * end_idx)));
-  const int max_idx = std::min<int>(
-      end_idx, static_cast<int>(std::ceil(max_percentile * end_idx)));
+  const size_t end_idx = coords_x.size() - 1;
+  const size_t min_idx = std::min<size_t>(
+      end_idx, static_cast<size_t>(std::floor(min_percentile * end_idx)));
+  const size_t max_idx = std::min<size_t>(
+      end_idx, static_cast<size_t>(std::ceil(max_percentile * end_idx)));
 
   std::nth_element(
       coords_x.begin(), coords_x.begin() + min_idx, coords_x.end());

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -51,9 +51,9 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
   THROW_CHECK_LE(min_percentile, max_percentile);
 
   const size_t end_idx = coords_x.size() - 1;
-  const size_t min_idx =
-      std::max(0lu, static_cast<size_t>(std::floor(min_percentile * end_idx)));
-  const size_t max_idx = std::min(
+  const size_t min_idx = std::min<size_t>(
+      end_idx, static_cast<size_t>(std::floor(min_percentile * end_idx)));
+  const size_t max_idx = std::min<size_t>(
       end_idx, static_cast<size_t>(std::ceil(max_percentile * end_idx)));
 
   std::nth_element(

--- a/src/colmap/geometry/normalization.h
+++ b/src/colmap/geometry/normalization.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#include "colmap/util/eigen_alignment.h"
-
 #include <vector>
 
 #include <Eigen/Core>

--- a/src/colmap/geometry/normalization.h
+++ b/src/colmap/geometry/normalization.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/util/eigen_alignment.h"
+
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace colmap {
+
+// Computes axis aligned bounding box for coordinates within the given
+// percentile range. Computes the centroid as the mean within the box.
+std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
+    double min_percentile,
+    double max_percentile,
+    std::vector<double> coords_x,
+    std::vector<double> coords_y,
+    std::vector<double> coords_z);
+
+}  // namespace colmap

--- a/src/colmap/geometry/normalization_test.cc
+++ b/src/colmap/geometry/normalization_test.cc
@@ -1,0 +1,86 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/geometry/normalization.h"
+
+#include "colmap/util/eigen_matchers.h"
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+TEST(ComputeBoundingBoxAndCentroid, SingleCoord) {
+  const auto [bbox, centroid] =
+      ComputeBoundingBoxAndCentroid(0, 1, {1}, {2}, {3});
+  EXPECT_EQ(bbox.min(), Eigen::Vector3d(1, 2, 3));
+  EXPECT_EQ(bbox.max(), Eigen::Vector3d(1, 2, 3));
+  EXPECT_EQ(centroid, Eigen::Vector3d(1, 2, 3));
+}
+
+TEST(ComputeBoundingBoxAndCentroid, TwoCoords) {
+  const auto [bbox, centroid] =
+      ComputeBoundingBoxAndCentroid(0, 1, {2, -1}, {3, -2}, {4, -3});
+  EXPECT_EQ(bbox.min(), Eigen::Vector3d(-1, -2, -3));
+  EXPECT_EQ(bbox.max(), Eigen::Vector3d(2, 3, 4));
+  EXPECT_EQ(centroid, Eigen::Vector3d(0.5, 0.5, 0.5));
+}
+
+TEST(ComputeBoundingBoxAndCentroid, ThreeCoords) {
+  const auto [bbox, centroid] =
+      ComputeBoundingBoxAndCentroid(0, 1, {2, -1, 5}, {3, -2, 5}, {4, -3, 5});
+  EXPECT_EQ(bbox.min(), Eigen::Vector3d(-1, -2, -3));
+  EXPECT_EQ(bbox.max(), Eigen::Vector3d(5, 5, 5));
+  EXPECT_THAT(centroid, EigenMatrixNear(Eigen::Vector3d(2, 2, 2), 1e-6));
+}
+
+TEST(ComputeBoundingBoxAndCentroid, FiveCoords) {
+  const auto [bbox1, centroid1] =
+      ComputeBoundingBoxAndCentroid(0,
+                                    1,
+                                    {2, -1, 5, 100, -100},
+                                    {3, -2, 5, 100, -100},
+                                    {4, -3, 5, 100, -100});
+  EXPECT_EQ(bbox1.min(), Eigen::Vector3d(-100, -100, -100));
+  EXPECT_EQ(bbox1.max(), Eigen::Vector3d(100, 100, 100));
+  EXPECT_THAT(centroid1, EigenMatrixNear(Eigen::Vector3d(1.2, 1.2, 1.2), 1e-6));
+
+  const auto [bbox2, centroid2] =
+      ComputeBoundingBoxAndCentroid(0.3,
+                                    0.7,
+                                    {2, -1, 5, 100, -100},
+                                    {3, -2, 5, 100, -100},
+                                    {4, -3, 5, 100, -100});
+  EXPECT_EQ(bbox2.min(), Eigen::Vector3d(-1, -2, -3));
+  EXPECT_EQ(bbox2.max(), Eigen::Vector3d(5, 5, 5));
+  EXPECT_THAT(centroid2, EigenMatrixNear(Eigen::Vector3d(2, 2, 2), 1e-6));
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -370,10 +370,10 @@ Reconstruction::ComputeBBBoxAndCentroid(const double min_percentile,
   }
 
   return ComputeBoundingBoxAndCentroid(min_percentile,
-                                 max_percentile,
-                                 std::move(coords_x),
-                                 std::move(coords_y),
-                                 std::move(coords_z));
+                                       max_percentile,
+                                       std::move(coords_x),
+                                       std::move(coords_y),
+                                       std::move(coords_z));
 }
 
 void Reconstruction::Transform(const Sim3d& new_from_old_world) {

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -303,7 +303,7 @@ Sim3d Reconstruction::Normalize(const bool fixed_scale,
   }
 
   const auto [bbox, centroid] =
-      ComputeBoundingBoxAndCentroid(min_percentile, max_percentile, use_images);
+      ComputeBBBoxAndCentroid(min_percentile, max_percentile, use_images);
 
   // Calculate scale and translation, such that
   // translation is applied before scaling.
@@ -324,8 +324,7 @@ Sim3d Reconstruction::Normalize(const bool fixed_scale,
 Eigen::Vector3d Reconstruction::ComputeCentroid(const double min_percentile,
                                                 const double max_percentile,
                                                 bool use_images) const {
-  return ComputeBoundingBoxAndCentroid(
-             min_percentile, max_percentile, use_images)
+  return ComputeBBBoxAndCentroid(min_percentile, max_percentile, use_images)
       .second;
 }
 
@@ -333,15 +332,14 @@ Eigen::AlignedBox3d Reconstruction::ComputeBoundingBox(
     const double min_percentile,
     const double max_percentile,
     bool use_images) const {
-  return ComputeBoundingBoxAndCentroid(
-             min_percentile, max_percentile, use_images)
+  return ComputeBBBoxAndCentroid(min_percentile, max_percentile, use_images)
       .first;
 }
 
 std::pair<Eigen::AlignedBox3d, Eigen::Vector3d>
-Reconstruction::ComputeBoundingBoxAndCentroid(const double min_percentile,
-                                              const double max_percentile,
-                                              const bool use_images) const {
+Reconstruction::ComputeBBBoxAndCentroid(const double min_percentile,
+                                        const double max_percentile,
+                                        const bool use_images) const {
   const size_t num_elements = use_images ? NumRegImages() : points3D_.size();
   if (num_elements == 0) {
     return std::make_pair(
@@ -371,11 +369,11 @@ Reconstruction::ComputeBoundingBoxAndCentroid(const double min_percentile,
     }
   }
 
-  return ::colmap::ComputeBoundingBoxAndCentroid(min_percentile,
-                                                 max_percentile,
-                                                 std::move(coords_x),
-                                                 std::move(coords_y),
-                                                 std::move(coords_z));
+  return ComputeBoundingBoxAndCentroid(min_percentile,
+                                 max_percentile,
+                                 std::move(coords_x),
+                                 std::move(coords_y),
+                                 std::move(coords_z));
 }
 
 void Reconstruction::Transform(const Sim3d& new_from_old_world) {

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -30,6 +30,7 @@
 #include "colmap/scene/reconstruction.h"
 
 #include "colmap/geometry/gps.h"
+#include "colmap/geometry/normalization.h"
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/triangulation.h"
 #include "colmap/scene/database_cache.h"
@@ -291,8 +292,8 @@ void Reconstruction::DeRegisterImage(const image_t image_id) {
 
 Sim3d Reconstruction::Normalize(const bool fixed_scale,
                                 const double extent,
-                                const double p0,
-                                const double p1,
+                                const double min_percentile,
+                                const double max_percentile,
                                 const bool use_images) {
   THROW_CHECK_GT(extent, 0);
 
@@ -301,101 +302,80 @@ Sim3d Reconstruction::Normalize(const bool fixed_scale,
     return Sim3d();
   }
 
-  auto bound = ComputeBoundsAndCentroid(p0, p1, use_images);
+  const auto [bbox, centroid] =
+      ComputeBoundingBoxAndCentroid(min_percentile, max_percentile, use_images);
 
   // Calculate scale and translation, such that
   // translation is applied before scaling.
   double scale = 1.;
   if (!fixed_scale) {
-    const double old_extent = (std::get<1>(bound) - std::get<0>(bound)).norm();
+    const double old_extent = bbox.diagonal().norm();
     if (old_extent >= std::numeric_limits<double>::epsilon()) {
       scale = extent / old_extent;
     }
   }
 
-  Sim3d tform(
-      scale, Eigen::Quaterniond::Identity(), -scale * std::get<2>(bound));
+  Sim3d tform(scale, Eigen::Quaterniond::Identity(), -scale * centroid);
   Transform(tform);
 
   return tform;
 }
 
-Eigen::Vector3d Reconstruction::ComputeCentroid(const double p0,
-                                                const double p1) const {
-  return std::get<2>(ComputeBoundsAndCentroid(p0, p1, false));
+Eigen::Vector3d Reconstruction::ComputeCentroid(const double min_percentile,
+                                                const double max_percentile,
+                                                bool use_images) const {
+  return ComputeBoundingBoxAndCentroid(
+             min_percentile, max_percentile, use_images)
+      .second;
 }
 
-std::pair<Eigen::Vector3d, Eigen::Vector3d> Reconstruction::ComputeBoundingBox(
-    const double p0, const double p1) const {
-  auto bound = ComputeBoundsAndCentroid(p0, p1, false);
-  return std::make_pair(std::get<0>(bound), std::get<1>(bound));
+Eigen::AlignedBox3d Reconstruction::ComputeBoundingBox(
+    const double min_percentile,
+    const double max_percentile,
+    bool use_images) const {
+  return ComputeBoundingBoxAndCentroid(
+             min_percentile, max_percentile, use_images)
+      .first;
 }
 
-std::tuple<Eigen::Vector3d, Eigen::Vector3d, Eigen::Vector3d>
-Reconstruction::ComputeBoundsAndCentroid(const double p0,
-                                         const double p1,
-                                         const bool use_images) const {
-  THROW_CHECK_GE(p0, 0);
-  THROW_CHECK_LE(p0, 1);
-  THROW_CHECK_GE(p1, 0);
-  THROW_CHECK_LE(p1, 1);
-  THROW_CHECK_LE(p0, p1);
-
+std::pair<Eigen::AlignedBox3d, Eigen::Vector3d>
+Reconstruction::ComputeBoundingBoxAndCentroid(const double min_percentile,
+                                              const double max_percentile,
+                                              const bool use_images) const {
   const size_t num_elements = use_images ? NumRegImages() : points3D_.size();
   if (num_elements == 0) {
-    return std::make_tuple(Eigen::Vector3d(0, 0, 0),
-                           Eigen::Vector3d(0, 0, 0),
-                           Eigen::Vector3d(0, 0, 0));
+    return std::make_tuple(
+        Eigen::AlignedBox3d(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0)),
+        Eigen::Vector3d(0, 0, 0));
   }
 
   // Coordinates of image centers or point locations.
-  std::vector<float> coords_x;
-  std::vector<float> coords_y;
-  std::vector<float> coords_z;
+  std::vector<double> coords_x;
+  std::vector<double> coords_y;
+  std::vector<double> coords_z;
+  coords_x.reserve(num_elements);
+  coords_y.reserve(num_elements);
+  coords_z.reserve(num_elements);
   if (use_images) {
-    coords_x.reserve(NumRegImages());
-    coords_y.reserve(NumRegImages());
-    coords_z.reserve(NumRegImages());
-    for (const image_t im_id : RegImageIds()) {
-      const Eigen::Vector3d proj_center = Image(im_id).ProjectionCenter();
-      coords_x.push_back(static_cast<float>(proj_center(0)));
-      coords_y.push_back(static_cast<float>(proj_center(1)));
-      coords_z.push_back(static_cast<float>(proj_center(2)));
+    for (const image_t image_id : RegImageIds()) {
+      const Eigen::Vector3d proj_center = Image(image_id).ProjectionCenter();
+      coords_x.push_back(proj_center(0));
+      coords_y.push_back(proj_center(1));
+      coords_z.push_back(proj_center(2));
     }
   } else {
-    coords_x.reserve(points3D_.size());
-    coords_y.reserve(points3D_.size());
-    coords_z.reserve(points3D_.size());
     for (const auto& point3D : points3D_) {
-      coords_x.push_back(static_cast<float>(point3D.second.xyz(0)));
-      coords_y.push_back(static_cast<float>(point3D.second.xyz(1)));
-      coords_z.push_back(static_cast<float>(point3D.second.xyz(2)));
+      coords_x.push_back(point3D.second.xyz(0));
+      coords_y.push_back(point3D.second.xyz(1));
+      coords_z.push_back(point3D.second.xyz(2));
     }
   }
 
-  // Determine robust bounding box and mean.
-
-  std::sort(coords_x.begin(), coords_x.end());
-  std::sort(coords_y.begin(), coords_y.end());
-  std::sort(coords_z.begin(), coords_z.end());
-
-  const size_t P0 = static_cast<size_t>(
-      (coords_x.size() > 3) ? p0 * (coords_x.size() - 1) : 0);
-  const size_t P1 = static_cast<size_t>(
-      (coords_x.size() > 3) ? p1 * (coords_x.size() - 1) : coords_x.size() - 1);
-
-  const Eigen::Vector3d bbox_min(coords_x[P0], coords_y[P0], coords_z[P0]);
-  const Eigen::Vector3d bbox_max(coords_x[P1], coords_y[P1], coords_z[P1]);
-
-  Eigen::Vector3d mean_coord(0, 0, 0);
-  for (size_t i = P0; i <= P1; ++i) {
-    mean_coord(0) += coords_x[i];
-    mean_coord(1) += coords_y[i];
-    mean_coord(2) += coords_z[i];
-  }
-  mean_coord /= P1 - P0 + 1;
-
-  return std::make_tuple(bbox_min, bbox_max, mean_coord);
+  return ::colmap::ComputeBoundingBoxAndCentroid(min_percentile,
+                                                 max_percentile,
+                                                 std::move(coords_x),
+                                                 std::move(coords_y),
+                                                 std::move(coords_z));
 }
 
 void Reconstruction::Transform(const Sim3d& new_from_old_world) {
@@ -410,8 +390,7 @@ void Reconstruction::Transform(const Sim3d& new_from_old_world) {
   }
 }
 
-Reconstruction Reconstruction::Crop(
-    const std::pair<Eigen::Vector3d, Eigen::Vector3d>& bbox) const {
+Reconstruction Reconstruction::Crop(const Eigen::AlignedBox3d& bbox) const {
   Reconstruction cropped_reconstruction;
   for (const auto& camera : cameras_) {
     cropped_reconstruction.AddCamera(camera.second);
@@ -427,8 +406,7 @@ Reconstruction Reconstruction::Crop(
   }
   std::unordered_set<image_t> registered_image_ids;
   for (const auto& point3D : points3D_) {
-    if ((point3D.second.xyz.array() >= bbox.first.array()).all() &&
-        (point3D.second.xyz.array() <= bbox.second.array()).all()) {
+    if (bbox.contains(point3D.second.xyz)) {
       for (const auto& track_el : point3D.second.track.Elements()) {
         registered_image_ids.insert(track_el.image_id);
       }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -344,7 +344,7 @@ Reconstruction::ComputeBoundingBoxAndCentroid(const double min_percentile,
                                               const bool use_images) const {
   const size_t num_elements = use_images ? NumRegImages() : points3D_.size();
   if (num_elements == 0) {
-    return std::make_tuple(
+    return std::make_pair(
         Eigen::AlignedBox3d(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0)),
         Eigen::Vector3d(0, 0, 0));
   }

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -246,7 +246,7 @@ class Reconstruction {
   void CreateImageDirs(const std::string& path) const;
 
  private:
-  std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
+  std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBBBoxAndCentroid(
       double min_percentile, double max_percentile, bool use_images) const;
 
   std::unordered_map<camera_t, struct Camera> cameras_;

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -170,10 +170,9 @@ class Reconstruction {
                                   bool use_images = false) const;
 
   // Compute the bounding box corners of camera centers or 3D points.
-  Eigen::AlignedBox3d ComputeBoundingBox(
-      double min_percentile = 0.0,
-      double max_percentile = 1.0,
-      bool use_images = false) const;
+  Eigen::AlignedBox3d ComputeBoundingBox(double min_percentile = 0.0,
+                                         double max_percentile = 1.0,
+                                         bool use_images = false) const;
 
   // Apply the 3D similarity transformation to all images and points.
   void Transform(const Sim3d& new_from_old_world);
@@ -182,8 +181,7 @@ class Reconstruction {
   // of the bounding box containing the included 3D points of the new
   // reconstruction. Only the cameras and images of the included points are
   // registered.
-  Reconstruction Crop(
-      const Eigen::AlignedBox3d& bbox) const;
+  Reconstruction Crop(const Eigen::AlignedBox3d& bbox) const;
 
   // Find specific image by name. Note that this uses linear search.
   const class Image* FindImageWithName(const std::string& name) const;

--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -195,16 +195,15 @@ void BindGeometry(py::module& m) {
       .def("diagonal", &Eigen::AlignedBox3d::diagonal)
       .def(
           "contains_point",
-          [](const Eigen::AlignedBox3d& self, const Eigen::Vector3d& x) {
-            return self.contains(x);
+          [](const Eigen::AlignedBox3d& self, const Eigen::Vector3d& point) {
+            return self.contains(point);
           },
-          "x"_a)
+          "point"_a)
       .def(
           "contains_bbox",
-          [](const Eigen::AlignedBox3d& self, const Eigen::AlignedBox3d& bbox) {
-            return self.contains(bbox);
-          },
-          "x"_a)
+          [](const Eigen::AlignedBox3d& self,
+             const Eigen::AlignedBox3d& other) { return self.contains(other); },
+          "other"_a)
       .def("__repr__", [](const Eigen::AlignedBox3d& self) {
         std::ostringstream ss;
         ss << "AlignedBox3d(min=[" << self.min().format(vec_fmt) << "], max=["

--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -177,6 +177,42 @@ void BindGeometry(py::module& m) {
       .def("is_covariance_valid", &PosePrior::IsCovarianceValid);
   MakeDataclass(PyPosePrior);
 
+  py::class_ext_<Eigen::AlignedBox3d> PyAlignedBox3d(m, "AlignedBox3d");
+  PyAlignedBox3d.def(py::init<>())
+      .def(py::init<const Eigen::Vector3d&, const Eigen::Vector3d&>(),
+           "min"_a,
+           "max"_a)
+      .def_property("min",
+                    py::overload_cast<>(&Eigen::AlignedBox3d::min),
+                    [](Eigen::AlignedBox3d& self, const Eigen::Vector3d& min) {
+                      self.min() = min;
+                    })
+      .def_property("max",
+                    py::overload_cast<>(&Eigen::AlignedBox3d::max),
+                    [](Eigen::AlignedBox3d& self, const Eigen::Vector3d& max) {
+                      self.max() = max;
+                    })
+      .def("diagonal", &Eigen::AlignedBox3d::diagonal)
+      .def(
+          "contains_point",
+          [](const Eigen::AlignedBox3d& self, const Eigen::Vector3d& x) {
+            return self.contains(x);
+          },
+          "x"_a)
+      .def(
+          "contains_bbox",
+          [](const Eigen::AlignedBox3d& self, const Eigen::AlignedBox3d& bbox) {
+            return self.contains(bbox);
+          },
+          "x"_a)
+      .def("__repr__", [](const Eigen::AlignedBox3d& self) {
+        std::ostringstream ss;
+        ss << "AlignedBox3d(min=[" << self.min().format(vec_fmt) << "], max=["
+           << self.max().format(vec_fmt) << "])";
+        return ss.str();
+      });
+  MakeDataclass(PyAlignedBox3d);
+
   BindHomographyMatrixGeometry(m);
   BindEssentialMatrixGeometry(m);
 }

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -159,25 +159,26 @@ void BindReconstruction(py::module& m) {
            &Reconstruction::Normalize,
            "fixed_scale"_a = false,
            "extent"_a = 10.0,
-           "p0"_a = 0.1,
-           "p1"_a = 0.9,
+           "min_percentile"_a = 0.1,
+           "max_percentile"_a = 0.9,
            "use_images"_a = true,
            "Normalize scene by scaling and translation to avoid degenerate"
            "visualization after bundle adjustment and to improve numerical"
            "stability of algorithms.\n\n"
            "Translates scene such that the mean of the camera centers or point"
-           "locations are at the origin of the coordinate system.\n\n"
-           "Scales scene such that the minimum and maximum camera centers are "
-           "at the given `extent`, whereas `p0` and `p1` determine the minimum "
-           "and maximum percentiles of the camera centers considered.")
+           "locations are at the origin of the coordinate system.\n\n Scales "
+           "scene such that the minimum and maximum camera centers (or points) "
+           "are  at the given `extent`, whereas `min_percentile` and  "
+           "`max_percentile` determine the minimum  and maximum percentiles of "
+           "the camera centers (or points) considered.")
       .def("transform",
            &Reconstruction::Transform,
            "new_from_old_world"_a,
            "Apply the 3D similarity transformation to all images and points.")
       .def("compute_bounding_box",
            &Reconstruction::ComputeBoundingBox,
-           "p0"_a = 0.0,
-           "p1"_a = 1.0)
+           "min_percentile"_a = 0.0,
+           "max_percentile"_a = 1.0)
       .def("crop", &Reconstruction::Crop, "bbox"_a)
       .def("find_image_with_name",
            &Reconstruction::FindImageWithName,

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -175,10 +175,16 @@ void BindReconstruction(py::module& m) {
            &Reconstruction::Transform,
            "new_from_old_world"_a,
            "Apply the 3D similarity transformation to all images and points.")
+      .def("compute_centroid",
+           &Reconstruction::ComputeCentroid,
+           "min_percentile"_a = 0.0,
+           "max_percentile"_a = 1.0,
+           "use_images"_a = false)
       .def("compute_bounding_box",
            &Reconstruction::ComputeBoundingBox,
            "min_percentile"_a = 0.0,
-           "max_percentile"_a = 1.0)
+           "max_percentile"_a = 1.0,
+           "use_images"_a = false)
       .def("crop", &Reconstruction::Crop, "bbox"_a)
       .def("find_image_with_name",
            &Reconstruction::FindImageWithName,


### PR DESCRIPTION
* Use nth_element instead of sort for faster ordering.
* Normalize in double precision to better handle large coordinates (e.g., GPS).
* Use Eigen's AlignedBox instead of pair of Vector3d for bbox.
* Extract bbox and centroid computation into reusable geometry module function. Add some more tests.