### PR TITLE
Rename RigCalibration to RigCalib

### DIFF
--- a/src/colmap/scene/frame.h
+++ b/src/colmap/scene/frame.h
@@ -82,12 +82,11 @@ class Frame {
   // Check whether the data id is existent in the frame
   inline bool HasData(data_t data_id) const;
 
-  // Access the rig calibration
-  inline const std::shared_ptr<class RigCalibration>& RigCalibration() const;
-  inline void SetRigCalibration(
-      std::shared_ptr<class RigCalibration> rig_calibration);
-  // Check if the frame has a non-trivial rig calibration
-  inline bool HasRigCalibration() const;
+  // Access the rig calib
+  inline const std::shared_ptr<class RigCalib>& RigCalib() const;
+  inline void SetRigCalib(std::shared_ptr<class RigCalib> rig_calib);
+  // Check if the frame has a non-trivial rig calib
+  inline bool HasRigCalib() const;
 
   // Access the frame from world transformation
   inline const Rigid3d& FrameFromWorld() const;
@@ -106,13 +105,13 @@ class Frame {
   frame_t frame_id_ = kInvalidFrameId;
   std::set<data_t> data_ids_;
 
-  // Store the frame_from_world transformation and an optional rig calibration.
-  // If the rig calibration is a nullptr, the frame becomes a single sensor
+  // Store the frame_from_world transformation and an optional rig calib.
+  // If the rig calib is a nullptr, the frame becomes a single sensor
   // case, where rig modeling is no longer needed.
   std::optional<Rigid3d> frame_from_world_;
 
-  // [Optional] Rig calibration
-  std::shared_ptr<class RigCalibration> rig_calibration_ = nullptr;
+  // [Optional] Rig calib
+  std::shared_ptr<class RigCalib> rig_calib_ = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -133,20 +132,19 @@ bool Frame::HasData(data_t data_id) const {
   return data_ids_.find(data_id) != data_ids_.end();
 }
 
-const std::shared_ptr<class RigCalibration>& Frame::RigCalibration() const {
-  return rig_calibration_;
+const std::shared_ptr<class RigCalib>& Frame::RigCalib() const {
+  return rig_calib_;
 }
 
-void Frame::SetRigCalibration(
-    std::shared_ptr<class RigCalibration> rig_calibration) {
-  rig_calibration_ = std::move(rig_calibration);
+void Frame::SetRigCalib(std::shared_ptr<class RigCalib> rig_calib) {
+  rig_calib_ = std::move(rig_calib);
 }
 
-bool Frame::HasRigCalibration() const {
-  if (!rig_calibration_)
+bool Frame::HasRigCalib() const {
+  if (!rig_calib_)
     return false;
   else
-    return rig_calibration_->NumSensors() > 1;
+    return rig_calib_->NumSensors() > 1;
 }
 
 const Rigid3d& Frame::FrameFromWorld() const {
@@ -180,11 +178,11 @@ bool Frame::HasPose() const { return frame_from_world_.has_value(); }
 void Frame::ResetPose() { frame_from_world_.reset(); }
 
 Rigid3d Frame::SensorFromWorld(sensor_t sensor_id) const {
-  if (!HasRigCalibration() || rig_calibration_->IsRefSensor(sensor_id)) {
+  if (!HasRigCalib() || rig_calib_->IsRefSensor(sensor_id)) {
     return FrameFromWorld();
   }
-  THROW_CHECK(rig_calibration_->HasSensor(sensor_id));
-  return rig_calibration_->SensorFromRig(sensor_id) * FrameFromWorld();
+  THROW_CHECK(rig_calib_->HasSensor(sensor_id));
+  return rig_calib_->SensorFromRig(sensor_id) * FrameFromWorld();
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/frame.h
+++ b/src/colmap/scene/frame.h
@@ -82,10 +82,10 @@ class Frame {
   // Check whether the data id is existent in the frame
   inline bool HasData(data_t data_id) const;
 
-  // Access the rig calib
+  // Access the rig calibration
   inline const std::shared_ptr<class RigCalib>& RigCalib() const;
   inline void SetRigCalib(std::shared_ptr<class RigCalib> rig_calib);
-  // Check if the frame has a non-trivial rig calib
+  // Check if the frame has a non-trivial rig calibration
   inline bool HasRigCalib() const;
 
   // Access the frame from world transformation
@@ -105,12 +105,12 @@ class Frame {
   frame_t frame_id_ = kInvalidFrameId;
   std::set<data_t> data_ids_;
 
-  // Store the frame_from_world transformation and an optional rig calib.
-  // If the rig calib is a nullptr, the frame becomes a single sensor
+  // Store the frame_from_world transformation and an optional rig calibration.
+  // If the rig calibration is a nullptr, the frame becomes a single sensor
   // case, where rig modeling is no longer needed.
   std::optional<Rigid3d> frame_from_world_;
 
-  // [Optional] Rig calib
+  // [Optional] Rig calibration
   std::shared_ptr<class RigCalib> rig_calib_ = nullptr;
 };
 

--- a/src/colmap/scene/frame_test.cc
+++ b/src/colmap/scene/frame_test.cc
@@ -42,21 +42,21 @@ TEST(Frame, Default) {
   Frame frame;
   EXPECT_EQ(frame.FrameId(), kInvalidFrameId);
   EXPECT_FALSE(frame.HasPose());
-  EXPECT_FALSE(frame.HasRigCalibration());
+  EXPECT_FALSE(frame.HasRigCalib());
 }
 
 TEST(Frame, SetUp) {
   sensor_t s1(SensorType::IMU, 0);
   sensor_t s2(SensorType::CAMERA, 0);
-  std::shared_ptr<RigCalibration> calib = std::make_shared<RigCalibration>();
+  std::shared_ptr<RigCalib> calib = std::make_shared<RigCalib>();
   calib->AddRefSensor(s1);
   calib->AddSensor(s2, TestRigid3d());
 
   Frame frame;
   frame.AddData(data_t(s1, 2));
   frame.AddData(data_t(s2, 5));
-  frame.SetRigCalibration(calib);
-  EXPECT_TRUE(frame.HasRigCalibration());
+  frame.SetRigCalib(calib);
+  EXPECT_TRUE(frame.HasRigCalib());
   EXPECT_FALSE(frame.HasPose());
 }
 

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -241,9 +241,8 @@ void Image::SetFrame(std::shared_ptr<class Frame> frame) {
 
 bool Image::HasNonTrivialFrame() const {
   THROW_CHECK(frame_) << "Invalid pointer to the corresponding frame";
-  return frame_->HasRigCalibration() &&
-         !frame_->RigCalibration()->IsRefSensor(
-             sensor_t(SensorType::CAMERA, CameraId()));
+  return frame_->HasRigCalib() && !frame_->RigCalib()->IsRefSensor(
+                                      sensor_t(SensorType::CAMERA, CameraId()));
 }
 
 Rigid3d Image::ComposeCamFromWorld() const {

--- a/src/colmap/sensor/rig_calib.cc
+++ b/src/colmap/sensor/rig_calib.cc
@@ -31,14 +31,14 @@
 
 namespace colmap {
 
-void RigCalibration::AddRefSensor(sensor_t ref_sensor_id) {
+void RigCalib::AddRefSensor(sensor_t ref_sensor_id) {
   THROW_CHECK(ref_sensor_id_ == kInvalidSensorId)
       << "Reference sensor already set";
   ref_sensor_id_ = ref_sensor_id;
 }
 
-void RigCalibration::AddSensor(sensor_t sensor_id,
-                               const std::optional<Rigid3d>& sensor_from_rig) {
+void RigCalib::AddSensor(sensor_t sensor_id,
+                         const std::optional<Rigid3d>& sensor_from_rig) {
   THROW_CHECK(NumSensors() >= 1)
       << "The reference sensor needs to added first before any "
          "sensor being added.";

--- a/src/colmap/sensor/rig_calib.h
+++ b/src/colmap/sensor/rig_calib.h
@@ -76,9 +76,9 @@ constexpr sensor_t kInvalidSensorId =
 // the reference frame since it is metric.
 // 2) Not having a reference frame brings a 6 DoF Gauge for each rig, which is
 // not ideal particularly when it comes to covariance estimation.
-class RigCalibration {
+class RigCalib {
  public:
-  RigCalibration() = default;
+  RigCalib() = default;
 
   // Access the unique identifier of the rig
   inline rig_t RigId() const;
@@ -130,28 +130,28 @@ class RigCalibration {
 // Implementation
 ////////////////////////////////////////////////////////////////////////////////
 
-rig_t RigCalibration::RigId() const { return rig_id_; }
+rig_t RigCalib::RigId() const { return rig_id_; }
 
-void RigCalibration::SetRigId(rig_t rig_id) { rig_id_ = rig_id; }
+void RigCalib::SetRigId(rig_t rig_id) { rig_id_ = rig_id; }
 
-bool RigCalibration::HasSensor(sensor_t sensor_id) const {
+bool RigCalib::HasSensor(sensor_t sensor_id) const {
   return sensor_id == ref_sensor_id_ ||
          sensors_from_rig_.find(sensor_id) != sensors_from_rig_.end();
 }
 
-size_t RigCalibration::NumSensors() const {
+size_t RigCalib::NumSensors() const {
   size_t n_sensors = sensors_from_rig_.size();
   if (ref_sensor_id_ != kInvalidSensorId) n_sensors += 1;
   return n_sensors;
 }
 
-sensor_t RigCalibration::RefSensorId() const { return ref_sensor_id_; }
+sensor_t RigCalib::RefSensorId() const { return ref_sensor_id_; }
 
-bool RigCalibration::IsRefSensor(sensor_t sensor_id) const {
+bool RigCalib::IsRefSensor(sensor_t sensor_id) const {
   return sensor_id == ref_sensor_id_;
 }
 
-Rigid3d& RigCalibration::SensorFromRig(sensor_t sensor_id) {
+Rigid3d& RigCalib::SensorFromRig(sensor_t sensor_id) {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "No reference is available for the SensorFromRig transformation of "
          "the reference sensor, which is identity";
@@ -165,7 +165,7 @@ Rigid3d& RigCalibration::SensorFromRig(sensor_t sensor_id) {
   return *sensors_from_rig_.at(sensor_id);
 }
 
-const Rigid3d& RigCalibration::SensorFromRig(sensor_t sensor_id) const {
+const Rigid3d& RigCalib::SensorFromRig(sensor_t sensor_id) const {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "No reference is available for the SensorFromRig transformation of "
          "the reference sensor, which is identity";
@@ -179,7 +179,7 @@ const Rigid3d& RigCalibration::SensorFromRig(sensor_t sensor_id) const {
   return *sensors_from_rig_.at(sensor_id);
 }
 
-std::optional<Rigid3d>& RigCalibration::MaybeSensorFromRig(sensor_t sensor_id) {
+std::optional<Rigid3d>& RigCalib::MaybeSensorFromRig(sensor_t sensor_id) {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "No reference is available for the SensorFromRig transformation of "
          "the reference sensor, which is identity";
@@ -191,7 +191,7 @@ std::optional<Rigid3d>& RigCalibration::MaybeSensorFromRig(sensor_t sensor_id) {
   return sensors_from_rig_.at(sensor_id);
 }
 
-const std::optional<Rigid3d>& RigCalibration::MaybeSensorFromRig(
+const std::optional<Rigid3d>& RigCalib::MaybeSensorFromRig(
     sensor_t sensor_id) const {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "No reference is available for the SensorFromRig transformation of "
@@ -204,8 +204,8 @@ const std::optional<Rigid3d>& RigCalibration::MaybeSensorFromRig(
   return sensors_from_rig_.at(sensor_id);
 }
 
-void RigCalibration::SetSensorFromRig(sensor_t sensor_id,
-                                      const Rigid3d& sensor_from_rig) {
+void RigCalib::SetSensorFromRig(sensor_t sensor_id,
+                                const Rigid3d& sensor_from_rig) {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "Cannot set the SensorFromRig transformation of the reference sensor, "
          "which is fixed to identity";
@@ -217,8 +217,8 @@ void RigCalibration::SetSensorFromRig(sensor_t sensor_id,
   sensors_from_rig_.at(sensor_id) = sensor_from_rig;
 }
 
-void RigCalibration::SetSensorFromRig(
-    sensor_t sensor_id, const std::optional<Rigid3d>& sensor_from_rig) {
+void RigCalib::SetSensorFromRig(sensor_t sensor_id,
+                                const std::optional<Rigid3d>& sensor_from_rig) {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "Cannot set the SensorFromRig transformation of the reference sensor, "
          "which is fixed to identity";
@@ -230,7 +230,7 @@ void RigCalibration::SetSensorFromRig(
   sensors_from_rig_.at(sensor_id) = sensor_from_rig;
 }
 
-bool RigCalibration::HasSensorFromRig(sensor_t sensor_id) const {
+bool RigCalib::HasSensorFromRig(sensor_t sensor_id) const {
   if (IsRefSensor(sensor_id))
     return true;  // SensorFromRig for the reference sensor is always identity
   if (sensors_from_rig_.find(sensor_id) == sensors_from_rig_.end())
@@ -241,7 +241,7 @@ bool RigCalibration::HasSensorFromRig(sensor_t sensor_id) const {
   return sensors_from_rig_.at(sensor_id).has_value();
 }
 
-void RigCalibration::ResetSensorFromRig(sensor_t sensor_id) {
+void RigCalib::ResetSensorFromRig(sensor_t sensor_id) {
   THROW_CHECK(!IsRefSensor(sensor_id))
       << "Cannot reset the SensorFromRig transformation of the reference "
          "sensor, "

--- a/src/colmap/sensor/rig_calib_test.cc
+++ b/src/colmap/sensor/rig_calib_test.cc
@@ -38,15 +38,15 @@ Rigid3d TestRigid3d() {
   return Rigid3d(Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d::Random());
 }
 
-TEST(RigCalibration, Default) {
-  RigCalibration calib;
+TEST(RigCalib, Default) {
+  RigCalib calib;
   EXPECT_EQ(calib.RigId(), kInvalidRigId);
   EXPECT_EQ(calib.RefSensorId(), kInvalidSensorId);
   EXPECT_EQ(calib.NumSensors(), 0);
 }
 
-TEST(RigCalibration, SetUp) {
-  RigCalibration calib;
+TEST(RigCalib, SetUp) {
+  RigCalib calib;
   calib.AddRefSensor(sensor_t(SensorType::IMU, 0));
   calib.AddSensor(sensor_t(SensorType::IMU, 1), TestRigid3d());
   calib.AddSensor(sensor_t(SensorType::CAMERA, 0), TestRigid3d());


### PR DESCRIPTION
Let's save us some characters to write going forward. Was starting to play around with serialization and got already annoyed by typing out the full RigRalibration name.