### PR TITLE
Update PoseLib to v2.0.5

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -37,8 +37,8 @@ endif()
 if(FETCH_POSELIB)
     include(FetchContent)
     FetchContent_Declare(poselib
-        URL https://github.com/PoseLib/PoseLib/archive/f119951fca625133112acde48daffa5f20eba451.zip
-        URL_HASH SHA256=3faa27d9d1f6ae7cc47602a66c10ac6f64457bc65a959d1880947d3b3bfe1ed1
+        URL https://github.com/PoseLib/PoseLib/archive/v2.0.5.zip
+        URL_HASH SHA256=3d8d71d94813da8e0c3a6df11ec3591614ad2e731e73f3de4982b9297321a38d
         ${_fetch_content_declare_args}
     )
     message(STATUS "Configuring PoseLib...")


### PR DESCRIPTION
## Summary
- Updates PoseLib from commit f119951 (between v2.0.4 and v2.0.5) to the v2.0.5 release tag
- This brings in 5 additional commits including homography solving improvements, Cauchy loss scaling fixes, and MSVC compatibility

## Test plan
- [x] CMake configure succeeds
- [x] Full build succeeds (verified on macOS arm64)