### PR TITLE
Update database bindings

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -22,6 +22,7 @@ find_package(OpenMP REQUIRED COMPONENTS C CXX)
 find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
              graph
              program_options
+             OPTIONAL_COMPONENTS
              system)
 
 find_package(Eigen3 ${COLMAP_FIND_TYPE})

--- a/python/examples/custom_incremental_pipeline.py
+++ b/python/examples/custom_incremental_pipeline.py
@@ -198,7 +198,7 @@ def reconstruct_sub_model(controller, mapper, mapper_options, reconstruction):
     if (
         reconstruction.num_reg_frames() >= 2
         and reconstruction.num_reg_frames() != ba_prev_num_reg_frames
-        and reconstruction.num_points3D != ba_prev_num_points
+        and reconstruction.num_points3D() != ba_prev_num_points
     ):
         iterative_global_refinement(options, mapper_options, mapper)
     return pycolmap.IncrementalMapperStatus.SUCCESS
@@ -341,7 +341,7 @@ def main(
     )
 
     # main runner
-    num_images = pycolmap.Database(database_path).num_images
+    num_images = pycolmap.Database(database_path).num_images()
     with enlighten.Manager() as manager:
         with manager.counter(
             total=num_images, desc="Images registered:"

--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -51,23 +51,23 @@ void BindDatabase(py::module& m) {
            &Database::ExistsInlierMatches,
            "image_id1"_a,
            "image_id2"_a)
-      .def_property_readonly("num_cameras", &Database::NumCameras)
-      .def_property_readonly("num_images", &Database::NumImages)
-      .def_property_readonly("num_pose_priors", &Database::NumPosePriors)
-      .def_property_readonly("num_keypoints", &Database::NumKeypoints)
+      .def("num_rigs", &Database::NumRigs)
+      .def("num_cameras", &Database::NumCameras)
+      .def("num_frames", &Database::NumFrames)
+      .def("num_images", &Database::NumImages)
+      .def("num_pose_priors", &Database::NumPosePriors)
+      .def("num_keypoints", &Database::NumKeypoints)
       .def("num_keypoints_for_image",
            &Database::NumKeypointsForImage,
            "image_id"_a)
-      .def_property_readonly("num_descriptors", &Database::NumDescriptors)
+      .def("num_descriptors", &Database::NumDescriptors)
       .def("num_descriptors_for_image",
            &Database::NumDescriptorsForImage,
            "image_id"_a)
-      .def_property_readonly("num_matches", &Database::NumMatches)
-      .def_property_readonly("num_inlier_matches", &Database::NumInlierMatches)
-      .def_property_readonly("num_matched_image_pairs",
-                             &Database::NumMatchedImagePairs)
-      .def_property_readonly("num_verified_image_pairs",
-                             &Database::NumVerifiedImagePairs)
+      .def("num_matches", &Database::NumMatches)
+      .def("num_inlier_matches", &Database::NumInlierMatches)
+      .def("num_matched_image_pairs", &Database::NumMatchedImagePairs)
+      .def("num_verified_image_pairs", &Database::NumVerifiedImagePairs)
       .def_static("image_pair_to_pair_id",
                   &Database::ImagePairToPairId,
                   "image_id1"_a,


### PR DESCRIPTION
* Add missing num_rigs/num_frames methods.
* Change to method instead of properties, as the underlying operation is not a trivial readout of a field. This is to make it consistent with the reconstruction object and was unintuitive before. This breaks backwards compatibility but is an easy one to fix.