### PR TITLE
Fix trailing comma-separation when printing list contents

### DIFF
--- a/src/colmap/scene/frame.cc
+++ b/src/colmap/scene/frame.cc
@@ -54,12 +54,12 @@ std::ostream& operator<<(std::ostream& stream, const Frame& frame) {
     stream << "Unknown";
   }
   stream << ", has_pose=" << frame.HasPose() << ", data_ids=[";
-  for (const auto& data_id : frame.DataIds()) {
-    stream << "(" << data_id.sensor_id.type << ", " << data_id.sensor_id.id
-           << ", " << data_id.id << "), ";
-  }
-  if (!frame.DataIds().empty()) {
-    stream.seekp(-2, std::ios_base::end);
+  for (auto it = frame.DataIds().begin(); it != frame.DataIds().end();) {
+    stream << "(" << it->sensor_id.type << ", " << it->sensor_id.id << ", "
+           << it->id << ")";
+    if (++it != frame.DataIds().end()) {
+      stream << ", ";
+    }
   }
   stream << "])";
   return stream;

--- a/src/colmap/scene/track.cc
+++ b/src/colmap/scene/track.cc
@@ -58,11 +58,11 @@ std::ostream& operator<<(std::ostream& stream, const TrackElement& track_el) {
 
 std::ostream& operator<<(std::ostream& stream, const Track& track) {
   stream << "Track(elements=[";
-  for (const auto& track_el : track.Elements()) {
-    stream << track_el << ", ";
-  }
-  if (track.Length() > 0) {
-    stream.seekp(-2, std::ios_base::end);
+  for (auto it = track.Elements().begin(); it != track.Elements().end();) {
+    stream << *it;
+    if (++it != track.Elements().end()) {
+      stream << ", ";
+    }
   }
   stream << "])";
   return stream;

--- a/src/colmap/sensor/rig.cc
+++ b/src/colmap/sensor/rig.cc
@@ -53,11 +53,11 @@ std::ostream& operator<<(std::ostream& stream, const Rig& rig) {
   stream << "Rig(rig_id=" << rig_id_str << ", ref_sensor_id=("
          << rig.RefSensorId().type << ", " << rig.RefSensorId().id
          << "), sensors=[";
-  for (const auto& [sensor_id, _] : rig.Sensors()) {
-    stream << "(" << sensor_id.type << ", " << sensor_id.id << "), ";
-  }
-  if (!rig.Sensors().empty()) {
-    stream.seekp(-2, std::ios_base::end);
+  for (auto it = rig.Sensors().begin(); it != rig.Sensors().end();) {
+    stream << "(" << it->first.type << ", " << it->first.id << ")";
+    if (++it != rig.Sensors().end()) {
+      stream << ", ";
+    }
   }
   stream << "])";
   return stream;


### PR DESCRIPTION
For whatever reason, the previous approach of using seekp does not always consistently work. Could not figure out why, so doing the safe thing and only printing out the trailing commas if needed in the first place.