### PR TITLE
Fix SVD computation in affine transform

### DIFF
--- a/src/colmap/estimators/affine_transform.cc
+++ b/src/colmap/estimators/affine_transform.cc
@@ -69,7 +69,7 @@ void AffineTransformEstimator::Estimate(const std::vector<X_t>& src,
     }
   } else {
     Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 6>> svd(
-        A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        A, Eigen::ComputeFullU | Eigen::ComputeFullV);
     if (svd.rank() < 6) {
       return;
     }


### PR DESCRIPTION
Fixes Eigen debug assertion:
```
JacobiSVD: thin U and V are only available when your matrix has a dynamic number of columns
```