### PR TITLE
Fix file THROW_CHECK_* macros from double evaluation of path expressions

### DIFF
--- a/src/colmap/util/file.h
+++ b/src/colmap/util/file.h
@@ -69,7 +69,7 @@
 #define THROW_CHECK_HAS_FILE_EXTENSION(path, ext)                              \
   {                                                                            \
     const auto& path_val = (path);                                             \
-    const auto& ext_val = ext;                                                 \
+    const auto& ext_val = (ext);                                               \
     THROW_CHECK(colmap::HasFileExtension(path_val, ext_val))                   \
         << "Path " << path_val << " does not match file extension " << ext_val \
         << ".";                                                                \


### PR DESCRIPTION
If `path` was an expression, it would lead to unintuitive double evaluation, which this PR prevents.