### PR TITLE
Fix chained match synthesis

### DIFF
--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -110,10 +110,17 @@ void SynthesizeChainedMatches(double inlier_match_ratio,
   std::unordered_map<image_pair_t, TwoViewGeometry> two_view_geometries;
   for (const auto& point3D : reconstruction->Points3D()) {
     std::vector<TrackElement> track_elements = point3D.second.track.Elements();
-    std::shuffle(track_elements.begin(), track_elements.end(), *PRNG);
+    std::sort(track_elements.begin(),
+              track_elements.end(),
+              [](const TrackElement& left, const TrackElement& right) {
+                return left.image_id < right.image_id;
+              });
     for (size_t i = 1; i < track_elements.size(); ++i) {
       const auto& prev_track_el = track_elements[i - 1];
       const auto& curr_track_el = track_elements[i];
+      if (curr_track_el.image_id != prev_track_el.image_id + 1) {
+        continue;
+      }
       const image_pair_t pair_id = Database::ImagePairToPairId(
           prev_track_el.image_id, curr_track_el.image_id);
       if (Database::SwapImagePair(prev_track_el.image_id,

--- a/src/colmap/scene/synthetic.h
+++ b/src/colmap/scene/synthetic.h
@@ -55,7 +55,8 @@ struct SyntheticDatasetOptions {
   enum class MatchConfig {
     // Exhaustive matches between all pairs of observations of a 3D point.
     EXHAUSTIVE = 1,
-    // Chain of matches with random start/end observations.
+    // Chain of matches between images with consecutive identifiers, i.e.,
+    // there are only matches between image pairs (image_id, image_id+1).
     CHAINED = 2,
   };
   MatchConfig match_config = MatchConfig::EXHAUSTIVE;

--- a/src/colmap/scene/synthetic_test.cc
+++ b/src/colmap/scene/synthetic_test.cc
@@ -191,6 +191,7 @@ TEST(SynthesizeDataset, ExhaustiveMatches) {
   SynthesizeDataset(options, &reconstruction, &database);
 
   const int num_image_pairs = options.num_images * (options.num_images - 1) / 2;
+  EXPECT_EQ(database.NumMatchedImagePairs(), num_image_pairs);
   EXPECT_EQ(database.NumVerifiedImagePairs(), num_image_pairs);
   EXPECT_EQ(database.NumInlierMatches(),
             num_image_pairs * options.num_points3D);
@@ -203,9 +204,19 @@ TEST(SynthesizeDataset, ChainedMatches) {
   options.match_config = SyntheticDatasetOptions::MatchConfig::CHAINED;
   SynthesizeDataset(options, &reconstruction, &database);
 
-  EXPECT_EQ(database.NumVerifiedImagePairs(), reconstruction.NumImages() - 1);
+  const int num_image_pairs = options.num_images - 1;
+  EXPECT_EQ(database.NumMatchedImagePairs(), num_image_pairs);
+  EXPECT_EQ(database.NumVerifiedImagePairs(), num_image_pairs);
   EXPECT_EQ(database.NumInlierMatches(),
-            (options.num_images - 1) * options.num_points3D);
+            num_image_pairs * options.num_points3D);
+  for (const auto& [pair_id, _] : database.ReadAllMatches()) {
+    const auto [image_id1, image_id2] = Database::PairIdToImagePair(pair_id);
+    EXPECT_EQ(image_id1 + 1, image_id2);
+  }
+  for (const auto& [pair_id, _] : database.ReadTwoViewGeometries()) {
+    const auto [image_id1, image_id2] = Database::PairIdToImagePair(pair_id);
+    EXPECT_EQ(image_id1 + 1, image_id2);
+  }
 }
 
 TEST(SynthesizeDataset, NoDatabase) {

--- a/src/colmap/scene/synthetic_test.cc
+++ b/src/colmap/scene/synthetic_test.cc
@@ -203,8 +203,7 @@ TEST(SynthesizeDataset, ChainedMatches) {
   options.match_config = SyntheticDatasetOptions::MatchConfig::CHAINED;
   SynthesizeDataset(options, &reconstruction, &database);
 
-  const int num_image_pairs = options.num_images * (options.num_images - 1) / 2;
-  EXPECT_EQ(database.NumVerifiedImagePairs(), num_image_pairs);
+  EXPECT_EQ(database.NumVerifiedImagePairs(), reconstruction.NumImages() - 1);
   EXPECT_EQ(database.NumInlierMatches(),
             (options.num_images - 1) * options.num_points3D);
 }


### PR DESCRIPTION
The chained match synthesis was meant to work differently than currently implemented, which would create a separate chain per 3D point track. This PR creates a consistent chain across all tracks leading to sufficient matches for downstream tests. Noticed the issue while observing non-deterministic behavior in our e2e pipeline tests depending on order of tests.