### PR TITLE
Update Windows build instructions for PyCOLMAP

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -35,8 +35,7 @@ python -m pip install . `
     -C skbuild.cmake.define.VCPKG_TARGET_TRIPLET="x64-windows"
 ```
 
-> [!NOTE]
-> If you get linker errors when building PyCOLMAP on Windows, be sure that the repository version matches the version you installed via VCPKG.
+If you get linker errors when building PyCOLMAP on Windows, be sure that the repository version matches the version you installed via VCPKG.
 
 
 </details>


### PR DESCRIPTION
The current build instructions for PyCOLMAP don't work on Windows. This PR adds some additional steps and context that should resolve the problem.