### PR TITLE
Display CLI floating-point defaults with 3 significant digits

### DIFF
--- a/src/colmap/controllers/option_manager.h
+++ b/src/colmap/controllers/option_manager.h
@@ -214,19 +214,25 @@ template <typename T>
 void OptionManager::AddDefaultOption(const std::string& name,
                                      T* option,
                                      const std::string& help_text) {
-  desc_->add_options()(
-      name.c_str(),
-      boost::program_options::value<T>(option)->default_value(*option),
-      help_text.c_str());
+  if constexpr (std::is_floating_point<T>::value) {
+    desc_->add_options()(
+        name.c_str(),
+        boost::program_options::value<T>(option)->default_value(
+            *option, StringPrintf("%.3g", *option)),
+        help_text.c_str());
+  } else {
+    desc_->add_options()(
+        name.c_str(),
+        boost::program_options::value<T>(option)->default_value(*option),
+        help_text.c_str());
+  }
 }
 
 template <typename T>
 void OptionManager::AddAndRegisterRequiredOption(const std::string& name,
                                                  T* option,
                                                  const std::string& help_text) {
-  desc_->add_options()(name.c_str(),
-                       boost::program_options::value<T>(option)->required(),
-                       help_text.c_str());
+  AddRequiredOption(name, option, help_text);
   RegisterOption(name, option);
 }
 
@@ -234,10 +240,7 @@ template <typename T>
 void OptionManager::AddAndRegisterDefaultOption(const std::string& name,
                                                 T* option,
                                                 const std::string& help_text) {
-  desc_->add_options()(
-      name.c_str(),
-      boost::program_options::value<T>(option)->default_value(*option),
-      help_text.c_str());
+  AddDefaultOption(name, option, help_text);
   RegisterOption(name, option);
 }
 


### PR DESCRIPTION
Limit floating-point default values in CLI display to 3 significant digits using StringPrintf("%.3g").

Example changes:  
- `--Mapper.min_focal_length_ratio (=0.10000000000000001)`   ->   `--Mapper.min_focal_length_ratio (=0.1) `
- `--Mapper.init_max_forward_motion (=0.94999999999999996)`  -> `--Mapper.init_max_forward_motion (=0.95) `
- `--SiftExtraction.dsp_min_scale arg (=0.16666666666666666)`  ->  `--SiftExtraction.dsp_min_scale arg (=0.167)`
- `--Example.large_number arg (=500000)`  ->  `--Example.large_number arg (=5e+05)`
- `--Example.small_number arg (=0.00005)`  ->  `--Example.small_number arg (=5e-05)` 