### PR TITLE
Fix incorrect registered frame check in rotation averaging

### DIFF
--- a/src/glomap/estimators/global_rotation_averaging.cc
+++ b/src/glomap/estimators/global_rotation_averaging.cc
@@ -869,8 +869,7 @@ double RotationEstimator::ComputeAverageStepSize(
         frame_to_pose_prior) {
   double total_update = 0;
   for (const auto& [frame_id, frame] : frames) {
-    if (frame.HasPose()) continue;
-    const auto pose_prior_it = frame_to_pose_prior.find(frame_id);
+    if (!frame.HasPose()) continue;    const auto pose_prior_it = frame_to_pose_prior.find(frame_id);
     const bool has_gravity = pose_prior_it != frame_to_pose_prior.end() &&
                              pose_prior_it->second->HasGravity();
     if (options_.use_gravity && has_gravity) {


### PR DESCRIPTION
This PR fixes an incorrect condition in `global_rotation_averaging.cc` where registered frames were skipped instead of unregistered ones during average step size computation.

**What was wrong**
The code skipped registered frames:
```cpp
if (frame.HasPose()) continue;

**FIX:**
if (!frame.HasPose()) continue;