### PR TITLE
Using IndexIVFScalarQuantizer instead of IndexIVFFlat to accelerate exhaustive_matcher

### DIFF
--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -34,8 +34,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
+#include <faiss/IndexIVFScalarQuantizer.h>
 #include <faiss/IndexPQ.h>
-#include <faiss/IndexScalarQuantizer.h>
 #include <omp.h>
 
 namespace colmap {
@@ -66,16 +66,28 @@ class FaissFeatureDescriptorIndex : public FeatureDescriptorIndex {
         const int num_centroids = 4 * std::sqrt(index_descriptors.data.rows());
         coarse_quantizer_ =
             std::make_unique<faiss::IndexFlatL2>(index_descriptors.data.cols());
-        index_ = std::make_unique<faiss::IndexIVFScalarQuantizer>(
-            /*quantizer=*/coarse_quantizer_.get(),
-            /*d=*/index_descriptors.data.cols(),
-            /*nlist_=*/num_centroids,
-            faiss::ScalarQuantizer::QT_8bit_direct,
-            faiss::METRIC_L2,
-            false);
-        auto* index_impl = dynamic_cast<faiss::IndexIVFScalarQuantizer*>(index_.get());
-        // Avoid warnings during the training phase.
-        index_impl->cp.min_points_per_centroid = 1;
+        if (type_ == FeatureExtractorType::SIFT) {
+          // SIFT descriptors are natively uint8, so QT_8bit_direct
+          // quantization is lossless and faster than flat indexing.
+          index_ = std::make_unique<faiss::IndexIVFScalarQuantizer>(
+              /*quantizer=*/coarse_quantizer_.get(),
+              /*d=*/index_descriptors.data.cols(),
+              /*nlist=*/num_centroids,
+              faiss::ScalarQuantizer::QT_8bit_direct,
+              faiss::METRIC_L2,
+              /*by_residual=*/false);
+          auto* index_impl =
+              static_cast<faiss::IndexIVFScalarQuantizer*>(index_.get());
+          index_impl->cp.min_points_per_centroid = 1;
+        } else {
+          index_ = std::make_unique<faiss::IndexIVFFlat>(
+              /*quantizer=*/coarse_quantizer_.get(),
+              /*d=*/index_descriptors.data.cols(),
+              /*nlist=*/num_centroids,
+              faiss::METRIC_L2);
+          auto* index_impl = static_cast<faiss::IndexIVFFlat*>(index_.get());
+          index_impl->cp.min_points_per_centroid = 1;
+        }
         index_->train(index_descriptors.data.rows(),
                       index_descriptors.data.data());
         index_->add(index_descriptors.data.rows(),

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -35,6 +35,7 @@
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexPQ.h>
+#include <faiss/IndexScalarQuantizer.h>
 #include <omp.h>
 
 namespace colmap {
@@ -65,11 +66,14 @@ class FaissFeatureDescriptorIndex : public FeatureDescriptorIndex {
         const int num_centroids = 4 * std::sqrt(index_descriptors.data.rows());
         coarse_quantizer_ =
             std::make_unique<faiss::IndexFlatL2>(index_descriptors.data.cols());
-        index_ = std::make_unique<faiss::IndexIVFFlat>(
+        index_ = std::make_unique<faiss::IndexIVFScalarQuantizer>(
             /*quantizer=*/coarse_quantizer_.get(),
             /*d=*/index_descriptors.data.cols(),
-            /*nlist_=*/num_centroids);
-        auto* index_impl = dynamic_cast<faiss::IndexIVFFlat*>(index_.get());
+            /*nlist_=*/num_centroids,
+            faiss::ScalarQuantizer::QuantizerType::QT_8bit_direct,
+            faiss::METRIC_L2,
+            false);
+        auto* index_impl = dynamic_cast<faiss::IndexIVFScalarQuantizer*>(index_.get());
         // Avoid warnings during the training phase.
         index_impl->cp.min_points_per_centroid = 1;
         index_->train(index_descriptors.data.rows(),

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -70,7 +70,7 @@ class FaissFeatureDescriptorIndex : public FeatureDescriptorIndex {
             /*quantizer=*/coarse_quantizer_.get(),
             /*d=*/index_descriptors.data.cols(),
             /*nlist_=*/num_centroids,
-            faiss::ScalarQuantizer::QuantizerType::QT_8bit_direct,
+            faiss::ScalarQuantizer::QT_8bit_direct,
             faiss::METRIC_L2,
             false);
         auto* index_impl = dynamic_cast<faiss::IndexIVFScalarQuantizer*>(index_.get());

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -34,8 +34,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
-#include <faiss/IndexScalarQuantizer.h>
 #include <faiss/IndexPQ.h>
+#include <faiss/IndexScalarQuantizer.h>
 #include <omp.h>
 
 namespace colmap {

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -34,7 +34,7 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
-#include <faiss/IndexIVFScalarQuantizer.h>
+#include <faiss/IndexScalarQuantizer.h>
 #include <faiss/IndexPQ.h>
 #include <omp.h>
 

--- a/src/colmap/feature/index_test.cc
+++ b/src/colmap/feature/index_test.cc
@@ -39,10 +39,10 @@ namespace colmap {
 namespace {
 
 FeatureDescriptorsFloat CreateRandomFeatureDescriptors(
-    const size_t num_features) {
+    const FeatureExtractorType type, const size_t num_features) {
   SetPRNGSeed(0);
   FeatureDescriptorsFloat descriptors;
-  descriptors.type = FeatureExtractorType::SIFT;
+  descriptors.type = type;
   descriptors.data.resize(num_features, 128);
   for (size_t i = 0; i < num_features; ++i) {
     for (size_t j = 0; j < 128; ++j) {
@@ -50,19 +50,31 @@ FeatureDescriptorsFloat CreateRandomFeatureDescriptors(
     }
   }
   L2NormalizeFeatureDescriptors(&descriptors.data);
+  if (type == FeatureExtractorType::SIFT) {
+    // Mimic the real SIFT pipeline: convert to uint8 [0,255] then back to
+    // float. This ensures values are integer-valued floats in [0, 255],
+    // which is required for QT_8bit_direct quantization.
+    descriptors.data =
+        FeatureDescriptorsToUnsignedByte(descriptors.data).cast<float>();
+  }
   return descriptors;
 }
 
+struct FeatureDescriptorIndexTestParams {
+  FeatureDescriptorIndex::Type index_type;
+  FeatureExtractorType extractor_type;
+  int num_descriptors;
+};
+
 class ParameterizedFeatureDescriptorIndexTests
-    : public ::testing::TestWithParam<
-          std::pair<FeatureDescriptorIndex::Type, /*num_descriptors=*/int>> {};
+    : public ::testing::TestWithParam<FeatureDescriptorIndexTestParams> {};
 
 TEST_P(ParameterizedFeatureDescriptorIndexTests, Nominal) {
-  const auto [type, num_descriptors] = GetParam();
+  const auto& params = GetParam();
 
   std::unique_ptr<FeatureDescriptorIndex> index;
   try {
-    index = FeatureDescriptorIndex::Create(type);
+    index = FeatureDescriptorIndex::Create(params.index_type);
   } catch (const std::runtime_error& e) {
     GTEST_SKIP() << "Skipping test due to: " << e.what();
   }
@@ -70,7 +82,8 @@ TEST_P(ParameterizedFeatureDescriptorIndexTests, Nominal) {
   EXPECT_NE(index, nullptr);
 
   const FeatureDescriptorsFloat index_descriptors =
-      CreateRandomFeatureDescriptors(num_descriptors);
+      CreateRandomFeatureDescriptors(params.extractor_type,
+                                     params.num_descriptors);
   const FeatureDescriptorsFloat& query_descriptors = index_descriptors;
   index->Build(index_descriptors);
 
@@ -127,16 +140,15 @@ TEST(FeatureDescriptorIndexTests, TypeMismatch) {
   ASSERT_NE(index, nullptr);
 
   // Prepare SIFT descriptors for index build.
-  FeatureDescriptorsFloat sift_desc =
-      CreateRandomFeatureDescriptors(kNumDescriptors);
+  FeatureDescriptorsFloat sift_desc = CreateRandomFeatureDescriptors(
+      FeatureExtractorType::SIFT, kNumDescriptors);
 
   // Prepare descriptors with a different type.
-  FeatureDescriptorsFloat undefined_desc =
-      CreateRandomFeatureDescriptors(kNumDescriptors);
-  undefined_desc.type = FeatureExtractorType::UNDEFINED;
+  FeatureDescriptorsFloat aliked_desc = CreateRandomFeatureDescriptors(
+      FeatureExtractorType::ALIKED_N16ROT, kNumDescriptors);
 
   // Build should throw when descriptor types are inconsistent.
-  index->Build(undefined_desc);
+  index->Build(aliked_desc);
 
   // Build correctly with SIFT so we can test Query mismatch.
   index->Build(sift_desc);
@@ -145,16 +157,26 @@ TEST(FeatureDescriptorIndexTests, TypeMismatch) {
   Eigen::RowMajorMatrixXi indices;
   Eigen::RowMajorMatrixXf distances;
   EXPECT_THROW(index->Search(
-                   /*num_neighbors=*/1, undefined_desc, indices, distances),
+                   /*num_neighbors=*/1, aliked_desc, indices, distances),
                std::invalid_argument);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     FeatureDescriptorIndexTests,
     ParameterizedFeatureDescriptorIndexTests,
-    ::testing::Values(std::make_pair(FeatureDescriptorIndex::Type::FAISS, 100),
-                      std::make_pair(FeatureDescriptorIndex::Type::FAISS,
-                                     1000)));
+    ::testing::Values(
+        FeatureDescriptorIndexTestParams{FeatureDescriptorIndex::Type::FAISS,
+                                         FeatureExtractorType::SIFT,
+                                         100},
+        FeatureDescriptorIndexTestParams{FeatureDescriptorIndex::Type::FAISS,
+                                         FeatureExtractorType::SIFT,
+                                         1000},
+        FeatureDescriptorIndexTestParams{FeatureDescriptorIndex::Type::FAISS,
+                                         FeatureExtractorType::ALIKED_N16ROT,
+                                         100},
+        FeatureDescriptorIndexTestParams{FeatureDescriptorIndex::Type::FAISS,
+                                         FeatureExtractorType::ALIKED_N16ROT,
+                                         1000}));
 
 }  // namespace
 }  // namespace colmap

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -60,6 +60,8 @@ if(FETCH_FAISS)
         ${_fetch_content_declare_args}
     )
     message(STATUS "Configuring faiss...")
+    # Use dynamic dispatch (dd) to automatically select the highest SIMD
+    # instruction set supported by the target machine (e.g., AVX2, AVX512).
     set(FAISS_OPT_LEVEL dd)
     set(FAISS_ENABLE_GPU OFF)
     set(FAISS_ENABLE_PYTHON OFF)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -55,11 +55,12 @@ endif()
 if(FETCH_FAISS)
     include(FetchContent)
     FetchContent_Declare(faiss
-        URL https://github.com/ahojnnes/faiss/archive/36b77353dc435383e0c23a709e7997a29d049041.zip
-        URL_HASH SHA256=aaf90b3dd3e353ff0bc3391581788cda7c510749023d1937707fc99c38ef2587
+        URL https://github.com/facebookresearch/faiss/archive/refs/tags/v1.14.1.zip
+        URL_HASH SHA256=4b1ae7e7a0a46385b4084f0e3945623a15fcf99d793bf44d82aae8e24f11e5f5
         ${_fetch_content_declare_args}
     )
     message(STATUS "Configuring faiss...")
+    set(FAISS_OPT_LEVEL dd)
     set(FAISS_ENABLE_GPU OFF)
     set(FAISS_ENABLE_PYTHON OFF)
     set(FAISS_ENABLE_MKL OFF)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -62,7 +62,10 @@ if(FETCH_FAISS)
     message(STATUS "Configuring faiss...")
     # Use dynamic dispatch (dd) to automatically select the highest SIMD
     # instruction set supported by the target machine (e.g., AVX2, AVX512).
-    set(FAISS_OPT_LEVEL dd)
+    # Dynamic dispatch is not supported on MSVC (faiss v1.14.1).
+    if(NOT IS_MSVC)
+        set(FAISS_OPT_LEVEL dd)
+    endif()
     set(FAISS_ENABLE_GPU OFF)
     set(FAISS_ENABLE_PYTHON OFF)
     set(FAISS_ENABLE_MKL OFF)


### PR DESCRIPTION
Performance Optimization: Achieved 1.25x speed improvement by replacing IndexIVFFlat with IndexIVFScalarQuantizer, utilizing uint8 quantization for direct vector similarity calculations while preserving accuracy.