### PR TITLE
Fix stale observation stats after incremental correspondence graph updates

### DIFF
--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -109,8 +109,11 @@ void ObservationManager::AddImage(const image_t image_id) {
   image_stats_.emplace(image_id, InitImageStat(image_id, image));
 
   if (correspondence_graph_) {
-    // Add image pair stats for all pairs involving the new image.
-    for (const auto& [other_image_id, _] : image_stats_) {
+    // Add image pair stats for all pairs involving the new image and refresh
+    // the cached stats for existing images, whose observation/correspondence
+    // counts may have increased when AddTwoViewGeometry added new
+    // correspondences.
+    for (auto& [other_image_id, other_stats] : image_stats_) {
       if (other_image_id == image_id) {
         continue;
       }
@@ -123,6 +126,11 @@ void ObservationManager::AddImage(const image_t image_id) {
         ImagePairStat image_pair_stat;
         image_pair_stat.num_total_corrs = num_matches;
         image_pair_stats_.emplace(pair_id, image_pair_stat);
+
+        other_stats.num_observations =
+            correspondence_graph_->NumObservationsForImage(other_image_id);
+        other_stats.num_correspondences =
+            correspondence_graph_->NumCorrespondencesForImage(other_image_id);
       }
     }
 

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -634,12 +634,11 @@ TEST(ObservationManager, Point3DVisibilityScore) {
 }
 
 TEST(ObservationManager, AddImage) {
-  // Simulate streaming setup: images 1,2 are registered with a triangulated
-  // point. Image 3 arrives, gets added, registered, and added to the track.
-  // Without AddImage(), the triangulation step would segfault because
-  // image_stats_[3] doesn't exist.
+  // Images 1,2 start registered with a triangulated point. Image 3 arrives
+  // incrementally with a match on a previously-unmatched point in image 1,
+  // which increases image 1's num_observations in the correspondence graph.
+  // AddImage must refresh the cached stats for existing images to stay in sync.
 
-  // Step 1: Start with images 1,2.
   auto graph = std::make_shared<CorrespondenceGraph>();
   graph->AddImage(1, 10);
   graph->AddImage(2, 10);
@@ -651,23 +650,24 @@ TEST(ObservationManager, AddImage) {
   GenerateReconstruction(2, reconstruction);
   ObservationManager obs_manager(reconstruction, graph);
 
-  // Step 2: Triangulate a point connecting image1:0 and image2:0.
+  // Triangulate a point connecting image1:0 and image2:0.
   Track track;
   track.AddElement(1, 0);
   track.AddElement(2, 0);
   const point3D_t point3D_id =
       obs_manager.AddPoint3D(Eigen::Vector3d(0, 0, 1), track);
 
-  // Step 3: Image 3 arrives with correspondences to the triangulated point.
+  // Image 3 arrives. Match {2, 1} hits image1:2 which had no prior
+  // correspondences, so image 1's num_observations in the correspondence graph
+  // goes 2 -> 3.
   graph->AddImage(3, 10);
   TwoViewGeometry tvg13;
-  tvg13.inlier_matches = {{0, 0}};  // image3:0 <-> image1:0
+  tvg13.inlier_matches = {{0, 0}, {2, 1}};
   graph->AddTwoViewGeometry(1, 3, tvg13);
   TwoViewGeometry tvg23;
-  tvg23.inlier_matches = {{0, 0}};  // image3:0 <-> image2:0
+  tvg23.inlier_matches = {{0, 0}};
   graph->AddTwoViewGeometry(2, 3, tvg23);
 
-  // Add image 3 to reconstruction (unregistered) and ObservationManager.
   {
     const Camera& camera = reconstruction.Camera(1);
     Frame frame;
@@ -686,19 +686,29 @@ TEST(ObservationManager, AddImage) {
   }
   obs_manager.AddImage(3);
 
-  // After AddImage, image 3 should already see the triangulated point
-  // through retroactive visibility propagation.
+  // Image 3 sees the triangulated point via retroactive visibility.
   EXPECT_EQ(obs_manager.NumVisiblePoints3D(3), 1);
-  EXPECT_EQ(obs_manager.NumObservations(3), 1);
-  EXPECT_EQ(obs_manager.NumCorrespondences(3), 2);
+  EXPECT_EQ(obs_manager.NumObservations(3), 2);
+  EXPECT_EQ(obs_manager.NumCorrespondences(3), 3);
 
-  // Step 4: Register image 3 and add it to the existing track.
-  // This would segfault without AddImage().
+  // Verify AddImage refreshed image 1's cached stats (was 2 obs, now 3).
+  EXPECT_EQ(obs_manager.NumObservations(1), 3);
+  EXPECT_EQ(obs_manager.NumCorrespondences(1), 4);
+
+  // Register image 3 and add it to the existing track.
   reconstruction.Frame(3).SetRigFromWorld(Rigid3d());
   obs_manager.RegisterFrame(3);
   obs_manager.AddObservation(point3D_id, TrackElement(3, 0));
-
   EXPECT_EQ(reconstruction.Point3D(point3D_id).track.Length(), 3);
+
+  // Triangulate a new point on image1:2 <-> image3:1. This calls
+  // IncrementCorrespondenceHasPoint3D on image 1, which would violate
+  // THROW_CHECK_LE(num_visible_points3D, num_observations) if the cached
+  // stats were stale.
+  Track track2;
+  track2.AddElement(1, 2);
+  track2.AddElement(3, 1);
+  obs_manager.AddPoint3D(Eigen::Vector3d(1, 0, 1), track2);
 }
 
 }  // namespace


### PR DESCRIPTION
Missed in https://github.com/colmap/colmap/pull/4279

ObservationManager caches num_observations and num_correspondences per image from the CorrespondenceGraph at construction time. When the graph is later mutated via AddTwoViewGeometry (as in the incremental pipeline), the counts for existing images increase in the CorrespondenceGraph but the cached copies in ObservationManager are never updated. This causes IncrementCorrespondenceHasPoint3D to hit THROW_CHECK_LE(num_visible_points3D, num_observations) when triangulating points on those images, since num_visible_points3D grows past the stale num_observations.