### PR TITLE
Define bindings in the correct order

### DIFF
--- a/pycolmap/generate_stubs.sh
+++ b/pycolmap/generate_stubs.sh
@@ -13,7 +13,6 @@ $PYTHON_EXEC -m pybind11_stubgen $PACKAGE_NAME -o $OUTPUT \
         --print-safe-value-reprs "[a-zA-Z]+Options\(\)"
 FILES=$(find $OUTPUT/$PACKAGE_NAME/ -name '*.pyi' -type f)
 
-perl -i -pe's/colmap:://g' $FILES
 perl -i -pe's/\b_core\b/pycolmap/g' $FILES
 perl -i -pe's/: ceres::([a-zA-Z]|::)+//g' $FILES
 perl -i -pe's/ -> ceres::([a-zA-Z]|::)+:$/:/g' $FILES

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -53,9 +53,9 @@ PYBIND11_MODULE(_core, m) {
   BindSensor(m);
   BindImage(m);
   BindEstimators(m);
+  BindFeature(m);
   BindRetrieval(m);
   BindSfm(m);
-  BindFeature(m);
   BindPipeline(m);
 
   m.def("set_random_seed",


### PR DESCRIPTION
Following an issue introduced in https://github.com/colmap/colmap/pull/3185, since the type annotation of `QueryOptions.add` depends on `FeatureKeypoint`.