### PR TITLE
Bug fix for generalized absolute pose estimator.

### DIFF
--- a/src/colmap/estimators/generalized_absolute_pose.cc
+++ b/src/colmap/estimators/generalized_absolute_pose.cc
@@ -68,6 +68,7 @@ void GP3PEstimator::Estimate(const std::vector<X_t>& points2D,
     poselib::gp3p(origins_in_rig, rays_in_rig, points3D, &poses);
   }
 
+  rigs_from_world->clear();
   rigs_from_world->reserve(poses.size());
   for (const poselib::CameraPose& pose : poses) {
     rigs_from_world->emplace_back(ConvertPoseLibPoseToRigid3d(pose));


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/4023. 

In the meantime the experiments also show that using Eigen::Matrix3x4d over Rigid3d can speed up the scoring by ~3 times, which was the bottleneck of ransac. This update is not urgent and is left for future PRs.