### PR TITLE
Upgrade Jimver/cuda-toolkit GH actions task to 0.2.23

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -91,7 +91,7 @@ jobs:
           .github/workflows/install-ccache.ps1 -Destination "${{ env.COMPILER_CACHE_DIR }}/bin"
 
       - name: Install CUDA
-        uses: Jimver/cuda-toolkit@v0.2.18
+        uses: Jimver/cuda-toolkit@v0.2.23
         if: matrix.config.cudaEnabled
         id: cuda-toolkit
         with:


### PR DESCRIPTION
Mitigates a GH action cache deprecation warning.