### PR TITLE
Fix ModelViewerWidget::ClearReconstruction

### DIFF
--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -445,6 +445,8 @@ void ModelViewerWidget::ClearReconstruction() {
   points3D.clear();
   reg_image_ids.clear();
   reconstruction = nullptr;
+  selected_image_id_ = kInvalidImageId;
+  selected_point3D_id_ = kInvalidPoint3DId;
   Upload();
 }
 


### PR DESCRIPTION
This PR fixs ModelViewerWidget.

This bug can be reproduced by following the steps:

1. Import model by Colmap gui.
2. Double click a image  of the model to view the information of the image.
3. Close the dialog of image information.
4. Import another model.
5. Colmap gui crashed.

`E20250809 00:49:34.254333 19348 image.h:265] 'frame_ptr_' Must be non NULL`
