### PR TITLE
Minor: add missing empty namespace in alignment testing script

### DIFF
--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -39,6 +39,7 @@
 #include <gtest/gtest.h>
 
 namespace colmap {
+namespace {
 
 Sim3d TestSim3d() {
   return Sim3d(RandomUniformReal<double>(0.5, 2),
@@ -206,4 +207,5 @@ TEST(Alignment, MergeReconstructions) {
             src_reconstruction.ComputeNumObservations());
 }
 
+}  // namespace
 }  // namespace colmap


### PR DESCRIPTION
To be consistent with all other tests