### PR TITLE
Fix reprojection error in camera rig cost function

### DIFF
--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -113,8 +113,8 @@ void BindCostFunctions(py::module& m_parent) {
                                   const Eigen::Vector2d&,
                                   const Rigid3d&>,
         "camera_model_id"_a,
-        "cam_from_rig"_a,
         "point2D"_a,
+        "cam_from_rig"_a,
         "Reprojection error for camera rig with constant cam-from-rig pose.");
   m.def("RigReprojErrorCost",
         &CreateCameraCostFunction<


### PR DESCRIPTION
Reorders arguments in BindCostFunctions to fix reprojection error in camera rig cost function. The parameters cam_from_rig and point2D were in incorrect order after a previous refactoring.