### PR TITLE
Fix crash in AdjustGlobalBundle after aggressive frame filtering

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1059,11 +1059,21 @@ bool IncrementalMapper::AdjustGlobalBundle(
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(obs_manager_);
 
+  const size_t num_reg_frames = reconstruction_->NumRegFrames();
+
+  // After filtering, the reconstruction may have fewer than 2 images,
+  // in which case global bundle adjustment is not possible.
+  if (num_reg_frames < 2) {
+    LOG(WARNING) << "At least two images must be registered for global "
+                    "bundle-adjustment";
+    return false;
+  }
+
   BundleAdjustmentOptions custom_ba_options = ba_options;
   // Use stricter convergence criteria for first registered images.
   constexpr size_t kMinNumRegFramesForFastBA = 10;
   const bool is_small_reconstruction =
-      reconstruction_->NumRegFrames() < kMinNumRegFramesForFastBA;
+      num_reg_frames < kMinNumRegFramesForFastBA;
   if (is_small_reconstruction && custom_ba_options.ceres) {
     custom_ba_options.ceres->solver_options.function_tolerance /= 10;
     custom_ba_options.ceres->solver_options.gradient_tolerance /= 10;
@@ -1082,12 +1092,6 @@ bool IncrementalMapper::AdjustGlobalBundle(
     for (const data_t& data_id : frame.ImageIds()) {
       ba_config.AddImage(data_id.id);
     }
-  }
-
-  // After filtering, the reconstruction may have fewer than 2 images,
-  // in which case global bundle adjustment is not possible.
-  if (ba_config.NumImages() < 2) {
-    return false;
   }
 
   // Fix the existing images, if option specified.

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1084,9 +1084,11 @@ bool IncrementalMapper::AdjustGlobalBundle(
     }
   }
 
-  THROW_CHECK_GE(ba_config.NumImages(), 2) << "At least two images must be "
-                                              "registered for global "
-                                              "bundle-adjustment";
+  // After filtering, the reconstruction may have fewer than 2 images,
+  // in which case global bundle adjustment is not possible.
+  if (ba_config.NumImages() < 2) {
+    return false;
+  }
 
   // Fix the existing images, if option specified.
   if (options.fix_existing_frames) {

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1059,21 +1059,11 @@ bool IncrementalMapper::AdjustGlobalBundle(
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(obs_manager_);
 
-  const size_t num_reg_frames = reconstruction_->NumRegFrames();
-
-  // After filtering, the reconstruction may have fewer than 2 images,
-  // in which case global bundle adjustment is not possible.
-  if (num_reg_frames < 2) {
-    LOG(WARNING) << "At least two images must be registered for global "
-                    "bundle-adjustment";
-    return false;
-  }
-
   BundleAdjustmentOptions custom_ba_options = ba_options;
   // Use stricter convergence criteria for first registered images.
   constexpr size_t kMinNumRegFramesForFastBA = 10;
   const bool is_small_reconstruction =
-      num_reg_frames < kMinNumRegFramesForFastBA;
+      reconstruction_->NumRegFrames() < kMinNumRegFramesForFastBA;
   if (is_small_reconstruction && custom_ba_options.ceres) {
     custom_ba_options.ceres->solver_options.function_tolerance /= 10;
     custom_ba_options.ceres->solver_options.gradient_tolerance /= 10;
@@ -1092,6 +1082,14 @@ bool IncrementalMapper::AdjustGlobalBundle(
     for (const data_t& data_id : frame.ImageIds()) {
       ba_config.AddImage(data_id.id);
     }
+  }
+
+  // After filtering, the reconstruction may have fewer than 2 images,
+  // in which case global bundle adjustment is not possible.
+  if (ba_config.NumImages() < 2) {
+    LOG(WARNING) << "At least two images must be registered for global "
+                    "bundle-adjustment";
+    return false;
   }
 
   // Fix the existing images, if option specified.

--- a/src/colmap/sfm/incremental_mapper_test.cc
+++ b/src/colmap/sfm/incremental_mapper_test.cc
@@ -577,6 +577,36 @@ TEST_F(IncrementalMapperLargeDatasetTest, FilterFramesRegStatsConsistency) {
   }
 }
 
+// Reproduces the crash when FilterFrames aggressively deregisters frames,
+// leaving fewer than 2 images for a subsequent AdjustGlobalBundle call.
+TEST_F(IncrementalMapperLargeDatasetTest,
+       AdjustGlobalBundleReturnsFalseAfterAggressiveFiltering) {
+  BeginWithSynthesizedReconstruction();
+
+  ASSERT_GE(reconstruction_->NumRegFrames(), 20);
+
+  // Delete observations in all but one frame. Because DeleteObservation
+  // removes shared 3D points, this cascades to the surviving frame too,
+  // so FilterFrames ends up deregistering all frames.
+  const auto reg_frame_ids = reconstruction_->RegFrameIds();
+  bool skipped_first = false;
+  for (const frame_t frame_id : reg_frame_ids) {
+    if (!skipped_first) {
+      skipped_first = true;
+      continue;
+    }
+    DeleteAllObservationsInFrame(frame_id);
+  }
+
+  mapper_->FilterFrames(options_);
+  ASSERT_LT(reconstruction_->NumRegImages(), 2);
+
+  // Before the fix, this would crash with:
+  //   THROW_CHECK_GE(ba_config.NumImages(), 2)
+  BundleAdjustmentOptions ba_options;
+  EXPECT_FALSE(mapper_->AdjustGlobalBundle(options_, ba_options));
+}
+
 TEST_F(IncrementalMapperTest, RegStatsResetBetweenReconstructions) {
   BeginWithSynthesizedReconstruction();
 

--- a/src/colmap/sfm/incremental_mapper_test.cc
+++ b/src/colmap/sfm/incremental_mapper_test.cc
@@ -580,31 +580,19 @@ TEST_F(IncrementalMapperLargeDatasetTest, FilterFramesRegStatsConsistency) {
 // Reproduces the crash when FilterFrames aggressively deregisters frames,
 // leaving fewer than 2 images for a subsequent AdjustGlobalBundle call.
 TEST_F(IncrementalMapperLargeDatasetTest,
-       AdjustGlobalBundleReturnsFalseAfterAggressiveFiltering) {
+       AdjustGlobalBundleReturnsFalseWithInsufficientFrames) {
   BeginWithSynthesizedReconstruction();
 
   ASSERT_GE(reconstruction_->NumRegFrames(), 20);
 
-  // Delete observations in all but one frame. Because DeleteObservation
-  // removes shared 3D points, this cascades to the surviving frame too,
-  // so FilterFrames ends up deregistering all frames.
-  const auto reg_frame_ids = reconstruction_->RegFrameIds();
-  bool skipped_first = false;
-  for (const frame_t frame_id : reg_frame_ids) {
-    if (!skipped_first) {
-      skipped_first = true;
-      continue;
-    }
+  for (const frame_t frame_id : reconstruction_->RegFrameIds()) {
     DeleteAllObservationsInFrame(frame_id);
   }
 
   mapper_->FilterFrames(options_);
   ASSERT_LT(reconstruction_->NumRegImages(), 2);
 
-  // Before the fix, this would crash with:
-  //   THROW_CHECK_GE(ba_config.NumImages(), 2)
-  BundleAdjustmentOptions ba_options;
-  EXPECT_FALSE(mapper_->AdjustGlobalBundle(options_, ba_options));
+  EXPECT_FALSE(mapper_->AdjustGlobalBundle(options_, /*ba_options=*/{}));
 }
 
 TEST_F(IncrementalMapperTest, RegStatsResetBetweenReconstructions) {


### PR DESCRIPTION
- When `FilterFrames` becomes active at exactly 20 registered frames (its `kMinNumFrames` threshold), it can aggressively deregister frames with bogus camera parameters — potentially leaving fewer than 2 images in the reconstruction.
- A subsequent `AdjustGlobalBundle` call (e.g., from the fallback `IterativeGlobalRefinement` at line 613 when no more images can be registered) then hits `THROW_CHECK_GE(ba_config.NumImages(), 2)` and crashes.
- Replace the hard check with a graceful early `return false`, consistent with the function's `bool` return type. This allows the pipeline to skip the adjustment and terminate naturally.