### PR TITLE
Bind ReprojectionErrorType and additional point filter methods in pycolmap

### DIFF
--- a/src/pycolmap/sfm/observation_manager.cc
+++ b/src/pycolmap/sfm/observation_manager.cc
@@ -112,8 +112,8 @@ void BindObservationManager(py::module& m) {
            &ObservationManager::FilterPoints3DWithSmallTriangulationAngle,
            "min_tri_angle"_a,
            "point3D_ids"_a,
-           "Filter 3D points with insufficient triangulation angle in degrees. Return "
-           "the number of filtered observations.")
+           "Filter 3D points with insufficient triangulation angle in degrees. "
+           "Return the number of filtered observations.")
       .def("filter_frames",
            &ObservationManager::FindFramesToFilter,
            "min_focal_length_ratio"_a,

--- a/src/pycolmap/sfm/observation_manager.cc
+++ b/src/pycolmap/sfm/observation_manager.cc
@@ -19,6 +19,13 @@ void BindObservationManager(py::module& m) {
       .def_readwrite("num_tri_corrs", &ImagePairStat::num_tri_corrs)
       .def_readwrite("num_total_corrs", &ImagePairStat::num_total_corrs);
 
+  auto PyReprojectionErrorType =
+      py::enum_<ReprojectionErrorType>(m, "ReprojectionErrorType")
+          .value("PIXEL", ReprojectionErrorType::PIXEL)
+          .value("NORMALIZED", ReprojectionErrorType::NORMALIZED)
+          .value("ANGULAR", ReprojectionErrorType::ANGULAR);
+  AddStringToEnumConstructor(PyReprojectionErrorType);
+
   py::classh<ObservationManager>(m, "ObservationManager")
       .def(py::init<Reconstruction&,
                     std::shared_ptr<const CorrespondenceGraph>>(),
@@ -92,6 +99,21 @@ void BindObservationManager(py::module& m) {
            &ObservationManager::FilterObservationsWithNegativeDepth,
            "Filter observations that have negative depth. Return the number of "
            "filtered observations.")
+      .def("filter_points3D_with_large_reprojection_error",
+           &ObservationManager::FilterPoints3DWithLargeReprojectionError,
+           "max_error"_a,
+           "point3D_ids"_a,
+           "error_type"_a = ReprojectionErrorType::PIXEL,
+           "Filter observations with large reprojection error. For PIXEL and "
+           "NORMALIZED, max_error is the reprojection error; for ANGULAR, it "
+           "is the angular error in degrees. Return the number of filtered "
+           "observations.")
+      .def("filter_points3D_with_small_triangulation_angle",
+           &ObservationManager::FilterPoints3DWithSmallTriangulationAngle,
+           "min_tri_angle"_a,
+           "point3D_ids"_a,
+           "Filter 3D points with insufficient triangulation angle. Return "
+           "the number of filtered observations.")
       .def("filter_frames",
            &ObservationManager::FindFramesToFilter,
            "min_focal_length_ratio"_a,

--- a/src/pycolmap/sfm/observation_manager.cc
+++ b/src/pycolmap/sfm/observation_manager.cc
@@ -112,7 +112,7 @@ void BindObservationManager(py::module& m) {
            &ObservationManager::FilterPoints3DWithSmallTriangulationAngle,
            "min_tri_angle"_a,
            "point3D_ids"_a,
-           "Filter 3D points with insufficient triangulation angle. Return "
+           "Filter 3D points with insufficient triangulation angle in degrees. Return "
            "the number of filtered observations.")
       .def("filter_frames",
            &ObservationManager::FindFramesToFilter,


### PR DESCRIPTION
Expose ObservationManager::FilterPoints3DWithLargeReprojectionError, which supports PIXEL, NORMALIZED, and ANGULAR reprojection error metrics, along with FilterPoints3DWithSmallTriangulationAngle. Also bind the ReprojectionErrorType enum so the angular-error mode is reachable from Python.