### PR TITLE
Add hierarchical_pose_prior_mapper to CLI

### DIFF
--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -96,6 +96,8 @@ int main(int argc, char** argv) {
   commands.emplace_back("feature_extractor", &colmap::RunFeatureExtractor);
   commands.emplace_back("feature_importer", &colmap::RunFeatureImporter);
   commands.emplace_back("hierarchical_mapper", &colmap::RunHierarchicalMapper);
+  commands.emplace_back("hierarchical_pose_prior_mapper",
+                        &colmap::RunHierarchicalPosePriorMapper);
   commands.emplace_back("image_deleter", &colmap::RunImageDeleter);
   commands.emplace_back("image_filterer", &colmap::RunImageFilterer);
   commands.emplace_back("image_rectifier", &colmap::RunImageRectifier);

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -48,6 +48,7 @@ int RunBundleAdjuster(int argc, char** argv);
 int RunColorExtractor(int argc, char** argv);
 int RunMapper(int argc, char** argv);
 int RunHierarchicalMapper(int argc, char** argv);
+int RunHierarchicalPosePriorMapper(int argc, char** argv);
 int RunPosePriorMapper(int argc, char** argv);
 int RunPointFiltering(int argc, char** argv);
 int RunPointTriangulator(int argc, char** argv);


### PR DESCRIPTION
### Summary

This adds a new CLI utility, `hierarchical_pose_prior_mapper`, which enables running the hierarchical mapping pipeline with pose priors.

### Implementation Notes

- The implementation closely mirrors the existing `hierarchical_mapper` and `pose_prior_mapper` logic.
- Currently, there is significant code duplication between `mapper` and `pose_prior_mapper`, and likewise between `hierarchical_mapper` and `hierarchical_pose_prior_mapper`.
- As a potential improvement, we could consolidate `mapper` and `pose_prior_mapper` into a single tool, with a flag to enable pose prior support — and do the same for their hierarchical counterparts. I'm happy to implement this refactor if it's aligned with project direction.