### PR TITLE
[Spherical Camera Support] Change essential matrix estimation to use camera rays

### DIFF
--- a/src/colmap/estimators/essential_matrix.cc
+++ b/src/colmap/estimators/essential_matrix.cc
@@ -35,37 +35,34 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
-#include <complex>
-
 #include <Eigen/Geometry>
 #include <Eigen/LU>
 #include <Eigen/SVD>
 
 namespace colmap {
 
-void EssentialMatrixFivePointEstimator::Estimate(
-    const std::vector<X_t>& points1,
-    const std::vector<Y_t>& points2,
-    std::vector<M_t>* models) {
-  THROW_CHECK_EQ(points1.size(), points2.size());
-  THROW_CHECK_GE(points1.size(), 5);
+void EssentialMatrixFivePointEstimator::Estimate(const std::vector<X_t>& rays1,
+                                                 const std::vector<Y_t>& rays2,
+                                                 std::vector<M_t>* models) {
+  THROW_CHECK_EQ(rays1.size(), rays2.size());
+  THROW_CHECK_GE(rays1.size(), 5);
   THROW_CHECK(models != nullptr);
 
   models->clear();
 
-  // Setup system of equations: [points2(i,:), 1]' * E * [points1(i,:), 1]'.
+  // Setup system of equations: [rays2(i,:), 1]' * E * [rays1(i,:), 1]'.
 
-  Eigen::Matrix<double, Eigen::Dynamic, 9> Q(points1.size(), 9);
-  for (size_t i = 0; i < points1.size(); ++i) {
-    Q.row(i) << points2[i].x() * points1[i].transpose().homogeneous(),
-        points2[i].y() * points1[i].transpose().homogeneous(),
-        points1[i].transpose().homogeneous();
+  Eigen::Matrix<double, Eigen::Dynamic, 9> Q(rays1.size(), 9);
+  for (size_t i = 0; i < rays1.size(); ++i) {
+    Q.row(i) << rays2[i].x() * rays1[i].transpose(),
+        rays2[i].y() * rays1[i].transpose(),
+        rays2[i].z() * rays1[i].transpose();
   }
 
   // Step 1: Extraction of the nullspace.
 
   Eigen::Matrix<double, 9, 4> E;
-  if (points1.size() == 5) {
+  if (rays1.size() == 5) {
     E = Q.transpose().fullPivHouseholderQr().matrixQ().rightCols<4>();
   } else {
     const Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> svd(
@@ -148,43 +145,33 @@ void EssentialMatrixFivePointEstimator::Estimate(
 }
 
 void EssentialMatrixFivePointEstimator::Residuals(
-    const std::vector<X_t>& points1,
-    const std::vector<Y_t>& points2,
+    const std::vector<X_t>& rays1,
+    const std::vector<Y_t>& rays2,
     const M_t& E,
     std::vector<double>* residuals) {
-  ComputeSquaredSampsonError(points1, points2, E, residuals);
+  ComputeSquaredSampsonError(rays1, rays2, E, residuals);
 }
 
-void EssentialMatrixEightPointEstimator::Estimate(
-    const std::vector<X_t>& points1,
-    const std::vector<Y_t>& points2,
-    std::vector<M_t>* models) {
-  THROW_CHECK_EQ(points1.size(), points2.size());
-  THROW_CHECK_GE(points1.size(), 8);
+void EssentialMatrixEightPointEstimator::Estimate(const std::vector<X_t>& rays1,
+                                                  const std::vector<Y_t>& rays2,
+                                                  std::vector<M_t>* models) {
+  THROW_CHECK_EQ(rays1.size(), rays2.size());
+  THROW_CHECK_GE(rays1.size(), 8);
   THROW_CHECK(models != nullptr);
 
   models->clear();
 
-  // Center and normalize image points for better numerical stability.
-  std::vector<X_t> normed_points1;
-  std::vector<Y_t> normed_points2;
-  Eigen::Matrix3d normed_from_orig1;
-  Eigen::Matrix3d normed_from_orig2;
-  CenterAndNormalizeImagePoints(points1, &normed_points1, &normed_from_orig1);
-  CenterAndNormalizeImagePoints(points2, &normed_points2, &normed_from_orig2);
-
   // Setup homogeneous linear equation as x2' * F * x1 = 0.
-  Eigen::Matrix<double, Eigen::Dynamic, 9> A(points1.size(), 9);
-  for (size_t i = 0; i < points1.size(); ++i) {
-    A.row(i) << normed_points2[i].x() *
-                    normed_points1[i].transpose().homogeneous(),
-        normed_points2[i].y() * normed_points1[i].transpose().homogeneous(),
-        normed_points1[i].transpose().homogeneous();
+  Eigen::Matrix<double, Eigen::Dynamic, 9> A(rays1.size(), 9);
+  for (size_t i = 0; i < rays1.size(); ++i) {
+    A.row(i) << rays2[i].x() * rays1[i].transpose(),
+        rays2[i].y() * rays1[i].transpose(),
+        rays2[i].z() * rays1[i].transpose();
   }
 
   // Solve for the nullspace of the constraint matrix.
   Eigen::Matrix3d Q;
-  if (points1.size() == 8) {
+  if (rays1.size() == 8) {
     Eigen::Matrix<double, 9, 9> QQ =
         A.transpose().householderQr().householderQ();
     Q = Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
@@ -202,19 +189,18 @@ void EssentialMatrixEightPointEstimator::Estimate(
       Q, Eigen::ComputeFullU | Eigen::ComputeFullV);
   Eigen::Vector3d singular_values = svd.singularValues();
   singular_values(2) = 0.0;
-  const Eigen::Matrix3d E =
-      svd.matrixU() * singular_values.asDiagonal() * svd.matrixV().transpose();
 
   models->resize(1);
-  (*models)[0] = normed_from_orig2.transpose() * E * normed_from_orig1;
+  (*models)[0] =
+      svd.matrixU() * singular_values.asDiagonal() * svd.matrixV().transpose();
 }
 
 void EssentialMatrixEightPointEstimator::Residuals(
-    const std::vector<X_t>& points1,
-    const std::vector<Y_t>& points2,
+    const std::vector<X_t>& rays1,
+    const std::vector<Y_t>& rays2,
     const M_t& E,
     std::vector<double>* residuals) {
-  ComputeSquaredSampsonError(points1, points2, E, residuals);
+  ComputeSquaredSampsonError(rays1, rays2, E, residuals);
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/essential_matrix.h
+++ b/src/colmap/estimators/essential_matrix.h
@@ -56,12 +56,12 @@ class EssentialMatrixFivePointEstimator {
   static const int kMinNumSamples = 5;
 
   // Estimate up to 10 possible essential matrix solutions from a set of
-  // corresponding rays.
+  // corresponding rays directions.
   //
   //  The number of corresponding rays must be at least 5.
   //
-  // @param rays1    First set of corresponding rays.
-  // @param rays2    Second set of corresponding rays.
+  // @param rays1    First set of corresponding rays directions.
+  // @param rays2    Second set of corresponding rays directions.
   //
   // @return         Up to 10 solutions as a vector of 3x3 essential matrices.
   static void Estimate(const std::vector<X_t>& rays1,
@@ -73,8 +73,8 @@ class EssentialMatrixFivePointEstimator {
   //
   // Residuals are defined as the squared Sampson error.
   //
-  // @param rays1      First set of corresponding rays.
-  // @param rays2      Second set of corresponding rays.
+  // @param rays1      First set of corresponding rays directions.
+  // @param rays2      Second set of corresponding rays directions.
   // @param E          3x3 essential matrix.
   // @param residuals  Output vector of residuals as squared Sampson errors.
   static void Residuals(const std::vector<X_t>& rays1,
@@ -97,12 +97,13 @@ class EssentialMatrixEightPointEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 8;
 
-  // Estimate essential matrix solutions from  set of corresponding rays.
+  // Estimate essential matrix solutions from  set of corresponding rays
+  // directions.
   //
   // The number of corresponding rays must be at least 8.
   //
-  // @param rays1    First set of corresponding rays.
-  // @param rays2    Second set of corresponding rays.
+  // @param rays1    First set of corresponding rays directions.
+  // @param rays2    Second set of corresponding rays directions.
   //
   // @return         Estimated 3x3 essential matrix.
   static void Estimate(const std::vector<X_t>& rays1,
@@ -114,8 +115,8 @@ class EssentialMatrixEightPointEstimator {
   //
   // Residuals are defined as the squared Sampson error.
   //
-  // @param rays1      First set of corresponding rays.
-  // @param rays2      Second set of corresponding rays.
+  // @param rays1      First set of corresponding rays directions.
+  // @param rays2      Second set of corresponding rays directions.
   // @param E          3x3 essential matrix.
   // @param residuals  Output vector of residuals as squared Sampson errors.
   static void Residuals(const std::vector<X_t>& rays1,

--- a/src/colmap/estimators/essential_matrix.h
+++ b/src/colmap/estimators/essential_matrix.h
@@ -48,37 +48,37 @@ namespace colmap {
 //    http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.86.8769
 class EssentialMatrixFivePointEstimator {
  public:
-  typedef Eigen::Vector2d X_t;
-  typedef Eigen::Vector2d Y_t;
+  typedef Eigen::Vector3d X_t;
+  typedef Eigen::Vector3d Y_t;
   typedef Eigen::Matrix3d M_t;
 
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 5;
 
   // Estimate up to 10 possible essential matrix solutions from a set of
-  // corresponding points.
+  // corresponding rays.
   //
-  //  The number of corresponding points must be at least 5.
+  //  The number of corresponding rays must be at least 5.
   //
-  // @param points1  First set of corresponding points.
-  // @param points2  Second set of corresponding points.
+  // @param rays1    First set of corresponding rays.
+  // @param rays2    Second set of corresponding rays.
   //
   // @return         Up to 10 solutions as a vector of 3x3 essential matrices.
-  static void Estimate(const std::vector<X_t>& points1,
-                       const std::vector<Y_t>& points2,
+  static void Estimate(const std::vector<X_t>& rays1,
+                       const std::vector<Y_t>& rays2,
                        std::vector<M_t>* models);
 
-  // Calculate the residuals of a set of corresponding points and a given
+  // Calculate the residuals of a set of corresponding rays and a given
   // essential matrix.
   //
   // Residuals are defined as the squared Sampson error.
   //
-  // @param points1    First set of corresponding points.
-  // @param points2    Second set of corresponding points.
+  // @param rays1      First set of corresponding rays.
+  // @param rays2      Second set of corresponding rays.
   // @param E          3x3 essential matrix.
-  // @param residuals  Output vector of residuals.
-  static void Residuals(const std::vector<X_t>& points1,
-                        const std::vector<Y_t>& points2,
+  // @param residuals  Output vector of residuals as squared Sampson errors.
+  static void Residuals(const std::vector<X_t>& rays1,
+                        const std::vector<Y_t>& rays2,
                         const M_t& E,
                         std::vector<double>* residuals);
 };
@@ -90,34 +90,36 @@ class EssentialMatrixFivePointEstimator {
 //    Hartley and Zisserman, Multiple View Geometry, algorithm 11.1, page 282.
 class EssentialMatrixEightPointEstimator {
  public:
-  typedef Eigen::Vector2d X_t;
-  typedef Eigen::Vector2d Y_t;
+  typedef Eigen::Vector3d X_t;
+  typedef Eigen::Vector3d Y_t;
   typedef Eigen::Matrix3d M_t;
 
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 8;
 
-  // Estimate essential matrix solutions from  set of corresponding points.
+  // Estimate essential matrix solutions from  set of corresponding rays.
   //
-  // The number of corresponding points must be at least 8.
+  // The number of corresponding rays must be at least 8.
   //
-  // @param points1  First set of corresponding points.
-  // @param points2  Second set of corresponding points.
-  static void Estimate(const std::vector<X_t>& points1,
-                       const std::vector<Y_t>& points2,
+  // @param rays1    First set of corresponding rays.
+  // @param rays2    Second set of corresponding rays.
+  //
+  // @return         Estimated 3x3 essential matrix.
+  static void Estimate(const std::vector<X_t>& rays1,
+                       const std::vector<Y_t>& rays2,
                        std::vector<M_t>* models);
 
-  // Calculate the residuals of a set of corresponding points and a given
+  // Calculate the residuals of a set of corresponding rays and a given
   // essential matrix.
   //
   // Residuals are defined as the squared Sampson error.
   //
-  // @param points1    First set of corresponding points.
-  // @param points2    Second set of corresponding points.
+  // @param rays1      First set of corresponding rays.
+  // @param rays2      Second set of corresponding rays.
   // @param E          3x3 essential matrix.
-  // @param residuals  Output vector of residuals.
-  static void Residuals(const std::vector<X_t>& points1,
-                        const std::vector<Y_t>& points2,
+  // @param residuals  Output vector of residuals as squared Sampson errors.
+  static void Residuals(const std::vector<X_t>& rays1,
+                        const std::vector<Y_t>& rays2,
                         const M_t& E,
                         std::vector<double>* residuals);
 };

--- a/src/colmap/estimators/essential_matrix_test.cc
+++ b/src/colmap/estimators/essential_matrix_test.cc
@@ -34,6 +34,7 @@
 #include "colmap/math/random.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>
@@ -42,22 +43,21 @@ namespace colmap {
 namespace {
 
 void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
-                                   size_t num_points,
-                                   std::vector<Eigen::Vector2d>& points1,
-                                   std::vector<Eigen::Vector2d>& points2) {
-  for (size_t i = 0; i < num_points; ++i) {
-    points1.push_back(Eigen::Vector2d::Random());
+                                   size_t num_rays,
+                                   std::vector<Eigen::Vector3d>& rays1,
+                                   std::vector<Eigen::Vector3d>& rays2) {
+  for (size_t i = 0; i < num_rays; ++i) {
+    rays1.push_back(Eigen::Vector3d::Random().normalized());
     const double random_depth = RandomUniformReal<double>(0.2, 2.0);
-    points2.push_back(
-        (cam2_from_cam1 * (random_depth * points1.back().homogeneous()))
-            .hnormalized());
+    rays2.push_back(
+        (cam2_from_cam1 * (random_depth * rays1.back())).normalized());
   }
 }
 
 template <typename Estimator>
 void ExpectAtLeastOneValidModel(const Estimator& estimator,
-                                const std::vector<Eigen::Vector2d>& points1,
-                                const std::vector<Eigen::Vector2d>& points2,
+                                const std::vector<Eigen::Vector3d>& rays1,
+                                const std::vector<Eigen::Vector3d>& rays2,
                                 Eigen::Matrix3d& expected_E,
                                 std::vector<Eigen::Matrix3d>& models,
                                 double E_eps = 1e-4,
@@ -70,35 +70,42 @@ void ExpectAtLeastOneValidModel(const Estimator& estimator,
       continue;
     }
 
+    bool all_residuals_small = true;
     std::vector<double> residuals;
-    estimator.Residuals(points1, points2, E, &residuals);
-    for (size_t j = 0; j < points1.size(); ++j) {
-      EXPECT_LT(residuals[j], r_eps);
+    estimator.Residuals(rays1, rays2, E, &residuals);
+    for (const double residual : residuals) {
+      if (residual > r_eps) {
+        all_residuals_small = false;
+        break;
+      }
     }
 
-    return;
+    if (all_residuals_small) {
+      return;
+    }
   }
-  ADD_FAILURE() << "No essential matrix is equal up to scale.";
+
+  ADD_FAILURE() << "No good solution found.";
 }
 
 class EssentialMatrixFivePointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
-  const size_t kNumPoints = GetParam();
+  const size_t kNumrays = GetParam();
   for (size_t k = 0; k < 100; ++k) {
     const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
                                  Eigen::Vector3d::Random());
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
-    std::vector<Eigen::Vector2d> points1;
-    std::vector<Eigen::Vector2d> points2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumPoints, points1, points2);
+    std::vector<Eigen::Vector3d> rays1;
+    std::vector<Eigen::Vector3d> rays2;
+    RandomEpipolarCorrespondences(cam2_from_cam1, kNumrays, rays1, rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
-    estimator.Estimate(points1, points2, &models);
+    estimator.Estimate(rays1, rays2, &models);
 
-    ExpectAtLeastOneValidModel(estimator, points1, points2, expected_E, models);
+    ExpectAtLeastOneValidModel(estimator, rays1, rays2, expected_E, models);
   }
 }
 
@@ -107,24 +114,24 @@ INSTANTIATE_TEST_SUITE_P(EssentialMatrixFivePointEstimator,
                          ::testing::Values(5, 20, 1000));
 
 TEST(EssentialMatrixEightPointEstimator, Reference) {
-  const double points1_raw[] = {1.839035,
-                                1.924743,
-                                0.543582,
-                                0.375221,
-                                0.473240,
-                                0.142522,
-                                0.964910,
-                                0.598376,
-                                0.102388,
-                                0.140092,
-                                15.994343,
-                                9.622164,
-                                0.285901,
-                                0.430055,
-                                0.091150,
-                                0.254594};
+  const double rays1_raw[] = {1.839035,
+                              1.924743,
+                              0.543582,
+                              0.375221,
+                              0.473240,
+                              0.142522,
+                              0.964910,
+                              0.598376,
+                              0.102388,
+                              0.140092,
+                              15.994343,
+                              9.622164,
+                              0.285901,
+                              0.430055,
+                              0.091150,
+                              0.254594};
 
-  const double points2_raw[] = {
+  const double rays2_raw[] = {
       1.002114,
       1.129644,
       1.521742,
@@ -143,31 +150,28 @@ TEST(EssentialMatrixEightPointEstimator, Reference) {
       1.028681,
   };
 
-  const size_t kNumPoints = 8;
-  std::vector<Eigen::Vector2d> points1(kNumPoints);
-  std::vector<Eigen::Vector2d> points2(kNumPoints);
-  for (size_t i = 0; i < kNumPoints; ++i) {
-    points1[i] = Eigen::Vector2d(points1_raw[2 * i], points1_raw[2 * i + 1]);
-    points2[i] = Eigen::Vector2d(points2_raw[2 * i], points2_raw[2 * i + 1]);
+  const size_t kNumrays = 8;
+  std::vector<Eigen::Vector3d> rays1(kNumrays);
+  std::vector<Eigen::Vector3d> rays2(kNumrays);
+  for (size_t i = 0; i < kNumrays; ++i) {
+    rays1[i] = Eigen::Vector3d(rays1_raw[2 * i], rays1_raw[2 * i + 1], 1);
+    rays2[i] = Eigen::Vector3d(rays2_raw[2 * i], rays2_raw[2 * i + 1], 1);
   }
 
   EssentialMatrixEightPointEstimator estimator;
   std::vector<Eigen::Matrix3d> models;
-  estimator.Estimate(points1, points2, &models);
+  estimator.Estimate(rays1, rays2, &models);
+
+  Eigen::Matrix3d expected_E;
+  expected_E << -0.315968, 0.604935, -0.0538653, -0.103596, 0.0652994,
+      0.0208669, 0.355946, -0.622327, 0.043552;
+  expected_E /= expected_E(2, 2);
 
   ASSERT_EQ(models.size(), 1);
-  const Eigen::Matrix3d& E = models[0];
+  Eigen::Matrix3d& E = models[0];
+  E /= E(2, 2);
 
-  // Reference values.
-  EXPECT_NEAR(E(0, 0), 0.217859, 1e-5);
-  EXPECT_NEAR(E(0, 1), -0.419282, 1e-5);
-  EXPECT_NEAR(E(0, 2), 0.0343075, 1e-5);
-  EXPECT_NEAR(E(1, 0), 0.0717941, 1e-5);
-  EXPECT_NEAR(E(1, 1), -0.0451643, 1e-5);
-  EXPECT_NEAR(E(1, 2), -0.0216073, 1e-5);
-  EXPECT_NEAR(E(2, 0), -0.248062, 1e-5);
-  EXPECT_NEAR(E(2, 1), 0.429478, 1e-5);
-  EXPECT_NEAR(E(2, 2), -0.0221019, 1e-5);
+  EXPECT_THAT(E, EigenMatrixNear(expected_E, 1e-5));
 
   // Check that the internal constraint is satisfied (two singular values equal
   // and one zero).
@@ -182,20 +186,20 @@ class EssentialMatrixEightPointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
-  const size_t kNumPoints = GetParam();
+  const size_t kNumrays = GetParam();
   for (size_t k = 0; k < 1; ++k) {
     const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
                                  Eigen::Vector3d::Random());
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
-    std::vector<Eigen::Vector2d> points1;
-    std::vector<Eigen::Vector2d> points2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumPoints, points1, points2);
+    std::vector<Eigen::Vector3d> rays1;
+    std::vector<Eigen::Vector3d> rays2;
+    RandomEpipolarCorrespondences(cam2_from_cam1, kNumrays, rays1, rays2);
 
     EssentialMatrixEightPointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
-    estimator.Estimate(points1, points2, &models);
+    estimator.Estimate(rays1, rays2, &models);
 
-    ExpectAtLeastOneValidModel(estimator, points1, points2, expected_E, models);
+    ExpectAtLeastOneValidModel(estimator, rays1, rays2, expected_E, models);
   }
 }
 

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -100,8 +100,17 @@ size_t EstimateRelativePose(const RANSACOptions& ransac_options,
                             const std::vector<Eigen::Vector2d>& points1,
                             const std::vector<Eigen::Vector2d>& points2,
                             Rigid3d* cam2_from_cam1) {
+  THROW_CHECK_EQ(points1.size(), points2.size());
+
+  std::vector<Eigen::Vector3d> rays1(points1.size());
+  std::vector<Eigen::Vector3d> rays2(points2.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    rays1[i] = points1[i].homogeneous();
+    rays2[i] = points1[i].homogeneous();
+  }
+
   RANSAC<EssentialMatrixFivePointEstimator> ransac(ransac_options);
-  const auto report = ransac.Estimate(points1, points2);
+  const auto report = ransac.Estimate(rays1, rays2);
 
   if (!report.success) {
     return 0;

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -429,15 +429,15 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
   // Extract corresponding points.
   std::vector<Eigen::Vector2d> matched_points1(matches.size());
   std::vector<Eigen::Vector2d> matched_points2(matches.size());
-  std::vector<Eigen::Vector2d> matched_points1_normalized(matches.size());
-  std::vector<Eigen::Vector2d> matched_points2_normalized(matches.size());
+  std::vector<Eigen::Vector3d> matched_rays1(matches.size());
+  std::vector<Eigen::Vector3d> matched_rays2(matches.size());
   for (size_t i = 0; i < matches.size(); ++i) {
     const point2D_t idx1 = matches[i].point2D_idx1;
     const point2D_t idx2 = matches[i].point2D_idx2;
     matched_points1[i] = points1[idx1];
     matched_points2[i] = points2[idx2];
-    matched_points1_normalized[i] = camera1.CamFromImg(points1[idx1]);
-    matched_points2_normalized[i] = camera2.CamFromImg(points2[idx2]);
+    matched_rays1[i] = camera1.CamFromImg(points1[idx1]).homogeneous();
+    matched_rays2[i] = camera2.CamFromImg(points2[idx2]).homogeneous();
   }
 
   // Estimate epipolar models.
@@ -450,8 +450,7 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   LORANSAC<EssentialMatrixFivePointEstimator, EssentialMatrixFivePointEstimator>
       E_ransac(E_ransac_options);
-  const auto E_report =
-      E_ransac.Estimate(matched_points1_normalized, matched_points2_normalized);
+  const auto E_report = E_ransac.Estimate(matched_rays1, matched_rays2);
   geometry.E = E_report.model;
 
   LORANSAC<FundamentalMatrixSevenPointEstimator,

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -81,7 +81,7 @@ inline double ComputeSquaredSampsonError(const Eigen::Vector3d& ray1,
                               epipolar_line1.x(),
                               epipolar_line1.y());
   const double denom_sq_norm = denom.squaredNorm();
-  if (denom_sq_norm < std::numeric_limits<double>::epsilon()) {
+  if (denom_sq_norm == 0) {
     return std::numeric_limits<double>::max();
   }
   return num * num / denom_sq_norm;

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -69,6 +69,26 @@ void CenterAndNormalizeImagePoints(const std::vector<Eigen::Vector2d>& points,
   }
 }
 
+namespace {
+
+inline double ComputeSquaredSampsonError(const Eigen::Vector3d& ray1,
+                                         const Eigen::Vector3d& ray2,
+                                         const Eigen::Matrix3d& E) {
+  const Eigen::Vector3d epipolar_line1 = E * ray1;
+  const double num = ray2.dot(epipolar_line1);
+  const Eigen::Vector4d denom(ray2.dot(E.col(0)),
+                              ray2.dot(E.col(1)),
+                              epipolar_line1.x(),
+                              epipolar_line1.y());
+  const double denom_sq_norm = denom.squaredNorm();
+  if (denom_sq_norm < std::numeric_limits<double>::epsilon()) {
+    return std::numeric_limits<double>::max();
+  }
+  return num * num / denom_sq_norm;
+}
+
+}  // namespace
+
 void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
                                 const std::vector<Eigen::Vector2d>& points2,
                                 const Eigen::Matrix3d& E,
@@ -77,14 +97,20 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
   THROW_CHECK_EQ(num_points1, points2.size());
   residuals->resize(num_points1);
   for (size_t i = 0; i < num_points1; ++i) {
-    const Eigen::Vector3d epipolar_line1 = E * points1[i].homogeneous();
-    const Eigen::Vector3d point2_homogeneous = points2[i].homogeneous();
-    const double num = point2_homogeneous.dot(epipolar_line1);
-    const Eigen::Vector4d denom(point2_homogeneous.dot(E.col(0)),
-                                point2_homogeneous.dot(E.col(1)),
-                                epipolar_line1.x(),
-                                epipolar_line1.y());
-    (*residuals)[i] = num * num / denom.squaredNorm();
+    (*residuals)[i] = ComputeSquaredSampsonError(
+        points1[i].homogeneous(), points2[i].homogeneous(), E);
+  }
+}
+
+void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& ray1,
+                                const std::vector<Eigen::Vector3d>& ray2,
+                                const Eigen::Matrix3d& E,
+                                std::vector<double>* residuals) {
+  const size_t num_ray1 = ray1.size();
+  THROW_CHECK_EQ(num_ray1, ray2.size());
+  residuals->resize(num_ray1);
+  for (size_t i = 0; i < num_ray1; ++i) {
+    (*residuals)[i] = ComputeSquaredSampsonError(ray1[i], ray2[i], E);
   }
 }
 

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -62,12 +62,16 @@ void CenterAndNormalizeImagePoints(const std::vector<Eigen::Vector2d>& points,
 //
 // Residuals are defined as the squared Sampson error.
 //
-// @param points1     First set of corresponding points as Nx2 matrix.
-// @param points2     Second set of corresponding points as Nx2 matrix.
+// @param points1     Corresponding points/rays.
+// @param points2     Corresponding points/rays.
 // @param E           3x3 fundamental or essential matrix.
 // @param residuals   Output vector of residuals.
 void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
                                 const std::vector<Eigen::Vector2d>& points2,
+                                const Eigen::Matrix3d& E,
+                                std::vector<double>* residuals);
+void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& rays1,
+                                const std::vector<Eigen::Vector3d>& rays2,
                                 const Eigen::Matrix3d& E,
                                 std::vector<double>* residuals);
 


### PR DESCRIPTION
This is the first in a series of PRs to support cameras with >180deg FOV (including spherical cameras). This PR should result in no behavioral change other than changes up to numerical precision.