### PR TITLE
feat: Added CUDA and cuDSS support to Dockercontainer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,11 +46,18 @@ RUN apt-get update && \
         libcgal-dev \
         libcurl4-openssl-dev \
         libssl-dev \
-        libmkl-full-dev \
+        libopenblas-dev \
         # Ceres dependencies
         libsuitesparse-dev \
         liblapack-dev \
         curl \
+        git && \
+        # Pycolmap
+        python3 \
+        python3-pip \
+        python3-dev && \
+        # cuDNN (required by ONNX Runtime CUDA provider for ALIKED/LightGlue)
+        libcudnn9-dev-cuda-${CUDA_MAJOR} \
         # cuBLAS (needed at link time by cuDSS; not included in the cuda:devel base image)
         libcublas-dev-${CUDA_MAJOR}-${CUDA_MINOR} \
         libcublas-${CUDA_MAJOR}-${CUDA_MINOR} && \
@@ -71,8 +78,7 @@ RUN cd /tmp && \
 # 2.3.0 (main branch, unreleased) is required for cuDSS sparse solver support;
 # the latest release tag (2.2.0) only satisfies the CUDA dense solver check.
 ARG CERES_GIT_REF=master
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && \
-    CUDSS_CMAKE_DIR=$(find /usr/lib /usr/local/lib -name "cudss-config.cmake" -o -name "cudssConfig.cmake" 2>/dev/null | tail -1 | xargs -r dirname) && \
+RUN CUDSS_CMAKE_DIR=$(find /usr/lib /usr/local/lib -name "cudss-config.cmake" -o -name "cudssConfig.cmake" 2>/dev/null | tail -1 | xargs -r dirname) && \
     git clone --recurse-submodules --branch ${CERES_GIT_REF} https://github.com/ceres-solver/ceres-solver.git /tmp/ceres-solver && \
     cmake -S /tmp/ceres-solver -B /tmp/ceres-build \
     -GNinja \
@@ -84,6 +90,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_BENCHMARKS=OFF && \
     ninja -C /tmp/ceres-build install && \
+    grep -q "find_dependency(CUDAToolkit" /usr/local/lib/cmake/Ceres/CeresConfig.cmake || \                                                                                                                                                           
+            { echo "FATAL: Ceres was built without CUDA support"; exit 1; } && \                                                                                                                                                                          
+    grep -q "find_dependency(cudss" /usr/local/lib/cmake/Ceres/CeresConfig.cmake || \                                                                                                                                                                 
+            { echo "FATAL: Ceres was built without cuDSS support"; exit 1; } && \
     rm -rf /tmp/ceres-solver /tmp/ceres-build
 
 # Fix issue in Ubuntu's openimageio CMake config.
@@ -92,27 +102,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /
 RUN mkdir -p /usr/include/opencv4
 
 # Copy source into the image.
-COPY . /colmap
+COPY colmap/ /colmap
 
 # Build and install COLMAP.
 RUN cd /colmap && \
     mkdir -p build/.ccache && \
     cd build && \
+    CUDSS_CMAKE_DIR=$(find /usr/lib /usr/local/lib -name "cudss-config.cmake" -o -name "cudssConfig.cmake" 2>/dev/null | tail -1 | xargs -r dirname) && \
     cmake .. \
         -GNinja \
         -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
         ${CUDSS_CMAKE_DIR:+-Dcudss_DIR="${CUDSS_CMAKE_DIR}"} \
         -DCMAKE_INSTALL_PREFIX=/colmap-install \
-        -DFETCHCONTENT_FULLY_DISCONNECTED=${FETCHCONTENT_FULLY_DISCONNECTED} \
-        -DBLA_VENDOR=Intel10_64lp && \
+        -DFETCHCONTENT_FULLY_DISCONNECTED=${FETCHCONTENT_FULLY_DISCONNECTED} && \
     ninja install
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    python3 \
-    python3-pip \
-    python3-dev && \
-    rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
     scikit-build-core pybind11 pybind11-stubgen ruff numpy
@@ -157,10 +160,8 @@ RUN apt-get update && \
         libqt6openglwidgets6 \
         libcurl4 \
         libssl3t64 \
-        libmkl-locale \
-        libmkl-intel-lp64 \
-        libmkl-intel-thread \
-        libmkl-core \
+        libcudnn9-cuda-${CUDA_MAJOR} \
+        libopenblas0 \
         libcublas-${CUDA_MAJOR}-${CUDA_MINOR} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This change removes the two following warnings when using the global mapper:
```bash
W20260309 14:40:29.665028 11030 global_positioning.cc:371] Requested to use GPU for bundle adjustment, but Ceres was compiled without CUDA support. Falling back to CPU-based dense solvers.
W20260309 14:40:29.665100 11030 global_positioning.cc:390] Requested to use GPU for bundle adjustment, but Ceres was compiled without cuDSS support. Falling back to CPU-based sparse solvers.
```

## Remarks

`cudss-cuda-${CUDA_MAJOR} libcudss0-cuda-${CUDA_MAJOR} libcudss0-dev-cuda-${CUDA_MAJOR} libcudss0-static-cuda-${CUDA_MAJOR} ` are installed instead of `cudss` directly as this by default installs `cudss` for both CUDA 12 and 13 which is not desirable as then Colmap tries to compile with 13 by default.

## Unresolved issues

When running the global mapper I sometimes run into the following issues:

```
Linear solver fatal error: cudssExecute with CUDSS_PHASE_FACTORIZATION failed Got error: CUDSS_STATUS_ALLOC_FAILED
```

This was already brought up in https://github.com/colmap/glomap/issues/239.

## Update 22.03

I experienced https://github.com/colmap/colmap/issues/3665 when running with `libmkl` so I initially switched to `intel-oneapi-mkl` which seems to be a lot more actively maintained but with this I had runtime errors like the one below leading me to switch back all the way to `libopenblas-dev`.

```
I20260322 00:56:56.497732 4176909 pairing.cc:367] Indexing image [1/8076]                                                                                                                                                                    
*** Aborted at 1774137417 (unix time) try "date -d @1774137417" if you are using GNU date ***                                                                                                                                                
PC: @                0x0 (unknown)                                                                                                                                                                                                           
*** SIGSEGV (@0x0) received by PID 4176842 (TID 0x740fcdbde6c0) from PID 0; stack trace: ***                                                                                                                                                 
    @     0x7412b9268206 (unknown)                                                                                                                                                                                                           
    @     0x7412bca70330 (unknown)                                                                                                                                                                                                           
    @     0x7412bca7298b (unknown)                                                                                                                                                                                                           
    @     0x7412bca72bbe exit                                                                                                                                                                                                                
    @     0x741262a231e8 mkl_serv_exit                                                                                                                                                                                                       
    @     0x741262a3315a mkl_blas_get_kernel_api_version                                                                                                                                                                                     
    @     0x741267592672 mkl_blas_sgemm                                                                                                                                                                                                      
    @     0x74126ab91441 mkl_blas__sgemm                                                                                                                                                                                                     
    @     0x7412adf4ad5a (unknown)                                                                                                                                                                                                           
    @     0x7412adf4c314 faiss::knn_L2sqr()                                                                                                                                                                                                  
    @     0x7412adf4c3e4 faiss::knn_L2sqr()                                                                                                                                                                                                  
    @     0x7412ade91885 faiss::IndexFlat::search()                                                                                                                                                                                          
    @     0x7412adecef91 (unknown)                                                                                                                                                                                                           
    @     0x741266f9cc35 GOMP_parallel                                                                                                                                                                                                       
    @     0x7412aded0ff0 faiss::IndexIVF::search()                                                                                                                                                                                           
    @     0x7412ad1cd7ca (unknown)                                                                                                                                                                                                           
    @     0x741266f9cc35 GOMP_parallel                                                                                                                                                                                                       
    @     0x7412ad1d33dd (unknown)                                                                                                                                                                                                           
    @     0x7412ad1d6584 (unknown)                                                                                                                                                                                                           
    @     0x7412ad15a2a8 colmap::VocabTreePairGenerator::IndexImages()                                                                                                                                                                       
    @     0x7412ad15ce50 colmap::VocabTreePairGenerator::VocabTreePairGenerator()                                                                                                                                                            
    @     0x7412ad161d75 colmap::SequentialPairGenerator::SequentialPairGenerator()                                                                                                                                                          
    @     0x7412ad12e70b (unknown)                                                                                                                                                                                                           
    @     0x7412ad136117 (unknown)                                                                                                                                                                                                           
    @     0x7412ade045a4 colmap::Thread::RunFunc()                                                                                                                                                                                           
    @     0x7412b9a03db4 (unknown)                                                                                                                                                                                                           
    @     0x7412bcac7aa4 (unknown)                                                                                                                                                                                                           
    @     0x7412bcb54c6c (unknown) 
```

## Test

This PR was tested with a full incremental mapping run on INF ETH student cluster running the container via apptainer and locally on a Ubuntu 22.04 machine.

## Additional

If desired a [devcontainer](https://containers.dev/) setup could be added for easier development with VSCode inside the container. I already have a working version of this.
