### PR TITLE
Fix BundleAdjustmentConfig::SetConstantRigFromWorldPose

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -160,7 +160,6 @@ bool BundleAdjustmentConfig::HasConstantSensorFromRigPose(
 
 void BundleAdjustmentConfig::SetConstantRigFromWorldPose(
     const frame_t frame_id) {
-  THROW_CHECK(HasImage(frame_id));
   constant_rig_from_world_poses_.insert(frame_id);
 }
 

--- a/src/colmap/estimators/covariance_test.cc
+++ b/src/colmap/estimators/covariance_test.cc
@@ -91,7 +91,7 @@ TEST_P(ParameterizedBACovarianceTests, CompareWithCeres) {
   for (const auto& [image_id, image] : reconstruction.Images()) {
     config.AddImage(image_id);
     if (test_options.fixed_cam_poses) {
-      config.SetConstantRigFromWorldPose(image_id);
+      config.SetConstantRigFromWorldPose(image.FrameId());
     }
     if (test_options.fixed_cam_intrinsics) {
       config.SetConstantCamIntrinsics(image.CameraId());


### PR DESCRIPTION
This PR fixes SetConstantRigFromWorldPose and corrects the call to SetConstantRigFromWorldPose.