### PR TITLE
Fix crash when built without GPU support

### DIFF
--- a/src/colmap/feature/extractor.h
+++ b/src/colmap/feature/extractor.h
@@ -54,7 +54,11 @@ struct FeatureExtractionOptions {
   int num_threads = -1;
 
   // Whether to use the GPU for feature extraction.
+#ifdef COLMAP_GPU_ENABLED
   bool use_gpu = true;
+#else
+  bool use_gpu = false;
+#endif
 
   // Index of the GPU used for feature extraction. For multi-GPU extraction,
   // you should separate multiple GPU indices by comma, e.g., "0,1,2,3".


### PR DESCRIPTION
`FeatureExtractionOptions::Check()` fails for unrelated commands like the model_aligner.