### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -22,6 +22,7 @@ find_package(OpenMP REQUIRED COMPONENTS C CXX)
 find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
              graph
              program_options
+             OPTIONAL_COMPONENTS
              system)
 
 find_package(Eigen3 ${COLMAP_FIND_TYPE})


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, the Boost.System stub library introduced back in 1.69[^1] has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3), which causes a CMake error.

This PR change using OPTIONAL_COMPONENTS is based on upstream comment `https://github.com/boostorg/system/issues/132#issuecomment-3146378680` given that no minimum Boost is mentioned for project.

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69