### PR TITLE
Cleanup redundant sqlite database merge implementation, consistent variable naming

### DIFF
--- a/src/colmap/util/enum_utils.h
+++ b/src/colmap/util/enum_utils.h
@@ -29,9 +29,11 @@
 
 #pragma once
 
-#include <boost/preprocessor.hpp>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
-namespace colmap {
+#include <boost/preprocessor.hpp>
 
 // Custom macro for enum to/from string support. Only enum structs / classes
 // with consecutive indexes are supported.
@@ -93,5 +95,3 @@ namespace colmap {
   inline std::ostream& operator<<(std::ostream& os, name value) { \
     return os << name##ToString(value);                           \
   }
-
-}  // namespace colmap

--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -38,11 +38,13 @@
 #include <string_view>
 #include <vector>
 
-#define THROW_CHECK_FILE_EXISTS(path) \
-  THROW_CHECK(ExistsFile(path)) << "File " << (path) << " does not exist."
+#define THROW_CHECK_FILE_EXISTS(path)   \
+  THROW_CHECK(colmap::ExistsFile(path)) \
+      << "File " << (path) << " does not exist."
 
-#define THROW_CHECK_DIR_EXISTS(path) \
-  THROW_CHECK(ExistsDir(path)) << "Directory " << (path) << " does not exist."
+#define THROW_CHECK_DIR_EXISTS(path)   \
+  THROW_CHECK(colmap::ExistsDir(path)) \
+      << "Directory " << (path) << " does not exist."
 
 #define THROW_CHECK_PATH_OPEN(path)                           \
   THROW_CHECK(std::ofstream(path, std::ios::trunc).is_open()) \
@@ -55,7 +57,7 @@
       << ". Is the path a directory or does the parent dir not exist?"
 
 #define THROW_CHECK_HAS_FILE_EXTENSION(path, ext)                        \
-  THROW_CHECK(HasFileExtension(path, ext))                               \
+  THROW_CHECK(colmap::HasFileExtension(path, ext))                       \
       << "Path " << (path) << " does not match file extension " << (ext) \
       << "."
 


### PR DESCRIPTION
* Database::Merge is implemented in the base class.
* There are no Add* methods anymore, they are all consistently called Write*.