### PR TITLE
Turn camera parameter access debug checks into throwing checks

### DIFF
--- a/src/colmap/estimators/absolute_pose_test.cc
+++ b/src/colmap/estimators/absolute_pose_test.cc
@@ -305,7 +305,7 @@ TEST(AbsolutePose, EPNP_BrokenSolveSignCase) {
 
 TEST(ComputeSquaredReprojectionError, Nominal) {
   const Camera camera = Camera::CreateFromModelId(
-      kInvalidCameraId, CameraModelId::kPinhole, 12, 34, 56);
+      kInvalidCameraId, CameraModelId::kSimplePinhole, 12, 34, 56);
   auto img_from_cam_func =
       std::bind(&Camera::ImgFromCam, &camera, std::placeholders::_1);
 

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -162,7 +162,7 @@ sensor_t Camera::SensorId() const {
 
 double Camera::FocalLength() const {
   const span<const size_t> idxs = FocalLengthIdxs();
-  DCHECK_EQ(idxs.size(), 1);
+  THROW_CHECK_EQ(idxs.size(), 1);
   return params[idxs[0]];
 }
 
@@ -185,37 +185,37 @@ void Camera::SetFocalLength(const double f) {
 
 void Camera::SetFocalLengthX(const double fx) {
   const span<const size_t> idxs = FocalLengthIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   params[idxs[0]] = fx;
 }
 
 void Camera::SetFocalLengthY(const double fy) {
   const span<const size_t> idxs = FocalLengthIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   params[idxs[1]] = fy;
 }
 
 double Camera::PrincipalPointX() const {
   const span<const size_t> idxs = PrincipalPointIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   return params[idxs[0]];
 }
 
 double Camera::PrincipalPointY() const {
   const span<const size_t> idxs = PrincipalPointIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   return params[idxs[1]];
 }
 
 void Camera::SetPrincipalPointX(const double cx) {
   const span<const size_t> idxs = PrincipalPointIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   params[idxs[0]] = cx;
 }
 
 void Camera::SetPrincipalPointY(const double cy) {
   const span<const size_t> idxs = PrincipalPointIdxs();
-  DCHECK_EQ(idxs.size(), 2);
+  THROW_CHECK_EQ(idxs.size(), 2);
   params[idxs[1]] = cy;
 }
 


### PR DESCRIPTION
The ComputeSquaredReprojectionError test failed in debug mode, because the pinhole model has 2 focal length parameters.