### PR TITLE
Remove year from copyright

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/COPYING.txt
+++ b/COPYING.txt
@@ -3,7 +3,7 @@ refers only to the license for COLMAP itself, independent of its dependencies,
 which are separately licensed. Building COLMAP with these dependencies may
 affect the resulting COLMAP license.
 
-    Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+    Copyright (c), ETH Zurich and UNC Chapel Hill.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ refers only to the license for COLMAP itself, independent of its thirdparty
 dependencies, which are separately licensed. Building COLMAP with these
 dependencies may affect the resulting COLMAP license.
 
-    Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+    Copyright (c), ETH Zurich and UNC Chapel Hill.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/compare.py
+++ b/benchmark/reconstruction/compare.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/download.py
+++ b/benchmark/reconstruction/download.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/evaluate.py
+++ b/benchmark/reconstruction/evaluate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/evaluation/blended_mvs.py
+++ b/benchmark/reconstruction/evaluation/blended_mvs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/evaluation/eth3d.py
+++ b/benchmark/reconstruction/evaluation/eth3d.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/evaluation/imc.py
+++ b/benchmark/reconstruction/evaluation/imc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindFLANN.cmake
+++ b/cmake/FindFLANN.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindFreeImage.cmake
+++ b/cmake/FindFreeImage.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindGlew.cmake
+++ b/cmake/FindGlew.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindGlog.cmake
+++ b/cmake/FindGlog.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/FindMetis.cmake
+++ b/cmake/FindMetis.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/GenerateVersionDefinitions.cmake
+++ b/cmake/GenerateVersionDefinitions.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/colmap-config-version.cmake.in
+++ b/cmake/colmap-config-version.cmake.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -8,7 +8,7 @@ dependencies may affect the resulting COLMAP license.
 
 .. code-block:: text
 
-    Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+    Copyright (c), ETH Zurich and UNC Chapel Hill.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/cmap2rgb.m
+++ b/scripts/matlab/cmap2rgb.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/plot_model.m
+++ b/scripts/matlab/plot_model.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/quat2rotmat.m
+++ b/scripts/matlab/quat2rotmat.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/read_array.m
+++ b/scripts/matlab/read_array.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/read_depth_map.m
+++ b/scripts/matlab/read_depth_map.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/read_model.m
+++ b/scripts/matlab/read_model.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/read_normal_map.m
+++ b/scripts/matlab/read_normal_map.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/read_ply.m
+++ b/scripts/matlab/read_ply.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/write_array.m
+++ b/scripts/matlab/write_array.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/matlab/write_ply.m
+++ b/scripts/matlab/write_ply.m
@@ -1,4 +1,4 @@
-% Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+% Copyright (c), ETH Zurich and UNC Chapel Hill.
 % All rights reserved.
 %
 % Redistribution and use in source and binary forms, with or without

--- a/scripts/python/build_windows_app.py
+++ b/scripts/python/build_windows_app.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/bundler_to_ply.py
+++ b/scripts/python/bundler_to_ply.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/clang_format_code.py
+++ b/scripts/python/clang_format_code.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/crawl_camera_specs.py
+++ b/scripts/python/crawl_camera_specs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/database.py
+++ b/scripts/python/database.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/export_inlier_matches.py
+++ b/scripts/python/export_inlier_matches.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/export_inlier_pairs.py
+++ b/scripts/python/export_inlier_pairs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/export_to_bundler.py
+++ b/scripts/python/export_to_bundler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/export_to_visualsfm.py
+++ b/scripts/python/export_to_visualsfm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/flickr_downloader.py
+++ b/scripts/python/flickr_downloader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/merge_ply_files.py
+++ b/scripts/python/merge_ply_files.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/migrate_database_pose_prior.py
+++ b/scripts/python/migrate_database_pose_prior.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/nvm_to_ply.py
+++ b/scripts/python/nvm_to_ply.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/read_write_dense.py
+++ b/scripts/python/read_write_dense.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/read_write_fused_vis.py
+++ b/scripts/python/read_write_fused_vis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/read_write_model.py
+++ b/scripts/python/read_write_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/test_read_write_dense.py
+++ b/scripts/python/test_read_write_dense.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/test_read_write_fused_vis.py
+++ b/scripts/python/test_read_write_fused_vis.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/test_read_write_model.py
+++ b/scripts/python/test_read_write_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/python/visualize_model.py
+++ b/scripts/python/visualize_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/build_mac_app.sh
+++ b/scripts/shell/build_mac_app.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/colmap.bat
+++ b/scripts/shell/colmap.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+rem Copyright (c), ETH Zurich and UNC Chapel Hill.
 rem All rights reserved.
 rem
 rem Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/images_to_video.sh
+++ b/scripts/shell/images_to_video.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/profile_binary.sh
+++ b/scripts/shell/profile_binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/restore_git_submodules.sh
+++ b/scripts/shell/restore_git_submodules.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/shell/run_tests.bat
+++ b/scripts/shell/run_tests.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+rem Copyright (c), ETH Zurich and UNC Chapel Hill.
 rem All rights reserved.
 rem
 rem Redistribution and use in source and binary forms, with or without

--- a/src/colmap/CMakeLists.txt
+++ b/src/colmap/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/CMakeLists.txt
+++ b/src/colmap/controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/automatic_reconstruction.h
+++ b/src/colmap/controllers/automatic_reconstruction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/bundle_adjustment.h
+++ b/src/colmap/controllers/bundle_adjustment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_extraction.cc
+++ b/src/colmap/controllers/feature_extraction.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_extraction.h
+++ b/src/colmap/controllers/feature_extraction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_matching.cc
+++ b/src/colmap/controllers/feature_matching.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_matching.h
+++ b/src/colmap/controllers/feature_matching.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/feature_matching_utils.h
+++ b/src/colmap/controllers/feature_matching_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/hierarchical_pipeline.cc
+++ b/src/colmap/controllers/hierarchical_pipeline.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/hierarchical_pipeline.h
+++ b/src/colmap/controllers/hierarchical_pipeline.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/hierarchical_pipeline_test.cc
+++ b/src/colmap/controllers/hierarchical_pipeline_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/image_reader.cc
+++ b/src/colmap/controllers/image_reader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/image_reader.h
+++ b/src/colmap/controllers/image_reader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/controllers/option_manager.h
+++ b/src/colmap/controllers/option_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/absolute_pose.cc
+++ b/src/colmap/estimators/absolute_pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/affine_transform.cc
+++ b/src/colmap/estimators/affine_transform.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/affine_transform.h
+++ b/src/colmap/estimators/affine_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/affine_transform_test.cc
+++ b/src/colmap/estimators/affine_transform_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/alignment.h
+++ b/src/colmap/estimators/alignment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/coordinate_frame.cc
+++ b/src/colmap/estimators/coordinate_frame.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/coordinate_frame.h
+++ b/src/colmap/estimators/coordinate_frame.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/covariance_test.cc
+++ b/src/colmap/estimators/covariance_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/essential_matrix.cc
+++ b/src/colmap/estimators/essential_matrix.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/essential_matrix.h
+++ b/src/colmap/estimators/essential_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/essential_matrix_coeffs.h
+++ b/src/colmap/estimators/essential_matrix_coeffs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/essential_matrix_poly.h
+++ b/src/colmap/estimators/essential_matrix_poly.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/essential_matrix_test.cc
+++ b/src/colmap/estimators/essential_matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/euclidean_transform.h
+++ b/src/colmap/estimators/euclidean_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/fundamental_matrix.cc
+++ b/src/colmap/estimators/fundamental_matrix.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/fundamental_matrix.h
+++ b/src/colmap/estimators/fundamental_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/fundamental_matrix_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_absolute_pose.cc
+++ b/src/colmap/estimators/generalized_absolute_pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_absolute_pose.h
+++ b/src/colmap/estimators/generalized_absolute_pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_absolute_pose_coeffs.cc
+++ b/src/colmap/estimators/generalized_absolute_pose_coeffs.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_absolute_pose_coeffs.h
+++ b/src/colmap/estimators/generalized_absolute_pose_coeffs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_absolute_pose_test.cc
+++ b/src/colmap/estimators/generalized_absolute_pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_pose.h
+++ b/src/colmap/estimators/generalized_pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_relative_pose.cc
+++ b/src/colmap/estimators/generalized_relative_pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_relative_pose.h
+++ b/src/colmap/estimators/generalized_relative_pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/generalized_relative_pose_test.cc
+++ b/src/colmap/estimators/generalized_relative_pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/homography_matrix.cc
+++ b/src/colmap/estimators/homography_matrix.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/homography_matrix.h
+++ b/src/colmap/estimators/homography_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/homography_matrix_test.cc
+++ b/src/colmap/estimators/homography_matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/manifold.h
+++ b/src/colmap/estimators/manifold.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/pose.h
+++ b/src/colmap/estimators/pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/pose_test.cc
+++ b/src/colmap/estimators/pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/similarity_transform.cc
+++ b/src/colmap/estimators/similarity_transform.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/translation_transform.h
+++ b/src/colmap/estimators/translation_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/translation_transform_test.cc
+++ b/src/colmap/estimators/translation_transform_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/triangulation.cc
+++ b/src/colmap/estimators/triangulation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/triangulation.h
+++ b/src/colmap/estimators/triangulation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/two_view_geometry.h
+++ b/src/colmap/estimators/two_view_geometry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/estimators/utils_test.cc
+++ b/src/colmap/estimators/utils_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/database.cc
+++ b/src/colmap/exe/database.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/database.h
+++ b/src/colmap/exe/database.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/feature.cc
+++ b/src/colmap/exe/feature.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/feature.h
+++ b/src/colmap/exe/feature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/gui.cc
+++ b/src/colmap/exe/gui.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/gui.h
+++ b/src/colmap/exe/gui.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/image.cc
+++ b/src/colmap/exe/image.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/image.h
+++ b/src/colmap/exe/image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/model.h
+++ b/src/colmap/exe/model.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/mvs.h
+++ b/src/colmap/exe/mvs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/vocab_tree.cc
+++ b/src/colmap/exe/vocab_tree.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/exe/vocab_tree.h
+++ b/src/colmap/exe/vocab_tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/CMakeLists.txt
+++ b/src/colmap/feature/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/extractor.h
+++ b/src/colmap/feature/extractor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/index.h
+++ b/src/colmap/feature/index.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/index_test.cc
+++ b/src/colmap/feature/index_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/pairing_test.cc
+++ b/src/colmap/feature/pairing_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/sift.h
+++ b/src/colmap/feature/sift.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/types.cc
+++ b/src/colmap/feature/types.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/types.h
+++ b/src/colmap/feature/types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/types_test.cc
+++ b/src/colmap/feature/types_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/utils.cc
+++ b/src/colmap/feature/utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/utils.h
+++ b/src/colmap/feature/utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/feature/utils_test.cc
+++ b/src/colmap/feature/utils_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/essential_matrix.cc
+++ b/src/colmap/geometry/essential_matrix.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/gps.cc
+++ b/src/colmap/geometry/gps.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/gps.h
+++ b/src/colmap/geometry/gps.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/gps_test.cc
+++ b/src/colmap/geometry/gps_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/homography_matrix.cc
+++ b/src/colmap/geometry/homography_matrix.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/homography_matrix.h
+++ b/src/colmap/geometry/homography_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/homography_matrix_test.cc
+++ b/src/colmap/geometry/homography_matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/normalization.cc
+++ b/src/colmap/geometry/normalization.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/normalization.h
+++ b/src/colmap/geometry/normalization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/normalization_test.cc
+++ b/src/colmap/geometry/normalization_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose_prior.cc
+++ b/src/colmap/geometry/pose_prior.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose_prior.h
+++ b/src/colmap/geometry/pose_prior.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose_prior_test.cc
+++ b/src/colmap/geometry/pose_prior_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/rigid3.cc
+++ b/src/colmap/geometry/rigid3.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/sim3.cc
+++ b/src/colmap/geometry/sim3.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/sim3.h
+++ b/src/colmap/geometry/sim3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/sim3_test.cc
+++ b/src/colmap/geometry/sim3_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/triangulation.h
+++ b/src/colmap/geometry/triangulation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/geometry/triangulation_test.cc
+++ b/src/colmap/geometry/triangulation_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/CMakeLists.txt
+++ b/src/colmap/image/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/line.cc
+++ b/src/colmap/image/line.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/line.h
+++ b/src/colmap/image/line.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/line_test.cc
+++ b/src/colmap/image/line_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/undistortion.h
+++ b/src/colmap/image/undistortion.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/warp.cc
+++ b/src/colmap/image/warp.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/warp.h
+++ b/src/colmap/image/warp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/image/warp_test.cc
+++ b/src/colmap/image/warp_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/CMakeLists.txt
+++ b/src/colmap/math/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/graph_cut.cc
+++ b/src/colmap/math/graph_cut.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/graph_cut.h
+++ b/src/colmap/math/graph_cut.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/graph_cut_test.cc
+++ b/src/colmap/math/graph_cut_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/math.cc
+++ b/src/colmap/math/math.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/math.h
+++ b/src/colmap/math/math.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/math_test.cc
+++ b/src/colmap/math/math_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/matrix.h
+++ b/src/colmap/math/matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/matrix_test.cc
+++ b/src/colmap/math/matrix_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/polynomial.cc
+++ b/src/colmap/math/polynomial.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/polynomial.h
+++ b/src/colmap/math/polynomial.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/polynomial_test.cc
+++ b/src/colmap/math/polynomial_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/random.cc
+++ b/src/colmap/math/random.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/random.h
+++ b/src/colmap/math/random.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/math/random_test.cc
+++ b/src/colmap/math/random_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/CMakeLists.txt
+++ b/src/colmap/mvs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/consistency_graph.cc
+++ b/src/colmap/mvs/consistency_graph.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/consistency_graph.h
+++ b/src/colmap/mvs/consistency_graph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/consistency_graph_test.cc
+++ b/src/colmap/mvs/consistency_graph_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/cuda_flip.h
+++ b/src/colmap/mvs/cuda_flip.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/cuda_rotate.h
+++ b/src/colmap/mvs/cuda_rotate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/cuda_texture.h
+++ b/src/colmap/mvs/cuda_texture.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/cuda_transpose.h
+++ b/src/colmap/mvs/cuda_transpose.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/depth_map.cc
+++ b/src/colmap/mvs/depth_map.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/depth_map.h
+++ b/src/colmap/mvs/depth_map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/depth_map_test.cc
+++ b/src/colmap/mvs/depth_map_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/fusion.cc
+++ b/src/colmap/mvs/fusion.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/fusion.h
+++ b/src/colmap/mvs/fusion.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat.h
+++ b/src/colmap/mvs/gpu_mat.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat_prng.cu
+++ b/src/colmap/mvs/gpu_mat_prng.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat_prng.h
+++ b/src/colmap/mvs/gpu_mat_prng.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat_ref_image.cu
+++ b/src/colmap/mvs/gpu_mat_ref_image.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat_ref_image.h
+++ b/src/colmap/mvs/gpu_mat_ref_image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/gpu_mat_test.cu
+++ b/src/colmap/mvs/gpu_mat_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/image.cc
+++ b/src/colmap/mvs/image.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/image.h
+++ b/src/colmap/mvs/image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/mat.cc
+++ b/src/colmap/mvs/mat.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/mat.h
+++ b/src/colmap/mvs/mat.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/mat_test.cc
+++ b/src/colmap/mvs/mat_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/meshing.cc
+++ b/src/colmap/mvs/meshing.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/meshing.h
+++ b/src/colmap/mvs/meshing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/model.cc
+++ b/src/colmap/mvs/model.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/model.h
+++ b/src/colmap/mvs/model.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/normal_map.cc
+++ b/src/colmap/mvs/normal_map.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/normal_map.h
+++ b/src/colmap/mvs/normal_map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/normal_map_test.cc
+++ b/src/colmap/mvs/normal_map_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match.cc
+++ b/src/colmap/mvs/patch_match.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match.h
+++ b/src/colmap/mvs/patch_match.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match_cuda.cu
+++ b/src/colmap/mvs/patch_match_cuda.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match_cuda.h
+++ b/src/colmap/mvs/patch_match_cuda.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match_options.cc
+++ b/src/colmap/mvs/patch_match_options.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/patch_match_options.h
+++ b/src/colmap/mvs/patch_match_options.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/workspace.cc
+++ b/src/colmap/mvs/workspace.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/mvs/workspace.h
+++ b/src/colmap/mvs/workspace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/CMakeLists.txt
+++ b/src/colmap/optim/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/combination_sampler.cc
+++ b/src/colmap/optim/combination_sampler.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/combination_sampler.h
+++ b/src/colmap/optim/combination_sampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/combination_sampler_test.cc
+++ b/src/colmap/optim/combination_sampler_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/least_absolute_deviations.cc
+++ b/src/colmap/optim/least_absolute_deviations.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/least_absolute_deviations.h
+++ b/src/colmap/optim/least_absolute_deviations.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/least_absolute_deviations_test.cc
+++ b/src/colmap/optim/least_absolute_deviations_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/loransac_test.cc
+++ b/src/colmap/optim/loransac_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/progressive_sampler.cc
+++ b/src/colmap/optim/progressive_sampler.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/progressive_sampler.h
+++ b/src/colmap/optim/progressive_sampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/progressive_sampler_test.cc
+++ b/src/colmap/optim/progressive_sampler_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/random_sampler.cc
+++ b/src/colmap/optim/random_sampler.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/random_sampler.h
+++ b/src/colmap/optim/random_sampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/random_sampler_test.cc
+++ b/src/colmap/optim/random_sampler_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/ransac.h
+++ b/src/colmap/optim/ransac.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/ransac_test.cc
+++ b/src/colmap/optim/ransac_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/sampler.h
+++ b/src/colmap/optim/sampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/sprt.cc
+++ b/src/colmap/optim/sprt.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/sprt.h
+++ b/src/colmap/optim/sprt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/support_measurement.cc
+++ b/src/colmap/optim/support_measurement.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/support_measurement.h
+++ b/src/colmap/optim/support_measurement.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/optim/support_measurement_test.cc
+++ b/src/colmap/optim/support_measurement_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/CMakeLists.txt
+++ b/src/colmap/retrieval/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/geometry.cc
+++ b/src/colmap/retrieval/geometry.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/geometry.h
+++ b/src/colmap/retrieval/geometry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/geometry_test.cc
+++ b/src/colmap/retrieval/geometry_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/inverted_file.h
+++ b/src/colmap/retrieval/inverted_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/inverted_file_entry.h
+++ b/src/colmap/retrieval/inverted_file_entry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/inverted_file_entry_test.cc
+++ b/src/colmap/retrieval/inverted_file_entry_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/inverted_index.h
+++ b/src/colmap/retrieval/inverted_index.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/resources.h
+++ b/src/colmap/retrieval/resources.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/utils.h
+++ b/src/colmap/retrieval/utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/visual_index.h
+++ b/src/colmap/retrieval/visual_index.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/vote_and_verify.cc
+++ b/src/colmap/retrieval/vote_and_verify.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/vote_and_verify.h
+++ b/src/colmap/retrieval/vote_and_verify.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/retrieval/vote_and_verify_test.cc
+++ b/src/colmap/retrieval/vote_and_verify_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/CMakeLists.txt
+++ b/src/colmap/scene/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera.cc
+++ b/src/colmap/scene/camera.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera_rig.cc
+++ b/src/colmap/scene/camera_rig.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera_rig.h
+++ b/src/colmap/scene/camera_rig.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera_rig_test.cc
+++ b/src/colmap/scene/camera_rig_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/correspondence_graph.cc
+++ b/src/colmap/scene/correspondence_graph.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/correspondence_graph_test.cc
+++ b/src/colmap/scene/correspondence_graph_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database_cache.h
+++ b/src/colmap/scene/database_cache.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database_cache_test.cc
+++ b/src/colmap/scene/database_cache_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/database_test.cc
+++ b/src/colmap/scene/database_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point2d.cc
+++ b/src/colmap/scene/point2d.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point2d.h
+++ b/src/colmap/scene/point2d.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point2d_test.cc
+++ b/src/colmap/scene/point2d_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point3d.cc
+++ b/src/colmap/scene/point3d.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point3d.h
+++ b/src/colmap/scene/point3d.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/point3d_test.cc
+++ b/src/colmap/scene/point3d_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/projection.cc
+++ b/src/colmap/scene/projection.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/projection.h
+++ b/src/colmap/scene/projection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/projection_test.cc
+++ b/src/colmap/scene/projection_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_io.h
+++ b/src/colmap/scene/reconstruction_io.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_io_test.cc
+++ b/src/colmap/scene/reconstruction_io_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_manager.cc
+++ b/src/colmap/scene/reconstruction_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_manager.h
+++ b/src/colmap/scene/reconstruction_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_manager_test.cc
+++ b/src/colmap/scene/reconstruction_manager_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/scene_clustering.cc
+++ b/src/colmap/scene/scene_clustering.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/scene_clustering.h
+++ b/src/colmap/scene/scene_clustering.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/scene_clustering_test.cc
+++ b/src/colmap/scene/scene_clustering_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/synthetic.h
+++ b/src/colmap/scene/synthetic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/synthetic_test.cc
+++ b/src/colmap/scene/synthetic_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/track.cc
+++ b/src/colmap/scene/track.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/track.h
+++ b/src/colmap/scene/track.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/track_test.cc
+++ b/src/colmap/scene/track_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/two_view_geometry.cc
+++ b/src/colmap/scene/two_view_geometry.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/two_view_geometry.h
+++ b/src/colmap/scene/two_view_geometry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/two_view_geometry_test.cc
+++ b/src/colmap/scene/two_view_geometry_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/visibility_pyramid.cc
+++ b/src/colmap/scene/visibility_pyramid.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/visibility_pyramid.h
+++ b/src/colmap/scene/visibility_pyramid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/scene/visibility_pyramid_test.cc
+++ b/src/colmap/scene/visibility_pyramid_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/CMakeLists.txt
+++ b/src/colmap/sensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/database.cc
+++ b/src/colmap/sensor/database.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/database.h
+++ b/src/colmap/sensor/database.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/database_test.cc
+++ b/src/colmap/sensor/database_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/models.cc
+++ b/src/colmap/sensor/models.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/specs.cc
+++ b/src/colmap/sensor/specs.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sensor/specs.h
+++ b/src/colmap/sensor/specs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/CMakeLists.txt
+++ b/src/colmap/sfm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_mapper_impl.cc
+++ b/src/colmap/sfm/incremental_mapper_impl.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_mapper_impl.h
+++ b/src/colmap/sfm/incremental_mapper_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/incremental_triangulator_test.cc
+++ b/src/colmap/sfm/incremental_triangulator_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/observation_manager.h
+++ b/src/colmap/sfm/observation_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/tools/CMakeLists.txt
+++ b/src/colmap/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/tools/example.cc
+++ b/src/colmap/tools/example.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/CMakeLists.txt
+++ b/src/colmap/ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/automatic_reconstruction_widget.cc
+++ b/src/colmap/ui/automatic_reconstruction_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/automatic_reconstruction_widget.h
+++ b/src/colmap/ui/automatic_reconstruction_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/bundle_adjustment_widget.cc
+++ b/src/colmap/ui/bundle_adjustment_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/bundle_adjustment_widget.h
+++ b/src/colmap/ui/bundle_adjustment_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/colormaps.cc
+++ b/src/colmap/ui/colormaps.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/colormaps.h
+++ b/src/colmap/ui/colormaps.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/database_management_widget.cc
+++ b/src/colmap/ui/database_management_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/database_management_widget.h
+++ b/src/colmap/ui/database_management_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/dense_reconstruction_widget.cc
+++ b/src/colmap/ui/dense_reconstruction_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/dense_reconstruction_widget.h
+++ b/src/colmap/ui/dense_reconstruction_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/feature_extraction_widget.cc
+++ b/src/colmap/ui/feature_extraction_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/feature_extraction_widget.h
+++ b/src/colmap/ui/feature_extraction_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/feature_matching_widget.h
+++ b/src/colmap/ui/feature_matching_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/image_viewer_widget.cc
+++ b/src/colmap/ui/image_viewer_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/image_viewer_widget.h
+++ b/src/colmap/ui/image_viewer_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/license_widget.cc
+++ b/src/colmap/ui/license_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,7 @@ LicenseWidget::LicenseWidget(QWidget* parent) : QTextEdit(parent) {
 
 QString LicenseWidget::GetCOLMAPLicense() const {
   QString license =
-      "Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.<br>"
+      "Copyright (c), ETH Zurich and UNC Chapel Hill.<br>"
       "All rights reserved.<br>"
       "<br>"
       "Redistribution and use in source and binary forms, with or without<br>"

--- a/src/colmap/ui/license_widget.h
+++ b/src/colmap/ui/license_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/line_painter.cc
+++ b/src/colmap/ui/line_painter.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/line_painter.h
+++ b/src/colmap/ui/line_painter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/log_widget.cc
+++ b/src/colmap/ui/log_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/log_widget.h
+++ b/src/colmap/ui/log_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/main_window.h
+++ b/src/colmap/ui/main_window.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/match_matrix_widget.cc
+++ b/src/colmap/ui/match_matrix_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/match_matrix_widget.h
+++ b/src/colmap/ui/match_matrix_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/model_viewer_widget.h
+++ b/src/colmap/ui/model_viewer_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/movie_grabber_widget.cc
+++ b/src/colmap/ui/movie_grabber_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/movie_grabber_widget.h
+++ b/src/colmap/ui/movie_grabber_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/options_widget.cc
+++ b/src/colmap/ui/options_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/options_widget.h
+++ b/src/colmap/ui/options_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/point_painter.cc
+++ b/src/colmap/ui/point_painter.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/point_painter.h
+++ b/src/colmap/ui/point_painter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/point_viewer_widget.cc
+++ b/src/colmap/ui/point_viewer_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/point_viewer_widget.h
+++ b/src/colmap/ui/point_viewer_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/project_widget.cc
+++ b/src/colmap/ui/project_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/project_widget.h
+++ b/src/colmap/ui/project_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/qt_utils.cc
+++ b/src/colmap/ui/qt_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/qt_utils.h
+++ b/src/colmap/ui/qt_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_manager_widget.cc
+++ b/src/colmap/ui/reconstruction_manager_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_manager_widget.h
+++ b/src/colmap/ui/reconstruction_manager_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_options_widget.h
+++ b/src/colmap/ui/reconstruction_options_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_stats_widget.cc
+++ b/src/colmap/ui/reconstruction_stats_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/reconstruction_stats_widget.h
+++ b/src/colmap/ui/reconstruction_stats_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/render_options.h
+++ b/src/colmap/ui/render_options.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/render_options_widget.h
+++ b/src/colmap/ui/render_options_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/thread_control_widget.cc
+++ b/src/colmap/ui/thread_control_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/thread_control_widget.h
+++ b/src/colmap/ui/thread_control_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/triangle_painter.cc
+++ b/src/colmap/ui/triangle_painter.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/triangle_painter.h
+++ b/src/colmap/ui/triangle_painter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/undistortion_widget.cc
+++ b/src/colmap/ui/undistortion_widget.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/ui/undistortion_widget.h
+++ b/src/colmap/ui/undistortion_widget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+# Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/base_controller.cc
+++ b/src/colmap/util/base_controller.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/base_controller.h
+++ b/src/colmap/util/base_controller.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cache.h
+++ b/src/colmap/util/cache.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cache_test.cc
+++ b/src/colmap/util/cache_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/controller_thread.h
+++ b/src/colmap/util/controller_thread.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cuda.cc
+++ b/src/colmap/util/cuda.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cuda.h
+++ b/src/colmap/util/cuda.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cudacc.cc
+++ b/src/colmap/util/cudacc.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/cudacc.h
+++ b/src/colmap/util/cudacc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/eigen_alignment.h
+++ b/src/colmap/util/eigen_alignment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/eigen_matchers.h
+++ b/src/colmap/util/eigen_matchers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/eigen_matchers_test.cc
+++ b/src/colmap/util/eigen_matchers_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/endian.cc
+++ b/src/colmap/util/endian.cc
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/endian.h
+++ b/src/colmap/util/endian.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/endian_test.cc
+++ b/src/colmap/util/endian_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/enum_to_string.h
+++ b/src/colmap/util/enum_to_string.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/enum_to_string_test.cc
+++ b/src/colmap/util/enum_to_string_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/gtest_main.cc
+++ b/src/colmap/util/gtest_main.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/logging.cc
+++ b/src/colmap/util/logging.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/logging_test.cc
+++ b/src/colmap/util/logging_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/misc.cc
+++ b/src/colmap/util/misc.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/misc.h
+++ b/src/colmap/util/misc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/misc_test.cc
+++ b/src/colmap/util/misc_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/opengl_utils.cc
+++ b/src/colmap/util/opengl_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/opengl_utils.h
+++ b/src/colmap/util/opengl_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/opengl_utils_test.cc
+++ b/src/colmap/util/opengl_utils_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/ply.cc
+++ b/src/colmap/util/ply.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/ply.h
+++ b/src/colmap/util/ply.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/sqlite3_utils.h
+++ b/src/colmap/util/sqlite3_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/string.cc
+++ b/src/colmap/util/string.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/string_test.cc
+++ b/src/colmap/util/string_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/testing.cc
+++ b/src/colmap/util/testing.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/testing.h
+++ b/src/colmap/util/testing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/threading.cc
+++ b/src/colmap/util/threading.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/threading.h
+++ b/src/colmap/util/threading.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/threading_test.cc
+++ b/src/colmap/util/threading_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/timer.cc
+++ b/src/colmap/util/timer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/timer.h
+++ b/src/colmap/util/timer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/timer_test.cc
+++ b/src/colmap/util/timer_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/types_test.cc
+++ b/src/colmap/util/types_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/version.cc.in
+++ b/src/colmap/util/version.cc.in
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/colmap/util/version.h
+++ b/src/colmap/util/version.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, ETH Zurich and UNC Chapel Hill.
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Prevent yearly updates (that we forgot last year) by removing unnecessary year in the copyright notice.