### PR TITLE
Fix incompatible .rst syntax in change log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -119,7 +119,7 @@ Full Change List (sorted temporally)
 ------------------------------------
 * Fix MSVC compatibility with ``isnan`` by @nharbiso in https://github.com/colmap/colmap/pull/3720
 * Include v3.13 to legacy dropdown. by @B1ueber2y in https://github.com/colmap/colmap/pull/3724
-* (bugfix) initializing added_two_view_geometry_options_ to false by @AlePuglisi in https://github.com/colmap/colmap/pull/3727
+* (bugfix) initializing added_two_view_geometry_options to false by @AlePuglisi in https://github.com/colmap/colmap/pull/3727
 * Update the tag of the doc submodule to the latest commit. by @B1ueber2y in https://github.com/colmap/colmap/pull/3729
 * Fix duplicated parameters for pycolmap.extract_features and fix pycolmap README. by @B1ueber2y in https://github.com/colmap/colmap/pull/3728
 * Document how to speed up bundle adjustment by @StonerLing in https://github.com/colmap/colmap/pull/3730
@@ -446,7 +446,7 @@ Full Change List (sorted temporally)
 * Expose more logging options in pycolmap by @ahojnnes in https://github.com/colmap/colmap/pull/4150
 * Load keypoints for all images to database cache for triangulation by @B1ueber2y in https://github.com/colmap/colmap/pull/4151
 * Add separate trial counter for structure-less registration by @B1ueber2y in https://github.com/colmap/colmap/pull/4152
-* Fix the usage of filter_frames_ in FindNextImages by @B1ueber2y in https://github.com/colmap/colmap/pull/4153
+* Fix the usage of filter_frames in FindNextImages by @B1ueber2y in https://github.com/colmap/colmap/pull/4153
 * Read inputs in parallel in patch match by @ahojnnes in https://github.com/colmap/colmap/pull/4154
 * Improved caching for faster and more reliable CI by @ahojnnes in https://github.com/colmap/colmap/pull/4156
 * Add retries for more reliable file download by @ahojnnes in https://github.com/colmap/colmap/pull/4157


### PR DESCRIPTION
Fixes when compiling docs:
```
CHANGELOG.rst:122: ERROR: Unknown target name: "added_two_view_geometry_options". [docutils]
CHANGELOG.rst:449: ERROR: Unknown target name: "filter_frames". [docutils]
```