### PR TITLE
Fixing OpenGL profiles on Linux (Ubuntu 25.10)

### DIFF
--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -318,6 +318,7 @@ ModelViewerWidget::ModelViewerWidget(QWidget* parent, OptionManager* options)
   format.setMajorVersion(3);
   format.setMinorVersion(2);
   format.setSamples(4);
+  format.setRenderableType(QSurfaceFormat::OpenGL);
   format.setProfile(QSurfaceFormat::CoreProfile);
 #ifdef DEBUG
   format.setOption(QSurfaceFormat::DebugContext);


### PR DESCRIPTION
On latest Ubuntu with nVidia drivers 580, the Qt OpenGL profiles get initialized as OpenGL ES by default. Running colmap then leads to:

```
OpenGLShader::compile(Vertex): 0(2) : error C0201: unsupported version 150
0(2) : error C7532: global type mat4 requires "#version 100" or later
0(4) : error C7532: global type vec3 requires "#version 100" or later
0(5) : error C7532: global type vec4 requires "#version 100" or later
0(6) : error C5060: out can't be used with non-varying v_pos
0(7) : error C5060: out can't be used with non-varying v_color
```

... and a lot of other similar printouts, with an empty viewport.

All the shaders in the repo are:

```
#version 150
```

-> OpenGL 3.2, compatibility profile. However, the QSurfaceFormat is set to 3.2, Core profile, and without explicitly defining the renderable type (which defaults to ES with the Ubuntu build).

This diff makes these options explicit.