### PR TITLE
Replace force_H_use with homography_usage in TwoViewGeometryOptions

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -327,9 +327,10 @@ void OptionManager::AddMatchingOptions() {
 
   AddAndRegisterDefaultOption("TwoViewGeometry.min_num_inliers",
                               &two_view_geometry->min_num_inliers);
-  AddAndRegisterDefaultOption("TwoViewGeometry.homography_usage",
-                              &two_view_geometry->homography_usage,
-                              "{0 = AUTO, 1 = FORCE, 2 = DISABLE}");
+  AddAndRegisterDefaultOption(
+      "TwoViewGeometry.homography_usage",
+      reinterpret_cast<int*>(&two_view_geometry->homography_usage),
+      "{0 = AUTO, 1 = FORCE, 2 = DISABLE}");
   AddAndRegisterDefaultOption("TwoViewGeometry.multiple_models",
                               &two_view_geometry->multiple_models);
   AddAndRegisterDefaultOption("TwoViewGeometry.compute_relative_pose",

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -327,6 +327,9 @@ void OptionManager::AddMatchingOptions() {
 
   AddAndRegisterDefaultOption("TwoViewGeometry.min_num_inliers",
                               &two_view_geometry->min_num_inliers);
+  AddAndRegisterDefaultOption("TwoViewGeometry.homography_usage",
+                              &two_view_geometry->homography_usage,
+                              "{0 = AUTO, 1 = FORCE, 2 = DISABLE}");
   AddAndRegisterDefaultOption("TwoViewGeometry.multiple_models",
                               &two_view_geometry->multiple_models);
   AddAndRegisterDefaultOption("TwoViewGeometry.compute_relative_pose",

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -152,8 +152,8 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
     const FeatureMatches& matches,
     const TwoViewGeometryOptions& options) {
   THROW_CHECK(options.Check());
-  THROW_CHECK_NE(options.homography_usage,
-                 TwoViewGeometryOptions::HomographyUsage::FORCE);
+  THROW_CHECK(options.homography_usage !=
+              TwoViewGeometryOptions::HomographyUsage::FORCE);
 
   TwoViewGeometry geometry;
 
@@ -294,8 +294,6 @@ bool TwoViewGeometryOptions::Check() const {
   CHECK_OPTION_LE(min_E_F_inlier_ratio, 1);
   CHECK_OPTION_GE(max_H_inlier_ratio, 0);
   CHECK_OPTION_LE(max_H_inlier_ratio, 1);
-  CHECK_OPTION_GE(homography_usage, HomographyUsage::AUTO);
-  CHECK_OPTION_LE(homography_usage, HomographyUsage::DISABLE);
   CHECK_OPTION_GE(watermark_min_inlier_ratio, 0);
   CHECK_OPTION_LE(watermark_min_inlier_ratio, 1);
   CHECK_OPTION_GE(watermark_border_size, 0);
@@ -461,8 +459,8 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
     const FeatureMatches& matches,
     const TwoViewGeometryOptions& options) {
   THROW_CHECK(options.Check());
-  THROW_CHECK_NE(options.homography_usage,
-                 TwoViewGeometryOptions::HomographyUsage::FORCE);
+  THROW_CHECK(options.homography_usage !=
+              TwoViewGeometryOptions::HomographyUsage::FORCE);
 
   TwoViewGeometry geometry;
 

--- a/src/colmap/estimators/two_view_geometry.h
+++ b/src/colmap/estimators/two_view_geometry.h
@@ -76,9 +76,19 @@ struct TwoViewGeometryOptions {
   // Whether to ignore watermark models in multiple model estimation.
   bool multiple_ignore_watermark = true;
 
-  // In case the user asks for it, only going to estimate a Homography
-  // between both cameras.
-  bool force_H_use = false;
+  enum HomographyUsage : uint8_t {
+    // Estimate H along with E and F, and select the best model based on inlier
+    // ratios.
+    AUTO = 0,
+    // Only estimate and use H.
+    FORCE = 1,
+    // Do not estimate or use H.
+    DISABLE = 2
+  };
+
+  // Specifies how to handle the homography model during two view geometry
+  // estimation.
+  int homography_usage = HomographyUsage::AUTO;
 
   // Whether to compute the relative pose between the two views.
   bool compute_relative_pose = false;

--- a/src/colmap/estimators/two_view_geometry.h
+++ b/src/colmap/estimators/two_view_geometry.h
@@ -87,7 +87,7 @@ struct TwoViewGeometryOptions {
   // Maximum displacement for points to be considered stationary matches.
   double stationary_matches_max_error = 4.0;
 
-  enum HomographyUsage : uint8_t {
+  enum class HomographyUsage : int {
     // Estimate H along with E/F, select the best model based on inlier ratios.
     AUTO = 0,
     // Only estimate and use H.
@@ -96,9 +96,8 @@ struct TwoViewGeometryOptions {
     DISABLE = 2
   };
 
-  // Specifies how to handle the homography model during two view geometry
-  // estimation.
-  int homography_usage = HomographyUsage::AUTO;
+  // Specifies how to handle homographies during two view geometry estimation.
+  HomographyUsage homography_usage = HomographyUsage::AUTO;
 
   // Whether to compute the relative pose between the two views.
   bool compute_relative_pose = false;

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -735,8 +735,8 @@ TEST(EstimateTwoViewGeometry, Stability) {
     synthetic_dataset_options.num_points3D = 500;
     synthetic_dataset_options.point2D_stddev = 0.5;
     synthetic_dataset_options.inlier_match_ratio = 0.95;
-    synthetic_dataset_options.sensor_from_rig_translation_stddev = 0.01;
-    synthetic_dataset_options.sensor_from_rig_rotation_stddev = 1.0;
+    synthetic_dataset_options.sensor_from_rig_translation_stddev = 0.005;
+    synthetic_dataset_options.sensor_from_rig_rotation_stddev = 0.1;
     synthetic_dataset_options.camera_has_prior_focal_length = true;
 
     TwoViewGeometryTestData test_data =

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -746,50 +746,5 @@ TEST(EstimateTwoViewGeometry, HomographyUsage) {
     EXPECT_NE(geometry.H, Eigen::Matrix3d::Zero());
   }
 }
-
-TEST(EstimateTwoViewGeometry, Stability) {
-  SetPRNGSeed(123);
-
-  SyntheticDatasetOptions synthetic_dataset_options;
-  synthetic_dataset_options.num_rigs = 2;
-  synthetic_dataset_options.num_cameras_per_rig = 1;
-  synthetic_dataset_options.num_frames_per_rig = 1;
-  synthetic_dataset_options.num_points3D = 500;
-  synthetic_dataset_options.point2D_stddev = 0.5;
-  synthetic_dataset_options.inlier_match_ratio = 0.95;
-  synthetic_dataset_options.camera_has_prior_focal_length = true;
-
-  TwoViewGeometryTestData test_data =
-      CreateTwoViewGeometryTestData(synthetic_dataset_options);
-
-  TwoViewGeometryOptions options;
-  options.homography_usage = TwoViewGeometryOptions::HomographyUsage::AUTO;
-  options.ransac_options.max_error = 4.0;
-  options.ransac_options.confidence = 0.999;
-  options.ransac_options.random_seed = 0;
-  TwoViewGeometry geometry0 = EstimateTwoViewGeometry(test_data.camera1,
-                                                      test_data.points1,
-                                                      test_data.camera2,
-                                                      test_data.points2,
-                                                      test_data.matches,
-                                                      options);
-
-  constexpr int kNumTests = 100;
-  for (int seed = 1; seed <= kNumTests; ++seed) {
-    options.ransac_options.random_seed = seed;
-    TwoViewGeometry geometry = EstimateTwoViewGeometry(test_data.camera1,
-                                                       test_data.points1,
-                                                       test_data.camera2,
-                                                       test_data.points2,
-                                                       test_data.matches,
-                                                       options);
-
-    EXPECT_THAT(geometry.E, EigenMatrixNear(geometry0.E, 1e-3));
-    EXPECT_THAT(geometry.F, EigenMatrixNear(geometry0.F, 1e-3));
-    EXPECT_THAT(geometry.H, EigenMatrixNear(geometry0.H, 5));
-    EXPECT_TRUE(AreFeatureMatchesNear(
-        geometry.inlier_matches, geometry0.inlier_matches, 0.95));
-  }
-}
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -748,94 +748,47 @@ TEST(EstimateTwoViewGeometry, HomographyUsage) {
 }
 
 TEST(EstimateTwoViewGeometry, Stability) {
-  {
-    SetPRNGSeed(123);
+  SetPRNGSeed(123);
 
-    SyntheticDatasetOptions synthetic_dataset_options;
-    synthetic_dataset_options.num_rigs = 2;
-    synthetic_dataset_options.num_cameras_per_rig = 1;
-    synthetic_dataset_options.num_frames_per_rig = 1;
-    synthetic_dataset_options.num_points3D = 500;
-    synthetic_dataset_options.point2D_stddev = 0.5;
-    synthetic_dataset_options.inlier_match_ratio = 0.95;
-    synthetic_dataset_options.camera_has_prior_focal_length = true;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.point2D_stddev = 0.5;
+  synthetic_dataset_options.inlier_match_ratio = 0.95;
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
 
-    TwoViewGeometryTestData test_data =
-        CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
 
-    TwoViewGeometryOptions options;
-    options.homography_usage = TwoViewGeometryOptions::HomographyUsage::AUTO;
-    options.ransac_options.max_error = 4.0;
-    options.ransac_options.confidence = 0.999;
-    options.ransac_options.random_seed = 0;
-    TwoViewGeometry geometry0 = EstimateTwoViewGeometry(test_data.camera1,
-                                                        test_data.points1,
-                                                        test_data.camera2,
-                                                        test_data.points2,
-                                                        test_data.matches,
-                                                        options);
+  TwoViewGeometryOptions options;
+  options.homography_usage = TwoViewGeometryOptions::HomographyUsage::AUTO;
+  options.ransac_options.max_error = 4.0;
+  options.ransac_options.confidence = 0.999;
+  options.ransac_options.random_seed = 0;
+  TwoViewGeometry geometry0 = EstimateTwoViewGeometry(test_data.camera1,
+                                                      test_data.points1,
+                                                      test_data.camera2,
+                                                      test_data.points2,
+                                                      test_data.matches,
+                                                      options);
 
-    constexpr int kNumTests = 100;
-    for (int seed = 1; seed <= kNumTests; ++seed) {
-      options.ransac_options.random_seed = seed;
-      TwoViewGeometry geometry = EstimateTwoViewGeometry(test_data.camera1,
-                                                         test_data.points1,
-                                                         test_data.camera2,
-                                                         test_data.points2,
-                                                         test_data.matches,
-                                                         options);
+  constexpr int kNumTests = 100;
+  for (int seed = 1; seed <= kNumTests; ++seed) {
+    options.ransac_options.random_seed = seed;
+    TwoViewGeometry geometry = EstimateTwoViewGeometry(test_data.camera1,
+                                                       test_data.points1,
+                                                       test_data.camera2,
+                                                       test_data.points2,
+                                                       test_data.matches,
+                                                       options);
 
-      EXPECT_THAT(geometry.E, EigenMatrixNear(geometry0.E, 1e-3));
-      EXPECT_THAT(geometry.F, EigenMatrixNear(geometry0.F, 1e-3));
-      EXPECT_THAT(geometry.H, EigenMatrixNear(geometry0.H, 5));
-      EXPECT_TRUE(AreFeatureMatchesNear(
-          geometry.inlier_matches, geometry0.inlier_matches, 0.95));
-    }
-  }
-
-  {
-    SetPRNGSeed(123);
-
-    SyntheticDatasetOptions synthetic_dataset_options;
-    synthetic_dataset_options.num_rigs = 1;
-    synthetic_dataset_options.num_cameras_per_rig = 2;
-    synthetic_dataset_options.num_frames_per_rig = 1;
-    synthetic_dataset_options.num_points3D = 500;
-    synthetic_dataset_options.point2D_stddev = 0.5;
-    synthetic_dataset_options.inlier_match_ratio = 0.95;
-    synthetic_dataset_options.sensor_from_rig_translation_stddev = 0.005;
-    synthetic_dataset_options.sensor_from_rig_rotation_stddev = 0.1;
-    synthetic_dataset_options.camera_has_prior_focal_length = true;
-
-    TwoViewGeometryTestData test_data =
-        CreateTwoViewGeometryTestData(synthetic_dataset_options);
-
-    TwoViewGeometryOptions options;
-    options.homography_usage = TwoViewGeometryOptions::HomographyUsage::FORCE;
-    options.ransac_options.max_error = 4.0;
-    options.ransac_options.confidence = 0.999;
-    options.ransac_options.random_seed = 0;
-    TwoViewGeometry geometry0 = EstimateTwoViewGeometry(test_data.camera1,
-                                                        test_data.points1,
-                                                        test_data.camera2,
-                                                        test_data.points2,
-                                                        test_data.matches,
-                                                        options);
-
-    constexpr int kNumTests = 100;
-    for (int seed = 1; seed <= kNumTests; ++seed) {
-      options.ransac_options.random_seed = seed;
-      TwoViewGeometry geometry = EstimateTwoViewGeometry(test_data.camera1,
-                                                         test_data.points1,
-                                                         test_data.camera2,
-                                                         test_data.points2,
-                                                         test_data.matches,
-                                                         options);
-
-      EXPECT_THAT(geometry.H, EigenMatrixNear(geometry0.H, 20));
-      EXPECT_TRUE(AreFeatureMatchesNear(
-          geometry.inlier_matches, geometry0.inlier_matches, 0.95));
-    }
+    EXPECT_THAT(geometry.E, EigenMatrixNear(geometry0.E, 1e-3));
+    EXPECT_THAT(geometry.F, EigenMatrixNear(geometry0.F, 1e-3));
+    EXPECT_THAT(geometry.H, EigenMatrixNear(geometry0.H, 5));
+    EXPECT_TRUE(AreFeatureMatchesNear(
+        geometry.inlier_matches, geometry0.inlier_matches, 0.95));
   }
 }
 }  // namespace

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -198,34 +198,6 @@ bool CheckEqualTwoViewGeometry(const TwoViewGeometry& geometry,
   return true;
 }
 
-bool AreFeatureMatchesNear(const FeatureMatches& actual,
-                           const FeatureMatches& expected,
-                           double min_overlap_ratio) {
-  size_t overlap = 0;
-  for (const auto& match_expected : expected) {
-    for (const auto& match_actual : actual) {
-      if (match_expected.point2D_idx1 == match_actual.point2D_idx1 &&
-          match_expected.point2D_idx2 == match_actual.point2D_idx2) {
-        ++overlap;
-        break;
-      }
-    }
-  }
-
-  size_t max_size = std::max(expected.size(), actual.size());
-  double ratio = max_size == 0 ? 1.0 : static_cast<double>(overlap) / max_size;
-
-  if (ratio < min_overlap_ratio) {
-    LOG(ERROR) << "FeatureMatches similarity ratio " << ratio << " < threshold "
-               << min_overlap_ratio << '\n'
-               << "Expected size: " << expected.size()
-               << ", Actual size: " << actual.size()
-               << ", Overlapping matches: " << overlap;
-    return false;
-  }
-  return true;
-}
-
 TEST(EstimateTwoViewGeometryPose, Calibrated) {
   constexpr int kNumTests = 100;
   int num_failures = 0;

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -163,8 +163,11 @@ void FeatureMatchingTab::CreateGeneralOptions() {
       &options_->two_view_geometry->ransac_options.random_seed, "random_seed");
   options_widget_->AddOptionInt(&options_->two_view_geometry->min_num_inliers,
                                 "min_num_inliers");
-  options_widget_->AddOptionInt(&options_->two_view_geometry->homography_usage,
-                                "homography_usage");
+  options_widget_->AddOptionInt(
+      reinterpret_cast<int*>(&options_->two_view_geometry->homography_usage),
+      "homography_usage",
+      0,
+      2);
   options_widget_->AddOptionBool(&options_->two_view_geometry->multiple_models,
                                  "multiple_models");
   options_widget_->AddOptionBool(

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -163,8 +163,15 @@ void FeatureMatchingTab::CreateGeneralOptions() {
       &options_->two_view_geometry->ransac_options.random_seed, "random_seed");
   options_widget_->AddOptionInt(&options_->two_view_geometry->min_num_inliers,
                                 "min_num_inliers");
+  options_widget_->AddOptionInt(&options_->two_view_geometry->homography_usage,
+                                "homography_usage");
   options_widget_->AddOptionBool(&options_->two_view_geometry->multiple_models,
                                  "multiple_models");
+  options_widget_->AddOptionBool(
+      &options_->two_view_geometry->compute_relative_pose,
+      "compute_relative_pose");
+  options_widget_->AddOptionBool(&options_->two_view_geometry->detect_watermark,
+                                 "detect_watermark");
   options_widget_->AddSpacer();
 
   QScrollArea* options_scroll_area = new QScrollArea(this);

--- a/src/pycolmap/estimators/two_view_geometry.cc
+++ b/src/pycolmap/estimators/two_view_geometry.cc
@@ -20,6 +20,15 @@ namespace py = pybind11;
 void BindTwoViewGeometryEstimator(py::module& m) {
   py::class_<TwoViewGeometryOptions> PyTwoViewGeometryOptions(
       m, "TwoViewGeometryOptions");
+
+  using HomographyUsage = TwoViewGeometryOptions::HomographyUsage;
+  py::enum_<HomographyUsage> PyHomographyUsage(
+      m, "TwoViewGeometryHomographyUsage");
+  PyHomographyUsage.value("AUTO", HomographyUsage::AUTO)
+      .value("FORCE", HomographyUsage::FORCE)
+      .value("DISABLE", HomographyUsage::DISABLE);
+  AddStringToEnumConstructor(PyHomographyUsage);
+
   PyTwoViewGeometryOptions.def(py::init<>())
       .def_readwrite("min_num_inliers",
                      &TwoViewGeometryOptions::min_num_inliers)
@@ -35,7 +44,8 @@ void BindTwoViewGeometryEstimator(py::module& m) {
                      &TwoViewGeometryOptions::detect_watermark)
       .def_readwrite("multiple_ignore_watermark",
                      &TwoViewGeometryOptions::multiple_ignore_watermark)
-      .def_readwrite("force_H_use", &TwoViewGeometryOptions::force_H_use)
+      .def_readwrite("homography_usage",
+                     &TwoViewGeometryOptions::homography_usage)
       .def_readwrite("compute_relative_pose",
                      &TwoViewGeometryOptions::compute_relative_pose)
       .def_readwrite("multiple_models",


### PR DESCRIPTION
Replace `force_H_use ` with `homography_usage`  to control whether and how homography is estimated during two-view geometry:

- `AUTO` (default): Estimate H, E, F, and choose the best model based on inlier ratios.
- `DISABLE`: Skip H.
- `FORCE`: Only use H.

Helps avoid instability in H estimation in cases of poor match quality (set `homography_usage` to `DISABLE`).
