### PR TITLE
Add ReadAllFramesData method to Database class for efficient frame data retrieval

### DIFF
--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -338,6 +338,8 @@ class Database {
   size_t SumColumn(const std::string& column, const std::string& table) const;
   size_t MaxColumn(const std::string& column, const std::string& table) const;
 
+  std::unordered_map<frame_t, std::vector<data_t>> ReadAllFramesData() const;
+
   sqlite3* database_ = nullptr;
 
   // Check if elements got removed from the database to only apply
@@ -398,6 +400,7 @@ class Database {
   sqlite3_stmt* sql_stmt_read_cameras_ = nullptr;
   sqlite3_stmt* sql_stmt_read_frame_ = nullptr;
   sqlite3_stmt* sql_stmt_read_frame_data_ = nullptr;
+  sqlite3_stmt* sql_stmt_read_frames_data_ = nullptr;
   sqlite3_stmt* sql_stmt_read_frames_ = nullptr;
   sqlite3_stmt* sql_stmt_read_image_id_ = nullptr;
   sqlite3_stmt* sql_stmt_read_image_with_name_ = nullptr;


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/3385

This new method retrieves all frame data in a single query, improving performance by reducing the number of database calls. The ReadAllFrames method has been updated to utilize this new functionality, matching data to frames more efficiently.

I'm mainly write python or javascript and I'm not very used to C++ so this PR might not be compliant with C++ best practices. Feel free to reject or ask for modifications.

I have tested it on my own datasets with the `colmap hierarchical_mapper`.

