### PR TITLE
Fix bundle adjustment performance regression due to changed Gauge

### DIFF
--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -91,6 +91,10 @@ void BundleAdjustmentController::Run() {
   for (const image_t image_id : reconstruction_->RegImageIds()) {
     ba_config.AddImage(image_id);
   }
+  // Fixing the gauge with two cameras leads to a more stable optimization
+  // with fewer steps as compared to fixing three points.
+  // TODO(jsch): Investigate whether it is safe to not fix the gauge at all,
+  // as initial experiments show that it is even faster.
   ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
 
   // Run bundle adjustment.

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -674,8 +674,8 @@ class DefaultBundleAdjuster : public BundleAdjuster {
       case BundleAdjustmentGauge::UNSPECIFIED:
         break;
       case BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD:
-        FixGaugeWithTwoCamsFromWorld(options,
-                                     config,
+        FixGaugeWithTwoCamsFromWorld(options_,
+                                     config_,
                                      parameterized_image_ids_,
                                      point3D_num_observations_,
                                      reconstruction,

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -808,6 +808,10 @@ bool IncrementalMapper::AdjustGlobalBundle(
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster;
   if (!use_prior_position) {
+    // Fixing the gauge with two cameras leads to a more stable optimization
+    // with fewer steps as compared to fixing three points.
+    // TODO(jsch): Investigate whether it is safe to not fix the gauge at all,
+    // as initial experiments show that it is even faster.
     ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
     bundle_adjuster = CreateDefaultBundleAdjuster(
         std::move(custom_ba_options), ba_config, *reconstruction_);

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -808,7 +808,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster;
   if (!use_prior_position) {
-    ba_config.FixGauge(BundleAdjustmentGauge::THREE_POINTS);
+    ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
     bundle_adjuster = CreateDefaultBundleAdjuster(
         std::move(custom_ba_options), ba_config, *reconstruction_);
   } else {


### PR DESCRIPTION
Based on reported issue https://github.com/colmap/colmap/issues/3479, I root-caused a performance regression in bundle adjustment to different gauge fixing behavior. In particular, the change from fixing the gauge with two cameras vs. fixing it with three points causes a ~40% slowdown in global bundle adjustment. No significant difference can be measured in local bundle adjustment. I could also not find a significant difference in the obtained solution quality. This PR reverts back to using two cameras for fixing the gauge. If no such two cameras can be found, which can occasionally happen in case of configured non-trivial rigs, we fall back to fixing three points.