### PR TITLE
Add random_seed to IncrementalMapper to control all RANSAC seeds for improved SfM reproducibility

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -89,6 +89,7 @@ IncrementalMapper::Options IncrementalPipelineOptions::Mapper() const {
   options.use_prior_position = use_prior_position;
   options.use_robust_loss_on_prior_position = use_robust_loss_on_prior_position;
   options.prior_position_loss_scale = prior_position_loss_scale;
+  options.random_seed = random_seed;
   return options;
 }
 
@@ -98,6 +99,7 @@ IncrementalTriangulator::Options IncrementalPipelineOptions::Triangulation()
   options.min_focal_length_ratio = min_focal_length_ratio;
   options.max_focal_length_ratio = max_focal_length_ratio;
   options.max_extra_param = max_extra_param;
+  options.random_seed = random_seed;
   return options;
 }
 
@@ -183,6 +185,8 @@ bool IncrementalPipelineOptions::Check() const {
   CHECK_OPTION_GE(ba_global_max_refinement_change, 0);
   CHECK_OPTION_GE(snapshot_frames_freq, 0);
   CHECK_OPTION_GT(prior_position_loss_scale, 0.);
+  CHECK_OPTION_GE(num_threads, -1);
+  CHECK_OPTION_GE(random_seed, -1);
   CHECK_OPTION(Mapper().Check());
   CHECK_OPTION(Triangulation().Check());
   return true;

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -74,6 +74,9 @@ struct IncrementalPipelineOptions {
   // The number of threads to use during reconstruction.
   int num_threads = -1;
 
+  // PRNG seed for all stochastic methods during reconstruction.
+  int random_seed = -1;
+
   // Thresholds for filtering images with degenerate intrinsics.
   double min_focal_length_ratio = 0.1;
   double max_focal_length_ratio = 10.0;

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -552,6 +552,7 @@ void OptionManager::AddMapperOptions() {
                               &mapper->init_num_trials);
   AddAndRegisterDefaultOption("Mapper.extract_colors", &mapper->extract_colors);
   AddAndRegisterDefaultOption("Mapper.num_threads", &mapper->num_threads);
+  AddAndRegisterDefaultOption("Mapper.random_seed", &mapper->random_seed);
   AddAndRegisterDefaultOption("Mapper.min_focal_length_ratio",
                               &mapper->min_focal_length_ratio);
   AddAndRegisterDefaultOption("Mapper.max_focal_length_ratio",

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -1031,10 +1031,8 @@ class PosePriorBundleAdjuster : public BundleAdjuster {
   }
 
   bool AlignReconstruction() {
-    RANSACOptions ransac_options;
-    if (prior_options_.ransac_max_error > 0) {
-      ransac_options.max_error = prior_options_.ransac_max_error;
-    } else {
+    RANSACOptions ransac_options = prior_options_.alignment_ransac_options;
+    if (ransac_options.max_error <= 0) {
       double max_stddev_sum = 0;
       size_t num_valid_covs = 0;
       for (const auto& [_, pose_prior] : pose_priors_) {

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/optim/ransac.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/enum_utils.h"
@@ -202,8 +203,8 @@ struct PosePriorBundleAdjustmentOptions {
   // (chi2 for 3DOF at 95% = 7.815).
   double prior_position_loss_scale = 7.815;
 
-  // Maximum RANSAC error for Sim3 alignment.
-  double ransac_max_error = 0.;
+  // Sim3 alignment options.
+  RANSACOptions alignment_ransac_options;
 };
 
 class BundleAdjuster {

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -62,6 +62,8 @@ bool IncrementalMapper::Options::Check() const {
   CHECK_OPTION_GE(filter_max_reproj_error, 0.0);
   CHECK_OPTION_GE(filter_min_tri_angle, 0.0);
   CHECK_OPTION_GE(max_reg_trials, 1);
+  CHECK_OPTION_GE(num_threads, -1);
+  CHECK_OPTION_GE(random_seed, -1);
   return true;
 }
 
@@ -301,6 +303,7 @@ bool IncrementalMapper::RegisterNextImage(const Options& options,
   abs_pose_options.ransac_options.max_error = options.abs_pose_max_error;
   abs_pose_options.ransac_options.min_inlier_ratio =
       options.abs_pose_min_inlier_ratio;
+  abs_pose_options.ransac_options.random_seed = options.random_seed;
 
   AbsolutePoseRefinementOptions abs_pose_refinement_options;
   if (reg_stats_.num_reg_images_per_camera[image.CameraId()] > 0) {
@@ -520,6 +523,7 @@ bool IncrementalMapper::RegisterNextGeneralFrame(const Options& options,
   RANSACOptions abs_pose_options;
   abs_pose_options.max_error = options.abs_pose_max_error;
   abs_pose_options.min_inlier_ratio = options.abs_pose_min_inlier_ratio;
+  abs_pose_options.random_seed = options.random_seed;
 
   AbsolutePoseRefinementOptions abs_pose_refinement_options;
   abs_pose_refinement_options.refine_focal_length = false;
@@ -820,6 +824,7 @@ bool IncrementalMapper::AdjustGlobalBundle(
     prior_options.use_robust_loss_on_prior_position =
         options.use_robust_loss_on_prior_position;
     prior_options.prior_position_loss_scale = options.prior_position_loss_scale;
+    prior_options.alignment_ransac_options.random_seed = options.random_seed;
     bundle_adjuster =
         CreatePosePriorBundleAdjuster(std::move(custom_ba_options),
                                       prior_options,

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -131,6 +131,9 @@ class IncrementalMapper {
     // Number of threads.
     int num_threads = -1;
 
+    // PRNG seed for all stochastic methods during reconstruction.
+    int random_seed = -1;
+
     // Method to find and select next best image to register.
     enum class ImageSelectionMethod {
       MAX_VISIBLE_POINTS_NUM,

--- a/src/colmap/sfm/incremental_mapper_impl.cc
+++ b/src/colmap/sfm/incremental_mapper_impl.cc
@@ -595,6 +595,7 @@ bool EstimateInitialGeneralizedTwoViewGeometry(
 
   RANSACOptions ransac_options;
   ransac_options.min_num_trials = 30;
+  ransac_options.random_seed = options.random_seed;
   // Compute the average normalized error.
   ransac_options.max_error = 0;
   for (const Camera& camera : cameras) {
@@ -686,6 +687,7 @@ bool IncrementalMapperImpl::EstimateInitialTwoViewGeometry(
   TwoViewGeometryOptions two_view_geometry_options;
   two_view_geometry_options.ransac_options.min_num_trials = 30;
   two_view_geometry_options.ransac_options.max_error = options.init_max_error;
+  two_view_geometry_options.ransac_options.random_seed = options.random_seed;
   TwoViewGeometry two_view_geometry = EstimateCalibratedTwoViewGeometry(
       camera1, points1, camera2, points2, matches, two_view_geometry_options);
 

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -79,6 +79,7 @@ bool IncrementalTriangulator::Options::Check() const {
   CHECK_OPTION_LE(re_min_ratio, 1);
   CHECK_OPTION_GE(re_max_trials, 0);
   CHECK_OPTION_GT(min_angle, 0);
+  CHECK_OPTION_GE(random_seed, -1);
   return true;
 }
 
@@ -179,6 +180,7 @@ size_t IncrementalTriangulator::CompleteImage(const Options& options,
   tri_options.residual_type =
       TriangulationEstimator::ResidualType::REPROJECTION_ERROR;
   tri_options.ransac_options.max_error = options.complete_max_reproj_error;
+  tri_options.ransac_options.random_seed = options.random_seed;
 
   // Correspondence data for reference observation in given image. We iterate
   // over all observations of the image and each observation once becomes
@@ -504,6 +506,7 @@ size_t IncrementalTriangulator::Create(
       TriangulationEstimator::ResidualType::ANGULAR_ERROR;
   tri_options.ransac_options.max_error =
       DegToRad(options.create_max_angle_error);
+  tri_options.ransac_options.random_seed = options.random_seed;
 
   // Estimate triangulation.
   Eigen::Vector3d xyz;

--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -83,6 +83,9 @@ class IncrementalTriangulator {
     double max_focal_length_ratio = 10.0;
     double max_extra_param = 1.0;
 
+    // PRNG seed for all stochastic methods during triangulation.
+    int random_seed = -1;
+
     bool Check() const;
   };
 

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -44,6 +44,7 @@ class MapperGeneralOptionsWidget : public OptionsWidget {
     AddOptionInt(&options->mapper->min_model_size, "min_model_size");
     AddOptionBool(&options->mapper->extract_colors, "extract_colors");
     AddOptionInt(&options->mapper->num_threads, "num_threads", -1);
+    AddOptionInt(&options->mapper->random_seed, "random_seed", -1);
     AddOptionInt(&options->mapper->min_num_matches, "min_num_matches");
     AddOptionBool(&options->mapper->ignore_watermarks, "ignore_watermarks");
     AddOptionDirPath(&options->mapper->snapshot_path, "snapshot_path");

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -62,6 +62,10 @@ void BindIncrementalPipeline(py::module& m) {
       .def_readwrite("num_threads",
                      &Opts::num_threads,
                      "The number of threads to use during reconstruction.")
+      .def_readwrite(
+          "random_seed",
+          &Opts::random_seed,
+          "PRNG seed for all stochastic methods during reconstruction.")
       .def_readwrite("min_focal_length_ratio",
                      &Opts::min_focal_length_ratio,
                      "The threshold used to filter and ignore images with "


### PR DESCRIPTION
This PR introduces a `random_seed` option in IncrementalMapper that controls the random seeds used in all RANSAC processes throughout the reconstruction pipeline. This enhancement improves SfM reproducibility, facilitating debugging and consistent testing.

Floating-point variations from Ceres optimization in multithreaded environments remain unavoidable.
