### PR TITLE
Improved code for view graph calibration cost functions

### DIFF
--- a/src/glomap/estimators/cost_functions.h
+++ b/src/glomap/estimators/cost_functions.h
@@ -134,8 +134,8 @@ struct RigUnknownBATAPairwiseDirectionCostFunctor {
 // for the Fetzer focal length estimation method. The coefficients encode the
 // relationship between the two focal lengths derived from the fundamental
 // matrix constraint.
-// Reference: Sweeney et al., "Optimizing the Viewing Graph for Structure-from-
-// Motion", ICCV 2015.
+// See: "Stable Intrinsic Auto-Calibration from Fundamental Matrices of Devices
+// with Uncorrelated Camera Parameters", Fetzer et al., WACV 2020.
 inline Eigen::Vector4d ComputeFetzerPolynomialCoefficients(
     const Eigen::Vector3d& ai,
     const Eigen::Vector3d& bi,
@@ -153,39 +153,50 @@ inline Eigen::Vector4d ComputeFetzerPolynomialCoefficients(
 // compute the polynomial coefficients for the Fetzer focal length method.
 // Returns three coefficient vectors used to estimate the two focal lengths.
 inline std::array<Eigen::Vector4d, 3> DecomposeFundamentalMatrixForFetzer(
-    const Eigen::Matrix3d& i1_G_i0) {
+    const Eigen::Matrix3d& i1_F_i0,
+    const Eigen::Vector2d& principal_point0,
+    const Eigen::Vector2d& principal_point1) {
+  Eigen::Matrix3d K0 = Eigen::Matrix3d::Identity(3, 3);
+  K0(0, 2) = principal_point0(0);
+  K0(1, 2) = principal_point0(1);
+
+  Eigen::Matrix3d K1 = Eigen::Matrix3d::Identity(3, 3);
+  K1(0, 2) = principal_point1(0);
+  K1(1, 2) = principal_point1(1);
+
+  const Eigen::Matrix3d i1_G_i0 = K1.transpose() * i1_F_i0 * K0;
+
   const Eigen::JacobiSVD<Eigen::Matrix3d> svd(
       i1_G_i0, Eigen::ComputeFullU | Eigen::ComputeFullV);
   const Eigen::Vector3d& s = svd.singularValues();
 
-  const Eigen::Vector3d v_0 = svd.matrixV().col(0);
-  const Eigen::Vector3d v_1 = svd.matrixV().col(1);
+  const Eigen::Vector3d v0 = svd.matrixV().col(0);
+  const Eigen::Vector3d v1 = svd.matrixV().col(1);
 
-  const Eigen::Vector3d u_0 = svd.matrixU().col(0);
-  const Eigen::Vector3d u_1 = svd.matrixU().col(1);
+  const Eigen::Vector3d u0 = svd.matrixU().col(0);
+  const Eigen::Vector3d u1 = svd.matrixU().col(1);
 
-  const Eigen::Vector3d ai(s(0) * s(0) * (v_0(0) * v_0(0) + v_0(1) * v_0(1)),
-                           s(0) * s(1) * (v_0(0) * v_1(0) + v_0(1) * v_1(1)),
-                           s(1) * s(1) * (v_1(0) * v_1(0) + v_1(1) * v_1(1)));
+  const Eigen::Vector3d ai(s(0) * s(0) * (v0(0) * v0(0) + v0(1) * v0(1)),
+                           s(0) * s(1) * (v0(0) * v1(0) + v0(1) * v1(1)),
+                           s(1) * s(1) * (v1(0) * v1(0) + v1(1) * v1(1)));
 
-  const Eigen::Vector3d aj(u_1(0) * u_1(0) + u_1(1) * u_1(1),
-                           -(u_0(0) * u_1(0) + u_0(1) * u_1(1)),
-                           u_0(0) * u_0(0) + u_0(1) * u_0(1));
+  const Eigen::Vector3d aj(u1(0) * u1(0) + u1(1) * u1(1),
+                           -(u0(0) * u1(0) + u0(1) * u1(1)),
+                           u0(0) * u0(0) + u0(1) * u0(1));
 
-  const Eigen::Vector3d bi(s(0) * s(0) * v_0(2) * v_0(2),
-                           s(0) * s(1) * v_0(2) * v_1(2),
-                           s(1) * s(1) * v_1(2) * v_1(2));
+  const Eigen::Vector3d bi(s(0) * s(0) * v0(2) * v0(2),
+                           s(0) * s(1) * v0(2) * v1(2),
+                           s(1) * s(1) * v1(2) * v1(2));
 
-  const Eigen::Vector3d bj(
-      u_1(2) * u_1(2), -(u_0(2) * u_1(2)), u_0(2) * u_0(2));
+  const Eigen::Vector3d bj(u1(2) * u1(2), -(u0(2) * u1(2)), u0(2) * u0(2));
 
-  const Eigen::Vector4d d_01 =
+  const Eigen::Vector4d d01 =
       ComputeFetzerPolynomialCoefficients(ai, bi, aj, bj, 1, 0);
-  const Eigen::Vector4d d_02 =
+  const Eigen::Vector4d d02 =
       ComputeFetzerPolynomialCoefficients(ai, bi, aj, bj, 0, 2);
-  const Eigen::Vector4d d_12 =
+  const Eigen::Vector4d d12 =
       ComputeFetzerPolynomialCoefficients(ai, bi, aj, bj, 2, 1);
-  return {d_01, d_02, d_12};
+  return {d01, d02, d12};
 }
 
 // Cost functor for estimating focal lengths from the fundamental matrix using
@@ -197,24 +208,9 @@ class FetzerFocalLengthCostFunctor {
  public:
   FetzerFocalLengthCostFunctor(const Eigen::Matrix3d& i1_F_i0,
                                const Eigen::Vector2d& principal_point0,
-                               const Eigen::Vector2d& principal_point1) {
-    Eigen::Matrix3d K0 = Eigen::Matrix3d::Identity(3, 3);
-    K0(0, 2) = principal_point0(0);
-    K0(1, 2) = principal_point0(1);
-
-    Eigen::Matrix3d K1 = Eigen::Matrix3d::Identity(3, 3);
-    K1(0, 2) = principal_point1(0);
-    K1(1, 2) = principal_point1(1);
-
-    const Eigen::Matrix3d i1_G_i0 = K1.transpose() * i1_F_i0 * K0;
-
-    const std::array<Eigen::Vector4d, 3> coeffs =
-        DecomposeFundamentalMatrixForFetzer(i1_G_i0);
-
-    d_01_ = coeffs[0];
-    d_02_ = coeffs[1];
-    d_12_ = coeffs[2];
-  }
+                               const Eigen::Vector2d& principal_point1)
+      : coeffs_(DecomposeFundamentalMatrixForFetzer(
+            i1_F_i0, principal_point0, principal_point1)) {}
 
   static ceres::CostFunction* Create(const Eigen::Matrix3d& i1_F_i0,
                                      const Eigen::Vector2d& principal_point0,
@@ -227,19 +223,19 @@ class FetzerFocalLengthCostFunctor {
 
   template <typename T>
   bool operator()(const T* const fi_, const T* const fj_, T* residuals) const {
-    const Eigen::Vector<T, 4> coeffs_01 = d_01_.cast<T>();
-    const Eigen::Vector<T, 4> coeffs_12 = d_12_.cast<T>();
+    const Eigen::Vector<T, 4> d01_ = coeffs_[0].cast<T>();
+    const Eigen::Vector<T, 4> d12_ = coeffs_[2].cast<T>();
 
     const T fi = fi_[0];
     const T fj = fj_[0];
 
-    T di = (fj * fj * coeffs_01(0) + coeffs_01(1));
-    T dj = (fi * fi * coeffs_12(0) + coeffs_12(2));
+    T di = (fj * fj * d01_(0) + d01_(1));
+    T dj = (fi * fi * d12_(0) + d12_(2));
     di = di == T(0) ? T(1e-6) : di;
     dj = dj == T(0) ? T(1e-6) : dj;
 
-    const T K0_01 = -(fj * fj * coeffs_01(2) + coeffs_01(3)) / di;
-    const T K1_12 = -(fi * fi * coeffs_12(1) + coeffs_12(3)) / dj;
+    const T K0_01 = -(fj * fj * d01_(2) + d01_(3)) / di;
+    const T K1_12 = -(fi * fi * d12_(1) + d12_(3)) / dj;
 
     residuals[0] = (fi * fi - K0_01) / (fi * fi);
     residuals[1] = (fj * fj - K1_12) / (fj * fj);
@@ -248,9 +244,7 @@ class FetzerFocalLengthCostFunctor {
   }
 
  private:
-  Eigen::Vector4d d_01_;
-  Eigen::Vector4d d_02_;
-  Eigen::Vector4d d_12_;
+  const std::array<Eigen::Vector4d, 3> coeffs_;
 };
 
 // Cost functor for estimating focal length from the fundamental matrix using
@@ -259,25 +253,10 @@ class FetzerFocalLengthCostFunctor {
 // expected focal length based on the fundamental matrix constraint.
 class FetzerFocalLengthSameCameraCostFunctor {
  public:
-  FetzerFocalLengthSameCameraCostFunctor(
-      const Eigen::Matrix3d& i1_F_i0, const Eigen::Vector2d& principal_point) {
-    Eigen::Matrix3d K0 = Eigen::Matrix3d::Identity(3, 3);
-    K0(0, 2) = principal_point(0);
-    K0(1, 2) = principal_point(1);
-
-    Eigen::Matrix3d K1 = Eigen::Matrix3d::Identity(3, 3);
-    K1(0, 2) = principal_point(0);
-    K1(1, 2) = principal_point(1);
-
-    const Eigen::Matrix3d i1_G_i0 = K1.transpose() * i1_F_i0 * K0;
-
-    const std::array<Eigen::Vector4d, 3> coeffs =
-        DecomposeFundamentalMatrixForFetzer(i1_G_i0);
-
-    d_01_ = coeffs[0];
-    d_02_ = coeffs[1];
-    d_12_ = coeffs[2];
-  }
+  FetzerFocalLengthSameCameraCostFunctor(const Eigen::Matrix3d& i1_F_i0,
+                                         const Eigen::Vector2d& principal_point)
+      : coeffs_(DecomposeFundamentalMatrixForFetzer(
+            i1_F_i0, principal_point, principal_point)) {}
 
   static ceres::CostFunction* Create(const Eigen::Matrix3d& i1_F_i0,
                                      const Eigen::Vector2d& principal_point) {
@@ -289,19 +268,19 @@ class FetzerFocalLengthSameCameraCostFunctor {
 
   template <typename T>
   bool operator()(const T* const fi_, T* residuals) const {
-    const Eigen::Vector<T, 4> coeffs_01 = d_01_.cast<T>();
-    const Eigen::Vector<T, 4> coeffs_12 = d_12_.cast<T>();
+    const Eigen::Vector<T, 4> d01_ = coeffs_[0].cast<T>();
+    const Eigen::Vector<T, 4> d12_ = coeffs_[2].cast<T>();
 
     const T fi = fi_[0];
     const T fj = fi_[0];
 
-    T di = (fj * fj * coeffs_01(0) + coeffs_01(1));
-    T dj = (fi * fi * coeffs_12(0) + coeffs_12(2));
+    T di = (fj * fj * d01_(0) + d01_(1));
+    T dj = (fi * fi * d12_(0) + d12_(2));
     di = di == T(0) ? T(1e-6) : di;
     dj = dj == T(0) ? T(1e-6) : dj;
 
-    const T K0_01 = -(fj * fj * coeffs_01(2) + coeffs_01(3)) / di;
-    const T K1_12 = -(fi * fi * coeffs_12(1) + coeffs_12(3)) / dj;
+    const T K0_01 = -(fj * fj * d01_(2) + d01_(3)) / di;
+    const T K1_12 = -(fi * fi * d12_(1) + d12_(3)) / dj;
 
     residuals[0] = (fi * fi - K0_01) / (fi * fi);
     residuals[1] = (fj * fj - K1_12) / (fj * fj);
@@ -310,9 +289,7 @@ class FetzerFocalLengthSameCameraCostFunctor {
   }
 
  private:
-  Eigen::Vector4d d_01_;
-  Eigen::Vector4d d_02_;
-  Eigen::Vector4d d_12_;
+  const std::array<Eigen::Vector4d, 3> coeffs_;
 };
 
 // Computes residual between estimated gravity and measured gravity prior.

--- a/src/glomap/estimators/view_graph_calibration.h
+++ b/src/glomap/estimators/view_graph_calibration.h
@@ -57,6 +57,8 @@ struct ViewGraphCalibratorOptions {
 // Calibrate the view graph by estimating focal lengths from fundamental
 // matrices. Filters image pairs with high calibration errors.
 // Then re-estimates relative poses using the calibrated cameras.
+// See: "Stable Intrinsic Auto-Calibration from Fundamental Matrices of Devices
+// with Uncorrelated Camera Parameters", Fetzer et al., WACV 2020.
 bool CalibrateViewGraph(const ViewGraphCalibratorOptions& options,
                         ViewGraph& view_graph,
                         colmap::Reconstruction& reconstruction);


### PR DESCRIPTION
After studying the paper again, I am not sure why we are omitting some of the u/v combinations (we only compute K0_01 and K1_12 but not any of the other like K1_01, etc.), in particular the d02 one that we compute but never use?