### PR TITLE
Add command line option for `TwoViewGeometry.detect_watermark`

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -341,6 +341,8 @@ void OptionManager::AddMatchingOptions() {
   AddAndRegisterDefaultOption(
       "TwoViewGeometry.min_inlier_ratio",
       &two_view_geometry->ransac_options.min_inlier_ratio);
+  AddAndRegisterDefaultOption("TwoViewGeometry.detect_watermark",
+                              &two_view_geometry->detect_watermark);
 }
 
 void OptionManager::AddExhaustivePairingOptions() {


### PR DESCRIPTION
This change adds a command line argument to toggle the `detect_watermark` flag.