### PR TITLE
Clear model outputs in all estimators and RANSACs

### DIFF
--- a/src/colmap/estimators/absolute_pose.cc
+++ b/src/colmap/estimators/absolute_pose.cc
@@ -48,6 +48,8 @@ void P3PEstimator::Estimate(const std::vector<X_t>& points2D,
   THROW_CHECK_EQ(points3D.size(), 3);
   THROW_CHECK_NOTNULL(cams_from_world);
 
+  cams_from_world->clear();
+
   std::vector<Eigen::Vector3d> rays(3);
   for (int i = 0; i < 3; ++i) {
     rays[i] = points2D[i].camera_ray;
@@ -76,6 +78,8 @@ void P4PFEstimator::Estimate(const std::vector<X_t>& points2D,
   THROW_CHECK_EQ(points2D.size(), 4);
   THROW_CHECK_EQ(points3D.size(), 4);
   THROW_CHECK_NOTNULL(models);
+
+  models->clear();
 
   std::vector<poselib::CameraPose> poses;
   std::vector<double> focals;

--- a/src/colmap/estimators/generalized_absolute_pose.cc
+++ b/src/colmap/estimators/generalized_absolute_pose.cc
@@ -47,6 +47,8 @@ void GP3PEstimator::Estimate(const std::vector<X_t>& points2D,
   THROW_CHECK_EQ(points3D.size(), 3);
   THROW_CHECK_NOTNULL(rigs_from_world);
 
+  rigs_from_world->clear();
+
   std::vector<Eigen::Vector3d> rays_in_rig(3);
   std::vector<Eigen::Vector3d> origins_in_rig(3);
   for (int i = 0; i < 3; ++i) {
@@ -68,7 +70,6 @@ void GP3PEstimator::Estimate(const std::vector<X_t>& points2D,
     poselib::gp3p(origins_in_rig, rays_in_rig, points3D, &poses);
   }
 
-  rigs_from_world->clear();
   rigs_from_world->reserve(poses.size());
   for (const poselib::CameraPose& pose : poses) {
     rigs_from_world->emplace_back(ConvertPoseLibPoseToRigid3d(pose));

--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -157,6 +157,7 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
     sampler.SampleXY(X, Y, &X_rand, &Y_rand);
 
     // Estimate model for current subset.
+    sample_models.clear();
     estimator.Estimate(X_rand, Y_rand, &sample_models);
 
     // Iterate through all estimated models
@@ -191,6 +192,7 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
               }
             }
 
+            local_models.clear();
             local_estimator.Estimate(X_inlier, Y_inlier, &local_models);
 
             const size_t prev_best_num_inliers = best_support.num_inliers;

--- a/src/colmap/optim/ransac.h
+++ b/src/colmap/optim/ransac.h
@@ -249,6 +249,7 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
     sampler.SampleXY(X, Y, &X_rand, &Y_rand);
 
     // Estimate model for current subset.
+    sample_models.clear();
     estimator.Estimate(X_rand, Y_rand, &sample_models);
 
     // Iterate through all estimated models.


### PR DESCRIPTION
* Both P3P and P4PF were missing calls to clear(). In practice, this was only an issue in P4PF, as poselib clears the solutions in P3P.
* Added further protection against such bugs in the future by clearing the sampled models explicitly also in the RANSACs before calling Estimate().