### PR TITLE
Consistent interface/tests for rigid3d/sim3d/affine2d, pycolmap bindings for rigid3d

### DIFF
--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -49,7 +49,7 @@ COLMAP_ADD_LIBRARY(
         homography_matrix.h homography_matrix.cc
         pose.h pose.cc
         generalized_pose.h generalized_pose.cc
-        similarity_transform.h
+        similarity_transform.h similarity_transform.cc
         translation_transform.h
         triangulation.h triangulation.cc
         two_view_geometry.h two_view_geometry.cc

--- a/src/colmap/estimators/affine_transform.cc
+++ b/src/colmap/estimators/affine_transform.cc
@@ -102,6 +102,7 @@ bool EstimateAffine2d(const std::vector<Eigen::Vector2d>& src,
   if (models.empty()) {
     return false;
   }
+  THROW_CHECK_EQ(models.size(), 1);
   tgt_from_src = models[0];
   return true;
 }

--- a/src/colmap/estimators/affine_transform.cc
+++ b/src/colmap/estimators/affine_transform.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/affine_transform.h"
 
+#include "colmap/optim/loransac.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
@@ -37,27 +38,27 @@
 
 namespace colmap {
 
-void AffineTransformEstimator::Estimate(const std::vector<X_t>& points1,
-                                        const std::vector<Y_t>& points2,
-                                        std::vector<M_t>* models) {
-  const size_t num_points = points1.size();
-  THROW_CHECK_EQ(num_points, points2.size());
+void AffineTransformEstimator::Estimate(const std::vector<X_t>& src,
+                                        const std::vector<Y_t>& tgt,
+                                        std::vector<M_t>* tgt_from_src) {
+  const size_t num_points = src.size();
+  THROW_CHECK_EQ(num_points, tgt.size());
   THROW_CHECK_GE(num_points, 3);
-  THROW_CHECK(models != nullptr);
+  THROW_CHECK(tgt_from_src != nullptr);
 
-  models->clear();
+  tgt_from_src->clear();
 
   // Sets up the linear system that we solve to obtain a least squared solution
   // for the affine transformation.
   Eigen::Matrix<double, Eigen::Dynamic, 6> A(2 * num_points, 6);
   Eigen::VectorXd b(2 * num_points, 1);
   for (size_t i = 0; i < num_points; ++i) {
-    A.block<1, 3>(2 * i, 0) = points1[i].transpose().homogeneous();
+    A.block<1, 3>(2 * i, 0) = src[i].transpose().homogeneous();
     A.block<1, 3>(2 * i, 3).setZero();
-    b(2 * i) = points2[i].x();
+    b(2 * i) = tgt[i].x();
     A.block<1, 3>(2 * i + 1, 0).setZero();
-    A.block<1, 3>(2 * i + 1, 3) = points1[i].transpose().homogeneous();
-    b(2 * i + 1) = points2[i].y();
+    A.block<1, 3>(2 * i + 1, 3) = src[i].transpose().homogeneous();
+    b(2 * i + 1) = tgt[i].y();
   }
 
   Eigen::Vector6d sol;
@@ -75,43 +76,47 @@ void AffineTransformEstimator::Estimate(const std::vector<X_t>& points1,
     sol = svd.solve(b);
   }
 
-  models->resize(1);
-  (*models)[0] =
+  tgt_from_src->resize(1);
+  (*tgt_from_src)[0] =
       Eigen::Map<const Eigen::Matrix<double, 3, 2>>(sol.data()).transpose();
 }
 
-void AffineTransformEstimator::Residuals(const std::vector<X_t>& points1,
-                                         const std::vector<Y_t>& points2,
-                                         const M_t& A,
+void AffineTransformEstimator::Residuals(const std::vector<X_t>& src,
+                                         const std::vector<Y_t>& tgt,
+                                         const M_t& tgt_from_src,
                                          std::vector<double>* residuals) {
-  THROW_CHECK_EQ(points1.size(), points2.size());
-
-  residuals->resize(points1.size());
-
-  // Note that this code might not be as nice as Eigen expressions,
-  // but it is significantly faster in various tests.
-
-  const double A_00 = A(0, 0);
-  const double A_01 = A(0, 1);
-  const double A_02 = A(0, 2);
-  const double A_10 = A(1, 0);
-  const double A_11 = A(1, 1);
-  const double A_12 = A(1, 2);
-
-  for (size_t i = 0; i < points1.size(); ++i) {
-    const double s_0 = points1[i](0);
-    const double s_1 = points1[i](1);
-    const double d_0 = points2[i](0);
-    const double d_1 = points2[i](1);
-
-    const double pd_0 = A_00 * s_0 + A_01 * s_1 + A_02;
-    const double pd_1 = A_10 * s_0 + A_11 * s_1 + A_12;
-
-    const double dd_0 = d_0 - pd_0;
-    const double dd_1 = d_1 - pd_1;
-
-    (*residuals)[i] = dd_0 * dd_0 + dd_1 * dd_1;
+  const size_t num_points = src.size();
+  THROW_CHECK_EQ(num_points, tgt.size());
+  residuals->resize(num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    (*residuals)[i] =
+        (tgt[i] - tgt_from_src * src[i].homogeneous()).squaredNorm();
   }
+}
+
+bool EstimateAffine2d(const std::vector<Eigen::Vector2d>& src,
+                      const std::vector<Eigen::Vector2d>& tgt,
+                      Eigen::Matrix2x3d& tgt_from_src) {
+  std::vector<Eigen::Matrix2x3d> models;
+  AffineTransformEstimator::Estimate(src, tgt, &models);
+  if (models.empty()) {
+    return false;
+  }
+  tgt_from_src = models[0];
+  return true;
+}
+
+typename RANSAC<AffineTransformEstimator>::Report EstimateAffine2dRobust(
+    const std::vector<Eigen::Vector2d>& src,
+    const std::vector<Eigen::Vector2d>& tgt,
+    const RANSACOptions& options,
+    Eigen::Matrix2x3d& tgt_from_src) {
+  LORANSAC<AffineTransformEstimator, AffineTransformEstimator> ransac(options);
+  auto report = ransac.Estimate(src, tgt);
+  if (report.success) {
+    tgt_from_src = report.model;
+  }
+  return report;
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/affine_transform.h
+++ b/src/colmap/estimators/affine_transform.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/optim/ransac.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
@@ -42,21 +43,31 @@ class AffineTransformEstimator {
  public:
   typedef Eigen::Vector2d X_t;
   typedef Eigen::Vector2d Y_t;
-  typedef Eigen::Matrix<double, 2, 3> M_t;
+  typedef Eigen::Matrix2x3d M_t;
 
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 3;
 
   // Estimate the affine transformation from at least 3 correspondences.
-  static void Estimate(const std::vector<X_t>& points1,
-                       const std::vector<Y_t>& points2,
-                       std::vector<M_t>* models);
+  static void Estimate(const std::vector<X_t>& src,
+                       const std::vector<Y_t>& tgt,
+                       std::vector<M_t>* tgt_from_src);
 
   // Compute the squared transformation error.
-  static void Residuals(const std::vector<X_t>& points1,
-                        const std::vector<Y_t>& points2,
-                        const M_t& E,
+  static void Residuals(const std::vector<X_t>& src,
+                        const std::vector<Y_t>& tgt,
+                        const M_t& tgt_from_src,
                         std::vector<double>* residuals);
 };
+
+bool EstimateAffine2d(const std::vector<Eigen::Vector2d>& src,
+                      const std::vector<Eigen::Vector2d>& tgt,
+                      Eigen::Matrix2x3d& tgt_from_src);
+
+typename RANSAC<AffineTransformEstimator>::Report EstimateAffine2dRobust(
+    const std::vector<Eigen::Vector2d>& src,
+    const std::vector<Eigen::Vector2d>& tgt,
+    const RANSACOptions& options,
+    Eigen::Matrix2x3d& tgt_from_src);
 
 }  // namespace colmap

--- a/src/colmap/estimators/affine_transform_test.cc
+++ b/src/colmap/estimators/affine_transform_test.cc
@@ -29,7 +29,9 @@
 
 #include "colmap/estimators/affine_transform.h"
 
+#include "colmap/math/random.h"
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
 #include "colmap/util/logging.h"
 
 #include <Eigen/Geometry>
@@ -38,117 +40,94 @@
 namespace colmap {
 namespace {
 
-TEST(AffineTransform, Minimal) {
-  for (int x = 0; x < 10; ++x) {
-    Eigen::Matrix<double, 2, 3> A;
-    A << x / 10.0, 0.2, 0.3, 30, 0.2, 0.1;
+std::pair<std::vector<Eigen::Vector2d>, std::vector<Eigen::Vector2d>>
+GenerateData(size_t num_inliers,
+             size_t num_outliers,
+             const Eigen::Matrix2x3d& tgt_from_src) {
+  std::vector<Eigen::Vector2d> src;
+  std::vector<Eigen::Vector2d> tgt;
 
-    std::vector<Eigen::Vector2d> src;
-    src.emplace_back(x, 10);
-    src.emplace_back(1, 0);
-    src.emplace_back(2, 1);
-
-    std::vector<Eigen::Vector2d> dst;
-    for (size_t i = 0; i < src.size(); ++i) {
-      dst.push_back(A * src[i].homogeneous());
-    }
-
-    AffineTransformEstimator estimator;
-    std::vector<Eigen::Matrix<double, 2, 3>> models;
-    estimator.Estimate(src, dst, &models);
-
-    ASSERT_EQ(models.size(), 1);
-
-    std::vector<double> residuals;
-    estimator.Residuals(src, dst, models[0], &residuals);
-
-    EXPECT_EQ(residuals.size(), src.size());
-
-    for (size_t i = 0; i < src.size(); ++i) {
-      EXPECT_LT(residuals[i], 1e-6);
-    }
+  // Generate inlier data.
+  for (size_t i = 0; i < num_inliers; ++i) {
+    src.emplace_back(i, std::sqrt(i) + 2);
+    tgt.push_back(tgt_from_src * src.back().homogeneous());
   }
+
+  // Add some faulty data.
+  for (size_t i = 0; i < num_outliers; ++i) {
+    src.emplace_back(RandomUniformReal(-3000.0, -2000.0),
+                     RandomUniformReal(-4000.0, -3000.0));
+    tgt.emplace_back(RandomUniformReal(-3000.0, -2000.0),
+                     RandomUniformReal(-4000.0, -3000.0));
+  }
+
+  return {std::move(src), std::move(tgt)};
 }
 
-TEST(AffineTransform, NonMinimal) {
-  for (int x = 0; x < 10; ++x) {
-    Eigen::Matrix<double, 2, 3> A;
-    A << x / 10.0, 0.2, 0.3, 30, 0.2, 0.1;
+void TestEstimateAffine2dWithNumCoords(const size_t num_coords) {
+  const Eigen::Matrix2x3d gt_tgt_from_src = Eigen::Matrix2x3d::Random();
+  const auto [src, tgt] = GenerateData(
+      /*num_inliers=*/num_coords,
+      /*num_outliers=*/0,
+      gt_tgt_from_src);
 
-    std::vector<Eigen::Vector2d> src;
-    src.emplace_back(x, 10);
-    src.emplace_back(1, 0);
-    src.emplace_back(2, 1);
-    src.emplace_back(-10, 10);
-    src.emplace_back(-2, 5);
-
-    std::vector<Eigen::Vector2d> dst;
-    for (size_t i = 0; i < src.size(); ++i) {
-      dst.push_back(A * src[i].homogeneous());
-    }
-
-    AffineTransformEstimator estimator;
-    std::vector<Eigen::Matrix<double, 2, 3>> models;
-    estimator.Estimate(src, dst, &models);
-
-    ASSERT_EQ(models.size(), 1);
-
-    std::vector<double> residuals;
-    estimator.Residuals(src, dst, models[0], &residuals);
-
-    EXPECT_EQ(residuals.size(), src.size());
-
-    for (size_t i = 0; i < src.size(); ++i) {
-      EXPECT_LT(residuals[i], 1e-6);
-    }
-  }
+  Eigen::Matrix2x3d tgt_from_src;
+  EXPECT_TRUE(EstimateAffine2d(src, tgt, tgt_from_src));
+  EXPECT_THAT(tgt_from_src, EigenMatrixNear(gt_tgt_from_src, 1e-6));
 }
 
-TEST(AffineTransform, MinimalDegenerate) {
-  for (int x = 0; x < 10; ++x) {
-    Eigen::Matrix<double, 2, 3> A;
-    A << x / 10.0, 0.2, 0.3, 30, 0.2, 0.1;
+TEST(Affine2d, EstimateMinimal) { TestEstimateAffine2dWithNumCoords(3); }
 
-    std::vector<Eigen::Vector2d> src;
-    src.emplace_back(0, 0);
-    src.emplace_back(0, 0);
-    src.emplace_back(2, 1);
-
-    std::vector<Eigen::Vector2d> dst;
-    for (size_t i = 0; i < src.size(); ++i) {
-      dst.push_back(A * src[i].homogeneous());
-    }
-
-    AffineTransformEstimator estimator;
-    std::vector<Eigen::Matrix<double, 2, 3>> models;
-    estimator.Estimate(src, dst, &models);
-
-    ASSERT_TRUE(models.empty());
-  }
+TEST(Affine2d, EstimateOverDetermined) {
+  TestEstimateAffine2dWithNumCoords(100);
 }
 
-TEST(AffineTransform, NonMinimalDegenerate) {
-  for (int x = 0; x < 10; ++x) {
-    Eigen::Matrix<double, 2, 3> A;
-    A << x / 10.0, 0.2, 0.3, 30, 0.2, 0.1;
+TEST(Affine2d, EstimateMinimalDegenerate) {
+  std::vector<Eigen::Vector2d> invalid_src_dst(3, Eigen::Vector2d::Zero());
+  Eigen::Matrix2x3d tgt_from_src;
+  EXPECT_FALSE(
+      EstimateAffine2d(invalid_src_dst, invalid_src_dst, tgt_from_src));
+}
 
-    std::vector<Eigen::Vector2d> src;
-    src.emplace_back(0, 0);
-    src.emplace_back(0, 0);
-    src.emplace_back(2, 1);
-    src.emplace_back(2, 1);
+TEST(Affine2d, EstimateNonMinimalDegenerate) {
+  std::vector<Eigen::Vector2d> invalid_src_dst(5, Eigen::Vector2d::Zero());
+  Eigen::Matrix2x3d tgt_from_src;
+  EXPECT_FALSE(
+      EstimateAffine2d(invalid_src_dst, invalid_src_dst, tgt_from_src));
+}
 
-    std::vector<Eigen::Vector2d> dst;
-    for (size_t i = 0; i < src.size(); ++i) {
-      dst.push_back(A * src[i].homogeneous());
+TEST(Affine2d, EstimateRobust) {
+  SetPRNGSeed(0);
+
+  const size_t num_inliers = 1000;
+  const size_t num_outliers = 400;
+
+  const Eigen::Matrix2x3d gt_tgt_from_src = Eigen::Matrix2x3d::Random();
+  const auto [src, tgt] = GenerateData(
+      /*num_inliers=*/num_inliers,
+      /*num_outliers=*/num_outliers,
+      gt_tgt_from_src);
+
+  // Robustly estimate transformation using RANSAC.
+  RANSACOptions options;
+  options.max_error = 10;
+  Eigen::Matrix2x3d tgt_from_src;
+  const auto report = EstimateAffine2dRobust(src, tgt, options, tgt_from_src);
+
+  EXPECT_TRUE(report.success);
+  EXPECT_GT(report.num_trials, 0);
+
+  // Make sure outliers were detected correctly.
+  EXPECT_EQ(report.support.num_inliers, num_inliers);
+  for (size_t i = 0; i < num_inliers + num_outliers; ++i) {
+    if (i >= num_inliers) {
+      EXPECT_FALSE(report.inlier_mask[i]);
+    } else {
+      EXPECT_TRUE(report.inlier_mask[i]);
     }
-
-    AffineTransformEstimator estimator;
-    std::vector<Eigen::Matrix<double, 2, 3>> models;
-    estimator.Estimate(src, dst, &models);
-
-    ASSERT_TRUE(models.empty());
   }
+
+  EXPECT_THAT(tgt_from_src, EigenMatrixNear(gt_tgt_from_src, 1e-6));
 }
 
 }  // namespace

--- a/src/colmap/estimators/affine_transform_test.cc
+++ b/src/colmap/estimators/affine_transform_test.cc
@@ -55,8 +55,7 @@ GenerateData(size_t num_inliers,
 
   // Add some faulty data.
   for (size_t i = 0; i < num_outliers; ++i) {
-    src.emplace_back(RandomUniformReal(-3000.0, -2000.0),
-                     RandomUniformReal(-4000.0, -3000.0));
+    src.emplace_back(i, std::sqrt(i) + 2);
     tgt.emplace_back(RandomUniformReal(-3000.0, -2000.0),
                      RandomUniformReal(-4000.0, -3000.0));
   }
@@ -83,17 +82,17 @@ TEST(Affine2d, EstimateOverDetermined) {
 }
 
 TEST(Affine2d, EstimateMinimalDegenerate) {
-  std::vector<Eigen::Vector2d> invalid_src_dst(3, Eigen::Vector2d::Zero());
+  std::vector<Eigen::Vector2d> degenerate_src_tgt(3, Eigen::Vector2d::Zero());
   Eigen::Matrix2x3d tgt_from_src;
   EXPECT_FALSE(
-      EstimateAffine2d(invalid_src_dst, invalid_src_dst, tgt_from_src));
+      EstimateAffine2d(degenerate_src_tgt, degenerate_src_tgt, tgt_from_src));
 }
 
 TEST(Affine2d, EstimateNonMinimalDegenerate) {
-  std::vector<Eigen::Vector2d> invalid_src_dst(5, Eigen::Vector2d::Zero());
+  std::vector<Eigen::Vector2d> degenerate_src_tgt(5, Eigen::Vector2d::Zero());
   Eigen::Matrix2x3d tgt_from_src;
   EXPECT_FALSE(
-      EstimateAffine2d(invalid_src_dst, invalid_src_dst, tgt_from_src));
+      EstimateAffine2d(degenerate_src_tgt, degenerate_src_tgt, tgt_from_src));
 }
 
 TEST(Affine2d, EstimateRobust) {

--- a/src/colmap/estimators/similarity_transform.cc
+++ b/src/colmap/estimators/similarity_transform.cc
@@ -1,0 +1,113 @@
+// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/estimators/similarity_transform.h"
+
+namespace colmap {
+namespace {
+
+template <bool kEstimateScale>
+inline bool EstimateRigidOrSim3d(const std::vector<Eigen::Vector3d>& src,
+                                 const std::vector<Eigen::Vector3d>& tgt,
+                                 Eigen::Matrix3x4d& tgt_from_src) {
+  std::vector<Eigen::Matrix3x4d> models;
+  SimilarityTransformEstimator<3, kEstimateScale>().Estimate(src, tgt, &models);
+  if (models.empty()) {
+    return false;
+  }
+  THROW_CHECK_EQ(models.size(), 1);
+  tgt_from_src = models[0];
+  return true;
+}
+
+template <bool kEstimateScale>
+inline typename RANSAC<SimilarityTransformEstimator<3, kEstimateScale>>::Report
+EstimateRigidOrSim3dRobust(const std::vector<Eigen::Vector3d>& src,
+                           const std::vector<Eigen::Vector3d>& tgt,
+                           const RANSACOptions& options,
+                           Eigen::Matrix3x4d& tgt_from_src) {
+  LORANSAC<SimilarityTransformEstimator<3, kEstimateScale>,
+           SimilarityTransformEstimator<3, kEstimateScale>>
+      ransac(options);
+  auto report = ransac.Estimate(src, tgt);
+  if (report.success) {
+    tgt_from_src = report.model;
+  }
+  return report;
+}
+
+}  // namespace
+
+bool EstimateRigid3d(const std::vector<Eigen::Vector3d>& src,
+                     const std::vector<Eigen::Vector3d>& tgt,
+                     Rigid3d& tgt_from_src) {
+  Eigen::Matrix3x4d tgt_from_src_mat;
+  if (!EstimateRigidOrSim3d<false>(src, tgt, tgt_from_src_mat)) {
+    return false;
+  }
+  tgt_from_src = Rigid3d::FromMatrix(tgt_from_src_mat);
+  return true;
+}
+
+typename RANSAC<SimilarityTransformEstimator<3, false>>::Report
+EstimateRigid3dRobust(const std::vector<Eigen::Vector3d>& src,
+                      const std::vector<Eigen::Vector3d>& tgt,
+                      const RANSACOptions& options,
+                      Rigid3d& tgt_from_src) {
+  Eigen::Matrix3x4d tgt_from_src_mat;
+  auto report =
+      EstimateRigidOrSim3dRobust<false>(src, tgt, options, tgt_from_src_mat);
+  tgt_from_src = Rigid3d::FromMatrix(tgt_from_src_mat);
+  return report;
+}
+
+bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
+                   const std::vector<Eigen::Vector3d>& tgt,
+                   Sim3d& tgt_from_src) {
+  Eigen::Matrix3x4d tgt_from_src_mat;
+  if (!EstimateRigidOrSim3d<true>(src, tgt, tgt_from_src_mat)) {
+    return false;
+  }
+  tgt_from_src = Sim3d::FromMatrix(tgt_from_src_mat);
+  return true;
+}
+
+typename RANSAC<SimilarityTransformEstimator<3, true>>::Report
+EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
+                    const std::vector<Eigen::Vector3d>& tgt,
+                    const RANSACOptions& options,
+                    Sim3d& tgt_from_src) {
+  Eigen::Matrix3x4d tgt_from_src_mat;
+  auto report =
+      EstimateRigidOrSim3dRobust<true>(src, tgt, options, tgt_from_src_mat);
+  tgt_from_src = Sim3d::FromMatrix(tgt_from_src_mat);
+  return report;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -131,9 +131,9 @@ void SimilarityTransformEstimator<kDim, kEstimateScale>::Estimate(
 
   using MatrixType = Eigen::Matrix<double, kDim, Eigen::Dynamic>;
   const Eigen::Map<const MatrixType, Eigen::Aligned16> src_mat(
-      reinterpret_cast<const double*>(src.data()), 2, src.size());
+      reinterpret_cast<const double*>(src.data()), kDim, src.size());
   const Eigen::Map<const MatrixType, Eigen::Aligned16> tgt_mat(
-      reinterpret_cast<const double*>(tgt.data()), 2, tgt.size());
+      reinterpret_cast<const double*>(tgt.data()), kDim, tgt.size());
 
   if (Eigen::FullPivLU<MatrixType>(src_mat).rank() < kMinNumSamples ||
       Eigen::FullPivLU<MatrixType>(tgt_mat).rank() < kMinNumSamples) {

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/geometry/rigid3.h"
 #include "colmap/geometry/sim3.h"
 #include "colmap/optim/loransac.h"
 #include "colmap/optim/ransac.h"
@@ -69,58 +70,49 @@ class SimilarityTransformEstimator {
   // Estimate the similarity transform.
   //
   // @param src      Set of corresponding source points.
-  // @param dst      Set of corresponding destination points.
+  // @param tgt      Set of corresponding destination points.
   //
   // @return         4x4 homogeneous transformation matrix.
   static void Estimate(const std::vector<X_t>& src,
-                       const std::vector<Y_t>& dst,
-                       std::vector<M_t>* models);
+                       const std::vector<Y_t>& tgt,
+                       std::vector<M_t>* tgt_from_src);
 
   // Calculate the transformation error for each corresponding point pair.
   //
   // Residuals are defined as the squared transformation error when
   // transforming the source to the destination coordinates.
   //
-  // @param src        Set of corresponding points in the source coordinate
-  //                   system as a Nx3 matrix.
-  // @param dst        Set of corresponding points in the destination
-  //                   coordinate system as a Nx3 matrix.
-  // @param matrix     4x4 homogeneous transformation matrix.
-  // @param residuals  Output vector of residuals for each point pair.
+  // @param src           Set of corresponding points in the source coordinate
+  //                      system as a Nx3 matrix.
+  // @param tgt           Set of corresponding points in the destination
+  //                      coordinate system as a Nx3 matrix.
+  // @param tgt_from_src  4x4 homogeneous transformation matrix.
+  // @param residuals     Output vector of residuals for each point pair.
   static void Residuals(const std::vector<X_t>& src,
-                        const std::vector<Y_t>& dst,
-                        const M_t& matrix,
+                        const std::vector<Y_t>& tgt,
+                        const M_t& tgt_from_src,
                         std::vector<double>* residuals);
 };
 
-inline bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
-                          const std::vector<Eigen::Vector3d>& tgt,
-                          Sim3d& tgt_from_src) {
-  std::vector<Eigen::Matrix3x4d> models;
-  SimilarityTransformEstimator<3, true>().Estimate(src, tgt, &models);
-  if (models.empty()) {
-    return false;
-  }
-  THROW_CHECK_EQ(models.size(), 1);
-  tgt_from_src = Sim3d::FromMatrix(models[0]);
-  return true;
-}
+bool EstimateRigid3d(const std::vector<Eigen::Vector3d>& src,
+                     const std::vector<Eigen::Vector3d>& tgt,
+                     Rigid3d& tgt_from_src);
 
-template <bool kEstimateScale = true>
-inline typename RANSAC<SimilarityTransformEstimator<3, kEstimateScale>>::Report
+typename RANSAC<SimilarityTransformEstimator<3, false>>::Report
+EstimateRigid3dRobust(const std::vector<Eigen::Vector3d>& src,
+                      const std::vector<Eigen::Vector3d>& tgt,
+                      const RANSACOptions& options,
+                      Rigid3d& tgt_from_src);
+
+bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
+                   const std::vector<Eigen::Vector3d>& tgt,
+                   Sim3d& tgt_from_src);
+
+typename RANSAC<SimilarityTransformEstimator<3, true>>::Report
 EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
                     const std::vector<Eigen::Vector3d>& tgt,
                     const RANSACOptions& options,
-                    Sim3d& tgt_from_src) {
-  LORANSAC<SimilarityTransformEstimator<3, kEstimateScale>,
-           SimilarityTransformEstimator<3, kEstimateScale>>
-      ransac(options);
-  auto report = ransac.Estimate(src, tgt);
-  if (report.success) {
-    tgt_from_src = Sim3d::FromMatrix(report.model);
-  }
-  return report;
-}
+                    Sim3d& tgt_from_src);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation
@@ -129,44 +121,43 @@ EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
 template <int kDim, bool kEstimateScale>
 void SimilarityTransformEstimator<kDim, kEstimateScale>::Estimate(
     const std::vector<X_t>& src,
-    const std::vector<Y_t>& dst,
+    const std::vector<Y_t>& tgt,
     std::vector<M_t>* models) {
-  THROW_CHECK_EQ(src.size(), dst.size());
+  THROW_CHECK_EQ(src.size(), tgt.size());
   THROW_CHECK(models != nullptr);
 
   models->clear();
 
   Eigen::Matrix<double, kDim, Eigen::Dynamic> src_mat(kDim, src.size());
-  Eigen::Matrix<double, kDim, Eigen::Dynamic> dst_mat(kDim, dst.size());
+  Eigen::Matrix<double, kDim, Eigen::Dynamic> dst_mat(kDim, tgt.size());
   for (size_t i = 0; i < src.size(); ++i) {
     src_mat.col(i) = src[i];
-    dst_mat.col(i) = dst[i];
+    dst_mat.col(i) = tgt[i];
   }
 
-  const M_t model = Eigen::umeyama(src_mat, dst_mat, kEstimateScale)
-                        .template topLeftCorner<kDim, kDim + 1>();
+  const M_t sol = Eigen::umeyama(src_mat, dst_mat, kEstimateScale)
+                      .template topLeftCorner<kDim, kDim + 1>();
 
-  if (model.array().isNaN().any()) {
+  if (sol.hasNaN()) {
     return;
   }
 
   models->resize(1);
-  (*models)[0] = model;
+  (*models)[0] = sol;
 }
 
 template <int kDim, bool kEstimateScale>
 void SimilarityTransformEstimator<kDim, kEstimateScale>::Residuals(
     const std::vector<X_t>& src,
-    const std::vector<Y_t>& dst,
-    const M_t& matrix,
+    const std::vector<Y_t>& tgt,
+    const M_t& tgt_from_src,
     std::vector<double>* residuals) {
-  THROW_CHECK_EQ(src.size(), dst.size());
-
-  residuals->resize(src.size());
-
-  for (size_t i = 0; i < src.size(); ++i) {
-    const Y_t dst_transformed = matrix * src[i].homogeneous();
-    (*residuals)[i] = (dst[i] - dst_transformed).squaredNorm();
+  const size_t num_points = src.size();
+  THROW_CHECK_EQ(num_points, tgt.size());
+  residuals->resize(num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    (*residuals)[i] =
+        (tgt[i] - tgt_from_src * src[i].homogeneous()).squaredNorm();
   }
 }
 

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -130,9 +130,9 @@ void SimilarityTransformEstimator<kDim, kEstimateScale>::Estimate(
   models->clear();
 
   using MatrixType = Eigen::Matrix<double, kDim, Eigen::Dynamic>;
-  const Eigen::Map<const MatrixType> src_mat(
+  const Eigen::Map<const MatrixType, Eigen::Aligned16> src_mat(
       reinterpret_cast<const double*>(src.data()), 2, src.size());
-  const Eigen::Map<const MatrixType> tgt_mat(
+  const Eigen::Map<const MatrixType, Eigen::Aligned16> tgt_mat(
       reinterpret_cast<const double*>(tgt.data()), 2, tgt.size());
 
   if (Eigen::FullPivLU<MatrixType>(src_mat).rank() < kMinNumSamples ||

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -130,9 +130,9 @@ void SimilarityTransformEstimator<kDim, kEstimateScale>::Estimate(
   models->clear();
 
   using MatrixType = Eigen::Matrix<double, kDim, Eigen::Dynamic>;
-  const Eigen::Map<const MatrixType, Eigen::Aligned16> src_mat(
+  const Eigen::Map<const MatrixType> src_mat(
       reinterpret_cast<const double*>(src.data()), kDim, src.size());
-  const Eigen::Map<const MatrixType, Eigen::Aligned16> tgt_mat(
+  const Eigen::Map<const MatrixType> tgt_mat(
       reinterpret_cast<const double*>(tgt.data()), kDim, tgt.size());
 
   if (Eigen::FullPivLU<MatrixType>(src_mat).rank() < kMinNumSamples ||

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -32,6 +32,7 @@
 #include "colmap/geometry/sim3.h"
 #include "colmap/math/random.h"
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>
@@ -39,20 +40,43 @@
 namespace colmap {
 namespace {
 
+std::pair<std::vector<Eigen::Vector3d>, std::vector<Eigen::Vector3d> >
+GenerateData(size_t num_inliers,
+             size_t num_outliers,
+             const Eigen::Matrix3x4d& tgt_from_src) {
+  std::vector<Eigen::Vector3d> src;
+  std::vector<Eigen::Vector3d> tgt;
+
+  // Generate inlier data.
+  for (size_t i = 0; i < num_inliers; ++i) {
+    src.emplace_back(i, std::sqrt(i) + 2, std::sqrt(2 * i + 2));
+    tgt.push_back(tgt_from_src * src.back().homogeneous());
+  }
+
+  // Add some faulty data.
+  for (size_t i = 0; i < num_outliers; ++i) {
+    src.emplace_back(RandomUniformReal(-3000.0, -2000.0),
+                     RandomUniformReal(-4000.0, -3000.0),
+                     RandomUniformReal(-5000.0, -4000.0));
+    tgt.emplace_back(RandomUniformReal(-3000.0, -2000.0),
+                     RandomUniformReal(-4000.0, -3000.0),
+                     RandomUniformReal(-5000.0, -4000.0));
+  }
+
+  return {std::move(src), std::move(tgt)};
+}
+
 void TestEstimateSim3dWithNumCoords(const size_t num_coords) {
   const Sim3d gt_tgt_from_src(RandomUniformReal<double>(0.1, 10),
                               Eigen::Quaterniond::UnitRandom(),
                               Eigen::Vector3d::Random());
-
-  std::vector<Eigen::Vector3d> src;
-  std::vector<Eigen::Vector3d> dst;
-  for (size_t i = 0; i < num_coords; ++i) {
-    src.emplace_back(i, i + 2, i * i);
-    dst.push_back(gt_tgt_from_src * src.back());
-  }
+  const auto [src, tgt] = GenerateData(
+      /*num_inliers=*/num_coords,
+      /*num_outliers=*/0,
+      gt_tgt_from_src.ToMatrix());
 
   Sim3d tgt_from_src;
-  EXPECT_TRUE(EstimateSim3d(src, dst, tgt_from_src));
+  EXPECT_TRUE(EstimateSim3d(src, tgt, tgt_from_src));
   EXPECT_NEAR(gt_tgt_from_src.scale, tgt_from_src.scale, 1e-6);
   EXPECT_LT(gt_tgt_from_src.rotation.angularDistance(tgt_from_src.rotation),
             1e-6);
@@ -64,36 +88,66 @@ TEST(Sim3d, EstimateMinimal) { TestEstimateSim3dWithNumCoords(3); }
 
 TEST(Sim3d, EstimateOverDetermined) { TestEstimateSim3dWithNumCoords(100); }
 
-TEST(Sim3d, EstimateDegenerate) {
+TEST(Sim3d, EstimateMinimalDegenerate) {
   std::vector<Eigen::Vector3d> invalid_src_dst(3, Eigen::Vector3d::Zero());
   Sim3d tgt_from_src;
   EXPECT_FALSE(EstimateSim3d(invalid_src_dst, invalid_src_dst, tgt_from_src));
 }
 
+TEST(Sim3d, EstimateNonMinimalDegenerate) {
+  std::vector<Eigen::Vector3d> invalid_src_dst(5, Eigen::Vector3d::Zero());
+  Sim3d tgt_from_src;
+  EXPECT_FALSE(EstimateSim3d(invalid_src_dst, invalid_src_dst, tgt_from_src));
+}
+
+TEST(Rigid3d, EstimateRobust) {
+  SetPRNGSeed(0);
+
+  const size_t num_inliers = 1000;
+  const size_t num_outliers = 400;
+
+  const Rigid3d gt_tgt_from_src(Eigen::Quaterniond::UnitRandom(),
+                                Eigen::Vector3d(100, 10, 10));
+  const auto [src, tgt] = GenerateData(
+      /*num_inliers=*/num_inliers,
+      /*num_outliers=*/num_outliers,
+      gt_tgt_from_src.ToMatrix());
+
+  // Robustly estimate transformation using RANSAC.
+  RANSACOptions options;
+  options.max_error = 10;
+  Rigid3d tgt_from_src;
+  const auto report = EstimateRigid3dRobust(src, tgt, options, tgt_from_src);
+
+  EXPECT_TRUE(report.success);
+  EXPECT_GT(report.num_trials, 0);
+
+  // Make sure outliers were detected correctly.
+  EXPECT_EQ(report.support.num_inliers, num_inliers);
+  for (size_t i = 0; i < num_inliers + num_outliers; ++i) {
+    if (i >= num_inliers) {
+      EXPECT_FALSE(report.inlier_mask[i]);
+    } else {
+      EXPECT_TRUE(report.inlier_mask[i]);
+    }
+  }
+
+  EXPECT_THAT(tgt_from_src.ToMatrix(),
+              EigenMatrixNear(gt_tgt_from_src.ToMatrix(), 1e-6));
+}
+
 TEST(Sim3d, EstimateRobust) {
   SetPRNGSeed(0);
 
-  const size_t num_samples = 1000;
+  const size_t num_inliers = 1000;
   const size_t num_outliers = 400;
 
-  // Create some arbitrary transformation.
-  const Sim3d expectedTgtFromSrc(
+  const Sim3d gt_tgt_from_src(
       2, Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d(100, 10, 10));
-
-  // Generate exact data
-  std::vector<Eigen::Vector3d> src;
-  std::vector<Eigen::Vector3d> tgt;
-  for (size_t i = 0; i < num_samples; ++i) {
-    src.emplace_back(i, std::sqrt(i) + 2, std::sqrt(2 * i + 2));
-    tgt.push_back(expectedTgtFromSrc * src.back());
-  }
-
-  // Add some faulty data.
-  for (size_t i = 0; i < num_outliers; ++i) {
-    tgt[i] = Eigen::Vector3d(RandomUniformReal(-3000.0, -2000.0),
-                             RandomUniformReal(-4000.0, -3000.0),
-                             RandomUniformReal(-5000.0, -4000.0));
-  }
+  const auto [src, tgt] = GenerateData(
+      /*num_inliers=*/num_inliers,
+      /*num_outliers=*/num_outliers,
+      gt_tgt_from_src.ToMatrix());
 
   // Robustly estimate transformation using RANSAC.
   RANSACOptions options;
@@ -105,19 +159,17 @@ TEST(Sim3d, EstimateRobust) {
   EXPECT_GT(report.num_trials, 0);
 
   // Make sure outliers were detected correctly.
-  EXPECT_EQ(report.support.num_inliers, num_samples - num_outliers);
-  for (size_t i = 0; i < num_samples; ++i) {
-    if (i < num_outliers) {
+  EXPECT_EQ(report.support.num_inliers, num_inliers);
+  for (size_t i = 0; i < num_inliers + num_outliers; ++i) {
+    if (i >= num_inliers) {
       EXPECT_FALSE(report.inlier_mask[i]);
     } else {
       EXPECT_TRUE(report.inlier_mask[i]);
     }
   }
 
-  // Make sure original transformation is estimated correctly.
-  const double matrix_diff =
-      (expectedTgtFromSrc.ToMatrix() - tgt_from_src.ToMatrix()).norm();
-  EXPECT_LT(matrix_diff, 1e-6);
+  EXPECT_THAT(tgt_from_src.ToMatrix(),
+              EigenMatrixNear(gt_tgt_from_src.ToMatrix(), 1e-6));
 }
 
 }  // namespace

--- a/src/colmap/geometry/essential_matrix.cc
+++ b/src/colmap/geometry/essential_matrix.cc
@@ -105,7 +105,7 @@ void FindOptimalImageObservations(const Eigen::Matrix3d& E,
   const Eigen::Vector3d& point1_homogeneous = point1.homogeneous();
   const Eigen::Vector3d& point2_homogeneous = point2.homogeneous();
 
-  Eigen::Matrix<double, 2, 3> S;
+  Eigen::Matrix2x3d S;
   S << 1, 0, 0, 0, 1, 0;
 
   // Epipolar lines.

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -79,7 +79,7 @@ std::pair<Eigen::AlignedBox3d, Eigen::Vector3d> ComputeBoundingBoxAndCentroid(
 
   Eigen::Vector3d centroid(0, 0, 0);
   const double normalization = 1.0 / (max_idx - min_idx + 1);
-  for (int i = min_idx; i <= max_idx; ++i) {
+  for (size_t i = min_idx; i <= max_idx; ++i) {
     centroid(0) += normalization * coords_x[i];
     centroid(1) += normalization * coords_y[i];
     centroid(2) += normalization * coords_z[i];

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -57,6 +57,13 @@ struct Rigid3d {
     return matrix;
   }
 
+  static inline Rigid3d FromMatrix(const Eigen::Matrix3x4d& matrix) {
+    Rigid3d t;
+    t.rotation = Eigen::Quaterniond(matrix.leftCols<3>()).normalized();
+    t.translation = matrix.rightCols<1>();
+    return t;
+  }
+
   // Adjoint matrix to propagate uncertainty on Rigid3d
   // [Reference] https://gtsam.org/2021/02/23/uncertainties-part3.html
   inline Eigen::Matrix6d Adjoint() const {

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -74,13 +74,22 @@ TEST(Rigid3d, Inverse) {
   }
 }
 
-TEST(Rigid3d, Matrix) {
+TEST(Rigid3d, ToMatrix) {
   const Rigid3d b_from_a = TestRigid3d();
   const Eigen::Matrix3x4d b_from_a_mat = b_from_a.ToMatrix();
   for (int i = 0; i < 100; ++i) {
     const Eigen::Vector3d x_in_a = Eigen::Vector3d::Random();
     EXPECT_LT((b_from_a * x_in_a - b_from_a_mat * x_in_a.homogeneous()).norm(),
               1e-6);
+  }
+}
+
+TEST(Rigid3d, FromMatrix) {
+  const Rigid3d b1_from_a = TestRigid3d();
+  const Rigid3d b2_from_a = Rigid3d::FromMatrix(b1_from_a.ToMatrix());
+  for (int i = 0; i < 100; ++i) {
+    const Eigen::Vector3d x_in_a = Eigen::Vector3d::Random();
+    EXPECT_LT((b1_from_a * x_in_a - b2_from_a * x_in_a).norm(), 1e-6);
   }
 }
 

--- a/src/colmap/retrieval/vote_and_verify.cc
+++ b/src/colmap/retrieval/vote_and_verify.cc
@@ -406,15 +406,14 @@ int VoteAndVerify(const VoteAndVerifyOptions& options,
     }
 
     // Local optimization on matching inlier points.
-    std::vector<Eigen::Matrix<double, 2, 3>> models;
+    std::vector<Eigen::Matrix2x3d> models;
     AffineTransformEstimator::Estimate(
         best_inlier_points1, best_inlier_points2, &models);
     THROW_CHECK_EQ(models.size(), 1);
-    const Eigen::Matrix<double, 2, 3>& A = models[0];
+    const Eigen::Matrix2x3d& A = models[0];
     Eigen::Matrix3d A_homogeneous = Eigen::Matrix3d::Identity();
     A_homogeneous.topRows<2>() = A;
-    const Eigen::Matrix<double, 2, 3> inv_A =
-        A_homogeneous.inverse().topRows<2>();
+    const Eigen::Matrix2x3d inv_A = A_homogeneous.inverse().topRows<2>();
 
     TwoWayTransform local_tform;
     local_tform.A12 = A.leftCols<2>().cast<float>();

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -62,6 +62,7 @@ namespace Eigen {
 
 using Matrix3x4f = Matrix<float, 3, 4>;
 using Matrix3x4d = Matrix<double, 3, 4>;
+using Matrix2x3d = Matrix<double, 2, 3>;
 using Matrix6d = Matrix<double, 6, 6>;
 using Vector3ub = Matrix<uint8_t, 3, 1>;
 using Vector4ub = Matrix<uint8_t, 4, 1>;

--- a/src/pycolmap/estimators/affine_transform.cc
+++ b/src/pycolmap/estimators/affine_transform.cc
@@ -16,30 +16,50 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-py::typing::Optional<py::dict> PyEstimateAffineTransform2D(
-    const std::vector<Eigen::Vector2d>& points2D1,
-    const std::vector<Eigen::Vector2d>& points2D2,
-    const RANSACOptions& options) {
-  py::gil_scoped_release release;
-  THROW_CHECK_EQ(points2D1.size(), points2D2.size());
-  LORANSAC<AffineTransformEstimator, AffineTransformEstimator> ransac(options);
-  const auto report = ransac.Estimate(points2D1, points2D2);
-  py::gil_scoped_acquire acquire;
-  if (!report.success) {
-    return py::none();
-  }
-  return py::dict("A"_a = report.model,
-                  "num_inliers"_a = report.support.num_inliers,
-                  "inlier_mask"_a = ToPythonMask(report.inlier_mask));
-}
-
 void BindAffineTransformEstimator(py::module& m) {
   auto est_options = m.attr("RANSACOptions")().cast<RANSACOptions>();
 
-  m.def("estimate_affine_transform2D",
-        &PyEstimateAffineTransform2D,
-        "points2D1"_a,
-        "points2D2"_a,
-        py::arg_v("estimation_options", est_options, "RANSACOptions()"),
-        "Robustly estimate 2D affine transformation using LO-RANSAC.");
+  m.def(
+      "estimate_affine2d",
+      [](const std::vector<Eigen::Vector3d>& src,
+         const std::vector<Eigen::Vector3d>& tgt)
+          -> py::typing::Optional<Eigen::Matrix2x3d> {
+        py::gil_scoped_release release;
+        Eigen::Matrix2x3d tgt_from_src;
+        const bool success = EstimateSim3d(src, tgt, tgt_from_src);
+        py::gil_scoped_acquire acquire;
+        if (success) {
+          return py::cast(tgt_from_src);
+        } else {
+          return py::none();
+        }
+      },
+      "src"_a,
+      "tgt"_a,
+      "Estimate the 2D affine transform tgt_from_src.");
+
+  m.def(
+      "estimate_affine2d_robust",
+      [](const std::vector<Eigen::Vector3d>& src,
+         const std::vector<Eigen::Vector3d>& tgt,
+         const RANSACOptions& options)
+          -> py::typing::Optional<Eigen::Matrix2x3d> {
+        py::gil_scoped_release release;
+        Eigen::Matrix2x3d tgt_from_src;
+        const auto report =
+            EstimateSim3dRobust(src, tgt, options, tgt_from_src);
+        py::gil_scoped_acquire acquire;
+        if (!report.success) {
+          return py::none();
+        }
+        return py::dict(
+            "tgt_from_src"_a = Eigen::Matrix2x3d::FromMatrix(report.model),
+            "num_inliers"_a = report.support.num_inliers,
+            "inlier_mask"_a = ToPythonMask(report.inlier_mask));
+      },
+      "src"_a,
+      "tgt"_a,
+      py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
+      "Robustly estimate the 2D affine transform tgt_from_src using "
+      "LO-RANSAC.");
 }

--- a/src/pycolmap/estimators/affine_transform.cc
+++ b/src/pycolmap/estimators/affine_transform.cc
@@ -52,10 +52,9 @@ void BindAffineTransformEstimator(py::module& m) {
         if (!report.success) {
           return py::none();
         }
-        return py::dict(
-            "tgt_from_src"_a = tgt_from_src,
-            "num_inliers"_a = report.support.num_inliers,
-            "inlier_mask"_a = ToPythonMask(report.inlier_mask));
+        return py::dict("tgt_from_src"_a = tgt_from_src,
+                        "num_inliers"_a = report.support.num_inliers,
+                        "inlier_mask"_a = ToPythonMask(report.inlier_mask));
       },
       "src"_a,
       "tgt"_a,

--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -78,10 +78,7 @@ void BindGeometry(py::module& m) {
       .def(py::init<const Eigen::Quaterniond&, const Eigen::Vector3d&>(),
            "rotation"_a,
            "translation"_a)
-      .def(py::init([](const Eigen::Matrix3x4d& matrix) {
-             return Rigid3d(Eigen::Quaterniond(matrix.leftCols<3>()),
-                            matrix.col(3));
-           }),
+      .def(py::init(&Rigid3d::FromMatrix),
            "matrix"_a,
            "3x4 transformation matrix.")
       .def_readwrite("rotation", &Rigid3d::rotation)


### PR DESCRIPTION
* Add new functions EstimateRigid3d, EstimateRigid3dRobust, EstimateAffine2d, Estimate2dRobust (consistent with existing EstimateSim3d and Sim3dRobust).
* Improved tests for all of the transformations.
* Expose estimate_rigid3d and estimate_rigid3d_robust in pycolmap bindings.
* Add Rigid3d::FromMatrix (consistent with Sim3d::FromMatrix).