### PR TITLE
Fix a bug affecting feature matching on GPU

### DIFF
--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -77,6 +77,12 @@ void FeatureMatcherWorker::Run() {
     THROW_CHECK_NOTNULL(matching_options_.sift->cpu_descriptor_index_cache);
   }
 
+  // Minimize the amount of allocated GPU memory by computing the maximum number
+  // of descriptors for any image over the whole database.
+  matching_options_.max_num_matches =
+      std::min<int>(matching_options_.max_num_matches,
+                    cache_->MaxNumKeypoints());
+
   std::unique_ptr<FeatureMatcher> matcher =
       FeatureMatcher::Create(matching_options_);
   if (matcher == nullptr) {
@@ -237,12 +243,6 @@ FeatureMatcherController::FeatureMatcherController(
     std::iota(gpu_indices.begin(), gpu_indices.end(), 0);
   }
 #endif  // COLMAP_CUDA_ENABLED
-
-  // Minimize the amount of allocated GPU memory by computing the maximum number
-  // of descriptors for any image over the whole database.
-  matching_options_.max_num_matches =
-      std::min<int>(matching_options_.max_num_matches,
-                    THROW_CHECK_NOTNULL(cache_)->MaxNumKeypoints());
 
   if (matching_options_.use_gpu) {
     auto matching_options_copy = matching_options_;


### PR DESCRIPTION
https://github.com/colmap/colmap/pull/3465 moved the call to `MaxNumKeypoints` from `FeatureMatcherController::Setup` to its constructor. Unfortunately, in the automatic reconstructor, the controllers are all created upfront, so `MaxNumKeypoints` is called when the database is empty and thus returns 0.

The proposed fix keeps the logic simple, with the only drawback that `MaxNumKeypoints` is called in each worker, which is OK since it's a cheap call.