### PR TITLE
Clear and log OpenImageIO errors

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -461,7 +461,9 @@ bool Bitmap::Read(const std::filesystem::path& path,
 
   const auto input = OIIO::ImageInput::open(path.string(), &config);
   if (!input) {
-    VLOG(3) << "Failed to read bitmap specs";
+    // Always retrieve the error to clear OIIO's pending error state.
+    const std::string error = OIIO::geterror();
+    VLOG(3) << "Failed to read bitmap: " << error;
     return false;
   }
 

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/util/testing.h"
 
+#include <fstream>
 #include <tuple>
 
 #include <OpenImageIO/imagebufalgo.h>
@@ -827,6 +828,36 @@ TEST_P(ParameterizedBitmapFormatTests, ReadGreyAlpha) {
   EXPECT_EQ(rgb_bitmap.Width(), width);
   EXPECT_EQ(rgb_bitmap.Height(), height);
   EXPECT_EQ(rgb_bitmap.Channels(), 3);
+}
+
+TEST(Bitmap, ReadNonImageFile) {
+  const auto test_dir = CreateTestDir();
+  const auto filename = test_dir / "not_an_image.txt";
+
+  // Create a non-image file
+  std::ofstream file(filename);
+  file << "This is not an image file";
+  file.close();
+
+  Bitmap bitmap;
+  EXPECT_FALSE(bitmap.Read(filename));
+
+  // Verify that OIIO error was cleared.
+  const std::string pending_error = OIIO::geterror();
+  EXPECT_TRUE(pending_error.empty())
+      << "OIIO error was not cleared: " << pending_error;
+}
+
+TEST(Bitmap, ReadNonExistentFile) {
+  const auto test_dir = CreateTestDir();
+
+  Bitmap bitmap;
+  EXPECT_FALSE(bitmap.Read(test_dir / "non_existent_file.png"));
+
+  // Verify that OIIO error was cleared.
+  const std::string pending_error = OIIO::geterror();
+  EXPECT_TRUE(pending_error.empty())
+      << "OIIO error was not cleared: " << pending_error;
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Failures to read an image result in OIIO errors, which need to be explicitly fetched, otherwise OIIO automatically reports these upon program exit. For example, when there is a .DS_Store file in a folder on a Mac, this would be logged out during feature extraction at the end of the process:
```
OpenImageIO exited with a pending error message that was never
retrieved via OIIO::geterror(). This was the error message:
OpenImageIO could not find a format reader for "./images/.DS_Store". Is it a file format that OpenImageIO doesn't know about?
```