### PR TITLE
Enforce compile-time type checking for option registration

### DIFF
--- a/src/colmap/controllers/base_option_manager.h
+++ b/src/colmap/controllers/base_option_manager.h
@@ -222,7 +222,7 @@ void BaseOptionManager::RegisterOption(const std::string& name,
     options_path_.emplace_back(
         name, reinterpret_cast<const std::filesystem::path*>(option));
   } else {
-    LOG(FATAL_THROW) << "Unsupported option type";
+    static_assert(always_false<T>::value, "Unsupported option type");
   }
 }
 

--- a/src/colmap/exe/image.cc
+++ b/src/colmap/exe/image.cc
@@ -163,7 +163,7 @@ int RunImageFilterer(int argc, char** argv) {
   double min_focal_length_ratio = 0.1;
   double max_focal_length_ratio = 10.0;
   double max_extra_param = 100.0;
-  size_t min_num_observations = 10;
+  int min_num_observations = 10;
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
@@ -193,7 +193,7 @@ int RunImageFilterer(int argc, char** argv) {
     bool enough_observations = false;
     for (const data_t& data_id : frame.ImageIds()) {
       const Image& image = reconstruction.Image(data_id.id);
-      if (image.NumPoints3D() >= min_num_observations) {
+      if (image.NumPoints3D() >= static_cast<size_t>(min_num_observations)) {
         enough_observations = true;
       }
     }

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -524,7 +524,7 @@ int RunPointFiltering(int argc, char** argv) {
   std::filesystem::path input_path;
   std::filesystem::path output_path;
 
-  size_t min_track_len = 2;
+  int min_track_len = 2;
   double max_reproj_error = 4.0;
   double min_tri_angle = 1.5;
 

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -331,6 +331,13 @@ struct filter_view {
   const filter_iterator<Iterator, Predicate> end_;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// Meta programming utilities / type traits.
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename>
+struct always_false : std::false_type {};
+
 }  // namespace colmap
 
 // This file provides specializations of the templated hash function for


### PR DESCRIPTION
Fixes #4147

Unsupported option types now fail at compile time via static_assert, making errors easier to diagnose and preventing unreachable runtime error paths.