### PR TITLE
Disambiguate ceres::GradientChecker constructor

### DIFF
--- a/src/colmap/estimators/cost_functions/reprojection_error_test.cc
+++ b/src/colmap/estimators/cost_functions/reprojection_error_test.cc
@@ -107,7 +107,14 @@ TEST(ReprojErrorCostFunctor, AnalyticalVersusAutoDiff) {
         ceres::NumericDiffOptions numeric_diff_options;
         ceres::GradientChecker gradient_checker(
             analytical_cost_function.get(),
+#if CERES_VERSION_MAJOR >= 3 || \
+    (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
             static_cast<const std::vector<const ceres::Manifold*>*>(nullptr),
+#else
+            static_cast<
+                const std::vector<const ceres::LocalParameterization*>*>(
+                nullptr),
+#endif
             numeric_diff_options);
         ceres::GradientChecker::ProbeResults results;
         EXPECT_TRUE(


### PR DESCRIPTION
The build failed with Ceres 2.1.0 because the GradientChecker constructor was ambiguous.