### PR TITLE
Fix incorrect propagation of incremental options in automatic reconstructor

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -291,7 +291,8 @@ void AutomaticReconstructionController::RunSparseMapper() {
   auto database = Database::Open(*option_manager_.database_path);
   switch (options_.mapper) {
     case Mapper::INCREMENTAL: {
-      auto options = std::make_shared<IncrementalPipelineOptions>(*option_manager_.mapper);
+      auto options =
+          std::make_shared<IncrementalPipelineOptions>(*option_manager_.mapper);
       options->image_path = *option_manager_.image_path;
       mapper = std::make_unique<IncrementalPipeline>(
           options, std::move(database), reconstruction_manager_);


### PR DESCRIPTION
Following a recent refactoring, points are not correctly colored:
```
W20260219 17:08:46.952725 58025892 incremental_pipeline.cc:90] Could not read image DSC_0518.JPG at path "".
```