### PR TITLE
Point_triangulator: optional intrinsics/extrinsics refinement + refine loop

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -519,6 +519,7 @@ int RunPointTriangulator(int argc, char** argv) {
   bool clear_points = true;
   bool refine_intrinsics = false;
   bool refine_extrinsics = false;
+  bool refine_loop = false;
 
   OptionManager options;
   options.AddDatabaseOptions();
@@ -539,8 +540,14 @@ int RunPointTriangulator(int argc, char** argv) {
                            &refine_extrinsics,
                            "Whether to refine the extrinsics (camera poses) "
                            "during triangulation");
+  options.AddDefaultOption(
+      "refine_loop",
+      &refine_loop,
+      "Run bundle adjustment loop to refine + complete/merge "
+      "+ filter after triangulation");
 
   options.AddMapperOptions();
+  options.AddBundleAdjustmentOptions();
   options.Parse(argc, argv);
 
   if (!ExistsDir(input_path)) {
@@ -565,7 +572,9 @@ int RunPointTriangulator(int argc, char** argv) {
                            *options.mapper,
                            clear_points,
                            refine_intrinsics,
-                           refine_extrinsics);
+                           refine_extrinsics,
+                           refine_loop,
+                           *options.bundle_adjustment);
   return EXIT_SUCCESS;
 }
 
@@ -577,9 +586,12 @@ void RunPointTriangulatorImpl(
     const IncrementalPipelineOptions& options,
     const bool clear_points,
     const bool refine_intrinsics,
-    const bool refine_extrinsics) {
+    const bool refine_extrinsics,
+    const bool refine_loop,
+    const BundleAdjustmentOptions& ba_options_input) {
   THROW_CHECK_GE(reconstruction->NumRegImages(), 2)
       << "Need at least two images for triangulation";
+
   if (clear_points) {
     const Database database(database_path);
     reconstruction->DeleteAllPoints2DAndPoints3D();
@@ -596,6 +608,54 @@ void RunPointTriangulatorImpl(
   IncrementalPipeline mapper(
       options_tmp, image_path, database_path, reconstruction_manager);
   mapper.TriangulateReconstruction(reconstruction);
+
+  if (refine_loop) {
+    PrintHeading1("Refinement loop (BA + complete/merge + filter)");
+
+    const Database db(database_path);
+    const size_t min_num_matches = static_cast<size_t>(options.min_num_matches);
+    std::unordered_set<std::string> image_names(options.image_names.begin(),
+                                                options.image_names.end());
+    auto database_cache = DatabaseCache::Create(
+        db, min_num_matches, options.ignore_watermarks, image_names);
+
+    IncrementalMapper mapper(database_cache);
+    mapper.BeginReconstruction(reconstruction);
+
+    BundleAdjustmentOptions ba = ba_options_input;
+    ba.refine_focal_length = ba.refine_focal_length || refine_intrinsics;
+    ba.refine_extra_params = ba.refine_extra_params || refine_intrinsics;
+
+    const int max_refinements = options.ba_global_max_refinements;
+    const double min_change = options.ba_global_max_refinement_change;
+
+    PrintHeading1("Bundle adjustment");
+    for (int i = 0; i < max_refinements; ++i) {
+      const size_t num_obs_before = reconstruction->ComputeNumObservations();
+
+      mapper.AdjustGlobalBundle(options.mapper, ba);
+
+      size_t num_changed = 0;
+      num_changed += mapper.CompleteAndMergeTracks(options.triangulation);
+      num_changed += mapper.FilterPoints(options.mapper);
+
+      const double changed_ratio =
+          num_obs_before == 0 ? 0.0
+                              : static_cast<double>(num_changed) /
+                                    static_cast<double>(num_obs_before);
+
+      std::cout << StringPrintf("  => Changed observations: %.6f",
+                                changed_ratio)
+                << std::endl;
+
+      if (changed_ratio < min_change) break;
+    }
+
+    reconstruction->ExtractColorsForAllImages(image_path);
+
+    mapper.EndReconstruction(/*discard=*/false);
+  }
+
   reconstruction->Write(output_path);
 }
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -518,6 +518,7 @@ int RunPointTriangulator(int argc, char** argv) {
   std::string output_path;
   bool clear_points = true;
   bool refine_intrinsics = false;
+  bool refine_extrinsics = false;
 
   OptionManager options;
   options.AddDatabaseOptions();
@@ -534,6 +535,11 @@ int RunPointTriangulator(int argc, char** argv) {
                            &refine_intrinsics,
                            "Whether to refine the intrinsics of the cameras "
                            "(fixing the principal point)");
+  options.AddDefaultOption("refine_extrinsics",
+                           &refine_extrinsics,
+                           "Whether to refine the extrinsics (camera poses) "
+                           "during triangulation");
+
   options.AddMapperOptions();
   options.Parse(argc, argv);
 
@@ -558,7 +564,8 @@ int RunPointTriangulator(int argc, char** argv) {
                            output_path,
                            *options.mapper,
                            clear_points,
-                           refine_intrinsics);
+                           refine_intrinsics,
+                           refine_extrinsics);
   return EXIT_SUCCESS;
 }
 
@@ -569,7 +576,8 @@ void RunPointTriangulatorImpl(
     const std::string& output_path,
     const IncrementalPipelineOptions& options,
     const bool clear_points,
-    const bool refine_intrinsics) {
+    const bool refine_intrinsics,
+    const bool refine_extrinsics) {
   THROW_CHECK_GE(reconstruction->NumRegImages(), 2)
       << "Need at least two images for triangulation";
   if (clear_points) {
@@ -579,7 +587,7 @@ void RunPointTriangulatorImpl(
   }
 
   auto options_tmp = std::make_shared<IncrementalPipelineOptions>(options);
-  options_tmp->fix_existing_frames = true;
+  options_tmp->fix_existing_frames = !refine_extrinsics;
   options_tmp->ba_refine_focal_length = refine_intrinsics;
   options_tmp->ba_refine_principal_point = false;
   options_tmp->ba_refine_extra_params = refine_intrinsics;

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -41,7 +41,8 @@ void RunPointTriangulatorImpl(
     const std::string& output_path,
     const IncrementalPipelineOptions& options,
     bool clear_points,
-    bool refine_intrinsics);
+    bool refine_intrinsics,
+    bool refine_extrinsics);
 
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -42,7 +42,9 @@ void RunPointTriangulatorImpl(
     const IncrementalPipelineOptions& options,
     bool clear_points,
     bool refine_intrinsics,
-    bool refine_extrinsics);
+    bool refine_extrinsics,
+    bool refine_loop,
+    const BundleAdjustmentOptions& ba_options);
 
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);


### PR DESCRIPTION
**WHAT IS DONE?**

The intention is to make point_triangulator more useful when starting from approximate poses. It adds three optional flags:

--refine_intrinsics (default 0): refine focal length and extra params (principal point stays fixed).
--refine_extrinsics (default 0): allow pose refinement; otherwise poses are kept fixed.
--refine_loop (default 0): after initial triangulation, run a short loop of global BA → CompleteAndMergeTracks → FilterPoints with early stopping.


**WHY IS THIS USEFUL?**

Running a standalone bundle adjustment after triangulation does not add/merge tracks using the improved geometry. The refine loop interleaves bundle adjustment with track completion and filtering, which typically yields a cleaner and more complete sparse model without chaining multiple commands.

This could fit the required features in issues like
https://github.com/colmap/colmap/issues/3502
https://github.com/colmap/colmap/issues/2819
https://github.com/colmap/colmap/issues/3433

Meanwhile maintenance is easier than doing a new mode for Colmap CLI


**HOW IT WORKS?**

Initial triangulation respects refine_extrinsics (fix_existing_frames = !refine_extrinsics).
In the loop, poses are optimized only if --refine_extrinsics=1; otherwise a  bundle adjustment is run with all poses kept constant.
Defaults preserve current behavior (no loop, poses fixed), so it doesn't break compatibility at all!