### PR TITLE
Fix two-view geometry pose estimation for homography

### DIFF
--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -85,6 +85,8 @@ GeneralizedCameraProblem BuildGeneralizedCameraProblem() {
 }
 
 TEST(EstimateGeneralizedAbsolutePose, Nominal) {
+  SetPRNGSeed();
+
   GeneralizedCameraProblem problem = BuildGeneralizedCameraProblem();
   const size_t num_points = problem.points2D.size();
 

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -371,6 +371,9 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
                             inlier_cam_points2,
                             &geometry->cam2_from_cam1,
                             &points3D);
+    if (points3D.empty()) {
+      return false;
+    }
   } else if (geometry->config ==
              TwoViewGeometry::ConfigurationType::UNCALIBRATED) {
     const Eigen::Matrix3d E = EssentialFromFundamentalMatrix(
@@ -380,6 +383,9 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
                             inlier_cam_points2,
                             &geometry->cam2_from_cam1,
                             &points3D);
+    if (points3D.empty()) {
+      return false;
+    }
   } else if (geometry->config == TwoViewGeometry::ConfigurationType::PLANAR ||
              geometry->config ==
                  TwoViewGeometry::ConfigurationType::PANORAMIC ||
@@ -394,6 +400,10 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
                              &geometry->cam2_from_cam1,
                              &normal,
                              &points3D);
+    if (geometry->config == TwoViewGeometry::ConfigurationType::PLANAR &&
+        points3D.empty()) {
+      return false;
+    }
   } else {
     return false;
   }

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -343,6 +343,9 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
 
   // Extract normalized inlier points.
   const size_t num_inlier_matches = geometry->inlier_matches.size();
+  if (num_inlier_matches == 0) {
+    return false;
+  }
   std::vector<Eigen::Vector2d> inlier_cam_points1(num_inlier_matches);
   std::vector<Eigen::Vector2d> inlier_cam_points2(num_inlier_matches);
   for (size_t i = 0; i < num_inlier_matches; ++i) {
@@ -400,6 +403,19 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
                              &geometry->cam2_from_cam1,
                              &normal,
                              &points3D);
+    if (geometry->config ==
+        TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC) {
+      if (geometry->cam2_from_cam1.translation.squaredNorm() < 1e-12) {
+        geometry->config = TwoViewGeometry::ConfigurationType::PANORAMIC;
+      } else {
+        geometry->config = TwoViewGeometry::ConfigurationType::PLANAR;
+      }
+    }
+
+    if (geometry->config == TwoViewGeometry::ConfigurationType::PANORAMIC) {
+      geometry->tri_angle = 0;
+    }
+
     if (geometry->config == TwoViewGeometry::ConfigurationType::PLANAR &&
         points3D.empty()) {
       return false;
@@ -408,25 +424,13 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
     return false;
   }
 
-  if (points3D.empty()) {
-    geometry->tri_angle = 0;
-  } else {
+  if (!points3D.empty()) {
     const Eigen::Vector3d proj_center1 = Eigen::Vector3d::Zero();
     const Eigen::Vector3d proj_center2 =
         geometry->cam2_from_cam1.rotation.inverse() *
         -geometry->cam2_from_cam1.translation;
     geometry->tri_angle = Median(
         CalculateTriangulationAngles(proj_center1, proj_center2, points3D));
-  }
-
-  if (geometry->config ==
-      TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC) {
-    if (geometry->cam2_from_cam1.translation.norm() < 1e-6) {
-      geometry->config = TwoViewGeometry::ConfigurationType::PANORAMIC;
-      geometry->tri_angle = 0;
-    } else {
-      geometry->config = TwoViewGeometry::ConfigurationType::PLANAR;
-    }
   }
 
   return true;

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -144,6 +144,7 @@ TwoViewGeometryTestData CreateTwoViewGeometryTestData(
 TEST(EstimateTwoViewGeometryPose, Calibrated) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
+    SetPRNGSeed(seed);
     const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
         TwoViewGeometry::ConfigurationType::CALIBRATED);
 
@@ -169,6 +170,7 @@ TEST(EstimateTwoViewGeometryPose, Calibrated) {
 }
 
 TEST(EstimateTwoViewGeometryPose, FailureDueToInsufficientMatches) {
+  SetPRNGSeed(0);
   for (const auto config : {TwoViewGeometry::ConfigurationType::CALIBRATED,
                             TwoViewGeometry::ConfigurationType::UNCALIBRATED,
                             TwoViewGeometry::ConfigurationType::PLANAR,
@@ -192,6 +194,7 @@ TEST(EstimateTwoViewGeometryPose, FailureDueToInsufficientMatches) {
 TEST(EstimateTwoViewGeometryPose, Uncalibrated) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
+    SetPRNGSeed(seed);
     const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
         TwoViewGeometry::ConfigurationType::UNCALIBRATED);
 
@@ -219,6 +222,7 @@ TEST(EstimateTwoViewGeometryPose, Uncalibrated) {
 TEST(EstimateTwoViewGeometryPose, Planar) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
+    SetPRNGSeed(seed);
     const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
         TwoViewGeometry::ConfigurationType::PLANAR);
 
@@ -245,6 +249,7 @@ TEST(EstimateTwoViewGeometryPose, Planar) {
 TEST(EstimateTwoViewGeometryPose, PlanarOrPanoramic) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
+    SetPRNGSeed(seed);
     for (const auto config : {TwoViewGeometry::ConfigurationType::PLANAR,
                               TwoViewGeometry::ConfigurationType::PANORAMIC}) {
       const TwoViewGeometryTestData test_data =

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -306,8 +306,8 @@ TEST(EstimateTwoViewGeometryPose, PlanarOrPanoramic) {
         num_failures++;
       }
     }
-    EXPECT_EQ(num_failures, 0);
   }
+  EXPECT_EQ(num_failures, 0);
 }
 
 }  // namespace

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -33,6 +33,7 @@
 #include "colmap/geometry/homography_matrix.h"
 #include "colmap/geometry/triangulation.h"
 #include "colmap/math/math.h"
+#include "colmap/math/random.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/eigen_alignment.h"
@@ -58,7 +59,7 @@ TwoViewGeometryTestData CreateTwoViewGeometryTestData(
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_cameras = 2;
   synthetic_dataset_options.num_images = 2;
-  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.num_points3D = 100;
   synthetic_dataset_options.point2D_stddev = 0;
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -269,7 +269,7 @@ TEST(EstimateTwoViewGeometryPose, Planar) {
                                    test_data.geometry,
                                    /*tri_angle_tol=*/1e-3,
                                    /*rotation_tol=*/1e-6,
-                                   /*translation_tol=*/1e-6,
+                                   /*translation_tol=*/1e-5,
                                    /*normalized_translation=*/false)) {
       num_failures++;
     }

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -55,11 +55,13 @@ struct TwoViewGeometryTestData {
 
 TwoViewGeometryTestData CreateTwoViewGeometryTestData(
     TwoViewGeometry::ConfigurationType config) {
+  SetPRNGSeed(42);
+
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_cameras = 2;
   synthetic_dataset_options.num_images = 2;
-  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.num_points3D = 50;
   synthetic_dataset_options.point2D_stddev = 0;
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -55,7 +55,7 @@ struct TwoViewGeometryTestData {
 
 TwoViewGeometryTestData CreateTwoViewGeometryTestData(
     TwoViewGeometry::ConfigurationType config) {
-  SetPRNGSeed(42);
+  SetPRNGSeed(10);
 
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -184,7 +184,8 @@ TEST(EstimateTwoViewGeometryPose, FailureDueToInsufficientMatches) {
                                              test_data.points1,
                                              test_data.camera2,
                                              test_data.points2,
-                                             &geometry)) << config;
+                                             &geometry))
+        << config;
   }
 }
 
@@ -241,29 +242,33 @@ TEST(EstimateTwoViewGeometryPose, Planar) {
   }
 }
 
-TEST(EstimateTwoViewGeometryPose, Panoramic) {
+TEST(EstimateTwoViewGeometryPose, PlanarOrPanoramic) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
-    const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
-        TwoViewGeometry::ConfigurationType::PANORAMIC);
+    for (const auto config : {TwoViewGeometry::ConfigurationType::PLANAR,
+                              TwoViewGeometry::ConfigurationType::PANORAMIC}) {
+      const TwoViewGeometryTestData test_data =
+          CreateTwoViewGeometryTestData(config);
 
-    TwoViewGeometry geometry;
-    geometry.config = test_data.geometry.config;
-    geometry.H = test_data.geometry.H;
-    geometry.inlier_matches = test_data.geometry.inlier_matches;
-    EXPECT_TRUE(EstimateTwoViewGeometryPose(test_data.camera1,
-                                            test_data.points1,
-                                            test_data.camera2,
-                                            test_data.points2,
-                                            &geometry));
-    EXPECT_NEAR(geometry.tri_angle, test_data.geometry.tri_angle, 1e-3);
-    EXPECT_NEAR(geometry.cam2_from_cam1.rotation.angularDistance(
-                    test_data.geometry.cam2_from_cam1.rotation),
-                0,
-                1e-6);
-    EXPECT_THAT(
-        geometry.cam2_from_cam1.translation,
-        EigenMatrixNear(test_data.geometry.cam2_from_cam1.translation, 1e-6));
+      TwoViewGeometry geometry;
+      geometry.config = TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC;
+      geometry.H = test_data.geometry.H;
+      geometry.inlier_matches = test_data.geometry.inlier_matches;
+      EXPECT_TRUE(EstimateTwoViewGeometryPose(test_data.camera1,
+                                              test_data.points1,
+                                              test_data.camera2,
+                                              test_data.points2,
+                                              &geometry));
+      EXPECT_EQ(geometry.config, config);
+      EXPECT_NEAR(geometry.tri_angle, test_data.geometry.tri_angle, 1e-3);
+      EXPECT_NEAR(geometry.cam2_from_cam1.rotation.angularDistance(
+                      test_data.geometry.cam2_from_cam1.rotation),
+                  0,
+                  1e-6);
+      EXPECT_THAT(
+          geometry.cam2_from_cam1.translation,
+          EigenMatrixNear(test_data.geometry.cam2_from_cam1.translation, 1e-6));
+    }
   }
 }
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -144,7 +144,6 @@ TwoViewGeometryTestData CreateTwoViewGeometryTestData(
 TEST(EstimateTwoViewGeometryPose, Calibrated) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
-    SetPRNGSeed(seed);
     const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
         TwoViewGeometry::ConfigurationType::CALIBRATED);
 
@@ -166,6 +165,26 @@ TEST(EstimateTwoViewGeometryPose, Calibrated) {
         geometry.cam2_from_cam1.translation,
         EigenMatrixNear(
             test_data.geometry.cam2_from_cam1.translation.normalized(), 1e-6));
+  }
+}
+
+TEST(EstimateTwoViewGeometryPose, FailureDueToInsufficientMatches) {
+  for (const auto config : {TwoViewGeometry::ConfigurationType::CALIBRATED,
+                            TwoViewGeometry::ConfigurationType::UNCALIBRATED,
+                            TwoViewGeometry::ConfigurationType::PLANAR,
+                            TwoViewGeometry::ConfigurationType::PANORAMIC}) {
+    TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(config);
+    test_data.geometry.inlier_matches.clear();
+
+    TwoViewGeometry geometry;
+    geometry.config = test_data.geometry.config;
+    geometry.E = test_data.geometry.E;
+    geometry.inlier_matches = test_data.geometry.inlier_matches;
+    EXPECT_FALSE(EstimateTwoViewGeometryPose(test_data.camera1,
+                                             test_data.points1,
+                                             test_data.camera2,
+                                             test_data.points2,
+                                             &geometry)) << config;
   }
 }
 
@@ -199,7 +218,6 @@ TEST(EstimateTwoViewGeometryPose, Uncalibrated) {
 TEST(EstimateTwoViewGeometryPose, Planar) {
   constexpr int kNumTests = 100;
   for (int seed = 0; seed < kNumTests; ++seed) {
-    SetPRNGSeed(seed);
     const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
         TwoViewGeometry::ConfigurationType::PLANAR);
 

--- a/src/colmap/geometry/homography_matrix.cc
+++ b/src/colmap/geometry/homography_matrix.cc
@@ -36,6 +36,7 @@
 #include "colmap/util/logging.h"
 
 #include <array>
+#include <iomanip>
 
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
@@ -44,12 +45,12 @@ namespace colmap {
 namespace {
 
 double ComputeOppositeOfMinor(const Eigen::Matrix3d& matrix,
-                              const size_t row,
-                              const size_t col) {
-  const size_t col1 = col == 0 ? 1 : 0;
-  const size_t col2 = col == 2 ? 1 : 2;
-  const size_t row1 = row == 0 ? 1 : 0;
-  const size_t row2 = row == 2 ? 1 : 2;
+                              const int row,
+                              const int col) {
+  const int col1 = col == 0 ? 1 : 0;
+  const int col2 = col == 2 ? 1 : 2;
+  const int row1 = row == 0 ? 1 : 0;
+  const int row2 = row == 2 ? 1 : 2;
   return (matrix(row1, col2) * matrix(row2, col1) -
           matrix(row1, col1) * matrix(row2, col2));
 }

--- a/src/colmap/geometry/homography_matrix.cc
+++ b/src/colmap/geometry/homography_matrix.cc
@@ -187,16 +187,19 @@ void DecomposeHomographyMatrix(const Eigen::Matrix3d& H,
   *normals = {-n1, n1, -n2, n2};
 }
 
-double CheckCheirality2(const Rigid3d& cam2_from_cam1,
-                        const std::vector<Eigen::Vector2d>& points1,
-                        const std::vector<Eigen::Vector2d>& points2,
-                        std::vector<Eigen::Vector3d>* points3D) {
+namespace {
+
+double CheckCheiralityAndReprojErrorSum(
+    const Rigid3d& cam2_from_cam1,
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2,
+    std::vector<Eigen::Vector3d>* points3D) {
   THROW_CHECK_EQ(points1.size(), points2.size());
   const Eigen::Matrix3x4d cam1_from_world = Eigen::Matrix3x4d::Identity();
   const Eigen::Matrix3x4d cam2_from_world = cam2_from_cam1.ToMatrix();
   constexpr double kMinDepth = std::numeric_limits<double>::epsilon();
   const double max_depth = 1000.0 * cam2_from_cam1.translation.norm();
-  double error_sum = 0;
+  double reproj_error_sum = 0;
   points3D->clear();
   for (size_t i = 0; i < points1.size(); ++i) {
     Eigen::Vector3d point3D;
@@ -219,11 +222,13 @@ double CheckCheirality2(const Rigid3d& cam2_from_cam1,
     }
     const double error1 = (points1[i] - point3D_in_cam1.hnormalized()).norm();
     const double error2 = (points2[i] - point3D_in_cam2.hnormalized()).norm();
-    error_sum += error1 + error2;
+    reproj_error_sum += error1 + error2;
     points3D->push_back(point3D);
   }
-  return error_sum;
+  return reproj_error_sum;
 }
+
+}  // namespace
 
 void PoseFromHomographyMatrix(const Eigen::Matrix3d& H,
                               const Eigen::Matrix3d& K1,
@@ -242,14 +247,14 @@ void PoseFromHomographyMatrix(const Eigen::Matrix3d& H,
 
   points3D->clear();
   std::vector<Eigen::Vector3d> tentative_points3D;
-  double best_error_sum = std::numeric_limits<double>::max();
+  double best_reproj_error_sum = std::numeric_limits<double>::max();
   for (size_t i = 0; i < cams2_from_cams1.size(); ++i) {
-    const double error_sum = CheckCheirality2(
+    const double reproj_error_sum = CheckCheiralityAndReprojErrorSum(
         cams2_from_cams1[i], points1, points2, &tentative_points3D);
     if (tentative_points3D.size() > points3D->size() ||
         (tentative_points3D.size() == points3D->size() &&
-         error_sum < best_error_sum)) {
-      best_error_sum = error_sum;
+         reproj_error_sum < best_reproj_error_sum)) {
+      best_reproj_error_sum = reproj_error_sum;
       *cam2_from_cam1 = cams2_from_cams1[i];
       *normal = normals[i];
       std::swap(*points3D, tentative_points3D);

--- a/src/colmap/geometry/homography_matrix.cc
+++ b/src/colmap/geometry/homography_matrix.cc
@@ -249,6 +249,9 @@ void PoseFromHomographyMatrix(const Eigen::Matrix3d& H,
   std::vector<Eigen::Vector3d> tentative_points3D;
   double best_reproj_error_sum = std::numeric_limits<double>::max();
   for (size_t i = 0; i < cams2_from_cams1.size(); ++i) {
+    // Note that we can typically eliminate 2 of the 4 solutions using the
+    // cheirality check. We can then typically narrow it down to 1 solution by
+    // picking the solution with minimal overall reprojection error.
     const double reproj_error_sum = CheckCheiralityAndReprojErrorSum(
         cams2_from_cams1[i], points1, points2, &tentative_points3D);
     if (tentative_points3D.size() > points3D->size() ||

--- a/src/colmap/geometry/homography_matrix_test.cc
+++ b/src/colmap/geometry/homography_matrix_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/eigen_matchers.h"
+#include "colmap/util/logging.h"
 
 #include <cmath>
 
@@ -75,19 +76,20 @@ TEST(DecomposeHomographyMatrix, Nominal) {
         (cams2_from_cams1[i].translation - ref_translation).norm() < kEps &&
         (normals[i] - ref_normal).norm() < kEps) {
       ref_solution_exists = true;
+      break;
     }
   }
   EXPECT_TRUE(ref_solution_exists);
 }
 
 TEST(DecomposeHomographyMatrix, Random) {
-  const int numIters = 100;
+  constexpr int kNumIters = 100;
 
   const double epsilon = 1e-6;
 
   const Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
 
-  for (int i = 0; i < numIters; ++i) {
+  for (int i = 0; i < kNumIters; ++i) {
     const Eigen::Matrix3d H = Eigen::Matrix3d::Random();
 
     if (std::abs(H.determinant()) < epsilon) {

--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -166,8 +166,9 @@ std::vector<double> CalculateTriangulationAngles(
       angles[i] = 0.0;
       continue;
     }
-    const double nominator =
-        ray_length_squared1 + ray_length_squared2 - baseline_length_squared;
+    const double nominator = std::max(
+        0.0,
+        ray_length_squared1 + ray_length_squared2 - baseline_length_squared);
     const double angle = std::abs(std::acos(nominator / denominator));
 
     // Triangulation is unstable for acute angles (far away points) and

--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -116,12 +116,13 @@ bool TriangulateOptimalPoint(const Eigen::Matrix3x4d& cam1_from_world_mat,
                           xyz);
 }
 
-double CalculateTriangulationAngle(const Eigen::Vector3d& proj_center1,
-                                   const Eigen::Vector3d& proj_center2,
-                                   const Eigen::Vector3d& point3D) {
-  const double baseline_length_squared =
-      (proj_center1 - proj_center2).squaredNorm();
+namespace {
 
+inline double CalculateTriangulationAngleWithKnownBaseline(
+    double baseline_length_squared,
+    const Eigen::Vector3d& proj_center1,
+    const Eigen::Vector3d& proj_center2,
+    const Eigen::Vector3d& point3D) {
   const double ray_length_squared1 = (point3D - proj_center1).squaredNorm();
   const double ray_length_squared2 = (point3D - proj_center2).squaredNorm();
 
@@ -134,7 +135,7 @@ double CalculateTriangulationAngle(const Eigen::Vector3d& proj_center1,
   const double nominator =
       ray_length_squared1 + ray_length_squared2 - baseline_length_squared;
   const double angle =
-      std::abs(std::acos(std::clamp(nominator / denominator, -1.0, 1.0)));
+      std::acos(std::clamp(nominator / denominator, -1.0, 1.0));
 
   // Triangulation is unstable for acute angles (far away points) and
   // obtuse angles (close points), so always compute the minimum angle
@@ -142,41 +143,28 @@ double CalculateTriangulationAngle(const Eigen::Vector3d& proj_center1,
   return std::min(angle, M_PI - angle);
 }
 
+}  // namespace
+
+double CalculateTriangulationAngle(const Eigen::Vector3d& proj_center1,
+                                   const Eigen::Vector3d& proj_center2,
+                                   const Eigen::Vector3d& point3D) {
+  const double baseline_length_squared =
+      (proj_center1 - proj_center2).squaredNorm();
+  return CalculateTriangulationAngleWithKnownBaseline(
+      baseline_length_squared, proj_center1, proj_center2, point3D);
+}
+
 std::vector<double> CalculateTriangulationAngles(
     const Eigen::Vector3d& proj_center1,
     const Eigen::Vector3d& proj_center2,
     const std::vector<Eigen::Vector3d>& points3D) {
-  // Baseline length between camera centers.
   const double baseline_length_squared =
       (proj_center1 - proj_center2).squaredNorm();
-
   std::vector<double> angles(points3D.size());
-
   for (size_t i = 0; i < points3D.size(); ++i) {
-    // Ray lengths from cameras to point.
-    const double ray_length_squared1 =
-        (points3D[i] - proj_center1).squaredNorm();
-    const double ray_length_squared2 =
-        (points3D[i] - proj_center2).squaredNorm();
-
-    // Using "law of cosines" to compute the enclosing angle between rays.
-    const double denominator =
-        2.0 * std::sqrt(ray_length_squared1 * ray_length_squared2);
-    if (denominator == 0.0) {
-      angles[i] = 0.0;
-      continue;
-    }
-    const double nominator = std::max(
-        0.0,
-        ray_length_squared1 + ray_length_squared2 - baseline_length_squared);
-    const double angle = std::abs(std::acos(nominator / denominator));
-
-    // Triangulation is unstable for acute angles (far away points) and
-    // obtuse angles (close points), so always compute the minimum angle
-    // between the two intersecting rays.
-    angles[i] = std::min(angle, M_PI - angle);
+    angles[i] = CalculateTriangulationAngleWithKnownBaseline(
+        baseline_length_squared, proj_center1, proj_center2, points3D[i]);
   }
-
   return angles;
 }
 

--- a/src/colmap/math/math.h
+++ b/src/colmap/math/math.h
@@ -45,7 +45,8 @@
 
 namespace colmap {
 
-// Return 1 if number is positive, -1 if negative, and 0 if the number is 0.
+// Return 1 if number is positive (including 0), -1 if negative.
+// Undefined behavior if the value is NaN.
 template <typename T>
 int SignOfNumber(T val);
 
@@ -166,7 +167,7 @@ bool NextCombination(Iterator first1,
 
 template <typename T>
 int SignOfNumber(const T val) {
-  return (T(0) < val) - (val < T(0));
+  return val >= 0 ? 1 : -1;
 }
 
 template <typename T>

--- a/src/colmap/math/math_test.cc
+++ b/src/colmap/math/math_test.cc
@@ -35,10 +35,9 @@ namespace colmap {
 namespace {
 
 TEST(SignOfNumber, Nominal) {
-  EXPECT_EQ(SignOfNumber(0), 0);
+  EXPECT_EQ(SignOfNumber(0), 1);
   EXPECT_EQ(SignOfNumber(-0.1), -1);
   EXPECT_EQ(SignOfNumber(0.1), 1);
-  EXPECT_EQ(SignOfNumber(std::numeric_limits<float>::quiet_NaN()), 0);
   EXPECT_EQ(SignOfNumber(std::numeric_limits<float>::infinity()), 1);
   EXPECT_EQ(SignOfNumber(-std::numeric_limits<float>::infinity()), -1);
 }

--- a/src/colmap/math/random.h
+++ b/src/colmap/math/random.h
@@ -89,7 +89,6 @@ T RandomUniformInteger(const T min, const T max) {
   }
 
   std::uniform_int_distribution<T> distribution(min, max);
-
   return distribution(*PRNG);
 }
 
@@ -100,7 +99,6 @@ T RandomUniformReal(const T min, const T max) {
   }
 
   std::uniform_real_distribution<T> distribution(min, max);
-
   return distribution(*PRNG);
 }
 

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -169,6 +169,10 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
   THROW_CHECK_GE(options.point2D_stddev, 0.);
   THROW_CHECK_GE(options.prior_position_stddev, 0.);
 
+  if (PRNG == nullptr) {
+    SetPRNGSeed();
+  }
+
   // Synthesize cameras.
   std::vector<camera_t> camera_ids(options.num_cameras);
   for (int camera_idx = 0; camera_idx < options.num_cameras; ++camera_idx) {


### PR DESCRIPTION
Fixing the unrelated issue of correctly initializing the PRNG in our synthetic scene generator revealed issues with homography pose estimation. Out of the 4 decomposed solutions, the cheirality check can only eliminate 2 and we would randomly pick one of them. I added a reprojection check to resolve the ambiguity. This PR addresses both issues jointly. Previously, on synthetically generated image pairs, half of the pairs would fail to correctly estimate the relative pose from the homography. Now, we achieve 100% success rate. I also added more test coverage.