### PR TITLE
Fix pycolmap ci build for pull requests

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -33,7 +33,7 @@ jobs:
       CCACHE_BASEDIR: ${{ github.workspace }}
       MACOSX_DEPLOYMENT_TARGET: 10.15
       # For faster builds in PRs, skip all but the latest Python versions.
-      PULL_REQUEST_CIBW_BUILD: cp312-{macosx,manylinux,win}*
+      PULL_REQUEST_CIBW_BUILD: cp3{8,12}-{macosx,manylinux,win}*
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -33,7 +33,7 @@ jobs:
       CCACHE_BASEDIR: ${{ github.workspace }}
       MACOSX_DEPLOYMENT_TARGET: 10.15
       # For faster builds in PRs, skip all but the latest Python versions.
-      PULL_REQUEST_CIBW_BUILD: cp38-{macosx,manylinux,win}*
+      PULL_REQUEST_CIBW_BUILD: cp312-{macosx,manylinux,win}*
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -32,8 +32,8 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/compiler-cache/ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
       MACOSX_DEPLOYMENT_TARGET: 10.15
-      # For faster builds in PRs, skip all but the latest Python versions.
-      PULL_REQUEST_CIBW_BUILD: cp3{8,12}-{macosx,manylinux,win}*
+      # For faster builds in PRs, skip all but the oldest Python versions.
+      PULL_REQUEST_CIBW_BUILD: cp38-{macosx,manylinux,win}*
     steps:
       - uses: actions/checkout@v4
 

--- a/src/pycolmap/sensor/bitmap.cc
+++ b/src/pycolmap/sensor/bitmap.cc
@@ -10,6 +10,11 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
+#ifdef _MSC_VER  // If compiling with MSVC
+#include <stddef.h>
+typedef ptrdiff_t ssize_t;
+#endif
+
 void BindBitmap(pybind11::module& m) {
   py::class_<Bitmap>(m, "Bitmap")
       .def(py::init<>())


### PR DESCRIPTION
We got hit by the partial python version for the pycolmap CI build again: https://github.com/colmap/colmap/actions/runs/13519440475/job/37775195384

And I just realized that we are always building 3.8 rather than 3.12 on all the pycolmap ci build for pull requests. Was this intended? As it does not align with the comment here: https://github.com/colmap/colmap/blob/main/.github/workflows/build-pycolmap.yml#L35