### PR TITLE
Use reference for image.camera and image.frame in pycolmap.

### DIFF
--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -71,7 +71,7 @@ void BindSceneImage(py::module& m) {
           "camera",
           [](Image& self) -> py::typing::Optional<Camera> {
             if (self.HasCameraPtr()) {
-              return py::cast(*self.CameraPtr());
+              return py::cast(self.CameraPtr());
             } else {
               return py::none();
             }
@@ -82,7 +82,7 @@ void BindSceneImage(py::module& m) {
           "frame",
           [](Image& self) -> py::typing::Optional<Frame> {
             if (self.HasFramePtr()) {
-              return py::cast(*self.FramePtr());
+              return py::cast(self.FramePtr());
             } else {
               return py::none();
             }


### PR DESCRIPTION
Seems to work without any tricks needed. 

```
(Pdb) rec
Reconstruction(num_rigs=2, num_cameras=2, num_frames=241, num_reg_frames=241, num_images=241, num_points3D=63691)
(Pdb) rec.images[1].camera
Camera(camera_id=1, model=SIMPLE_PINHOLE, width=1024, height=764, params=[1559.64, 512, 384] (f, cx, cy))
(Pdb) rec.cameras[1]
Camera(camera_id=1, model=SIMPLE_PINHOLE, width=1024, height=764, params=[1559.64, 512, 384] (f, cx, cy))
(Pdb) rec.images[1].camera.params *= 2
(Pdb) rec.cameras[1]
Camera(camera_id=1, model=SIMPLE_PINHOLE, width=1024, height=764, params=[3119.28, 1024, 768] (f, cx, cy))
(Pdb)
```