### PR TITLE
Add support for pose prior rotation in database and pose_piror_mapper

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -145,6 +145,7 @@ The available commands can be listed using the command::
           patch_match_stereo
           point_filtering
           point_triangulator
+          pose_prior_importer
           pose_prior_mapper
           poisson_mesher
           project_generator
@@ -233,6 +234,8 @@ available as ``colmap [command]``:
 
 - ``mapper``: Sparse 3D reconstruction / mapping of the dataset using SfM after
   performing feature extraction and matching.
+
+- ``pose_prior_importer``: Imports pose priors into the database from a file.
 
 - ``pose_prior_mapper`` Sparse 3D reconstruction / mapping using pose priors.
 

--- a/src/colmap/controllers/feature_extraction.cc
+++ b/src/colmap/controllers/feature_extraction.cc
@@ -290,7 +290,7 @@ class FeatureWriterThread : public Thread {
 
         if (image_data.image.ImageId() == kInvalidImageId) {
           image_data.image.SetImageId(database_->WriteImage(image_data.image));
-          if (image_data.pose_prior.IsValid()) {
+          if (image_data.pose_prior.HasValidPosition()) {
             LOG(INFO) << StringPrintf(
                 "  GPS:             LAT=%.3f, LON=%.3f, ALT=%.3f",
                 image_data.pose_prior.position.x(),
@@ -581,7 +581,7 @@ class FeatureImporterController : public Thread {
 
         if (image.ImageId() == kInvalidImageId) {
           image.SetImageId(database.WriteImage(image));
-          if (pose_prior.IsValid()) {
+          if (pose_prior.HasValidPosition()) {
             database.WritePosePrior(image.ImageId(), pose_prior);
           }
           Frame frame;

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -86,7 +86,7 @@ IncrementalMapper::Options IncrementalPipelineOptions::Mapper() const {
   options.num_threads = num_threads;
   options.local_ba_num_images = ba_local_num_images;
   options.fix_existing_frames = fix_existing_frames;
-  options.use_prior_position = use_prior_position;
+  options.use_pose_prior = use_pose_prior;
   options.use_robust_loss_on_prior_position = use_robust_loss_on_prior_position;
   options.prior_position_loss_scale = prior_position_loss_scale;
   return options;
@@ -279,7 +279,7 @@ bool IncrementalPipeline::LoadDatabase() {
 
   // If prior positions are to be used and setup from the database, convert
   // geographic coords. to cartesian ones
-  if (options_->use_prior_position) {
+  if (options_->use_pose_prior) {
     return database_cache_->SetupPosePriors();
   }
 

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -122,8 +122,8 @@ struct IncrementalPipelineOptions {
   bool ba_use_gpu = false;
   std::string ba_gpu_index = "-1";
 
-  // Whether to use priors on the camera positions.
-  bool use_prior_position = false;
+  // Whether to use pose priors.
+  bool use_pose_prior = false;
 
   // Whether to use a robust loss on prior camera positions.
   bool use_robust_loss_on_prior_position = false;

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -364,11 +364,14 @@ TEST(IncrementalPipeline, PriorBasedSfMWithoutNoise) {
 
   synthetic_dataset_options.use_prior_position = true;
   synthetic_dataset_options.prior_position_stddev = 0.0;
+  synthetic_dataset_options.use_prior_rotation = true;
+  synthetic_dataset_options.prior_rotation_stddev = 0.0;
+
   SynthesizeDataset(synthetic_dataset_options, &gt_reconstruction, &database);
 
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
-  mapper_options->use_prior_position = true;
+  mapper_options->use_pose_prior = true;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
   IncrementalPipeline mapper(mapper_options,
@@ -404,12 +407,15 @@ TEST(IncrementalPipeline, PriorBasedSfMWithoutNoiseAndWithNonTrivialFrames) {
 
   synthetic_dataset_options.use_prior_position = true;
   synthetic_dataset_options.prior_position_stddev = 0.0;
+  synthetic_dataset_options.use_prior_rotation = true;
+  synthetic_dataset_options.prior_rotation_stddev = 0.0;
+
   SynthesizeDataset(synthetic_dataset_options, &gt_reconstruction, &database);
 
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
 
-  mapper_options->use_prior_position = true;
+  mapper_options->use_pose_prior = true;
   mapper_options->use_robust_loss_on_prior_position = true;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
@@ -442,12 +448,14 @@ TEST(IncrementalPipeline, PriorBasedSfMWithNoise) {
 
   synthetic_dataset_options.use_prior_position = true;
   synthetic_dataset_options.prior_position_stddev = 1.5;
+  synthetic_dataset_options.use_prior_rotation = true;
+  synthetic_dataset_options.prior_rotation_stddev = 1.5;
   SynthesizeDataset(synthetic_dataset_options, &gt_reconstruction, &database);
 
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
 
-  mapper_options->use_prior_position = true;
+  mapper_options->use_pose_prior = true;
   mapper_options->use_robust_loss_on_prior_position = true;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
@@ -486,7 +494,7 @@ TEST(IncrementalPipeline, GPSPriorBasedSfMWithNoise) {
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
 
-  mapper_options->use_prior_position = true;
+  mapper_options->use_pose_prior = true;
   mapper_options->use_robust_loss_on_prior_position = true;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -250,7 +250,7 @@ bool AlignReconstructionToPosePriors(
   for (const image_t image_id : src_reconstruction.RegImageIds()) {
     const auto pose_prior_it = tgt_pose_priors.find(image_id);
     if (pose_prior_it != tgt_pose_priors.end() &&
-        pose_prior_it->second.IsValid()) {
+        pose_prior_it->second.HasValidPosition()) {
       const auto& image = src_reconstruction.Image(image_id);
       src.push_back(image.ProjectionCenter());
       tgt.push_back(pose_prior_it->second.position);

--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -118,6 +118,7 @@ int main(int argc, char** argv) {
   commands.emplace_back("patch_match_stereo", &colmap::RunPatchMatchStereo);
   commands.emplace_back("point_filtering", &colmap::RunPointFiltering);
   commands.emplace_back("point_triangulator", &colmap::RunPointTriangulator);
+  commands.emplace_back("pose_prior_importer", &colmap::RunPosePriorImporter);
   commands.emplace_back("pose_prior_mapper", &colmap::RunPosePriorMapper);
   commands.emplace_back("poisson_mesher", &colmap::RunPoissonMesher);
   commands.emplace_back("project_generator", &colmap::RunProjectGenerator);

--- a/src/colmap/exe/database.cc
+++ b/src/colmap/exe/database.cc
@@ -42,6 +42,17 @@
 
 namespace colmap {
 
+namespace {
+
+bool HasFields(const std::unordered_map<std::string, size_t>& col_idx,
+               const std::vector<std::string>& fields) {
+  for (const auto& f : fields) {
+    if (col_idx.find(f) == col_idx.end()) return false;
+  }
+  return true;
+}
+}  // namespace
+
 int RunDatabaseCleaner(int argc, char** argv) {
   std::string type;
 
@@ -156,6 +167,147 @@ int RunRigConfigurator(int argc, char** argv) {
     reconstruction->Write(output_path);
   }
 
+  return EXIT_SUCCESS;
+}
+
+// Pose prior input file format:
+// Each line corresponds to one image's pose prior and can include position,
+// rotation, and their uncertainties. Can be NaN or omitted if unknown.
+//
+// Columns:
+//   name          - Image name, must match database image name.
+//   x, y, z       - Position in world coordinates.
+//   cs            - World coordinate system
+//   std_x, std_y, std_z
+//                 - Standard deviations of position prior.
+//                   Used to construct the position covariance matrix.
+//   qw, qx, qy, qz
+//                 - Quaternion representing world-to-camera rotation.
+//                   Follows the Hamilton convention: q = [qw, qx, qy, qz].
+//   std_rx, std_ry, std_rz
+//                 - Standard deviations of rotation prior in radians.
+//                   Represent uncertainties in the axis-angle representation
+//                   around x, y, z axes respectively.
+//
+int RunPosePriorImporter(int argc, char** argv) {
+  std::string input_path;
+  bool clear_existing = false;
+
+  OptionManager options;
+  options.AddDatabaseOptions();
+  options.AddRequiredOption(
+      "input_path",
+      &input_path,
+      "Pose prior input file supportted columns:\n"
+      "# name x y z cs std_x std_y std_z qw qx qy qz std_rx std_ry std_rz\n");
+  options.AddDefaultOption("clear_existing",
+                           &clear_existing,
+                           "Remove all existing pose priors from the database "
+                           "before importing new ones.");
+  options.Parse(argc, argv);
+
+  Database database(*options.database_path);
+
+  std::ifstream infile(input_path);
+  if (!infile.is_open()) {
+    LOG(ERROR) << "Could not open file: " << input_path;
+    return EXIT_FAILURE;
+  }
+
+  std::unordered_map<std::string, size_t> col_idx;
+  std::vector<std::string> column_names;
+  std::string line;
+
+  // Read header
+  while (std::getline(infile, line)) {
+    if (line.empty() || line[0] != '#') continue;
+    std::istringstream ss(line.substr(1));
+    std::string field;
+    size_t idx = 0;
+    while (ss >> field) {
+      col_idx[field] = idx++;
+      column_names.push_back(field);
+    }
+    break;
+  }
+
+  if (col_idx.empty() || col_idx.find("name") == col_idx.end()) {
+    LOG(ERROR) << "Invalid or missing header line with # name ...";
+    return EXIT_FAILURE;
+  }
+
+  std::unordered_map<std::string, image_t> name_to_id;
+  for (const auto& image : database.ReadAllImages()) {
+    name_to_id[image.Name()] = image.ImageId();
+  }
+
+  size_t num_imported = 0;
+  while (std::getline(infile, line)) {
+    if (line.empty() || line[0] == '#') continue;
+    std::istringstream ss(line);
+    std::vector<std::string> tokens;
+    std::string token;
+    while (ss >> token) tokens.push_back(token);
+    if (tokens.size() < 1) continue;
+
+    const std::string& name = tokens[col_idx["name"]];
+    if (name_to_id.find(name) == name_to_id.end()) {
+      LOG(WARNING) << "Image name not found in database: " << name;
+      continue;
+    }
+    image_t image_id = name_to_id[name];
+
+    PosePrior prior;
+
+    if (HasFields(col_idx, {"x", "y", "z"})) {
+      prior.position = Eigen::Vector3d(std::stod(tokens[col_idx["x"]]),
+                                       std::stod(tokens[col_idx["y"]]),
+                                       std::stod(tokens[col_idx["z"]]));
+    }
+
+    if (HasFields(col_idx, {"cs"})) {
+      std::string system = tokens[col_idx["cs"]];
+      StringToUpper(&system);
+      prior.coordinate_system = PosePrior::CoordinateSystemFromString(system);
+    } else {
+      // Default to CARTESIAN if no coordinate system is specified
+      prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+    }
+
+    if (HasFields(col_idx, {"std_x", "std_y", "std_z"})) {
+      Eigen::Vector3d stddev(std::stod(tokens[col_idx["std_x"]]),
+                             std::stod(tokens[col_idx["std_y"]]),
+                             std::stod(tokens[col_idx["std_z"]]));
+      prior.position_covariance = stddev.cwiseProduct(stddev).asDiagonal();
+    }
+
+    if (HasFields(col_idx, {"qw", "qx", "qy", "qz"})) {
+      prior.rotation = Eigen::Quaterniond(std::stod(tokens[col_idx["qw"]]),
+                                          std::stod(tokens[col_idx["qx"]]),
+                                          std::stod(tokens[col_idx["qy"]]),
+                                          std::stod(tokens[col_idx["qz"]]))
+                           .normalized();
+    }
+
+    if (HasFields(col_idx, {"std_rx", "std_ry", "std_rz"})) {
+      Eigen::Vector3d stddev(std::stod(tokens[col_idx["std_rx"]]),
+                             std::stod(tokens[col_idx["std_ry"]]),
+                             std::stod(tokens[col_idx["std_rz"]]));
+      prior.rotation_covariance = stddev.cwiseProduct(stddev).asDiagonal();
+    }
+
+    if (!database.ExistsPosePrior(image_id)) {
+      database.WritePosePrior(image_id, prior);
+    } else {
+      LOG(WARNING) << "Overwriting exsiting pose prior for image #" << image_id;
+      database.UpdatePosePrior(image_id, prior);
+    }
+
+    num_imported++;
+  }
+
+  LOG(INFO) << "Imported pose priors for " << num_imported
+            << " images with fields: " << VectorToCSV(column_names);
   return EXIT_SUCCESS;
 }
 

--- a/src/colmap/exe/database.h
+++ b/src/colmap/exe/database.h
@@ -33,5 +33,6 @@ int RunDatabaseCleaner(int argc, char** argv);
 int RunDatabaseCreator(int argc, char** argv);
 int RunDatabaseMerger(int argc, char** argv);
 int RunRigConfigurator(int argc, char** argv);
+int RunPosePriorImporter(int argc, char** argv);
 
 }  // namespace colmap

--- a/src/colmap/geometry/pose_prior.cc
+++ b/src/colmap/geometry/pose_prior.cc
@@ -34,10 +34,19 @@ namespace colmap {
 std::ostream& operator<<(std::ostream& stream, const PosePrior& prior) {
   const static Eigen::IOFormat kVecFmt(
       Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ");
-  stream << "PosePrior(position=[" << prior.position.format(kVecFmt)
-         << "], position_covariance=["
-         << prior.position_covariance.format(kVecFmt) << "], coordinate_system="
-         << PosePrior::CoordinateSystemToString(prior.coordinate_system) << ")";
+
+  stream << "PosePrior(\n"
+         << "  position=[" << prior.position.format(kVecFmt) << "],\n"
+         << "  position_covariance=["
+         << prior.position_covariance.format(kVecFmt) << "],\n"
+         << "  rotation=["
+         << prior.rotation.coeffs().transpose().format(kVecFmt)
+         << "],  // [x, y, z, w]\n"
+         << "  rotation_covariance=["
+         << prior.rotation_covariance.format(kVecFmt) << "],\n"
+         << "  coordinate_system="
+         << PosePrior::CoordinateSystemToString(prior.coordinate_system) << "\n"
+         << ")";
   return stream;
 }
 

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -368,6 +368,7 @@ bool DatabaseCache::SetupPosePriors() {
   }
 
   // Convert geographic to cartesian
+  bool has_prior_rotation_in_wgs84 = false;
   if (prior_is_gps) {
     // GPS reference to be used for EllipsoidToENU conversion
     const double ref_lat = v_gps_prior[0][0];
@@ -383,12 +384,18 @@ bool DatabaseCache::SetupPosePriors() {
       pose_prior.position = *xyz_prior_it;
       pose_prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
       ++xyz_prior_it;
+      
+      has_prior_rotation_in_wgs84 |= pose_prior.HasValidRotation();
     }
   } else if (!prior_is_gps && !v_gps_prior.empty()) {
     LOG(ERROR)
         << "Database is mixing GPS & non-GPS prior positions... Aborting";
     return false;
   }
+
+  LOG_IF(WARNING, has_prior_rotation_in_wgs84)
+      << "Pose prior position is in WGS84 (GPS) coordinates; "
+         "ignoring prior rotation.";
 
   timer.PrintMinutes();
 

--- a/src/colmap/scene/database_cache_test.cc
+++ b/src/colmap/scene/database_cache_test.cc
@@ -151,9 +151,9 @@ TEST(DatabaseCache, ConstructFromDatabase) {
   EXPECT_EQ(cache->Image(images[3].ImageId()).NumPoints2D(), 3);
 
   EXPECT_TRUE(cache->ExistsPosePrior(images[0].ImageId()));
-  EXPECT_TRUE(cache->PosePrior(images[0].ImageId()).IsValid());
+  EXPECT_TRUE(cache->PosePrior(images[0].ImageId()).HasValidPosition());
   EXPECT_TRUE(cache->ExistsPosePrior(images[1].ImageId()));
-  EXPECT_TRUE(cache->PosePrior(images[1].ImageId()).IsValid());
+  EXPECT_TRUE(cache->PosePrior(images[1].ImageId()).HasValidPosition());
   EXPECT_FALSE(cache->ExistsPosePrior(images[2].ImageId()));
   EXPECT_FALSE(cache->ExistsPosePrior(images[3].ImageId()));
 
@@ -262,9 +262,9 @@ TEST(DatabaseCache, ConstructFromLegacyDatabaseWithoutRigsAndFrames) {
   EXPECT_EQ(cache->Image(1).NumPoints2D(), 10);
   EXPECT_EQ(cache->Image(2).NumPoints2D(), 5);
   EXPECT_EQ(cache->Image(3).NumPoints2D(), 7);
-  EXPECT_TRUE(cache->PosePrior(1).IsValid());
-  EXPECT_TRUE(cache->PosePrior(2).IsValid());
-  EXPECT_TRUE(cache->PosePrior(3).IsValid());
+  EXPECT_TRUE(cache->PosePrior(1).HasValidPosition());
+  EXPECT_TRUE(cache->PosePrior(2).HasValidPosition());
+  EXPECT_TRUE(cache->PosePrior(3).HasValidPosition());
   const auto correspondence_graph = cache->CorrespondenceGraph();
   EXPECT_TRUE(cache->CorrespondenceGraph()->ExistsImage(1));
   EXPECT_EQ(cache->CorrespondenceGraph()->NumCorrespondencesForImage(1), 2);
@@ -295,8 +295,8 @@ TEST(DatabaseCache, ConstructFromLegacyDatabaseWithCustomImages) {
   EXPECT_TRUE(cache->ExistsImage(3));
   EXPECT_EQ(cache->Image(1).NumPoints2D(), 10);
   EXPECT_EQ(cache->Image(3).NumPoints2D(), 7);
-  EXPECT_TRUE(cache->PosePrior(1).IsValid());
-  EXPECT_TRUE(cache->PosePrior(3).IsValid());
+  EXPECT_TRUE(cache->PosePrior(1).HasValidPosition());
+  EXPECT_TRUE(cache->PosePrior(3).HasValidPosition());
   const auto correspondence_graph = cache->CorrespondenceGraph();
   EXPECT_TRUE(cache->CorrespondenceGraph()->ExistsImage(1));
   EXPECT_EQ(cache->CorrespondenceGraph()->NumCorrespondencesForImage(1), 1);

--- a/src/colmap/scene/synthetic.h
+++ b/src/colmap/scene/synthetic.h
@@ -68,6 +68,9 @@ struct SyntheticDatasetOptions {
   bool use_prior_position = false;
   bool use_geographic_coords_prior = false;
   double prior_position_stddev = 1.5;
+
+  bool use_prior_rotation = false;
+  double prior_rotation_stddev = 1.5;
 };
 
 void SynthesizeDataset(const SyntheticDatasetOptions& options,

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -803,11 +803,11 @@ bool IncrementalMapper::AdjustGlobalBundle(
   }
 
   // Only use prior pose if at least 3 images have been registered.
-  const bool use_prior_position =
-      options.use_prior_position && ba_config.NumImages() > 2;
+  const bool use_pose_prior =
+      options.use_pose_prior && ba_config.NumImages() > 2;
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster;
-  if (!use_prior_position) {
+  if (!use_pose_prior) {
     ba_config.FixGauge(BundleAdjustmentGauge::THREE_POINTS);
     bundle_adjuster = CreateDefaultBundleAdjuster(
         std::move(custom_ba_options), ba_config, *reconstruction_);
@@ -875,7 +875,7 @@ void IncrementalMapper::IterativeGlobalRefinement(
   for (int i = 0; i < max_num_refinements; ++i) {
     const size_t num_observations = reconstruction_->ComputeNumObservations();
     AdjustGlobalBundle(options, ba_options);
-    if (normalize_reconstruction && !options.use_prior_position) {
+    if (normalize_reconstruction && !options.use_pose_prior) {
       // Normalize scene for numerical stability and
       // to avoid large scale changes in the viewer.
       reconstruction_->Normalize();

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -118,8 +118,8 @@ class IncrementalMapper {
     // If reconstruction is provided as input, fix the existing image poses.
     bool fix_existing_frames = false;
 
-    // Whether to use prior camera positions
-    bool use_prior_position = false;
+    // Whether to use pose pirors.
+    bool use_pose_prior = false;
 
     // Whether to use a robust loss on prior locations
     bool use_robust_loss_on_prior_position = false;

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -184,7 +184,7 @@ class MapperPriorsOptionsWidget : public OptionsWidget {
  public:
   MapperPriorsOptionsWidget(QWidget* parent, OptionManager* options)
       : OptionsWidget(parent) {
-    AddOptionBool(&options->mapper->use_prior_position, "use_prior_position");
+    AddOptionBool(&options->mapper->use_pose_prior, "use_pose_prior");
     AddOptionBool(&options->mapper->use_robust_loss_on_prior_position,
                   "use_robust_loss_on_prior_position");
     AddOptionDouble(&options->mapper->prior_position_loss_scale,

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -153,9 +153,9 @@ void BindIncrementalPipeline(py::module& m) {
       .def_readwrite("ba_gpu_index",
                      &IncrementalPipelineOptions::ba_gpu_index,
                      "Index of CUDA GPU to use for BA, if available.")
-      .def_readwrite("use_prior_position",
-                     &Opts::use_prior_position,
-                     "Whether to use priors on the camera positions.")
+      .def_readwrite("use_pose_prior",
+                     &Opts::use_pose_prior,
+                     "Whether to use pose priors.")
       .def_readwrite("use_robust_loss_on_prior_position",
                      &Opts::use_robust_loss_on_prior_position,
                      "Whether to use a robust loss on prior camera positions.")


### PR DESCRIPTION
- Extend pose prior format to include rotation as quaternion in database,
- support optional rotation covariance (axis-angle std dev)
- Update importer, database schema, and pose prior mapper to handle rotation priors