### PR TITLE
Change std::filesystem::relative to lexically_relative for NormalizePath.

### DIFF
--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -169,7 +169,7 @@ std::string NormalizePath(const std::filesystem::path& path) {
 
 std::string GetNormalizedRelativePath(const std::filesystem::path& full_path,
                                       const std::filesystem::path& base_path) {
-  return NormalizePath(std::filesystem::relative(full_path, base_path));
+  return NormalizePath(full_path.lexically_relative(base_path));
 }
 
 std::vector<std::filesystem::path> GetRecursiveFileList(

--- a/src/colmap/util/file.cc
+++ b/src/colmap/util/file.cc
@@ -169,7 +169,7 @@ std::string NormalizePath(const std::filesystem::path& path) {
 
 std::string GetNormalizedRelativePath(const std::filesystem::path& full_path,
                                       const std::filesystem::path& base_path) {
-  return NormalizePath(full_path.lexically_relative(base_path));
+  return NormalizePath(full_path.lexically_proximate(base_path));
 }
 
 std::vector<std::filesystem::path> GetRecursiveFileList(

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -150,6 +150,28 @@ TEST(GetNormalizedRelativePath, Nominal) {
   }
 }
 
+TEST(GetNormalizedRelativePath, PreservesSymlinkStructure) {
+  const auto dir = CreateTestDir();
+  const auto target_dir = dir / "folder";
+  const auto file_path = target_dir / "sub-folder" / "file.txt";
+  CreateDirIfNotExists(file_path.parent_path(), /*recursive=*/true);
+  {
+    std::ofstream file(file_path);
+  }
+
+  const auto symlink_dir = dir / "images_link";
+  try {
+    // Might fail on Windows if symlinks are not enabled.
+    std::filesystem::create_directory_symlink(target_dir, symlink_dir);
+  } catch (const std::filesystem::filesystem_error& e) {
+    GTEST_SKIP() << "Could not create symlink: " << e.what();
+  }
+
+  EXPECT_EQ(GetNormalizedRelativePath(file_path, symlink_dir),
+            NormalizePath(std::filesystem::path("..") / "folder" /
+                          "sub-folder" / "file.txt"));
+}
+
 TEST(FileCopy, Nominal) {
   const auto dir = CreateTestDir();
   const auto src_path = dir / "source.txt";


### PR DESCRIPTION
Currently, NormalizePath will use std::filesystem::relative to compute the relative location of the images to the image_path in the image_reader. However, as std::filesystem::relative is defined as using weakly_canonical, it will resolve symlinks [(ref)](https://en.cppreference.com/w/cpp/filesystem/relative.html). 

This leads to counterintuitive issues when processing folders which contain images as symlinks. An example:

/path/to/real/image.png
/path/to/symlinks/image.png

image_path: /path/to/symlinks

Now NormalizePath will resolve to e.g. ../real/image.png instead of symlinks/image.png. This in turn can cause images to be duplicated during feature extraction as the image names are suddenly "new".