### PR TITLE
rig_from_world and sensor_from_rig in pycolmap should return reference rather than copy.

### DIFF
--- a/src/pycolmap/scene/frame.cc
+++ b/src/pycolmap/scene/frame.cc
@@ -55,16 +55,9 @@ void BindFrame(py::module& m) {
            "Make the rig pointer a nullptr.")
       .def_property(
           "rig_from_world",
-          [](Frame& self) -> py::typing::Optional<Rigid3d> {
-            if (self.HasPose()) {
-              return py::cast(self.RigFromWorld());
-            } else {
-              return py::none();
-            }
-          },
-          [](Frame& self, const Rigid3d& rig_from_world) {
-            self.SetRigFromWorld(rig_from_world);
-          },
+          py::overload_cast<>(&Frame::MaybeRigFromWorld),
+          py::overload_cast<const std::optional<Rigid3d>&>(
+              &Frame::SetRigFromWorld),
           "The pose of the frame, defined as the transformation from world to "
           "rig space.")
       .def("has_pose", &Frame::HasPose, "Whether the frame has a valid pose.")

--- a/src/pycolmap/sensor/rig.cc
+++ b/src/pycolmap/sensor/rig.cc
@@ -42,19 +42,12 @@ void BindSensorRig(py::module& m) {
       .def("sensor_ids",
            &Rig::SensorIds,
            "Get all sensor ids (including the reference sensor) in the rig.")
-      .def(
-          "sensor_from_rig",
-          [](Rig& self, sensor_t sensor_id) -> py::typing::Optional<Rigid3d> {
-            if (const std::optional<Rigid3d> sensor_from_rig =
-                    self.MaybeSensorFromRig(sensor_id);
-                sensor_from_rig.has_value()) {
-              return py::cast(*sensor_from_rig);
-            } else {
-              return py::none();
-            }
-          },
-          "The pose of the frame, defined as the transformation from world to "
-          "rig space.")
+      .def("sensor_from_rig",
+           py::overload_cast<>(&Rig::MaybeSensorFromRig),
+           py::overload_cast<sensor_t, const std::optional<Rigid3d>&>(
+               &Rig::SetSensorFromRig),
+           "The pose of the frame, defined as the transformation from world to "
+           "rig space.")
       .def_property_readonly(
           "non_ref_sensors",
           py::overload_cast<>(&Rig::NonRefSensors),

--- a/src/pycolmap/sensor/rig.cc
+++ b/src/pycolmap/sensor/rig.cc
@@ -44,10 +44,13 @@ void BindSensorRig(py::module& m) {
            "Get all sensor ids (including the reference sensor) in the rig.")
       .def("sensor_from_rig",
            py::overload_cast<sensor_t>(&Rig::MaybeSensorFromRig),
+           "sensor_id"_a,
            "The the transformation from rig to the sensor.")
       .def("set_sensor_from_rig",
            py::overload_cast<sensor_t, const std::optional<Rigid3d>&>(
                &Rig::SetSensorFromRig),
+           "sensor_id"_a,
+           "sensor_from_rig"_a,
            "Set the sensor_from_rig transformation.")
       .def_property_readonly(
           "non_ref_sensors",

--- a/src/pycolmap/sensor/rig.cc
+++ b/src/pycolmap/sensor/rig.cc
@@ -44,10 +44,11 @@ void BindSensorRig(py::module& m) {
            "Get all sensor ids (including the reference sensor) in the rig.")
       .def("sensor_from_rig",
            py::overload_cast<sensor_t>(&Rig::MaybeSensorFromRig),
+           "The the transformation from rig to the sensor.")
+      .def("set_sensor_from_rig",
            py::overload_cast<sensor_t, const std::optional<Rigid3d>&>(
                &Rig::SetSensorFromRig),
-           "The pose of the frame, defined as the transformation from world to "
-           "rig space.")
+           "Set the sensor_from_rig transformation.")
       .def_property_readonly(
           "non_ref_sensors",
           py::overload_cast<>(&Rig::NonRefSensors),

--- a/src/pycolmap/sensor/rig.cc
+++ b/src/pycolmap/sensor/rig.cc
@@ -43,7 +43,7 @@ void BindSensorRig(py::module& m) {
            &Rig::SensorIds,
            "Get all sensor ids (including the reference sensor) in the rig.")
       .def("sensor_from_rig",
-           py::overload_cast<>(&Rig::MaybeSensorFromRig),
+           py::overload_cast<sensor_t>(&Rig::MaybeSensorFromRig),
            py::overload_cast<sensor_t, const std::optional<Rigid3d>&>(
                &Rig::SetSensorFromRig),
            "The pose of the frame, defined as the transformation from world to "


### PR DESCRIPTION
This is a crucial fix. Without this the python side problem construction with pyceres will never work. Broken since the rig abstraction in colmap 3.12. 

Equivalent reference in ``image.cam_from_world`` from COLMAP 3.11: https://github.com/colmap/colmap/blob/release/3.11/src/pycolmap/scene/image.cc#L81-L87

To reproduce:
```
import pycolmap

recon = pycolmap.Reconstruction("example/sfm/0")
rig_from_world_1 = recon.frames[1].rig_from_world
rig_from_world_2 = recon.frames[1].rig_from_world
print(id(rig_from_world_1))
print(id(rig_from_world_2))
assert(id(rig_from_world_1) == id(rig_from_world_2))
```

The assertion fails without this fix. 