### PR TITLE
Add GPU scheduling for benchmark evaluation scenes

### DIFF
--- a/benchmark/reconstruction/evaluation/covisibility.py
+++ b/benchmark/reconstruction/evaluation/covisibility.py
@@ -289,6 +289,7 @@ def filter_covisibility(
         pair_ids, _ = database.read_two_view_geometry_num_inliers()
         total_pairs = len(pair_ids)
         filtered_count = 0
+        missing_gt_image_names: set[str] = set()
 
         for pair_id in pair_ids:
             image_id1, image_id2 = pycolmap.pair_id_to_image_pair(pair_id)
@@ -298,9 +299,16 @@ def filter_covisibility(
             if name1 is None or name2 is None:
                 continue
 
-            if not is_covisible(
-                images_gt_by_name[name1], images_gt_by_name[name2]
-            ):
+            image_gt1 = images_gt_by_name.get(name1)
+            image_gt2 = images_gt_by_name.get(name2)
+            if image_gt1 is None:
+                missing_gt_image_names.add(name1)
+            if image_gt2 is None:
+                missing_gt_image_names.add(name2)
+            if image_gt1 is None or image_gt2 is None:
+                continue
+
+            if not is_covisible(image_gt1, image_gt2):
                 # Only delete the two-view geometry, so it will be ignored
                 # during reconstruction but keep the raw matches, so upon
                 # re-running the pipeline, the matches will be re-computed,
@@ -312,3 +320,8 @@ def filter_covisibility(
             f"Co-visibility filtering: {filtered_count}/{total_pairs} pairs "
             f"removed, {total_pairs - filtered_count} kept"
         )
+        if missing_gt_image_names:
+            pycolmap.logging.warning(
+                f"Skipped pairs involving {len(missing_gt_image_names)} "
+                f"database image(s) without a GT counterpart"
+            )

--- a/benchmark/reconstruction/evaluation/imc.py
+++ b/benchmark/reconstruction/evaluation/imc.py
@@ -31,10 +31,10 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+
 import pycolmap
 
 from .utils import Dataset, SceneInfo
-
 
 _POINTS3D_FILENAME = "points3D.txt"
 

--- a/benchmark/reconstruction/evaluation/imc.py
+++ b/benchmark/reconstruction/evaluation/imc.py
@@ -27,11 +27,72 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import tempfile
 from pathlib import Path
 
+import numpy as np
 import pycolmap
 
 from .utils import Dataset, SceneInfo
+
+
+_POINTS3D_FILENAME = "points3D.txt"
+
+
+def _read_points3D_lenient(
+    path: Path, valid_image_ids: set[int]
+) -> dict[int, pycolmap.Point3D]:
+    """Parse points3D.txt, dropping track elements whose image_id is not in
+    valid_image_ids and skipping any point3D whose track becomes empty."""
+    points3D: dict[int, pycolmap.Point3D] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            tokens = line.split()
+            point3D_id = int(tokens[0])
+            xyz = [float(v) for v in tokens[1:4]]
+            rgb = [int(v) for v in tokens[4:7]]
+            error = float(tokens[7])
+            elements = []
+            track_tokens = tokens[8:]
+            for i in range(0, len(track_tokens), 2):
+                image_id = int(track_tokens[i])
+                point2D_idx = int(track_tokens[i + 1])
+                if image_id in valid_image_ids:
+                    elements.append(
+                        pycolmap.TrackElement(image_id, point2D_idx)
+                    )
+            if not elements:
+                continue
+            point3D = pycolmap.Point3D()
+            point3D.xyz = np.array(xyz)
+            point3D.color = np.array(rgb, dtype=np.uint8)
+            point3D.error = error
+            point3D.track = pycolmap.Track(elements)
+            points3D[point3D_id] = point3D
+    return points3D
+
+
+def _read_sparse_sfm_without_points3D(
+    sfm_path: Path,
+) -> pycolmap.Reconstruction:
+    """Read an SfM reconstruction's cameras/rigs/frames/images, skipping
+    points3D entirely.
+
+    Some IMC scenes ship with points3D.txt referencing image_ids absent from
+    images.txt, which makes the strict pycolmap reader abort. Callers can
+    parse points3D separately via _read_points3D_lenient if needed.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for src_file in sfm_path.iterdir():
+            if src_file.name == _POINTS3D_FILENAME:
+                continue
+            (tmp_path / src_file.name).symlink_to(src_file.resolve())
+        (tmp_path / _POINTS3D_FILENAME).touch()
+        return pycolmap.Reconstruction(tmp_path)
 
 
 class _DatasetIMC(Dataset):
@@ -102,7 +163,7 @@ class _DatasetIMC(Dataset):
         scene_path = scene_info.image_path.parent
         sfm_path = scene_path / "sfm"
 
-        sparse_sfm = pycolmap.Reconstruction(sfm_path)
+        sparse_sfm = _read_sparse_sfm_without_points3D(sfm_path)
         sparse_gt = pycolmap.Reconstruction()
 
         train_image_ids = set()
@@ -133,6 +194,12 @@ class _DatasetIMC(Dataset):
             image.reset_camera_ptr()
             image.reset_frame_ptr()
             sparse_gt.add_image(image)
+
+        points3D = _read_points3D_lenient(
+            sfm_path / _POINTS3D_FILENAME, train_image_ids
+        )
+        for point3D_id, point3D in points3D.items():
+            sparse_gt.add_point3D_with_id(point3D_id, point3D)
 
         scene_info.sparse_gt_path.mkdir(exist_ok=True)
         sparse_gt.write(scene_info.sparse_gt_path)

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -30,11 +30,14 @@
 import argparse
 import collections
 import copy
+import ctypes
 import dataclasses
 import datetime
 import functools
 import multiprocessing
+import platform
 import shutil
+import signal
 import subprocess
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -47,6 +50,45 @@ import pycolmap
 
 from .covisibility import filter_covisibility  # noqa: F401
 from .geometry import normalize_vec, vec_angular_dist_deg  # noqa: F401
+
+_PR_SET_PDEATHSIG = 1
+_LIBC = (
+    ctypes.CDLL("libc.so.6", use_errno=True)
+    if platform.system() == "Linux"
+    else None
+)
+
+
+def _set_pdeathsig() -> None:
+    """preexec_fn: ensure child process is killed if parent dies."""
+    if _LIBC is not None:
+        _LIBC.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
+
+
+def _init_pool_worker() -> None:
+    """Pool initializer: ignore SIGINT in workers so the main process
+    handles KeyboardInterrupt and terminates the pool cleanly."""
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def _run_with_log(
+    cmd: list, log_path: Path, check: bool = True, **kwargs
+) -> int:
+    """Run a subprocess, redirecting stdout+stderr to log_path (overwrite).
+
+    Always uses preexec_fn=_set_pdeathsig so children die with their parent.
+    Raises CalledProcessError on non-zero exit when check=True.
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "wb") as fh:
+        runner = subprocess.check_call if check else subprocess.call
+        return runner(
+            cmd,
+            stdout=fh,
+            stderr=subprocess.STDOUT,
+            preexec_fn=_set_pdeathsig,
+            **kwargs,
+        )
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -185,10 +227,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--use_gpu", default=True, action="store_true")
     parser.add_argument("--use_cpu", dest="use_gpu", action="store_false")
     parser.add_argument(
-        "--parallelism",
+        "--num_threads",
         type=int,
-        default=multiprocessing.cpu_count(),
-        help="Number of processes for parallel reconstruction.",
+        default=-1,
+        help=(
+            "Total number of threads to use across all parallel scenes. "
+            "Defaults to the number of logical CPU cores (-1)."
+        ),
+    )
+    parser.add_argument(
+        "--num_parallel_scenes",
+        type=int,
+        default=-1,
+        help=(
+            "Number of scenes to reconstruct in parallel. "
+            "Defaults to max(1, num_threads // 4) (-1)."
+        ),
     )
     parser.add_argument(
         "--feature",
@@ -273,6 +327,10 @@ def parse_args() -> argparse.Namespace:
     )
     args = parser.parse_args()
     args.colmap_path = Path(args.colmap_path).resolve()
+    if args.num_threads <= 0:
+        args.num_threads = multiprocessing.cpu_count()
+    if args.num_parallel_scenes <= 0:
+        args.num_parallel_scenes = max(1, args.num_threads // 4)
     if args.overwrite_database:
         pycolmap.logging.info(
             "Overwriting database also overwrites reconstruction"
@@ -353,6 +411,7 @@ def colmap_reconstruction(
                 "matches",
             ],
             cwd=workspace_path,
+            preexec_fn=_set_pdeathsig,
         )
 
     # TODO: Expose automatic reconstruction through pycolmap bindings instead
@@ -377,7 +436,7 @@ def colmap_reconstruction(
         args.quality,
     ]
 
-    subprocess.check_call(
+    _run_with_log(
         colmap_args
         + (colmap_extra_args or [])
         + [
@@ -390,13 +449,14 @@ def colmap_reconstruction(
             "--dense",
             "0",
         ],
+        workspace_path / "extraction.log",
         cwd=workspace_path,
     )
 
     if camera_priors_sparse_gt is not None:
         set_camera_priors(database_path, camera_priors_sparse_gt)
 
-    subprocess.check_call(
+    _run_with_log(
         colmap_args
         + (colmap_extra_args or [])
         + [
@@ -409,6 +469,7 @@ def colmap_reconstruction(
             "--dense",
             "0",
         ],
+        workspace_path / "matching.log",
         cwd=workspace_path,
     )
 
@@ -426,7 +487,7 @@ def colmap_reconstruction(
     # initialize an OpenGL context and Mac on Apple silicon tends to assign GUI
     # applications to the low efficiency cores but we want to use the
     # performance cores.
-    subprocess.check_call(
+    _run_with_log(
         colmap_args
         + (colmap_extra_args or [])
         + [
@@ -439,6 +500,7 @@ def colmap_reconstruction(
             "--dense",
             "0",
         ],
+        workspace_path / "reconstruction.log",
         cwd=workspace_path,
     )
 
@@ -458,7 +520,7 @@ def colmap_alignment(
 
     if sparse_path.exists():
         sparse_aligned_path.mkdir(parents=True, exist_ok=True)
-        subprocess.call(
+        _run_with_log(
             [
                 args.colmap_path,
                 "model_aligner",
@@ -470,7 +532,9 @@ def colmap_alignment(
                 sparse_aligned_path,
                 "--alignment_max_error",
                 str(max_ref_model_error),
-            ]
+            ],
+            sparse_aligned_path.parent / "alignment.log",
+            check=False,
         )
 
 
@@ -587,23 +651,32 @@ def process_scenes(
 ) -> MetricsByCatByScene:
     error_thresholds = get_error_thresholds(args)
 
-    num_threads = min(
-        args.parallelism, 2 * max(1, int(args.parallelism / len(scene_infos)))
-    )
-    with multiprocessing.Pool(processes=args.parallelism) as p:
-        results = list(
-            p.imap_unordered(
-                functools.partial(
-                    process_scene,
-                    args,
-                    prepare_scene=prepare_scene,
-                    position_accuracy_gt=position_accuracy_gt,
-                    num_threads=num_threads,
-                ),
-                scene_infos,
-                chunksize=1,
+    num_parallel_scenes = min(args.num_parallel_scenes, len(scene_infos))
+    num_threads_per_scene = max(2, args.num_threads // num_parallel_scenes)
+    with multiprocessing.Pool(
+        processes=num_parallel_scenes, initializer=_init_pool_worker
+    ) as p:
+        try:
+            results = list(
+                p.imap_unordered(
+                    functools.partial(
+                        process_scene,
+                        args,
+                        prepare_scene=prepare_scene,
+                        position_accuracy_gt=position_accuracy_gt,
+                        num_threads=num_threads_per_scene,
+                    ),
+                    scene_infos,
+                    chunksize=1,
+                )
             )
-        )
+        except KeyboardInterrupt:
+            pycolmap.logging.warning(
+                "Interrupted, terminating workers and child processes..."
+            )
+            p.terminate()
+            p.join()
+            raise
 
     metrics: MetricsByCatByScene = collections.defaultdict(dict)
     errors_by_category: dict[str, list] = collections.defaultdict(list)

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -662,7 +662,8 @@ def _parse_gpu_index(args: argparse.Namespace) -> list[int]:
         if num_devices <= 0:
             return [-1]
         return list(range(num_devices))
-    return [int(idx) for idx in args.gpu_index.split(",")]
+    indices = [int(idx) for idx in args.gpu_index.split(",") if idx.strip()]
+    return indices if indices else [-1]
 
 
 def _process_scene_with_gpu(

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -245,6 +245,14 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--gpu_index",
+        type=str,
+        default="-1",
+        help="GPU indices to use for reconstruction. "
+        "Use '-1' to auto-detect and use all available GPUs. "
+        "Use comma-separated indices like '0,1,2' to specify exact GPUs.",
+    )
+    parser.add_argument(
         "--feature",
         default="sift",
         choices=["sift", "aliked"],
@@ -385,6 +393,7 @@ def colmap_reconstruction(
     covisibility_sparse_gt: pycolmap.Reconstruction | None = None,
     colmap_extra_args: list | None = None,
     num_threads: int = 1,
+    gpu_index: str = "-1",
 ) -> None:
     workspace_path.mkdir(parents=True, exist_ok=True)
 
@@ -426,6 +435,8 @@ def colmap_reconstruction(
         workspace_path,
         "--use_gpu",
         "1" if args.use_gpu else "0",
+        "--gpu_index",
+        gpu_index,
         "--num_threads",
         str(num_threads),
         "--feature",
@@ -544,6 +555,7 @@ def process_scene(
     prepare_scene: Callable[[SceneInfo], None],
     position_accuracy_gt: float,
     num_threads: int,
+    gpu_index: str = "-1",
 ) -> SceneResult:
     pycolmap.logging.info(
         f"Processing dataset={scene_info.dataset}, "
@@ -569,6 +581,7 @@ def process_scene(
         ),
         num_threads=num_threads,
         colmap_extra_args=scene_info.colmap_extra_args,
+        gpu_index=gpu_index,
     )
 
     # Merge all sub-models into a single reconstruction. Each sub-model will be
@@ -643,6 +656,33 @@ def process_scene(
     )
 
 
+def _parse_gpu_index(args: argparse.Namespace) -> list[int]:
+    if args.gpu_index == "-1":
+        num_devices = pycolmap.get_num_cuda_devices()
+        if num_devices <= 0:
+            return [-1]
+        return list(range(num_devices))
+    return [int(idx) for idx in args.gpu_index.split(",")]
+
+
+def _process_scene_with_gpu(
+    scene_info_and_gpu: tuple[SceneInfo, str],
+    args: argparse.Namespace,
+    prepare_scene: Callable[[SceneInfo], None],
+    position_accuracy_gt: float,
+    num_threads: int,
+) -> SceneResult:
+    scene_info, gpu_index = scene_info_and_gpu
+    return process_scene(
+        args=args,
+        scene_info=scene_info,
+        prepare_scene=prepare_scene,
+        position_accuracy_gt=position_accuracy_gt,
+        num_threads=num_threads,
+        gpu_index=gpu_index,
+    )
+
+
 def process_scenes(
     args: argparse.Namespace,
     scene_infos: list[SceneInfo],
@@ -650,6 +690,12 @@ def process_scenes(
     position_accuracy_gt: float,
 ) -> MetricsByCatByScene:
     error_thresholds = get_error_thresholds(args)
+
+    gpu_index = _parse_gpu_index(args)
+    scene_gpu_pairs = [
+        (scene_info, str(gpu_index[i % len(gpu_index)]))
+        for i, scene_info in enumerate(scene_infos)
+    ]
 
     num_parallel_scenes = min(args.num_parallel_scenes, len(scene_infos))
     num_threads_per_scene = max(2, args.num_threads // num_parallel_scenes)
@@ -660,13 +706,13 @@ def process_scenes(
             results = list(
                 p.imap_unordered(
                     functools.partial(
-                        process_scene,
-                        args,
+                        _process_scene_with_gpu,
+                        args=args,
                         prepare_scene=prepare_scene,
                         position_accuracy_gt=position_accuracy_gt,
                         num_threads=num_threads_per_scene,
                     ),
-                    scene_infos,
+                    scene_gpu_pairs,
                     chunksize=1,
                 )
             )

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -27,6 +27,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import argparse
+
 import numpy as np
 import pytest
 
@@ -34,6 +36,7 @@ import pycolmap
 
 from .utils import (
     Metrics,
+    _parse_gpu_index,
     compute_abs_errors,
     compute_auc,
     compute_avg_metrics,
@@ -42,6 +45,35 @@ from .utils import (
     diff_metrics,
     get_scores,
 )
+
+
+class TestParseGpuIndex:
+    @staticmethod
+    def _make_args(gpu_index: str) -> argparse.Namespace:
+        return argparse.Namespace(gpu_index=gpu_index)
+
+    def test_single_gpu(self):
+        assert _parse_gpu_index(self._make_args("0")) == [0]
+
+    def test_multiple_gpus(self):
+        assert _parse_gpu_index(self._make_args("0,1,2")) == [0, 1, 2]
+
+    def test_trailing_comma(self):
+        assert _parse_gpu_index(self._make_args("1,")) == [1]
+
+    def test_empty_string(self):
+        assert _parse_gpu_index(self._make_args("")) == [-1]
+
+    def test_only_commas(self):
+        assert _parse_gpu_index(self._make_args(",")) == [-1]
+
+    def test_auto_detect(self, monkeypatch):
+        monkeypatch.setattr(pycolmap, "get_num_cuda_devices", lambda: 3)
+        assert _parse_gpu_index(self._make_args("-1")) == [0, 1, 2]
+
+    def test_auto_detect_no_devices(self, monkeypatch):
+        monkeypatch.setattr(pycolmap, "get_num_cuda_devices", lambda: 0)
+        assert _parse_gpu_index(self._make_args("-1")) == [-1]
 
 
 class TestComputeAuc:


### PR DESCRIPTION
Distribute reconstruction scenes across available GPUs using round-robin scheduling. Add --gpu_index argument to control which GPUs to use, with auto-detection of all CUDA devices by default. Each scene is assigned a specific GPU index, enabling efficient multi-GPU utilization during parallel benchmark evaluation.

Also fix numpy deprecation: np.acos -> np.arccos.