### PR TITLE
Retire Reconstruction::IsImageRegistered in favor of existing Image::HasPose

### DIFF
--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -204,7 +204,7 @@ bool AlignReconstructionToLocations(
       continue;
     }
 
-    if (!src_reconstruction.IsImageRegistered(src_image->ImageId())) {
+    if (!src_image->HasPose()) {
       continue;
     }
 
@@ -388,11 +388,11 @@ bool AlignReconstructionsViaPoints(const Reconstruction& src_reconstruction,
     counts.clear();
     // Count how often a 3D point in tgt is associated to this 3D point.
     for (const auto& track_el : src_point3D.second.track.Elements()) {
-      if (!tgt_reconstruction.IsImageRegistered(track_el.image_id)) {
+      const Image& tgt_image = tgt_reconstruction.Image(track_el.image_id);
+      if (!tgt_image.HasPose()) {
         continue;
       }
-      const Point2D& tgt_point2D = tgt_reconstruction.Image(track_el.image_id)
-                                       .Point2D(track_el.point2D_idx);
+      const Point2D& tgt_point2D = tgt_image.Point2D(track_el.point2D_idx);
       if (tgt_point2D.HasPoint3D()) {
         if (counts.find(tgt_point2D.point3D_id) != counts.end()) {
           counts[tgt_point2D.point3D_id]++;

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -115,7 +115,7 @@ void Reconstruction::TearDown() {
   // Remove all not yet registered images.
   std::unordered_set<camera_t> keep_camera_ids;
   for (auto it = images_.begin(); it != images_.end();) {
-    if (IsImageRegistered(it->first)) {
+    if (it->second.HasPose()) {
       keep_camera_ids.insert(it->second.CameraId());
       ++it;
     } else {
@@ -436,8 +436,7 @@ std::vector<std::pair<image_t, image_t>> Reconstruction::FindCommonRegImageIds(
   for (const auto image_id : RegImageIds()) {
     const auto& image = Image(image_id);
     const auto* other_image = other.FindImageWithName(image.Name());
-    if (other_image != nullptr &&
-        other.IsImageRegistered(other_image->ImageId())) {
+    if (other_image != nullptr && other_image->HasPose()) {
       common_reg_image_ids.emplace_back(image_id, other_image->ImageId());
     }
   }

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -145,9 +145,6 @@ class Reconstruction {
   // De-register an existing image, and all its references.
   void DeRegisterImage(image_t image_id);
 
-  // Check if image is registered.
-  inline bool IsImageRegistered(image_t image_id) const;
-
   // Normalize scene by scaling and translation to improve numerical stability
   // of algorithms.
   //
@@ -356,10 +353,6 @@ bool Reconstruction::ExistsImage(const image_t image_id) const {
 
 bool Reconstruction::ExistsPoint3D(const point3D_t point3D_id) const {
   return points3D_.find(point3D_id) != points3D_.end();
-}
-
-bool Reconstruction::IsImageRegistered(const image_t image_id) const {
-  return reg_image_ids_.find(image_id) != reg_image_ids_.end();
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/reconstruction_io.cc
+++ b/src/colmap/scene/reconstruction_io.cc
@@ -1082,7 +1082,7 @@ void ExportVRML(const Reconstruction& reconstruction,
   points.emplace_back(-six / 3.0, +siy / 3.0, six * 1.0 * 2.0);
 
   for (const auto& [image_id, image] : reconstruction.Images()) {
-    if (!reconstruction.IsImageRegistered(image_id)) {
+    if (!image.HasPose()) {
       continue;
     }
 

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -167,7 +167,7 @@ TEST(Reconstruction, AddImage) {
   reconstruction.AddImage(image);
   EXPECT_TRUE(reconstruction.ExistsImage(1));
   EXPECT_EQ(reconstruction.Image(1).ImageId(), 1);
-  EXPECT_FALSE(reconstruction.IsImageRegistered(1));
+  EXPECT_FALSE(reconstruction.Image(1).HasPose());
   EXPECT_EQ(reconstruction.Images().count(1), 1);
   EXPECT_EQ(reconstruction.Images().size(), 1);
   EXPECT_EQ(reconstruction.NumCameras(), 1);
@@ -276,15 +276,12 @@ TEST(Reconstruction, RegisterImage) {
   GenerateReconstruction(1, &reconstruction);
   EXPECT_EQ(reconstruction.NumRegImages(), 1);
   EXPECT_TRUE(reconstruction.Image(1).HasPose());
-  EXPECT_TRUE(reconstruction.IsImageRegistered(1));
   reconstruction.RegisterImage(1);
   EXPECT_EQ(reconstruction.NumRegImages(), 1);
   EXPECT_TRUE(reconstruction.Image(1).HasPose());
-  EXPECT_TRUE(reconstruction.IsImageRegistered(1));
   reconstruction.DeRegisterImage(1);
   EXPECT_EQ(reconstruction.NumRegImages(), 0);
   EXPECT_FALSE(reconstruction.Image(1).HasPose());
-  EXPECT_FALSE(reconstruction.IsImageRegistered(1));
 }
 
 TEST(Reconstruction, Normalize) {
@@ -444,9 +441,9 @@ TEST(Reconstruction, Crop) {
   EXPECT_EQ(cropped2.NumImages(), 3);
   EXPECT_EQ(cropped2.NumRegImages(), 2);
   EXPECT_EQ(cropped2.NumPoints3D(), 3);
-  EXPECT_TRUE(cropped2.IsImageRegistered(1));
-  EXPECT_TRUE(cropped2.IsImageRegistered(2));
-  EXPECT_FALSE(cropped2.IsImageRegistered(3));
+  EXPECT_TRUE(cropped2.Image(1).HasPose());
+  EXPECT_TRUE(cropped2.Image(2).HasPose());
+  EXPECT_FALSE(cropped2.Image(3).HasPose());
 }
 
 TEST(Reconstruction, Transform) {

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -31,9 +31,9 @@ void BindReconstruction(py::module& m) {
       .def(py::init<>())
       .def(py::init<const Reconstruction&>(), "reconstruction"_a)
       .def(py::init([](const std::string& path) {
-             auto reconstruction = std::make_shared<Reconstruction>();
-             reconstruction->Read(path);
-             return reconstruction;
+    auto reconstruction = std::make_shared<Reconstruction>();
+    reconstruction->Read(path);
+    return reconstruction;
            }),
            "path"_a)
       .def("read",
@@ -213,45 +213,46 @@ void BindReconstruction(py::module& m) {
       .def(
           "check",
           [](Reconstruction& self) {
-            for (auto& p3D_p : self.Points3D()) {
-              const Point3D& p3D = p3D_p.second;
-              const point3D_t p3Did = p3D_p.first;
-              for (auto& track_el : p3D.track.Elements()) {
-                image_t image_id = track_el.image_id;
-                point2D_t point2D_idx = track_el.point2D_idx;
-                THROW_CHECK(self.ExistsImage(image_id)) << image_id;
-                const Image& image = self.Image(image_id);
-                THROW_CHECK(image.HasPose());
-                THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);
-              }
-            }
-            for (auto& image_id : self.RegImageIds()) {
-              THROW_CHECK(self.Image(image_id).HasCameraId()) << image_id;
-              camera_t camera_id = self.Image(image_id).CameraId();
-              THROW_CHECK(self.ExistsCamera(camera_id)) << camera_id;
-            }
+    for (auto& p3D_p : self.Points3D()) {
+      const Point3D& p3D = p3D_p.second;
+      const point3D_t p3Did = p3D_p.first;
+      for (auto& track_el : p3D.track.Elements()) {
+        image_t image_id = track_el.image_id;
+        point2D_t point2D_idx = track_el.point2D_idx;
+        THROW_CHECK(self.ExistsImage(image_id)) << image_id;
+        const Image& image = self.Image(image_id);
+        THROW_CHECK(image.HasPose());
+        THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);
+      }
+    }
+    for (auto& image_id : self.RegImageIds()) {
+      THROW_CHECK(self.Image(image_id).HasCameraId()) << image_id;
+      camera_t camera_id = self.Image(image_id).CameraId();
+      THROW_CHECK(self.ExistsCamera(camera_id)) << camera_id;
+    }
           },
           "Check if current reconstruction is well formed.")
       .def("__copy__",
-           [](const Reconstruction& self) { return Reconstruction(self); })
+           [](const Reconstruction& self) {
+    return Reconstruction(self); })
       .def("__deepcopy__",
            [](const Reconstruction& self, const py::dict&) {
-             return Reconstruction(self);
+    return Reconstruction(self);
            })
       .def("__repr__", &CreateRepresentation<Reconstruction>)
       .def("summary", [](const Reconstruction& self) {
-        std::ostringstream ss;
-        ss << "Reconstruction:"
-           << "\n\tnum_cameras = " << self.NumCameras()
-           << "\n\tnum_images = " << self.NumImages()
-           << "\n\tnum_reg_images = " << self.NumRegImages()
-           << "\n\tnum_points3D = " << self.NumPoints3D()
-           << "\n\tnum_observations = " << self.ComputeNumObservations()
-           << "\n\tmean_track_length = " << self.ComputeMeanTrackLength()
-           << "\n\tmean_observations_per_image = "
-           << self.ComputeMeanObservationsPerRegImage()
-           << "\n\tmean_reprojection_error = "
-           << self.ComputeMeanReprojectionError();
-        return ss.str();
+    std::ostringstream ss;
+    ss << "Reconstruction:"
+       << "\n\tnum_cameras = " << self.NumCameras()
+       << "\n\tnum_images = " << self.NumImages()
+       << "\n\tnum_reg_images = " << self.NumRegImages()
+       << "\n\tnum_points3D = " << self.NumPoints3D()
+       << "\n\tnum_observations = " << self.ComputeNumObservations()
+       << "\n\tmean_track_length = " << self.ComputeMeanTrackLength()
+       << "\n\tmean_observations_per_image = "
+       << self.ComputeMeanObservationsPerRegImage()
+       << "\n\tmean_reprojection_error = "
+       << self.ComputeMeanReprojectionError();
+    return ss.str();
       });
 }

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -135,9 +135,6 @@ void BindReconstruction(py::module& m) {
            &Reconstruction::DeRegisterImage,
            "image_id"_a,
            "De-register an existing image, and all its references.")
-      .def("is_image_registered",
-           &Reconstruction::IsImageRegistered,
-           "image_id"_a,
            "Check if image is registered.")
       .def("normalize",
            &Reconstruction::Normalize,
@@ -223,7 +220,6 @@ void BindReconstruction(py::module& m) {
                 image_t image_id = track_el.image_id;
                 point2D_t point2D_idx = track_el.point2D_idx;
                 THROW_CHECK(self.ExistsImage(image_id)) << image_id;
-                THROW_CHECK(self.IsImageRegistered(image_id)) << image_id;
                 const Image& image = self.Image(image_id);
                 THROW_CHECK(image.HasPose());
                 THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -31,9 +31,9 @@ void BindReconstruction(py::module& m) {
       .def(py::init<>())
       .def(py::init<const Reconstruction&>(), "reconstruction"_a)
       .def(py::init([](const std::string& path) {
-    auto reconstruction = std::make_shared<Reconstruction>();
-    reconstruction->Read(path);
-    return reconstruction;
+             auto reconstruction = std::make_shared<Reconstruction>();
+             reconstruction->Read(path);
+             return reconstruction;
            }),
            "path"_a)
       .def("read",
@@ -135,7 +135,6 @@ void BindReconstruction(py::module& m) {
            &Reconstruction::DeRegisterImage,
            "image_id"_a,
            "De-register an existing image, and all its references.")
-           "Check if image is registered.")
       .def("normalize",
            &Reconstruction::Normalize,
            "fixed_scale"_a = false,
@@ -213,46 +212,45 @@ void BindReconstruction(py::module& m) {
       .def(
           "check",
           [](Reconstruction& self) {
-    for (auto& p3D_p : self.Points3D()) {
-      const Point3D& p3D = p3D_p.second;
-      const point3D_t p3Did = p3D_p.first;
-      for (auto& track_el : p3D.track.Elements()) {
-        image_t image_id = track_el.image_id;
-        point2D_t point2D_idx = track_el.point2D_idx;
-        THROW_CHECK(self.ExistsImage(image_id)) << image_id;
-        const Image& image = self.Image(image_id);
-        THROW_CHECK(image.HasPose());
-        THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);
-      }
-    }
-    for (auto& image_id : self.RegImageIds()) {
-      THROW_CHECK(self.Image(image_id).HasCameraId()) << image_id;
-      camera_t camera_id = self.Image(image_id).CameraId();
-      THROW_CHECK(self.ExistsCamera(camera_id)) << camera_id;
-    }
+            for (auto& p3D_p : self.Points3D()) {
+              const Point3D& p3D = p3D_p.second;
+              const point3D_t p3Did = p3D_p.first;
+              for (auto& track_el : p3D.track.Elements()) {
+                image_t image_id = track_el.image_id;
+                point2D_t point2D_idx = track_el.point2D_idx;
+                THROW_CHECK(self.ExistsImage(image_id)) << image_id;
+                const Image& image = self.Image(image_id);
+                THROW_CHECK(image.HasPose());
+                THROW_CHECK_EQ(image.Point2D(point2D_idx).point3D_id, p3Did);
+              }
+            }
+            for (auto& image_id : self.RegImageIds()) {
+              THROW_CHECK(self.Image(image_id).HasCameraId()) << image_id;
+              camera_t camera_id = self.Image(image_id).CameraId();
+              THROW_CHECK(self.ExistsCamera(camera_id)) << camera_id;
+            }
           },
           "Check if current reconstruction is well formed.")
       .def("__copy__",
-           [](const Reconstruction& self) {
-    return Reconstruction(self); })
+           [](const Reconstruction& self) { return Reconstruction(self); })
       .def("__deepcopy__",
            [](const Reconstruction& self, const py::dict&) {
-    return Reconstruction(self);
+             return Reconstruction(self);
            })
       .def("__repr__", &CreateRepresentation<Reconstruction>)
       .def("summary", [](const Reconstruction& self) {
-    std::ostringstream ss;
-    ss << "Reconstruction:"
-       << "\n\tnum_cameras = " << self.NumCameras()
-       << "\n\tnum_images = " << self.NumImages()
-       << "\n\tnum_reg_images = " << self.NumRegImages()
-       << "\n\tnum_points3D = " << self.NumPoints3D()
-       << "\n\tnum_observations = " << self.ComputeNumObservations()
-       << "\n\tmean_track_length = " << self.ComputeMeanTrackLength()
-       << "\n\tmean_observations_per_image = "
-       << self.ComputeMeanObservationsPerRegImage()
-       << "\n\tmean_reprojection_error = "
-       << self.ComputeMeanReprojectionError();
-    return ss.str();
+        std::ostringstream ss;
+        ss << "Reconstruction:"
+           << "\n\tnum_cameras = " << self.NumCameras()
+           << "\n\tnum_images = " << self.NumImages()
+           << "\n\tnum_reg_images = " << self.NumRegImages()
+           << "\n\tnum_points3D = " << self.NumPoints3D()
+           << "\n\tnum_observations = " << self.ComputeNumObservations()
+           << "\n\tmean_track_length = " << self.ComputeMeanTrackLength()
+           << "\n\tmean_observations_per_image = "
+           << self.ComputeMeanObservationsPerRegImage()
+           << "\n\tmean_reprojection_error = "
+           << self.ComputeMeanReprojectionError();
+        return ss.str();
       });
 }


### PR DESCRIPTION
The two are semantically identical. The registered_image_ids set only exists for efficiently iterating over the set of registered images.