### PR TITLE
Fix compilation errors with PoissonRecon

### DIFF
--- a/src/thirdparty/PoissonRecon/Ply.h
+++ b/src/thirdparty/PoissonRecon/Ply.h
@@ -340,7 +340,7 @@ public:
 	PlyOrientedVertex( void ) { ; }
 	PlyOrientedVertex( Point3D< Real > p , Point3D< Real > n ) : point(p) , normal(n) { ; }
   	PlyOrientedVertex operator + ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point+p.point , normal+p.normal ); }
-	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.value , normal-p.normal ); }
+	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.point , normal-p.normal ); }
 	template< class _Real > PlyOrientedVertex operator * ( _Real s ) const { return PlyOrientedVertex( point*s , normal*s ); }
 	template< class _Real > PlyOrientedVertex operator / ( _Real s ) const { return PlyOrientedVertex( point/s , normal/s ); }
 	PlyOrientedVertex& operator += ( PlyOrientedVertex p ) { point += p.point , normal += p.normal ; return *this; }
@@ -386,7 +386,7 @@ public:
 		}
 
 	  	_PlyColorVertex operator + ( _PlyColorVertex p ) const { return _PlyColorVertex( point+p.point , color+p.color ); }
-		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.value , color-p.color ); }
+		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.point , color-p.color ); }
 		template< class _Real > _PlyColorVertex operator * ( _Real s ) const { return _PlyColorVertex( point*s , color*s ); }
 		template< class _Real > _PlyColorVertex operator / ( _Real s ) const { return _PlyColorVertex( point/s , color/s ); }
 		_PlyColorVertex& operator += ( _PlyColorVertex p ) { point += p.point , color += p.color ; return *this; }

--- a/src/thirdparty/PoissonRecon/SparseMatrix.inl
+++ b/src/thirdparty/PoissonRecon/SparseMatrix.inl
@@ -195,7 +195,7 @@ void SparseMatrix< T >::SetRowSize( int row , int count )
 template<class T>
 void SparseMatrix<T>::SetZero()
 {
-	Resize(this->m_N, this->m_M);
+	Resize(this->rows, this->_maxEntriesPerRow);
 }
 
 template<class T>


### PR DESCRIPTION
Trying to compile colmap with gcc-14.2.1 lead to compilation errors in PoissonRecon third party library.

These errors weren't visible before since it is a templated class, and these methods were never called, and hence never evaluated by the compiler to be correctly formed.
