### PR TITLE
Configure trivial rigs for unconfigured images

### DIFF
--- a/src/colmap/scene/rig_test.cc
+++ b/src/colmap/scene/rig_test.cc
@@ -255,5 +255,35 @@ TEST(ApplyRigConfig, WithoutReconstruction) {
   EXPECT_EQ(database.ReadCamera(sensor_id2.id), camera2.camera);
 }
 
+TEST(ApplyRigConfig, WithUnconfiguredSingleAndConfiguredMultiCameraRigs) {
+  Database database(Database::kInMemoryDatabasePath);
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions options;
+  options.num_rigs = 1;
+  options.num_cameras_per_rig = 2;
+  options.num_frames_per_rig = 5;
+  SynthesizeDataset(options, &reconstruction, &database);
+
+  options.num_rigs = 1;
+  options.num_cameras_per_rig = 1;
+  options.num_frames_per_rig = 3;
+  SynthesizeDataset(options, &reconstruction, &database);
+
+  std::vector<RigConfig> configs;
+  auto& config = configs.emplace_back();
+  auto& camera1 = config.cameras.emplace_back();
+  camera1.image_prefix = "camera000001_";
+  camera1.ref_sensor = true;
+  auto& camera2 = config.cameras.emplace_back();
+  camera2.image_prefix = "camera000002_";
+
+  ApplyRigConfig(configs, database, &reconstruction);
+  EXPECT_EQ(database.NumRigs(), 2);
+  EXPECT_EQ(database.NumFrames(), 8);
+  EXPECT_EQ(reconstruction.NumRigs(), 2);
+  EXPECT_EQ(reconstruction.NumFrames(), 8);
+  EXPECT_EQ(reconstruction.NumRegFrames(), 8);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/scene/synthetic.cc
+++ b/src/colmap/scene/synthetic.cc
@@ -97,9 +97,12 @@ void SynthesizeExhaustiveMatches(double inlier_match_ratio,
       AddOutlierMatches(
           inlier_match_ratio, num_points2D1, num_points2D2, &matches);
 
-      database->WriteMatches(image1.ImageId(), image2.ImageId(), matches);
-      database->WriteTwoViewGeometry(
-          image1.ImageId(), image2.ImageId(), two_view_geometry);
+      if (!database->ExistsMatches(image_id1, image_id2)) {
+        database->WriteMatches(image_id1, image_id2, matches);
+      }
+      if (!database->ExistsInlierMatches(image_id1, image_id2)) {
+        database->WriteTwoViewGeometry(image_id1, image_id2, two_view_geometry);
+      }
     }
   }
 }
@@ -134,32 +137,34 @@ void SynthesizeChainedMatches(double inlier_match_ratio,
     }
   }
 
-  for (auto& two_view_geometry : two_view_geometries) {
-    const auto image_pair =
-        Database::PairIdToImagePair(two_view_geometry.first);
-    const auto& image1 = reconstruction->Image(image_pair.first);
+  for (auto& [pair_id, two_view_geometry] : two_view_geometries) {
+    const auto [image_id1, image_id2] = Database::PairIdToImagePair(pair_id);
+    const auto& image1 = reconstruction->Image(image_id1);
     const auto& camera1 = *image1.CameraPtr();
-    const auto& image2 = reconstruction->Image(image_pair.second);
+    const auto& image2 = reconstruction->Image(image_id2);
     const auto& camera2 = *image2.CameraPtr();
-    two_view_geometry.second.config = TwoViewGeometry::CALIBRATED;
-    two_view_geometry.second.cam2_from_cam1 =
+    two_view_geometry.config = TwoViewGeometry::CALIBRATED;
+    two_view_geometry.cam2_from_cam1 =
         image2.CamFromWorld() * Inverse(image1.CamFromWorld());
-    two_view_geometry.second.E =
-        EssentialMatrixFromPose(two_view_geometry.second.cam2_from_cam1);
-    two_view_geometry.second.F =
+    two_view_geometry.E =
+        EssentialMatrixFromPose(two_view_geometry.cam2_from_cam1);
+    two_view_geometry.F =
         FundamentalFromEssentialMatrix(camera2.CalibrationMatrix(),
-                                       two_view_geometry.second.E,
+                                       two_view_geometry.E,
                                        camera1.CalibrationMatrix());
 
-    FeatureMatches matches = two_view_geometry.second.inlier_matches;
+    FeatureMatches matches = two_view_geometry.inlier_matches;
     AddOutlierMatches(inlier_match_ratio,
                       image1.NumPoints2D(),
                       image2.NumPoints2D(),
                       &matches);
 
-    database->WriteMatches(image1.ImageId(), image2.ImageId(), matches);
-    database->WriteTwoViewGeometry(
-        image1.ImageId(), image2.ImageId(), two_view_geometry.second);
+    if (!database->ExistsMatches(image_id1, image_id2)) {
+      database->WriteMatches(image_id1, image_id2, matches);
+    }
+    if (!database->ExistsInlierMatches(image_id1, image_id2)) {
+      database->WriteTwoViewGeometry(image_id1, image_id2, two_view_geometry);
+    }
   }
 }
 
@@ -183,9 +188,12 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
   }
 
   // Synthesize 3D points on unit sphere centered at origin.
+  std::unordered_set<point3D_t> new_points3D_ids;
+  new_points3D_ids.reserve(options.num_points3D);
   for (int point3D_idx = 0; point3D_idx < options.num_points3D; ++point3D_idx) {
-    reconstruction->AddPoint3D(Eigen::Vector3d::Random().normalized(),
-                               /*track=*/{});
+    new_points3D_ids.insert(
+        reconstruction->AddPoint3D(Eigen::Vector3d::Random().normalized(),
+                                   /*track=*/{}));
   }
 
   int total_num_images = (database == nullptr) ? 0 : database->NumImages();
@@ -300,8 +308,14 @@ void SynthesizeDataset(const SyntheticDatasetOptions& options,
         points2D.reserve(options.num_points3D +
                          options.num_points2D_without_point3D);
 
-        // Create 3D point observations by project all 3D points to the image.
+        // Create 3D point observations by projecting 3D points to the image.
         for (auto& [point3D_id, point3D] : reconstruction->Points3D()) {
+          if (new_points3D_ids.count(point3D_id) == 0) {
+            // If a non-empty reconstruction is given, only add tracks for newly
+            // added images and 3D points.
+            continue;
+          }
+
           Point2D point2D;
           const std::optional<Eigen::Vector2d> proj_point2D =
               camera.ImgFromCam(cam_from_world * point3D.xyz);

--- a/src/colmap/scene/synthetic_test.cc
+++ b/src/colmap/scene/synthetic_test.cc
@@ -117,8 +117,10 @@ TEST(SynthesizeDataset, Nominal) {
   EXPECT_EQ(reconstruction.ComputeNumObservations(),
             reconstruction.NumImages() * options.num_points3D);
 
-  // All observations should be perfect and have sufficient triangulation angle.
-  // No points or observations should be filtered.
+  EXPECT_EQ(reconstruction.NumPoints3D(), options.num_points3D);
+
+  // All observations should be perfect and have sufficient triangulation
+  // angle. No points or observations should be filtered.
   const double kMaxReprojError = 1e-3;
   const double kMinTriAngleDeg = 0.4;
   std::unordered_map<image_t, Eigen::Vector3d> proj_centers;
@@ -163,6 +165,39 @@ TEST(SynthesizeDataset, Nominal) {
 
     EXPECT_GE(max_tri_angle, DegToRad(kMinTriAngleDeg));
   }
+}
+
+TEST(SynthesizeDataset, MultipleTimes) {
+  Database database(Database::kInMemoryDatabasePath);
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions options;
+  options.num_rigs = 2;
+  options.num_cameras_per_rig = 3;
+  options.num_frames_per_rig = 3;
+  SynthesizeDataset(options, &reconstruction, &database);
+  SynthesizeDataset(options, &reconstruction, &database);
+
+  EXPECT_EQ(database.NumRigs(), 2 * options.num_rigs);
+  EXPECT_EQ(reconstruction.NumRigs(), database.NumRigs());
+
+  EXPECT_EQ(database.NumCameras(),
+            2 * options.num_rigs * options.num_cameras_per_rig);
+  EXPECT_EQ(reconstruction.NumCameras(), database.NumCameras());
+
+  EXPECT_EQ(database.NumFrames(),
+            2 * options.num_rigs * options.num_frames_per_rig);
+  EXPECT_EQ(database.NumFrames(), reconstruction.NumFrames());
+
+  EXPECT_EQ(database.NumImages(),
+            2 * options.num_rigs * options.num_cameras_per_rig *
+                options.num_frames_per_rig);
+  EXPECT_EQ(database.NumImages(), reconstruction.NumImages());
+
+  const int num_image_pairs =
+      reconstruction.NumImages() * (reconstruction.NumImages() - 1) / 2;
+  EXPECT_EQ(database.NumVerifiedImagePairs(), num_image_pairs);
+
+  EXPECT_EQ(reconstruction.NumPoints3D(), 2 * options.num_points3D);
 }
 
 TEST(SynthesizeDataset, WithNoise) {


### PR DESCRIPTION
This PR adds support for configuring rigs for only a subset of images. The images without configuration are assigned to trivial rigs/frames.