### PR TITLE
Store log_scale instead of scale in colmap::Sim3d

### DIFF
--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -48,7 +48,7 @@ Sim3d TestSim3d() {
 }
 
 void ExpectEqualSim3d(const Sim3d& gt_tgt_from_src, const Sim3d& tgt_from_src) {
-  EXPECT_NEAR(gt_tgt_from_src.scale, tgt_from_src.scale, 1e-6);
+  EXPECT_NEAR(gt_tgt_from_src.GetScale(), tgt_from_src.GetScale(), 1e-6);
   EXPECT_LT(gt_tgt_from_src.rotation.angularDistance(tgt_from_src.rotation),
             1e-6);
   EXPECT_LT((gt_tgt_from_src.translation - tgt_from_src.translation).norm(),

--- a/src/colmap/estimators/coordinate_frame.cc
+++ b/src/colmap/estimators/coordinate_frame.cc
@@ -365,7 +365,7 @@ void AlignToENUPlane(Reconstruction* reconstruction,
   rot_mat << -sin_lon, cos_lon, 0, -cos_lon * sin_lat, -sin_lon * sin_lat,
       cos_lat, cos_lon * cos_lat, sin_lon * cos_lat, sin_lat;
 
-  const double scale = unscaled ? 1.0 / aligned_from_original->scale : 1.0;
+  const double scale = unscaled ? 1.0 / aligned_from_original->GetScale() : 1.0;
   *aligned_from_original =
       Sim3d(scale, Eigen::Quaterniond(rot_mat), -scale * rot_mat * centroid);
   reconstruction->Transform(*aligned_from_original);

--- a/src/colmap/estimators/cost_functions.h
+++ b/src/colmap/estimators/cost_functions.h
@@ -461,11 +461,12 @@ struct Point3DAlignmentCostFunctor
   bool operator()(const T* const point_in_a,
                   const T* const b_from_a_rotation,
                   const T* const b_from_a_translation,
-                  const T* const b_from_a_scale,
+                  const T* const b_from_a_log_scale,
                   T* residuals_ptr) const {
+    const T b_from_a_scale = ceres::exp(b_from_a_log_scale[0]);
     const Eigen::Matrix<T, 3, 1> point_in_b =
         EigenQuaternionMap<T>(b_from_a_rotation) *
-            EigenVector3Map<T>(point_in_a) * b_from_a_scale[0] +
+            EigenVector3Map<T>(point_in_a) * b_from_a_scale +
         EigenVector3Map<T>(b_from_a_translation);
     Eigen::Map<Eigen::Matrix<T, 3, 1>> residuals(residuals_ptr);
     residuals = point_in_b - point_in_b_prior_.cast<T>();

--- a/src/colmap/estimators/cost_functions_test.cc
+++ b/src/colmap/estimators/cost_functions_test.cc
@@ -398,7 +398,7 @@ TEST(Point3DAlignmentCostFunctor, Nominal) {
   const double* parameters[4] = {point.data(),
                                  tform.rotation.coeffs().data(),
                                  tform.translation.data(),
-                                 &tform.scale};
+                                 &tform.log_scale};
   double residuals[3];
   EXPECT_TRUE(cost_function->Evaluate(parameters, residuals, nullptr));
 

--- a/src/colmap/estimators/similarity_transform_test.cc
+++ b/src/colmap/estimators/similarity_transform_test.cc
@@ -148,7 +148,7 @@ void TestEstimateSim3dWithNumCoords(const size_t num_coords) {
 
   Sim3d tgt_from_src;
   EXPECT_TRUE(EstimateSim3d(src, tgt, tgt_from_src));
-  EXPECT_NEAR(gt_tgt_from_src.scale, tgt_from_src.scale, 1e-6);
+  EXPECT_NEAR(gt_tgt_from_src.GetScale(), tgt_from_src.GetScale(), 1e-6);
   EXPECT_LT(gt_tgt_from_src.rotation.angularDistance(tgt_from_src.rotation),
             1e-6);
   EXPECT_LT((gt_tgt_from_src.translation - tgt_from_src.translation).norm(),

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -78,7 +78,7 @@ Eigen::Vector3d TransformLatLonAltToModelCoords(const Sim3d& tform,
   Eigen::Vector3d xyz =
       tform * GPSTransform(GPSTransform::Ellipsoid::WGS84)
                   .EllipsoidToECEF({Eigen::Vector3d(lat, lon, 0.0)})[0];
-  xyz(2) = tform.scale * alt;
+  xyz(2) = tform.GetScale() * alt;
   return xyz;
 }
 
@@ -413,7 +413,7 @@ int RunModelAligner(int argc, char** argv) {
 
         // Update the Sim3 transformation in case it is stored next.
         tform =
-            Sim3d(tform.scale, tform.rotation, tform.translation + trans_align);
+            Sim3d(tform.GetScale(), tform.rotation, tform.translation + trans_align);
 
         break;
       }
@@ -940,7 +940,7 @@ int RunModelSplitter(int argc, char** argv) {
                            std::numeric_limits<double>::max(),
                            std::numeric_limits<double>::max());
     for (size_t i = 0; i < parts.size(); ++i) {
-      extent(i) = parts[i] * tform.scale;
+      extent(i) = parts[i] * tform.GetScale();
     }
 
     const Eigen::AlignedBox3d bbox = reconstruction.ComputeBoundingBox();

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -412,8 +412,8 @@ int RunModelAligner(int argc, char** argv) {
         reconstruction.Transform(origin_align);
 
         // Update the Sim3 transformation in case it is stored next.
-        tform =
-            Sim3d(tform.GetScale(), tform.rotation, tform.translation + trans_align);
+        tform = Sim3d(
+            tform.GetScale(), tform.rotation, tform.translation + trans_align);
 
         break;
       }

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -168,8 +168,9 @@ Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,
   const Sim3d cam_from_new_world =
       Sim3d(1, cam_from_world.rotation, cam_from_world.translation) *
       Inverse(new_from_old_world);
-  return Rigid3d(cam_from_new_world.rotation,
-                 cam_from_new_world.translation * new_from_old_world.GetScale());
+  return Rigid3d(
+      cam_from_new_world.rotation,
+      cam_from_new_world.translation * new_from_old_world.GetScale());
 }
 
 }  // namespace colmap

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -169,7 +169,7 @@ Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,
       Sim3d(1, cam_from_world.rotation, cam_from_world.translation) *
       Inverse(new_from_old_world);
   return Rigid3d(cam_from_new_world.rotation,
-                 cam_from_new_world.translation * new_from_old_world.scale);
+                 cam_from_new_world.translation * new_from_old_world.GetScale());
 }
 
 }  // namespace colmap

--- a/src/colmap/geometry/sim3.cc
+++ b/src/colmap/geometry/sim3.cc
@@ -40,7 +40,7 @@ void Sim3d::ToFile(const std::string& path) const {
   THROW_CHECK(file.good()) << path;
   // Ensure that we don't loose any precision by storing in text.
   file.precision(17);
-  file << scale << " " << rotation.w() << " " << rotation.x() << " "
+  file << GetScale() << " " << rotation.w() << " " << rotation.x() << " "
        << rotation.y() << " " << rotation.z() << " " << translation.x() << " "
        << translation.y() << " " << translation.z() << '\n';
 }
@@ -49,7 +49,9 @@ Sim3d Sim3d::FromFile(const std::string& path) {
   std::ifstream file(path);
   THROW_CHECK(file.good()) << path;
   Sim3d t;
-  file >> t.scale;
+  double scale;
+  file >> scale;
+  t.SetScale(scale);
   file >> t.rotation.w();
   file >> t.rotation.x();
   file >> t.rotation.y();
@@ -63,7 +65,7 @@ Sim3d Sim3d::FromFile(const std::string& path) {
 std::ostream& operator<<(std::ostream& stream, const Sim3d& tform) {
   const static Eigen::IOFormat kVecFmt(
       Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ");
-  stream << "Sim3d(scale=" << tform.scale << ", rotation_xyzw=["
+  stream << "Sim3d(scale=" << tform.GetScale() << ", rotation_xyzw=["
          << tform.rotation.coeffs().format(kVecFmt) << "], translation=["
          << tform.translation.format(kVecFmt) << "])";
   return stream;

--- a/src/colmap/geometry/sim3.h
+++ b/src/colmap/geometry/sim3.h
@@ -42,7 +42,7 @@ namespace colmap {
 // 3D similarity transform with 7 degrees of freedom.
 // Transforms point x from a to b as: x_in_b = scale * R * x_in_a + t.
 struct Sim3d {
-  double scale = 1;
+  double log_scale = 0.;
   Eigen::Quaterniond rotation = Eigen::Quaterniond::Identity();
   Eigen::Vector3d translation = Eigen::Vector3d::Zero();
 
@@ -50,20 +50,32 @@ struct Sim3d {
   Sim3d(double scale,
         const Eigen::Quaterniond& rotation,
         const Eigen::Vector3d& translation)
-      : scale(scale), rotation(rotation), translation(translation) {}
+      : rotation(rotation), translation(translation) {
+          SetScale(scale);
+      }
+
+  inline double GetScale() const {
+      return std::exp(log_scale);
+  }
+
+  inline void SetScale(double const scale) {
+      THROW_CHECK_GT(scale, 0);
+      log_scale = std::log(scale);
+  }
 
   inline Eigen::Matrix3x4d ToMatrix() const {
     Eigen::Matrix3x4d matrix;
-    matrix.leftCols<3>() = scale * rotation.toRotationMatrix();
+    matrix.leftCols<3>() = GetScale() * rotation.toRotationMatrix();
     matrix.col(3) = translation;
     return matrix;
   }
 
   static inline Sim3d FromMatrix(const Eigen::Matrix3x4d& matrix) {
     Sim3d t;
-    t.scale = matrix.col(0).norm();
+    double scale = matrix.col(0).norm();
+    t.SetScale(scale);
     t.rotation =
-        Eigen::Quaterniond(matrix.leftCols<3>() / t.scale).normalized();
+        Eigen::Quaterniond(matrix.leftCols<3>() / scale).normalized();
     t.translation = matrix.rightCols<1>();
     return t;
   }
@@ -76,10 +88,10 @@ struct Sim3d {
 // Return inverse transform.
 inline Sim3d Inverse(const Sim3d& b_from_a) {
   Sim3d a_from_b;
-  a_from_b.scale = 1 / b_from_a.scale;
+  a_from_b.log_scale = - b_from_a.log_scale;
   a_from_b.rotation = b_from_a.rotation.inverse();
   a_from_b.translation =
-      (a_from_b.rotation * b_from_a.translation) / -b_from_a.scale;
+      (a_from_b.rotation * b_from_a.translation) / -b_from_a.GetScale();
   return a_from_b;
 }
 
@@ -97,23 +109,23 @@ inline Sim3d Inverse(const Sim3d& b_from_a) {
 //      x_in_c = d_from_c * (c_from_b * (b_from_a * x_in_a))
 // which will apply the transformations as a chain on the point.
 inline Eigen::Vector3d operator*(const Sim3d& t, const Eigen::Vector3d& x) {
-  return t.scale * (t.rotation * x) + t.translation;
+  return t.GetScale() * (t.rotation * x) + t.translation;
 }
 
 // Concatenate transforms such one can write expressions like:
 //      d_from_a = d_from_c * c_from_b * b_from_a
 inline Sim3d operator*(const Sim3d& c_from_b, const Sim3d& b_from_a) {
   Sim3d c_from_a;
-  c_from_a.scale = c_from_b.scale * b_from_a.scale;
+  c_from_a.log_scale = c_from_b.log_scale + b_from_a.log_scale;
   c_from_a.rotation = (c_from_b.rotation * b_from_a.rotation).normalized();
   c_from_a.translation =
       c_from_b.translation +
-      (c_from_b.scale * (c_from_b.rotation * b_from_a.translation));
+      (c_from_b.GetScale() * (c_from_b.rotation * b_from_a.translation));
   return c_from_a;
 }
 
 inline bool operator==(const Sim3d& left, const Sim3d& right) {
-  return left.scale == right.scale &&
+  return left.log_scale == right.log_scale &&
          left.rotation.coeffs() == right.rotation.coeffs() &&
          left.translation == right.translation;
 }

--- a/src/colmap/geometry/sim3.h
+++ b/src/colmap/geometry/sim3.h
@@ -51,16 +51,14 @@ struct Sim3d {
         const Eigen::Quaterniond& rotation,
         const Eigen::Vector3d& translation)
       : rotation(rotation), translation(translation) {
-          SetScale(scale);
-      }
-
-  inline double GetScale() const {
-      return std::exp(log_scale);
+    SetScale(scale);
   }
 
+  inline double GetScale() const { return std::exp(log_scale); }
+
   inline void SetScale(double const scale) {
-      THROW_CHECK_GT(scale, 0);
-      log_scale = std::log(scale);
+    THROW_CHECK_GT(scale, 0);
+    log_scale = std::log(scale);
   }
 
   inline Eigen::Matrix3x4d ToMatrix() const {
@@ -74,8 +72,7 @@ struct Sim3d {
     Sim3d t;
     double scale = matrix.col(0).norm();
     t.SetScale(scale);
-    t.rotation =
-        Eigen::Quaterniond(matrix.leftCols<3>() / scale).normalized();
+    t.rotation = Eigen::Quaterniond(matrix.leftCols<3>() / scale).normalized();
     t.translation = matrix.rightCols<1>();
     return t;
   }
@@ -88,7 +85,7 @@ struct Sim3d {
 // Return inverse transform.
 inline Sim3d Inverse(const Sim3d& b_from_a) {
   Sim3d a_from_b;
-  a_from_b.log_scale = - b_from_a.log_scale;
+  a_from_b.log_scale = -b_from_a.log_scale;
   a_from_b.rotation = b_from_a.rotation.inverse();
   a_from_b.translation =
       (a_from_b.rotation * b_from_a.translation) / -b_from_a.GetScale();

--- a/src/colmap/geometry/sim3_matchers.h
+++ b/src/colmap/geometry/sim3_matchers.h
@@ -45,7 +45,7 @@ class Sim3dEqMatcher : public testing::MatcherInterface<T> {
   bool MatchAndExplain(T lhs,
                        testing::MatchResultListener* listener) const override {
     // Note that with use !(a == b) to handle NaNs.
-    if (!(lhs.scale == rhs_.scale)) {
+    if (!(lhs.log_scale == rhs_.log_scale)) {
       return false;
     }
     if (!(lhs.rotation.coeffs() == rhs_.rotation.coeffs())) {
@@ -78,7 +78,7 @@ class Sim3dNearMatcher : public testing::MatcherInterface<T> {
   bool MatchAndExplain(T lhs,
                        testing::MatchResultListener* listener) const override {
     // Note that with use !(a <= b) to handle NaNs.
-    if (!(std::abs(lhs.scale - rhs_.scale) <= stol_)) {
+    if (!(std::abs(lhs.GetScale() - rhs_.GetScale()) <= stol_)) {
       *listener << " exceed scale threshold " << stol_;
       return false;
     }

--- a/src/colmap/geometry/sim3_matchers_test.cc
+++ b/src/colmap/geometry/sim3_matchers_test.cc
@@ -48,7 +48,7 @@ TEST(Sim3d, Eq) {
   const Sim3d x(2, Eigen::Quaterniond::UnitRandom(), Eigen::Vector3d::Random());
   Sim3d y = x;
   EXPECT_THAT(x, Sim3dEq(y));
-  y.scale += 1e-7;
+  y.SetScale(y.GetScale() + 1e-7);
   EXPECT_THAT(x, testing::Not(Sim3dEq(y)));
   y = x;
   y.rotation.w() += 1e-7;

--- a/src/colmap/geometry/sim3_test.cc
+++ b/src/colmap/geometry/sim3_test.cc
@@ -49,7 +49,8 @@ Sim3d TestSim3d() {
 
 TEST(Sim3d, Default) {
   const Sim3d tform;
-  EXPECT_EQ(tform.scale, 1);
+  EXPECT_EQ(tform.log_scale, 0);
+  EXPECT_EQ(tform.GetScale(), 1);
   EXPECT_EQ(tform.rotation.coeffs(), Eigen::Quaterniond::Identity().coeffs());
   EXPECT_EQ(tform.translation, Eigen::Vector3d::Zero());
 }
@@ -166,7 +167,7 @@ TEST(Sim3d, ToFromFile) {
   const Sim3d written = TestSim3d();
   written.ToFile(path);
   const Sim3d read = Sim3d::FromFile(path);
-  EXPECT_EQ(written.scale, read.scale);
+  EXPECT_EQ(written.log_scale, read.log_scale);
   EXPECT_EQ(written.rotation.coeffs(), read.rotation.coeffs());
   EXPECT_EQ(written.translation, read.translation);
 }

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -509,7 +509,7 @@ void Reconstruction::Transform(const Sim3d& new_from_old_world) {
   for (auto& [_, rig] : rigs_) {
     for (auto& [_, sensor_from_rig] : rig.Sensors()) {
       if (sensor_from_rig.has_value()) {
-        sensor_from_rig->translation *= new_from_old_world.scale;
+        sensor_from_rig->translation *= new_from_old_world.GetScale();
       }
     }
   }

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -436,7 +436,7 @@ TEST(Reconstruction, Normalize) {
     reconstruction.DeRegisterFrame(frame_id);
   }
   Sim3d tform = reconstruction.Normalize(/*fixed_scale=*/false);
-  EXPECT_EQ(tform.scale, 1);
+  EXPECT_EQ(tform.log_scale, 0);
   EXPECT_EQ(tform.rotation.coeffs(), Eigen::Quaterniond::Identity().coeffs());
   EXPECT_EQ(tform.translation, Eigen::Vector3d::Zero());
   reconstruction.Frame(1).SetRigFromWorld(Rigid3d());

--- a/src/pycolmap/geometry/sim3.cc
+++ b/src/pycolmap/geometry/sim3.cc
@@ -31,8 +31,8 @@ void BindSim3(py::module& m) {
             return py::array({}, {}, &self.log_scale, py::cast(self));
           },
           [](Sim3d& self, double log_scale) { self.log_scale = log_scale; })
-      .def_property("scale", &Sim3d::GetScale, &Sim3d::SetScale);
-  .def_readwrite("rotation", &Sim3d::rotation)
+      .def_property("scale", &Sim3d::GetScale, &Sim3d::SetScale)
+      .def_readwrite("rotation", &Sim3d::rotation)
       .def_readwrite("translation", &Sim3d::translation)
       .def("matrix", &Sim3d::ToMatrix)
       .def(py::self * Sim3d())

--- a/src/pycolmap/geometry/sim3.cc
+++ b/src/pycolmap/geometry/sim3.cc
@@ -26,12 +26,13 @@ void BindSim3(py::module& m) {
            "matrix"_a,
            "3x4 transformation matrix.")
       .def_property(
-          "scale",
+          "log_scale",
           [](Sim3d& self) {
-            return py::array({}, {}, &self.scale, py::cast(self));
+            return py::array({}, {}, &self.log_scale, py::cast(self));
           },
-          [](Sim3d& self, double scale) { self.scale = scale; })
-      .def_readwrite("rotation", &Sim3d::rotation)
+          [](Sim3d& self, double log_scale) { self.log_scale = log_scale; })
+      .def_property("scale", &Sim3d::GetScale, &Sim3d::SetScale);
+  .def_readwrite("rotation", &Sim3d::rotation)
       .def_readwrite("translation", &Sim3d::translation)
       .def("matrix", &Sim3d::ToMatrix)
       .def(py::self * Sim3d())
@@ -40,7 +41,7 @@ void BindSim3(py::module& m) {
            [](const Sim3d& t,
               const py::EigenDRef<const Eigen::MatrixX3d>& points)
                -> Eigen::MatrixX3d {
-             return (t.scale *
+             return (t.GetScale() *
                      (points * t.rotation.toRotationMatrix().transpose()))
                         .rowwise() +
                     t.translation.transpose();


### PR DESCRIPTION
log_scale spans the full space and has benefits in optimization. The python interfaces for ``sim3d.scale`` kept unchanged, while the C++ interfaces change to ``SetScale(scale)`` and ``GetScale()``. Update the cost function as well. 

In preparation for removing the ``PositiveExponentialManifold`` from colmap. 

Example:
```
In [1]: import pycolmap

In [2]: sim3 = pycolmap.Sim3d()

In [3]: sim3
Out[3]: Sim3d(scale=1, rotation_xyzw=[0, 0, 0, 1], translation=[0, 0, 0])

In [4]: sim3.scale = 2.0

In [5]: sim3
Out[5]: Sim3d(scale=2, rotation_xyzw=[0, 0, 0, 1], translation=[0, 0, 0])

In [6]: sim3.log_scale
Out[6]: array(0.69314718)

In [7]: sim3.log_scale = -1.0

In [8]: sim3
Out[8]: Sim3d(scale=0.367879, rotation_xyzw=[0, 0, 0, 1], translation=[0, 0, 0])
```