### PR TITLE
Use non-deprecated SQLite3::SQLite3 CMake target

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -35,6 +35,10 @@ if(DEFINED glog_VERSION_MAJOR)
 endif()
 
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
+# Older CMake versions define SQLite::SQLite3 instead of SQLite3::SQLite3.
+if(NOT TARGET SQLite3::SQLite3 AND TARGET SQLite::SQLite3)
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 
 set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL ${COLMAP_FIND_TYPE})

--- a/src/colmap/scene/CMakeLists.txt
+++ b/src/colmap/scene/CMakeLists.txt
@@ -73,7 +73,7 @@ COLMAP_ADD_LIBRARY(
         colmap_scene_types
         colmap_util
         Eigen3::Eigen
-        SQLite::SQLite3
+        SQLite3::SQLite3
     PRIVATE_LINK_LIBS
         colmap_optim
 )


### PR DESCRIPTION
Replace deprecated SQLite::SQLite3 target with SQLite3::SQLite3. Add a backwards-compatibility alias in FindDependencies.cmake for older CMake versions that only define SQLite::SQLite3.