### PR TITLE
Adjust reconstruction consistency checks

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -262,10 +262,10 @@ void Reconstruction::AddCamera(struct Camera camera) {
 
 void Reconstruction::AddFrame(class Frame frame) {
   THROW_CHECK(frame.HasRigId());
-  THROW_CHECK_GT(frame.NumDataIds(), 0)
-      << "A frame with no associated data is "
-         "never useful in the reconstruction.";
   auto& rig = Rig(frame.RigId());
+  for (const auto& data_id : frame.DataIds()) {
+    THROW_CHECK(rig.HasSensor(data_id.sensor_id));
+  }
   if (frame.HasRigPtr()) {
     THROW_CHECK_EQ(frame.RigPtr(), &rig);
   } else {
@@ -290,6 +290,7 @@ void Reconstruction::AddImage(class Image image) {
   }
   THROW_CHECK(image.HasFrameId());
   auto& frame = Frame(image.FrameId());
+  THROW_CHECK(frame.HasDataId(image.DataId()));
   if (image.HasFramePtr()) {
     THROW_CHECK_EQ(image.FramePtr(), &frame);
   } else {


### PR DESCRIPTION
It's hugely inconvenient to require data to already be in the frame when a frame is added to the reconstruction and it broke a bunch of internal code. Instead, I am tightening some of the other checks, where I am now checking that when adding an image, the corresponding frame has the image and the equivalent for the sensors in frames.