### PR TITLE
Optionally include runtime benchmarks in main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(CGAL_ENABLED "Whether to enable the CGAL library" ON)
 option(LSD_ENABLED "Whether to enable the LSD library" ON)
 option(DOWNLOAD_ENABLED "Whether to enable (automatic) download of resources (requires Curl/OpenSSL)" ON)
 option(UNINSTALL_ENABLED "Whether to create a target to 'uninstall' colmap" ON)
+option(BENCHMARK_ENABLED "Whether to enable runtime benchmarking support" OFF)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 option(FETCH_FAISS "Whether to consume faiss using FetchContent or find_package" ON)
 option(ALL_SOURCE_TARGET "Whether to create a target for all source files (for Visual Studio / XCode development)" OFF)
@@ -257,6 +258,10 @@ link_directories(${COLMAP_LINK_DIRS})
 add_subdirectory(src/colmap)
 add_subdirectory(src/glomap)
 add_subdirectory(src/thirdparty)
+
+if(BENCHMARK_ENABLED)
+    add_subdirectory(benchmark/runtime)
+endif()
 
 ################################################################################
 # Generate source groups for Visual Studio, XCode, etc.

--- a/benchmark/runtime/CMakeLists.txt
+++ b/benchmark/runtime/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
-project(colmap_benchmarks)
-
-find_package(colmap REQUIRED)
 find_package(benchmark REQUIRED)
 
 add_executable(benchmark_cost_functions cost_functions.cc)
-target_link_libraries(benchmark_cost_functions PRIVATE colmap::colmap benchmark::benchmark)
+target_link_libraries(benchmark_cost_functions PRIVATE colmap_estimators benchmark::benchmark)

--- a/benchmark/runtime/README.md
+++ b/benchmark/runtime/README.md
@@ -3,10 +3,12 @@
 ## Installation
 
 1. Install [google/benchmark](https://github.com/google/benchmark).
-2. Build the benchmarking executables:
+   For example, using homebrew on a Mac: `brew install google-benchmark`.
+2. Build and run the benchmarking executables:
+
 ```bash
-mkdir build && cd build
-cmake .. -GNinja && ninja
+cmake .. -DBENCHMARK_ENABLED=ON
+ninja benchmark/runtime/benchmark_cost_functions
 ```
 
 To reduce the variance, consider setting up your system appropriately [following these instructions](https://github.com/google/benchmark/blob/main/docs/reducing_variance.md).
@@ -14,6 +16,7 @@ To reduce the variance, consider setting up your system appropriately [following
 ## Running the benchmarks
 
 Cost functions:
+
 ```bash
-./benchmark_cost_functions --benchmark_display_aggregates_only=true --benchmark_repetitions=50
+./benchmark/runtime/benchmark_cost_functions --benchmark_display_aggregates_only=true --benchmark_repetitions=50
 ```

--- a/benchmark/runtime/cost_functions.cc
+++ b/benchmark/runtime/cost_functions.cc
@@ -3,7 +3,6 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/eigen_alignment.h"
-#include "colmap/util/logging.h"
 
 #include <benchmark/benchmark.h>
 #include <ceres/ceres.h>


### PR DESCRIPTION
To facilitate a tigher evaluation loop and iterating on optimizing performance with code changes, I am including the runtime benchmark in the main project, so we can skip the install step.