### PR TITLE
Add Reconstruction::IsValid to check if a reconstruction object is not broken.

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -131,17 +131,23 @@ std::unordered_set<point3D_t> Reconstruction::Point3DIds() const {
   return point3D_ids;
 }
 
-bool Reconstruction::CheckIsValid() const {
+bool Reconstruction::IsValid() const {
   // Check object associations: rig-frame-image-camera references and pointers.
   // Check rigs.
   for (const auto& [rig_id, rig] : rigs_) {
     for (const sensor_t& sensor_id : rig.SensorIds()) {
-      if (sensor_id.type == SensorType::CAMERA) {
-        if (!ExistsCamera(sensor_id.id)) {
-          LOG(WARNING) << "Rig " << rig_id << " has sensor (camera) "
-                       << sensor_id.id << " which does not exist";
-          return false;
-        }
+      switch (sensor_id.type) {
+        case SensorType::CAMERA:
+          if (!ExistsCamera(sensor_id.id)) {
+            LOG(WARNING) << "Rig " << rig_id << " has sensor (camera) "
+                         << sensor_id.id << " which does not exist";
+            return false;
+          }
+          break;
+        case SensorType::IMU:
+        case SensorType::INVALID:
+          // Only camera sensors are currently supported.
+          break;
       }
     }
   }

--- a/src/colmap/scene/reconstruction.h
+++ b/src/colmap/scene/reconstruction.h
@@ -106,7 +106,7 @@ class Reconstruction {
   inline bool ExistsPoint3D(point3D_t point3D_id) const;
 
   // Check whether the reconstruction object is internally consistent.
-  bool CheckIsValid() const;
+  bool IsValid() const;
 
   // Load data from given `DatabaseCache`.
   void Load(const DatabaseCache& database_cache);

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -1019,34 +1019,34 @@ TEST(Reconstruction, TranscribeImageIdsToDatabase) {
           db_image1.ImageId(), db_image2.ImageId(), db_image3.ImageId()));
 }
 
-TEST(Reconstruction, CheckIsValid) {
+TEST(Reconstruction, IsValid) {
   Reconstruction reconstruction;
   GenerateReconstruction(2, &reconstruction);
   Track track;
   track.AddElement(1, 0);
   track.AddElement(2, 1);
   reconstruction.AddPoint3D(Eigen::Vector3d::Random(), track);
-  EXPECT_TRUE(reconstruction.CheckIsValid());
+  EXPECT_TRUE(reconstruction.IsValid());
 
-  // Test wrong frame pointer for image.
+  // Test empty frame pointer for image.
   {
     Reconstruction reconstruction_copy(reconstruction);
-    reconstruction_copy.Image(1).SetFrameId(2);
-    EXPECT_FALSE(reconstruction_copy.CheckIsValid());
+    reconstruction_copy.Image(1).ResetFramePtr();
+    EXPECT_FALSE(reconstruction_copy.IsValid());
   }
 
   // Test breaking track consistency by directly modifying point3D track.
   {
     Reconstruction reconstruction_copy(reconstruction);
     reconstruction_copy.Point3D(1).track.SetElement(0, TrackElement(1, 5));
-    EXPECT_FALSE(reconstruction_copy.CheckIsValid());
+    EXPECT_FALSE(reconstruction_copy.IsValid());
   }
 
   // Test registered frame without pose.
   {
     Reconstruction reconstruction_copy(reconstruction);
     reconstruction_copy.Frame(1).ResetPose();
-    EXPECT_FALSE(reconstruction_copy.CheckIsValid());
+    EXPECT_FALSE(reconstruction_copy.IsValid());
   }
 }
 

--- a/src/pycolmap/scene/reconstruction.cc
+++ b/src/pycolmap/scene/reconstruction.cc
@@ -103,8 +103,8 @@ void BindReconstruction(py::module& m) {
       .def("exists_frame", &Reconstruction::ExistsFrame, "frame_id"_a)
       .def("exists_image", &Reconstruction::ExistsImage, "image_id"_a)
       .def("exists_point3D", &Reconstruction::ExistsPoint3D, "point3D_id"_a)
-      .def("check_is_valid",
-           &Reconstruction::CheckIsValid,
+      .def("is_valid",
+           &Reconstruction::IsValid,
            "Check whether the reconstruction object is internally consistent.")
       .def("load", &Reconstruction::Load, "database_cache"_a)
       .def("tear_down", &Reconstruction::TearDown)


### PR DESCRIPTION
In such significant refactorization of glomap, I believe we have reached a point where we keep hitting broken reconstruction (e.g., https://github.com/colmap/colmap/pull/3867 and https://github.com/colmap/colmap/pull/3877). I think its right time to add a method with good verbal messages. This can be very helpful for improving code safety and easy debugging. A small test with three nominal wrong operations are included. 