### PR TITLE
Ensure download support on Ubuntu by installing libssl-dev for crypto

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -94,6 +94,7 @@ Dependencies from the default Ubuntu repositories::
         libcgal-dev \
         libceres-dev \
         libcurl4-openssl-dev \
+        libssl-dev \
         libmkl-full-dev
 
 Alternatively, you can also build against Qt 5 instead of Qt 6 using::

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
         libcgal-dev \
         libceres-dev \
         libcurl4-openssl-dev \
+        libssl-dev \
         libmkl-full-dev
 
 # Build and install COLMAP.
@@ -79,6 +80,7 @@ RUN apt-get update && \
         libqt6widgets6 \
         libqt6openglwidgets6 \
         libcurl4 \
+        libssl3t64 \
         libmkl-locale \
         libmkl-intel-lp64 \
         libmkl-intel-thread \


### PR DESCRIPTION
Discovered by the fact that download support was disabled in our docker image, because the required crypto library was not found due to missing headers.