### PR TITLE
Replace incorrect call to nonZeros

### DIFF
--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -185,7 +185,7 @@ bool ComputeLInverse(Eigen::SparseMatrix<double>& S, Eigen::MatrixXd& L_inv) {
 
   const Eigen::VectorXd D_dense = ldlt_S.vectorD();
 
-  const int rank = D_dense.nonZeros();
+  const int rank = (D_dense.array().abs() > 1e-6).count();
   if (rank < S.rows()) {
     LOG(WARNING) << StringPrintf(
         "Unable to compute covariance. The Schur complement on pose/other "


### PR DESCRIPTION
The `nonZeros()` method is a member of Eigen's sparse types, but `D_dense` is a dense vector - in this case it always returns `D_dense.size()`, which is incorrect. See related discussion in https://github.com/colmap/colmap/pull/1494.