### PR TITLE
Fix runtime error in panorama_sfm.py with sequential matching

### DIFF
--- a/python/examples/panorama_sfm.py
+++ b/python/examples/panorama_sfm.py
@@ -216,7 +216,7 @@ def run(args):
     if args.matcher == "sequential":
         pycolmap.match_sequential(
             database_path,
-            pycolmap.SequentialMatchingOptions(loop_detection=True),
+            matching_options=pycolmap.SequentialMatchingOptions(loop_detection=True),
         )
     elif args.matcher == "exhaustive":
         pycolmap.match_exhaustive(database_path)

--- a/python/examples/panorama_sfm.py
+++ b/python/examples/panorama_sfm.py
@@ -216,7 +216,9 @@ def run(args):
     if args.matcher == "sequential":
         pycolmap.match_sequential(
             database_path,
-            matching_options=pycolmap.SequentialMatchingOptions(loop_detection=True),
+            matching_options=pycolmap.SequentialMatchingOptions(
+                loop_detection=True
+            ),
         )
     elif args.matcher == "exhaustive":
         pycolmap.match_exhaustive(database_path)


### PR DESCRIPTION
## Issue
When running `panorama_sfm.py` with sequential matching, an error occurs because `match_sequential()` expects `sift_options` as the second argument, but receives a `SequentialMatchingOptions` object instead, resulting in a runtime error:


```
TypeError: match_sequential(): incompatible function arguments. The following argument types are supported:
    1. (database_path: str, sift_options: pycolmap._core.SiftMatchingOptions = SiftMatchingOptions(), matching_options: pycolmap._core.SequentialMatchingOptions = SequentialMatchingOptions(), verification_options: pycolmap._core.TwoViewGeometryOptions = TwoViewGeometryOptions(), device: pycolmap._core.Device = Device.auto) -> None

Invoked with: PosixPath('sfm/database.db'), SequentialMatchingOptions(overlap=10, quadratic_overlap=True, expand_rig_images=True, loop_detection=True, loop_detection_period=10, loop_detection_num_images=50, loop_detection_num_nearest_neighbors=1, loop_detection_num_checks=256, loop_detection_num_images_after_verification=0, loop_detection_max_num_features=-1, vocab_tree_path='')
```

## Solution
Modified the function call to pass `SequentialMatchingOptions` as a keyword argument, ensuring it's correctly assigned to the `matching_options` parameter. This maintains the expected argument structure while resolving the runtime error.

## Testing
After implementing this fix, `panorama_sfm.py` with sequential matching executes successfully.

Environment: Python 3.10, Colmap/PyColmap main branch built from source

Thanks for creating such a useful tool!