### PR TITLE
Fix inverted units in ExifFocalLength metadata extraction

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -340,21 +340,21 @@ std::optional<double> Bitmap::ExifFocalLength() const {
         double pixels_per_mm = 0;
         switch (focal_x_res_unit) {
           case 2:  // inches
-            pixels_per_mm = focal_x_res * 25.4;
+            pixels_per_mm = focal_x_res / 25.4;
             break;
           case 3:  // cm
-            pixels_per_mm = focal_x_res * 10.0;
+            pixels_per_mm = focal_x_res / 10.0;
             break;
           case 4:  // mm
             pixels_per_mm = focal_x_res * 1.0;
             break;
           case 5:  // um
-            pixels_per_mm = focal_x_res * 0.1;
+            pixels_per_mm = focal_x_res * 1000.0;
             break;
           default:
             LOG(FATAL) << "Unexpected FocalPlaneXResolution value";
         }
-        return focal_length_mm / pixels_per_mm;
+        return focal_length_mm * pixels_per_mm;
       }
     }
 


### PR DESCRIPTION
This PR corrects the focal length calculation logic within the FocalPlaneXResolution metadata block. 

The current implementation in the main branch contains a double inversion error:
1. Unit Conversion: It was treating resolution units as "distance per pixel" rather than "pixels per unit" (e.g., multiplying by 25.4 for inches instead of dividing), leading to an incorrect pixel density scale.
2. Final Calculation: It was dividing focal_length_mm by pixels_per_mm. The correct projection from millimeters to pixels requires multiplication (f_px = f_mm * pixels_per_mm).

This regression causes focal length estimates to be near zero (orders of magnitude too small), which prevents successful image registration and triangulation. 

The fix aligns the OpenImageIO-based metadata extraction with the correct physical camera model and restores the behavior found in previous stable releases (v3.13).