### PR TITLE
Consistent and improved logging of headings

### DIFF
--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -69,7 +69,7 @@ BundleAdjustmentController::BundleAdjustmentController(
 void BundleAdjustmentController::Run() {
   THROW_CHECK_NOTNULL(reconstruction_);
 
-  PrintHeading1("Global bundle adjustment");
+  LOG_HEADING1("Global bundle adjustment");
   Timer run_timer;
   run_timer.Start();
 

--- a/src/colmap/controllers/feature_extraction.cc
+++ b/src/colmap/controllers/feature_extraction.cc
@@ -437,7 +437,7 @@ class FeatureExtractorController : public Thread {
 
  private:
   void Run() override {
-    PrintHeading1("Feature extraction");
+    LOG_HEADING1("Feature extraction");
     Timer run_timer;
     run_timer.Start();
 
@@ -537,7 +537,7 @@ class FeatureImporterController : public Thread {
 
  private:
   void Run() override {
-    PrintHeading1("Feature import");
+    LOG_HEADING1("Feature import");
     Timer run_timer;
     run_timer.Start();
 

--- a/src/colmap/controllers/feature_matching.cc
+++ b/src/colmap/controllers/feature_matching.cc
@@ -175,7 +175,7 @@ class FeatureMatcherThread : public Thread {
 
  private:
   void Run() override {
-    PrintHeading1("Feature matching & geometric verification");
+    LOG_HEADING1("Feature matching & geometric verification");
 
     Timer run_timer;
     run_timer.Start();
@@ -209,7 +209,7 @@ class FeatureMatcherThread : public Thread {
     if (!matching_options_.skip_geometric_verification &&
         matching_options_.rig_verification) {
       run_timer.Restart();
-      PrintHeading1("Rig verification");
+      LOG_HEADING1("Rig verification");
       RigVerification(
           database_, cache_, geometry_options_, matching_options_.num_threads);
       run_timer.PrintMinutes();
@@ -262,7 +262,7 @@ class GeometricVerifierThread : public Thread {
 
  private:
   void Run() override {
-    PrintHeading1("Geometric verification");
+    LOG_HEADING1("Geometric verification");
 
     Timer run_timer;
     run_timer.Start();
@@ -289,7 +289,7 @@ class GeometricVerifierThread : public Thread {
 
     if (verifier_.Options().rig_verification) {
       run_timer.Restart();
-      PrintHeading1("Rig verification");
+      LOG_HEADING1("Rig verification");
       RigVerification(database_,
                       cache_,
                       geometry_options_,
@@ -384,7 +384,7 @@ class FeaturePairsFeatureMatcher : public Thread {
 
  private:
   void Run() override {
-    PrintHeading1("Importing matches");
+    LOG_HEADING1("Importing matches");
     Timer run_timer;
     run_timer.Start();
 

--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/two_view_geometry.h"
 #include "colmap/scene/database_cache.h"
+#include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 #include "glomap/io/colmap_io.h"
@@ -53,7 +54,7 @@ GlobalPipeline::GlobalPipeline(
 
 void GlobalPipeline::Run() {
   if (!options_.skip_view_graph_calibration) {
-    LOG(INFO) << "----- Running view graph calibration -----";
+    LOG_HEADING1("Running view graph calibration");
     Timer run_timer;
     run_timer.Start();
     ViewGraphCalibrationOptions vgc_options = options_.view_graph_calibration;

--- a/src/colmap/controllers/hierarchical_pipeline.cc
+++ b/src/colmap/controllers/hierarchical_pipeline.cc
@@ -143,7 +143,7 @@ HierarchicalPipeline::HierarchicalPipeline(
 }
 
 void HierarchicalPipeline::Run() {
-  PrintHeading1("Partitioning scene");
+  LOG_HEADING1("Partitioning scene");
   Timer run_timer;
   run_timer.Start();
 
@@ -176,7 +176,7 @@ void HierarchicalPipeline::Run() {
   // Reconstruct clusters
   //////////////////////////////////////////////////////////////////////////////
 
-  PrintHeading1("Reconstructing clusters");
+  LOG_HEADING1("Reconstructing clusters");
 
   // Determine the number of workers and threads per worker.
   const int kMaxNumThreads = -1;
@@ -258,7 +258,7 @@ void HierarchicalPipeline::Run() {
   //////////////////////////////////////////////////////////////////////////////
 
   if (leaf_clusters.size() > 1) {
-    PrintHeading1("Merging clusters");
+    LOG_HEADING1("Merging clusters");
 
     MergeClusters(*scene_clustering.GetRootCluster(), &reconstruction_managers);
   }

--- a/src/colmap/controllers/rotation_averaging.cc
+++ b/src/colmap/controllers/rotation_averaging.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/two_view_geometry.h"
 #include "colmap/util/logging.h"
+#include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 #include "glomap/sfm/global_mapper.h"
@@ -68,7 +69,7 @@ void RotationAveragingController::Run() {
   glomap::GlobalMapper mapper(database_cache_);
   mapper.BeginReconstruction(reconstruction_);
 
-  LOG(INFO) << "----- Running rotation averaging -----";
+  LOG_HEADING1("Running rotation averaging");
   if (!mapper.RotationAveraging(options.rotation_estimation)) {
     LOG(ERROR) << "Failed to solve rotation averaging";
     return;

--- a/src/colmap/estimators/coordinate_frame.cc
+++ b/src/colmap/estimators/coordinate_frame.cc
@@ -168,10 +168,10 @@ Eigen::Matrix3d EstimateManhattanWorldFrame(
     const auto& image = reconstruction.Image(image_id);
     const auto& camera = *image.CameraPtr();
 
-    PrintHeading1(StringPrintf("Processing image %s (%d / %d)",
-                               image.Name().c_str(),
-                               ++image_idx,
-                               reconstruction.NumRegImages()));
+    LOG_HEADING1(StringPrintf("Processing image %s (%d / %d)",
+                              image.Name().c_str(),
+                              ++image_idx,
+                              reconstruction.NumRegImages()));
 
     LOG(INFO) << "Reading image...";
 
@@ -273,7 +273,7 @@ Eigen::Matrix3d EstimateManhattanWorldFrame(
     }
   }
 
-  PrintHeading1("Computing coordinate frame");
+  LOG_HEADING1("Computing coordinate frame");
 
   Eigen::Matrix3d frame = Eigen::Matrix3d::Zero();
 

--- a/src/colmap/exe/image.cc
+++ b/src/colmap/exe/image.cc
@@ -280,7 +280,7 @@ int RunImageRegistrator(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  PrintHeading1("Loading database");
+  LOG_HEADING1("Loading database");
 
   std::shared_ptr<DatabaseCache> database_cache;
 
@@ -312,8 +312,8 @@ int RunImageRegistrator(int argc, char** argv) {
       continue;
     }
 
-    PrintHeading1("Registering image #" + std::to_string(image.first) + " (" +
-                  std::to_string(reconstruction->NumRegImages() + 1) + ")");
+    LOG_HEADING1("Registering image #" + std::to_string(image.first) + " (" +
+                 std::to_string(reconstruction->NumRegImages() + 1) + ")");
 
     LOG(INFO) << "\n=> Image sees "
               << mapper.ObservationManager().NumVisiblePoints3D(image.first)
@@ -369,7 +369,7 @@ int RunImageUndistorter(int argc, char** argv) {
 
   CreateDirIfNotExists(output_path);
 
-  PrintHeading1("Reading reconstruction");
+  LOG_HEADING1("Reading reconstruction");
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
   LOG(INFO) << StringPrintf("=> Reconstruction with %d images and %d points",

--- a/src/colmap/exe/model.cc
+++ b/src/colmap/exe/model.cc
@@ -357,10 +357,10 @@ int RunModelAligner(int argc, char** argv) {
   Sim3d tform;
 
   if (alignment_type == "plane") {
-    PrintHeading2("Aligning reconstruction to principal plane");
+    LOG_HEADING2("Aligning reconstruction to principal plane");
     AlignToPrincipalPlane(&reconstruction, &tform);
   } else {
-    PrintHeading2("Aligning reconstruction to " + alignment_type);
+    LOG_HEADING2("Aligning reconstruction to " + alignment_type);
     LOG(INFO) << StringPrintf("=> Using %d reference images",
                               ref_image_names.size());
 
@@ -393,7 +393,7 @@ int RunModelAligner(int argc, char** argv) {
                               Median(errors));
 
     if (alignment_success && StringStartsWith(alignment_type, "enu-plane")) {
-      PrintHeading2("Aligning ECEF aligned reconstruction to ENU plane");
+      LOG_HEADING2("Aligning ECEF aligned reconstruction to ENU plane");
       AlignToENUPlane(
           &reconstruction, &tform, alignment_type == "enu-plane-unscaled");
     }
@@ -469,7 +469,7 @@ int RunModelAnalyzer(int argc, char** argv) {
 
   // verbose information
   if (verbose) {
-    PrintHeading2("Cameras");
+    LOG_HEADING2("Cameras");
     for (const auto& camera : reconstruction.Cameras()) {
       LOG(INFO) << StringPrintf(" - Camera Id: %d, Model Name: %s, Params: %s",
                                 camera.first,
@@ -477,7 +477,7 @@ int RunModelAnalyzer(int argc, char** argv) {
                                 camera.second.ParamsToString().c_str());
     }
 
-    PrintHeading2("Images");
+    LOG_HEADING2("Images");
     for (const auto& image_id : reconstruction.RegImageIds()) {
       LOG(INFO) << StringPrintf(" - Registered Image Id: %d, Name: %s",
                                 image_id,
@@ -552,17 +552,17 @@ bool CompareModels(const Reconstruction& reconstruction1,
                    const double max_proj_center_error,
                    std::vector<ImageAlignmentError>& errors,
                    Sim3d& rec2_from_rec1) {
-  PrintHeading1("Reconstruction 1");
+  LOG_HEADING1("Reconstruction 1");
   LOG(INFO) << StringPrintf("Frames: %d", reconstruction1.NumRegFrames());
   LOG(INFO) << StringPrintf("Images: %d", reconstruction1.NumRegImages());
   LOG(INFO) << StringPrintf("Points: %d", reconstruction1.NumPoints3D());
 
-  PrintHeading1("Reconstruction 2");
+  LOG_HEADING1("Reconstruction 2");
   LOG(INFO) << StringPrintf("Frames: %d", reconstruction2.NumRegFrames());
   LOG(INFO) << StringPrintf("Images: %d", reconstruction2.NumRegImages());
   LOG(INFO) << StringPrintf("Points: %d", reconstruction2.NumPoints3D());
 
-  PrintHeading1("Comparing reconstructed image poses");
+  LOG_HEADING1("Comparing reconstructed image poses");
   const std::vector<std::pair<image_t, image_t>> common_image_ids =
       reconstruction1.FindCommonRegImageIds(reconstruction2);
   LOG(INFO) << StringPrintf("Common images: %d", common_image_ids.size());
@@ -596,7 +596,7 @@ bool CompareModels(const Reconstruction& reconstruction1,
   errors = ComputeImageAlignmentError(
       reconstruction1, reconstruction2, rec2_from_rec1);
 
-  PrintHeading2("Image alignment error summary");
+  LOG_HEADING2("Image alignment error summary");
   PrintComparisonSummary(std::cout, errors);
 
   return true;
@@ -694,12 +694,12 @@ int RunModelCropper(int argc, char** argv) {
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
 
-  PrintHeading2("Calculating boundary coordinates");
+  LOG_HEADING2("Calculating boundary coordinates");
   Eigen::AlignedBox3d bounding_box;
   if (boundary_elements.size() == 6) {
     Sim3d tform;
     if (!gps_transform_path.empty()) {
-      PrintHeading2("Reading model to ECEF transform");
+      LOG_HEADING2("Reading model to ECEF transform");
       is_gps = true;
       tform = Inverse(Sim3d::FromFile(gps_transform_path));
     }
@@ -724,7 +724,7 @@ int RunModelCropper(int argc, char** argv) {
                                                      boundary_elements[1]);
   }
 
-  PrintHeading2("Cropping reconstruction");
+  LOG_HEADING2("Cropping reconstruction");
   reconstruction.Crop(bounding_box).Write(output_path);
   WriteBoundingBox(output_path, bounding_box);
 
@@ -750,21 +750,21 @@ int RunModelMerger(int argc, char** argv) {
 
   Reconstruction reconstruction1;
   reconstruction1.Read(input_path1);
-  PrintHeading2("Reconstruction 1");
+  LOG_HEADING2("Reconstruction 1");
   LOG(INFO) << StringPrintf("Images: %d", reconstruction1.NumRegImages());
   LOG(INFO) << StringPrintf("Points: %d", reconstruction1.NumPoints3D());
 
   Reconstruction reconstruction2;
   reconstruction2.Read(input_path2);
-  PrintHeading2("Reconstruction 2");
+  LOG_HEADING2("Reconstruction 2");
   LOG(INFO) << StringPrintf("Images: %d", reconstruction2.NumRegImages());
   LOG(INFO) << StringPrintf("Points: %d", reconstruction2.NumPoints3D());
 
-  PrintHeading2("Merging reconstructions");
+  LOG_HEADING2("Merging reconstructions");
   if (MergeAndFilterReconstructions(
           max_reproj_error, reconstruction1, reconstruction2)) {
     LOG(INFO) << "=> Merge succeeded";
-    PrintHeading2("Merged reconstruction");
+    LOG_HEADING2("Merged reconstruction");
     LOG(INFO) << StringPrintf("Images: %d", reconstruction2.NumRegImages());
     LOG(INFO) << StringPrintf("Points: %d", reconstruction2.NumPoints3D());
   } else {
@@ -821,7 +821,7 @@ int RunModelOrientationAligner(int argc, char** argv) {
   Reconstruction reconstruction;
   reconstruction.Read(input_path);
 
-  PrintHeading1("Aligning Reconstruction");
+  LOG_HEADING1("Aligning Reconstruction");
 
   Sim3d new_from_old_world;
 
@@ -913,7 +913,7 @@ int RunModelSplitter(int argc, char** argv) {
     overlap_ratio = 0.0;
   }
 
-  PrintHeading1("Splitting sparse model");
+  LOG_HEADING1("Splitting sparse model");
   LOG(INFO) << StringPrintf("=> Using \"%s\" split type", split_type.c_str());
 
   Reconstruction reconstruction;
@@ -921,14 +921,14 @@ int RunModelSplitter(int argc, char** argv) {
 
   Sim3d tform;
   if (!gps_transform_path.empty()) {
-    PrintHeading2("Reading model to ECEF transform");
+    LOG_HEADING2("Reading model to ECEF transform");
     is_gps = true;
     tform = Inverse(Sim3d::FromFile(gps_transform_path));
   }
 
   // Create the necessary number of reconstructions based on the split method
   // and get the bounding boxes for each sub-reconstruction
-  PrintHeading2("Computing bounding boxes");
+  LOG_HEADING2("Computing bounding boxes");
   std::vector<std::string> tile_keys;
   std::vector<Eigen::AlignedBox3d> exact_bboxes;
   StringToLower(&split_type);
@@ -991,7 +991,7 @@ int RunModelSplitter(int argc, char** argv) {
     padded_bboxes.emplace_back(bbox.min() - padding, bbox.max() + padding);
   }
 
-  PrintHeading2("Applying split and writing reconstructions");
+  LOG_HEADING2("Applying split and writing reconstructions");
   const size_t num_parts = padded_bboxes.size();
   LOG(INFO) << StringPrintf("=> Splitting to %d parts", num_parts);
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -593,7 +593,7 @@ int RunPointTriangulator(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  PrintHeading1("Loading model");
+  LOG_HEADING1("Loading model");
 
   auto reconstruction = std::make_shared<Reconstruction>();
   reconstruction->Read(input_path);

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -152,7 +152,8 @@ COLMAPUndistorter::COLMAPUndistorter(const UndistortCameraOptions& options,
       image_ids_(image_ids) {}
 
 void COLMAPUndistorter::Run() {
-  PrintHeading1("Image undistortion");
+  LOG_HEADING1("Image undistortion");
+
   Timer run_timer;
   run_timer.Start();
 
@@ -294,9 +295,10 @@ PMVSUndistorter::PMVSUndistorter(const UndistortCameraOptions& options,
       reconstruction_(reconstruction) {}
 
 void PMVSUndistorter::Run() {
+  LOG_HEADING1("Image undistortion (CMVS/PMVS)");
+
   Timer run_timer;
   run_timer.Start();
-  PrintHeading1("Image undistortion (CMVS/PMVS)");
 
   CreateDirIfNotExists(JoinPaths(output_path_, "pmvs"));
   CreateDirIfNotExists(JoinPaths(output_path_, "pmvs/txt"));
@@ -529,9 +531,10 @@ CMPMVSUndistorter::CMPMVSUndistorter(const UndistortCameraOptions& options,
       reconstruction_(reconstruction) {}
 
 void CMPMVSUndistorter::Run() {
+  LOG_HEADING1("Image undistortion (CMP-MVS)");
+
   Timer run_timer;
   run_timer.Start();
-  PrintHeading1("Image undistortion (CMP-MVS)");
 
   ThreadPool thread_pool;
   std::vector<std::shared_future<bool>> futures;
@@ -596,9 +599,10 @@ PureImageUndistorter::PureImageUndistorter(
       image_names_and_cameras_(image_names_and_cameras) {}
 
 void PureImageUndistorter::Run() {
+  LOG_HEADING1("Image undistortion");
+
   Timer run_timer;
   run_timer.Start();
-  PrintHeading1("Image undistortion");
 
   CreateDirIfNotExists(output_path_);
 
@@ -662,7 +666,8 @@ StereoImageRectifier::StereoImageRectifier(
       reconstruction_(reconstruction) {}
 
 void StereoImageRectifier::Run() {
-  PrintHeading1("Stereo rectification");
+  LOG_HEADING1("Stereo rectification");
+
   Timer run_timer;
   run_timer.Start();
 

--- a/src/colmap/mvs/fusion.cc
+++ b/src/colmap/mvs/fusion.cc
@@ -75,7 +75,7 @@ int FindNextImage(const std::vector<std::vector<int>>& overlapping_images,
 
 void StereoFusionOptions::Print() const {
 #define PrintOption(option) LOG(INFO) << #option ": " << (option);
-  PrintHeading2("StereoFusion::Options");
+  LOG_HEADING2("StereoFusion::Options");
   PrintOption(mask_path);
   PrintOption(max_image_size);
   PrintOption(min_num_pixels);

--- a/src/colmap/mvs/patch_match.cc
+++ b/src/colmap/mvs/patch_match.cc
@@ -50,7 +50,7 @@ PatchMatch::PatchMatch(const PatchMatchOptions& options, const Problem& problem)
 PatchMatch::~PatchMatch() {}
 
 void PatchMatch::Problem::Print() const {
-  PrintHeading2("PatchMatch::Problem");
+  LOG_HEADING2("PatchMatch::Problem");
   LOG(INFO) << "ref_image_idx: " << ref_image_idx;
   LOG(INFO) << "src_image_idxs: ";
   if (!src_image_idxs.empty()) {
@@ -124,7 +124,7 @@ void PatchMatch::Check() const {
 }
 
 void PatchMatch::Run() {
-  PrintHeading2("PatchMatch::Run");
+  LOG_HEADING2("PatchMatch::Run");
 
   Check();
 
@@ -409,10 +409,10 @@ void PatchMatchController::ProcessProblem(const PatchMatchOptions& options,
     return;
   }
 
-  PrintHeading1(StringPrintf("Processing view %d / %d for %s",
-                             problem_idx + 1,
-                             problems_.size(),
-                             image_name.c_str()));
+  LOG_HEADING1(StringPrintf("Processing view %d / %d for %s",
+                            problem_idx + 1,
+                            problems_.size(),
+                            image_name.c_str()));
 
   auto patch_match_options = options;
 

--- a/src/colmap/mvs/patch_match_options.cc
+++ b/src/colmap/mvs/patch_match_options.cc
@@ -43,7 +43,7 @@ const static size_t kMaxPatchMatchWindowRadius = 32;
 #define PrintOption(option) LOG(INFO) << #option ": " << option
 
 void PatchMatchOptions::Print() const {
-  PrintHeading2("PatchMatchOptions");
+  LOG_HEADING2("PatchMatchOptions");
   PrintOption(max_image_size);
   PrintOption(gpu_index);
   PrintOption(depth_min);

--- a/src/colmap/util/misc.cc
+++ b/src/colmap/util/misc.cc
@@ -32,24 +32,8 @@
 #include "colmap/util/logging.h"
 
 #include <cstdarg>
-#include <sstream>
 
 namespace colmap {
-
-void PrintHeading1(const std::string& heading) {
-  std::ostringstream log;
-  log << '\n' << std::string(78, '=') << '\n';
-  log << heading << '\n';
-  log << std::string(78, '=');
-  LOG(INFO) << log.str();
-}
-
-void PrintHeading2(const std::string& heading) {
-  std::ostringstream log;
-  log << '\n' << heading << '\n';
-  log << std::string(std::min<int>(heading.size(), 78), '-');
-  LOG(INFO) << log.str();
-}
 
 void RemoveCommandLineArgument(const std::string& arg, int* argc, char** argv) {
   for (int i = 0; i < *argc; ++i) {

--- a/src/colmap/util/misc.h
+++ b/src/colmap/util/misc.h
@@ -44,11 +44,13 @@ namespace colmap {
 #define STRINGIFY_(s) #s
 #endif  // STRINGIFY
 
-// Log first-order heading with over- and underscores.
-void PrintHeading1(const std::string& heading);
+#ifndef LOG_HEADING1
+#define LOG_HEADING1(message) LOG(INFO) << "=== " << (message) << " ===";
+#endif  // LOG_HEADING1
 
-// Log second-order heading with underscores.
-void PrintHeading2(const std::string& heading);
+#ifndef LOG_HEADING2
+#define LOG_HEADING2(message) LOG(INFO) << "--- " << (message) << " ---";
+#endif  // LOG_HEADING2
 
 // Check if vector contains elements.
 template <typename T>

--- a/src/glomap/sfm/global_mapper.cc
+++ b/src/glomap/sfm/global_mapper.cc
@@ -5,6 +5,7 @@
 #include "colmap/sfm/incremental_mapper.h"
 #include "colmap/sfm/observation_manager.h"
 #include "colmap/util/logging.h"
+#include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 #include "glomap/estimators/rotation_averaging.h"
@@ -441,7 +442,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Run rotation averaging
   if (!opts.skip_rotation_averaging) {
-    LOG(INFO) << "----- Running rotation averaging -----";
+    LOG_HEADING1("Running rotation averaging");
     colmap::Timer run_timer;
     run_timer.Start();
     if (!RotationAveraging(opts.rotation_averaging)) {
@@ -453,7 +454,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Track establishment and selection
   if (!opts.skip_track_establishment) {
-    LOG(INFO) << "----- Running track establishment -----";
+    LOG_HEADING1("Running track establishment");
     colmap::Timer run_timer;
     run_timer.Start();
     EstablishTracks(opts);
@@ -463,7 +464,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Global positioning
   if (!opts.skip_global_positioning) {
-    LOG(INFO) << "----- Running global positioning -----";
+    LOG_HEADING1("Running global positioning");
     colmap::Timer run_timer;
     run_timer.Start();
     if (!GlobalPositioning(opts.global_positioning,
@@ -478,7 +479,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Bundle adjustment
   if (!opts.skip_bundle_adjustment) {
-    LOG(INFO) << "----- Running iterative bundle adjustment -----";
+    LOG_HEADING1("Running iterative bundle adjustment");
     colmap::Timer run_timer;
     run_timer.Start();
     if (!IterativeBundleAdjustment(opts.bundle_adjustment,
@@ -493,7 +494,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Retriangulation
   if (!opts.skip_retriangulation) {
-    LOG(INFO) << "----- Running iterative retriangulation and refinement -----";
+    LOG_HEADING1("Running iterative retriangulation and refinement");
     colmap::Timer run_timer;
     run_timer.Start();
     if (!IterativeRetriangulateAndRefine(opts.retriangulation,
@@ -508,7 +509,7 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
 
   // Reconstruction pruning
   if (!opts.skip_pruning) {
-    LOG(INFO) << "----- Running postprocessing -----";
+    LOG_HEADING1("Running postprocessing");
     colmap::Timer run_timer;
     run_timer.Start();
     cluster_ids = PruneWeaklyConnectedFrames(*reconstruction_);


### PR DESCRIPTION
* Consistently uses the same format in colmap and glomap.
* Changes the heading format to always log in a single line instead of the multi-line format before.
* Inlines the logging code, such that the source of the log message can be easily traced (i.e., instead of before always showing "misc.cc:XX" it now shows the actual source file as the origin).