### PR TITLE
Early exit pycolmap windows build on errors

### DIFF
--- a/.github/workflows/install-ccache.ps1
+++ b/.github/workflows/install-ccache.ps1
@@ -10,6 +10,8 @@ $url = "https://github.com/ccache/ccache/releases/download/v$version/$folder.zip
 $expectedSha256 = "98AEA520D66905B8BA7A8E648A4CC0CA941D5E119D441F1E879A4A9045BF18F6"
 
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$PSNativeCommandUseErrorActionPreference = $true
 
 try {
     New-Item -Path "$Destination" -ItemType Container -ErrorAction SilentlyContinue

--- a/python/ci/install-colmap-windows.ps1
+++ b/python/ci/install-colmap-windows.ps1
@@ -1,3 +1,7 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$PSNativeCommandUseErrorActionPreference = $true
+
 $CURRDIR = $PWD
 
 $COMPILER_TOOLS_DIR = "${env:COMPILER_CACHE_DIR}/bin"


### PR DESCRIPTION
Previously, a failure in the colmap build would not stop the build but happily continue the CI pipeline only then later to fail with an error that colmap was not found (because not installed earlier due to errors).