### PR TITLE
Disable auto vacuum to speed up CloseImpl

### DIFF
--- a/src/colmap/exe/database.cc
+++ b/src/colmap/exe/database.cc
@@ -153,7 +153,9 @@ int RunRigConfigurator(int argc, char** argv) {
     reconstruction->Read(input_path);
   }
 
-  auto database = Database::Open(database_path);
+  Database::Options database_options;
+  database_options["disable_auto_vacuum"] = "1";
+  auto database = Database::Open(database_path, database_options);
 
   ApplyRigConfig(
       ReadRigConfig(rig_config_path),

--- a/src/colmap/scene/database.cc
+++ b/src/colmap/scene/database.cc
@@ -41,10 +41,11 @@ void Database::Register(Factory factory) {
 
 Database::~Database() = default;
 
-std::shared_ptr<Database> Database::Open(const std::string& path) {
+std::shared_ptr<Database> Database::Open(const std::string& path,
+                                         const Options& options) {
   for (auto it = factories_.rbegin(); it != factories_.rend(); ++it) {
     try {
-      return (*it)(path);
+      return (*it)(path, options);
     } catch (const std::exception& e) {
       LOG(WARNING)
           << "Failed to open database with registered factory, because: "

--- a/src/colmap/scene/database.h
+++ b/src/colmap/scene/database.h
@@ -38,6 +38,7 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/types.h"
 
+#include <map>
 #include <mutex>
 #include <vector>
 
@@ -59,10 +60,13 @@ typedef Eigen::Matrix<point2D_t, Eigen::Dynamic, 2, Eigen::RowMajor>
 // and trailing `EndTransaction`.
 class Database {
  public:
+  using Options = std::map<std::string, std::string>;
+
   // Factory function to create a database implementation for a given path.
   // The factory should be robust to handle non-supported files and return a
   // runtime_error in that case.
-  using Factory = std::function<std::shared_ptr<Database>(const std::string&)>;
+  using Factory = std::function<std::shared_ptr<Database>(const std::string&,
+                                                          const Options&)>;
 
   // Register a factory to open a database implementation. Database factories
   // are tried in reverse order of registration. In other words, later
@@ -73,7 +77,8 @@ class Database {
   virtual ~Database();
 
   // Open database and throw a runtime_error if none of the factories succeeds.
-  static std::shared_ptr<Database> Open(const std::string& path);
+  static std::shared_ptr<Database> Open(const std::string& path,
+                                        const Options& options = {});
 
   // Explicitly close the database before destruction.
   virtual void Close() = 0;

--- a/src/colmap/scene/database_sqlite.cc
+++ b/src/colmap/scene/database_sqlite.cc
@@ -407,7 +407,8 @@ void WriteFrameData(const frame_t frame_id,
 
 class SqliteDatabase : public Database {
  public:
-  SqliteDatabase() : database_(nullptr) {}
+  SqliteDatabase(bool disable_auto_vacuum = false)
+      : disable_auto_vacuum_(disable_auto_vacuum), database_(nullptr) {}
 
   // Open and close database. The same database should not be opened
   // concurrently in multiple threads or processes.
@@ -415,8 +416,15 @@ class SqliteDatabase : public Database {
   // On Windows, the input path is converted from the local code page to UTF-8
   // for compatibility with SQLite. On POSIX platforms, the path is assumed to
   // be UTF-8.
-  static std::shared_ptr<Database> Open(const std::string& path) {
-    auto database = std::make_shared<SqliteDatabase>();
+  static std::shared_ptr<Database> Open(const std::string& path,
+                                        const Options& options = {}) {
+    bool disable_auto_vacuum = false;
+    auto iter = options.find("disable_auto_vacuum");
+    if (iter != options.end()) {
+      disable_auto_vacuum = std::stoi(iter->second);
+    }
+
+    auto database = std::make_shared<SqliteDatabase>(disable_auto_vacuum);
 
     // SQLITE_OPEN_NOMUTEX specifies that the connection should not have a
     // mutex (so that we don't serialize the connection's operations).
@@ -446,7 +454,11 @@ class SqliteDatabase : public Database {
     SQLITE3_EXEC(database->database_, "PRAGMA foreign_keys=ON", nullptr);
 
     // Disable auto vacuum to speed up CloseImpl
-    SQLITE3_EXEC(database->database_, "PRAGMA auto_vacuum=0", nullptr);
+    if (disable_auto_vacuum) {
+      SQLITE3_EXEC(database->database_, "PRAGMA auto_vacuum=1", nullptr);
+    } else {
+      SQLITE3_EXEC(database->database_, "PRAGMA auto_vacuum=0", nullptr);
+    }
 
     database->CreateTables();
     database->UpdateSchema();
@@ -459,7 +471,10 @@ class SqliteDatabase : public Database {
     if (database_ != nullptr) {
       FinalizeSQLStatements();
       if (database_entry_deleted_) {
-        SQLITE3_EXEC(database_, "VACUUM", nullptr);
+        if (!disable_auto_vacuum_) {
+          SQLITE3_EXEC(database_, "VACUUM", nullptr);
+        }
+
         database_entry_deleted_ = false;
       }
       SQLITE3_CALL(sqlite3_close_v2(database_));
@@ -2163,7 +2178,7 @@ class SqliteDatabase : public Database {
 
     return max;
   }
-
+  bool disable_auto_vacuum_ = true;
   sqlite3* database_ = nullptr;
 
   // Check if elements got removed from the database to only apply
@@ -2263,8 +2278,9 @@ std::mutex SqliteDatabase::update_schema_mutex_;
 
 }  // namespace
 
-std::shared_ptr<Database> OpenSqliteDatabase(const std::string& path) {
-  return SqliteDatabase::Open(path);
+std::shared_ptr<Database> OpenSqliteDatabase(const std::string& path,
+                                             const Database::Options& options) {
+  return SqliteDatabase::Open(path, options);
 }
 
 }  // namespace colmap

--- a/src/colmap/scene/database_sqlite.h
+++ b/src/colmap/scene/database_sqlite.h
@@ -39,6 +39,7 @@ namespace colmap {
 // Can be used to construct temporary in-memory database.
 constexpr inline char kInMemorySqliteDatabasePath[] = ":memory:";
 
-std::shared_ptr<Database> OpenSqliteDatabase(const std::string& path);
+std::shared_ptr<Database> OpenSqliteDatabase(
+    const std::string& path, const Database::Options& options = {});
 
 }  // namespace colmap


### PR DESCRIPTION
After calling the ApplyRigConfig function, the exe may experience long I/O cycles (90% utilization). Investigation revealed that the Database destructor was particularly time-consuming. Further investigation revealed that this was caused by setting auto_vacuum to 1. If auto_vacuum is 0, SQLite does not clean up deleted space when deleting data, allowing it to reuse the deleted space when adding data later.
The ApplyRigConfig function primarily deletes frames and rigs. However, frames and rigs occupy very little storage space, so clearing them would not yield significant benefits.

Changing from
SQLITE3_EXEC(database->database_, "PRAGMA auto_vacuum=1", nullptr);
to
SQLITE3_EXEC(database->database_, "PRAGMA auto_vacuum=0", nullptr);
reduces the time it takes to destroy the database, especially when the SQLite database size reaches 1-10GB.