### PR TITLE
Fix Windows build instructions for PyCOLMAP

### DIFF
--- a/doc/pycolmap/index.rst
+++ b/doc/pycolmap/index.rst
@@ -26,11 +26,20 @@ To build PyCOLMAP from source, follow these steps:
 
       python -m pip install .
 
-   * On Windows, after installing COLMAP via VCPKG, run in powershell::
+   * On Windows, after installing COLMAP via VCPKG per the installation guide above:
 
-      python -m pip install . `
-          --cmake.define.CMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
-          --cmake.define.VCPKG_TARGET_TRIPLET="x64-windows"
+     1. Determine the installed COLMAP version:
+        ``<VCPKG_ROOT>\packages\colmap_<TRIPLET>\tools\colmap\colmap.exe help``
+     2. Check out the corresponding version tag: ``git checkout tags/3.XX.X``
+     3. Run the following in PowerShell, replacing ``$VCPKG_ROOT`` with your vcpkg
+        installation root::
+
+           python -m pip install . `
+               -C skbuild.cmake.define.CMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+               -C skbuild.cmake.define.VCPKG_TARGET_TRIPLET="x64-windows"
+
+     If you get linker errors when building PyCOLMAP on Windows, ensure the
+     repository version matches the COLMAP version installed via VCPKG.
 
 Some features, such as cost functions, require that `PyCeres
 <https://github.com/cvg/pyceres>`_ is installed in the same manner as PyCOLMAP,

--- a/python/README.md
+++ b/python/README.md
@@ -22,12 +22,18 @@ The wheels are automatically built and pushed to [PyPI](https://pypi.org/project
      ```bash
      python -m pip install .
      ```
-   - On Windows, after installing COLMAP [via VCPKG](https://colmap.github.io/install.html#id3), run in powershell:
-     ```powershell
-     python -m pip install . `
-         --cmake.define.CMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
-         --cmake.define.VCPKG_TARGET_TRIPLET="x64-windows"
-     ```
+   - On Windows, after installing COLMAP via VCPKG per the installation guide above:
+     1. Determine the installed COLMAP version: `<VCPKG_ROOT>\packages\colmap_<TRIPLET>\tools\colmap\colmap.exe help`
+     2. Check out the corresponding version tag: `git checkout tags/3.XX.X`
+     3. Run the following in PowerShell, replacing `$VCPKG_ROOT` with your vcpkg installation root:
+        ```powershell
+        python -m pip install . `
+            -C skbuild.cmake.define.CMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -C skbuild.cmake.define.VCPKG_TARGET_TRIPLET="x64-windows"
+        ```
+
+   If you get linker errors when building PyCOLMAP on Windows, ensure the repository version matches the COLMAP version installed via VCPKG.
+
 
 </details>
 


### PR DESCRIPTION
## Summary

The current build instructions for PyCOLMAP don't work on Windows. This PR:

- Fixes the pip install syntax from `--cmake.define` to the correct `-C skbuild.cmake.define` format
- Adds steps to verify the installed COLMAP version and check out the matching tag, which is required to avoid linker errors
- Updates both `python/README.md` and `doc/pycolmap/index.rst` with consistent instructions

Based on #3746 by @JCRPaquin, rebased onto main and addressing @sarlinpe's comment to also update `doc/pycolmap/index.rst`.