### PR TITLE
[Spherical Camera Support]  Change absolute pose estimation to use camera rays

### DIFF
--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -41,7 +41,7 @@ namespace colmap {
 namespace {
 
 TEST(AbsolutePose, P3P) {
-  const std::vector<Eigen::Vector3d> points3D = {
+  const std::vector<Eigen::Vector3d> points = {
       Eigen::Vector3d(1, 1, 1),
       Eigen::Vector3d(0, 1, 1),
       Eigen::Vector3d(3, 1.0, 4),
@@ -52,9 +52,9 @@ TEST(AbsolutePose, P3P) {
       Eigen::Vector3d(2, 1, 7),
   };
 
-  auto points3D_faulty = points3D;
-  for (size_t i = 0; i < points3D.size(); ++i) {
-    points3D_faulty[i](0) = 20;
+  auto points_faulty = points;
+  for (size_t i = 0; i < points.size(); ++i) {
+    points_faulty[i](0) = 20;
   }
 
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
@@ -66,16 +66,15 @@ TEST(AbsolutePose, P3P) {
           Eigen::Vector3d(tx, 0, 0));
 
       // Project points to camera coordinate system.
-      std::vector<Eigen::Vector2d> points2D;
-      for (size_t i = 0; i < points3D.size(); ++i) {
-        points2D.push_back(
-            (expected_cam_from_world * points3D[i]).hnormalized());
+      std::vector<Eigen::Vector3d> rays;
+      for (size_t i = 0; i < points.size(); ++i) {
+        rays.push_back((expected_cam_from_world * points[i]).normalized());
       }
 
       RANSACOptions options;
       options.max_error = 1e-5;
       RANSAC<P3PEstimator> ransac(options);
-      const auto report = ransac.Estimate(points2D, points3D);
+      const auto report = ransac.Estimate(rays, points);
 
       EXPECT_TRUE(report.success);
       EXPECT_LT((expected_cam_from_world.ToMatrix() - report.model).norm(),
@@ -83,14 +82,13 @@ TEST(AbsolutePose, P3P) {
 
       // Test residuals of exact points.
       std::vector<double> residuals;
-      P3PEstimator::Residuals(points2D, points3D, report.model, &residuals);
+      P3PEstimator::Residuals(rays, points, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_LT(residuals[i], 1e-3);
       }
 
       // Test residuals of faulty points.
-      P3PEstimator::Residuals(
-          points2D, points3D_faulty, report.model, &residuals);
+      P3PEstimator::Residuals(rays, points_faulty, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_GT(residuals[i], 0.1);
       }
@@ -163,7 +161,7 @@ TEST(AbsolutePose, P4PF) {
 }
 
 TEST(AbsolutePose, EPNP) {
-  const std::vector<Eigen::Vector3d> points3D = {
+  const std::vector<Eigen::Vector3d> points = {
       Eigen::Vector3d(1, 1, 1),
       Eigen::Vector3d(0, 1, 1),
       Eigen::Vector3d(3, 1.0, 4),
@@ -174,9 +172,9 @@ TEST(AbsolutePose, EPNP) {
       Eigen::Vector3d(2, 1, 7),
   };
 
-  auto points3D_faulty = points3D;
-  for (size_t i = 0; i < points3D.size(); ++i) {
-    points3D_faulty[i](0) = 20;
+  auto points_faulty = points;
+  for (size_t i = 0; i < points.size(); ++i) {
+    points_faulty[i](0) = 20;
   }
 
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
@@ -188,16 +186,15 @@ TEST(AbsolutePose, EPNP) {
           Eigen::Vector3d(tx, 0, 0));
 
       // Project points to camera coordinate system.
-      std::vector<Eigen::Vector2d> points2D;
-      for (size_t i = 0; i < points3D.size(); ++i) {
-        points2D.push_back(
-            (expected_cam_from_world * points3D[i]).hnormalized());
+      std::vector<Eigen::Vector3d> rays;
+      for (size_t i = 0; i < points.size(); ++i) {
+        rays.push_back((expected_cam_from_world * points[i]).normalized());
       }
 
       RANSACOptions options;
       options.max_error = 1e-5;
       RANSAC<EPNPEstimator> ransac(options);
-      const auto report = ransac.Estimate(points2D, points3D);
+      const auto report = ransac.Estimate(rays, points);
 
       EXPECT_TRUE(report.success);
       EXPECT_LT((expected_cam_from_world.ToMatrix() - report.model).norm(),
@@ -205,14 +202,13 @@ TEST(AbsolutePose, EPNP) {
 
       // Test residuals of exact points.
       std::vector<double> residuals;
-      EPNPEstimator::Residuals(points2D, points3D, report.model, &residuals);
+      EPNPEstimator::Residuals(rays, points, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_LT(residuals[i], 1e-3);
       }
 
       // Test residuals of faulty points.
-      EPNPEstimator::Residuals(
-          points2D, points3D_faulty, report.model, &residuals);
+      EPNPEstimator::Residuals(rays, points_faulty, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_GT(residuals[i], 0.1);
       }
@@ -221,59 +217,82 @@ TEST(AbsolutePose, EPNP) {
 }
 
 TEST(AbsolutePose, EPNP_BrokenSolveSignCase) {
-  std::vector<Eigen::Vector2d> points2D;
-  points2D.emplace_back(-2.6783007931074532e-01, 5.3457197430746251e-01);
-  points2D.emplace_back(-4.2629907287470264e-01, 7.5623350319519789e-01);
-  points2D.emplace_back(-1.6767413005963930e-01, -1.3387172544910089e-01);
-  points2D.emplace_back(-5.6616329720373559e-02, 2.3621156497739373e-01);
-  points2D.emplace_back(-1.7721225948969935e-01, 2.3395366792735982e-02);
-  points2D.emplace_back(-5.1836259886632222e-02, -4.4380694271927049e-02);
-  points2D.emplace_back(-3.5897765845560037e-01, 1.6252721078589397e-01);
-  points2D.emplace_back(2.7057324473684058e-01, -1.4067450104631887e-01);
-  points2D.emplace_back(-2.5811166424334520e-01, 8.0167171300227366e-02);
-  points2D.emplace_back(2.0239567448222310e-02, -3.2845953375344145e-01);
-  points2D.emplace_back(4.2571014715170657e-01, -2.8321173570154773e-01);
-  points2D.emplace_back(-5.4597596412987237e-01, 9.1431935871671977e-02);
+  std::vector<Eigen::Vector3d> rays;
+  rays.push_back(
+      Eigen::Vector3d(-2.6783007931074532e-01, 5.3457197430746251e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-4.2629907287470264e-01, 7.5623350319519789e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-1.6767413005963930e-01, -1.3387172544910089e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-5.6616329720373559e-02, 2.3621156497739373e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-1.7721225948969935e-01, 2.3395366792735982e-02, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-5.1836259886632222e-02, -4.4380694271927049e-02, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-3.5897765845560037e-01, 1.6252721078589397e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(2.7057324473684058e-01, -1.4067450104631887e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-2.5811166424334520e-01, 8.0167171300227366e-02, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(2.0239567448222310e-02, -3.2845953375344145e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(4.2571014715170657e-01, -2.8321173570154773e-01, 1)
+          .normalized());
+  rays.push_back(
+      Eigen::Vector3d(-5.4597596412987237e-01, 9.1431935871671977e-02, 1)
+          .normalized());
 
-  std::vector<Eigen::Vector3d> points3D;
-  points3D.emplace_back(
+  std::vector<Eigen::Vector3d> points;
+  points.emplace_back(
       4.4276865308679305e+00, -1.3384364366019632e+00, -3.5997423085253892e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       2.7278555252512309e+00, -3.8152996187231392e-01, -2.6558518399902824e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       4.8548566083054894e+00, -1.4756197433631739e+00, -6.8274946022490501e-01);
-  points3D.emplace_back(
+  points.emplace_back(
       3.1523013527998449e+00, -1.3377020437938025e+00, -1.6443269301929087e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       3.8551679771512073e+00, -1.0557700545885551e+00, -1.1695994508851486e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       5.9571373150353812e+00, -2.6120646101684555e+00, -1.0841441206050342e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       6.3287088499358894e+00, -1.1761274755817175e+00, -2.5951879774151583e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       2.3005305990121250e+00, -1.4019796626800123e+00, -4.4485464455072321e-01);
-  points3D.emplace_back(
+  points.emplace_back(
       5.9816859934587354e+00, -1.4211814511691452e+00, -2.0285923889293449e+00);
-  points3D.emplace_back(
+  points.emplace_back(
       5.2543344690665457e+00, -2.3389255564264144e+00, 4.3708173185524052e-01);
-  points3D.emplace_back(
+  points.emplace_back(
       3.2181599245991688e+00, -2.8906671988445098e+00, 2.6825718150064348e-01);
-  points3D.emplace_back(
+  points.emplace_back(
       4.4592895306946758e+00, -9.1235241641579902e-03, -1.6555237117970871e+00);
 
   std::vector<EPNPEstimator::M_t> models;
-  EPNPEstimator::Estimate(points2D, points3D, &models);
+  EPNPEstimator::Estimate(rays, points, &models);
 
   ASSERT_EQ(models.size(), 1);
 
   double reproj = 0.0;
-  for (size_t i = 0; i < points3D.size(); ++i) {
+  for (size_t i = 0; i < points.size(); ++i) {
     reproj +=
-        ((models[0] * points3D[i].homogeneous()).hnormalized() - points2D[i])
-            .norm();
+        ((models[0] * points[i].homogeneous()).normalized() - rays[i]).norm();
   }
 
-  EXPECT_TRUE(reproj < 0.2);
+  EXPECT_LT(reproj, 0.2);
 }
 
 }  // namespace

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -84,7 +84,7 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
   } else {
     // Convert normalized error to angular error.
     custom_ransac_options.max_error =
-      std::atan(custom_ransac_options.max_error);
+        std::atan(custom_ransac_options.max_error);
     std::vector<Eigen::Vector3d> rays(points2D.size());
     for (size_t i = 0; i < points2D.size(); ++i) {
       rays[i] = camera->CamFromImg(points2D[i]).homogeneous().normalized();

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -88,11 +88,10 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
   }
 }
 
-void ComputeSquaredReprojError(
-    const std::vector<Eigen::Vector2d>& points2D,
-    const std::vector<Eigen::Vector3d>& points3D,
-    const Eigen::Matrix3x4d& cam_from_world,
-    std::vector<double>* residuals) {
+void ComputeSquaredReprojError(const std::vector<Eigen::Vector2d>& points2D,
+                               const std::vector<Eigen::Vector3d>& points3D,
+                               const Eigen::Matrix3x4d& cam_from_world,
+                               std::vector<double>* residuals) {
   const size_t num_points2D = points2D.size();
   THROW_CHECK_EQ(num_points2D, points3D.size());
   residuals->resize(num_points2D);

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -79,11 +79,10 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
 // @param points3D        3D world points.
 // @param cam_from_world  3x4 projection matrix.
 // @param residuals       Output vector of residuals.
-void ComputeSquaredReprojError(
-    const std::vector<Eigen::Vector2d>& points2D,
-    const std::vector<Eigen::Vector3d>& points3D,
-    const Eigen::Matrix3x4d& cam_from_world,
-    std::vector<double>* residuals);
+void ComputeSquaredReprojError(const std::vector<Eigen::Vector2d>& points2D,
+                               const std::vector<Eigen::Vector3d>& points3D,
+                               const Eigen::Matrix3x4d& cam_from_world,
+                               std::vector<double>* residuals);
 
 // Calculate the squared angular error given a set of ray-point
 // correspondences and a projection matrix.

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -79,9 +79,22 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector2d>& points1,
 // @param points3D        3D world points.
 // @param cam_from_world  3x4 projection matrix.
 // @param residuals       Output vector of residuals.
-void ComputeSquaredReprojectionError(
+void ComputeSquaredReprojError(
     const std::vector<Eigen::Vector2d>& points2D,
     const std::vector<Eigen::Vector3d>& points3D,
+    const Eigen::Matrix3x4d& cam_from_world,
+    std::vector<double>* residuals);
+
+// Calculate the squared angular error given a set of ray-point
+// correspondences and a projection matrix.
+//
+// @param rays            Corresponding rays in camera frame.
+// @param points          Corresponding 3D points in world frame.
+// @param cam_from_world  3x4 projection matrix.
+// @param residuals       Output vector of residuals.
+void ComputeSquaredAngularReprojError(
+    const std::vector<Eigen::Vector3d>& rays,
+    const std::vector<Eigen::Vector3d>& points,
     const Eigen::Matrix3x4d& cam_from_world,
     std::vector<double>* residuals);
 

--- a/src/colmap/estimators/utils_test.cc
+++ b/src/colmap/estimators/utils_test.cc
@@ -123,8 +123,8 @@ TEST(ComputeSquaredAngularReprojError, Nominal) {
 
   EXPECT_EQ(residuals.size(), 3);
   EXPECT_EQ(residuals[0], 0);
-  EXPECT_EQ(residuals[1], EIGEN_PI / 2 * EIGEN_PI / 2);
-  EXPECT_EQ(residuals[2], EIGEN_PI * EIGEN_PI);
+  EXPECT_NEAR(residuals[1], EIGEN_PI / 2 * EIGEN_PI / 2, 1e-6);
+  EXPECT_NEAR(residuals[2], EIGEN_PI * EIGEN_PI, 1e-6);
 }
 
 }  // namespace

--- a/src/colmap/estimators/utils_test.cc
+++ b/src/colmap/estimators/utils_test.cc
@@ -123,8 +123,8 @@ TEST(ComputeSquaredAngularReprojError, Nominal) {
 
   EXPECT_EQ(residuals.size(), 3);
   EXPECT_EQ(residuals[0], 0);
-  EXPECT_EQ(residuals[1], M_PI / 2 * M_PI / 2);
-  EXPECT_EQ(residuals[2], M_PI * M_PI);
+  EXPECT_EQ(residuals[1], EIGEN_PI / 2 * EIGEN_PI / 2);
+  EXPECT_EQ(residuals[2], EIGEN_PI * EIGEN_PI);
 }
 
 }  // namespace

--- a/src/colmap/estimators/utils_test.cc
+++ b/src/colmap/estimators/utils_test.cc
@@ -81,7 +81,7 @@ TEST(ComputeSquaredSampsonError, Nominal) {
   EXPECT_EQ(residuals[2], 2);
 }
 
-TEST(ComputeSquaredReprojectionError, Nominal) {
+TEST(ComputeSquaredReprojError, Nominal) {
   std::vector<Eigen::Vector2d> points2D;
   points2D.emplace_back(0, 0);
   points2D.emplace_back(0, 0);
@@ -95,13 +95,36 @@ TEST(ComputeSquaredReprojectionError, Nominal) {
                                Eigen::Vector3d(1, 0, 0));
 
   std::vector<double> residuals;
-  ComputeSquaredReprojectionError(
+  ComputeSquaredReprojError(
       points2D, points3D, cam_from_world.ToMatrix(), &residuals);
 
   EXPECT_EQ(residuals.size(), 3);
   EXPECT_EQ(residuals[0], 9);
   EXPECT_EQ(residuals[1], 10);
   EXPECT_EQ(residuals[2], 13);
+}
+
+TEST(ComputeSquaredAngularReprojError, Nominal) {
+  std::vector<Eigen::Vector3d> rays;
+  rays.emplace_back(0, 0, 1);
+  rays.emplace_back(0, 0, 1);
+  rays.emplace_back(0, 0, 1);
+  std::vector<Eigen::Vector3d> points;
+  points.emplace_back(-1, 0, 1);
+  points.emplace_back(-1, 1, 0);
+  points.emplace_back(-1, 0, -1);
+
+  const Rigid3d cam_from_world(Eigen::Quaterniond::Identity(),
+                               Eigen::Vector3d(1, 0, 0));
+
+  std::vector<double> residuals;
+  ComputeSquaredAngularReprojError(
+      rays, points, cam_from_world.ToMatrix(), &residuals);
+
+  EXPECT_EQ(residuals.size(), 3);
+  EXPECT_EQ(residuals[0], 0);
+  EXPECT_EQ(residuals[1], M_PI / 2 * M_PI / 2);
+  EXPECT_EQ(residuals[2], M_PI * M_PI);
 }
 
 }  // namespace


### PR DESCRIPTION
This results in some behavioral change due to using angular errors in PNP RANSAC. To minimize behavioral change, I decided to convert the existing error thresholds in pixels to an angular error (at the center of the image). Benchmarking results on ETH3D show no significant change in performance (A: main, B: this PR) for scenes with stable initialization. The large difference in meadow is caused by random failure to initialize the scene and unrelated to this change.
```
I20250216 09:31:59.453352 990463 compare.py:main:58] Results A - B:
=====scenes===== ======AUC @ X deg (%)====== ===images=== =components=
                  0.5    1.0    5.0    10.0     reg   all  num largest

==============================eth3d=dslr==============================
botanical_garden   0.01   0.00   0.00   0.00      0     0    0       0
boulders           0.02   0.01   0.00   0.00      0     0    0       0
bridge             0.01   0.00   0.00   0.00      0     0    0       0
courtyard          0.02   0.00   0.00   0.00      0     0    0       0
delivery_area      0.01   0.00   0.00   0.00      0     0    0       0
door              -0.02   0.01   0.00   0.00      0     0    0       0
electro            0.15   0.11   0.03   0.01      0     0    0       0
exhibition_hall    1.40   1.05   0.20   0.12      0     0    0       0
facade            -0.01  -0.00  -0.00  -0.00      0     0    0       0
kicker            -0.11  -0.06  -0.01  -0.01      0     0    0       0
lecture_room       0.08   0.05   0.01   0.01      0     0    0       0
living_room        0.20   0.13   0.03   0.02      0     0    0       0
lounge            -0.05  -0.02  -0.00  -0.00      0     0    0       0
meadow           -63.10 -70.82 -85.83 -88.37     -9     0   -1      -9
observatory        0.01   0.01   0.00   0.00      0     0    0       0
office            -0.15  -0.07  -0.08  -0.04      0     0    0       0
old_computer      -0.60  -0.27  -0.06  -0.03      0     0    0       0
pipes              1.25   0.81   0.16   0.08      0     0    0       0
playground        -0.05  -0.02  -0.01  -0.00      0     0    0       0
relief             0.03   0.02   0.00   0.00      0     0    0       0
relief_2          -0.13  -0.05  -0.01  -0.01      0     0    0       0
statue            -0.00  -0.00  -0.00  -0.00      0     0    0       0
terrace           -0.04  -0.02  -0.00  -0.00      0     0    0       0
terrace_2          0.15   0.07   0.01   0.01      0     0    0       0
terrains           0.12   0.07   0.02   0.01      0     0    0       0
----------------------------------------------------------------------
overall           -0.16  -0.22  -0.38  -0.40     -9     0   -1      -9
----------------------------------------------------------------------
average           -2.43  -2.76  -3.42  -3.53      0     0    0       0
```