### PR TITLE
Camera models perform valid projection test

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -108,7 +108,6 @@ jobs:
           key: v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.cmakeBuildType }}-${{ matrix.config.asanEnabled }}--${{ matrix.config.cudaEnabled }}-${{ github.run_id }}-${{ github.run_number }}
           restore-keys: v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.cmakeBuildType }}-${{ matrix.config.asanEnabled }}--${{ matrix.config.cudaEnabled }}
           path: ${{ env.COMPILER_CACHE_DIR }}
-      
       - name: Install compiler cache
         run: |
           mkdir -p "$CCACHE_DIR" "$CTCACHE_DIR"
@@ -248,6 +247,8 @@ jobs:
           Xvfb :99 &
           sleep 3
           cd build
+          export GLOG_v=1
+          export GLOG_logtostderr=1
           ctest -E "$ctestExclusions" --output-on-failure
 
       - name: Run E2E tests
@@ -295,7 +296,6 @@ jobs:
           indicators: true
           output: both
           thresholds: '75 90'
-      
       # TODO: Add code coverage comment to PR. Currently, this action reports
       # coverage for the entire repository, not just the changed files in the PR.
       # We could manually filter the coverage report to only include the changed

--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -306,7 +306,6 @@ TEST(AbsolutePose, EPNP_BrokenSolveSignCase) {
 TEST(ComputeSquaredReprojectionError, Nominal) {
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
-
   auto img_from_cam_func =
       std::bind(&Camera::ImgFromCam, &camera, std::placeholders::_1);
 

--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -62,17 +62,8 @@ TEST(AbsolutePose, P3P) {
 
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
-
-  // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
-  // returns an optional.
-  auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
-      -> std::optional<Eigen::Vector2d> {
-    if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
-      return std::nullopt;
-    } else {
-      return camera.ImgFromCam(point3D_in_cam.hnormalized());
-    }
-  };
+  ImgFromCamFunc img_from_cam_func =
+      std::bind(&Camera::ImgFromCam, &camera, std::placeholders::_1);
 
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
   for (double qx = 0; qx < 1; qx += 0.2) {
@@ -200,17 +191,8 @@ TEST(AbsolutePose, EPNP) {
 
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
-
-  // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
-  // returns an optional.
-  auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
-      -> std::optional<Eigen::Vector2d> {
-    if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
-      return std::nullopt;
-    } else {
-      return camera.ImgFromCam(point3D_in_cam.hnormalized());
-    }
-  };
+  auto img_from_cam_func =
+      std::bind(&Camera::ImgFromCam, &camera, std::placeholders::_1);
 
   // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
   for (double qx = 0; qx < 1; qx += 0.2) {
@@ -325,16 +307,8 @@ TEST(ComputeSquaredReprojectionError, Nominal) {
   const Camera camera = Camera::CreateFromModelId(
       kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
 
-  // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
-  // returns an optional.
-  auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
-      -> std::optional<Eigen::Vector2d> {
-    if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
-      return std::nullopt;
-    } else {
-      return camera.ImgFromCam(point3D_in_cam.hnormalized());
-    }
-  };
+  auto img_from_cam_func =
+      std::bind(&Camera::ImgFromCam, &camera, std::placeholders::_1);
 
   std::vector<Eigen::Vector3d> points3D;
   points3D.emplace_back(-1, 0, 1);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -701,12 +701,13 @@ class RigBundleAdjuster : public BundleAdjuster {
     CameraRig* camera_rig = nullptr;
     Eigen::Matrix3x4d cam_from_world_mat = Eigen::Matrix3x4d::Zero();
 
-    if (image_id_to_camera_rig_.count(image_id) > 0) {
+    if (const auto it = image_id_to_camera_rig_.find(image_id);
+        it != image_id_to_camera_rig_.end()) {
       THROW_CHECK(!constant_cam_pose)
           << "Images contained in a camera rig must not have constant pose";
       THROW_CHECK(!constant_cam_position)
           << "Images contained in a camera rig must not have constant tvec";
-      camera_rig = image_id_to_camera_rig_.at(image_id);
+      camera_rig = it->second;
       Rigid3d& rig_from_world = *image_id_to_rig_from_world_.at(image_id);
       rig_from_world_rotation = rig_from_world.rotation.coeffs().data();
       rig_from_world_translation = rig_from_world.translation.data();

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -164,14 +164,11 @@ void GenerateReconstruction(const size_t num_images,
             RandomUniformReal(-1.0, 1.0), RandomUniformReal(-1.0, 1.0), 10)));
     reconstruction->AddImage(image);
 
-    const Eigen::Matrix3x4d cam_from_world_matrix =
-        image.CamFromWorld().ToMatrix();
-
     std::vector<Eigen::Vector2d> points2D;
     for (const auto& point3D : reconstruction->Points3D()) {
       // Get exact projection of 3D point.
-      std::optional<Eigen::Vector2d> point2D = camera.ImgFromCam(
-          (image.CamFromWorld() * point3D.second.xyz).hnormalized());
+      std::optional<Eigen::Vector2d> point2D =
+          camera.ImgFromCam(image.CamFromWorld() * point3D.second.xyz);
       ASSERT_TRUE(point2D.has_value());
       // Add some uniform noise.
       *point2D += Eigen::Vector2d(RandomUniformReal(-2.0, 2.0),

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -162,21 +162,21 @@ void GenerateReconstruction(const size_t num_images,
         Eigen::Quaterniond::Identity(),
         Eigen::Vector3d(
             RandomUniformReal(-1.0, 1.0), RandomUniformReal(-1.0, 1.0), 10)));
-    reconstruction->AddImage(image);
 
     std::vector<Eigen::Vector2d> points2D;
     for (const auto& point3D : reconstruction->Points3D()) {
       // Get exact projection of 3D point.
       std::optional<Eigen::Vector2d> point2D =
           camera.ImgFromCam(image.CamFromWorld() * point3D.second.xyz);
-      ASSERT_TRUE(point2D.has_value());
+      CHECK(point2D.has_value());
       // Add some uniform noise.
       *point2D += Eigen::Vector2d(RandomUniformReal(-2.0, 2.0),
                                   RandomUniformReal(-2.0, 2.0));
       points2D.push_back(*point2D);
     }
 
-    reconstruction->Image(image_id).SetPoints2D(points2D);
+    image.SetPoints2D(points2D);
+    reconstruction->AddImage(std::move(image));
   }
 
   for (size_t i = 0; i < num_images; ++i) {
@@ -654,7 +654,9 @@ TEST(RigBundleAdjuster, TwoView) {
   std::vector<CameraRig> camera_rigs;
   camera_rigs.emplace_back();
   camera_rigs[0].AddCamera(0, Rigid3d());
-  camera_rigs[0].AddCamera(1, Rigid3d());
+  camera_rigs[0].AddCamera(1,
+                           reconstruction.Image(1).CamFromWorld() *
+                               Inverse(reconstruction.Image(0).CamFromWorld()));
   camera_rigs[0].AddSnapshot({0, 1});
   camera_rigs[0].SetRefCameraId(0);
   const auto orig_camera_rigs = camera_rigs;
@@ -709,7 +711,9 @@ TEST(RigBundleAdjuster, FourView) {
   std::vector<CameraRig> camera_rigs;
   camera_rigs.emplace_back();
   camera_rigs[0].AddCamera(0, Rigid3d());
-  camera_rigs[0].AddCamera(1, Rigid3d());
+  camera_rigs[0].AddCamera(1,
+                           reconstruction.Image(1).CamFromWorld() *
+                               Inverse(reconstruction.Image(0).CamFromWorld()));
   camera_rigs[0].AddSnapshot({0, 1});
   camera_rigs[0].AddSnapshot({2, 3});
   camera_rigs[0].SetRefCameraId(0);
@@ -765,7 +769,9 @@ TEST(RigBundleAdjuster, ConstantFourView) {
   std::vector<CameraRig> camera_rigs;
   camera_rigs.emplace_back();
   camera_rigs[0].AddCamera(0, Rigid3d());
-  camera_rigs[0].AddCamera(1, Rigid3d());
+  camera_rigs[0].AddCamera(1,
+                           reconstruction.Image(1).CamFromWorld() *
+                               Inverse(reconstruction.Image(0).CamFromWorld()));
   camera_rigs[0].AddSnapshot({0, 1});
   camera_rigs[0].AddSnapshot({2, 3});
   camera_rigs[0].SetRefCameraId(0);
@@ -821,7 +827,9 @@ TEST(RigBundleAdjuster, FourViewPartial) {
   std::vector<CameraRig> camera_rigs;
   camera_rigs.emplace_back();
   camera_rigs[0].AddCamera(0, Rigid3d());
-  camera_rigs[0].AddCamera(1, Rigid3d());
+  camera_rigs[0].AddCamera(1,
+                           reconstruction.Image(1).CamFromWorld() *
+                               Inverse(reconstruction.Image(0).CamFromWorld()));
   camera_rigs[0].AddSnapshot({0, 1});
   camera_rigs[0].AddSnapshot({2});
   camera_rigs[0].SetRefCameraId(0);

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -169,15 +169,14 @@ void GenerateReconstruction(const size_t num_images,
 
     std::vector<Eigen::Vector2d> points2D;
     for (const auto& point3D : reconstruction->Points3D()) {
-      EXPECT_TRUE(
-          HasPointPositiveDepth(cam_from_world_matrix, point3D.second.xyz));
       // Get exact projection of 3D point.
-      Eigen::Vector2d point2D = camera.ImgFromCam(
+      std::optional<Eigen::Vector2d> point2D = camera.ImgFromCam(
           (image.CamFromWorld() * point3D.second.xyz).hnormalized());
+      ASSERT_TRUE(point2D.has_value());
       // Add some uniform noise.
-      point2D += Eigen::Vector2d(RandomUniformReal(-2.0, 2.0),
-                                 RandomUniformReal(-2.0, 2.0));
-      points2D.push_back(point2D);
+      *point2D += Eigen::Vector2d(RandomUniformReal(-2.0, 2.0),
+                                  RandomUniformReal(-2.0, 2.0));
+      points2D.push_back(*point2D);
     }
 
     reconstruction->Image(image_id).SetPoints2D(points2D);

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -97,14 +97,18 @@ class ReprojErrorCostFunctor
         EigenQuaternionMap<T>(cam_from_world_rotation) *
             EigenVector3Map<T>(point3D) +
         EigenVector3Map<T>(cam_from_world_translation);
-    CameraModel::ImgFromCam(camera_params,
-                            point3D_in_cam[0],
-                            point3D_in_cam[1],
-                            point3D_in_cam[2],
-                            &residuals[0],
-                            &residuals[1]);
-    residuals[0] -= T(observed_x_);
-    residuals[1] -= T(observed_y_);
+    if (CameraModel::ImgFromCam(camera_params,
+                                point3D_in_cam[0],
+                                point3D_in_cam[1],
+                                point3D_in_cam[2],
+                                &residuals[0],
+                                &residuals[1])) {
+      residuals[0] -= T(observed_x_);
+      residuals[1] -= T(observed_y_);
+    } else {
+      residuals[0] = T(0);
+      residuals[1] = T(0);
+    }
     return true;
   }
 
@@ -214,14 +218,18 @@ class RigReprojErrorCostFunctor
                  EigenVector3Map<T>(point3D) +
              EigenVector3Map<T>(rig_from_world_translation)) +
         EigenVector3Map<T>(cam_from_rig_translation);
-    CameraModel::ImgFromCam(camera_params,
-                            point3D_in_cam[0],
-                            point3D_in_cam[1],
-                            point3D_in_cam[2],
-                            &residuals[0],
-                            &residuals[1]);
-    residuals[0] -= T(observed_x_);
-    residuals[1] -= T(observed_y_);
+    if (CameraModel::ImgFromCam(camera_params,
+                                point3D_in_cam[0],
+                                point3D_in_cam[1],
+                                point3D_in_cam[2],
+                                &residuals[0],
+                                &residuals[1])) {
+      residuals[0] -= T(observed_x_);
+      residuals[1] -= T(observed_y_);
+    } else {
+      residuals[0] = T(0);
+      residuals[1] = T(0);
+    }
     return true;
   }
 

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -80,17 +80,8 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
           camera->CamFromImg(points2D[i]).homogeneous().normalized();
     }
 
-    // TODO(jsch): Replace this with camera->ImgFromCam() once the camera class
-    // returns an optional.
-    auto img_from_cam_func = [&camera](const Eigen::Vector3d& point3D_in_cam)
-        -> std::optional<Eigen::Vector2d> {
-      if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
-        return std::nullopt;
-      } else {
-        return camera->ImgFromCam(point3D_in_cam.hnormalized());
-      }
-    };
-
+    ImgFromCamFunc img_from_cam_func =
+        std::bind(&Camera::ImgFromCam, camera, std::placeholders::_1);
     LORANSAC<P3PEstimator, EPNPEstimator> ransac(
         options.ransac_options,
         P3PEstimator(img_from_cam_func),

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -853,17 +853,21 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Left border.
       const Eigen::Vector2d point1_in_cam =
           camera.CamFromImg(Eigen::Vector2d(0.5, y + 0.5));
-      const Eigen::Vector2d undistorted_point1 =
+      const std::optional<Eigen::Vector2d> undistorted_point1 =
           undistorted_camera.ImgFromCam(point1_in_cam);
-      left_min_x = std::min(left_min_x, undistorted_point1(0));
-      left_max_x = std::max(left_max_x, undistorted_point1(0));
+      if (undistorted_point1) {
+      left_min_x = std::min(left_min_x, undistorted_point1->x());
+      left_max_x = std::max(left_max_x, undistorted_point1->x());
+      }
       // Right border.
       const Eigen::Vector2d point2_in_cam =
           camera.CamFromImg(Eigen::Vector2d(camera.width - 0.5, y + 0.5));
-      const Eigen::Vector2d undistorted_point2 =
+      const std::optional<Eigen::Vector2d> undistorted_point2 =
           undistorted_camera.ImgFromCam(point2_in_cam);
-      right_min_x = std::min(right_min_x, undistorted_point2(0));
-      right_max_x = std::max(right_max_x, undistorted_point2(0));
+      if (undistorted_point2) {
+      right_min_x = std::min(right_min_x, undistorted_point2->x());
+      right_max_x = std::max(right_max_x, undistorted_point2->x());
+      }
     }
 
     // Determine min, max coordinates along left / right image border.
@@ -877,17 +881,21 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Top border.
       const Eigen::Vector2d point1_in_cam =
           camera.CamFromImg(Eigen::Vector2d(x + 0.5, 0.5));
-      const Eigen::Vector2d undistorted_point1 =
+      const std::optional<Eigen::Vector2d> undistorted_point1 =
           undistorted_camera.ImgFromCam(point1_in_cam);
-      top_min_y = std::min(top_min_y, undistorted_point1(1));
-      top_max_y = std::max(top_max_y, undistorted_point1(1));
+          if (undistorted_point1) {
+      top_min_y = std::min(top_min_y, undistorted_point1->y());
+      top_max_y = std::max(top_max_y, undistorted_point1->y());
+          }
       // Bottom border.
       const Eigen::Vector2d point2_in_cam =
           camera.CamFromImg(Eigen::Vector2d(x + 0.5, camera.height - 0.5));
-      const Eigen::Vector2d undistorted_point2 =
+      const std::optional<Eigen::Vector2d> undistorted_point2 =
           undistorted_camera.ImgFromCam(point2_in_cam);
-      bottom_min_y = std::min(bottom_min_y, undistorted_point2(1));
-      bottom_max_y = std::max(bottom_max_y, undistorted_point2(1));
+          if (undistorted_point2) {
+      bottom_min_y = std::min(bottom_min_y, undistorted_point2->y());
+      bottom_max_y = std::max(bottom_max_y, undistorted_point2->y());
+          }
     }
 
     const double cx = undistorted_camera.PrincipalPointX();
@@ -990,8 +998,13 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
     for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();
          ++point2D_idx) {
       auto& point2D = image.Point2D(point2D_idx);
-      point2D.xy = undistorted_camera.ImgFromCam(
+      const std::optional<Eigen::Vector2d> undistorted_point = undistorted_camera.ImgFromCam(
           distorted_camera.CamFromImg(point2D.xy));
+      if (undistorted_point) {
+        point2D.xy = *undistorted_point;
+      } else {
+        point2D.xy = Eigen::Vector2d::Constant(std::numeric_limits<double>::quiet_NaN());
+      }
     }
   }
 }

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -854,19 +854,19 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       const Eigen::Vector2d point1_in_cam =
           camera.CamFromImg(Eigen::Vector2d(0.5, y + 0.5));
       const std::optional<Eigen::Vector2d> undistorted_point1 =
-          undistorted_camera.ImgFromCam(point1_in_cam);
+          undistorted_camera.ImgFromCam(point1_in_cam.homogeneous());
       if (undistorted_point1) {
-      left_min_x = std::min(left_min_x, undistorted_point1->x());
-      left_max_x = std::max(left_max_x, undistorted_point1->x());
+        left_min_x = std::min(left_min_x, undistorted_point1->x());
+        left_max_x = std::max(left_max_x, undistorted_point1->x());
       }
       // Right border.
       const Eigen::Vector2d point2_in_cam =
           camera.CamFromImg(Eigen::Vector2d(camera.width - 0.5, y + 0.5));
       const std::optional<Eigen::Vector2d> undistorted_point2 =
-          undistorted_camera.ImgFromCam(point2_in_cam);
+          undistorted_camera.ImgFromCam(point2_in_cam.homogeneous());
       if (undistorted_point2) {
-      right_min_x = std::min(right_min_x, undistorted_point2->x());
-      right_max_x = std::max(right_max_x, undistorted_point2->x());
+        right_min_x = std::min(right_min_x, undistorted_point2->x());
+        right_max_x = std::max(right_max_x, undistorted_point2->x());
       }
     }
 
@@ -882,20 +882,20 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       const Eigen::Vector2d point1_in_cam =
           camera.CamFromImg(Eigen::Vector2d(x + 0.5, 0.5));
       const std::optional<Eigen::Vector2d> undistorted_point1 =
-          undistorted_camera.ImgFromCam(point1_in_cam);
-          if (undistorted_point1) {
-      top_min_y = std::min(top_min_y, undistorted_point1->y());
-      top_max_y = std::max(top_max_y, undistorted_point1->y());
-          }
+          undistorted_camera.ImgFromCam(point1_in_cam.homogeneous());
+      if (undistorted_point1) {
+        top_min_y = std::min(top_min_y, undistorted_point1->y());
+        top_max_y = std::max(top_max_y, undistorted_point1->y());
+      }
       // Bottom border.
       const Eigen::Vector2d point2_in_cam =
           camera.CamFromImg(Eigen::Vector2d(x + 0.5, camera.height - 0.5));
       const std::optional<Eigen::Vector2d> undistorted_point2 =
-          undistorted_camera.ImgFromCam(point2_in_cam);
-          if (undistorted_point2) {
-      bottom_min_y = std::min(bottom_min_y, undistorted_point2->y());
-      bottom_max_y = std::max(bottom_max_y, undistorted_point2->y());
-          }
+          undistorted_camera.ImgFromCam(point2_in_cam.homogeneous());
+      if (undistorted_point2) {
+        bottom_min_y = std::min(bottom_min_y, undistorted_point2->y());
+        bottom_max_y = std::max(bottom_max_y, undistorted_point2->y());
+      }
     }
 
     const double cx = undistorted_camera.PrincipalPointX();
@@ -998,12 +998,14 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
     for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();
          ++point2D_idx) {
       auto& point2D = image.Point2D(point2D_idx);
-      const std::optional<Eigen::Vector2d> undistorted_point = undistorted_camera.ImgFromCam(
-          distorted_camera.CamFromImg(point2D.xy));
+      const std::optional<Eigen::Vector2d> undistorted_point =
+          undistorted_camera.ImgFromCam(
+              distorted_camera.CamFromImg(point2D.xy).homogeneous());
       if (undistorted_point) {
         point2D.xy = *undistorted_point;
       } else {
-        point2D.xy = Eigen::Vector2d::Constant(std::numeric_limits<double>::quiet_NaN());
+        point2D.xy =
+            Eigen::Vector2d::Constant(std::numeric_limits<double>::quiet_NaN());
       }
     }
   }

--- a/src/colmap/image/warp.cc
+++ b/src/colmap/image/warp.cc
@@ -82,11 +82,11 @@ void WarpImageBetweenCameras(const Camera& source_camera,
       // Camera models assume that the upper left pixel center is (0.5, 0.5).
       const Eigen::Vector2d cam_point =
           scaled_target_camera.CamFromImg(image_point);
-      const Eigen::Vector2d source_point = source_camera.ImgFromCam(cam_point);
+      const std::optional<Eigen::Vector2d> source_point = source_camera.ImgFromCam(cam_point);
 
       BitmapColor<float> color;
-      if (source_image.InterpolateBilinear(
-              source_point.x() - 0.5, source_point.y() - 0.5, &color)) {
+      if (source_point && source_image.InterpolateBilinear(
+              source_point->x() - 0.5, source_point->y() - 0.5, &color)) {
         target_image->SetPixel(x, y, color.Cast<uint8_t>());
       } else {
         target_image->SetPixel(x, y, BitmapColor<uint8_t>(0));
@@ -158,11 +158,11 @@ void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
       const Eigen::Vector3d warped_point = H * image_point;
       const Eigen::Vector2d cam_point =
           target_camera.CamFromImg(warped_point.hnormalized());
-      const Eigen::Vector2d source_point = source_camera.ImgFromCam(cam_point);
+      const std::optional<Eigen::Vector2d> source_point = source_camera.ImgFromCam(cam_point);
 
       BitmapColor<float> color;
-      if (source_image.InterpolateBilinear(
-              source_point.x() - 0.5, source_point.y() - 0.5, &color)) {
+      if (source_point && source_image.InterpolateBilinear(
+              source_point->x() - 0.5, source_point->y() - 0.5, &color)) {
         target_image->SetPixel(x, y, color.Cast<uint8_t>());
       } else {
         target_image->SetPixel(x, y, BitmapColor<uint8_t>(0));

--- a/src/colmap/image/warp.cc
+++ b/src/colmap/image/warp.cc
@@ -82,10 +82,12 @@ void WarpImageBetweenCameras(const Camera& source_camera,
       // Camera models assume that the upper left pixel center is (0.5, 0.5).
       const Eigen::Vector2d cam_point =
           scaled_target_camera.CamFromImg(image_point);
-      const std::optional<Eigen::Vector2d> source_point = source_camera.ImgFromCam(cam_point);
+      const std::optional<Eigen::Vector2d> source_point =
+          source_camera.ImgFromCam(cam_point.homogeneous());
 
       BitmapColor<float> color;
-      if (source_point && source_image.InterpolateBilinear(
+      if (source_point &&
+          source_image.InterpolateBilinear(
               source_point->x() - 0.5, source_point->y() - 0.5, &color)) {
         target_image->SetPixel(x, y, color.Cast<uint8_t>());
       } else {
@@ -158,10 +160,12 @@ void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
       const Eigen::Vector3d warped_point = H * image_point;
       const Eigen::Vector2d cam_point =
           target_camera.CamFromImg(warped_point.hnormalized());
-      const std::optional<Eigen::Vector2d> source_point = source_camera.ImgFromCam(cam_point);
+      const std::optional<Eigen::Vector2d> source_point =
+          source_camera.ImgFromCam(cam_point.homogeneous());
 
       BitmapColor<float> color;
-      if (source_point && source_image.InterpolateBilinear(
+      if (source_point &&
+          source_image.InterpolateBilinear(
               source_point->x() - 0.5, source_point->y() - 0.5, &color)) {
         target_image->SetPixel(x, y, color.Cast<uint8_t>());
       } else {

--- a/src/colmap/mvs/meshing.cc
+++ b/src/colmap/mvs/meshing.cc
@@ -395,12 +395,13 @@ class DelaunayMeshingInput {
           }
 
           // Check reprojection error between the two points.
-          const Eigen::Vector2f point_proj =
-              camera.ImgFromCam(point_local.hnormalized().cast<double>())
-                  .cast<float>();
-          const Eigen::Vector2f cell_point_proj =
-              camera.ImgFromCam(cell_point_local.hnormalized().cast<double>())
-                  .cast<float>();
+          const std::optional<Eigen::Vector2d> point_proj =
+              camera.ImgFromCam(point_local.hnormalized().cast<double>());
+          const std::optional<Eigen::Vector2d> cell_point_proj =
+              camera.ImgFromCam(cell_point_local.hnormalized().cast<double>());
+          if (!point_proj || !cell_point_proj) {
+            continue;
+          }
           const float squared_proj_dist =
               (point_proj - cell_point_proj).squaredNorm();
           if (squared_proj_dist > max_squared_proj_dist) {

--- a/src/colmap/mvs/meshing.cc
+++ b/src/colmap/mvs/meshing.cc
@@ -396,14 +396,14 @@ class DelaunayMeshingInput {
 
           // Check reprojection error between the two points.
           const std::optional<Eigen::Vector2d> point_proj =
-              camera.ImgFromCam(point_local.hnormalized().cast<double>());
+              camera.ImgFromCam(point_local.cast<double>());
           const std::optional<Eigen::Vector2d> cell_point_proj =
-              camera.ImgFromCam(cell_point_local.hnormalized().cast<double>());
+              camera.ImgFromCam(cell_point_local.cast<double>());
           if (!point_proj || !cell_point_proj) {
             continue;
           }
           const float squared_proj_dist =
-              (point_proj - cell_point_proj).squaredNorm();
+              (*point_proj - *cell_point_proj).squaredNorm();
           if (squared_proj_dist > max_squared_proj_dist) {
             insert_point = true;
             break;

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -131,7 +131,7 @@ struct Camera {
   inline double CamFromImgThreshold(double threshold) const;
 
   // Project point from camera frame to image plane.
-  inline Eigen::Vector2d ImgFromCam(const Eigen::Vector2d& cam_point) const;
+  inline std::optional<Eigen::Vector2d> ImgFromCam(const Eigen::Vector2d& cam_point) const;
 
   // Rescale camera dimensions and accordingly the focal length and
   // and the principal point.
@@ -251,7 +251,8 @@ double Camera::CamFromImgThreshold(const double threshold) const {
   return CameraModelCamFromImgThreshold(model_id, params, threshold);
 }
 
-Eigen::Vector2d Camera::ImgFromCam(const Eigen::Vector2d& cam_point) const {
+std::optional<Eigen::Vector2d> Camera::ImgFromCam(
+    const Eigen::Vector2d& cam_point) const {
   return CameraModelImgFromCam(model_id, params, cam_point.homogeneous());
 }
 

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -131,7 +131,8 @@ struct Camera {
   inline double CamFromImgThreshold(double threshold) const;
 
   // Project point from camera frame to image plane.
-  inline std::optional<Eigen::Vector2d> ImgFromCam(const Eigen::Vector2d& cam_point) const;
+  inline std::optional<Eigen::Vector2d> ImgFromCam(
+      const Eigen::Vector3d& cam_point) const;
 
   // Rescale camera dimensions and accordingly the focal length and
   // and the principal point.
@@ -252,8 +253,8 @@ double Camera::CamFromImgThreshold(const double threshold) const {
 }
 
 std::optional<Eigen::Vector2d> Camera::ImgFromCam(
-    const Eigen::Vector2d& cam_point) const {
-  return CameraModelImgFromCam(model_id, params, cam_point.homogeneous());
+    const Eigen::Vector3d& cam_point) const {
+  return CameraModelImgFromCam(model_id, params, cam_point);
 }
 
 bool Camera::operator==(const Camera& other) const {

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -291,10 +291,8 @@ TEST(Camera, ImgFromCam) {
   Camera camera;
   EXPECT_THROW(camera.ImgFromCam(Eigen::Vector2d::Zero()), std::domain_error);
   camera = Camera::CreateFromModelName(1, "SIMPLE_PINHOLE", 1.0, 1, 1);
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(0.0, 0.0))(0), 0.5);
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(0.0, 0.0))(1), 0.5);
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(-0.5, -0.5))(0), 0.0);
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(-0.5, -0.5))(1), 0.0);
+  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(0.0, 0.0)).value(), Eigen::Vector2d(0.5, 0.5));
+  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(-0.5, -0.5)).value(), Eigen::Vector2d(0.0, 0.0));
 }
 
 TEST(Camera, Rescale) {

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -289,10 +289,12 @@ TEST(Camera, CamFromImgThreshold) {
 
 TEST(Camera, ImgFromCam) {
   Camera camera;
-  EXPECT_THROW(camera.ImgFromCam(Eigen::Vector2d::Zero()), std::domain_error);
+  EXPECT_THROW(camera.ImgFromCam(Eigen::Vector3d::Zero()), std::domain_error);
   camera = Camera::CreateFromModelName(1, "SIMPLE_PINHOLE", 1.0, 1, 1);
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(0.0, 0.0)).value(), Eigen::Vector2d(0.5, 0.5));
-  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector2d(-0.5, -0.5)).value(), Eigen::Vector2d(0.0, 0.0));
+  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector3d(0.0, 0.0, 1)).value(),
+            Eigen::Vector2d(0.5, 0.5));
+  EXPECT_EQ(camera.ImgFromCam(Eigen::Vector3d(-0.5, -0.5, 1)).value(),
+            Eigen::Vector2d(0.0, 0.0));
 }
 
 TEST(Camera, Rescale) {

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -134,11 +134,11 @@ Eigen::Vector3d Image::ViewingDirection() const {
   return CamFromWorld().rotation.toRotationMatrix().row(2);
 }
 
-std::pair<bool, Eigen::Vector2d> Image::ProjectPoint(
+std::optional<Eigen::Vector2d> Image::ProjectPoint(
     const Eigen::Vector3d& point3D) const {
   THROW_CHECK(HasCameraPtr());
   const Eigen::Vector3d point3D_in_cam = CamFromWorld() * point3D;
-  return {true, camera_ptr_->ImgFromCam(point3D_in_cam.hnormalized())};
+  return camera_ptr_->ImgFromCam(point3D_in_cam);
 }
 
 std::ostream& operator<<(std::ostream& stream, const Image& image) {

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -138,9 +138,6 @@ std::pair<bool, Eigen::Vector2d> Image::ProjectPoint(
     const Eigen::Vector3d& point3D) const {
   THROW_CHECK(HasCameraPtr());
   const Eigen::Vector3d point3D_in_cam = CamFromWorld() * point3D;
-  if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
-    return {false, Eigen::Vector2d()};
-  }
   return {true, camera_ptr_->ImgFromCam(point3D_in_cam.hnormalized())};
 }
 

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -138,8 +138,8 @@ class Image {
   Eigen::Vector3d ViewingDirection() const;
 
   // Reproject the 3D point onto the image in pixels (throws if the camera
-  // object was not set). Return false if the 3D point is behind the camera.
-  std::pair<bool, Eigen::Vector2d> ProjectPoint(
+  // object was not set). Return null if the 3D point is behind the camera.
+  std::optional<Eigen::Vector2d> ProjectPoint(
       const Eigen::Vector3d& point3D) const;
 
   inline bool operator==(const Image& other) const;

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -59,6 +59,9 @@ class Image {
   // Initialize a new Frame object if the image has a trivial frame.
   Image(const Image& other);
   Image& operator=(const Image& other);
+  // Move construct/assign.
+  Image(Image&& other) = default;
+  Image& operator=(Image&& other) = default;
 
   // Access the unique identifier of the image.
   inline image_t ImageId() const;

--- a/src/colmap/scene/image_test.cc
+++ b/src/colmap/scene/image_test.cc
@@ -251,11 +251,12 @@ TEST(Image, ProjectPoint) {
       Camera::CreateFromModelId(1, CameraModelId::kSimplePinhole, 1, 1, 1);
   image.SetCameraId(camera.camera_id);
   image.SetCameraPtr(&camera);
-  const auto result = image.ProjectPoint(Eigen::Vector3d(2, 0, 1));
-  EXPECT_TRUE(result.first);
-  EXPECT_EQ(result.second, Eigen::Vector2d(2.5, 0.5));
-  EXPECT_FALSE(image.ProjectPoint(Eigen::Vector3d(2, 0, 0)).first);
-  EXPECT_FALSE(image.ProjectPoint(Eigen::Vector3d(2, 0, -1)).first);
+  const std::optional<Eigen::Vector2d> result =
+      image.ProjectPoint(Eigen::Vector3d(2, 0, 1));
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), Eigen::Vector2d(2.5, 0.5));
+  EXPECT_FALSE(image.ProjectPoint(Eigen::Vector3d(2, 0, 0)).has_value());
+  EXPECT_FALSE(image.ProjectPoint(Eigen::Vector3d(2, 0, -1)).has_value());
 }
 
 }  // namespace

--- a/src/colmap/scene/projection.cc
+++ b/src/colmap/scene/projection.cc
@@ -39,14 +39,12 @@ double CalculateSquaredReprojectionError(const Eigen::Vector2d& point2D,
                                          const Rigid3d& cam_from_world,
                                          const Camera& camera) {
   const Eigen::Vector3d point3D_in_cam = cam_from_world * point3D;
-
-  // Check that point is infront of camera.
-  if (point3D_in_cam.z() < std::numeric_limits<double>::epsilon()) {
+  const std::optional<Eigen::Vector2d> proj_point2D =
+      camera.ImgFromCam(point3D_in_cam);
+  if (proj_point2D) {
     return std::numeric_limits<double>::max();
   }
-
-  return (camera.ImgFromCam(point3D_in_cam.hnormalized()) - point2D)
-      .squaredNorm();
+  return (*proj_point2D - point2D).squaredNorm();
 }
 
 double CalculateSquaredReprojectionError(
@@ -54,21 +52,13 @@ double CalculateSquaredReprojectionError(
     const Eigen::Vector3d& point3D,
     const Eigen::Matrix3x4d& cam_from_world,
     const Camera& camera) {
-  const double proj_z = cam_from_world.row(2).dot(point3D.homogeneous());
-
-  // Check that point is infront of camera.
-  if (proj_z < std::numeric_limits<double>::epsilon()) {
+  const Eigen::Vector3d point3D_in_cam = cam_from_world * point3D.homogeneous();
+  const std::optional<Eigen::Vector2d> proj_point2D =
+      camera.ImgFromCam(point3D_in_cam);
+  if (!proj_point2D) {
     return std::numeric_limits<double>::max();
   }
-
-  const double proj_x = cam_from_world.row(0).dot(point3D.homogeneous());
-  const double proj_y = cam_from_world.row(1).dot(point3D.homogeneous());
-  const double inv_proj_z = 1.0 / proj_z;
-
-  const Eigen::Vector2d proj_point2D = camera.ImgFromCam(
-      Eigen::Vector2d(inv_proj_z * proj_x, inv_proj_z * proj_y));
-
-  return (proj_point2D - point2D).squaredNorm();
+  return (*proj_point2D - point2D).squaredNorm();
 }
 
 double CalculateAngularError(const Eigen::Vector2d& point2D,

--- a/src/colmap/scene/projection.cc
+++ b/src/colmap/scene/projection.cc
@@ -41,7 +41,7 @@ double CalculateSquaredReprojectionError(const Eigen::Vector2d& point2D,
   const Eigen::Vector3d point3D_in_cam = cam_from_world * point3D;
   const std::optional<Eigen::Vector2d> proj_point2D =
       camera.ImgFromCam(point3D_in_cam);
-  if (proj_point2D) {
+  if (!proj_point2D) {
     return std::numeric_limits<double>::max();
   }
   return (*proj_point2D - point2D).squaredNorm();

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -214,7 +214,7 @@ void ReadImagesText(Reconstruction& reconstruction, std::istream& stream) {
       }
     }
 
-    reconstruction.AddImage(image);
+    reconstruction.AddImage(std::move(image));
   }
 }
 
@@ -377,7 +377,7 @@ void ReadImagesBinary(Reconstruction& reconstruction, std::istream& stream) {
       }
     }
 
-    reconstruction.AddImage(image);
+    reconstruction.AddImage(std::move(image));
   }
 }
 

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -221,8 +221,11 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
     // Create 3D point observations by project all 3D points to the image.
     for (auto& point3D : reconstruction->Points3D()) {
       Point2D point2D;
-      point2D.xy = camera.ImgFromCam(
-          (image.CamFromWorld() * point3D.second.xyz).hnormalized());
+      if (const std::optional<Eigen::Vector2d> proj_point2D =
+              camera.ImgFromCam(image.CamFromWorld() * point3D.second.xyz);
+          proj_point2D.has_value()) {
+        point2D.xy = *proj_point2D;
+      }
       if (options.point2D_stddev > 0) {
         const Eigen::Vector2d noise(
             RandomGaussian<double>(0, options.point2D_stddev),

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -318,7 +318,7 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
 
     image.SetImageId(image_id);
     image.SetPoints2D(points2D);
-    reconstruction->AddImage(image);
+    reconstruction->AddImage(std::move(image));
     reconstruction->RegisterImage(image_id);
   }
 

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -36,6 +36,7 @@
 
 #include <array>
 #include <cfloat>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -128,7 +128,7 @@ MAKE_ENUM_CLASS_OVERLOAD_STREAM(CameraModelId,
   static inline std::vector<double> InitializeParams(                         \
       double focal_length, size_t width, size_t height);                      \
   template <typename T>                                                       \
-  static void ImgFromCam(const T* params, T u, T v, T w, T* x, T* y);         \
+  static bool ImgFromCam(const T* params, T u, T v, T w, T* x, T* y);         \
   static inline void CamFromImg(const double* params,                         \
                                 double x,                                     \
                                 double y,                                     \
@@ -733,8 +733,12 @@ std::vector<double> SimplePinholeCameraModel::InitializeParams(
 }
 
 template <typename T>
-void SimplePinholeCameraModel::ImgFromCam(
+bool SimplePinholeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f = params[0];
   const T c1 = params[1];
   const T c2 = params[2];
@@ -744,6 +748,8 @@ void SimplePinholeCameraModel::ImgFromCam(
   // Transform to image coordinates
   *x = f * u / w + c1;
   *y = f * v / w + c2;
+
+  return true;
 }
 
 void SimplePinholeCameraModel::CamFromImg(
@@ -782,8 +788,12 @@ std::vector<double> PinholeCameraModel::InitializeParams(
 }
 
 template <typename T>
-void PinholeCameraModel::ImgFromCam(
+bool PinholeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f1 = params[0];
   const T f2 = params[1];
   const T c1 = params[2];
@@ -794,6 +804,8 @@ void PinholeCameraModel::ImgFromCam(
   // Transform to image coordinates
   *x = f1 * u / w + c1;
   *y = f2 * v / w + c2;
+
+  return true;
 }
 
 void PinholeCameraModel::CamFromImg(
@@ -833,8 +845,12 @@ std::vector<double> SimpleRadialCameraModel::InitializeParams(
 }
 
 template <typename T>
-void SimpleRadialCameraModel::ImgFromCam(
+bool SimpleRadialCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f = params[0];
   const T c1 = params[1];
   const T c2 = params[2];
@@ -851,6 +867,8 @@ void SimpleRadialCameraModel::ImgFromCam(
   // Transform to image coordinates
   *x = f * *x + c1;
   *y = f * *y + c2;
+
+  return false;
 }
 
 void SimpleRadialCameraModel::CamFromImg(
@@ -905,7 +923,11 @@ std::vector<double> RadialCameraModel::InitializeParams(
 }
 
 template <typename T>
-void RadialCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+bool RadialCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f = params[0];
   const T c1 = params[1];
   const T c2 = params[2];
@@ -922,6 +944,8 @@ void RadialCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
   // Transform to image coordinates
   *x = f * *x + c1;
   *y = f * *y + c2;
+
+  return true;
 }
 
 void RadialCameraModel::CamFromImg(
@@ -977,7 +1001,11 @@ std::vector<double> OpenCVCameraModel::InitializeParams(
 }
 
 template <typename T>
-void OpenCVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+bool OpenCVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f1 = params[0];
   const T f2 = params[1];
   const T c1 = params[2];
@@ -995,6 +1023,8 @@ void OpenCVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
   // Transform to image coordinates
   *x = f1 * *x + c1;
   *y = f2 * *y + c2;
+
+  return true;
 }
 
 void OpenCVCameraModel::CamFromImg(
@@ -1078,8 +1108,12 @@ void OpenCVFisheyeCameraModel::FisheyeFromImg(
 }
 
 template <typename T>
-void OpenCVFisheyeCameraModel::ImgFromCam(
+bool OpenCVFisheyeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   u /= w;
   v /= w;
   T uu, vv;
@@ -1091,6 +1125,8 @@ void OpenCVFisheyeCameraModel::ImgFromCam(
 
   // Transform to image coordinates
   ImgFromFisheye(params, uu + duu, vv + dvv, x, y);
+
+  return true;
 }
 
 void OpenCVFisheyeCameraModel::CamFromImg(
@@ -1156,8 +1192,12 @@ std::vector<double> FullOpenCVCameraModel::InitializeParams(
 }
 
 template <typename T>
-void FullOpenCVCameraModel::ImgFromCam(
+bool FullOpenCVCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f1 = params[0];
   const T f2 = params[1];
   const T c1 = params[2];
@@ -1175,6 +1215,8 @@ void FullOpenCVCameraModel::ImgFromCam(
   // Transform to image coordinates
   *x = f1 * *x + c1;
   *y = f2 * *y + c2;
+
+  return true;
 }
 
 void FullOpenCVCameraModel::CamFromImg(
@@ -1242,7 +1284,11 @@ std::vector<double> FOVCameraModel::InitializeParams(const double focal_length,
 }
 
 template <typename T>
-void FOVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+bool FOVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   const T f1 = params[0];
   const T f2 = params[1];
   const T c1 = params[2];
@@ -1257,6 +1303,8 @@ void FOVCameraModel::ImgFromCam(const T* params, T u, T v, T w, T* x, T* y) {
   // Transform to image coordinates
   *x = f1 * *x + c1;
   *y = f2 * *y + c2;
+
+  return true;
 }
 
 void FOVCameraModel::CamFromImg(
@@ -1401,8 +1449,12 @@ void SimpleRadialFisheyeCameraModel::FisheyeFromImg(
 }
 
 template <typename T>
-void SimpleRadialFisheyeCameraModel::ImgFromCam(
+bool SimpleRadialFisheyeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   u /= w;
   v /= w;
   T uu, vv;
@@ -1414,6 +1466,8 @@ void SimpleRadialFisheyeCameraModel::ImgFromCam(
 
   // Transform to image coordinates
   ImgFromFisheye(params, uu + duu, vv + dvv, x, y);
+
+  return true;
 }
 
 void SimpleRadialFisheyeCameraModel::CamFromImg(
@@ -1483,8 +1537,12 @@ void RadialFisheyeCameraModel::FisheyeFromImg(
 }
 
 template <typename T>
-void RadialFisheyeCameraModel::ImgFromCam(
+bool RadialFisheyeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   u /= w;
   v /= w;
   T uu, vv;
@@ -1496,6 +1554,8 @@ void RadialFisheyeCameraModel::ImgFromCam(
 
   // Transform to image coordinates
   ImgFromFisheye(params, uu + duu, vv + dvv, x, y);
+
+  return true;
 }
 
 void RadialFisheyeCameraModel::CamFromImg(
@@ -1581,8 +1641,12 @@ void ThinPrismFisheyeCameraModel::FisheyeFromImg(
 }
 
 template <typename T>
-void ThinPrismFisheyeCameraModel::ImgFromCam(
+bool ThinPrismFisheyeCameraModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   u /= w;
   v /= w;
   T uu, vv;
@@ -1594,6 +1658,8 @@ void ThinPrismFisheyeCameraModel::ImgFromCam(
 
   // Transform to image coordinates
   ImgFromFisheye(params, uu + duu, vv + dvv, x, y);
+
+  return true;
 }
 
 void ThinPrismFisheyeCameraModel::CamFromImg(
@@ -1690,8 +1756,12 @@ void RadTanThinPrismFisheyeModel::FisheyeFromImg(
 }
 
 template <typename T>
-void RadTanThinPrismFisheyeModel::ImgFromCam(
+bool RadTanThinPrismFisheyeModel::ImgFromCam(
     const T* params, T u, T v, T w, T* x, T* y) {
+  if (w < std::numeric_limits<T>::epsilon()) {
+    return false;
+  }
+
   u /= w;
   v /= w;
   T uu, vv;
@@ -1700,6 +1770,8 @@ void RadTanThinPrismFisheyeModel::ImgFromCam(
   T duu, dvv;
   Distortion(&params[4], uu, vv, &duu, &dvv);
   ImgFromFisheye(params, uu + duu, vv + dvv, x, y);
+
+  return true;
 }
 
 void RadTanThinPrismFisheyeModel::CamFromImg(
@@ -1759,22 +1831,25 @@ void RadTanThinPrismFisheyeModel::Distortion(
   *dv = y_distorted - v;
 }
 
-Eigen::Vector2d CameraModelImgFromCam(const CameraModelId model_id,
-                                      const std::vector<double>& params,
-                                      const Eigen::Vector3d& uvw) {
+std::optional<Eigen::Vector2d> CameraModelImgFromCam(
+    const CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector3d& uvw) {
   Eigen::Vector2d xy;
   switch (model_id) {
-#define CAMERA_MODEL_CASE(CameraModel)                               \
-  case CameraModel::model_id:                                        \
-    CameraModel::ImgFromCam(                                         \
-        params.data(), uvw.x(), uvw.y(), uvw.z(), &xy.x(), &xy.y()); \
+#define CAMERA_MODEL_CASE(CameraModel)                                     \
+  case CameraModel::model_id:                                              \
+    if (CameraModel::ImgFromCam(                                           \
+            params.data(), uvw.x(), uvw.y(), uvw.z(), &xy.x(), &xy.y())) { \
+      return xy;                                                           \
+    }                                                                      \
     break;
 
     CAMERA_MODEL_SWITCH_CASES
 
 #undef CAMERA_MODEL_CASE
   }
-  return xy;
+  return std::nullopt;
 }
 
 Eigen::Vector3d CameraModelCamFromImg(const CameraModelId model_id,

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -538,9 +538,10 @@ bool CameraModelHasBogusParams(CameraModelId model_id,
 // @param params       Array of camera parameters.
 // @param u, v         Coordinates in camera system as (u, v, 1).
 // @param x, y         Output image coordinates in pixels.
-inline Eigen::Vector2d CameraModelImgFromCam(CameraModelId model_id,
-                                             const std::vector<double>& params,
-                                             const Eigen::Vector3d& uvw);
+inline std::optional<Eigen::Vector2d> CameraModelImgFromCam(
+    CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector3d& uvw);
 
 // Transform image to camera coordinates.
 //
@@ -868,7 +869,7 @@ bool SimpleRadialCameraModel::ImgFromCam(
   *x = f * *x + c1;
   *y = f * *y + c2;
 
-  return false;
+  return true;
 }
 
 void SimpleRadialCameraModel::CamFromImg(

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -68,10 +68,11 @@ void TestCamToCamFromImg(const std::vector<double>& params,
                          const double w0) {
   double u, v, w, x, y;
   CameraModel::ImgFromCam(params.data(), u0, v0, w0, &x, &y);
-  const Eigen::Vector2d xy = CameraModelImgFromCam(
+  const std::optional<Eigen::Vector2d> xy = CameraModelImgFromCam(
       CameraModel::model_id, params, Eigen::Vector3d(u0, v0, w0));
-  EXPECT_EQ(x, xy.x());
-  EXPECT_EQ(y, xy.y());
+  ASSERT_TRUE(xy.has_value());
+  EXPECT_EQ(x, xy->x());
+  EXPECT_EQ(y, xy->y());
   CameraModel::CamFromImg(params.data(), x, y, &u, &v, &w);
   EXPECT_NEAR(u, u0 / w0, 1e-6);
   EXPECT_NEAR(v, v0 / w0, 1e-6);
@@ -88,7 +89,7 @@ void TestCamFromImgToImg(const std::vector<double>& params,
   EXPECT_EQ(u, uvw.x());
   EXPECT_EQ(v, uvw.y());
   EXPECT_EQ(w, uvw.z());
-  CameraModel::ImgFromCam(params.data(), u, v, w, &x, &y);
+  ASSERT_TRUE(CameraModel::ImgFromCam(params.data(), u, v, w, &x, &y));
   EXPECT_NEAR(x, x0, 1e-6);
   EXPECT_NEAR(y, y0, 1e-6);
 }

--- a/src/colmap/ui/point_viewer_widget.cc
+++ b/src/colmap/ui/point_viewer_widget.cc
@@ -181,9 +181,14 @@ void PointViewerWidget::Show(const point3D_t point3D_id) {
     const Image& image = model_viewer_widget_->images[track_el.first.image_id];
     const Camera& camera = model_viewer_widget_->cameras[image.CameraId()];
     const Point2D& point2D = image.Point2D(track_el.first.point2D_idx);
-    const Eigen::Vector2d proj_point2D =
-        camera.ImgFromCam((image.CamFromWorld() * point3D.xyz).hnormalized());
-    const double reproj_error = (point2D.xy - proj_point2D).norm();
+    const std::optional<Eigen::Vector2d> proj_point2D =
+        camera.ImgFromCam(image.CamFromWorld() * point3D.xyz);
+    if (!proj_point2D) {
+      LOG(WARNING) << "Failed to project point into image " << image.Name();
+      continue;
+    }
+
+    const double reproj_error = (point2D.xy - *proj_point2D).norm();
 
     Bitmap bitmap;
     const std::string path = JoinPaths(*options_->image_path, image.Name());
@@ -214,8 +219,8 @@ void PointViewerWidget::Show(const point3D_t point3D_id) {
     pen.setColor(Qt::red);
     painter.setPen(pen);
 
-    const int proj_x = static_cast<int>(std::round(proj_point2D.x()));
-    const int proj_y = static_cast<int>(std::round(proj_point2D.y()));
+    const int proj_x = static_cast<int>(std::round(proj_point2D->x()));
+    const int proj_y = static_cast<int>(std::round(proj_point2D->y()));
     painter.drawEllipse(proj_x - 5, proj_y - 5, 10, 10);
     painter.drawEllipse(proj_x - 15, proj_y - 15, 30, 30);
     painter.drawEllipse(proj_x - 45, proj_y - 45, 90, 90);

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -148,7 +148,14 @@ void BindCamera(py::module& m) {
              const py::EigenDRef<const Eigen::MatrixX2d>& world_points) {
             std::vector<Eigen::Vector2d> image_points(world_points.rows());
             for (size_t idx = 0; idx < world_points.rows(); ++idx) {
-              image_points[idx] = self.ImgFromCam(world_points.row(idx));
+              const std::optional<Eigen::Vector2d> image_point =
+                  self.ImgFromCam(world_points.row(idx).homogeneous());
+              if (image_point) {
+                image_points[idx] = *image_point;
+              } else {
+                image_points[idx].setConstant(
+                    std::numeric_limits<double>::quiet_NaN());
+              }
             }
             return image_points;
           },
@@ -168,7 +175,14 @@ void BindCamera(py::module& m) {
           [](const Camera& self, const Point2DVector& world_points) {
             std::vector<Eigen::Vector2d> image_points(world_points.size());
             for (size_t idx = 0; idx < world_points.size(); ++idx) {
-              image_points[idx] = self.ImgFromCam(world_points[idx].xy);
+              const std::optional<Eigen::Vector2d> image_point =
+                  self.ImgFromCam(world_points[idx].xy.homogeneous());
+              if (image_point) {
+                image_points[idx] = *image_point;
+              } else {
+                image_points[idx].setConstant(
+                    std::numeric_limits<double>::quiet_NaN());
+              }
             }
             return image_points;
           },

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -159,8 +159,8 @@ void BindCamera(py::module& m) {
           [](const Camera& self,
              const py::EigenDRef<const Eigen::MatrixX3d>& cam_points) {
             const size_t num_points = cam_points.rows();
-            std::vector<Eigen::Vector2d> image_points(cam_points.rows());
-            for (size_t i = 0; i < cam_points.rows(); ++i) {
+            std::vector<Eigen::Vector2d> image_points(num_points);
+            for (size_t i = 0; i < num_points; ++i) {
               const std::optional<Eigen::Vector2d> image_point =
                   self.ImgFromCam(cam_points.row(i));
               if (image_point) {
@@ -197,14 +197,15 @@ void BindCamera(py::module& m) {
                 "img_from_cam() with normalized 2D points as input is "
                 "deprecated. Instead, pass 3D points in the camera frame.",
                 1);
-            std::vector<Eigen::Vector2d> image_points(cam_points.size());
-            for (size_t idx = 0; idx < cam_points.size(); ++idx) {
+            const size_t num_points = cam_points.size();
+            std::vector<Eigen::Vector2d> image_points(num_points);
+            for (size_t i = 0; i < num_points; ++i) {
               const std::optional<Eigen::Vector2d> image_point =
-                  self.ImgFromCam(cam_points[idx].xy.homogeneous());
+                  self.ImgFromCam(cam_points[i].xy.homogeneous());
               if (image_point) {
-                image_points[idx] = *image_point;
+                image_points[i] = *image_point;
               } else {
-                image_points[idx].setConstant(
+                image_points[i].setConstant(
                     std::numeric_limits<double>::quiet_NaN());
               }
             }

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -110,7 +110,7 @@ void BindCamera(py::module& m) {
       .def("cam_from_img",
            &Camera::CamFromImg,
            "image_point"_a,
-           "Project point in image plane to world / infinity.")
+           "Project point in image plane to camera frame.")
       .def(
           "cam_from_img",
           [](const Camera& self,
@@ -122,7 +122,7 @@ void BindCamera(py::module& m) {
             return world_points;
           },
           "image_points"_a,
-          "Project list of points in image plane to world / infinity.")
+          "Project list of points in image plane to camera frame.")
       .def(
           "cam_from_img",
           [](const Camera& self, const Point2DVector& image_points) {
@@ -133,7 +133,7 @@ void BindCamera(py::module& m) {
             return world_points;
           },
           "image_points"_a,
-          "Project list of points in image plane to world / infinity.")
+          "Project list of points in image plane to camera frame.")
       .def("cam_from_img_threshold",
            &Camera::CamFromImgThreshold,
            "threshold"_a,
@@ -141,42 +141,66 @@ void BindCamera(py::module& m) {
       .def("img_from_cam",
            &Camera::ImgFromCam,
            "cam_point"_a,
-           "Project point from world / infinity to image plane.")
+           "Project point from camera frame to image plane.")
+      .def(
+          "img_from_cam",
+          [](const Camera& self, const Eigen::Vector2d& cam_point) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "img_from_cam() with normalized 2D points as input is "
+                "deprecated. Instead, pass 3D points in the camera frame.",
+                1);
+            return self.ImgFromCam(cam_point.homogeneous());
+          },
+          "cam_point"_a,
+          "(Deprecated) Project point from camera frame to image plane.")
       .def(
           "img_from_cam",
           [](const Camera& self,
-             const py::EigenDRef<const Eigen::MatrixX2d>& world_points) {
-            std::vector<Eigen::Vector2d> image_points(world_points.rows());
-            for (size_t idx = 0; idx < world_points.rows(); ++idx) {
+             const py::EigenDRef<const Eigen::MatrixX3d>& cam_points) {
+            const size_t num_points = cam_points.rows();
+            std::vector<Eigen::Vector2d> image_points(cam_points.rows());
+            for (size_t i = 0; i < cam_points.rows(); ++i) {
               const std::optional<Eigen::Vector2d> image_point =
-                  self.ImgFromCam(world_points.row(idx).homogeneous());
+                  self.ImgFromCam(cam_points.row(i));
               if (image_point) {
-                image_points[idx] = *image_point;
+                image_points[i] = *image_point;
               } else {
-                image_points[idx].setConstant(
+                image_points[i].setConstant(
                     std::numeric_limits<double>::quiet_NaN());
               }
             }
             return image_points;
           },
           "cam_points"_a,
-          "Project list of points from world / infinity to image plane.")
+          "Project list of points from camera frame to image plane.")
       .def(
           "img_from_cam",
           [](const Camera& self,
-             const py::EigenDRef<const Eigen::MatrixX3d>& world_points) {
+             const py::EigenDRef<const Eigen::MatrixX2d>& cam_points) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "img_from_cam() with normalized 2D points as input is "
+                "deprecated. Instead, pass 3D points in the camera frame.",
+                1);
             return py::cast(self).attr("img_from_cam")(
-                world_points.rowwise().hnormalized());
+                cam_points.rowwise().homogeneous());
           },
           "cam_points"_a,
-          "Project list of points from world / infinity to image plane.")
+          "(Deprecated) Project list of points from camera frame to image "
+          "plane.")
       .def(
           "img_from_cam",
-          [](const Camera& self, const Point2DVector& world_points) {
-            std::vector<Eigen::Vector2d> image_points(world_points.size());
-            for (size_t idx = 0; idx < world_points.size(); ++idx) {
+          [](const Camera& self, const Point2DVector& cam_points) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "img_from_cam() with normalized 2D points as input is "
+                "deprecated. Instead, pass 3D points in the camera frame.",
+                1);
+            std::vector<Eigen::Vector2d> image_points(cam_points.size());
+            for (size_t idx = 0; idx < cam_points.size(); ++idx) {
               const std::optional<Eigen::Vector2d> image_point =
-                  self.ImgFromCam(world_points[idx].xy.homogeneous());
+                  self.ImgFromCam(cam_points[idx].xy.homogeneous());
               if (image_point) {
                 image_points[idx] = *image_point;
               } else {
@@ -187,7 +211,7 @@ void BindCamera(py::module& m) {
             return image_points;
           },
           "cam_points"_a,
-          "Project list of points from world / infinity to image plane.")
+          "Project list of points from camera frame to image plane.")
       .def("rescale",
            py::overload_cast<size_t, size_t>(&Camera::Rescale),
            "new_width"_a,

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -126,19 +126,10 @@ void BindImage(py::module& m) {
       .def("viewing_direction",
            &Image::ViewingDirection,
            "Extract the viewing direction of the image.")
-      .def(
-          "project_point",
-          [](const Image& self, const Eigen::Vector3d& point3D)
-              -> py::typing::Optional<Eigen::Vector2d> {
-            auto result = self.ProjectPoint(point3D);
-            if (result.first) {
-              return py::cast(result.second);
-            } else {
-              return py::none();
-            }
-          },
-          "Project 3D point onto the image",
-          "point3D"_a)
+      .def("project_point",
+           &Image::ProjectPoint,
+           "Project 3D point onto the image",
+           "point3D"_a)
       .def("has_camera_id",
            &Image::HasCameraId,
            "Check whether identifier of camera has been set.")


### PR DESCRIPTION
Towards supporting spherical / large FOV cameras for which a different logic will have to be implemented than for perspective projection models. The logic is now specialized and localized within the camera model and the user just knows about valid or invalid projections. This can also be used to more robustly deal with numerical issues in distortion computation (as we have for some of the fisheye models).

The next PRs will do the equivalent for CamFromImg to return camera rays rather than image points as well as remove redundant "HasPointPositiveDepth/Cheirality" checks.