### PR TITLE
Remove legacy cluster_ids in the global pipeline.

### DIFF
--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -106,8 +106,7 @@ void GlobalPipeline::Run() {
 
   Timer run_timer;
   run_timer.Start();
-  std::unordered_map<frame_t, int> cluster_ids;
-  global_mapper.Solve(mapper_options, cluster_ids);
+  global_mapper.Solve(mapper_options);
   LOG(INFO) << "Reconstruction done in " << run_timer.ElapsedSeconds()
             << " seconds";
 

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -448,8 +448,7 @@ bool GlobalMapper::IterativeRetriangulateAndRefine(
   return true;
 }
 
-bool GlobalMapper::Solve(const GlobalMapperOptions& options,
-                         std::unordered_map<frame_t, int>& cluster_ids) {
+bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(pose_graph_);
 

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -105,8 +105,7 @@ class GlobalMapper {
       const std::shared_ptr<Reconstruction>& reconstruction);
 
   // Run the global SfM pipeline.
-  bool Solve(const GlobalMapperOptions& options,
-             std::unordered_map<frame_t, int>& cluster_ids);
+  bool Solve(const GlobalMapperOptions& options);
 
   // Run rotation averaging to estimate global rotations.
   bool RotationAveraging(const RotationEstimatorOptions& options);

--- a/src/colmap/sfm/global_mapper_test.cc
+++ b/src/colmap/sfm/global_mapper_test.cc
@@ -36,8 +36,7 @@ TEST(GlobalMapper, WithoutNoise) {
   GlobalMapper global_mapper(CreateDatabaseCache(*database));
   global_mapper.BeginReconstruction(reconstruction);
 
-  std::unordered_map<frame_t, int> cluster_ids;
-  global_mapper.Solve(GlobalMapperOptions(), cluster_ids);
+  global_mapper.Solve(GlobalMapperOptions());
 
   EXPECT_THAT(gt_reconstruction,
               ReconstructionNear(*reconstruction,
@@ -67,8 +66,7 @@ TEST(GlobalMapper, WithoutNoiseWithNonTrivialKnownRig) {
   GlobalMapper global_mapper(CreateDatabaseCache(*database));
   global_mapper.BeginReconstruction(reconstruction);
 
-  std::unordered_map<frame_t, int> cluster_ids;
-  global_mapper.Solve(GlobalMapperOptions(), cluster_ids);
+  global_mapper.Solve(GlobalMapperOptions());
 
   EXPECT_THAT(gt_reconstruction,
               ReconstructionNear(*reconstruction,
@@ -108,8 +106,7 @@ TEST(GlobalMapper, WithoutNoiseWithNonTrivialUnknownRig) {
     }
   }
 
-  std::unordered_map<frame_t, int> cluster_ids;
-  global_mapper.Solve(GlobalMapperOptions(), cluster_ids);
+  global_mapper.Solve(GlobalMapperOptions());
 
   EXPECT_THAT(gt_reconstruction,
               ReconstructionNear(*reconstruction,
@@ -140,8 +137,7 @@ TEST(GlobalMapper, WithNoiseAndOutliers) {
   GlobalMapper global_mapper(CreateDatabaseCache(*database));
   global_mapper.BeginReconstruction(reconstruction);
 
-  std::unordered_map<frame_t, int> cluster_ids;
-  global_mapper.Solve(GlobalMapperOptions(), cluster_ids);
+  global_mapper.Solve(GlobalMapperOptions());
 
   EXPECT_THAT(gt_reconstruction,
               ReconstructionNear(*reconstruction,


### PR DESCRIPTION
The ``cluster_ids`` variable is useless after https://github.com/colmap/colmap/pull/4008