### PR TITLE
Add explicit tests for fixing gauge freedom and bugfix

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -871,5 +871,92 @@ TEST(DefaultBundleAdjuster, ConstantExtraParam) {
   }
 }
 
+TEST(DefaultBundleAdjuster, FixGaugeWithThreePoints) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 100;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  const Reconstruction orig_reconstruction = reconstruction;
+
+  BundleAdjustmentConfig config;
+  config.AddImage(1);
+  config.AddImage(2);
+
+  auto ExpectValidSolve = [&config, &reconstruction](
+                              const int num_effective_parameters_reduced) {
+    const auto summary1 = CreateDefaultBundleAdjuster(
+                              BundleAdjustmentOptions(), config, reconstruction)
+                              ->Solve();
+    ASSERT_NE(summary1.termination_type, ceres::FAILURE);
+    EXPECT_EQ(summary1.num_effective_parameters_reduced,
+              num_effective_parameters_reduced);
+  };
+
+  ExpectValidSolve(316);
+
+  config.FixGauge(BundleAdjustmentGauge::THREE_POINTS);
+  ExpectValidSolve(307);
+
+  config.AddConstantPoint(1);
+  ExpectValidSolve(307);
+
+  config.AddConstantPoint(2);
+  config.AddConstantPoint(3);
+  ExpectValidSolve(307);
+
+  config.AddConstantPoint(4);
+  ExpectValidSolve(304);
+}
+
+TEST(DefaultBundleAdjuster, FixGaugeWithTwoCamsFromWorld) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 100;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  const Reconstruction orig_reconstruction = reconstruction;
+
+  BundleAdjustmentOptions options;
+
+  BundleAdjustmentConfig config;
+  config.AddImage(1);
+  config.AddImage(2);
+  config.AddImage(3);
+  config.AddImage(4);
+
+  auto ExpectValidSolve = [&options, &config, &reconstruction](
+                              const int num_effective_parameters_reduced) {
+    const auto summary1 =
+        CreateDefaultBundleAdjuster(options, config, reconstruction)->Solve();
+    ASSERT_NE(summary1.termination_type, ceres::FAILURE);
+    EXPECT_EQ(summary1.num_effective_parameters_reduced,
+              num_effective_parameters_reduced);
+  };
+
+  options.refine_rig_from_world = false;
+  ExpectValidSolve(320);
+
+  options.refine_rig_from_world = true;
+  ExpectValidSolve(332);
+
+  options.refine_rig_from_world = false;
+  config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+  ExpectValidSolve(320);
+
+  options.refine_rig_from_world = true;
+  ExpectValidSolve(325);
+
+  config.SetConstantRigFromWorldPose(1);
+  ExpectValidSolve(325);
+
+  config.SetConstantRigFromWorldPose(2);
+  ExpectValidSolve(320);
+}
+
 }  // namespace
 }  // namespace colmap


### PR DESCRIPTION
No surprise... It turns out that writing a few tests helps with uncovering bugs. This PR adds tests for both gauge fixing options, improves the behavior when some cameras are already fixed, and fixes a bug when points are already fixed (introduced by the recent perf regression fix).