### PR TITLE
Return bad initial pair when number of triangulation is less than abs_pose_min_num_inliers

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -346,7 +346,8 @@ IncrementalPipeline::Status IncrementalPipeline::InitializeReconstruction(
   }
 
   // Number of triangulated points not enough for registering future images.
-  if (int(reconstruction.NumPoints3D()) < mapper_options.abs_pose_min_num_inliers) {
+  if (int(reconstruction.NumPoints3D()) <
+      mapper_options.abs_pose_min_num_inliers) {
     return Status::BAD_INITIAL_PAIR;
   }
 

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -346,7 +346,7 @@ IncrementalPipeline::Status IncrementalPipeline::InitializeReconstruction(
   }
 
   // Number of triangulated points not enough for registering future images.
-  if (int(reconstruction.NumPoints3D()) <
+  if (static_cast<int>(reconstruction.NumPoints3D()) <
       mapper_options.abs_pose_min_num_inliers) {
     return Status::BAD_INITIAL_PAIR;
   }

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -345,6 +345,11 @@ IncrementalPipeline::Status IncrementalPipeline::InitializeReconstruction(
     return Status::BAD_INITIAL_PAIR;
   }
 
+  // Number of triangulated points not enough for registering future images.
+  if (int(reconstruction.NumPoints3D()) < mapper_options.abs_pose_min_num_inliers) {
+    return Status::BAD_INITIAL_PAIR;
+  }
+
   if (options_->extract_colors) {
     for (const image_t image_id : {image_id1, image_id2}) {
       const Image& image = reconstruction.Image(image_id);


### PR DESCRIPTION
Otherwise ``FindNextImages`` will return empty and the process will save a reconstruction with only two frames: https://github.com/colmap/colmap/blob/main/src/colmap/controllers/incremental_pipeline.cc#L575