### PR TITLE
Fix comment for C++20 support.

### DIFF
--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -177,8 +177,8 @@ struct data_t {
 constexpr data_t kInvalidDataId =
     data_t(kInvalidSensorId, std::numeric_limits<uint32_t>::max());
 
-// Simple implementation of C++20's std::span, as Ubuntu 20.04's default GCC
-// version does not come with full C++20 and we still want to support it.
+// Simple implementation of C++20's std::span. Used for compatibility with CUDA
+// toolchains that lack full C++20 standard library support.
 template <typename T>
 class span {
   T* ptr_;


### PR DESCRIPTION
Ubuntu 20.04 should no longer be a problem since https://github.com/colmap/colmap/pull/3203, but the latest cuda still lacks full c++20 support. 