### PR TITLE
Always try to decompose relative poses at the start of global pipeline.

### DIFF
--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -46,9 +46,7 @@ GlobalPipeline::GlobalPipeline(
       database_(std::move(THROW_CHECK_NOTNULL(database))),
       reconstruction_manager_(
           std::move(THROW_CHECK_NOTNULL(reconstruction_manager))) {
-  if (options_.decompose_relative_pose &&
-      (options_.skip_view_graph_calibration ||
-       !options_.view_graph_calibration.reestimate_relative_pose)) {
+  if (options_.decompose_relative_pose) {
     MaybeDecomposeAndWriteRelativePoses(database_.get());
   }
 }


### PR DESCRIPTION
Fix regression issues from https://github.com/colmap/colmap/pull/3960. This was due to the fact that relative pose re-estimation only works on pairs that are newly calibrated. So if every camera is calibrated, the relative pose wont be decomposed without this fix. 

This actually reveals another inconsistency from https://github.com/colmap/colmap/pull/3943. If it is the calibrated case, the original code will just skip relative pose re-estimation so that the default colmap two-view geometry is respected, rather than the one in the re-estimation.