### PR TITLE
Speedup reconstruction benchmarking by dynamic scheduling

### DIFF
--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -540,15 +540,18 @@ def process_scenes(
         args.parallelism, 2 * max(1, int(args.parallelism / len(scene_infos)))
     )
     with multiprocessing.Pool(processes=args.parallelism) as p:
-        results = p.map(
-            functools.partial(
-                process_scene,
-                args,
-                prepare_scene=prepare_scene,
-                position_accuracy_gt=position_accuracy_gt,
-                num_threads=num_threads,
-            ),
-            scene_infos,
+        results = list(
+            p.imap_unordered(
+                functools.partial(
+                    process_scene,
+                    args,
+                    prepare_scene=prepare_scene,
+                    position_accuracy_gt=position_accuracy_gt,
+                    num_threads=num_threads,
+                ),
+                scene_infos,
+                chunksize=1,
+            )
         )
 
     metrics: MetricsByCatByScene = collections.defaultdict(dict)


### PR DESCRIPTION
Done. The change from `p.map()` to `p.imap_unordered(..., chunksize=1)`:

- **Dynamic scheduling**: Each worker gets the next task as soon as it finishes, rather than being assigned a static chunk upfront. This avoids idle workers waiting when some reconstructions finish faster than expected.
- **Large-first ordering preserved**: Since `imap_unordered` submits tasks in input order with `chunksize=1`, the largest collections are still submitted first, ensuring long-running tasks start early.
- **`imap_unordered` vs `imap`**: Using `unordered` avoids blocking on slow tasks — results are collected as they complete. Since the downstream aggregation doesn't depend on order, this is safe.