### PR TITLE
Ignore compile_commands.json in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ LocalConfig.cmake
 src/colmap/util/version.cc
 CMakeUserPresets.json
 .clangd
+compile_commands.json
 
 # Custom directories
 .idea/


### PR DESCRIPTION
Avoid accidentally checking in compile commands database when configuring the project with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.