### PR TITLE
Correctly set the rpath in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,17 @@ if(IS_MACOS)
     add_link_options(LINKER:-no_warn_duplicate_libraries)
 endif()
 
+# Correctly set RPATH to look up dependencies.
+if(NOT IS_MSVC)
+    if (IS_MACOS)
+        set(RPATH_BASE "@executable_path")
+    else ()
+        set(RPATH_BASE "$ORIGIN")
+    endif ()
+    file(RELATIVE_PATH INSTALL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+    list(APPEND CMAKE_INSTALL_RPATH "${RPATH_BASE}/${INSTALL_LIB_DIR}")
+endif()
+
 if(IS_DEBUG)
     add_compile_definitions(EIGEN_INITIALIZE_MATRICES_BY_NAN)
 endif()


### PR DESCRIPTION
On macOS, the ONNX runtime is dynamically linked as rpath and correctly copied into $CMAKE_INSTALL_PREFIX/lib, but the executable fails to find it:
```bash
$ colmap
dyld[11547]: Library not loaded: @rpath/libonnxruntime.1.24.1.dylib
  Referenced from: <A09CACEF-7AC0-306B-A18D-81290DCBB49E> $HOME/.local/bin/colmap
  Reason: no LC_RPATH's found

$ otool -L $(which colmap)
$HOME/.local/bin/colmap:
        ...
        @rpath/libonnxruntime.1.24.1.dylib (compatibility version 0.0.0, current version 1.24.1)
        ...
```
Setting CMAKE_INSTALL_RPATH seems to fix it.