### PR TITLE
Fix coordinate bug in ComputeEqualPartsBboxes

### DIFF
--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -59,7 +59,7 @@ std::vector<Eigen::AlignedBox3d> ComputeEqualPartsBboxes(
     for (int j = 0; j < split(1); ++j) {
       for (int i = 0; i < split(0); ++i) {
         Eigen::Vector3d min(bbox.min().x() + i * offset(0),
-                            bbox.min().z() + j * offset(1),
+                            bbox.min().y() + j * offset(1),
                             bbox.min().z() + k * offset(2));
         bboxes.emplace_back(min, min + offset);
       }


### PR DESCRIPTION
No existing tests for this functionality. Leaving it for future work to extract more code from the "exe" folder into testable library modules. Addresses: https://github.com/colmap/colmap/issues/3699