### PR TITLE
(bugfix) initializing added_two_view_geometry_options_ to false

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -848,7 +848,7 @@ void OptionManager::Reset() {
   added_image_options_ = false;
   added_feature_extraction_options_ = false;
   added_feature_matching_options_ = false;
-  added_two_view_geometry_options_ = false; 
+  added_two_view_geometry_options_ = false;
   added_exhaustive_pairing_options_ = false;
   added_sequential_pairing_options_ = false;
   added_vocab_tree_pairing_options_ = false;


### PR DESCRIPTION
This PR fix issue #3726 `Failed to parse options unrecognised option 'TwoViewGeometry.multiple_models'  `<br/>

Missing initialization of `added_two_view_geometry_options_` When in [main_window.cc](https://github.com/colmap/colmap/blob/main/src/colmap/ui/main_window.cc) the [ProjectOpen()](https://github.com/colmap/colmap/blob/main/src/colmap/ui/main_window.cc#L728) function is called and [ReRead()](https://github.com/colmap/colmap/blob/main/src/colmap/ui/main_window.cc#L742) (and then [Reset()](https://github.com/colmap/colmap/blob/main/src/colmap/controllers/option_manager.cc#L832)) is called in the OptionManager.

Then [AddTwoViewGeometryOptions](https://github.com/colmap/colmap/blob/main/src/colmap/controllers/option_manager.cc#L331) fails.

This initialization solve this issue.  