### PR TITLE
Expose FeatureMatchingOptions (including GPU flag) in Python verify_matches binding

### DIFF
--- a/src/pycolmap/pipeline/match_features.cc
+++ b/src/pycolmap/pipeline/match_features.cc
@@ -52,13 +52,11 @@ void MatchFeatures(const std::string& database_path,
 
 void VerifyMatches(const std::string& database_path,
                    const std::string& pairs_path,
-                   const TwoViewGeometryOptions& verification_options) {
+                   const TwoViewGeometryOptions& verification_options,
+                   const FeatureMatchingOptions& matching_options) {
   THROW_CHECK_FILE_EXISTS(database_path);
   THROW_CHECK_FILE_EXISTS(pairs_path);
   py::gil_scoped_release release;  // verification is multi-threaded
-
-  FeatureMatchingOptions matching_options;
-  matching_options.use_gpu = false;
 
   ImportedPairingOptions matcher_options;
   matcher_options.match_list_path = pairs_path;
@@ -275,7 +273,9 @@ void BindMatchFeatures(py::module& m) {
         "database_path"_a,
         "pairs_path"_a,
         py::arg_v(
-            "options", TwoViewGeometryOptions(), "TwoViewGeometryOptions()"),
+            "verification_options", TwoViewGeometryOptions(), "TwoViewGeometryOptions()"),
+        py::arg_v(
+            "matching_options", FeatureMatchingOptions(), "FeatureMatchingOptions()"),
         "Run geometric verification of the matches");
 
   py::class_<PairGenerator>(m, "PairGenerator")


### PR DESCRIPTION
- This change adds an explicit `matching_options` argument to the Python binding for `verify_matches`, so that users can enable CUDA acceleration when COLMAP itself was built with GPU support.

- When `colmap` is compiled from source with CUDA enabled, its feature matcher can leverage the GPU for substantial speed‑ups. Previously our Python wrapper always used the default (CPU‑only) `FeatureMatchingOptions`, hiding this capability.

- The new parameter is optional and defaults to the existing behavior. 

- However, I’ve refactored the options passed to `TwoViewGeometryOptions` from `options` to `verification_options` , but I’m not sure if that part of the API change is fully compatible or requires further adjustment.

- Motivation: In my work, I utilized a deep‑learning-based feature extractor and matcher to a very large dataset (over 20,000 images). After importing the features and matches into the COLMAP database, I must run `verify_matches` before reconstruction. On the dataset of this scale, the CPU‑only two‑view geometry verification step becomes prohibitively slow.