### PR TITLE
Fix MaybeLoadImages

### DIFF
--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -434,7 +434,8 @@ void FeatureMatcherController::Match(
     if (matching_options_.skip_image_pairs_in_same_frame) {
       const Image& image1 = cache_->GetImage(image_id1);
       const Image& image2 = cache_->GetImage(image_id2);
-      if (image1.HasFrameId() && image2.HasFrameId() &&
+      if (image1.HasFrameId() &&
+          image2.HasFrameId() &&
           image1.FrameId() == image2.FrameId()) {
         continue;
       }

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -434,7 +434,8 @@ void FeatureMatcherController::Match(
     if (matching_options_.skip_image_pairs_in_same_frame) {
       const Image& image1 = cache_->GetImage(image_id1);
       const Image& image2 = cache_->GetImage(image_id2);
-      if (image1.FrameId() == image2.FrameId()) {
+      if ((image1.HasFrameId() && image2.HasFrameId()) &&
+          image1.FrameId() == image2.FrameId()) {
         continue;
       }
     }

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -434,7 +434,7 @@ void FeatureMatcherController::Match(
     if (matching_options_.skip_image_pairs_in_same_frame) {
       const Image& image1 = cache_->GetImage(image_id1);
       const Image& image2 = cache_->GetImage(image_id2);
-      if ((image1.HasFrameId() && image2.HasFrameId()) &&
+      if (image1.HasFrameId() && image2.HasFrameId() &&
           image1.FrameId() == image2.FrameId()) {
         continue;
       }

--- a/src/colmap/controllers/feature_matching_utils.cc
+++ b/src/colmap/controllers/feature_matching_utils.cc
@@ -434,8 +434,7 @@ void FeatureMatcherController::Match(
     if (matching_options_.skip_image_pairs_in_same_frame) {
       const Image& image1 = cache_->GetImage(image_id1);
       const Image& image2 = cache_->GetImage(image_id2);
-      if (image1.HasFrameId() &&
-          image2.HasFrameId() &&
+      if (image1.HasFrameId() && image2.HasFrameId() &&
           image1.FrameId() == image2.FrameId()) {
         continue;
       }

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -275,9 +275,7 @@ void FeatureMatcherCache::MaybeLoadFrames() {
 }
 
 void FeatureMatcherCache::MaybeLoadImages() {
-  {
-    MaybeLoadFrames();
-  }
+  MaybeLoadFrames();
 
   std::lock_guard<std::mutex> lock(database_mutex_);
   if (images_cache_) {

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -285,7 +285,7 @@ void FeatureMatcherCache::MaybeLoadImages() {
   }
 
   // Handle legacy databases without frames.
-  bool has_frames = !frames_cache_->empty();
+  const bool has_frames = !frames_cache_->empty();
   std::unordered_map<image_t, frame_t> image_to_frame_id;
   if (has_frames) {
     for (const auto& [frame_id, frame] : *frames_cache_) {


### PR DESCRIPTION
This PR fixs the bug of using skip_image_pairs_in_same_frame=true

```
   // Avoid self-matches within a frame.
    if (matching_options_.skip_image_pairs_in_same_frame) {
      const Image& image1 = cache_->GetImage(image_id1);
      const Image& image2 = cache_->GetImage(image_id2);
      if (image1.FrameId() == image2.FrameId()) {
        continue;
      }
    }
```
The image's frame ID is not set in MaybeLoadImages. The default value for all images is the same, causing all pairs to be skipped.

Solution:
1. Set the image's frame ID in MaybeLoadImages.
2. Check the validity of the image's frame ID before comparing.
