### PR TITLE
Depth residuals and Depth BA for MP-SfM

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -245,6 +245,20 @@ std::unique_ptr<BundleAdjuster> CreatePosePriorBundleAdjuster(
     std::unordered_map<image_t, PosePrior> pose_priors,
     Reconstruction& reconstruction);
 
+// Adds a depth prior to the bundle adjustment problem.
+void DepthPriorBundleAdjuster(ceres::Problem* problem,
+                              image_t image_id,
+                              const std::vector<point3D_t>& point3D_ids,
+                              const std::vector<double>& depths,
+                              const std::vector<double>& loss_magnitudes,
+                              const std::vector<double>& loss_params,
+                              BundleAdjustmentOptions::LossFunctionType loss_type,
+                              double* shift_scale_ptr, 
+                              Reconstruction& reconstruction,
+                              bool logloss = false,
+                              bool fix_shift = false,
+                              bool fix_scale = false);
+
 void PrintSolverSummary(const ceres::Solver::Summary& summary,
                         const std::string& header);
 

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -530,6 +530,104 @@ class CovarianceWeightedCostFunctor {
   const CostFunctor cost_;
 };
 
+// Cost function for constraining the depth of a point in the camera frame 
+// with depth priors.
+struct ScaledDepthErrorCostFunction {
+  public:
+   ScaledDepthErrorCostFunction(const double depth) : depth_(depth) {}
+   static ceres::CostFunction* Create(const double depth) {
+     return (
+         new ceres::
+             AutoDiffCostFunction<ScaledDepthErrorCostFunction, 1, 4, 3, 3, 2>(
+                 new ScaledDepthErrorCostFunction(depth)));
+   }
+   template <typename T>
+   bool operator()(const T* const cam_from_world_rotation,
+                   const T* const cam_from_world_translation,
+                   const T* const point3D,
+                   const T* const shift_scale,
+                   T* residuals) const {
+     *residuals = (EigenQuaternionMap<T>(cam_from_world_rotation) *
+                   EigenVector3Map<T>(point3D))[2] +
+                  cam_from_world_translation[2] - shift_scale[0] -
+                  T(depth_) * exp(shift_scale[1]);
+     return true;
+   }
+  private:
+   const double depth_;
+ };
+ 
+// Cost function for constraining the depth of a point in the camera frame 
+// with depth priors, with a fixed camera pose.
+ struct ScaledDepthErrorConstantPoseCostFunction
+     : public ScaledDepthErrorCostFunction {
+   using Parent = ScaledDepthErrorCostFunction;
+  public:
+   ScaledDepthErrorConstantPoseCostFunction(const Rigid3d& cam_from_world,
+                                            const double depth)
+       : Parent(depth), cam_from_world_(cam_from_world) {}
+   static ceres::CostFunction* Create(const Rigid3d& cam_from_world,
+                                      const double depth) {
+     return (new ceres::AutoDiffCostFunction<
+             ScaledDepthErrorConstantPoseCostFunction,
+             1,
+             3,
+             2>(
+         new ScaledDepthErrorConstantPoseCostFunction(cam_from_world, depth)));
+   }
+   template <typename T>
+   bool operator()(const T* const point3D,
+                   const T* const shift_scale,
+                   T* residuals) const {
+     const Eigen::Quaternion<T> cam_from_world_rotation =
+         cam_from_world_.rotation.cast<T>();
+     const Eigen::Matrix<T, 3, 1> cam_from_world_translation =
+         cam_from_world_.translation.cast<T>();
+     return Parent::operator()(cam_from_world_rotation.coeffs().data(),
+                               cam_from_world_translation.data(),
+                               point3D,
+                               shift_scale,
+                               residuals);
+   }
+  private:
+   const Rigid3d& cam_from_world_;
+ };
+
+ // Cost function for constraining the depth of a point in the camera frame
+ // with depth priors, with a fixed camera pose, in log space.
+ struct LogScaledDepthErrorCostFunction {
+  public:
+   LogScaledDepthErrorCostFunction(const double depth) : depth_(depth) {}
+ 
+   static ceres::CostFunction* Create(const double depth) {
+     return new ceres::AutoDiffCostFunction<LogScaledDepthErrorCostFunction, 1, 4, 3, 3, 2>(
+         new LogScaledDepthErrorCostFunction(depth));
+   }
+ 
+   template <typename T>
+   bool operator()(const T* const cam_from_world_rotation,
+                   const T* const cam_from_world_translation,
+                   const T* const point3D,
+                   const T* const shift_scale,
+                   T* residuals) const {
+     // Compute the predicted depth in the camera frame.
+     T d_pred = (EigenQuaternionMap<T>(cam_from_world_rotation) *
+                 EigenVector3Map<T>(point3D))[2] +
+                cam_from_world_translation[2];
+ 
+     if (d_pred <= T(0)) {
+       *residuals = T(0);
+       return true;
+     }
+ 
+     *residuals = ceres::log(d_pred) - (ceres::log(T(depth_)) + shift_scale[1]);
+     return true;
+   }
+ 
+  private:
+   const double depth_;
+ };
+
 template <template <typename> class CostFunctor, typename... Args>
 ceres::CostFunction* CreateCameraCostFunction(
     const CameraModelId camera_model_id, Args&&... args) {

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -457,5 +457,44 @@ TEST(CovarianceWeightedCostFunctor, AbsolutePosePositionPriorCostFunctor) {
       residuals[2], -0.5 * std::sqrt(2) * world_from_cam.translation[2], 1e-6);
 }
 
+TEST(ScaledDepthError, Nominal) {
+  const double depth_prior = 2.0;
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      ScaledDepthErrorCostFunction::Create(depth_prior));
+  double cam_from_world_rotation[4] = {0, 0, 0, 1};
+  double cam_from_world_translation[3] = {0, 0, 0};
+  double point3D[3] = {0, 0, 3};
+  double shift_scale[2] = {0, 0};
+  double residuals[1];
+  const double* parameters[4] = {cam_from_world_rotation,
+                                 cam_from_world_translation,
+                                 point3D,
+                                 shift_scale};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], 1);
+  point3D[2] = 2;
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], 0);
+  cam_from_world_translation[2] = 2;
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], 2);
+  cam_from_world_translation[0] = 1;
+  cam_from_world_translation[1] = 3;
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], 2);
+  shift_scale[1] = std::log(2);
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], 0);
+  shift_scale[0] = 1;
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], -1);
+  std::unique_ptr<ceres::CostFunction> cost_function_with_noise(
+      IsotropicNoiseCostFunctionWrapper<ScaledDepthErrorCostFunction>::Create(
+          2.0, depth_prior));
+  EXPECT_TRUE(
+      cost_function_with_noise->Evaluate(parameters, residuals, nullptr));
+  EXPECT_EQ(residuals[0], -0.5);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -184,4 +184,16 @@ void BindCostFunctions(py::module& m_parent) {
         "point_in_b_prior"_a,
         "Error between 3D points transformed by a 3D similarity transform. "
         "with prior covariance");
+
+  m.def("ScaledDepthErrorCost", 
+        &ScaledDepthErrorCostFunction::Create, 
+        "depth"_a,
+        "Scaled depth error cost function.");
+  m.def("ScaledDepthErrorCost",
+        &ScaledDepthErrorConstantPoseCostFunction::Create,
+        "cam_from_world"_a,
+        "depth"_a,
+        "Scaled depth error cost function with constant camera pose.");
+  m.def(
+      "LogScaledDepthErrorCost", &LogScaledDepthErrorCostFunction::Create, "depth"_a);
 }


### PR DESCRIPTION
Splitting my last PR into 2 Part 2.

These functions are tailored for MP-SfM, and can not be used in pure COLMAP.

See original PR https://github.com/colmap/colmap/pull/3269