### PR TITLE
Fix FLANN-based CPU feature matcher crash in pycolmap

### DIFF
--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -102,7 +102,7 @@ class FlannFeatureDescriptorIndex : public FeatureDescriptorIndex {
   constexpr static int kNumTreesInForest = 4;
   constexpr static int kNumLeavesToVisit = 128;
 
-  using FlannIndexType = flann::Index<flann::L2<uint8_t>>;
+  using FlannIndexType = flann::KDTreeIndex<flann::L2<uint8_t>>;
   std::unique_ptr<FlannIndexType> index_;
   int num_index_descriptors_ = 0;
 };


### PR DESCRIPTION
Unclear whether this is a principled fix or just random luck. In theory, I would have expected the previous API usage to be valid, but it consistently fixes the crash on my Mac M3 Pro machine.