### PR TITLE
Use DeRegisterFrame over ResetPose in view graph and track retriangulation.

### DIFF
--- a/src/glomap/scene/view_graph.cc
+++ b/src/glomap/scene/view_graph.cc
@@ -82,8 +82,8 @@ int ViewGraph::KeepLargestConnectedComponents(
   const std::unordered_set<frame_t>& largest_component =
       connected_components[max_comp];
   for (const auto& [frame_id, frame] : reconstruction.Frames()) {
-    if (largest_component.count(frame_id) == 0) {
-      reconstruction.Frame(frame_id).ResetPose();
+    if (largest_component.count(frame_id) == 0 && frame.HasPose()) {
+      reconstruction.DeRegisterFrame(frame_id);
     }
   }
 

--- a/src/glomap/scene/view_graph_test.cc
+++ b/src/glomap/scene/view_graph_test.cc
@@ -149,7 +149,7 @@ TEST(ViewGraph, FilterByRelativeRotation) {
   view_graph.image_pairs.emplace(pair_id3, std::move(pair3));
   view_graph.image_pairs.emplace(pair_id4, std::move(pair4));
 
-  reconstruction.Image(id4).FramePtr()->ResetPose();
+  reconstruction.DeRegisterFrame(reconstruction.Image(id4).FrameId());
 
   view_graph.FilterByRelativeRotation(reconstruction, 5.0);
 

--- a/src/glomap/sfm/track_retriangulation.cc
+++ b/src/glomap/sfm/track_retriangulation.cc
@@ -49,7 +49,7 @@ bool RetriangulateTracks(const TriangulatorOptions& options,
   for (const auto& [image_id, image] : reconstruction.Images()) {
     if (!database_cache->ExistsImage(image_id) && image.HasPose()) {
       image_ids_notconnected.push_back(image_id);
-      image.FramePtr()->ResetPose();
+      reconstruction.DeRegisterFrame(image.FrameId());
     }
   }
 


### PR DESCRIPTION
Did some regression tests of global pipeline, and found a bug introduced in https://github.com/colmap/colmap/pull/3805.

From this commit hash the global positioning throws when not all images are successfully registered. This PR fixes the issue. 