### PR TITLE
Add min_num_neighbors constraint for spatial matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Custom files
 LocalConfig.cmake
 src/colmap/util/version.cc
+CMakeUserPresets.json
+.clangd
 
 # Custom directories
 .idea/

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -421,6 +421,8 @@ void OptionManager::AddSpatialMatchingOptions() {
                               &spatial_matching->ignore_z);
   AddAndRegisterDefaultOption("SpatialMatching.max_num_neighbors",
                               &spatial_matching->max_num_neighbors);
+  AddAndRegisterDefaultOption("SpatialMatching.min_num_neighbors",
+                              &spatial_matching->min_num_neighbors);
   AddAndRegisterDefaultOption("SpatialMatching.max_distance",
                               &spatial_matching->max_distance);
 }

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -560,12 +560,17 @@ SpatialPairGenerator::SpatialPairGenerator(
   Eigen::RowMajorMatrixXf position_matrix = ReadPositionPriorData(*cache);
   const size_t num_positions = position_idxs_.size();
 
-  THROW_CHECK_LT(options_.min_num_neighbors, num_positions);
-
   LOG(INFO) << StringPrintf(" in %.3fs", timer.ElapsedSeconds());
   if (num_positions == 0) {
     LOG(INFO) << "=> No images with location data.";
     return;
+  }
+  if (num_positions <= options_.min_num_neighbors) {
+    LOG(WARNING) << StringPrintf(
+        "min_num_neighbors (%d) exceeds number of images with location data "
+        "(%zu), this may limit the number of matched pairs.",
+        options_.min_num_neighbors,
+        num_positions);
   }
 
   timer.Restart();
@@ -583,14 +588,14 @@ SpatialPairGenerator::SpatialPairGenerator(
   image_pairs_.reserve(knn_);
 
   index_matrix_.resize(num_positions, knn_);
-  distance_matrix_.resize(num_positions, knn_);
+  distance_squared_matrix_.resize(num_positions, knn_);
 
   omp_set_num_threads(GetEffectiveNumThreads(options_.num_threads));
 
   search_index.search(position_matrix.rows(),
                       position_matrix.data(),
                       knn_,
-                      distance_matrix_.data(),
+                      distance_squared_matrix_.data(),
                       index_matrix_.data());
 
   LOG(INFO) << StringPrintf(" in %.3fs", timer.ElapsedSeconds());
@@ -618,7 +623,7 @@ std::vector<std::pair<image_t, image_t>> SpatialPairGenerator::Next() {
 
   LOG(INFO) << StringPrintf(
       "Matching image [%d/%d]", current_idx_ + 1, position_idxs_.size());
-  const float max_distance =
+  const float max_distance_squared =
       static_cast<float>(options_.max_distance * options_.max_distance);
   for (int j = 0; j < knn_; ++j) {
     // Check if query equals result.
@@ -628,7 +633,7 @@ std::vector<std::pair<image_t, image_t>> SpatialPairGenerator::Next() {
 
     // Since the nearest neighbors are sorted by distance, we can break
     // once the distance is too large and enough neighbors are collected.
-    if (distance_matrix_(current_idx_, j) > max_distance &&
+    if (distance_squared_matrix_(current_idx_, j) > max_distance_squared &&
         j > options_.min_num_neighbors) {
       break;
     }

--- a/src/colmap/feature/pairing.cc
+++ b/src/colmap/feature/pairing.cc
@@ -132,10 +132,11 @@ VocabTreeMatchingOptions SequentialMatchingOptions::VocabTreeOptions() const {
 }
 
 bool SpatialMatchingOptions::Check() const {
+  CHECK_OPTION_GE(max_distance, 0.0);
   CHECK_OPTION_GT(max_num_neighbors, 0);
-  CHECK_OPTION_GT(max_distance, 0.0);
-  CHECK_OPTION_GE(min_num_neighbors, 0);
   CHECK_OPTION_LE(min_num_neighbors, max_num_neighbors);
+  CHECK_OPTION_GE(min_num_neighbors, 0);
+  CHECK_OPTION(max_distance > 0.0 || min_num_neighbors > 0);
   return true;
 }
 
@@ -593,34 +594,6 @@ SpatialPairGenerator::SpatialPairGenerator(
                       index_matrix_.data());
 
   LOG(INFO) << StringPrintf(" in %.3fs", timer.ElapsedSeconds());
-
-  const bool kAdjustsMaxDistance = options_.min_num_neighbors != 0;
-  if (!kAdjustsMaxDistance) {
-    max_distance_squared_ = options.max_distance * options.max_distance;
-  } else {
-    max_distance_squared_ = std::numeric_limits<double>::lowest();
-    for (size_t i = 0; i < num_positions; ++i) {
-      max_distance_squared_ =
-          std::max<double>(max_distance_squared_,
-                           distance_matrix_(i, options_.min_num_neighbors));
-    }
-  }
-
-  std::vector<int> neighbor_counts(distance_matrix_.rows());
-  for (int i = 0; i < distance_matrix_.rows(); ++i) {
-    neighbor_counts[i] =
-        (distance_matrix_.row(i).segment(1, knn_ - 1).array() <=
-         max_distance_squared_)
-            .count();
-  }
-  int median_neighbors = Median(neighbor_counts);
-
-  LOG(INFO) << StringPrintf(
-      "Using %s spatial maximum match distance: %.3f, median neighbor "
-      "count: %d",
-      kAdjustsMaxDistance ? "adjusted" : "fixed",
-      std::sqrt(max_distance_squared_),
-      median_neighbors);
 }
 
 SpatialPairGenerator::SpatialPairGenerator(
@@ -645,14 +618,18 @@ std::vector<std::pair<image_t, image_t>> SpatialPairGenerator::Next() {
 
   LOG(INFO) << StringPrintf(
       "Matching image [%d/%d]", current_idx_ + 1, position_idxs_.size());
+  const float max_distance =
+      static_cast<float>(options_.max_distance * options_.max_distance);
   for (int j = 0; j < knn_; ++j) {
     // Check if query equals result.
     if (index_matrix_(current_idx_, j) == static_cast<int>(current_idx_)) {
       continue;
     }
 
-    // Since the nearest neighbors are sorted by distance, we can break.
-    if (distance_matrix_(current_idx_, j) > max_distance_squared_) {
+    // Since the nearest neighbors are sorted by distance, we can break
+    // once the distance is too large and enough neighbors are collected.
+    if (distance_matrix_(current_idx_, j) > max_distance &&
+        j > options_.min_num_neighbors) {
       break;
     }
 

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -167,8 +167,8 @@ struct SpatialMatchingOptions {
   // The maximum number of nearest neighbors to match.
   int max_num_neighbors = 50;
 
-  // Minimum number of nearest neighbors to match. The maximum matching distance
-  // is adjusted to ensure this minimum.
+  // Minimum number of nearest neighbors to match. Neighbors include those
+  // within max_distance or to satisfy min_num_neighbors.
   int min_num_neighbors = 0;
 
   // The maximum distance between the query and nearest neighbor. For GPS
@@ -354,7 +354,6 @@ class SpatialPairGenerator : public PairGenerator {
   std::vector<size_t> position_idxs_;
   size_t current_idx_ = 0;
   int knn_ = 0;
-  double max_distance_squared_ = 0.0;
 };
 
 class TransitivePairGenerator : public PairGenerator {

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -167,6 +167,10 @@ struct SpatialMatchingOptions {
   // The maximum number of nearest neighbors to match.
   int max_num_neighbors = 50;
 
+  // Minimum number of nearest neighbors to match. The maximum matching distance
+  // is adjusted to ensure this minimum.
+  int min_num_neighbors = 0;
+
   // The maximum distance between the query and nearest neighbor. For GPS
   // coordinates the unit is Euclidean distance in meters.
   double max_distance = 100;
@@ -350,6 +354,7 @@ class SpatialPairGenerator : public PairGenerator {
   std::vector<size_t> position_idxs_;
   size_t current_idx_ = 0;
   int knn_ = 0;
+  double max_distance_squared_ = 0.0;
 };
 
 class TransitivePairGenerator : public PairGenerator {

--- a/src/colmap/feature/pairing.h
+++ b/src/colmap/feature/pairing.h
@@ -167,7 +167,7 @@ struct SpatialMatchingOptions {
   // The maximum number of nearest neighbors to match.
   int max_num_neighbors = 50;
 
-  // Minimum number of nearest neighbors to match. Neighbors include those
+  // The minimum number of nearest neighbors to match. Neighbors include those
   // within max_distance or to satisfy min_num_neighbors.
   int min_num_neighbors = 0;
 
@@ -349,7 +349,7 @@ class SpatialPairGenerator : public PairGenerator {
   std::vector<std::pair<image_t, image_t>> image_pairs_;
   Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       index_matrix_;
-  Eigen::RowMajorMatrixXf distance_matrix_;
+  Eigen::RowMajorMatrixXf distance_squared_matrix_;
   std::vector<image_t> image_ids_;
   std::vector<size_t> position_idxs_;
   size_t current_idx_ = 0;

--- a/src/colmap/feature/pairing_test.cc
+++ b/src/colmap/feature/pairing_test.cc
@@ -367,12 +367,9 @@ TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {
   const auto images = db->ReadAllImages();
 
   db->WritePosePrior(images[0].ImageId(), PosePrior(Eigen::Vector3d(1, 1, 2)));
-  db->WritePosePrior(images[1].ImageId(),
-                     PosePrior(Eigen::Vector3d(1, 2, 3)));  // +\sqrt{2}
-  db->WritePosePrior(images[2].ImageId(),
-                     PosePrior(Eigen::Vector3d(2, 3, 4)));  // +\sqrt{3}
-  db->WritePosePrior(images[3].ImageId(),
-                     PosePrior(Eigen::Vector3d(2, 4, 12)));  // +\sqrt{65}
+  db->WritePosePrior(images[1].ImageId(), PosePrior(Eigen::Vector3d(1, 2, 3)));
+  db->WritePosePrior(images[2].ImageId(), PosePrior(Eigen::Vector3d(2, 3, 4)));
+  db->WritePosePrior(images[3].ImageId(), PosePrior(Eigen::Vector3d(2, 4, 12)));
 
   SpatialMatchingOptions options;
   options.ignore_z = false;
@@ -445,10 +442,6 @@ TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {
                     std::make_pair(images[3].ImageId(), images[1].ImageId()),
                     std::make_pair(images[3].ImageId(), images[0].ImageId())));
     EXPECT_TRUE(generator.Next().empty());
-  }
-  {
-    options.min_num_neighbors = 4;
-    EXPECT_ANY_THROW(SpatialPairGenerator(options, db));
   }
 }
 

--- a/src/colmap/feature/pairing_test.cc
+++ b/src/colmap/feature/pairing_test.cc
@@ -375,25 +375,26 @@ TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {
                      PosePrior(Eigen::Vector3d(2, 4, 12)));  // +\sqrt{65}
 
   SpatialMatchingOptions options;
-  {
-    options.ignore_z = false;
-    options.max_num_neighbors = kNumImages;
+  options.ignore_z = false;
+  options.max_num_neighbors = kNumImages;
+  options.max_distance = 0.0;
 
+  {
+    options.min_num_neighbors = 0;
+    EXPECT_FALSE(options.Check());
+  }
+  {
     options.min_num_neighbors = 1;
     SpatialPairGenerator generator(options, db);
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
-                    std::make_pair(images[0].ImageId(), images[1].ImageId()),
-                    std::make_pair(images[0].ImageId(), images[2].ImageId())));
+                    std::make_pair(images[0].ImageId(), images[1].ImageId())));
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
-                    std::make_pair(images[1].ImageId(), images[0].ImageId()),
-                    std::make_pair(images[1].ImageId(), images[2].ImageId())));
+                    std::make_pair(images[1].ImageId(), images[0].ImageId())));
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
-                    std::make_pair(images[2].ImageId(), images[1].ImageId()),
-                    std::make_pair(images[2].ImageId(), images[0].ImageId()),
-                    std::make_pair(images[2].ImageId(), images[3].ImageId())));
+                    std::make_pair(images[2].ImageId(), images[1].ImageId())));
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
                     std::make_pair(images[3].ImageId(), images[2].ImageId())));
@@ -409,13 +410,11 @@ TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
                     std::make_pair(images[1].ImageId(), images[0].ImageId()),
-                    std::make_pair(images[1].ImageId(), images[2].ImageId()),
-                    std::make_pair(images[1].ImageId(), images[3].ImageId())));
+                    std::make_pair(images[1].ImageId(), images[2].ImageId())));
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
                     std::make_pair(images[2].ImageId(), images[1].ImageId()),
-                    std::make_pair(images[2].ImageId(), images[0].ImageId()),
-                    std::make_pair(images[2].ImageId(), images[3].ImageId())));
+                    std::make_pair(images[2].ImageId(), images[0].ImageId())));
     EXPECT_THAT(generator.Next(),
                 testing::ElementsAre(
                     std::make_pair(images[3].ImageId(), images[2].ImageId()),
@@ -449,7 +448,7 @@ TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {
   }
   {
     options.min_num_neighbors = 4;
-    EXPECT_THROW(SpatialPairGenerator(options, db), std::exception);
+    EXPECT_ANY_THROW(SpatialPairGenerator(options, db));
   }
 }
 

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -271,6 +271,8 @@ SpatialMatchingTab::SpatialMatchingTab(QWidget* parent, OptionManager* options)
                                  "ignore_z");
   options_widget_->AddOptionInt(&options_->spatial_matching->max_num_neighbors,
                                 "max_num_neighbors");
+  options_widget_->AddOptionInt(&options_->spatial_matching->min_num_neighbors,
+                                "min_num_neighbors");
   options_widget_->AddOptionDouble(&options_->spatial_matching->max_distance,
                                    "max_distance");
 

--- a/src/pycolmap/pipeline/match_features.cc
+++ b/src/pycolmap/pipeline/match_features.cc
@@ -89,6 +89,11 @@ void BindMatchFeatures(py::module& m) {
           .def_readwrite("max_num_neighbors",
                          &SpMOpts::max_num_neighbors,
                          "The maximum number of nearest neighbors to match.")
+          .def_readwrite(
+              "min_num_neighbors",
+              &SpMOpts::min_num_neighbors,
+              "Minimum number of nearest neighbors to match. The maximum "
+              "matching distance is adjusted to ensure this minimum.")
           .def_readwrite("max_distance",
                          &SpMOpts::max_distance,
                          "The maximum distance between the query and nearest "

--- a/src/pycolmap/pipeline/match_features.cc
+++ b/src/pycolmap/pipeline/match_features.cc
@@ -92,8 +92,8 @@ void BindMatchFeatures(py::module& m) {
           .def_readwrite(
               "min_num_neighbors",
               &SpMOpts::min_num_neighbors,
-              "Minimum number of nearest neighbors to match. The maximum "
-              "matching distance is adjusted to ensure this minimum.")
+              "Minimum number of nearest neighbors to match. Neighbors include "
+              "those within max_distance or to satisfy min_num_neighbors.")
           .def_readwrite("max_distance",
                          &SpMOpts::max_distance,
                          "The maximum distance between the query and nearest "

--- a/src/pycolmap/pipeline/match_features.cc
+++ b/src/pycolmap/pipeline/match_features.cc
@@ -92,8 +92,9 @@ void BindMatchFeatures(py::module& m) {
           .def_readwrite(
               "min_num_neighbors",
               &SpMOpts::min_num_neighbors,
-              "Minimum number of nearest neighbors to match. Neighbors include "
-              "those within max_distance or to satisfy min_num_neighbors.")
+              "The minimum number of nearest neighbors to match. Neighbors "
+              "include those within max_distance or to satisfy "
+              "min_num_neighbors.")
           .def_readwrite("max_distance",
                          &SpMOpts::max_distance,
                          "The maximum distance between the query and nearest "


### PR DESCRIPTION
This PR adds a `min_num_neighbors` option to `spatial_matcher`, ensuring that each image is matched with at least the specified number of neighbors. This makes matching more adaptive to different image distributions and removes the need to manually tune `max_distance` in some cases.

- Adds `min_num_neighbors` to `SpatialMatchingOptions`. When set to a positive value, the matcher will always include at least that number of neighbors, even if some exceed max_distance
- Adds `CMakeUserPresets.json` and `.clangd` to `.gitignore`