### PR TITLE
refactor: Replace OpenSqliteDatabase with Database::Open

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -572,7 +572,7 @@ void RunPointTriangulatorImpl(
   if (clear_points) {
     reconstruction->DeleteAllPoints2DAndPoints3D();
     reconstruction->TranscribeImageIdsToDatabase(
-        *OpenSqliteDatabase(database_path));
+        *Database::Open(database_path));
   }
 
   auto options_tmp = std::make_shared<IncrementalPipelineOptions>(options);


### PR DESCRIPTION
- Unify database opening method in the RunPointTriangulatorImpl function

- Use the new Database::Open factory method instead of the legacy OpenSqliteDatabase

- Maintain existing functionality while improving code consistency