### PR TITLE
fix: using ALIKED feature extractor with pycolmap

### DIFF
--- a/src/pycolmap/pipeline/extract_features.cc
+++ b/src/pycolmap/pipeline/extract_features.cc
@@ -34,7 +34,7 @@ void ExtractFeatures(const std::filesystem::path& database_path,
 
   UpdateImageReaderOptionsFromCameraMode(reader_options, camera_mode);
   reader_options.image_path = image_path;
-  reader_options.as_rgb |= extraction_options.RequiresRGB();
+  reader_options.as_rgb = extraction_options.RequiresRGB();
 
   if (!image_names.empty()) {
     reader_options.image_names = image_names;


### PR DESCRIPTION
## Summary

Looks like the python bindings don't pass through the `RequiresRGB()` option from the extraction options. This causes an exception when trying to use the ALIKED feature extractor.

```
E20260318 00:15:30.424098 938475 aliked.cc:166] Check failed: bitmap.IsRGB()
terminate called after throwing an instance of 'std::invalid_argument'
```


## Reproducing

Using colmap built from source with `-DONNX_ENABLED=ON`, this will fail


```python
from argparse import ArgumentParser
from pathlib import Path

import pycolmap


def main():
    parser = ArgumentParser()
    parser.add_argument("image_path")
    parser.add_argument("--database-path", default="database.db")
    args = parser.parse_args()

    image_path = Path(args.image_path)
    image_dir = image_path if image_path.is_dir() else image_path.parent
    image_names = [] if image_path.is_dir() else [image_path.name]

    pycolmap.extract_features(
        database_path=args.database_path,
        image_path=str(image_dir),
        image_names=image_names,
        extraction_options=pycolmap.FeatureExtractionOptions(
            type=pycolmap.FeatureExtractorType.ALIKED_N16ROT,
        ),
    )


if __name__ == "__main__":
    main()
```

however running it from the cli will succeed

```
./bin/colmap feature_extractor --database_path database.db --image_path ./imgs  --FeatureExtraction.type ALIKED_N16ROT
```

## AI Disclaimer

FWIW Codex found this bug and suggested the fix.