### PR TITLE
Consistently name local BA options and deduplicate local_ba_num_images

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -85,7 +85,6 @@ IncrementalMapper::Options IncrementalPipelineOptions::Mapper() const {
   options.max_focal_length_ratio = max_focal_length_ratio;
   options.max_extra_param = max_extra_param;
   options.num_threads = num_threads;
-  options.local_ba_num_images = ba_local_num_images;
   options.fix_existing_frames = fix_existing_frames;
   options.constant_rigs = constant_rigs;
   options.constant_cameras = constant_cameras;
@@ -175,7 +174,6 @@ bool IncrementalPipelineOptions::Check() const {
   CHECK_OPTION_GT(min_focal_length_ratio, 0);
   CHECK_OPTION_GT(max_focal_length_ratio, 0);
   CHECK_OPTION_GE(max_extra_param, 0);
-  CHECK_OPTION_GE(ba_local_num_images, 2);
   CHECK_OPTION_GE(ba_local_max_num_iterations, 0);
   CHECK_OPTION_GT(ba_global_frames_ratio, 1.0);
   CHECK_OPTION_GT(ba_global_points_ratio, 1.0);

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -99,9 +99,6 @@ struct IncrementalPipelineOptions {
   // enable multi-threading solving of the problems.
   int ba_min_num_residuals_for_cpu_multi_threading = 50000;
 
-  // The number of images to optimize in local bundle adjustment.
-  int ba_local_num_images = 6;
-
   // Ceres solver function tolerance for local bundle adjustment
   double ba_local_function_tolerance = 0.0;
 

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -581,8 +581,6 @@ void OptionManager::AddMapperOptions() {
                               &mapper->ba_refine_extra_params);
   AddAndRegisterDefaultOption("Mapper.ba_refine_sensor_from_rig",
                               &mapper->ba_refine_sensor_from_rig);
-  AddAndRegisterDefaultOption("Mapper.ba_local_num_images",
-                              &mapper->ba_local_num_images);
   AddAndRegisterDefaultOption("Mapper.ba_local_function_tolerance",
                               &mapper->ba_local_function_tolerance);
   AddAndRegisterDefaultOption("Mapper.ba_local_max_num_iterations",
@@ -641,8 +639,10 @@ void OptionManager::AddMapperOptions() {
                               &mapper->mapper.filter_min_tri_angle);
   AddAndRegisterDefaultOption("Mapper.max_reg_trials",
                               &mapper->mapper.max_reg_trials);
-  AddAndRegisterDefaultOption("Mapper.local_ba_min_tri_angle",
-                              &mapper->mapper.local_ba_min_tri_angle);
+  AddAndRegisterDefaultOption("Mapper.ba_local_num_images",
+                              &mapper->mapper.ba_local_num_images);
+  AddAndRegisterDefaultOption("Mapper.ba_local_min_tri_angle",
+                              &mapper->mapper.ba_local_min_tri_angle);
 
   AddDefaultOption("Mapper.image_list_path", &mapper_image_list_path_);
   AddDefaultOption("Mapper.constant_rig_list_path",

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -54,8 +54,8 @@ bool IncrementalMapper::Options::Check() const {
   CHECK_OPTION_GT(abs_pose_min_num_inliers, 0);
   CHECK_OPTION_GE(abs_pose_min_inlier_ratio, 0.0);
   CHECK_OPTION_LE(abs_pose_min_inlier_ratio, 1.0);
-  CHECK_OPTION_GE(local_ba_num_images, 2);
-  CHECK_OPTION_GE(local_ba_min_tri_angle, 0.0);
+  CHECK_OPTION_GE(ba_local_num_images, 2);
+  CHECK_OPTION_GE(ba_local_min_tri_angle, 0.0);
   CHECK_OPTION_GE(min_focal_length_ratio, 0.0);
   CHECK_OPTION_GE(max_focal_length_ratio, min_focal_length_ratio);
   CHECK_OPTION_GE(max_extra_param, 0.0);

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -95,10 +95,10 @@ class IncrementalMapper {
     bool abs_pose_refine_extra_params = true;
 
     // Number of images to optimize in local bundle adjustment.
-    int local_ba_num_images = 6;
+    int ba_local_num_images = 6;
 
     // Minimum triangulation for images to be chosen in local bundle adjustment.
-    double local_ba_min_tri_angle = 6;
+    double ba_local_min_tri_angle = 6;
 
     // Thresholds for bogus camera parameters. Images with bogus camera
     // parameters are filtered and ignored in triangulation.

--- a/src/colmap/sfm/incremental_mapper_impl.cc
+++ b/src/colmap/sfm/incremental_mapper_impl.cc
@@ -406,7 +406,7 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
   // neighbor images, hence the subtraction of 1.
 
   const size_t num_images =
-      static_cast<size_t>(options.local_ba_num_images - 1);
+      static_cast<size_t>(options.ba_local_num_images - 1);
   const size_t num_eff_images = std::min(num_images, overlapping_images.size());
 
   // Extract most connected images and ensure sufficient triangulation angle.
@@ -430,7 +430,7 @@ std::vector<image_t> IncrementalMapperImpl::FindLocalBundle(
   // again. In the end, if we still haven't found enough images, we simply use
   // the most overlapping images.
 
-  const double min_tri_angle_rad = DegToRad(options.local_ba_min_tri_angle);
+  const double min_tri_angle_rad = DegToRad(options.ba_local_min_tri_angle);
 
   // The selection thresholds (minimum triangulation angle, minimum number of
   // shared observations), which are successively relaxed.

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -132,7 +132,7 @@ class MapperBundleAdjustmentOptionsWidget : public OptionsWidget {
     AddSpacer();
 
     AddSection("Local Bundle Adjustment");
-    AddOptionInt(&options->mapper->ba_local_num_images, "num_images");
+    AddOptionInt(&options->mapper->mapper.ba_local_num_images, "num_images");
     AddOptionInt(&options->mapper->ba_local_max_num_iterations,
                  "max_num_iterations");
     AddOptionInt(

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -98,10 +98,6 @@ void BindIncrementalPipeline(py::module& m) {
           "The minimum number of residuals per bundle adjustment problem to "
           "enable multi-threading solving of the problems.")
       .def_readwrite(
-          "ba_local_num_images",
-          &Opts::ba_local_num_images,
-          "The number of images to optimize in local bundle adjustment.")
-      .def_readwrite(
           "ba_local_function_tolerance",
           &Opts::ba_local_function_tolerance,
           "Ceres solver function tolerance for local bundle adjustment.")

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -316,11 +316,11 @@ void BindIncrementalMapperOptions(py::module& m) {
                      &Opts::abs_pose_refine_extra_params,
                      "Whether to estimate the extra parameters in absolute "
                      "pose estimation.")
-      .def_readwrite("local_ba_num_images",
-                     &Opts::local_ba_num_images,
+      .def_readwrite("ba_local_num_images",
+                     &Opts::ba_local_num_images,
                      "Number of images to optimize in local bundle adjustment.")
-      .def_readwrite("local_ba_min_tri_angle",
-                     &Opts::local_ba_min_tri_angle,
+      .def_readwrite("ba_local_min_tri_angle",
+                     &Opts::ba_local_min_tri_angle,
                      "Minimum triangulation for images to be chosen in local "
                      "bundle adjustment.")
       .def_readwrite("min_focal_length_ratio",


### PR DESCRIPTION
* Fixes redundant definition of local_ba_num_images option.
* Renames local_ba_* options to ba_local_* for consistency with all other ba_local/ba_global options.