### PR TITLE
Fix synthetic prior generation when stddev=0

### DIFF
--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -282,15 +282,14 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
     }
 
     if (options.use_prior_position) {
-      const Eigen::Vector3d noise(
-          RandomGaussian<double>(0, options.prior_position_stddev),
-          RandomGaussian<double>(0, options.prior_position_stddev),
-          RandomGaussian<double>(0, options.prior_position_stddev));
-
-      PosePrior noisy_prior(proj_center + noise,
+      PosePrior noisy_prior(proj_center,
                             PosePrior::CoordinateSystem::CARTESIAN);
 
       if (options.prior_position_stddev > 0.) {
+        noisy_prior.position += Eigen::Vector3d(
+            RandomGaussian<double>(0, options.prior_position_stddev),
+            RandomGaussian<double>(0, options.prior_position_stddev),
+            RandomGaussian<double>(0, options.prior_position_stddev));
         noisy_prior.position_covariance = options.prior_position_stddev *
                                           options.prior_position_stddev *
                                           Eigen::Matrix3d::Identity();


### PR DESCRIPTION
Passing zero standard deviation to the Gaussian distribution causes undefined behavior in some standard library implementations.