### PR TITLE
Fix bug when toggling rendering

### DIFF
--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -1372,7 +1372,7 @@ void MainWindow::RenderToggle() {
   } else {
     render_options_widget_->automatic_update = true;
     render_options_widget_->counter = 0;
-    Render();
+    RenderNow();
     action_render_toggle_->setIcon(QIcon(":/media/render-enabled.png"));
     action_render_toggle_->setText(tr("Disable rendering"));
   }


### PR DESCRIPTION
Without this change, the application crashes when toggling the rendering directly after initialization, because no reconstruction was selected.