### PR TITLE
Add legacy docs from 3.8 to 3.11.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -119,3 +119,4 @@ support (special credits to `Torsten Sattler <https://tsattler.github.io>`_).
    contribution
    license
    bibliography
+   legacy

--- a/doc/legacy.rst
+++ b/doc/legacy.rst
@@ -1,0 +1,10 @@
+Legacy Documentations
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   v3.11 (2024-11-28) <https://colmap.github.io/legacy/3.11/index.html>
+   v3.10 (2024-07-23) <https://colmap.github.io/legacy/3.10/index.html>
+   v3.9 (2024-01-06) <https://colmap.github.io/legacy/3.9/index.html>
+   v3.8 (2023-01-31) <https://colmap.github.io/legacy/3.8/index.html>


### PR DESCRIPTION
Dependent on https://github.com/colmap/colmap.github.io/pull/14