### PR TITLE
Fix doc ordering for sphinx==0.9.1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,30 +300,30 @@ autoclass_content = "both"
 autodoc_member_order = "bysource"
 autodoc_typehints = "both"
 python_maximum_signature_line_length = 120
+autodoc_use_legacy_class_based = True
 
 
-class MyClassDocumenter(autodoc.ClassDocumenter):
-    def sort_members(
-        self, documenters: list[tuple[autodoc.Documenter, bool]], order: str
-    ) -> list[tuple[autodoc.Documenter, bool]]:
-        """Order the members by their definition order."""
-        class_names = list(self.object.__dict__)
+def sort_members(
+    self, documenters: list[tuple[autodoc.Documenter, bool]], order: str
+) -> list[tuple[autodoc.Documenter, bool]]:
+    """Order the members by their definition order."""
+    class_names = list(self.object.__dict__)
 
-        def keyfunc(entry: tuple[autodoc.Documenter, bool]) -> int:
-            name = entry[0].name.split("::")[1].split(".")[1]
-            if name in class_names:
-                return class_names.index(name)
-            else:
-                return len(class_names)
+    def keyfunc(entry: tuple[autodoc.Documenter, bool]) -> int:
+        name = entry[0].name.split("::")[1].split(".")[1]
+        if name in class_names:
+            return class_names.index(name)
+        else:
+            return len(class_names)
 
-        documenters.sort(key=keyfunc)
-        return documenters
+    documenters.sort(key=keyfunc)
+    return documenters
 
 
 # autodoc_member_order=bysource does not work for C++-defined classes since they
 # cannot be introspected and do not have an __all__ list. Instead,
 # we extract the definition order from object.__dict__.
-autodoc.ClassDocumenter = MyClassDocumenter
+autodoc.ClassDocumenter.sort_members = sort_members
 
 
 def process_doc(app, what, name, obj, options, lines):


### PR DESCRIPTION
https://github.com/colmap/colmap/pull/4086 broke the ordering of the API documentation, as reflected at https://colmap.github.io/pycolmap/pycolmap.html (we want class members to be ordered by source, not alphabetically, such that properties are grouped together). This PR fixes it. I haven't figured out how to use the newer, non-legacy API, so leaving this for later.