### PR TITLE
Fix setup_ubuntu.sh for docker

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,2 +1,34 @@
+#!/bin/bash
+
+# Check if argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <host_directory>"
+    echo "Example: $0 ../dataset/"
+    exit 1
+fi
+
+# Check if the provided directory exists
+if [ ! -d "$1" ]; then
+    echo "Error: Directory '$1' does not exist"
+    exit 1
+fi
+
+# Get absolute path
+HOST_DIR=$(realpath "$1")
+
+echo "Pulling latest COLMAP Docker image..."
 docker pull colmap/colmap:latest
-docker run --gpus all -w /working -v $1:/working -it colmap/colmap:latest
+
+echo "Running COLMAP container with directory: $HOST_DIR"
+
+# Try different GPU configurations in order of preference
+if docker run --rm --runtime=nvidia colmap/colmap:latest colmap --help >/dev/null 2>&1; then
+    echo "✅ Using GPU acceleration with --runtime=nvidia"
+    docker run --runtime=nvidia -w /working -v "$HOST_DIR":/working -it colmap/colmap:latest
+elif docker run --rm colmap/colmap:latest colmap --help >/dev/null 2>&1; then
+    echo "✅ Using default runtime (may include GPU if configured)"
+    docker run -w /working -v "$HOST_DIR":/working -it colmap/colmap:latest
+else
+    echo "⚠️  Container test failed, trying anyway in CPU mode"
+    docker run -w /working -v "$HOST_DIR":/working -it colmap/colmap:latest
+fi

--- a/docker/setup-ubuntu.sh
+++ b/docker/setup-ubuntu.sh
@@ -1,11 +1,63 @@
 # Add the package repositories
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+# ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 # Install nvidia-container-toolkit
-sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo apt-get update 
+export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.17.8-1
+sudo apt-get install -y \
+    nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+    nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+    libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+    libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
+
+# Configure the Docker daemon to use nvidia runtime
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Verify NVIDIA drivers are accessible
+echo "Checking NVIDIA drivers..."
+if nvidia-smi; then
+    echo "✅ NVIDIA drivers working"
+else
+    echo "❌ NVIDIA drivers not found - install NVIDIA drivers first"
+    exit 1
+fi
+
+# Configure Docker daemon to use nvidia as default runtime
+echo "Configuring Docker daemon for NVIDIA runtime..."
+sudo mkdir -p /etc/docker
+echo '{
+    "default-runtime": "nvidia",
+    "runtimes": {
+        "nvidia": {
+            "path": "nvidia-container-runtime",
+            "runtimeArgs": []
+        }
+    }
+}' | sudo tee /etc/docker/daemon.json
+
 sudo systemctl restart docker
 
 # Check that it worked!
-docker run --gpus all nvidia/cuda:10.2-base nvidia-smi
+echo "Testing GPU support in Docker container..."
+if docker run --rm --runtime=nvidia nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04 nvidia-smi; then
+    echo "✅ GPU support successfully configured with --runtime=nvidia!"
+elif docker run --rm nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi; then
+    echo "✅ GPU support working with default nvidia runtime!"
+elif docker run --rm --runtime=nvidia nvidia/cuda:11.8-base-ubuntu22.04 nvidia-smi; then
+    echo "✅ GPU support working with CUDA 11.8!"
+else
+    echo "❌ GPU support test failed"
+    echo "Debug information:"
+    echo "Docker daemon config:"
+    cat /etc/docker/daemon.json
+    echo ""
+    echo "Docker runtime info:"
+    docker info | grep -A 5 -i runtime
+    echo ""
+    echo "Try manual test with: docker run --rm --runtime=nvidia nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
+fi


### PR DESCRIPTION
# Objective
current setup-ubuntu.sh doen't work becasue cuda10.2 image is no more existed in docker.
So I fixed it.

# Test
Confirm I can run 
```
./setup-ubuntu.sh
./run.sh dataset/
```
and run automatic_reconstructor works well inside the docker.