### PR TITLE
Add pytest on the e2e python pipeline into CI.

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -173,7 +173,7 @@ jobs:
           package-dir: ./
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.config.arch }}
-          CIBW_TEST_REQUIRES: 'pytest'
+          CIBW_TEST_REQUIRES: 'pytest enlighten==1.13.0'
           CIBW_TEST_COMMAND: 'pytest {project}/python/examples/custom_incremental_pipeline_test.py'
       - name: Archive wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -174,7 +174,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.config.arch }}
           CIBW_TEST_REQUIRES: 'pytest'
-          CIBW_TEST_COMMAND: 'pytest python/examples/custom_incremental_pipeline_test.py'
+          CIBW_TEST_COMMAND: 'pytest {project}/python/examples/custom_incremental_pipeline_test.py'
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -173,6 +173,8 @@ jobs:
           package-dir: ./
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.config.arch }}
+          CIBW_TEST_REQUIRES: 'pytest'
+          CIBW_TEST_COMMAND: 'pytest python/examples/custom_incremental_pipeline_test.py'
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR only integrates the python custom pipeline into the CI, to catch relevant issues (typically broken interfaces). We could make the tests more structured once we want to add more coverage on the python side. 