### PR TITLE
Add a test to ensure THROW_CHECK conditions are evaluated exactly once

### DIFF
--- a/src/colmap/util/logging_test.cc
+++ b/src/colmap/util/logging_test.cc
@@ -69,6 +69,7 @@ TEST(ExceptionLogging, NumConditionEvals) {
   try {
     THROW_CHECK(!func());
   } catch (...) {
+    LOG(INFO) << "Caught exception";
   }
   EXPECT_EQ(num_calls, 2);
 }


### PR DESCRIPTION
To prevent accidental wrong definition of the THROW_CHECK macros to evaluate the condition twice.