### PR TITLE
Compute absolute pose estimation error in image space

### DIFF
--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -77,6 +77,35 @@ TEST(IncrementalPipeline, WithoutNoise) {
   synthetic_dataset_options.num_images = 7;
   synthetic_dataset_options.num_points3D = 50;
   synthetic_dataset_options.point2D_stddev = 0;
+  synthetic_dataset_options.camera_has_prior_focal_length = false;
+  SynthesizeDataset(synthetic_dataset_options, &gt_reconstruction, &database);
+
+  auto reconstruction_manager = std::make_shared<ReconstructionManager>();
+  IncrementalPipeline mapper(std::make_shared<IncrementalPipelineOptions>(),
+                             /*image_path=*/"",
+                             database_path,
+                             reconstruction_manager);
+  mapper.Run();
+
+  ASSERT_EQ(reconstruction_manager->Size(), 1);
+  ExpectEqualReconstructions(gt_reconstruction,
+                             *reconstruction_manager->Get(0),
+                             /*max_rotation_error_deg=*/1e-2,
+                             /*max_proj_center_error=*/1e-4,
+                             /*num_obs_tolerance=*/0);
+}
+
+TEST(IncrementalPipeline, WithPriorFocalLength) {
+  const std::string database_path = CreateTestDir() + "/database.db";
+
+  Database database(database_path);
+  Reconstruction gt_reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_cameras = 2;
+  synthetic_dataset_options.num_images = 7;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.point2D_stddev = 0;
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
   SynthesizeDataset(synthetic_dataset_options, &gt_reconstruction, &database);
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();

--- a/src/colmap/estimators/absolute_pose.cc
+++ b/src/colmap/estimators/absolute_pose.cc
@@ -39,17 +39,47 @@
 #include <PoseLib/solvers/p4pf.h>
 
 namespace colmap {
+namespace {
+
+void ComputeSquaredReprojectionError(
+    const std::vector<Point2DWithRay>& points2D,
+    const std::vector<Eigen::Vector3d>& points3D,
+    const Eigen::Matrix3x4d& cam_from_world,
+    const std::function<std::optional<Eigen::Vector2d>(const Eigen::Vector3d&)>&
+        img_from_cam_func,
+    std::vector<double>* residuals) {
+  const size_t num_points = points2D.size();
+  THROW_CHECK_EQ(num_points, points3D.size());
+  residuals->resize(num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    const Eigen::Vector3d point3D_in_cam =
+        cam_from_world * points3D[i].homogeneous();
+    const std::optional<Eigen::Vector2d> proj_image_point =
+        img_from_cam_func(point3D_in_cam);
+    if (proj_image_point) {
+      (*residuals)[i] =
+          (*proj_image_point - points2D[i].image_point).squaredNorm();
+    } else {
+      (*residuals)[i] = std::numeric_limits<double>::max();
+    }
+  }
+}
+
+}  // namespace
+
+P3PEstimator::P3PEstimator(ImgFromCamFunc img_from_cam_func)
+    : img_from_cam_func_(std::move(img_from_cam_func)) {}
 
 void P3PEstimator::Estimate(const std::vector<X_t>& points2D,
                             const std::vector<Y_t>& points3D,
-                            std::vector<M_t>* cams_from_world) {
+                            std::vector<M_t>* cams_from_world) const {
   THROW_CHECK_EQ(points2D.size(), 3);
   THROW_CHECK_EQ(points3D.size(), 3);
   THROW_CHECK_NOTNULL(cams_from_world);
 
   std::vector<Eigen::Vector3d> rays(3);
   for (int i = 0; i < 3; ++i) {
-    rays[i] = points2D[i].homogeneous().normalized();
+    rays[i] = points2D[i].camera_ray;
   }
 
   std::vector<poselib::CameraPose> poses;
@@ -64,9 +94,9 @@ void P3PEstimator::Estimate(const std::vector<X_t>& points2D,
 void P3PEstimator::Residuals(const std::vector<X_t>& points2D,
                              const std::vector<Y_t>& points3D,
                              const M_t& cam_from_world,
-                             std::vector<double>* residuals) {
+                             std::vector<double>* residuals) const {
   ComputeSquaredReprojectionError(
-      points2D, points3D, cam_from_world, residuals);
+      points2D, points3D, cam_from_world, img_from_cam_func_, residuals);
 }
 
 void P4PFEstimator::Estimate(const std::vector<X_t>& points2D,
@@ -109,6 +139,9 @@ void P4PFEstimator::Residuals(const std::vector<X_t>& points2D,
   }
 }
 
+EPNPEstimator::EPNPEstimator(ImgFromCamFunc img_from_cam_func)
+    : img_from_cam_func_(std::move(img_from_cam_func)) {}
+
 void EPNPEstimator::Estimate(const std::vector<X_t>& points2D,
                              const std::vector<Y_t>& points3D,
                              std::vector<M_t>* cams_from_world) {
@@ -118,9 +151,8 @@ void EPNPEstimator::Estimate(const std::vector<X_t>& points2D,
 
   cams_from_world->clear();
 
-  EPNPEstimator epnp;
   M_t cam_from_world;
-  if (!epnp.ComputePose(points2D, points3D, &cam_from_world)) {
+  if (!ComputePose(points2D, points3D, &cam_from_world)) {
     return;
   }
 
@@ -131,13 +163,13 @@ void EPNPEstimator::Estimate(const std::vector<X_t>& points2D,
 void EPNPEstimator::Residuals(const std::vector<X_t>& points2D,
                               const std::vector<Y_t>& points3D,
                               const M_t& cam_from_world,
-                              std::vector<double>* residuals) {
+                              std::vector<double>* residuals) const {
   ComputeSquaredReprojectionError(
-      points2D, points3D, cam_from_world, residuals);
+      points2D, points3D, cam_from_world, img_from_cam_func_, residuals);
 }
 
-bool EPNPEstimator::ComputePose(const std::vector<Eigen::Vector2d>& points2D,
-                                const std::vector<Eigen::Vector3d>& points3D,
+bool EPNPEstimator::ComputePose(const std::vector<X_t>& points2D,
+                                const std::vector<Y_t>& points3D,
                                 Eigen::Matrix3x4d* cam_from_world) {
   points2D_ = &points2D;
   points3D_ = &points3D;
@@ -242,16 +274,21 @@ bool EPNPEstimator::ComputeBarycentricCoordinates() {
 }
 
 Eigen::Matrix<double, Eigen::Dynamic, 12> EPNPEstimator::ComputeM() {
-  Eigen::Matrix<double, Eigen::Dynamic, 12> M(2 * points2D_->size(), 12);
+  Eigen::Matrix<double, Eigen::Dynamic, 12> M(3 * points2D_->size(), 12);
   for (size_t i = 0; i < points3D_->size(); ++i) {
+    const Eigen::Vector3d& ray = (*points2D_)[i].camera_ray;
     for (size_t j = 0; j < 4; ++j) {
-      M(2 * i, 3 * j) = alphas_[i][j];
-      M(2 * i, 3 * j + 1) = 0.0;
-      M(2 * i, 3 * j + 2) = -alphas_[i][j] * (*points2D_)[i].x();
+      M(3 * i, 3 * j) = 0.0;
+      M(3 * i, 3 * j + 1) = -alphas_[i][j] * ray.z();
+      M(3 * i, 3 * j + 2) = alphas_[i][j] * ray.y();
 
-      M(2 * i + 1, 3 * j) = 0.0;
-      M(2 * i + 1, 3 * j + 1) = alphas_[i][j];
-      M(2 * i + 1, 3 * j + 2) = -alphas_[i][j] * (*points2D_)[i].y();
+      M(3 * i + 1, 3 * j) = alphas_[i][j] * ray.z();
+      M(3 * i + 1, 3 * j + 1) = 0.0;
+      M(3 * i + 1, 3 * j + 2) = -alphas_[i][j] * ray.x();
+
+      M(3 * i + 2, 3 * j) = -alphas_[i][j] * ray.y();
+      M(3 * i + 2, 3 * j + 1) = alphas_[i][j] * ray.x();
+      M(3 * i + 2, 3 * j + 2) = 0;
     }
   }
   return M;
@@ -440,7 +477,7 @@ double EPNPEstimator::ComputeRT(const Eigen::Matrix<double, 12, 12>& Ut,
 
   EstimateRT(R, t);
 
-  return ComputeTotalReprojectionError(*R, *t);
+  return ComputeTotalError(*R, *t);
 }
 
 void EPNPEstimator::ComputeCcs(const Eigen::Vector4d& betas,
@@ -523,22 +560,22 @@ void EPNPEstimator::EstimateRT(Eigen::Matrix3d* R, Eigen::Vector3d* t) {
   *t = pc0 - *R * pw0;
 }
 
-double EPNPEstimator::ComputeTotalReprojectionError(const Eigen::Matrix3d& R,
-                                                    const Eigen::Vector3d& t) {
+double EPNPEstimator::ComputeTotalError(const Eigen::Matrix3d& R,
+                                        const Eigen::Vector3d& t) {
   Eigen::Matrix3x4d cam_from_world;
   cam_from_world.leftCols<3>() = R;
   cam_from_world.rightCols<1>() = t;
 
   std::vector<double> residuals;
   ComputeSquaredReprojectionError(
-      *points2D_, *points3D_, cam_from_world, &residuals);
+      *points2D_, *points3D_, cam_from_world, img_from_cam_func_, &residuals);
 
-  double reproj_error = 0.0;
+  double error = 0.0;
   for (const double residual : residuals) {
-    reproj_error += std::sqrt(residual);
+    error += std::sqrt(residual);
   }
 
-  return reproj_error;
+  return error;
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -33,6 +33,7 @@
 #include "colmap/util/types.h"
 
 #include <array>
+#include <optional>
 #include <vector>
 
 #include <Eigen/Core>

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -41,6 +41,7 @@
 namespace colmap {
 
 // Function mapping 3D point in the camera frame to 2D point in the image.
+// Returns null if the point projection is invalid (e.g., behind the camera).
 using ImgFromCamFunc =
     std::function<std::optional<Eigen::Vector2d>(const Eigen::Vector3d&)>;
 
@@ -217,5 +218,13 @@ class EPNPEstimator {
   std::array<Eigen::Vector3d, 4> cws_;
   std::array<Eigen::Vector3d, 4> ccs_;
 };
+
+// Compute squared reprojection error in pixels.
+void ComputeSquaredReprojectionError(
+    const std::vector<Point2DWithRay>& points2D,
+    const std::vector<Eigen::Vector3d>& points3D,
+    const Eigen::Matrix3x4d& cam_from_world,
+    const ImgFromCamFunc& img_from_cam_func,
+    std::vector<double>* residuals);
 
 }  // namespace colmap

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -39,12 +39,21 @@
 
 namespace colmap {
 
+// Function mapping 3D point in the camera frame to 2D point in the image.
+using ImgFromCamFunc =
+    std::function<std::optional<Eigen::Vector2d>(const Eigen::Vector3d&)>;
+
+struct Point2DWithRay {
+  // The 2D image point in pixels.
+  Eigen::Vector2d image_point;
+  // The normaled 3D ray direction in the camera frame.
+  Eigen::Vector3d camera_ray;
+};
+
 class P3PEstimator {
  public:
   // The 2D image feature observations.
-  // TODO(jsch): Possibly change to 3D ray directions and express residuals as
-  // angular errors. Needs some evaluation.
-  typedef Eigen::Vector2d X_t;
+  typedef Point2DWithRay X_t;
   // The observed 3D features in the world frame.
   typedef Eigen::Vector3d Y_t;
   // The transformation from the world to the camera frame.
@@ -53,6 +62,8 @@ class P3PEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 3;
 
+  P3PEstimator(ImgFromCamFunc img_from_cam_func);
+
   // Estimate the most probable solution of the P3P problem from a set of
   // three 2D-3D point correspondences.
   //
@@ -60,9 +71,9 @@ class P3PEstimator {
   // @param points3D   3D world points as 3x3 matrix.
   //
   // @return           Most probable pose as length-1 vector of a 3x4 matrix.
-  static void Estimate(const std::vector<X_t>& points2D,
-                       const std::vector<Y_t>& points3D,
-                       std::vector<M_t>* cams_from_world);
+  void Estimate(const std::vector<X_t>& points2D,
+                const std::vector<Y_t>& points3D,
+                std::vector<M_t>* cams_from_world) const;
 
   // Calculate the squared reprojection error given a set of 2D-3D point
   // correspondences and a projection matrix.
@@ -71,10 +82,13 @@ class P3PEstimator {
   // @param points3D        3D world points as Nx3 matrix.
   // @param cam_from_world  3x4 projection matrix.
   // @param residuals       Output vector of residuals.
-  static void Residuals(const std::vector<X_t>& points2D,
-                        const std::vector<Y_t>& points3D,
-                        const M_t& cam_from_world,
-                        std::vector<double>* residuals);
+  void Residuals(const std::vector<X_t>& points2D,
+                 const std::vector<Y_t>& points3D,
+                 const M_t& cam_from_world,
+                 std::vector<double>* residuals) const;
+
+ private:
+  const ImgFromCamFunc img_from_cam_func_;
 };
 
 // Minimal solver for 6-DOF pose and focal length.
@@ -118,7 +132,7 @@ class P4PFEstimator {
 class EPNPEstimator {
  public:
   // The 2D image feature observations.
-  typedef Eigen::Vector2d X_t;
+  typedef Point2DWithRay X_t;
   // The observed 3D features in the world frame.
   typedef Eigen::Vector3d Y_t;
   // The transformation from the world to the camera frame.
@@ -127,6 +141,8 @@ class EPNPEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 4;
 
+  EPNPEstimator(ImgFromCamFunc img_from_cam_func);
+
   // Estimate the most probable solution of the P3P problem from a set of
   // three 2D-3D point correspondences.
   //
@@ -134,9 +150,9 @@ class EPNPEstimator {
   // @param points3D   3D world points as 3x3 matrix.
   //
   // @return           Most probable pose as length-1 vector of a 3x4 matrix.
-  static void Estimate(const std::vector<X_t>& points2D,
-                       const std::vector<Y_t>& points3D,
-                       std::vector<M_t>* cams_from_world);
+  void Estimate(const std::vector<X_t>& points2D,
+                const std::vector<Y_t>& points3D,
+                std::vector<M_t>* cams_from_world);
 
   // Calculate the squared reprojection error given a set of 2D-3D point
   // correspondences and a projection matrix.
@@ -145,14 +161,14 @@ class EPNPEstimator {
   // @param points3D        3D world points as Nx3 matrix.
   // @param cam_from_world  3x4 projection matrix.
   // @param residuals       Output vector of residuals.
-  static void Residuals(const std::vector<X_t>& points2D,
-                        const std::vector<Y_t>& points3D,
-                        const M_t& cam_from_world,
-                        std::vector<double>* residuals);
+  void Residuals(const std::vector<X_t>& points2D,
+                 const std::vector<Y_t>& points3D,
+                 const M_t& cam_from_world,
+                 std::vector<double>* residuals) const;
 
  private:
-  bool ComputePose(const std::vector<Eigen::Vector2d>& points2D,
-                   const std::vector<Eigen::Vector3d>& points3D,
+  bool ComputePose(const std::vector<X_t>& points2D,
+                   const std::vector<Y_t>& points3D,
                    Eigen::Matrix3x4d* cam_from_world);
 
   void ChooseControlPoints();
@@ -190,11 +206,11 @@ class EPNPEstimator {
 
   void EstimateRT(Eigen::Matrix3d* R, Eigen::Vector3d* t);
 
-  double ComputeTotalReprojectionError(const Eigen::Matrix3d& R,
-                                       const Eigen::Vector3d& t);
+  double ComputeTotalError(const Eigen::Matrix3d& R, const Eigen::Vector3d& t);
 
-  const std::vector<Eigen::Vector2d>* points2D_ = nullptr;
-  const std::vector<Eigen::Vector3d>* points3D_ = nullptr;
+  const ImgFromCamFunc img_from_cam_func_;
+  const std::vector<X_t>* points2D_ = nullptr;
+  const std::vector<Y_t>* points3D_ = nullptr;
   std::vector<Eigen::Vector3d> pcs_;
   std::vector<Eigen::Vector4d> alphas_;
   std::array<Eigen::Vector3d, 4> cws_;

--- a/src/colmap/estimators/absolute_pose.h
+++ b/src/colmap/estimators/absolute_pose.h
@@ -63,7 +63,7 @@ class P3PEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 3;
 
-  P3PEstimator(ImgFromCamFunc img_from_cam_func);
+  explicit P3PEstimator(ImgFromCamFunc img_from_cam_func);
 
   // Estimate the most probable solution of the P3P problem from a set of
   // three 2D-3D point correspondences.
@@ -142,7 +142,7 @@ class EPNPEstimator {
   // The minimum number of samples needed to estimate a model.
   static const int kMinNumSamples = 4;
 
-  EPNPEstimator(ImgFromCamFunc img_from_cam_func);
+  explicit EPNPEstimator(ImgFromCamFunc img_from_cam_func);
 
   // Estimate the most probable solution of the P3P problem from a set of
   // three 2D-3D point correspondences.

--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -32,6 +32,8 @@
 #include "colmap/geometry/pose.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/optim/ransac.h"
+#include "colmap/scene/camera.h"
+#include "colmap/sensor/models.h"
 #include "colmap/util/eigen_alignment.h"
 
 #include <Eigen/Core>
@@ -57,6 +59,20 @@ TEST(AbsolutePose, P3P) {
     points3D_faulty[i](0) = 20;
   }
 
+  const Camera camera = Camera::CreateFromModelId(
+      kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
+
+  // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
+  // returns an optional.
+  auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
+      -> std::optional<Eigen::Vector2d> {
+    if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
+      return std::nullopt;
+    } else {
+      return camera.ImgFromCam(point3D_in_cam.hnormalized());
+    }
+  };
+
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
   for (double qx = 0; qx < 1; qx += 0.2) {
     // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
@@ -66,30 +82,32 @@ TEST(AbsolutePose, P3P) {
           Eigen::Vector3d(tx, 0, 0));
 
       // Project points to camera coordinate system.
-      std::vector<Eigen::Vector2d> points2D;
+      std::vector<P3PEstimator::X_t> points2D;
       for (size_t i = 0; i < points3D.size(); ++i) {
-        points2D.push_back(
-            (expected_cam_from_world * points3D[i]).hnormalized());
+        auto& point2D = points2D.emplace_back();
+        point2D.camera_ray =
+            (expected_cam_from_world * points3D[i]).normalized();
+        point2D.image_point = img_from_cam_func(point2D.camera_ray).value();
       }
 
       RANSACOptions options;
-      options.max_error = 1e-5;
-      RANSAC<P3PEstimator> ransac(options);
+      options.max_error = 1e-3;
+      RANSAC<P3PEstimator> ransac(options, P3PEstimator(img_from_cam_func));
       const auto report = ransac.Estimate(points2D, points3D);
 
       EXPECT_TRUE(report.success);
       EXPECT_LT((expected_cam_from_world.ToMatrix() - report.model).norm(),
-                1e-3);
+                1e-5);
 
       // Test residuals of exact points.
       std::vector<double> residuals;
-      P3PEstimator::Residuals(points2D, points3D, report.model, &residuals);
+      ransac.estimator.Residuals(points2D, points3D, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_LT(residuals[i], 1e-3);
       }
 
       // Test residuals of faulty points.
-      P3PEstimator::Residuals(
+      ransac.estimator.Residuals(
           points2D, points3D_faulty, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_GT(residuals[i], 0.1);
@@ -179,6 +197,20 @@ TEST(AbsolutePose, EPNP) {
     points3D_faulty[i](0) = 20;
   }
 
+  const Camera camera = Camera::CreateFromModelId(
+      kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
+
+  // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
+  // returns an optional.
+  auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
+      -> std::optional<Eigen::Vector2d> {
+    if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
+      return std::nullopt;
+    } else {
+      return camera.ImgFromCam(point3D_in_cam.hnormalized());
+    }
+  };
+
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
   for (double qx = 0; qx < 1; qx += 0.2) {
     // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
@@ -188,15 +220,17 @@ TEST(AbsolutePose, EPNP) {
           Eigen::Vector3d(tx, 0, 0));
 
       // Project points to camera coordinate system.
-      std::vector<Eigen::Vector2d> points2D;
+      std::vector<EPNPEstimator::X_t> points2D;
       for (size_t i = 0; i < points3D.size(); ++i) {
-        points2D.push_back(
-            (expected_cam_from_world * points3D[i]).hnormalized());
+        auto& point2D = points2D.emplace_back();
+        point2D.camera_ray =
+            (expected_cam_from_world * points3D[i]).normalized();
+        point2D.image_point = img_from_cam_func(point2D.camera_ray).value();
       }
 
       RANSACOptions options;
       options.max_error = 1e-5;
-      RANSAC<EPNPEstimator> ransac(options);
+      RANSAC<EPNPEstimator> ransac(options, EPNPEstimator(img_from_cam_func));
       const auto report = ransac.Estimate(points2D, points3D);
 
       EXPECT_TRUE(report.success);
@@ -205,13 +239,13 @@ TEST(AbsolutePose, EPNP) {
 
       // Test residuals of exact points.
       std::vector<double> residuals;
-      EPNPEstimator::Residuals(points2D, points3D, report.model, &residuals);
+      ransac.estimator.Residuals(points2D, points3D, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_LT(residuals[i], 1e-3);
       }
 
       // Test residuals of faulty points.
-      EPNPEstimator::Residuals(
+      ransac.estimator.Residuals(
           points2D, points3D_faulty, report.model, &residuals);
       for (size_t i = 0; i < residuals.size(); ++i) {
         EXPECT_GT(residuals[i], 0.1);
@@ -221,19 +255,26 @@ TEST(AbsolutePose, EPNP) {
 }
 
 TEST(AbsolutePose, EPNP_BrokenSolveSignCase) {
-  std::vector<Eigen::Vector2d> points2D;
-  points2D.emplace_back(-2.6783007931074532e-01, 5.3457197430746251e-01);
-  points2D.emplace_back(-4.2629907287470264e-01, 7.5623350319519789e-01);
-  points2D.emplace_back(-1.6767413005963930e-01, -1.3387172544910089e-01);
-  points2D.emplace_back(-5.6616329720373559e-02, 2.3621156497739373e-01);
-  points2D.emplace_back(-1.7721225948969935e-01, 2.3395366792735982e-02);
-  points2D.emplace_back(-5.1836259886632222e-02, -4.4380694271927049e-02);
-  points2D.emplace_back(-3.5897765845560037e-01, 1.6252721078589397e-01);
-  points2D.emplace_back(2.7057324473684058e-01, -1.4067450104631887e-01);
-  points2D.emplace_back(-2.5811166424334520e-01, 8.0167171300227366e-02);
-  points2D.emplace_back(2.0239567448222310e-02, -3.2845953375344145e-01);
-  points2D.emplace_back(4.2571014715170657e-01, -2.8321173570154773e-01);
-  points2D.emplace_back(-5.4597596412987237e-01, 9.1431935871671977e-02);
+  std::vector<Eigen::Vector2d> image_points;
+  image_points.emplace_back(-2.6783007931074532e-01, 5.3457197430746251e-01);
+  image_points.emplace_back(-4.2629907287470264e-01, 7.5623350319519789e-01);
+  image_points.emplace_back(-1.6767413005963930e-01, -1.3387172544910089e-01);
+  image_points.emplace_back(-5.6616329720373559e-02, 2.3621156497739373e-01);
+  image_points.emplace_back(-1.7721225948969935e-01, 2.3395366792735982e-02);
+  image_points.emplace_back(-5.1836259886632222e-02, -4.4380694271927049e-02);
+  image_points.emplace_back(-3.5897765845560037e-01, 1.6252721078589397e-01);
+  image_points.emplace_back(2.7057324473684058e-01, -1.4067450104631887e-01);
+  image_points.emplace_back(-2.5811166424334520e-01, 8.0167171300227366e-02);
+  image_points.emplace_back(2.0239567448222310e-02, -3.2845953375344145e-01);
+  image_points.emplace_back(4.2571014715170657e-01, -2.8321173570154773e-01);
+  image_points.emplace_back(-5.4597596412987237e-01, 9.1431935871671977e-02);
+
+  std::vector<EPNPEstimator::X_t> points2D;
+  for (size_t i = 0; i < image_points.size(); ++i) {
+    auto& point2D = points2D.emplace_back();
+    point2D.image_point = image_points[i];
+    point2D.camera_ray = point2D.image_point.homogeneous().normalized();
+  }
 
   std::vector<Eigen::Vector3d> points3D;
   points3D.emplace_back(
@@ -262,15 +303,18 @@ TEST(AbsolutePose, EPNP_BrokenSolveSignCase) {
       4.4592895306946758e+00, -9.1235241641579902e-03, -1.6555237117970871e+00);
 
   std::vector<EPNPEstimator::M_t> models;
-  EPNPEstimator::Estimate(points2D, points3D, &models);
+  EPNPEstimator estimator([](const Eigen::Vector3d& point3D_in_cam) {
+    return point3D_in_cam.hnormalized();
+  });
+  estimator.Estimate(points2D, points3D, &models);
 
   ASSERT_EQ(models.size(), 1);
 
   double reproj = 0.0;
   for (size_t i = 0; i < points3D.size(); ++i) {
-    reproj +=
-        ((models[0] * points3D[i].homogeneous()).hnormalized() - points2D[i])
-            .norm();
+    reproj += ((models[0] * points3D[i].homogeneous()).hnormalized() -
+               points2D[i].image_point)
+                  .norm();
   }
 
   EXPECT_TRUE(reproj < 0.2);

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -56,36 +56,27 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
   inlier_mask->clear();
 
   if (options.estimate_focal_length) {
-    std::vector<Eigen::Vector2d> points2D_normalized(points2D.size());
-    for (size_t i = 0; i < points2D.size(); ++i) {
-      points2D_normalized[i] = camera->CamFromImg(points2D[i]);
-    }
-
-    auto custom_ransac_options = options.ransac_options;
-    custom_ransac_options.max_error =
-        camera->CamFromImgThreshold(options.ransac_options.max_error);
-
     // TODO(jsch): Implement non-minimal solver for LORANSAC refinement.
     // Experiments showed marginal difference between RANSAC/LORANSAC for PNPF
     // after refining the estimates of this function using RefineAbsolutePose.
-    RANSAC<P4PFEstimator> ransac(custom_ransac_options);
-    auto report = ransac.Estimate(points2D_normalized, points3D);
+    RANSAC<P4PFEstimator> ransac(options.ransac_options);
+    auto report = ransac.Estimate(points2D, points3D);
     if (report.success) {
       *cam_from_world =
           Rigid3d(Eigen::Quaterniond(report.model.cam_from_world.leftCols<3>()),
                   report.model.cam_from_world.col(3));
       for (const size_t idx : camera->FocalLengthIdxs()) {
-        camera->params[idx] *= report.model.focal_length;
+        camera->params[idx] = report.model.focal_length;
       }
       *num_inliers = report.support.num_inliers;
       *inlier_mask = std::move(report.inlier_mask);
       return true;
     }
   } else {
-    std::vector<P3PEstimator::X_t> estimator_points2D(points2D.size());
+    std::vector<P3PEstimator::X_t> points2D_with_rays(points2D.size());
     for (size_t i = 0; i < points2D.size(); ++i) {
-      estimator_points2D[i].image_point = points2D[i];
-      estimator_points2D[i].camera_ray =
+      points2D_with_rays[i].image_point = points2D[i];
+      points2D_with_rays[i].camera_ray =
           camera->CamFromImg(points2D[i]).homogeneous().normalized();
     }
 
@@ -104,7 +95,7 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
         options.ransac_options,
         P3PEstimator(img_from_cam_func),
         EPNPEstimator(img_from_cam_func));
-    auto report = ransac.Estimate(estimator_points2D, points3D);
+    auto report = ransac.Estimate(points2D_with_rays, points3D);
     if (report.success) {
       *cam_from_world = Rigid3d(Eigen::Quaterniond(report.model.leftCols<3>()),
                                 report.model.col(3));

--- a/src/colmap/estimators/utils.cc
+++ b/src/colmap/estimators/utils.cc
@@ -114,25 +114,4 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& ray1,
   }
 }
 
-void ComputeSquaredReprojectionError(
-    const std::vector<Eigen::Vector2d>& points2D,
-    const std::vector<Eigen::Vector3d>& points3D,
-    const Eigen::Matrix3x4d& cam_from_world,
-    std::vector<double>* residuals) {
-  const size_t num_points2D = points2D.size();
-  THROW_CHECK_EQ(num_points2D, points3D.size());
-  residuals->resize(num_points2D);
-  for (size_t i = 0; i < num_points2D; ++i) {
-    const Eigen::Vector3d point3D_in_cam =
-        cam_from_world * points3D[i].homogeneous();
-    // Check if 3D point is in front of camera.
-    if (point3D_in_cam.z() > std::numeric_limits<double>::epsilon()) {
-      (*residuals)[i] =
-          (point3D_in_cam.hnormalized() - points2D[i]).squaredNorm();
-    } else {
-      (*residuals)[i] = std::numeric_limits<double>::max();
-    }
-  }
-}
-
 }  // namespace colmap

--- a/src/colmap/estimators/utils.h
+++ b/src/colmap/estimators/utils.h
@@ -75,18 +75,4 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& rays1,
                                 const Eigen::Matrix3d& E,
                                 std::vector<double>* residuals);
 
-// Calculate the squared reprojection error given a set of 2D-3D point
-// correspondences and a projection matrix. Returns DBL_MAX if a 3D point is
-// behind the given camera.
-//
-// @param points2D        Normalized 2D image points.
-// @param points3D        3D world points.
-// @param cam_from_world  3x4 projection matrix.
-// @param residuals       Output vector of residuals.
-void ComputeSquaredReprojectionError(
-    const std::vector<Eigen::Vector2d>& points2D,
-    const std::vector<Eigen::Vector3d>& points3D,
-    const Eigen::Matrix3x4d& cam_from_world,
-    std::vector<double>* residuals);
-
 }  // namespace colmap

--- a/src/colmap/estimators/utils_test.cc
+++ b/src/colmap/estimators/utils_test.cc
@@ -81,28 +81,5 @@ TEST(ComputeSquaredSampsonError, Nominal) {
   EXPECT_EQ(residuals[2], 2);
 }
 
-TEST(ComputeSquaredReprojectionError, Nominal) {
-  std::vector<Eigen::Vector2d> points2D;
-  points2D.emplace_back(0, 0);
-  points2D.emplace_back(0, 0);
-  points2D.emplace_back(0, 0);
-  std::vector<Eigen::Vector3d> points3D;
-  points3D.emplace_back(2, 0, 1);
-  points3D.emplace_back(2, 1, 1);
-  points3D.emplace_back(2, 2, 1);
-
-  const Rigid3d cam_from_world(Eigen::Quaterniond::Identity(),
-                               Eigen::Vector3d(1, 0, 0));
-
-  std::vector<double> residuals;
-  ComputeSquaredReprojectionError(
-      points2D, points3D, cam_from_world.ToMatrix(), &residuals);
-
-  EXPECT_EQ(residuals.size(), 3);
-  EXPECT_EQ(residuals[0], 9);
-  EXPECT_EQ(residuals[1], 10);
-  EXPECT_EQ(residuals[2], 13);
-}
-
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -178,6 +178,7 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
     camera.model_id = options.camera_model_id;
     camera.params = options.camera_params;
     THROW_CHECK(camera.VerifyParams());
+    camera.has_prior_focal_length = options.camera_has_prior_focal_length;
     const camera_t camera_id =
         (database == nullptr) ? camera_idx + 1 : database->WriteCamera(camera);
     camera_ids[camera_idx] = camera_id;

--- a/src/colmap/scene/synthetic.h
+++ b/src/colmap/scene/synthetic.h
@@ -45,6 +45,7 @@ struct SyntheticDatasetOptions {
   int camera_height = 768;
   CameraModelId camera_model_id = SimpleRadialCameraModel::model_id;
   std::vector<double> camera_params = {1280, 512, 384, 0.05};
+  bool camera_has_prior_focal_length = false;
 
   int num_points2D_without_point3D = 10;
   double point2D_stddev = 0.0;


### PR DESCRIPTION
A/B comparison against main branch. Changes mostly up to numerical noise except for "meadow" as the usual outlier.
```
I20250217 19:45:49.373275 1782301 compare.py:main:58] Results A - B:
=====scenes===== ======AUC @ X deg (%)====== ===images=== =components=
                  0.5    1.0    5.0    10.0     reg   all  num largest

==============================eth3d=dslr==============================
botanical_garden  -0.03  -0.02  -0.00  -0.00      0     0    0       0
boulders          -0.01  -0.00  -0.00  -0.00      0     0    0       0
bridge             0.00   0.00   0.00   0.00      0     0    0       0
courtyard          0.01   0.00   0.00   0.00      0     0    0       0
delivery_area      0.00   0.00   0.00   0.00      0     0    0       0
door              -0.00  -0.00  -0.00  -0.00      0     0    0       0
electro           -0.03  -0.00   0.00   0.00      0     0    0       0
exhibition_hall    0.01  -0.02  -0.00  -0.00      0     0    0       0
facade            -0.01  -0.01  -0.00  -0.00      0     0    0       0
kicker            -0.04  -0.02  -0.00  -0.00      0     0    0       0
lecture_room       0.00  -0.00  -0.00  -0.00      0     0    0       0
living_room        0.03   0.02   0.00   0.00      0     0    0       0
lounge            -0.03  -0.01  -0.00  -0.00      0     0    0       0
meadow            -3.93  -2.52  -0.50  -0.25      0     0    0       0
observatory        0.00   0.00   0.00   0.00      0     0    0       0
office            -0.03  -0.03  -0.01  -0.01      0     0    0       0
old_computer      -0.68  -0.35  -0.08  -0.04      0     0    0       0
pipes              1.50   0.95   0.19   0.09      0     0    0       0
playground        -0.03  -0.02  -0.00  -0.00      0     0    0       0
relief             0.03   0.02   0.00   0.00      0     0    0       0
relief_2          -0.00  -0.00  -0.00  -0.00      0     0    0       0
statue             0.00   0.00   0.00   0.00      0     0    0       0
terrace           -0.04  -0.02  -0.00  -0.00      0     0    0       0
terrace_2         -0.00  -0.00  -0.00  -0.00      0     0    0       0
terrains           0.00   0.00  -0.00  -0.00      0     0    0       0
----------------------------------------------------------------------
overall           -0.06  -0.03  -0.01  -0.00      0     0    0       0
----------------------------------------------------------------------
average           -0.13  -0.08  -0.02  -0.01      0     0    0       0
```