### PR TITLE
Fix random seed stability tests for incremental mapper

### DIFF
--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -601,7 +601,7 @@ TEST(IncrementalPipeline, SfMWithRandomSeedStability) {
 
   constexpr int kRandomSeed = 42;
 
-    // Single-threaded execution.
+  // Single-threaded execution.
   {
     auto reconstruction_manager0 =
         run_mapper(/*num_threads=*/1, /*random_seed=*/kRandomSeed);


### PR DESCRIPTION
The test case for the prior mapper was incorrectly disabling prior positions. Also explicitly sets the number of threads to avoid single threaded execution on machines with 1 logical core.