### PR TITLE
Expose raw SIFT descriptor matching in pycolmap via SiftMatcher

### DIFF
--- a/src/pycolmap/feature/matching.cc
+++ b/src/pycolmap/feature/matching.cc
@@ -9,9 +9,79 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 
+inline static constexpr int kDescDim = 128;
+
 using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
+
+class SiftMatcher {
+ public:
+  SiftMatcher(std::optional<FeatureMatchingOptions> options, Device device)
+      : use_gpu_(IsGPU(device)), next_image_id_(1) {
+    if (options) {
+      options_ = std::move(*options);
+    }
+
+    if (!options_.sift) {
+      options_.sift = std::make_shared<SiftMatchingOptions>();
+    }
+
+    options_.use_gpu = use_gpu_;
+
+    if (!use_gpu_ && !options_.sift->cpu_brute_force_matcher) {
+      THROW_CHECK(false)
+          << "FAISS CPU matching (cpu_brute_force_matcher=False) is not "
+             "supported in this interface. Please use "
+             "cpu_brute_force_matcher=True.";
+    }
+
+    THROW_CHECK(options_.Check());
+    matcher_ = THROW_CHECK_NOTNULL(FeatureMatcher::Create(options_));
+  }
+
+  PyFeatureMatches Match(
+      const Eigen::Ref<const FeatureDescriptorsFloat>& descriptors1,
+      const Eigen::Ref<const FeatureDescriptorsFloat>& descriptors2,
+      std::optional<image_t> image_id1 = std::nullopt,
+      std::optional<image_t> image_id2 = std::nullopt) {
+    THROW_CHECK_EQ(descriptors1.cols(), kDescDim);
+    THROW_CHECK_EQ(descriptors2.cols(), kDescDim);
+
+    // If ids are not provided, generate unique ids so the matcher cannot reuse
+    // cached descriptors across calls.
+    const image_t id1 = image_id1.value_or(next_image_id_.fetch_add(1));
+    const image_t id2 = image_id2.value_or(next_image_id_.fetch_add(1));
+
+    auto desc1 = std::make_shared<FeatureDescriptors>(
+        FeatureDescriptorsToUnsignedByte(descriptors1));
+    auto desc2 = std::make_shared<FeatureDescriptors>(
+        FeatureDescriptorsToUnsignedByte(descriptors2));
+
+    FeatureMatcher::Image im1, im2;
+    im1.image_id = id1;
+    im2.image_id = id2;
+    im1.descriptors = std::move(desc1);
+    im2.descriptors = std::move(desc2);
+
+    FeatureMatches matches;
+    {
+      py::gil_scoped_release release;
+      matcher_->Match(im1, im2, &matches);
+    }
+    return FeatureMatchesToMatrix(matches);
+  }
+
+  const FeatureMatchingOptions& Options() const { return options_; }
+  Device GetDevice() const { return use_gpu_ ? Device::CUDA : Device::CPU; }
+
+ private:
+  std::unique_ptr<FeatureMatcher> matcher_;
+  FeatureMatchingOptions options_;
+  bool use_gpu_ = false;
+
+  std::atomic<image_t> next_image_id_{1};
+};
 
 void BindFeatureMatching(py::module& m) {
   auto PySiftMatchingOptions =
@@ -74,4 +144,24 @@ void BindFeatureMatching(py::module& m) {
           .def_readwrite("sift", &FeatureMatchingOptions::sift)
           .def("check", &FeatureMatchingOptions::Check);
   MakeDataclass(PyFeatureMatchingOptions);
+
+  py::classh<SiftMatcher>(m, "SiftMatcher")
+      .def(py::init<std::optional<FeatureMatchingOptions>, Device>(),
+           "options"_a = std::nullopt,
+           "device"_a = Device::AUTO)
+      .def("match",
+           &SiftMatcher::Match,
+           "descriptors1"_a.noconvert(),
+           "descriptors2"_a.noconvert(),
+           "image_id1"_a = std::nullopt,
+           "image_id2"_a = std::nullopt,
+           "If you repeatedly match pairs that share an image (e.g., (A,B), "
+           "(A,C), ...), providing stable image_id1/image_id2 can speed up GPU "
+           "matching by allowing reuse of cached descriptors. If omitted, "
+           "reuse will not occur."
+           "Warning: image_id values must consistently identify the same "
+           "descriptors; reusing an image_id for different descriptors can "
+           "lead to incorrect matches when caching is enabled.")
+      .def_property_readonly("options", &SiftMatcher::Options)
+      .def_property_readonly("device", &SiftMatcher::GetDevice);
 }


### PR DESCRIPTION
## Summary

This PR adds a small Python wrapper to match SIFT descriptors directly (without a database).

Related to #3667.

## What’s included

- New `pycolmap.SiftMatcher` wrapper around COLMAP `FeatureMatcher`
- GPU matching and CPU brute-force matching supported
- Added docstring explained how to cache descriptors on GPU with `image_id` and warning that reusing an `image_id` for different descriptors can produce incorrect results.

## Limitation

- CPU FAISS matching (`cpu_brute_force_matcher=False`) is not supported. See follow-up question.

## Example

```python
sift = pycolmap.Sift()
k1, d1 = sift.extract(img1)
k2, d2 = sift.extract(img2)

matcher = pycolmap.SiftMatcher(device=pycolmap.Device.cuda)  # or Device.cpu
matches = matcher.match(d1, d2, image_id1=1, image_id2=2)
```

## Follow-ups

- If this looks good,  I can go ahead and implement the `MatchGuided` function as part of this class.
- For CPU FAISS, do you have any ideas or comments about integrating index caching?