### PR TITLE
Add docker instruction link to docs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -41,6 +41,12 @@ are not officially signed. The provided COLMAP binaries are automatically built
 from GitHub Actions CI machines. If you do not trust them, you can build from
 source as described below.
 
+Docker
+------
+
+COLMAP provides a pre-built Docker image with CUDA support. For detailed
+instructions on how to build and run COLMAP using Docker, please refer to the
+`Docker documentation <https://github.com/colmap/colmap/tree/main/docker>`__.
 
 -----------------
 Build from Source

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,6 +40,12 @@
     colmap automatic_reconstructor --image_path ./images --workspace_path .
     ```
 
+5. Alternatively, you can run the *run-gui* script, which will start the graphical user interface of COLMAP:
+
+    ```
+    ./run-gui.sh /path/where/your/working/folder/is
+    ```
+
 ## Build from Scratch
 
 After completing steps 1-3, you can alternatively build the docker image from

--- a/docker/run-gui.sh
+++ b/docker/run-gui.sh
@@ -2,6 +2,8 @@ docker pull colmap/colmap:latest
 docker run \
     -e QT_XCB_GL_INTEGRATION=xcb_egl \
     -e DISPLAY=:0 \
+    -w /working \
+    -v $1:/working \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     --gpus all \
     --privileged \


### PR DESCRIPTION
I found that some of my collaborators aren't aware of the pre-built Docker image. I think it would be helpful to mention it somewhere on the documentation's installation page.