### PR TITLE
Fix deadlock during feature matching

### DIFF
--- a/src/colmap/controllers/feature_matching.cc
+++ b/src/colmap/controllers/feature_matching.cc
@@ -86,10 +86,6 @@ class FeatureMatcherThread : public Thread {
       timer.Start();
       const std::vector<std::pair<image_t, image_t>> image_pairs =
           pair_generator->Next();
-      std::unique_ptr<DatabaseTransaction> database_transaction;
-      cache_->AccessDatabase([&database_transaction](Database& database) {
-        database_transaction = std::make_unique<DatabaseTransaction>(&database);
-      });
       matcher_.Match(image_pairs);
       PrintElapsedTime(timer);
     }


### PR DESCRIPTION
The switch to faiss revealed a rare deadlock that can occur when simultaneously reading from the feature matching cache while acquiring the database transaction. This was reliably reproducible with a debugger. Removing the transaction leads to minor performance degradation when writing to the database.