### PR TITLE
Cosmetic cleanup for absolute pose tests

### DIFF
--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -133,8 +133,9 @@ TEST(EstimateGeneralizedAbsolutePose, Nominal) {
                                               &inlier_mask));
   EXPECT_EQ(num_inliers, unique_inlier_ids.size());
   EXPECT_EQ(inlier_mask, gt_inlier_mask);
-  EXPECT_THAT(rig_from_world,
-              Rigid3dNear(problem, /*rtol=*/1e-6, /*ttol=*/1e-6));
+  EXPECT_THAT(
+      rig_from_world,
+      Rigid3dNear(problem.gt_rig_from_world, /*rtol=*/1e-6, /*ttol=*/1e-6));
 }
 
 TEST(RefineGeneralizedAbsolutePose, Nominal) {

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/generalized_absolute_pose.h"
 #include "colmap/geometry/rigid3.h"
+#include "colmap/geometry/rigid3_matchers.h"
 #include "colmap/math/random.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/scene/camera.h"
@@ -44,7 +45,7 @@
 namespace colmap {
 namespace {
 
-struct GeneralizedCameraProblem {
+struct GeneralizedAbsolutePoseProblem {
   Rigid3d gt_rig_from_world;
   std::vector<Eigen::Vector2d> points2D;
   std::vector<Eigen::Vector3d> points3D;
@@ -54,7 +55,7 @@ struct GeneralizedCameraProblem {
   std::vector<Camera> cameras;
 };
 
-GeneralizedCameraProblem BuildGeneralizedCameraProblem() {
+GeneralizedAbsolutePoseProblem BuildGeneralizedCameraProblem() {
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 3;
@@ -64,7 +65,7 @@ GeneralizedCameraProblem BuildGeneralizedCameraProblem() {
   synthetic_dataset_options.point2D_stddev = 0;
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
 
-  GeneralizedCameraProblem problem;
+  GeneralizedAbsolutePoseProblem problem;
   problem.gt_rig_from_world =
       Rigid3d(Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d::Random());
   for (const image_t image_id : reconstruction.RegImageIds()) {
@@ -88,7 +89,7 @@ GeneralizedCameraProblem BuildGeneralizedCameraProblem() {
 TEST(EstimateGeneralizedAbsolutePose, Nominal) {
   SetPRNGSeed();
 
-  GeneralizedCameraProblem problem = BuildGeneralizedCameraProblem();
+  GeneralizedAbsolutePoseProblem problem = BuildGeneralizedCameraProblem();
   const size_t num_points = problem.points2D.size();
 
   const double gt_inlier_ratio = 0.8;
@@ -132,16 +133,12 @@ TEST(EstimateGeneralizedAbsolutePose, Nominal) {
                                               &inlier_mask));
   EXPECT_EQ(num_inliers, unique_inlier_ids.size());
   EXPECT_EQ(inlier_mask, gt_inlier_mask);
-  EXPECT_LT(problem.gt_rig_from_world.rotation.angularDistance(
-                rig_from_world.rotation),
-            1e-6);
-  EXPECT_LT((problem.gt_rig_from_world.translation - rig_from_world.translation)
-                .norm(),
-            1e-6);
+  EXPECT_THAT(rig_from_world,
+              Rigid3dNear(problem, /*rtol=*/1e-6, /*ttol=*/1e-6));
 }
 
 TEST(RefineGeneralizedAbsolutePose, Nominal) {
-  GeneralizedCameraProblem problem = BuildGeneralizedCameraProblem();
+  GeneralizedAbsolutePoseProblem problem = BuildGeneralizedCameraProblem();
   const std::vector<char> gt_inlier_mask(problem.points2D.size(), true);
 
   const double rotation_noise_degree = 1;
@@ -163,12 +160,9 @@ TEST(RefineGeneralizedAbsolutePose, Nominal) {
                                             problem.cams_from_rig,
                                             &rig_from_world,
                                             &problem.cameras));
-  EXPECT_LT(problem.gt_rig_from_world.rotation.angularDistance(
-                rig_from_world.rotation),
-            1e-6);
-  EXPECT_LT((problem.gt_rig_from_world.translation - rig_from_world.translation)
-                .norm(),
-            1e-6);
+  EXPECT_THAT(
+      rig_from_world,
+      Rigid3dNear(problem.gt_rig_from_world, /*rtol=*/1e-6, /*ttol=*/1e-6));
 }
 
 }  // namespace

--- a/src/colmap/estimators/pose_test.cc
+++ b/src/colmap/estimators/pose_test.cc
@@ -40,7 +40,7 @@
 namespace colmap {
 namespace {
 
-struct EstimateAbsolutePoseTestData {
+struct AbsolutePoseProblem {
   Reconstruction reconstruction;
   Image image;
   Camera camera;
@@ -48,159 +48,154 @@ struct EstimateAbsolutePoseTestData {
   std::vector<Eigen::Vector3d> points3D;
 };
 
-EstimateAbsolutePoseTestData CreateAbsolutePoseTestData() {
-  EstimateAbsolutePoseTestData test_data;
+AbsolutePoseProblem CreateAbsolutePoseTestData() {
+  AbsolutePoseProblem problem;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
   synthetic_dataset_options.num_frames_per_rig = 2;
   synthetic_dataset_options.num_points3D = 100;
   synthetic_dataset_options.point2D_stddev = 0;
-  SynthesizeDataset(synthetic_dataset_options, &test_data.reconstruction);
+  SynthesizeDataset(synthetic_dataset_options, &problem.reconstruction);
 
-  test_data.image = test_data.reconstruction.Image(1);
-  test_data.camera = *test_data.image.CameraPtr();
-  CHECK_EQ(test_data.camera.model_id, CameraModelId::kSimpleRadial);
-  for (const auto& point2D : test_data.image.Points2D()) {
+  problem.image = problem.reconstruction.Image(1);
+  problem.camera = *problem.image.CameraPtr();
+  CHECK_EQ(problem.camera.model_id, CameraModelId::kSimpleRadial);
+  for (const auto& point2D : problem.image.Points2D()) {
     if (point2D.HasPoint3D()) {
-      test_data.points2D.push_back(point2D.xy);
-      test_data.points3D.push_back(
-          test_data.reconstruction.Point3D(point2D.point3D_id).xyz);
+      problem.points2D.push_back(point2D.xy);
+      problem.points3D.push_back(
+          problem.reconstruction.Point3D(point2D.point3D_id).xyz);
     }
   }
 
-  return test_data;
+  return problem;
 }
 
 TEST(EstimateAbsolutePose, Nominal) {
-  const EstimateAbsolutePoseTestData test_data = CreateAbsolutePoseTestData();
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData();
 
   AbsolutePoseEstimationOptions options;
   Rigid3d cam_from_world;
   size_t num_inliers = 0;
   std::vector<char> inlier_mask;
-  Camera camera = test_data.camera;
+  Camera camera = problem.camera;
   EXPECT_TRUE(EstimateAbsolutePose(options,
-                                   test_data.points2D,
-                                   test_data.points3D,
+                                   problem.points2D,
+                                   problem.points3D,
                                    &cam_from_world,
                                    &camera,
                                    &num_inliers,
                                    &inlier_mask));
   EXPECT_THAT(
       cam_from_world,
-      Rigid3dNear(
-          test_data.image.CamFromWorld(), /*rtol=*/1e-6, /*ttol=*/1e-6));
-  EXPECT_EQ(camera, test_data.camera);
-  EXPECT_EQ(num_inliers, test_data.points2D.size());
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-6, /*ttol=*/1e-6));
+  EXPECT_EQ(camera, problem.camera);
+  EXPECT_EQ(num_inliers, problem.points2D.size());
   EXPECT_THAT(inlier_mask, testing::Each(testing::Eq(true)));
 }
 
 TEST(EstimateAbsolutePose, EstimateFocalLength) {
-  const EstimateAbsolutePoseTestData test_data = CreateAbsolutePoseTestData();
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData();
 
   AbsolutePoseEstimationOptions options;
   options.estimate_focal_length = true;
   Rigid3d cam_from_world;
   size_t num_inliers = 0;
   std::vector<char> inlier_mask;
-  Camera camera = test_data.camera;
+  Camera camera = problem.camera;
   EXPECT_TRUE(EstimateAbsolutePose(options,
-                                   test_data.points2D,
-                                   test_data.points3D,
+                                   problem.points2D,
+                                   problem.points3D,
                                    &cam_from_world,
                                    &camera,
                                    &num_inliers,
                                    &inlier_mask));
   EXPECT_THAT(
       cam_from_world,
-      Rigid3dNear(
-          test_data.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-2));
-  EXPECT_NEAR(camera.FocalLength(), test_data.camera.FocalLength(), 5);
-  camera.SetFocalLength(test_data.camera.FocalLength());
-  EXPECT_EQ(camera, test_data.camera);
-  EXPECT_EQ(num_inliers, test_data.points2D.size());
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-2));
+  EXPECT_NEAR(camera.FocalLength(), problem.camera.FocalLength(), 5);
+  camera.SetFocalLength(problem.camera.FocalLength());
+  EXPECT_EQ(camera, problem.camera);
+  EXPECT_EQ(num_inliers, problem.points2D.size());
   EXPECT_THAT(inlier_mask, testing::Each(testing::Eq(true)));
 }
 
 TEST(RefineAbsolutePose, Nominal) {
-  const EstimateAbsolutePoseTestData test_data = CreateAbsolutePoseTestData();
-  std::vector<char> inlier_mask(test_data.points2D.size(), true);
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData();
+  std::vector<char> inlier_mask(problem.points2D.size(), true);
 
   AbsolutePoseRefinementOptions options;
-  Rigid3d cam_from_world = test_data.image.CamFromWorld();
+  Rigid3d cam_from_world = problem.image.CamFromWorld();
   cam_from_world =
       cam_from_world * Rigid3d(Eigen::Quaterniond(Eigen::AngleAxisd(
                                    0.1, Eigen::Vector3d::Random())),
                                0.1 * Eigen::Vector3d::Random());
-  Camera camera = test_data.camera;
+  Camera camera = problem.camera;
   Eigen::Matrix6d cam_from_world_cov = Eigen::Matrix6d::Zero();
   EXPECT_TRUE(RefineAbsolutePose(options,
                                  inlier_mask,
-                                 test_data.points2D,
-                                 test_data.points3D,
+                                 problem.points2D,
+                                 problem.points3D,
                                  &cam_from_world,
                                  &camera,
                                  &cam_from_world_cov));
   EXPECT_THAT(
       cam_from_world,
-      Rigid3dNear(
-          test_data.image.CamFromWorld(), /*rtol=*/1e-6, /*ttol=*/1e-6));
-  EXPECT_EQ(camera, test_data.camera);
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-6, /*ttol=*/1e-6));
+  EXPECT_EQ(camera, problem.camera);
   EXPECT_NE(cam_from_world_cov, Eigen::Matrix6d::Zero());
 }
 
 TEST(RefineAbsolutePose, RefineFocalLength) {
-  const EstimateAbsolutePoseTestData test_data = CreateAbsolutePoseTestData();
-  std::vector<char> inlier_mask(test_data.points2D.size(), true);
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData();
+  std::vector<char> inlier_mask(problem.points2D.size(), true);
 
   AbsolutePoseRefinementOptions options;
   options.refine_focal_length = true;
-  Rigid3d cam_from_world = test_data.image.CamFromWorld();
-  Camera camera = test_data.camera;
+  Rigid3d cam_from_world = problem.image.CamFromWorld();
+  Camera camera = problem.camera;
   camera.SetFocalLength(0.9 * camera.FocalLength());
   Eigen::Matrix6d cam_from_world_cov = Eigen::Matrix6d::Zero();
   EXPECT_TRUE(RefineAbsolutePose(options,
                                  inlier_mask,
-                                 test_data.points2D,
-                                 test_data.points3D,
+                                 problem.points2D,
+                                 problem.points3D,
                                  &cam_from_world,
                                  &camera,
                                  &cam_from_world_cov));
   EXPECT_THAT(
       cam_from_world,
-      Rigid3dNear(
-          test_data.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
-  EXPECT_NEAR(camera.FocalLength(), test_data.camera.FocalLength(), 5);
-  camera.SetFocalLength(test_data.camera.FocalLength());
-  EXPECT_EQ(camera, test_data.camera);
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
+  EXPECT_NEAR(camera.FocalLength(), problem.camera.FocalLength(), 5);
+  camera.SetFocalLength(problem.camera.FocalLength());
+  EXPECT_EQ(camera, problem.camera);
   EXPECT_NE(cam_from_world_cov, Eigen::Matrix6d::Zero());
 }
 
 TEST(RefineAbsolutePose, RefineExtraParams) {
-  const EstimateAbsolutePoseTestData test_data = CreateAbsolutePoseTestData();
-  std::vector<char> inlier_mask(test_data.points2D.size(), true);
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData();
+  std::vector<char> inlier_mask(problem.points2D.size(), true);
 
   AbsolutePoseRefinementOptions options;
   options.refine_extra_params = true;
-  Rigid3d cam_from_world = test_data.image.CamFromWorld();
-  Camera camera = test_data.camera;
+  Rigid3d cam_from_world = problem.image.CamFromWorld();
+  Camera camera = problem.camera;
   camera.params.at(3) += 0.1;
   Eigen::Matrix6d cam_from_world_cov = Eigen::Matrix6d::Zero();
   EXPECT_TRUE(RefineAbsolutePose(options,
                                  inlier_mask,
-                                 test_data.points2D,
-                                 test_data.points3D,
+                                 problem.points2D,
+                                 problem.points3D,
                                  &cam_from_world,
                                  &camera,
                                  &cam_from_world_cov));
   EXPECT_THAT(
       cam_from_world,
-      Rigid3dNear(
-          test_data.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
-  EXPECT_NEAR(camera.params.at(3), test_data.camera.params.at(3), 1e-3);
-  camera.params.at(3) = test_data.camera.params.at(3);
-  EXPECT_EQ(camera, test_data.camera);
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
+  EXPECT_NEAR(camera.params.at(3), problem.camera.params.at(3), 1e-3);
+  camera.params.at(3) = problem.camera.params.at(3);
+  EXPECT_EQ(camera, problem.camera);
   EXPECT_NE(cam_from_world_cov, Eigen::Matrix6d::Zero());
 }
 


### PR DESCRIPTION
* Consistent naming and structure.
* Use of new Rigid3d gmock matcher in generalized pose tests.