### PR TITLE
Remove check in database_cache.cc that breaks backwards compatibility with image_list_file_path

### DIFF
--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -167,9 +167,6 @@ void DatabaseCache::Load(const Database& database,
       }
     } else {
       for (auto& image : images) {
-        if (!image_names.empty() && image_names.count(image.Name()) == 0) {
-          continue;
-        }
         // For backwards compatibility with old databases from before having
         // support for rigs/frames, we create a frame for each image.
         class Frame frame;


### PR DESCRIPTION
If we try to load a pre-3.12 (pre sensor rig support) db, and we also pass `--image_list_path`, the db loading will fail mainly due to the lines I am removing in this PR. Not sure why we have those in there.

The error that pops up without this change:
```
I20250711 11:43:48.726486 140208169588800 incremental_pipeline.cc:253] Loading database
I20250711 11:43:48.728317 140208169588800 database_cache.cc:66] Loading rigs...
I20250711 11:43:48.728328 140208169588800 database_cache.cc:76]  0 in 0.000s
I20250711 11:43:48.728333 140208169588800 database_cache.cc:84] Loading cameras...
I20250711 11:43:48.728343 140208169588800 database_cache.cc:102]  1 in 0.000s
I20250711 11:43:48.728346 140208169588800 database_cache.cc:110] Loading frames...
I20250711 11:43:48.728351 140208169588800 database_cache.cc:127]  0 in 0.000s
I20250711 11:43:48.728355 140208169588800 database_cache.cc:135] Loading matches...
I20250711 11:43:48.756288 140208169588800 database_cache.cc:140]  9644 in 0.028s
I20250711 11:43:48.756310 140208169588800 database_cache.cc:156] Loading images...
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
*** Aborted at 1752227028 (unix time) try "date -d @1752227028" if you are using GNU date ***
PC: @     0x7f84c62ef00b signal
```

The actual error is coming from here:
```
        const frame_t frame_id1 = image_to_frame_id.at(image_id1);
        const frame_t frame_id2 = image_to_frame_id.at(image_id2);
```
line 205, 206 