### PR TITLE
Add missing include

### DIFF
--- a/src/colmap/feature/matcher.h
+++ b/src/colmap/feature/matcher.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/feature/types.h"
+#include "colmap/geometry/pose_prior.h"
 #include "colmap/scene/camera.h"
 #include "colmap/scene/two_view_geometry.h"
 #include "colmap/util/types.h"


### PR DESCRIPTION
Fixes an error at HEAD following a race condition between https://github.com/colmap/colmap/pull/4132 and https://github.com/colmap/colmap/pull/4135.