### PR TITLE
Fix missing PRNG initialization

### DIFF
--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -85,6 +85,8 @@ GeneralizedCameraProblem BuildGeneralizedCameraProblem() {
 }
 
 TEST(EstimateGeneralizedAbsolutePose, Nominal) {
+  SetPRNGSeed();
+
   GeneralizedCameraProblem problem = BuildGeneralizedCameraProblem();
   const size_t num_points = problem.points2D.size();
 

--- a/src/colmap/math/random.h
+++ b/src/colmap/math/random.h
@@ -89,7 +89,6 @@ T RandomUniformInteger(const T min, const T max) {
   }
 
   std::uniform_int_distribution<T> distribution(min, max);
-
   return distribution(*PRNG);
 }
 
@@ -100,7 +99,6 @@ T RandomUniformReal(const T min, const T max) {
   }
 
   std::uniform_real_distribution<T> distribution(min, max);
-
   return distribution(*PRNG);
 }
 

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -169,6 +169,10 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
   THROW_CHECK_GE(options.point2D_stddev, 0.);
   THROW_CHECK_GE(options.prior_position_stddev, 0.);
 
+  if (PRNG == nullptr) {
+    SetPRNGSeed();
+  }
+
   // Synthesize cameras.
   std::vector<camera_t> camera_ids(options.num_cameras);
   for (int camera_idx = 0; camera_idx < options.num_cameras; ++camera_idx) {


### PR DESCRIPTION
In a few places, we directly dereference the PRNG pointer for use in std::shuffle. This leads to null pointer dereference if the PRNG was not initialized before, which requires an explicit call to SetPRGNSeed. In most conditions this would be done by a previous call to the random number generator helpers but not under some other conditions.