### PR TITLE
Expand option manager test coverage

### DIFF
--- a/src/colmap/controllers/option_manager_test.cc
+++ b/src/colmap/controllers/option_manager_test.cc
@@ -590,8 +590,8 @@ TEST(OptionManager, WriteAndReadBundleAdjustmentOptions) {
   EXPECT_FALSE(reader.bundle_adjustment->refine_focal_length);
   EXPECT_TRUE(reader.bundle_adjustment->refine_principal_point);
   EXPECT_EQ(reader.bundle_adjustment->min_track_length, 5);
-  EXPECT_EQ(
-      reader.bundle_adjustment->ceres->solver_options.max_num_iterations, 200);
+  EXPECT_EQ(reader.bundle_adjustment->ceres->solver_options.max_num_iterations,
+            200);
 }
 
 TEST(OptionManager, WriteAndReadStereoOptions) {


### PR DESCRIPTION
## Summary
- Expand test coverage for `controllers/option_manager.cc` from 13 tests to 51 tests
- Cover quality modifier methods (ModifyFor*), PostParse file loading, Write/Read round-trips for all option categories, INI parsing edge cases, idempotency, and command-line parsing for sub-options

## New test coverage areas
- **Quality modifiers** (7 tests): Verify all ModifyFor{Individual,Video,Internet}Data and ModifyFor{Low,Medium,High,Extreme}Quality set expected values
- **PostParse** (4 tests): Mapper image list, global mapper image list, constant rig/camera list file loading, and empty path handling
- **Write/Read round-trips** (12 tests): Bundle adjustment, stereo, meshing, render, gravity refiner, reconstruction clusterer, sequential/spatial/transitive pairing, two-view geometry, global mapper, and all-options round-trip
- **INI parsing** (2 tests): Unregistered options with allow_unregistered=true (warning path) and allow_unregistered=false (rejection path)
- **Idempotency** (1 test): All remaining Add*Options methods called twice without error
- **Command-line parsing** (4 tests): Feature matching, mapper sub-options, global mapper sub-options, patch match stereo
- **Other** (8 tests): Composite Add* dependency wiring, Reset-then-re-add, constructor with add_project_options=false, Check on defaults, ResetOptions for all sub-structs, Read failure on Check failure, cumulative quality modifiers

## Test plan
```
cd build && cmake --build . --target colmap_controllers_option_manager_test -j$(sysctl -n hw.logicalcpu)
./src/colmap/controllers/option_manager_test
```

All 51 tests pass:
```
[==========] Running 51 tests from 1 test suite.
[  PASSED  ] 51 tests.
```