### PR TITLE
fix:  Fix pyceres .problem attribute on CeresBundleAdjuster returned by factory functions

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -1082,7 +1082,7 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
 
 }  // namespace
 
-std::unique_ptr<BundleAdjuster> CreateDefaultCeresBundleAdjuster(
+std::unique_ptr<CeresBundleAdjuster> CreateDefaultCeresBundleAdjuster(
     const BundleAdjustmentOptions& options,
     const BundleAdjustmentConfig& config,
     Reconstruction& reconstruction) {
@@ -1090,7 +1090,7 @@ std::unique_ptr<BundleAdjuster> CreateDefaultCeresBundleAdjuster(
       options, config, reconstruction);
 }
 
-std::unique_ptr<BundleAdjuster> CreatePosePriorCeresBundleAdjuster(
+std::unique_ptr<CeresBundleAdjuster> CreatePosePriorCeresBundleAdjuster(
     const BundleAdjustmentOptions& options,
     const PosePriorBundleAdjustmentOptions& prior_options,
     const BundleAdjustmentConfig& config,

--- a/src/colmap/estimators/bundle_adjustment_ceres.h
+++ b/src/colmap/estimators/bundle_adjustment_ceres.h
@@ -120,12 +120,12 @@ class CeresBundleAdjuster : public BundleAdjuster {
   virtual std::shared_ptr<ceres::Problem>& Problem() = 0;
 };
 
-std::unique_ptr<BundleAdjuster> CreateDefaultCeresBundleAdjuster(
+std::unique_ptr<CeresBundleAdjuster> CreateDefaultCeresBundleAdjuster(
     const BundleAdjustmentOptions& options,
     const BundleAdjustmentConfig& config,
     Reconstruction& reconstruction);
 
-std::unique_ptr<BundleAdjuster> CreatePosePriorCeresBundleAdjuster(
+std::unique_ptr<CeresBundleAdjuster> CreatePosePriorCeresBundleAdjuster(
     const BundleAdjustmentOptions& options,
     const PosePriorBundleAdjustmentOptions& prior_options,
     const BundleAdjustmentConfig& config,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                          
                
- Change return type of `CreateDefaultCeresBundleAdjuster` and `CreatePosePriorCeresBundleAdjuster` from `std::unique_ptr<BundleAdjuster> to std::unique_ptr<CeresBundleAdjuster>`
- This fixes pybind11 not exposing the .problem property when these factory functions are called from Python

## Problem

After #4042, `CreateDefaultCeresBundleAdjuster` returns `unique_ptr<BundleAdjuster>` (base class). Pybind11 uses the declared return type to determine the Python wrapper class, so it wraps the result as BundleAdjuster — which doesn't have `.problem`. This breaks the `vi_optimization.py` example from #2625  as well as `example.py`.

Fixes #4285, fixes #4313.

## Tested

With the above changes `example.py` runs again without errors.