### PR TITLE
Replace glog version preprocessor checks with constexpr bool

### DIFF
--- a/src/colmap/controllers/base_option_manager.cc
+++ b/src/colmap/controllers/base_option_manager.cc
@@ -81,9 +81,9 @@ void BaseOptionManager::AddLogOptions() {
   AddDefaultOption("log_severity",
                    &FLAGS_minloglevel,
                    "0:INFO, 1:WARNING, 2:ERROR, 3:FATAL");
-  if constexpr (kGlogHasColorSupport) {
-    AddDefaultOption("log_color", &FLAGS_colorlogtostderr);
-  }
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+  AddDefaultOption("log_color", &FLAGS_colorlogtostderr);
+#endif
 }
 
 void BaseOptionManager::AddDatabaseOptions() {
@@ -129,9 +129,9 @@ void BaseOptionManager::ResetImpl(bool reset_logging) {
     FLAGS_log_dir = "";
     FLAGS_v = 0;
     FLAGS_minloglevel = 0;
-    if constexpr (kGlogHasColorSupport) {
-      FLAGS_colorlogtostderr = true;
-    }
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+    FLAGS_colorlogtostderr = true;
+#endif
     ApplyLogFlags();
   }
 
@@ -189,21 +189,21 @@ void BaseOptionManager::ApplyEnumConversions() {
 
 void BaseOptionManager::ApplyLogFlags() {
   FLAGS_logtostderr = false;
-  if constexpr (kGlogHasStdoutSupport) {
-    FLAGS_logtostdout = false;
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  FLAGS_logtostdout = false;
+#endif
   FLAGS_alsologtostderr = false;
 
   if (log_target_ == "stderr") {
     FLAGS_logtostderr = true;
   } else if (log_target_ == "stdout") {
-    if constexpr (kGlogHasStdoutSupport) {
-      FLAGS_logtostdout = true;
-    } else {
-      LOG(WARNING) << "log_target=stdout requires glog >= 0.6. "
-                      "Falling back to stderr.";
-      FLAGS_logtostderr = true;
-    }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+    FLAGS_logtostdout = true;
+#else
+    LOG(WARNING) << "log_target=stdout requires glog >= 0.6. "
+                    "Falling back to stderr.";
+    FLAGS_logtostderr = true;
+#endif
   } else if (log_target_ == "file") {
   } else if (log_target_ == "stderr_and_file") {
     FLAGS_alsologtostderr = true;
@@ -213,9 +213,9 @@ void BaseOptionManager::ApplyLogFlags() {
     FLAGS_alsologtostderr = true;
   }
 
-  if constexpr (kGlogHasStdoutSupport) {
-    FLAGS_colorlogtostdout = FLAGS_colorlogtostderr;
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  FLAGS_colorlogtostdout = FLAGS_colorlogtostderr;
+#endif
 
   if (!FLAGS_log_dir.empty() &&
       (log_target_ == "file" || log_target_ == "stderr_and_file")) {

--- a/src/colmap/controllers/base_option_manager_test.cc
+++ b/src/colmap/controllers/base_option_manager_test.cc
@@ -498,9 +498,9 @@ TEST(BaseOptionManager, LogOptions) {
 
     EXPECT_TRUE(options.Parse(argv.size(), argv.data()));
     EXPECT_EQ(FLAGS_logtostderr, expect_stderr);
-    if constexpr (kGlogHasStdoutSupport) {
-      EXPECT_EQ(FLAGS_logtostdout, expect_stdout);
-    }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+    EXPECT_EQ(FLAGS_logtostdout, expect_stdout);
+#endif
     EXPECT_EQ(FLAGS_alsologtostderr, expect_stderr_and_file);
   };
 
@@ -508,17 +508,18 @@ TEST(BaseOptionManager, LogOptions) {
                  /*expect_stderr=*/true,
                  /*expect_stdout=*/false,
                  /*expect_and_file=*/false);
-  if constexpr (kGlogHasStdoutSupport) {
-    VerifyLogState("stdout",
-                   /*expect_stderr=*/false,
-                   /*expect_stdout=*/true,
-                   /*expect_and_file=*/false);
-  } else {
-    VerifyLogState("stdout",
-                   /*expect_stderr=*/true,
-                   /*expect_stdout=*/false,
-                   /*expect_and_file=*/false);
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  VerifyLogState("stdout",
+                 /*expect_stderr=*/false,
+                 /*expect_stdout=*/true,
+                 /*expect_and_file=*/false);
+#else
+  // glog < 0.6 does not support FLAGS_logtostdout, falls back to stderr.
+  VerifyLogState("stdout",
+                 /*expect_stderr=*/true,
+                 /*expect_stdout=*/false,
+                 /*expect_and_file=*/false);
+#endif
   VerifyLogState("file",
                  /*expect_stderr=*/false,
                  /*expect_stdout=*/false,

--- a/src/colmap/ui/log_widget.cc
+++ b/src/colmap/ui/log_widget.cc
@@ -135,7 +135,8 @@ void LogWidget::Flush() {
 
   text_box_->moveCursor(QTextCursor::End);
 
-  if (kGlogHasColorSupport && FLAGS_colorlogtostderr) {
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+  if (FLAGS_colorlogtostderr) {
     for (const auto& entry : text_queue_) {
       QTextCharFormat format;
       switch (entry.severity) {
@@ -153,7 +154,9 @@ void LogWidget::Flush() {
       text_box_->setCurrentCharFormat(format);
       text_box_->insertPlainText(QString::fromStdString(entry.text));
     }
-  } else {
+  } else
+#endif
+  {
     for (const auto& entry : text_queue_) {
       text_box_->insertPlainText(QString::fromStdString(entry.text));
     }

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -104,11 +104,11 @@ std::string GetLogTarget() {
     return "stderr";
   }
 
-  if constexpr (kGlogHasStdoutSupport) {
-    if (FLAGS_logtostdout) {
-      return "stdout";
-    }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  if (FLAGS_logtostdout) {
+    return "stdout";
   }
+#endif
 
   if (FLAGS_alsologtostderr) {
     return "stderr_and_file";
@@ -124,26 +124,26 @@ void ApplyLogOptions(const std::string& log_target,
   FLAGS_v = verbosity;
   FLAGS_minloglevel = min_severity;
 
-  if constexpr (kGlogHasColorSupport) {
-    FLAGS_colorlogtostderr = color;
-  }
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+  FLAGS_colorlogtostderr = color;
+#endif
 
   FLAGS_logtostderr = false;
-  if constexpr (kGlogHasStdoutSupport) {
-    FLAGS_logtostdout = false;
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  FLAGS_logtostdout = false;
+#endif
   FLAGS_alsologtostderr = false;
 
   if (log_target == "stderr") {
     FLAGS_logtostderr = true;
   } else if (log_target == "stdout") {
-    if constexpr (kGlogHasStdoutSupport) {
-      FLAGS_logtostdout = true;
-    } else {
-      LOG(WARNING) << "log_target=stdout requires glog >= 0.6. "
-                      "Falling back to stderr.";
-      FLAGS_logtostderr = true;
-    }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+    FLAGS_logtostdout = true;
+#else
+    LOG(WARNING) << "log_target=stdout requires glog >= 0.6. "
+                    "Falling back to stderr.";
+    FLAGS_logtostderr = true;
+#endif
   } else if (log_target == "file") {
     // default file logging
   } else if (log_target == "stderr_and_file") {
@@ -154,9 +154,9 @@ void ApplyLogOptions(const std::string& log_target,
     FLAGS_alsologtostderr = true;
   }
 
-  if constexpr (kGlogHasStdoutSupport) {
-    FLAGS_colorlogtostdout = FLAGS_colorlogtostderr;
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  FLAGS_colorlogtostdout = FLAGS_colorlogtostderr;
+#endif
 }
 
 }  // anonymous namespace
@@ -1645,13 +1645,12 @@ void MainWindow::SetLogOptions() {
   form_layout->addRow("Minimum severity", min_severity_box);
 
   // Color
-  QComboBox* color_box = nullptr;
-  if constexpr (kGlogHasColorSupport) {
-    color_box = new QComboBox(&dialog);
-    color_box->addItems({"Disabled", "Enabled"});
-    color_box->setCurrentIndex(static_cast<int>(FLAGS_colorlogtostderr));
-    form_layout->addRow("Colored logging", color_box);
-  }
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+  QComboBox* color_box = new QComboBox(&dialog);
+  color_box->addItems({"Disabled", "Enabled"});
+  color_box->setCurrentIndex(static_cast<int>(FLAGS_colorlogtostderr));
+  form_layout->addRow("Colored logging", color_box);
+#endif
 
   QDialogButtonBox* buttons = new QDialogButtonBox(
       QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
@@ -1662,14 +1661,15 @@ void MainWindow::SetLogOptions() {
   form_layout->addRow(buttons);
 
   if (dialog.exec() == QDialog::Accepted) {
-    int color_index = 0;
-    if constexpr (kGlogHasColorSupport) {
-      color_index = color_box->currentIndex();
-    }
     ApplyLogOptions(log_target_box->currentText().toStdString(),
                     verbosity_box->value(),
                     min_severity_box->currentIndex(),
-                    color_index);
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+                    color_box->currentIndex()
+#else
+                    0
+#endif
+    );
   }
 }
 

--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -97,20 +97,18 @@
 
 namespace colmap {
 
-constexpr bool kGlogHasColorSupport =
 #if !defined(GLOG_VERSION_MAJOR) || GLOG_VERSION_MAJOR > 0 || \
     GLOG_VERSION_MINOR >= 4
-    true;
+#define COLMAP_GLOG_HAS_COLOR_SUPPORT 1
 #else
-    false;
+#define COLMAP_GLOG_HAS_COLOR_SUPPORT 0
 #endif
 
-constexpr bool kGlogHasStdoutSupport =
 #if defined(GLOG_VERSION_MAJOR) && \
     (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6)
-    true;
+#define COLMAP_GLOG_HAS_STDOUT_SUPPORT 1
 #else
-    false;
+#define COLMAP_GLOG_HAS_STDOUT_SUPPORT 0
 #endif
 
 // Initialize glog at the beginning of the program.

--- a/src/pycolmap/util/logging.cc
+++ b/src/pycolmap/util/logging.cc
@@ -100,13 +100,13 @@ void BindLogging(py::module& m) {
           },
           py::arg("message"));
 
-  if constexpr (colmap::kGlogHasStdoutSupport) {
-    PyLogging.def_readwrite_static("logtostdout", &FLAGS_logtostdout)
-        .def_readwrite_static("colorlogtostdout", &FLAGS_colorlogtostdout);
-  }
-  if constexpr (colmap::kGlogHasColorSupport) {
-    PyLogging.def_readwrite_static("colorlogtostderr", &FLAGS_colorlogtostderr);
-  }
+#if COLMAP_GLOG_HAS_STDOUT_SUPPORT
+  PyLogging.def_readwrite_static("logtostdout", &FLAGS_logtostdout)
+      .def_readwrite_static("colorlogtostdout", &FLAGS_colorlogtostdout);
+#endif
+#if COLMAP_GLOG_HAS_COLOR_SUPPORT
+  PyLogging.def_readwrite_static("colorlogtostderr", &FLAGS_colorlogtostderr);
+#endif
 
 #if defined(GLOG_VERSION_MAJOR) && \
     (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6)


### PR DESCRIPTION
* Introduce kGlogHasStdoutAndColorSupport constexpr bool in logging.h to centralize the glog >= 0.6 feature detection. Replace all scattered #if defined(GLOG_VERSION_MAJOR) preprocessor conditionals with if constexpr checks throughout the codebase.
* Fixes a few missing code sections where the condition was missing and thus failed to compile on older glog versions.
* Move the anonymous namespace in main_window.cc inside the colmap namespace, add missing logging.h include in pycolmap/util/logging.cc.