### PR TITLE
Fix covariance propagation of pose inverse

### DIFF
--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -81,13 +81,6 @@ bool DecomposeProjectionMatrix(const Eigen::Matrix3x4d& P,
   return true;
 }
 
-Eigen::Matrix3d CrossProductMatrix(const Eigen::Vector3d& vector) {
-  Eigen::Matrix3d matrix;
-  matrix << 0, -vector(2), vector(1), vector(2), 0, -vector(0), -vector(1),
-      vector(0), 0;
-  return matrix;
-}
-
 void RotationMatrixToEulerAngles(const Eigen::Matrix3d& R,
                                  double* rx,
                                  double* ry,

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -51,9 +51,6 @@ bool DecomposeProjectionMatrix(const Eigen::Matrix3x4d& proj_matrix,
                                Eigen::Matrix3d* R,
                                Eigen::Vector3d* T);
 
-// Compose the skew symmetric cross product matrix from a vector.
-Eigen::Matrix3d CrossProductMatrix(const Eigen::Vector3d& vector);
-
 // Convert 3D rotation matrix to Euler angles.
 //
 // The convention `R = Rx * Ry * Rz` is used,

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -64,14 +64,6 @@ TEST(DecomposeProjectionMatrix, Nominal) {
   }
 }
 
-TEST(CrossProductMatrix, Nominal) {
-  EXPECT_EQ(CrossProductMatrix(Eigen::Vector3d(0, 0, 0)),
-            Eigen::Matrix3d::Zero());
-  Eigen::Matrix3d ref_matrix;
-  ref_matrix << 0, -3, 2, 3, 0, -1, -2, 1, 0;
-  EXPECT_EQ(CrossProductMatrix(Eigen::Vector3d(1, 2, 3)), ref_matrix);
-}
-
 TEST(EulerAngles, X) {
   const double rx = 0.3;
   const double ry = 0;

--- a/src/colmap/geometry/rigid3.cc
+++ b/src/colmap/geometry/rigid3.cc
@@ -33,6 +33,13 @@
 
 namespace colmap {
 
+Eigen::Matrix3d CrossProductMatrix(const Eigen::Vector3d& vector) {
+  Eigen::Matrix3d matrix;
+  matrix << 0, -vector(2), vector(1), vector(2), 0, -vector(0), -vector(1),
+      vector(0), 0;
+  return matrix;
+}
+
 std::ostream& operator<<(std::ostream& stream, const Rigid3d& tform) {
   const static Eigen::IOFormat kVecFmt(
       Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ");

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -38,6 +38,9 @@
 
 namespace colmap {
 
+// Compose the skew symmetric cross product matrix from a vector.
+Eigen::Matrix3d CrossProductMatrix(const Eigen::Vector3d& vector);
+
 // 3D rigid transform with 6 degrees of freedom.
 // Transforms point x from a to b as: x_in_b = R * x_in_a + t.
 struct Rigid3d {
@@ -75,6 +78,15 @@ struct Rigid3d {
     adjoint.block<3, 3>(3, 3) = adjoint.block<3, 3>(0, 0);
     return adjoint;
   }
+
+  inline Eigen::Matrix6d AdjointInverse() const {
+    Eigen::Matrix6d adjoint_inv;
+    adjoint_inv.block<3, 3>(0, 0) = rotation.toRotationMatrix().transpose();
+    adjoint_inv.block<3, 3>(0, 3).setZero();
+    adjoint_inv.block<3, 3>(3, 0) = - adjoint_inv.block<3, 3>(0, 0) * CrossProductMatrix(translation);
+    adjoint_inv.block<3, 3>(3, 3) = adjoint_inv.block<3, 3>(0, 0);
+    return adjoint_inv;
+  }
 };
 
 // Return inverse transform.
@@ -88,8 +100,8 @@ inline Rigid3d Inverse(const Rigid3d& b_from_a) {
 // Update covariance (6x6) for rigid3d.inverse()
 inline Eigen::Matrix6d GetCovarianceForRigid3dInverse(
     const Rigid3d& rigid3, const Eigen::Matrix6d& covar) {
-  const Eigen::Matrix6d adjoint = rigid3.Adjoint();
-  return adjoint * covar * adjoint.transpose();
+  const Eigen::Matrix6d adjoint_inv = rigid3.AdjointInverse();
+  return adjoint_inv * covar * adjoint_inv.transpose();
 }
 
 // Apply transform to point such that one can write expressions like:

--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -83,7 +83,8 @@ struct Rigid3d {
     Eigen::Matrix6d adjoint_inv;
     adjoint_inv.block<3, 3>(0, 0) = rotation.toRotationMatrix().transpose();
     adjoint_inv.block<3, 3>(0, 3).setZero();
-    adjoint_inv.block<3, 3>(3, 0) = - adjoint_inv.block<3, 3>(0, 0) * CrossProductMatrix(translation);
+    adjoint_inv.block<3, 3>(3, 0) =
+        -adjoint_inv.block<3, 3>(0, 0) * CrossProductMatrix(translation);
     adjoint_inv.block<3, 3>(3, 3) = adjoint_inv.block<3, 3>(0, 0);
     return adjoint_inv;
   }

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -40,6 +40,14 @@ Rigid3d TestRigid3d() {
   return Rigid3d(Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d::Random());
 }
 
+TEST(CrossProductMatrix, Nominal) {
+  EXPECT_EQ(CrossProductMatrix(Eigen::Vector3d(0, 0, 0)),
+            Eigen::Matrix3d::Zero());
+  Eigen::Matrix3d ref_matrix;
+  ref_matrix << 0, -3, 2, 3, 0, -1, -2, 1, 0;
+  EXPECT_EQ(CrossProductMatrix(Eigen::Vector3d(1, 2, 3)), ref_matrix);
+}
+
 TEST(Rigid3d, Default) {
   const Rigid3d tform;
   EXPECT_EQ(tform.rotation.coeffs(), Eigen::Quaterniond::Identity().coeffs());

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -144,6 +144,16 @@ TEST(Rigid3d, Compose) {
 
 TEST(Rigid3d, Adjoint) {
   const Rigid3d b_from_a = TestRigid3d();
+  const Eigen::Matrix6d adjoint = b_from_a.Adjoint();
+  const Eigen::Matrix6d adjoint_inv = b_from_a.AdjointInverse();
+  EXPECT_LT((adjoint * adjoint_inv - Eigen::Matrix6d::Identity()).norm(), 1e-6);
+  const Rigid3d a_from_b = Inverse(b_from_a);
+  const Eigen::Matrix6d adjoint_a_from_b = a_from_b.Adjoint();
+  EXPECT_LT((adjoint_inv - adjoint_a_from_b).norm(), 1e-6);
+}
+
+TEST(Rigid3d, CovariancePropagation) {
+  const Rigid3d b_from_a = TestRigid3d();
   const Eigen::Matrix6d A = Eigen::Matrix6d::Random();
   const Eigen::Matrix6d cov_b_from_a = A * A.transpose();
   const Eigen::Matrix6d cov_a_from_b =

--- a/src/pycolmap/geometry/bindings.cc
+++ b/src/pycolmap/geometry/bindings.cc
@@ -85,6 +85,7 @@ void BindGeometry(py::module& m) {
       .def_readwrite("translation", &Rigid3d::translation)
       .def("matrix", &Rigid3d::ToMatrix)
       .def("adjoint", &Rigid3d::Adjoint)
+      .def("adjoint_inverse", &Rigid3d::AdjointInverse)
       .def(py::self * Rigid3d())
       .def(py::self * Eigen::Vector3d())
       .def("__mul__",


### PR DESCRIPTION
The covariance propagation of pose inverse via adjoint introduced in https://github.com/colmap/colmap/pull/2598 followed the lamar convention, which was just found to be actually broken here: https://github.com/microsoft/lamar-benchmark/pull/84.

This PR fixes the propagation and added more cycle-consistent tests on the property of the adjoint matrix. To simplify the code for calculating adjoint inverse the function ``CrossProductMatrix`` is moved into ``rigid3.h``. 