### PR TITLE
Add docs on the left convention in COLMAP for covariance propagation.

### DIFF
--- a/src/colmap/geometry/rigid3.h
+++ b/src/colmap/geometry/rigid3.h
@@ -99,6 +99,13 @@ inline Rigid3d Inverse(const Rigid3d& b_from_a) {
 }
 
 // Update covariance (6x6) for rigid3d.inverse()
+//
+// [Reference] Joan Solà, Jeremie Deray, Dinesh Atchuthan, A micro Lie theory
+// for state estimation in robotics, 2018.
+// In COLMAP we follow the left convention (rather than the right convention as
+// in the reference paper and GTSAM). With the left convention the Jacobian of
+// the inverse is -Ad(X^-1). This can be easily derived combining Eqs. (62) and
+// (57) in the paper.
 inline Eigen::Matrix6d GetCovarianceForRigid3dInverse(
     const Rigid3d& rigid3, const Eigen::Matrix6d& covar) {
   const Eigen::Matrix6d adjoint_inv = rigid3.AdjointInverse();


### PR DESCRIPTION
This was a big confusion. I added some comments to explain why the fix in https://github.com/colmap/colmap/pull/3155 was correct. 

In the end its because that in COLMAP we use the left convention, while in GTSAM and its reference paper here https://arxiv.org/pdf/1812.01537 the right convention was employed.

This is also in preparation for another PR on propagating relative pose covariance in COLMAP (with left convention) with cross-pose correlation available. This will encode the fact that the close image has lower relative pose covariance and does not get affected by Gauge ambiguity. 