### PR TITLE
Fix undefined behavior in feature match swapping

### DIFF
--- a/src/colmap/scene/database_sqlite.cc
+++ b/src/colmap/scene/database_sqlite.cc
@@ -45,7 +45,9 @@ struct Sqlite3StmtContext {
 };
 
 void SwapFeatureMatchesBlob(FeatureMatchesBlob* matches) {
-  matches->col(0).swap(matches->col(1));
+  for (size_t i = 0; i < matches->rows(); ++i) {
+    std::swap((*matches)(i, 0), (*matches)(i, 1));
+  }
 }
 
 FeatureKeypointsBlob FeatureKeypointsToBlob(const FeatureKeypoints& keypoints) {


### PR DESCRIPTION
Fixes potential undefined behavior:
```
UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset include/Eigen/src/Core/Block.h:347:25
```