### PR TITLE
Only create OpenGL context in automatic reconstruction if necessary

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -109,35 +109,39 @@ AutomaticReconstructionController::AutomaticReconstructionController(
   option_manager_.mapper->ba_gpu_index = options_.gpu_index;
   option_manager_.bundle_adjustment->gpu_index = options_.gpu_index;
 
-  feature_extractor_ = CreateFeatureExtractorController(
-      reader_options, *option_manager_.sift_extraction);
-
-  exhaustive_matcher_ =
-      CreateExhaustiveFeatureMatcher(*option_manager_.exhaustive_matching,
-                                     *option_manager_.sift_matching,
-                                     *option_manager_.two_view_geometry,
-                                     *option_manager_.database_path);
-
-  if (!options_.vocab_tree_path.empty()) {
-    option_manager_.sequential_matching->loop_detection = true;
-    option_manager_.sequential_matching->vocab_tree_path =
-        options_.vocab_tree_path;
+  if (options_.extraction) {
+    feature_extractor_ = CreateFeatureExtractorController(
+        reader_options, *option_manager_.sift_extraction);
   }
 
-  sequential_matcher_ =
-      CreateSequentialFeatureMatcher(*option_manager_.sequential_matching,
-                                     *option_manager_.sift_matching,
-                                     *option_manager_.two_view_geometry,
-                                     *option_manager_.database_path);
+  if (options_.matching) {
+    exhaustive_matcher_ =
+        CreateExhaustiveFeatureMatcher(*option_manager_.exhaustive_matching,
+                                       *option_manager_.sift_matching,
+                                       *option_manager_.two_view_geometry,
+                                       *option_manager_.database_path);
 
-  if (!options_.vocab_tree_path.empty()) {
-    option_manager_.vocab_tree_matching->vocab_tree_path =
-        options_.vocab_tree_path;
-    vocab_tree_matcher_ =
-        CreateVocabTreeFeatureMatcher(*option_manager_.vocab_tree_matching,
-                                      *option_manager_.sift_matching,
-                                      *option_manager_.two_view_geometry,
-                                      *option_manager_.database_path);
+    if (!options_.vocab_tree_path.empty()) {
+      option_manager_.sequential_matching->loop_detection = true;
+      option_manager_.sequential_matching->vocab_tree_path =
+          options_.vocab_tree_path;
+    }
+
+    sequential_matcher_ =
+        CreateSequentialFeatureMatcher(*option_manager_.sequential_matching,
+                                       *option_manager_.sift_matching,
+                                       *option_manager_.two_view_geometry,
+                                       *option_manager_.database_path);
+
+    if (!options_.vocab_tree_path.empty()) {
+      option_manager_.vocab_tree_matching->vocab_tree_path =
+          options_.vocab_tree_path;
+      vocab_tree_matcher_ =
+          CreateVocabTreeFeatureMatcher(*option_manager_.vocab_tree_matching,
+                                        *option_manager_.sift_matching,
+                                        *option_manager_.two_view_geometry,
+                                        *option_manager_.database_path);
+    }
   }
 }
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -142,7 +142,8 @@ int RunAutomaticReconstructor(int argc, char** argv) {
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
 
-  if (reconstruction_options.use_gpu && kUseOpenGL) {
+  if (reconstruction_options.use_gpu && kUseOpenGL &&
+      (reconstruction_options.extraction || reconstruction_options.matching)) {
     QApplication app(argc, argv);
     AutomaticReconstructionController controller(reconstruction_options,
                                                  reconstruction_manager);


### PR DESCRIPTION
Only creates OpenGL context if feature extraction and matching stages are executed on the GPU. Previously, we would always create a context, even if not necessary.