### PR TITLE
Remove metis/gklib version overrides from vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -38,16 +38,6 @@
             "host": true
         }
     ],
-    "overrides": [
-        {
-            "name": "metis",
-            "version": "2022-07-27"
-        },
-        {
-            "name": "gklib",
-            "version": "2023-03-27"
-        }
-    ],
     "default-features": [
         "gui",
         "download"


### PR DESCRIPTION
## Summary
- Removes pinned version overrides for metis (2022-07-27) and gklib (2023-03-27) from vcpkg.json
- These overrides date from 2022/2023 and may no longer be necessary with current vcpkg ports

## Test plan
- [x] CMake configure succeeds (non-vcpkg build)
- [ ] Verify with a vcpkg-based build (Windows CI)