### PR TITLE
Fix maybe-uninitialized warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,6 @@ if(IS_GNU)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
         message(FATAL_ERROR "GCC version 4.8 or older not supported")
     endif()
-
-    # Hide incorrect warnings for uninitialized Eigen variables under GCC.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-maybe-uninitialized")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 endif()
 
 if(IS_MACOS)

--- a/src/colmap/estimators/similarity_transform.cc
+++ b/src/colmap/estimators/similarity_transform.cc
@@ -67,7 +67,7 @@ EstimateRigidOrSim3dRobust(const std::vector<Eigen::Vector3d>& src,
 bool EstimateRigid3d(const std::vector<Eigen::Vector3d>& src,
                      const std::vector<Eigen::Vector3d>& tgt,
                      Rigid3d& tgt_from_src) {
-  Eigen::Matrix3x4d tgt_from_src_mat;
+  Eigen::Matrix3x4d tgt_from_src_mat = Eigen::Matrix3x4d::Zero();
   if (!EstimateRigidOrSim3d<false>(src, tgt, tgt_from_src_mat)) {
     return false;
   }
@@ -80,7 +80,7 @@ EstimateRigid3dRobust(const std::vector<Eigen::Vector3d>& src,
                       const std::vector<Eigen::Vector3d>& tgt,
                       const RANSACOptions& options,
                       Rigid3d& tgt_from_src) {
-  Eigen::Matrix3x4d tgt_from_src_mat;
+  Eigen::Matrix3x4d tgt_from_src_mat = Eigen::Matrix3x4d::Zero();
   auto report =
       EstimateRigidOrSim3dRobust<false>(src, tgt, options, tgt_from_src_mat);
   tgt_from_src = Rigid3d::FromMatrix(tgt_from_src_mat);
@@ -90,7 +90,7 @@ EstimateRigid3dRobust(const std::vector<Eigen::Vector3d>& src,
 bool EstimateSim3d(const std::vector<Eigen::Vector3d>& src,
                    const std::vector<Eigen::Vector3d>& tgt,
                    Sim3d& tgt_from_src) {
-  Eigen::Matrix3x4d tgt_from_src_mat;
+  Eigen::Matrix3x4d tgt_from_src_mat = Eigen::Matrix3x4d::Zero();
   if (!EstimateRigidOrSim3d<true>(src, tgt, tgt_from_src_mat)) {
     return false;
   }
@@ -103,7 +103,7 @@ EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
                     const std::vector<Eigen::Vector3d>& tgt,
                     const RANSACOptions& options,
                     Sim3d& tgt_from_src) {
-  Eigen::Matrix3x4d tgt_from_src_mat;
+  Eigen::Matrix3x4d tgt_from_src_mat = Eigen::Matrix3x4d::Zero();
   auto report =
       EstimateRigidOrSim3dRobust<true>(src, tgt, options, tgt_from_src_mat);
   tgt_from_src = Sim3d::FromMatrix(tgt_from_src_mat);

--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -35,6 +35,7 @@
 #include "colmap/util/logging.h"
 
 #include <cfloat>
+#include <optional>
 #include <random>
 #include <stdexcept>
 #include <vector>
@@ -117,7 +118,7 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
   }
 
   typename SupportMeasurer::Support best_support;
-  typename Estimator::M_t best_model;
+  std::optional<typename Estimator::M_t> best_model;
   bool best_model_is_local = false;
 
   bool abort = false;
@@ -234,8 +235,12 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
     }
   }
 
+  if (!best_model.has_value()) {
+    return report;
+  }
+
   report.support = best_support;
-  report.model = best_model;
+  report.model = best_model.value();
 
   // No valid model was found
   if (report.support.num_inliers < estimator.kMinNumSamples) {

--- a/src/colmap/optim/ransac.h
+++ b/src/colmap/optim/ransac.h
@@ -34,6 +34,7 @@
 #include "colmap/util/logging.h"
 
 #include <cfloat>
+#include <optional>
 #include <random>
 #include <stdexcept>
 #include <vector>
@@ -201,7 +202,7 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
   }
 
   typename SupportMeasurer::Support best_support;
-  typename Estimator::M_t best_model;
+  std::optional<typename Estimator::M_t> best_model;
 
   bool abort = false;
 
@@ -259,8 +260,12 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
     }
   }
 
+  if (!best_model.has_value()) {
+    return report;
+  }
+
   report.support = best_support;
-  report.model = best_model;
+  report.model = best_model.value();
 
   // No valid model was found.
   if (report.support.num_inliers < estimator.kMinNumSamples) {


### PR DESCRIPTION
Fix some code that result in maybe-uninitialized compiler warnings:
 - best_model in ransac and loransac can be uninitialized -> use optional,
 - initialize Eigen matrices to 0 in EstimateRigid3d and other similar functions.

Also, don't turn the warning type off CMakeLists.txt.

Unfortunately, there are 3 other such warnings that originate outside, namely in boost graph.

