### PR TITLE
Cleanup outdated pycolmap deprecations

### DIFF
--- a/src/pycolmap/estimators/essential_matrix.cc
+++ b/src/pycolmap/estimators/essential_matrix.cc
@@ -105,5 +105,4 @@ void BindEssentialMatrixEstimator(py::module& m) {
         py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
         "Robustly estimate essential matrix with LO-RANSAC and decompose it "
         "using the cheirality check.");
-  DefDeprecation(m, "essential_matrix_estimation", "estimate_essential_matrix");
 }

--- a/src/pycolmap/estimators/fundamental_matrix.cc
+++ b/src/pycolmap/estimators/fundamental_matrix.cc
@@ -46,6 +46,4 @@ void BindFundamentalMatrixEstimator(py::module& m) {
         "points2D2"_a,
         py::arg_v("estimation_options", ransac_options, "RANSACOptions()"),
         "Robustly estimate fundamental matrix with LO-RANSAC.");
-  DefDeprecation(
-      m, "fundamental_matrix_estimation", "estimate_fundamental_matrix");
 }

--- a/src/pycolmap/estimators/generalized_pose.cc
+++ b/src/pycolmap/estimators/generalized_pose.cc
@@ -209,9 +209,6 @@ void BindGeneralizedAbsolutePoseEstimator(py::module& m) {
         "return_covariance"_a = false,
         "Robustly estimate generalized absolute pose using LO-RANSAC"
         "followed by non-linear refinement.");
-  DefDeprecation(m,
-                 "rig_absolute_pose_estimation",
-                 "estimate_and_refine_generalized_absolute_pose");
 
   m.def("estimate_generalized_relative_pose",
         &PyEstimateGeneralizedRelativePose,

--- a/src/pycolmap/estimators/homography_matrix.cc
+++ b/src/pycolmap/estimators/homography_matrix.cc
@@ -43,6 +43,4 @@ void BindHomographyMatrixEstimator(py::module& m) {
         "points2D2"_a,
         py::arg_v("estimation_options", est_options, "RANSACOptions()"),
         "Robustly estimate homography matrix using LO-RANSAC.");
-  DefDeprecation(
-      m, "homography_matrix_estimation", "estimate_homography_matrix");
 }

--- a/src/pycolmap/estimators/pose.cc
+++ b/src/pycolmap/estimators/pose.cc
@@ -228,8 +228,6 @@ void BindAbsolutePoseEstimator(py::module& m) {
         "return_covariance"_a = false,
         "Robust absolute pose estimation with LO-RANSAC "
         "followed by non-linear refinement.");
-  DefDeprecation(
-      m, "absolute_pose_estimation", "estimate_and_refine_absolute_pose");
 
   m.def("estimate_relative_pose",
         &PyEstimateRelativePose,

--- a/src/pycolmap/estimators/two_view_geometry.cc
+++ b/src/pycolmap/estimators/two_view_geometry.cc
@@ -136,5 +136,4 @@ void BindTwoViewGeometryEstimator(py::module& m) {
       "Calculate the squared Sampson error for a given essential or "
       "fundamental matrix.",
       py::call_guard<py::gil_scoped_release>());
-  DefDeprecation(m, "squared_sampson_error", "compute_squared_sampson_error");
 }

--- a/src/pycolmap/feature/extraction.cc
+++ b/src/pycolmap/feature/extraction.cc
@@ -35,18 +35,6 @@ class Sift {
       : use_gpu_(IsGPU(device)) {
     if (options) {
       options_ = std::move(*options);
-    } else {
-      // For backwards compatibility.
-      PyErr_WarnEx(PyExc_DeprecationWarning,
-                   "No SIFT extraction options specified. Setting them to "
-                   "peak_threshold=0.01, first_octave=0, max_image_size=7000 "
-                   "for backwards compatibility. If you want to keep the "
-                   "settings, explicitly specify them, because the defaults "
-                   "will change in the next major release.",
-                   1);
-      options_.max_image_size = 7000;
-      options_.sift->peak_threshold = 0.01;
-      options_.sift->first_octave = 0;
     }
     options_.use_gpu = use_gpu_;
     THROW_CHECK(options_.Check());

--- a/src/pycolmap/geometry/homography_matrix.cc
+++ b/src/pycolmap/geometry/homography_matrix.cc
@@ -41,5 +41,4 @@ void BindHomographyMatrixGeometry(py::module& m) {
         "cam_rays2"_a,
         "Recover the most probable pose from the given homography matrix using "
         "the cheirality check.");
-  DefDeprecation(m, "homography_decomposition", "pose_from_homography_matrix");
 }

--- a/src/pycolmap/geometry/triangulation.cc
+++ b/src/pycolmap/geometry/triangulation.cc
@@ -43,9 +43,6 @@ void BindTriangulation(py::module& m) {
         "proj_center2"_a,
         "point3D"_a,
         "Calculate triangulation angle in radians.");
-  DefDeprecation(m, "TriangulatePoint", "triangulate_point");
-  DefDeprecation(
-      m, "CalculateTriangulationAngle", "calculate_triangulation_angle");
 
   m.def(
       "triangulate_mid_point",

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -173,18 +173,6 @@ void BindCamera(py::module& m) {
            "Project point from camera frame to image plane.")
       .def(
           "img_from_cam",
-          [](const Camera& self, const Eigen::Vector2d& cam_point) {
-            PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "img_from_cam() with normalized 2D points as input is "
-                "deprecated. Instead, pass 3D points in the camera frame.",
-                1);
-            return self.ImgFromCam(cam_point.homogeneous());
-          },
-          "cam_point"_a,
-          "(Deprecated) Project point from camera frame to image plane.")
-      .def(
-          "img_from_cam",
           [](const Camera& self,
              const py::EigenDRef<const Eigen::MatrixX3d>& cam_points) {
             const size_t num_points = cam_points.rows();
@@ -192,45 +180,6 @@ void BindCamera(py::module& m) {
             for (size_t i = 0; i < num_points; ++i) {
               const std::optional<Eigen::Vector2d> image_point =
                   self.ImgFromCam(cam_points.row(i));
-              if (image_point) {
-                image_points[i] = *image_point;
-              } else {
-                image_points[i].setConstant(
-                    std::numeric_limits<double>::quiet_NaN());
-              }
-            }
-            return image_points;
-          },
-          "cam_points"_a,
-          "Project list of points from camera frame to image plane.")
-      .def(
-          "img_from_cam",
-          [](const Camera& self,
-             const py::EigenDRef<const Eigen::MatrixX2d>& cam_points) {
-            PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "img_from_cam() with normalized 2D points as input is "
-                "deprecated. Instead, pass 3D points in the camera frame.",
-                1);
-            return py::cast(self).attr("img_from_cam")(
-                cam_points.rowwise().homogeneous());
-          },
-          "cam_points"_a,
-          "(Deprecated) Project list of points from camera frame to image "
-          "plane.")
-      .def(
-          "img_from_cam",
-          [](const Camera& self, const Point2DVector& cam_points) {
-            PyErr_WarnEx(
-                PyExc_DeprecationWarning,
-                "img_from_cam() with normalized 2D points as input is "
-                "deprecated. Instead, pass 3D points in the camera frame.",
-                1);
-            const size_t num_points = cam_points.size();
-            std::vector<Eigen::Vector2d> image_points(num_points);
-            for (size_t i = 0; i < num_points; ++i) {
-              const std::optional<Eigen::Vector2d> image_point =
-                  self.ImgFromCam(cam_points[i].xy.homogeneous());
               if (image_point) {
                 image_points[i] = *image_point;
               } else {


### PR DESCRIPTION
Some overdue housekeeping:
  1. src/pycolmap/estimators/homography_matrix.cc - Removed homography_matrix_estimation alias                                                                                                                                                                                                        
  2. src/pycolmap/estimators/pose.cc - Removed absolute_pose_estimation alias                                                                                                                                                                                                                         
  3. src/pycolmap/estimators/fundamental_matrix.cc - Removed fundamental_matrix_estimation alias                                                                                                                                                                                                      
  4. src/pycolmap/estimators/two_view_geometry.cc - Removed squared_sampson_error alias                                                                                                                                                                                                               
  5. src/pycolmap/estimators/essential_matrix.cc - Removed essential_matrix_estimation alias                                                                                                                                                                                                          
  6. src/pycolmap/geometry/homography_matrix.cc - Removed homography_decomposition alias                                                                                                                                                                                                              
  7. src/pycolmap/feature/extraction.cc - Removed backwards-compatibility SIFT defaults warning                                                                                                                                                                                                       
  8. src/pycolmap/scene/camera.cc - Removed 3 deprecated img_from_cam overloads (2D point versions)                                                                                                                                                                                                   
  9. src/pycolmap/geometry/triangulation.cc - Removed TriangulatePoint and CalculateTriangulationAngle aliases                                                                                                                                                                                        
  10. src/pycolmap/estimators/generalized_pose.cc - Removed rig_absolute_pose_estimation alias 
  
All the newer deprecations (after Nov 7, 2025) are still in place:                                                                                                                                                                                                                                  
  - correspondence_graph.cc:138-144 - Jan 10, 2026 deprecations (kept)                                                                                                                                                                                                                                
  - camera.cc:205 - Jan 12, 2026 Camera.create deprecation (kept)                                                                                                                                                                                                                                     
  - pose_prior.cc:36-37 - Dec 2, 2025 deprecations (kept)            