### PR TITLE
Re-enable interface support for covariance estimation from a raw Ceres::Problem

### DIFF
--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -272,6 +272,13 @@ std::optional<BACovariance> EstimateBACovariance(
     const Reconstruction& reconstruction,
     BundleAdjuster& bundle_adjuster) {
   ceres::Problem& problem = *THROW_CHECK_NOTNULL(bundle_adjuster.Problem());
+  return EstimateBACovariance(options, reconstruction, problem);
+}
+
+std::optional<BACovariance> EstimateBACovariance(
+    const BACovarianceOptions& options,
+    const Reconstruction& reconstruction,
+    ceres::Problem& problem) {
   const bool estimate_point_covs =
       options.params == BACovarianceOptions::Params::POINTS ||
       options.params == BACovarianceOptions::Params::POSES_AND_POINTS ||

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -115,6 +115,10 @@ std::optional<BACovariance> EstimateBACovariance(
     const BACovarianceOptions& options,
     const Reconstruction& reconstruction,
     BundleAdjuster& bundle_adjuster);
+std::optional<BACovariance> EstimateBACovariance(
+    const BACovarianceOptions& options,
+    const Reconstruction& reconstruction,
+    ceres::Problem& problem);
 
 namespace internal {
 

--- a/src/pycolmap/estimators/covariance.cc
+++ b/src/pycolmap/estimators/covariance.cc
@@ -97,8 +97,21 @@ void BindCovarianceEstimator(py::module& m) {
            "variable in the problem.");
 
   m.def(
+      "estimate_ba_covariance_from_problem",
+      py::overload_cast<const BACovarianceOptions&, const Reconstruction&, ceres::Problem&>(&EstimateBACovariance),
+      "options"_a,
+      "reconstruction"_a,
+      "problem"_a,
+      "Computes covariances for the parameters in a bundle adjustment "
+      "problem. It is important that the problem has a structure suitable for "
+      "solving using the Schur complement trick. This is the case for the "
+      "standard configuration of bundle adjustment problems, but be careful "
+      "if you modify the underlying problem with custom residuals. Returns "
+      "null if the estimation was not successful.");
+
+  m.def(
       "estimate_ba_covariance",
-      &EstimateBACovariance,
+      py::overload_cast<const BACovarianceOptions&, const Reconstruction&, BundleAdjuster&>(&EstimateBACovariance),
       "options"_a,
       "reconstruction"_a,
       "bundle_adjuster"_a,


### PR DESCRIPTION
Sincere request to re-enable this feature. Exposing this interface will make dev much easier when problem is constructed with pyceres, for example, with ``pycolmap.cost_functions.ReprojErrorCost`` and non-identity keypoint covariance (e.g. with a scaled covariance due to resizing). Given that we expose the ``pycolmap.cost_functions`` module there is no downside to support this.  