### PR TITLE
Include cassert

### DIFF
--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -36,6 +36,8 @@
 #include "colmap/util/logging.h"
 #include "colmap/util/misc.h"
 
+#include <cassert>
+
 namespace colmap {
 
 bool MergeAndFilterReconstructions(const double max_reproj_error,


### PR DESCRIPTION
gcc 15.2.1 on ArchLinux complains that the assert macro cannot be found.