### PR TITLE
Update CMakeLists.txt , fix linux build error

### DIFF
--- a/src/colmap/scene/CMakeLists.txt
+++ b/src/colmap/scene/CMakeLists.txt
@@ -57,6 +57,7 @@ COLMAP_ADD_LIBRARY(
         colmap_util
         Eigen3::Eigen
         SQLite::SQLite3
+        ${CMAKE_DL_LIBS}
 )
 
 COLMAP_ADD_TEST(

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -54,6 +54,7 @@ COLMAP_ADD_LIBRARY(
         Eigen3::Eigen
         glog::glog
         SQLite::SQLite3
+        ${CMAKE_DL_LIBS}
     PRIVATE_LINK_LIBS
         Boost::boost
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>


### PR DESCRIPTION
Update CMakeLists.txt , fix linux build error.
fix: /usr/bin/ld: libsqlite3.a(sqlite3.c.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'