### PR TITLE
Add rotation averaging options to GlobalMapper configuration

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -782,6 +782,10 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.retriangulation.min_angle);
 
   // Rotation averaging options.
+  AddDefaultOption("GlobalMapper.ra_use_gravity",
+                   &global_mapper->mapper.rotation_averaging.use_gravity);
+  AddDefaultOption("GlobalMapper.ra_use_stratified",
+                   &global_mapper->mapper.rotation_averaging.use_stratified);
   AddDefaultOption(
       "GlobalMapper.ra_max_rotation_error_deg",
       &global_mapper->mapper.rotation_averaging.max_rotation_error_deg);


### PR DESCRIPTION
## Background
`RotationEstimatorOptions.use_gravity` is fully exposed through`pycolmap` via `GlobalMapperOptions().rotation_averaging.use_gravity`, but the CLI's `AddGlobalMapperOptions()` in `option_manager.cc` only registers one rotation-averaging sub-option (`ra_max_rotation_error_deg`). The`use_gravity` and `use_stratified` flags are missing.

## Change

Expose the options `GlobalMapper.ra_use_gravity` and `GlobalMapper.ra_use_stratified` on the CLI.
