### PR TITLE
Update feature index to use float descriptors and distances

### DIFF
--- a/src/colmap/feature/index.h
+++ b/src/colmap/feature/index.h
@@ -48,12 +48,12 @@ class FeatureDescriptorIndex {
   static std::unique_ptr<FeatureDescriptorIndex> Create(
       Type type = Type::DEFAULT, int num_threads = 1);
 
-  virtual void Build(const FeatureDescriptors& descriptors) = 0;
+  virtual void Build(const FeatureDescriptorsFloat& descriptors) = 0;
 
   virtual void Search(int num_neighbors,
-                      const FeatureDescriptors& query_descriptors,
+                      const FeatureDescriptorsFloat& query_descriptors,
                       Eigen::RowMajorMatrixXi& indices,
-                      Eigen::RowMajorMatrixXi& l2_dists) const = 0;
+                      Eigen::RowMajorMatrixXf& l2_dists) const = 0;
 };
 
 }  // namespace colmap

--- a/src/colmap/feature/index_test.cc
+++ b/src/colmap/feature/index_test.cc
@@ -38,7 +38,8 @@
 namespace colmap {
 namespace {
 
-FeatureDescriptors CreateRandomFeatureDescriptors(const size_t num_features) {
+FeatureDescriptorsFloat CreateRandomFeatureDescriptors(
+    const size_t num_features) {
   SetPRNGSeed(0);
   FeatureDescriptorsFloat descriptors(num_features, 128);
   for (size_t i = 0; i < num_features; ++i) {
@@ -47,7 +48,7 @@ FeatureDescriptors CreateRandomFeatureDescriptors(const size_t num_features) {
     }
   }
   L2NormalizeFeatureDescriptors(&descriptors);
-  return FeatureDescriptorsToUnsignedByte(descriptors);
+  return descriptors;
 }
 
 class ParameterizedFeatureDescriptorIndexTests
@@ -66,13 +67,13 @@ TEST_P(ParameterizedFeatureDescriptorIndexTests, Nominal) {
 
   EXPECT_NE(index, nullptr);
 
-  const FeatureDescriptors index_descriptors =
+  const FeatureDescriptorsFloat index_descriptors =
       CreateRandomFeatureDescriptors(num_descriptors);
-  const FeatureDescriptors& query_descriptors = index_descriptors;
+  const FeatureDescriptorsFloat& query_descriptors = index_descriptors;
   index->Build(index_descriptors);
 
   Eigen::RowMajorMatrixXi indices;
-  Eigen::RowMajorMatrixXi distances;
+  Eigen::RowMajorMatrixXf distances;
   index->Search(/*num_neighbors=*/1, query_descriptors, indices, distances);
 
   ASSERT_EQ(indices.rows(), query_descriptors.rows());
@@ -82,7 +83,7 @@ TEST_P(ParameterizedFeatureDescriptorIndexTests, Nominal) {
 
   for (int i = 0; i < query_descriptors.rows(); ++i) {
     EXPECT_EQ(indices(i, 0), i);
-    EXPECT_EQ(distances(i, 0), 0);
+    EXPECT_NEAR(distances(i, 0), 0, 1e-6);
   }
 
   index->Search(/*num_neighbors=*/2, query_descriptors, indices, distances);
@@ -93,12 +94,13 @@ TEST_P(ParameterizedFeatureDescriptorIndexTests, Nominal) {
 
   for (int i = 0; i < query_descriptors.rows(); ++i) {
     EXPECT_EQ(indices(i, 0), i);
-    EXPECT_EQ(distances(i, 0), 0);
+    EXPECT_NEAR(distances(i, 0), 0, 1e-6);
     EXPECT_NE(indices(i, 1), i);
-    EXPECT_EQ(distances(i, 1),
-              (query_descriptors.row(i).cast<int>() -
-               index_descriptors.row(indices(i, 1)).cast<int>())
-                  .squaredNorm());
+    EXPECT_NEAR(
+        distances(i, 1),
+        (query_descriptors.row(i) - index_descriptors.row(indices(i, 1)))
+            .squaredNorm(),
+        1e-6);
   }
 
   index->Search(/*num_neighbors=*/index_descriptors.rows() + 1,

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -38,7 +38,7 @@ FeatureMatcherCache::FeatureMatcherCache(
       descriptor_index_cache_(cache_size_, [this](const image_t image_id) {
         auto descriptors = GetDescriptors(image_id);
         auto index = FeatureDescriptorIndex::Create();
-        index->Build(*descriptors);
+        index->Build(descriptors->cast<float>());
         return index;
       }) {
   keypoints_cache_ =

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -732,7 +732,7 @@ std::unique_ptr<FeatureExtractor> CreateSiftFeatureExtractor(
 namespace {
 
 size_t FindBestMatchesOneWayBruteForce(
-    const Eigen::RowMajorMatrixXi& dot_products,
+    const Eigen::RowMajorMatrixXf& dot_products,
     const float max_ratio,
     const float max_distance,
     std::vector<int>* matches) {
@@ -744,10 +744,10 @@ size_t FindBestMatchesOneWayBruteForce(
 
   for (Eigen::Index i1 = 0; i1 < dot_products.rows(); ++i1) {
     int best_d2_idx = -1;
-    int best_dot_product = 0;
-    int second_best_dot_product = 0;
+    float best_dot_product = 0;
+    float second_best_dot_product = 0;
     for (Eigen::Index i2 = 0; i2 < dot_products.cols(); ++i2) {
-      const int dot_product = dot_products(i1, i2);
+      const float dot_product = dot_products(i1, i2);
       if (dot_product > best_dot_product) {
         best_d2_idx = i2;
         second_best_dot_product = best_dot_product;
@@ -787,7 +787,7 @@ size_t FindBestMatchesOneWayBruteForce(
   return num_matches;
 }
 
-void FindBestMatchesBruteForce(const Eigen::RowMajorMatrixXi& dot_products,
+void FindBestMatchesBruteForce(const Eigen::RowMajorMatrixXf& dot_products,
                                const float max_ratio,
                                const float max_distance,
                                const bool cross_check,
@@ -826,22 +826,22 @@ void FindBestMatchesBruteForce(const Eigen::RowMajorMatrixXi& dot_products,
 }
 
 size_t FindBestMatchesOneWayIndex(const Eigen::RowMajorMatrixXi& indices,
-                                  const Eigen::RowMajorMatrixXi& l2_dists,
+                                  const Eigen::RowMajorMatrixXf& l2_dists,
                                   const float max_ratio,
                                   const float max_distance,
                                   std::vector<int>* matches) {
-  const int max_l2_dist = kSqSiftDescriptorNorm * max_distance * max_distance;
+  const float max_l2_dist = kSqSiftDescriptorNorm * max_distance * max_distance;
 
   size_t num_matches = 0;
   matches->resize(indices.rows(), -1);
 
   for (int d1_idx = 0; d1_idx < indices.rows(); ++d1_idx) {
     int best_d2_idx = -1;
-    int best_l2_dist = std::numeric_limits<int>::max();
-    int second_best_l2_dist = std::numeric_limits<int>::max();
+    float best_l2_dist = std::numeric_limits<float>::max();
+    float second_best_l2_dist = std::numeric_limits<float>::max();
     for (int n_idx = 0; n_idx < indices.cols(); ++n_idx) {
       const int d2_idx = indices(d1_idx, n_idx);
-      const int l2_dist = l2_dists(d1_idx, n_idx);
+      const float l2_dist = l2_dists(d1_idx, n_idx);
       if (l2_dist < best_l2_dist) {
         best_d2_idx = d2_idx;
         second_best_l2_dist = best_l2_dist;
@@ -863,8 +863,7 @@ size_t FindBestMatchesOneWayIndex(const Eigen::RowMajorMatrixXi& indices,
 
     // Check if match passes ratio test. Keep this comparison >= in order to
     // ensure that the case of best == second_best is detected.
-    if (std::sqrt(static_cast<float>(best_l2_dist)) >=
-        max_ratio * std::sqrt(static_cast<float>(second_best_l2_dist))) {
+    if (std::sqrt(best_l2_dist) >= max_ratio * std::sqrt(second_best_l2_dist)) {
       continue;
     }
 
@@ -876,9 +875,9 @@ size_t FindBestMatchesOneWayIndex(const Eigen::RowMajorMatrixXi& indices,
 }
 
 void FindBestMatchesIndex(const Eigen::RowMajorMatrixXi& indices_1to2,
-                          const Eigen::RowMajorMatrixXi& l2_dists_1to2,
+                          const Eigen::RowMajorMatrixXf& l2_dists_1to2,
                           const Eigen::RowMajorMatrixXi& indices_2to1,
-                          const Eigen::RowMajorMatrixXi& l2_dists_2to1,
+                          const Eigen::RowMajorMatrixXf& l2_dists_2to1,
                           const float max_ratio,
                           const float max_distance,
                           const bool cross_check,
@@ -921,7 +920,7 @@ enum class DistanceType {
   DOT_PRODUCT,
 };
 
-Eigen::RowMajorMatrixXi ComputeSiftDistanceMatrix(
+Eigen::RowMajorMatrixXf ComputeSiftDistanceMatrix(
     const DistanceType distance_type,
     const FeatureKeypoints* keypoints1,
     const FeatureKeypoints* keypoints2,
@@ -940,7 +939,7 @@ Eigen::RowMajorMatrixXi ComputeSiftDistanceMatrix(
   const Eigen::Matrix<int, Eigen::Dynamic, 128> descriptors2_int =
       descriptors2.cast<int>();
 
-  Eigen::RowMajorMatrixXi distances(descriptors1.rows(), descriptors2.rows());
+  Eigen::RowMajorMatrixXf distances(descriptors1.rows(), descriptors2.rows());
   for (FeatureDescriptors::Index i1 = 0; i1 < descriptors1.rows(); ++i1) {
     for (FeatureDescriptors::Index i2 = 0; i2 < descriptors2.rows(); ++i2) {
       if (guided_filter != nullptr && guided_filter((*keypoints1)[i1].x,
@@ -1016,7 +1015,7 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
     }
 
     if (options_.cpu_brute_force_matcher) {
-      const Eigen::RowMajorMatrixXi dot_products =
+      const Eigen::RowMajorMatrixXf dot_products =
           ComputeSiftDistanceMatrix(DistanceType::DOT_PRODUCT,
                                     nullptr,
                                     nullptr,
@@ -1032,14 +1031,17 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
     }
 
     Eigen::RowMajorMatrixXi indices_1to2;
-    Eigen::RowMajorMatrixXi l2_dists_1to2;
+    Eigen::RowMajorMatrixXf l2_dists_1to2;
     Eigen::RowMajorMatrixXi indices_2to1;
-    Eigen::RowMajorMatrixXi l2_dists_2to1;
+    Eigen::RowMajorMatrixXf l2_dists_2to1;
     index2_->Search(
-        /*num_neighbors=*/2, *image1.descriptors, indices_1to2, l2_dists_1to2);
+        /*num_neighbors=*/2,
+        image1.descriptors->cast<float>(),
+        indices_1to2,
+        l2_dists_1to2);
     if (options_.cross_check) {
       index1_->Search(/*num_neighbors=*/2,
-                      *image2.descriptors,
+                      image2.descriptors->cast<float>(),
                       indices_2to1,
                       l2_dists_2to1);
     }
@@ -1122,14 +1124,14 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
 
     THROW_CHECK(guided_filter);
 
-    const Eigen::RowMajorMatrixXi l2_dists_1to2 =
+    const Eigen::RowMajorMatrixXf l2_dists_1to2 =
         ComputeSiftDistanceMatrix(DistanceType::L2,
                                   image1.keypoints.get(),
                                   image2.keypoints.get(),
                                   *image1.descriptors,
                                   *image2.descriptors,
                                   guided_filter);
-    const Eigen::RowMajorMatrixXi l2_dists_2to1 = l2_dists_1to2.transpose();
+    const Eigen::RowMajorMatrixXf l2_dists_2to1 = l2_dists_1to2.transpose();
 
     Eigen::RowMajorMatrixXi indices_1to2(l2_dists_1to2.rows(),
                                          l2_dists_1to2.cols());

--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -359,7 +359,7 @@ struct FeatureDescriptorIndexCacheHelper {
       const std::vector<FeatureMatcher::Image>& images)
       : index_cache(100, [this](const image_t image_id) {
           auto index = FeatureDescriptorIndex::Create();
-          index->Build(*this->image_descriptors_.at(image_id));
+          index->Build(this->image_descriptors_.at(image_id)->cast<float>());
           return index;
         }) {
     for (const auto& image : images) {


### PR DESCRIPTION
Avoids unnecessary copy of data and enables future support of non-sift (i.e., aliked) features.