### PR TITLE
Update PyPI publishing

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -186,6 +186,12 @@ jobs:
     name: Publish wheels to PyPI
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      # This URL is only for display in the GitHub UI
+      url: https://pypi.org/p/pycolmap
+    permissions:
+      id-token: write
     # We publish the wheel to pypi when a new tag is pushed,
     # either by creating a new GitHub release or explicitly with `git tag`
     if: ${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags') }}
@@ -197,9 +203,7 @@ jobs:
       - name: Move wheels
         run: mkdir ./wheelhouse && mv ./artifacts/**/*.whl ./wheelhouse/
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           skip-existing: true
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ./wheelhouse/


### PR DESCRIPTION
Following https://github.com/pypa/gh-action-pypi-publish

- Update to the latest version
- Switch to trusted publishing instead of the now-discouraged API tokens. I have set this up for both pycolmap and the new pycolmap-cuda12 package (which will be automatically created on the next release)

<img width="794" height="173" alt="Screenshot 2025-11-05 at 09 27 53" src="https://github.com/user-attachments/assets/6a1bf98a-fbde-40c2-b360-f5a646e40595" />
<img width="665" height="126" alt="Screenshot 2025-11-05 at 09 27 44" src="https://github.com/user-attachments/assets/86663259-508c-49fa-9720-e3f7955f05b4" />
