### PR TITLE
Fix MSVC compatibility with `isnan`

### DIFF
--- a/src/thirdparty/VLFeat/host.h
+++ b/src/thirdparty/VLFeat/host.h
@@ -314,8 +314,8 @@ defined(__DOXYGEN__)
 #  define VL_INLINE static __inline
 #if defined _MSC_VER && _MSC_VER < 1900
 #  define snprintf _snprintf
-#endif
 #  define isnan _isnan
+#endif
 #  ifdef VL_BUILD_DLL
 #    ifdef __cplusplus
 #      define VL_EXPORT extern "C" __declspec(dllexport)


### PR DESCRIPTION
Fixes buggy unconditional redefinition of `isnan` to `_isnan` when using MSVC, which raises errors when using C++'s `std::isnan`, as it gets redefined to the nonexistent `std::_isnan`. 

`isnan` is available on recent versions of MSVC, since [VS 2015](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/isnan-isnan-isnanf?view=msvc-140). Before this version in VS 2013, [only `_isnan` appears to be available](https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2013/tzthab44(v=vs.120)). VS 2015 corresponds to [`_MSC_VER` being set to `1900`](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170#version-macros), so it appears that the `define` should be moved into the above `#if` block. This seems to be verified by it also being the same place that the [VLFeat source code places the `#define`](https://github.com/vlfeat/vlfeat/blob/master/vl/host.h#L317).