### PR TITLE
Update FAQ on dense stereo stage requirements

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -177,7 +177,7 @@ during the dense stereo stage, you have to manually specify the source images,
 as described :ref:`here <faq-dense-manual-source>`. The dense stereo stage
 now also requires a manual specification of the depth range.
 
-Finally, in this case, Fusion will fail to successfully match points if min_num_pixels is
+Finally, in this case, fusion will fail to successfully match points if min_num_pixels is
 left at the default (greater than 1). So also set that parameter, as below::
 
     colmap patch_match_stereo \


### PR DESCRIPTION
Clarify requirements for min_num_pixels in dense reconstruction from known poses, without reference to any prior sparse point cloud. As discovered / discussed in #1844 