### PR TITLE
Remove Ubuntu 20.04 from the CI

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -71,26 +71,6 @@ jobs:
             checkCodeFormat: false,
             coverageEnabled: false,
           },
-          {
-            os: ubuntu-20.04,
-            cmakeBuildType: Release,
-            asanEnabled: false,
-            guiEnabled: true,
-            cudaEnabled: false,
-            e2eTests: false,
-            checkCodeFormat: false,
-            coverageEnabled: false,
-          },
-          {
-            os: ubuntu-20.04,
-            cmakeBuildType: Release,
-            asanEnabled: false,
-            guiEnabled: false,
-            cudaEnabled: true,
-            e2eTests: false,
-            checkCodeFormat: false,
-            coverageEnabled: false,
-          },
         ]
 
     env:


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will be fully unsupported by 2025-04-01 and temporarily removed on March 4, 11, 18, 25: https://github.com/actions/runner-images/issues/11101