### PR TITLE
Overload pybind11 type_caster from int to C++ uint types to support -1 as input in pycolmap

### DIFF
--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -3,6 +3,7 @@
 #include "colmap/geometry/rigid3.h"
 
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -5,6 +5,7 @@
 #include "colmap/util/types.h"
 
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 #include "pycolmap/utils.h"
 
 #include <memory>

--- a/src/pycolmap/scene/track.cc
+++ b/src/pycolmap/scene/track.cc
@@ -5,6 +5,7 @@
 #include "colmap/util/types.h"
 
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 
 #include <memory>
 

--- a/src/pycolmap/sfm/incremental_triangulator.cc
+++ b/src/pycolmap/sfm/incremental_triangulator.cc
@@ -1,6 +1,7 @@
 #include "colmap/sfm/incremental_triangulator.h"
 
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 
 #include <memory>
 


### PR DESCRIPTION
Fixes: https://github.com/colmap/colmap/issues/3070