### PR TITLE
Explicitly accept dragMoveEvent to fix broken drag-and-drop in Qt6

### DIFF
--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -230,11 +230,11 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent* event) {
-  const QMimeData* mime_data = event->mimeData();
-  if (mime_data->hasUrls()) {
-    return event->acceptProposedAction();
-  }
-  event->ignore();
+  HandleDragEvent(event);
+}
+
+void MainWindow::dragMoveEvent(QDragMoveEvent* event) {
+  HandleDragEvent(event);
 }
 
 void MainWindow::dropEvent(QDropEvent* event) {
@@ -801,6 +801,14 @@ void MainWindow::CreateControllers() {
           action_reconstruction_reset_->trigger();
         }
       });
+}
+
+void MainWindow::HandleDragEvent(QDropEvent* event) {
+  if (event->mimeData()->hasUrls()) {
+    event->acceptProposedAction();
+  } else {
+    event->ignore();
+  }
 }
 
 void MainWindow::ProjectNew() {

--- a/src/colmap/ui/main_window.h
+++ b/src/colmap/ui/main_window.h
@@ -67,6 +67,7 @@ class MainWindow : public QMainWindow {
  protected:
   void closeEvent(QCloseEvent* event) override;
   void dragEnterEvent(QDragEnterEvent* event) override;
+  void dragMoveEvent(QDragMoveEvent* event) override;
   void dropEvent(QDropEvent* event) override;
 
  private:
@@ -80,6 +81,8 @@ class MainWindow : public QMainWindow {
   void CreateToolbar();
   void CreateStatusbar();
   void CreateControllers();
+
+  void HandleDragEvent(QDropEvent* event);
 
   void ProjectNew();
   bool ProjectOpen();


### PR DESCRIPTION
In Qt 6, drag-and-drop operations fail if `dragMoveEvent` is not explicitly handled, even if `dragEnterEvent` is accepted. This PR implements `dragMoveEvent` to ensure compatibility with Qt 6's stricter event propagation while maintaining backward compatibility with Qt 5.