### PR TITLE
Covariance-aware Umeyama for pose prior mapper

### DIFF
--- a/src/colmap/estimators/similarity_transform.cc
+++ b/src/colmap/estimators/similarity_transform.cc
@@ -110,4 +110,251 @@ EstimateSim3dRobust(const std::vector<Eigen::Vector3d>& src,
   return report;
 }
 
+bool WeightedUmeyama(const std::vector<Eigen::Vector3d>& src_points,
+                     const std::vector<Eigen::Vector3d>& dst_points,
+                     const std::vector<Eigen::Matrix3d>& covariances,
+                     Sim3d* tgt_from_src) {
+  CHECK_EQ(src_points.size(), dst_points.size());
+  CHECK_EQ(src_points.size(), covariances.size());
+  
+  // Convert vector of points to Eigen matrices for the template version
+  using MatrixType = Eigen::Matrix<double, 3, Eigen::Dynamic>;
+  MatrixType src_mat(3, src_points.size());
+  MatrixType dst_mat(3, dst_points.size());
+  
+  for (size_t i = 0; i < src_points.size(); ++i) {
+    src_mat.col(i) = src_points[i];
+    dst_mat.col(i) = dst_points[i];
+  }
+  
+  // Call the template version to do the actual computation
+  Eigen::Matrix<double, 3, 4> tgt_from_src_mat = 
+      WeightedUmeyama(src_mat, dst_mat, covariances, true);
+  
+  // Check if result is valid
+  if (tgt_from_src_mat.hasNaN()) {
+    return false;
+  }
+  
+  // Convert result to Sim3d
+  *tgt_from_src = Sim3d::FromMatrix(tgt_from_src_mat);
+  
+  return true;
+}
+
+template <typename Derived1, typename Derived2>
+Eigen::Matrix<typename Derived1::Scalar, Derived1::RowsAtCompileTime,
+              Derived1::RowsAtCompileTime + 1>
+WeightedUmeyama(const Eigen::MatrixBase<Derived1>& src,
+               const Eigen::MatrixBase<Derived2>& dst,
+               const std::vector<Eigen::Matrix3d>& covariances,
+               bool with_scaling) {
+  typedef typename Derived1::Scalar Scalar;
+  typedef Eigen::Matrix<Scalar, Derived1::RowsAtCompileTime, 1> Vector;
+  typedef Eigen::Matrix<Scalar, Derived1::RowsAtCompileTime,
+                        Derived1::RowsAtCompileTime>
+      Matrix;
+  typedef Eigen::Matrix<Scalar, Derived1::RowsAtCompileTime,
+                        Derived1::RowsAtCompileTime + 1>
+      Result;
+
+  const int rows = src.rows();
+  const int cols = src.cols();
+
+  THROW_CHECK_EQ(rows, dst.rows());
+  THROW_CHECK_EQ(cols, dst.cols());
+  THROW_CHECK_EQ(static_cast<size_t>(cols), covariances.size());
+
+  // Prepare weight matrix for each axis based on the inverse of variance
+  std::vector<Vector> weights(cols);
+  
+  // Create axis-specific weights from covariance diagonal
+  for (int i = 0; i < cols; ++i) {
+    // Extract axis variances from covariance
+    Vector variances = covariances[i].diagonal();
+    // Convert to weights (higher uncertainty = lower weight)
+    // Apply a minimum threshold for numerical stability
+    for (int j = 0; j < rows; j++) {
+      weights[i](j) = 1.0 / std::max(variances(j), 1e-8);
+    }
+  }
+
+  // Compute weighted centroids
+  Vector src_mean = Vector::Zero(rows);
+  Vector dst_mean = Vector::Zero(rows);
+  Vector weight_sum = Vector::Zero(rows);
+  
+  for (int i = 0; i < cols; ++i) {
+    for (int j = 0; j < rows; j++) {
+      src_mean(j) += weights[i](j) * src.col(i)(j);
+      dst_mean(j) += weights[i](j) * dst.col(i)(j);
+      weight_sum(j) += weights[i](j);
+    }
+  }
+  
+  // Normalize by weight sum
+  for (int j = 0; j < rows; j++) {
+    if (weight_sum(j) > 0) {
+      src_mean(j) /= weight_sum(j);
+      dst_mean(j) /= weight_sum(j);
+    }
+  }
+
+  // Compute weighted covariance matrix
+  Matrix covariance = Matrix::Zero(rows, rows);
+  Scalar src_variance = 0.0;
+  
+  for (int i = 0; i < cols; ++i) {
+    Vector src_diff = src.col(i) - src_mean;
+    Vector dst_diff = dst.col(i) - dst_mean;
+    
+    // Weight each dimension according to its uncertainty
+    Vector weighted_src_diff = src_diff;
+    for (int j = 0; j < rows; j++) {
+      weighted_src_diff(j) *= std::sqrt(weights[i](j));
+      dst_diff(j) *= std::sqrt(weights[i](j));
+    }
+    
+    // Build weighted cross-covariance
+    covariance += dst_diff * weighted_src_diff.transpose();
+    
+    // For source variance
+    src_variance += weighted_src_diff.squaredNorm();
+  }
+  
+  // SVD
+  Eigen::JacobiSVD<Matrix> svd(covariance, 
+                            Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Matrix rotation = svd.matrixU() * svd.matrixV().transpose();
+  
+  // Special case: reflection
+  if (rotation.determinant() < 0) {
+    Matrix S = Matrix::Identity(rows, rows);
+    S(rows - 1, rows - 1) = -1;
+    rotation = svd.matrixU() * S * svd.matrixV().transpose();
+  }
+  
+  // Compute scaling factor
+  Scalar scale = 1;
+  if (with_scaling && src_variance > 0) {
+    scale = svd.singularValues().sum() / src_variance;
+  }
+  
+  // Compute translation
+  Vector translation = dst_mean - scale * rotation * src_mean;
+  
+  // Compose similarity transformation matrix
+  Result similarity;
+  similarity.template block<Derived1::RowsAtCompileTime, 
+                           Derived1::RowsAtCompileTime>(0, 0) = scale * rotation;
+  similarity.col(rows) = translation;
+  
+  // Verify that the transformation actually improves the alignment
+  double before_error = 0.0;
+  double after_error = 0.0;
+  
+  for (int i = 0; i < cols; ++i) {
+    Vector transformed = scale * rotation * src.col(i) + translation;
+    
+    // Calculate weighted MSE for each point
+    for (int j = 0; j < rows; j++) {
+      before_error += weights[i](j) * std::pow(dst.col(i)(j) - src.col(i)(j), 2);
+      after_error += weights[i](j) * std::pow(dst.col(i)(j) - transformed(j), 2);
+    }
+  }
+  
+  // If the transform makes the error worse, return identity transform
+  if (after_error > before_error) {
+    LOG(WARNING) << "Weighted alignment increased error from " << before_error 
+                 << " to " << after_error << ", falling back to identity transform";
+    similarity.template block<Derived1::RowsAtCompileTime, 
+                           Derived1::RowsAtCompileTime>(0, 0) = Matrix::Identity(rows, rows);
+    similarity.col(rows) = Vector::Zero(rows);
+  } else {
+    LOG(INFO) << "Weighted alignment improved error from " << before_error 
+              << " to " << after_error;
+  }
+  
+  return similarity;
+}
+
+// Template instantiation for the 3D case we need
+template Eigen::Matrix<double, 3, 4> WeightedUmeyama<
+    Eigen::Matrix<double, 3, Eigen::Dynamic>,
+    Eigen::Matrix<double, 3, Eigen::Dynamic>>(
+    const Eigen::MatrixBase<Eigen::Matrix<double, 3, Eigen::Dynamic>>& src,
+    const Eigen::MatrixBase<Eigen::Matrix<double, 3, Eigen::Dynamic>>& dst,
+    const std::vector<Eigen::Matrix3d>& covariances,
+    bool with_scaling);
+
+bool EstimateWeightedSim3d(const std::vector<Eigen::Vector3d>& src,
+                          const std::vector<Eigen::Vector3d>& tgt,
+                          const std::vector<Eigen::Matrix3d>& covariances,
+                          Sim3d& tgt_from_src) {
+  CHECK_EQ(src.size(), tgt.size());
+  CHECK_EQ(src.size(), covariances.size());
+  
+  if (src.size() < 3) {
+    return false;
+  }
+  
+  return WeightedUmeyama(src, tgt, covariances, &tgt_from_src);
+}
+
+void PrintAxisErrors(const std::vector<Eigen::Vector3d>& src,
+                    const std::vector<Eigen::Vector3d>& tgt,
+                    const std::vector<Eigen::Matrix3d>& covariances,
+                    const Sim3d& tgt_from_src) {
+  CHECK_EQ(src.size(), tgt.size());
+  CHECK_EQ(src.size(), covariances.size());
+  
+  // Compute per-axis weights based on the inverse of variances
+  std::vector<Eigen::Vector3d> weights(src.size());
+  Eigen::Vector3d total_weights = Eigen::Vector3d::Zero();
+  
+  // Extract axis-specific weights from covariance diagonal
+  for (size_t i = 0; i < src.size(); ++i) {
+    // Get diagonal elements (variances for each axis)
+    Eigen::Vector3d variances = covariances[i].diagonal();
+    
+    // Convert to weights (higher uncertainty = lower weight)
+    for (int j = 0; j < 3; j++) {
+      weights[i](j) = 1.0 / std::max(variances(j), 1e-8);
+      total_weights(j) += weights[i](j);
+    }
+  }
+  
+  // Normalize weights per axis
+  for (size_t i = 0; i < weights.size(); ++i) {
+    for (int j = 0; j < 3; j++) {
+      if (total_weights(j) > 0) {
+        weights[i](j) /= total_weights(j);
+      }
+    }
+  }
+  
+  Eigen::Vector3d weighted_mse = Eigen::Vector3d::Zero();
+  double total_mse = 0.0;
+  
+  for (size_t i = 0; i < src.size(); ++i) {
+    const Eigen::Vector3d transformed = tgt_from_src * src[i];
+    const Eigen::Vector3d diff = tgt[i] - transformed;
+    
+    // Calculate per-axis weighted MSE
+    for (int j = 0; j < 3; ++j) {
+      weighted_mse(j) += weights[i](j) * diff(j) * diff(j);
+    }
+    
+    // Calculate total weighted MSE (sum of per-axis MSEs)
+    total_mse += diff(0) * diff(0) * weights[i](0) + 
+                 diff(1) * diff(1) * weights[i](1) + 
+                 diff(2) * diff(2) * weights[i](2);
+  }
+  
+  LOG(INFO) << "Weighted MSE per axis - X: " << weighted_mse(0)
+            << ", Y: " << weighted_mse(1)
+            << ", Z: " << weighted_mse(2)
+            << ", Total: " << total_mse;
+}
+
 }  // namespace colmap

--- a/src/colmap/estimators/similarity_transform.h
+++ b/src/colmap/estimators/similarity_transform.h
@@ -41,8 +41,33 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <Eigen/Dense>
 
 namespace colmap {
+
+// Estimates a 3D similarity transform with per-axis weighting from covariance matrices
+bool EstimateWeightedSim3d(const std::vector<Eigen::Vector3d>& src,
+                          const std::vector<Eigen::Vector3d>& tgt,
+                          const std::vector<Eigen::Matrix3d>& covariances,
+                          Sim3d& tgt_from_src);
+
+// Estimates a 3D similarity transform with per-axis weighting from covariances
+// Uses the diagonal elements of covariance matrices to determine per-axis weights
+// Higher uncertainty (variance) in an axis results in lower weight for that axis
+bool WeightedUmeyama(const std::vector<Eigen::Vector3d>& src_points,
+                    const std::vector<Eigen::Vector3d>& dst_points,
+                    const std::vector<Eigen::Matrix3d>& covariances,
+                    Sim3d* tgt_from_src);
+
+// Template implementation of weighted Umeyama algorithm that handles per-axis uncertainty
+// The template version is used internally by the vector-based version above
+template <typename Derived1, typename Derived2>
+Eigen::Matrix<typename Derived1::Scalar, Derived1::RowsAtCompileTime,
+              Derived1::RowsAtCompileTime + 1>
+WeightedUmeyama(const Eigen::MatrixBase<Derived1>& src,
+               const Eigen::MatrixBase<Derived2>& dst,
+               const std::vector<Eigen::Matrix3d>& covariances,
+               bool with_scaling = true);
 
 // N-D similarity transform estimator from corresponding point pairs in the
 // source and destination coordinate systems.


### PR DESCRIPTION
### Summary
Pose prior covariance matrices are used during pose prior BA but not for the Sim3 alignment. In the case where pose priors have significantly lower/higher uncertainties for different axes, this leads to a very bad alignment, loosing all the benefits of the pose prior BA.

### Practical application

For underwater surveys, we often only have access to depth/altitude measurements. In addition, calibration is tougher due to refraction. Also, we mainly observe flat surfaces from a top-down view and for long distances. Because of this, a small difference in distortion parameters can lead to significant curve-like drift (see first figure below). Incorporating depth/altitude measurements into the BA is a very good way to regularize the camera parameters and enable a flat reconstruction.

We ran COLMAP pose prior mapper with and without the covariance-weighted Umeyama on a sample of our data. Since we only have access to depth measurements, the X and Y axes of our pose priors are uniform random values between -10 and 10.

Both following models were obtained using this command:
```
colmap pose_prior_mapper --database_path database.db --image_path images/ --output_path weighted/ --Mapper.ba_refine_principal_point 1 --overwrite_priors_covariance 1 --prior_position_std_x 10000.0 --prior_position_std_y 10000.0 --prior_position_std_z 0.01 --Mapper.ba_global_max_num_iterations 20 --Mapper.ba_global_max_refinements 3 --Mapper.ba_global_function_tolerance 0.00000001
```

**Without weighted Umeyama:**
![classic](https://github.com/user-attachments/assets/f2c5a0da-9285-47a7-8906-a3325dbb7636)


**With weighted Umeyama:**
![weighted](https://github.com/user-attachments/assets/46514706-223d-40f5-a9d4-21f7cff947ba)

You can find the images, database and COLMAP models here: https://drive.google.com/file/d/1dDQOfejPgSZYCfdlnQcSFlefAb819ZW4/view?usp=sharing

### Pull request
The code is dirty, this should not be merged. Please let me know if you feel that this is a useful feature that should be integrated in the project. In this case I can do some cleaning.

**Side note:** it seems that the pose prior mapper is performing Sim3 alignment with RANSAC by default - this feels quite hard to setup RANSAC with covariance-aware Umeyama - maybe a parameter could control whether or not to use RANSAC for this step (or maybe I am missing something).