### PR TITLE
Ensure UTF-8 encoding for database paths passed to SQLite open

### DIFF
--- a/src/colmap/scene/CMakeLists.txt
+++ b/src/colmap/scene/CMakeLists.txt
@@ -83,10 +83,12 @@ COLMAP_ADD_TEST(
     SRCS database_test.cc
     LINK_LIBS colmap_scene
 )
-if(MSVC)
-    target_compile_options(colmap_scene_database_test PRIVATE /utf-8)
-else()
-    target_compile_options(colmap_scene_database_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+if(TESTS_ENABLED)
+    if(MSVC)
+        target_compile_options(colmap_scene_database_test PRIVATE /utf-8)
+    else()
+        target_compile_options(colmap_scene_database_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+    endif()
 endif()
 COLMAP_ADD_TEST(
     NAME frame_test

--- a/src/colmap/scene/CMakeLists.txt
+++ b/src/colmap/scene/CMakeLists.txt
@@ -83,6 +83,11 @@ COLMAP_ADD_TEST(
     SRCS database_test.cc
     LINK_LIBS colmap_scene
 )
+if(MSVC)
+    target_compile_options(colmap_scene_database_test PRIVATE /utf-8)
+else()
+    target_compile_options(colmap_scene_database_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+endif()
 COLMAP_ADD_TEST(
     NAME frame_test
     SRCS frame_test.cc

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -432,7 +432,7 @@ void Database::Open(const std::string& path) {
   // Modifications to the database will still be serialized, but multiple
   // connections can read concurrently.
   SQLITE3_CALL(sqlite3_open_v2(
-      path.c_str(),
+      PlatformToUTF8(path).c_str(),
       &database_,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX,
       nullptr));

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -78,6 +78,10 @@ class Database {
 
   // Open and close database. The same database should not be opened
   // concurrently in multiple threads or processes.
+  //
+  // On Windows, the input path is converted from the local code page to UTF-8
+  // for compatibility with SQLite. On POSIX platforms, the path is assumed to
+  // be UTF-8.
   void Open(const std::string& path);
   void Close();
 

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -145,6 +145,11 @@ COLMAP_ADD_TEST(
     SRCS string_test.cc
     LINK_LIBS colmap_util
 )
+if(MSVC)
+    target_compile_options(colmap_util_string_test PRIVATE /utf-8)
+else()
+    target_compile_options(colmap_util_string_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+endif()
 COLMAP_ADD_TEST(
     NAME threading_test
     SRCS threading_test.cc

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -145,10 +145,12 @@ COLMAP_ADD_TEST(
     SRCS string_test.cc
     LINK_LIBS colmap_util
 )
-if(MSVC)
-    target_compile_options(colmap_util_string_test PRIVATE /utf-8)
-else()
-    target_compile_options(colmap_util_string_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+if(TESTS_ENABLED)
+    if(MSVC)
+        target_compile_options(colmap_util_string_test PRIVATE /utf-8)
+    else()
+        target_compile_options(colmap_util_string_test PRIVATE -finput-charset=UTF-8 -fexec-charset=UTF-8)
+    endif()
 endif()
 COLMAP_ADD_TEST(
     NAME threading_test

--- a/src/colmap/util/string.cc
+++ b/src/colmap/util/string.cc
@@ -36,6 +36,10 @@
 
 #include <boost/algorithm/string.hpp>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 namespace colmap {
 namespace {
 
@@ -126,6 +130,67 @@ bool IsNotWhiteSpace(const int character) {
 
 }  // namespace
 
+namespace internal {
+#ifdef _WIN32
+std::string CodePageToUTF8Win(const std::string& str, unsigned int code_page) {
+  int wide_len = MultiByteToWideChar(code_page, 0, str.c_str(), -1, nullptr, 0);
+  if (wide_len <= 0) return "";
+
+  std::wstring wide_str(wide_len, L'\0');
+  MultiByteToWideChar(code_page, 0, str.c_str(), -1, &wide_str[0], wide_len);
+
+  int utf8_len = WideCharToMultiByte(
+      CP_UTF8, 0, wide_str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+  if (utf8_len <= 0) return "";
+
+  std::string utf8_str(utf8_len, '\0');
+  WideCharToMultiByte(CP_UTF8,
+                      0,
+                      wide_str.c_str(),
+                      -1,
+                      &utf8_str[0],
+                      utf8_len,
+                      nullptr,
+                      nullptr);
+
+  if (!utf8_str.empty() && utf8_str.back() == '\0') {
+    utf8_str.pop_back();
+  }
+
+  return utf8_str;
+};
+
+std::string UTF8ToCodePageWin(const std::string& str, unsigned int code_page) {
+  int wide_len = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+  if (wide_len <= 0) return "";
+
+  std::wstring wide_str(wide_len, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide_str[0], wide_len);
+
+  int local_len = WideCharToMultiByte(
+      code_page, 0, wide_str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+  if (local_len <= 0) return "";
+
+  std::string local_str(local_len, '\0');
+  WideCharToMultiByte(code_page,
+                      0,
+                      wide_str.c_str(),
+                      -1,
+                      &local_str[0],
+                      local_len,
+                      nullptr,
+                      nullptr);
+
+  if (!local_str.empty() && local_str.back() == '\0') {
+    local_str.pop_back();
+  }
+
+  return local_str;
+}
+
+#endif
+}  // namespace internal
+
 std::string StringPrintf(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
@@ -200,6 +265,24 @@ void StringToUpper(std::string* str) {
 
 bool StringContains(const std::string& str, const std::string& sub_str) {
   return str.find(sub_str) != std::string::npos;
+}
+
+std::string PlatformToUTF8(const std::string& str) {
+#ifdef _WIN32
+  return internal::CodePageToUTF8Win(str, GetACP());
+#else
+  // Assume UTF-8 on POSIX systems
+  return input;
+#endif
+}
+
+std::string UTF8ToPlatform(const std::string& str) {
+#ifdef _WIN32
+  return internal::UTF8ToCodePageWin(str, GetACP());
+#else
+  // On POSIX, assume UTF-8 is the system encoding
+  return utf8_str;
+#endif
 }
 
 }  // namespace colmap

--- a/src/colmap/util/string.cc
+++ b/src/colmap/util/string.cc
@@ -131,7 +131,9 @@ bool IsNotWhiteSpace(const int character) {
 }  // namespace
 
 namespace internal {
+
 #ifdef _WIN32
+
 std::string CodePageToUTF8Win(const std::string& str, unsigned int code_page) {
   int wide_len = MultiByteToWideChar(code_page, 0, str.c_str(), -1, nullptr, 0);
   if (wide_len <= 0) return "";
@@ -189,6 +191,7 @@ std::string UTF8ToCodePageWin(const std::string& str, unsigned int code_page) {
 }
 
 #endif
+
 }  // namespace internal
 
 std::string StringPrintf(const char* format, ...) {
@@ -271,8 +274,8 @@ std::string PlatformToUTF8(const std::string& str) {
 #ifdef _WIN32
   return internal::CodePageToUTF8Win(str, GetACP());
 #else
-  // Assume UTF-8 on POSIX systems
-  return input;
+  // Assume UTF-8 on POSIX systems.
+  return str;
 #endif
 }
 
@@ -280,8 +283,8 @@ std::string UTF8ToPlatform(const std::string& str) {
 #ifdef _WIN32
   return internal::UTF8ToCodePageWin(str, GetACP());
 #else
-  // On POSIX, assume UTF-8 is the system encoding
-  return utf8_str;
+  // On POSIX, assume UTF-8 is the system encoding.
+  return str;
 #endif
 }
 

--- a/src/colmap/util/string.h
+++ b/src/colmap/util/string.h
@@ -34,6 +34,22 @@
 
 namespace colmap {
 
+namespace internal {
+#ifdef _WIN32
+// Convert a string from the specified Windows code page to UTF-8.
+//
+// This function is used internally for unit testing to verify roundtrip
+// correctness of encoding conversions independent of the system code page.
+std::string CodePageToUTF8Win(const std::string& str, unsigned int code_page);
+
+// Convert a UTF-8 string to the specified Windows code page.
+//
+// This function is used internally for unit testing to verify roundtrip
+// correctness of encoding conversions independent of the system code page.
+std::string UTF8ToCodePageWin(const std::string& str, unsigned int code_page);
+#endif
+}  // namespace internal
+
 // Format string by replacing embedded format specifiers with their respective
 // values, see `printf` for more details. This is a modified implementation
 // of Google's BSD-licensed StringPrintf function.
@@ -65,5 +81,15 @@ void StringToUpper(std::string* str);
 
 // Check whether the sub-string is contained in the given string.
 bool StringContains(const std::string& str, const std::string& sub_str);
+
+// Convert a string from the platform's default encoding to UTF-8.
+// On Windows: converts from ANSI code page (ACP) to UTF-8.
+// On POSIX: assumes the input is already UTF-8 and returns it unchanged.
+std::string PlatformToUTF8(const std::string& str);
+
+// Convert a UTF-8 encoded string to the platform's default encoding.
+// On Windows: converts to ANSI code page (ACP).
+// On POSIX: returns the input unchanged.
+std::string UTF8ToPlatform(const std::string& str);
 
 }  // namespace colmap

--- a/src/colmap/util/string.h
+++ b/src/colmap/util/string.h
@@ -34,22 +34,6 @@
 
 namespace colmap {
 
-namespace internal {
-#ifdef _WIN32
-// Convert a string from the specified Windows code page to UTF-8.
-//
-// This function is used internally for unit testing to verify roundtrip
-// correctness of encoding conversions independent of the system code page.
-std::string CodePageToUTF8Win(const std::string& str, unsigned int code_page);
-
-// Convert a UTF-8 string to the specified Windows code page.
-//
-// This function is used internally for unit testing to verify roundtrip
-// correctness of encoding conversions independent of the system code page.
-std::string UTF8ToCodePageWin(const std::string& str, unsigned int code_page);
-#endif
-}  // namespace internal
-
 // Format string by replacing embedded format specifiers with their respective
 // values, see `printf` for more details. This is a modified implementation
 // of Google's BSD-licensed StringPrintf function.
@@ -91,5 +75,21 @@ std::string PlatformToUTF8(const std::string& str);
 // On Windows: converts to ANSI code page (ACP).
 // On POSIX: returns the input unchanged.
 std::string UTF8ToPlatform(const std::string& str);
+
+namespace internal {
+#ifdef _WIN32
+// Convert a string from the specified Windows code page to UTF-8.
+//
+// This function is used internally for unit testing to verify roundtrip
+// correctness of encoding conversions independent of the system code page.
+std::string CodePageToUTF8Win(const std::string& str, unsigned int code_page);
+
+// Convert a UTF-8 string to the specified Windows code page.
+//
+// This function is used internally for unit testing to verify roundtrip
+// correctness of encoding conversions independent of the system code page.
+std::string UTF8ToCodePageWin(const std::string& str, unsigned int code_page);
+#endif
+}  // namespace internal
 
 }  // namespace colmap

--- a/src/colmap/util/string_test.cc
+++ b/src/colmap/util/string_test.cc
@@ -29,6 +29,9 @@
 
 #include "colmap/util/string.h"
 
+#include <array>
+#include <string_view>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -224,6 +227,87 @@ TEST(StringContains, Nominal) {
   EXPECT_FALSE(StringContains("", "a"));
   EXPECT_FALSE(StringContains("ab", "c"));
 }
+
+#ifdef _WIN32
+TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtripWin) {
+  const std::array<std::pair<std::string_view, unsigned int>, 12>
+      kUTF8StringsWithCodePage = {{// English
+                                   {u8"Bundle Adjustment", 0},
+                                   // Simplified Chinese
+                                   {u8"光束法平差", 936},
+                                   // Japanese
+                                   {u8"バンドル調整", 932},
+                                   // Korean
+                                   {u8"번들조정", 949},
+                                   // French
+                                   {u8"Ajustement de faisceau", 1252},
+                                   // German
+                                   {u8"Bündelanpassung", 1252},
+                                   // Russian
+                                   {u8"Байндл-адаптация", 1251},
+                                   // Greek
+                                   {u8"Προσαρμογή δεσμίδας", 1253},
+                                   // Turkish
+                                   {u8"Işın Demeti Ayarı", 1254},
+                                   // Hebrew
+                                   {u8"התאמת צרור", 1255},
+                                   // Arabic
+                                   {u8"ضبط الحزمة", 1256},
+                                   // Thai
+                                   {u8"ปรับค่ากลุ่มภาพ", 874}}};
+
+  for (const auto& [utf8_str, code_page] : kUTF8StringsWithCodePage) {
+    std::string original(utf8_str);
+    // NOTE:
+    // internal::UTF8ToCodePageWin and internal::CodePageToUTF8Win are internal
+    // helpers used by the public API (UTF8ToPlatform / PlatformToUTF8) on
+    // Windows. By explicitly specifying the code page, we can verify that the
+    // internal logic correctly handles various legacy encodings independently
+    // of the system ACP.
+    std::string platform_encoded =
+        internal::UTF8ToCodePageWin(original, code_page);
+    std::string roundtrip =
+        internal::CodePageToUTF8Win(platform_encoded, code_page);
+    EXPECT_EQ(roundtrip, original);
+  }
+}
+#else
+TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtripPosix) {
+  const std::array<std::string_view, 12> kUTF8Strings = {{
+      // English
+      u8"Bundle Adjustment",
+      // Simplified Chinese
+      u8"光束法平差",
+      // Japanese
+      u8"バンドル調整",
+      // Korean
+      u8"번들조정",
+      // French
+      u8"Ajustement de faisceau",
+      // German
+      u8"Bündelanpassung",
+      // Russian
+      u8"Байндл-адаптация",
+      // Greek
+      u8"Προσαρμογή δεσμίδας",
+      // Turkish
+      u8"Işın Demeti Ayarı",
+      // Hebrew
+      u8"התאמת צרור",
+      // Arabic
+      u8"ضبط الحزمة",
+      // Thai
+      u8"ปรับค่ากลุ่มภาพ",
+  }};
+
+  for (const std::string_view utf8_str : kUTF8Strings) {
+    std::string original(utf8_str);
+    std::string platform_encoded = UTF8ToPlatform(original);
+    std::string roundtrip = PlatformToUTF8(platform_encoded);
+    EXPECT_EQ(roundtrip, original);
+  }
+}
+#endif
 
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/util/string_test.cc
+++ b/src/colmap/util/string_test.cc
@@ -44,6 +44,32 @@ namespace {
     EXPECT_EQ(str_inplace, ref_str);            \
   }
 
+const std::unordered_map<unsigned int, std::string> kCodePageToUTF8Strings = {
+    {// English
+     {0, u8"Bundle Adjustment"},
+     // Simplified Chinese
+     {936, u8"光束法平差"},
+     // Japanese
+     {932, u8"バンドル調整"},
+     // Korean
+     {949, u8"번들조정"},
+     // French
+     {1252, u8"Ajustement de faisceau"},
+     // German
+     {1252, u8"Bündelanpassung"},
+     // Russian
+     {1251, u8"Байндл-адаптация"},
+     // Greek
+     {1253, u8"Προσαρμογή δεσμίδας"},
+     // Turkish
+     {1254, u8"Işın Demeti Ayarı"},
+     // Hebrew
+     {1255, u8"התאמת צרור"},
+     // Arabic
+     {1256, u8"ضبط الحزمة"},
+     // Thai
+     {874, u8"ปรับค่ากลุ่มภาพ"}}};
+
 TEST(StringPrintf, Nominal) {
   EXPECT_EQ(StringPrintf("%s", "test"), "test");
   EXPECT_EQ(StringPrintf("%d", 1), "1");
@@ -228,36 +254,9 @@ TEST(StringContains, Nominal) {
   EXPECT_FALSE(StringContains("ab", "c"));
 }
 
+TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtrip) {
+  for (const auto& [code_page, original] : kCodePageToUTF8Strings) {
 #ifdef _WIN32
-TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtripWin) {
-  const std::array<std::pair<std::string_view, unsigned int>, 12>
-      kUTF8StringsWithCodePage = {{// English
-                                   {u8"Bundle Adjustment", 0},
-                                   // Simplified Chinese
-                                   {u8"光束法平差", 936},
-                                   // Japanese
-                                   {u8"バンドル調整", 932},
-                                   // Korean
-                                   {u8"번들조정", 949},
-                                   // French
-                                   {u8"Ajustement de faisceau", 1252},
-                                   // German
-                                   {u8"Bündelanpassung", 1252},
-                                   // Russian
-                                   {u8"Байндл-адаптация", 1251},
-                                   // Greek
-                                   {u8"Προσαρμογή δεσμίδας", 1253},
-                                   // Turkish
-                                   {u8"Işın Demeti Ayarı", 1254},
-                                   // Hebrew
-                                   {u8"התאמת צרור", 1255},
-                                   // Arabic
-                                   {u8"ضبط الحزمة", 1256},
-                                   // Thai
-                                   {u8"ปรับค่ากลุ่มภาพ", 874}}};
-
-  for (const auto& [utf8_str, code_page] : kUTF8StringsWithCodePage) {
-    std::string original(utf8_str);
     // NOTE:
     // internal::UTF8ToCodePageWin and internal::CodePageToUTF8Win are internal
     // helpers used by the public API (UTF8ToPlatform / PlatformToUTF8) on
@@ -268,46 +267,14 @@ TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtripWin) {
         internal::UTF8ToCodePageWin(original, code_page);
     std::string roundtrip =
         internal::CodePageToUTF8Win(platform_encoded, code_page);
-    EXPECT_EQ(roundtrip, original);
-  }
-}
 #else
-TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtripPosix) {
-  const std::array<std::string_view, 12> kUTF8Strings = {{
-      // English
-      u8"Bundle Adjustment",
-      // Simplified Chinese
-      u8"光束法平差",
-      // Japanese
-      u8"バンドル調整",
-      // Korean
-      u8"번들조정",
-      // French
-      u8"Ajustement de faisceau",
-      // German
-      u8"Bündelanpassung",
-      // Russian
-      u8"Байндл-адаптация",
-      // Greek
-      u8"Προσαρμογή δεσμίδας",
-      // Turkish
-      u8"Işın Demeti Ayarı",
-      // Hebrew
-      u8"התאמת צרור",
-      // Arabic
-      u8"ضبط الحزمة",
-      // Thai
-      u8"ปรับค่ากลุ่มภาพ",
-  }};
-
-  for (const std::string_view utf8_str : kUTF8Strings) {
-    std::string original(utf8_str);
     std::string platform_encoded = UTF8ToPlatform(original);
     std::string roundtrip = PlatformToUTF8(platform_encoded);
+#endif
+
     EXPECT_EQ(roundtrip, original);
   }
 }
-#endif
 
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/util/string_test.cc
+++ b/src/colmap/util/string_test.cc
@@ -44,32 +44,6 @@ namespace {
     EXPECT_EQ(str_inplace, ref_str);            \
   }
 
-const std::unordered_map<unsigned int, std::string> kCodePageToUTF8Strings = {
-    {// English
-     {0, u8"Bundle Adjustment"},
-     // Simplified Chinese
-     {936, u8"光束法平差"},
-     // Japanese
-     {932, u8"バンドル調整"},
-     // Korean
-     {949, u8"번들조정"},
-     // French
-     {1252, u8"Ajustement de faisceau"},
-     // German
-     {1252, u8"Bündelanpassung"},
-     // Russian
-     {1251, u8"Байндл-адаптация"},
-     // Greek
-     {1253, u8"Προσαρμογή δεσμίδας"},
-     // Turkish
-     {1254, u8"Işın Demeti Ayarı"},
-     // Hebrew
-     {1255, u8"התאמת צרור"},
-     // Arabic
-     {1256, u8"ضبط الحزمة"},
-     // Thai
-     {874, u8"ปรับค่ากลุ่มภาพ"}}};
-
 TEST(StringPrintf, Nominal) {
   EXPECT_EQ(StringPrintf("%s", "test"), "test");
   EXPECT_EQ(StringPrintf("%d", 1), "1");
@@ -255,6 +229,32 @@ TEST(StringContains, Nominal) {
 }
 
 TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtrip) {
+  const std::unordered_map<int, std::string> kCodePageToUTF8Strings = {
+      {// English
+       {0, u8"Bundle Adjustment"},
+       // Simplified Chinese
+       {936, u8"光束法平差"},
+       // Japanese
+       {932, u8"バンドル調整"},
+       // Korean
+       {949, u8"번들조정"},
+       // French
+       {1252, u8"Ajustement de faisceau"},
+       // German
+       {1252, u8"Bündelanpassung"},
+       // Russian
+       {1251, u8"Байндл-адаптация"},
+       // Greek
+       {1253, u8"Προσαρμογή δεσμίδας"},
+       // Turkish
+       {1254, u8"Işın Demeti Ayarı"},
+       // Hebrew
+       {1255, u8"התאמת צרור"},
+       // Arabic
+       {1256, u8"ضبط الحزمة"},
+       // Thai
+       {874, u8"ปรับค่ากลุ่มภาพ"}}};
+
   for (const auto& [code_page, original] : kCodePageToUTF8Strings) {
 #ifdef _WIN32
     // NOTE:
@@ -263,13 +263,13 @@ TEST(ConversionBetweenPlatformAndUTF8, NonASCIIStringRoundtrip) {
     // Windows. By explicitly specifying the code page, we can verify that the
     // internal logic correctly handles various legacy encodings independently
     // of the system ACP.
-    std::string platform_encoded =
+    const std::string platform_encoded =
         internal::UTF8ToCodePageWin(original, code_page);
-    std::string roundtrip =
+    const std::string roundtrip =
         internal::CodePageToUTF8Win(platform_encoded, code_page);
 #else
-    std::string platform_encoded = UTF8ToPlatform(original);
-    std::string roundtrip = PlatformToUTF8(platform_encoded);
+    const std::string platform_encoded = UTF8ToPlatform(original);
+    const std::string roundtrip = PlatformToUTF8(platform_encoded);
 #endif
 
     EXPECT_EQ(roundtrip, original);


### PR DESCRIPTION
`sqlite3_open_v2` only accepts UTF-8 encoded paths. This PR adds a function to convert ANSI (platform) strings to UTF-8 on Windows to correctly handle paths containing non-ASCII characters.