### PR TITLE
Add changes needed for MP-SfM

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = [
+    "scikit-build-core>=0.3.3",
+    "pybind11==2.13.6",
+    "pybind11_stubgen @ git+https://github.com/sarlinpe/pybind11-stubgen@sarlinpe/fix-2024-11",
+    "numpy",
+    "ruff==0.6.7",
+    "clang-format==19.1.0",
+]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pycolmap"
+# WARNING: This version must follow the MAJOR.MINOR.PATCH format. If only
+# MAJOR.MINOR is used, cibuildwheel will add a .dev0 patch version, which
+# results in releasing a pre-release version on PyPI.
+version = "3.12.0.dev0"
+description = "COLMAP bindings"
+readme = "README.md"
+authors = [
+  { name = "Johannes Schönberger", email = "jsch@demuc.de" },
+  { name = "Mihai Dusmanu", email = "mihai.dusmanu@gmail.com" },
+  { name = "Paul-Edouard Sarlin", email = "psarlin@ethz.ch" },
+  { name = "Shaohui Liu", email = "b1ueber2y@gmail.com" },
+  { name = "Philipp Lindenberger", email = "plindenbe@ethz.ch" },
+]
+license = {text = "BSD-3-Clause"}
+urls = {Repository = "https://github.com/colmap/colmap"}
+requires-python = ">=3.8"
+dependencies = ["numpy"]
+classifiers = [
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+[tool.scikit-build]
+wheel.expand-macos-universal-tags = true
+
+[tool.cibuildwheel]
+build = "cp3{8,9,10,11,12}-{macosx,manylinux,win}*"
+archs = ["auto64"]
+test-requires = "mypy==1.12.1"
+test-command = "python -c \"import pycolmap; print(pycolmap.__version__)\" &&  python -m mypy --package pycolmap --implicit-optional"
+
+[tool.cibuildwheel.environment]
+VCPKG_COMMIT_ID = "3b57fb2e1ff55613db14d2aaf0a30529289c7050"
+
+[tool.cibuildwheel.linux]
+before-all = "{package}/ci/install-colmap-almalinux.sh"
+
+[tool.cibuildwheel.macos]
+before-all = "{package}/ci/install-colmap-macos.sh"
+
+[tool.cibuildwheel.windows]
+before-all = "pwsh -File {package}/ci/install-colmap-windows.ps1"
+before-build = "pip install delvewheel"
+test-command = "pwsh -File {package}/ci/test-colmap-windows.ps1"

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -117,6 +117,9 @@ struct BundleAdjustmentOptions {
 
   // Scaling factor determines residual at which robustification takes place.
   double loss_function_scale = 1.0;
+  
+  // Magnitude determines the scaling of the residual
+  double loss_function_magnitude = 1.0;
 
   // Whether to refine the focal length parameter group.
   bool refine_focal_length = true;
@@ -244,6 +247,20 @@ std::unique_ptr<BundleAdjuster> CreatePosePriorBundleAdjuster(
     BundleAdjustmentConfig config,
     std::unordered_map<image_t, PosePrior> pose_priors,
     Reconstruction& reconstruction);
+
+// Adds a depth prior to the bundle adjustment problem.
+void ExtendBundleAdjusterWithDepth(ceres::Problem* problem,
+                                   image_t image_id,
+                                   const std::vector<point3D_t>& point3D_ids,
+                                   const std::vector<double>& depths,
+                                   const std::vector<double>& loss_magnitudes,
+                                   const std::vector<double>& loss_params,
+                                   const std::string& loss_name,
+                                   double* shift_scale_ptr, 
+                                   Reconstruction& reconstruction,
+                                   bool loggloss = false,
+                                   bool fix_shift = false,
+                                   bool fix_scale = false);
 
 void PrintSolverSummary(const ceres::Solver::Summary& summary,
                         const std::string& header);

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -416,6 +416,9 @@ std::vector<PoseParam> GetPoseParams(const Reconstruction& reconstruction,
   std::vector<PoseParam> params;
   params.reserve(reconstruction.NumImages());
   for (const auto& [image_id, image] : reconstruction.Images()) {
+    if (!image.HasPose()) {
+      continue;
+    }
     const double* qvec = image.CamFromWorld().rotation.coeffs().data();
     if (!problem.HasParameterBlock(qvec) ||
         problem.IsParameterBlockConstant(const_cast<double*>(qvec))) {

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -302,7 +302,9 @@ size_t IncrementalTriangulator::MergeAllTracks(const Options& options) {
   return num_merged;
 }
 
-size_t IncrementalTriangulator::Retriangulate(const Options& options) {
+size_t IncrementalTriangulator::Retriangulate(
+  const Options& options,
+  const std::unordered_set<image_t>& ignore_image_ids) {
   THROW_CHECK(options.Check());
 
   size_t num_tris = 0;
@@ -328,6 +330,11 @@ size_t IncrementalTriangulator::Retriangulate(const Options& options) {
     std::tie(image_id1, image_id2) =
         Database::PairIdToImagePair(image_pair.first);
 
+    if (!ignore_image_ids.empty() &&
+        (ignore_image_ids.count(image_id1) > 0 || ignore_image_ids.count(image_id2) > 0)) {
+      continue;
+    }
+    
     const Image& image1 = reconstruction_.Image(image_id1);
     if (!image1.HasPose()) {
       continue;

--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -134,7 +134,8 @@ class IncrementalTriangulator {
   // Image pairs are under-reconstructed if less than `Options::tri_re_min_ratio
   // > tri_ratio`, where `tri_ratio` is the number of triangulated matches over
   // inlier matches between the image pair.
-  size_t Retriangulate(const Options& options);
+  size_t Retriangulate(const Options& options,
+    const std::unordered_set<image_t>& ignore_image_ids = {});
 
   // Indicate that a 3D point has been modified.
   void AddModifiedPoint3D(point3D_t point3D_id);

--- a/src/colmap/sfm/observation_manager.h
+++ b/src/colmap/sfm/observation_manager.h
@@ -93,6 +93,8 @@ class ObservationManager {
   size_t FilterPoints3DInImages(double max_reproj_error,
                                 double min_tri_angle,
                                 const std::unordered_set<image_t>& image_ids);
+  std::vector<bool> FindPoints3DWithGoodTriangulationAngle(
+        double min_tri_angle, const std::vector<point3D_t>& point3D_ids) const;
   size_t FilterAllPoints3D(double max_reproj_error, double min_tri_angle);
 
   // Filter observations that have negative depth.

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -91,6 +91,9 @@ void BindBundleAdjuster(py::module& m) {
                          &BAOpts::loss_function_scale,
                          "Scaling factor determines residual at which "
                          "robustification takes place.")
+          .def_readwrite("loss_function_magnitude",
+                         &BAOpts::loss_function_magnitude,
+                         "Magnitude determines the scaling of the residual.")
           .def_readwrite("refine_focal_length",
                          &BAOpts::refine_focal_length,
                          "Whether to refine the focal length parameter group.")
@@ -199,4 +202,42 @@ void BindBundleAdjuster(py::module& m) {
         "config"_a,
         "pose_priors"_a,
         "reconstruction"_a);
+        
+  m.def("extend_bundle_adjuster_with_depth",
+        [](ceres::Problem* problem,
+            image_t image_id,
+            const std::vector<point3D_t>& point3D_ids,
+            const std::vector<double>& depths,
+            const std::vector<double>& loss_magnitudes,
+            const std::vector<double>& loss_params,
+            const std::string& loss_name,
+            py::array_t<double> shift_scale,
+            Reconstruction& reconstruction,
+            bool logloss,
+            bool fix_shift,
+            bool fix_scale) {
+
+            auto buf = shift_scale.request();
+            if (buf.ndim != 1 || buf.shape[0] != 2)
+                throw std::runtime_error("shift_scale must have exactly 2 elements.");
+
+            double* shift_scale_ptr = static_cast<double*>(buf.ptr);
+
+            ExtendBundleAdjusterWithDepth(problem, image_id, point3D_ids, depths,
+                                            loss_magnitudes, loss_params, loss_name,
+                                            shift_scale_ptr, reconstruction,
+                                            logloss, fix_shift, fix_scale);
+        },
+        "problem"_a,
+        "image_id"_a,
+        "point3D_ids"_a,
+        "depths"_a,
+        "loss_magnitudes"_a,
+        "loss_params"_a,
+        "loss_name"_a,
+        "shift_scale"_a,
+        "reconstruction"_a,
+        "logloss"_a = false,
+        "fix_shift"_a = false,
+        "fix_scale"_a = false);
 }

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -184,4 +184,16 @@ void BindCostFunctions(py::module& m_parent) {
         "point_in_b_prior"_a,
         "Error between 3D points transformed by a 3D similarity transform. "
         "with prior covariance");
+
+  m.def("ScaledDepthErrorCost", 
+        &ScaledDepthErrorCostFunction::Create, 
+        "depth"_a,
+        "Scaled depth error cost function.");
+  m.def("ScaledDepthErrorCost",
+        &ScaledDepthErrorConstantPoseCostFunction::Create,
+        "cam_from_world"_a,
+        "depth"_a,
+        "Scaled depth error cost function with constant camera pose.");
+  m.def(
+      "TruncatedLogScaledDepthErrorCost", &TruncatedLogScaledDepthErrorCostFunction::Create, "depth"_a);
 }

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -105,6 +105,58 @@ void BindSceneImage(py::module& m) {
            py::overload_cast<camera_t>(&Image::Point2D),
            "point2D_idx"_a,
            "Direct accessor for a point2D.")
+      .def("get_xy",
+           [](const Image& self, std::optional<std::vector<point2D_t>> point_ids = std::nullopt) -> py::array {
+               std::vector<double> xy_coords;
+
+               if (!point_ids) {
+                    // Use all Point2D IDs if none are provided
+                    point_ids = std::vector<point2D_t>(self.NumPoints2D());
+                    std::iota(point_ids->begin(), point_ids->end(), 0);
+               }
+
+               for (const auto& id : *point_ids) {
+                    const auto& point2D = self.Point2D(id);
+                    xy_coords.push_back(point2D.xy(0));
+                    xy_coords.push_back(point2D.xy(1));
+               }
+
+               py::ssize_t num_points = static_cast<py::ssize_t>(point_ids->size());
+               std::vector<py::ssize_t> shape{num_points, 2};
+               std::vector<py::ssize_t> strides{2 * sizeof(double), sizeof(double)};
+
+               return py::array(py::buffer_info(
+                    xy_coords.data(),
+                    sizeof(double),
+                    py::format_descriptor<double>::format(),
+                    2,
+                    shape,
+                    strides
+               ));
+           },
+           "point_ids"_a = std::nullopt,
+           "Get an Nx2 numpy array of xy coordinates for the specified 2D point IDs. "
+           "If no IDs are provided, return all.")
+      .def("get_point3D_ids",
+           [](const Image& self, std::optional<std::vector<point2D_t>> point_ids = std::nullopt) {
+               std::vector<point3D_t> point3D_ids;
+ 
+               if (!point_ids) {
+                   // Use all Point2D IDs if none are provided
+                   point_ids = std::vector<point2D_t>(self.NumPoints2D());
+                   std::iota(point_ids->begin(), point_ids->end(), 0);
+               }
+ 
+               for (const auto& id : *point_ids) {
+                   const auto& point2D = self.Point2D(id);
+                   point3D_ids.push_back(point2D.HasPoint3D() ? point2D.point3D_id : kInvalidPoint3DId);
+               }
+               return point3D_ids;
+           },
+           "point_ids"_a = std::nullopt,
+           "Get a list of 3D point IDs corresponding to the specified 2D point IDs. Returns -1 for points "
+           "without a 3D point. If no IDs are provided, return for all."
+       )
       .def(
           "set_point3D_for_point2D",
           &Image::SetPoint3DForPoint2D,

--- a/src/pycolmap/sfm/incremental_triangulator.cc
+++ b/src/pycolmap/sfm/incremental_triangulator.cc
@@ -100,7 +100,9 @@ void BindIncrementalTriangulator(py::module& m) {
            &IncrementalTriangulator::MergeAllTracks,
            "options"_a)
       .def(
-          "retriangulate", &IncrementalTriangulator::Retriangulate, "options"_a)
+          "retriangulate", &IncrementalTriangulator::Retriangulate,
+          "options"_a,
+          "ignore_image_ids"_a = std::unordered_set<image_t>())
       .def("add_modified_point3D",
            &IncrementalTriangulator::AddModifiedPoint3D,
            "point3D_id"_a)

--- a/src/pycolmap/sfm/observation_manager.cc
+++ b/src/pycolmap/sfm/observation_manager.cc
@@ -134,5 +134,11 @@ void BindObservationManager(py::module& m) {
            "any more and has a correspondence to this image point. This assumes"
            "that `IncrementCorrespondenceHasPoint3D` was called for the same"
            "image point and correspondence before.")
+      .def("find_points3D_with_good_triangulation_angle",
+          &ObservationManager::FindPoints3DWithGoodTriangulationAngle,
+          "min_tri_angle"_a,
+          "point3D_ids"_a,
+          "Find 3D points with sufficient triangulation angle. "
+          "Returns a boolean mask.")
       .def("__repr__", &CreateRepresentation<ObservationManager>);
 }


### PR DESCRIPTION
### Summary
This PR introduces the core functionality required for MP-SfM. It adds new Ceres cost functions and integrates them into COLMAP’s pipeline via ExtendBundleAdjusterWithDepth, with full Python bindings. Additionally, it includes several utility functions to improve the robustness and efficiency of the MP-SfM pipeline, particularly in challenging reconstruction scenarios.

### Main Changes

- Added two new Ceres cost functions: ScaledDepthErrorCostFunction and TruncatedLogScaledDepthErrorCostFunction
- ExtendBundleAdjusterWithDepth: adds per-3D point depth constraints efficiently to an existing BA problem 
- Utility pybindings:
  - get_xy and get_point3D_ids methods in Image avoid iterating in python 
  - FindPoints3DWithGoodTriangulationAngle: follows "FilterPoints3DWithSmallTriangulationAngle" but instead returns the points. Needed in MP-SfM and is inefficient in python. However, it is unclear if this should be in observation manager. 
- Extended Retringulate() with optional exclusion of specific image IDs. This is needed because for low-overlap pairs, introducing high error 3D points can be harmful