### PR TITLE
Fix project config CLI override precedence

### DIFF
--- a/src/colmap/controllers/base_option_manager.cc
+++ b/src/colmap/controllers/base_option_manager.cc
@@ -253,9 +253,21 @@ bool BaseOptionManager::Parse(const int argc, char** argv) {
       if (!Read(*project_path)) {
         return false;
       }
-    } else {
-      vmap.notify();
     }
+
+    if (vmap.count("project_path")) {
+      // When a project file is loaded, only re-apply explicit CLI arguments so
+      // config-loaded values are preserved while CLI overrides still win.
+      for (auto it = vmap.begin(); it != vmap.end();) {
+        if (it->first == "project_path" || it->second.defaulted()) {
+          it = vmap.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+
+    vmap.notify();
 
     ApplyEnumConversions();
     ApplyLogFlags();

--- a/src/colmap/controllers/base_option_manager_test.cc
+++ b/src/colmap/controllers/base_option_manager_test.cc
@@ -323,6 +323,46 @@ TEST(BaseOptionManager, ParseWithProjectPath) {
   EXPECT_EQ(*options.image_path, *options_write.image_path);
 }
 
+TEST(BaseOptionManager, ParseWithProjectPathAndCliOverrides) {
+  const auto test_dir = CreateTestDir();
+  const auto config_path = test_dir / "config.ini";
+  const auto config_images_path = test_dir / "images_from_config";
+  const auto cli_images_path = test_dir / "images_from_cli";
+  CreateDirIfNotExists(config_images_path);
+  CreateDirIfNotExists(cli_images_path);
+
+  BaseOptionManager options_write;
+  options_write.AddDatabaseOptions();
+  options_write.AddImageOptions();
+  *options_write.database_path = test_dir / "database_from_config.db";
+  *options_write.image_path = config_images_path;
+  options_write.Write(config_path);
+
+  BaseOptionManager options;
+  options.AddDatabaseOptions();
+  options.AddImageOptions();
+
+  const std::vector<std::string> args = {
+      "colmap",
+      "--project_path",
+      config_path.string(),
+      "--image_path",
+      cli_images_path.string(),
+  };
+
+  std::vector<char*> argv;
+  argv.reserve(args.size());
+  for (auto& arg : args) {
+    argv.push_back(const_cast<char*>(arg.c_str()));
+  }
+
+  EXPECT_TRUE(options.Parse(argv.size(), argv.data()));
+
+  EXPECT_EQ(*options.project_path, config_path);
+  EXPECT_EQ(*options.database_path, *options_write.database_path);
+  EXPECT_EQ(*options.image_path, cli_images_path);
+}
+
 TEST(BaseOptionManager, ParseEmptyArguments) {
   BaseOptionManager options;
 

--- a/src/colmap/controllers/option_manager_test.cc
+++ b/src/colmap/controllers/option_manager_test.cc
@@ -309,6 +309,55 @@ TEST(OptionManager, ParseWithProjectPath) {
   EXPECT_EQ(options.feature_extraction->max_image_size, 3000);
 }
 
+TEST(OptionManager, ParseWithProjectPathAndCliOverrides) {
+  const auto test_dir = CreateTestDir();
+  const auto config_path = test_dir / "config.ini";
+  const auto config_image_path = test_dir / "images_from_config";
+  const auto custom_image_path = test_dir / "images_from_cli";
+  CreateDirIfNotExists(config_image_path);
+  CreateDirIfNotExists(custom_image_path);
+
+  OptionManager options_write;
+  options_write.AddDatabaseOptions();
+  options_write.AddImageOptions();
+  options_write.AddFeatureExtractionOptions();
+
+  *options_write.database_path = test_dir / "database_from_config.db";
+  *options_write.image_path = config_image_path;
+  options_write.feature_extraction->max_image_size = 3000;
+  options_write.feature_extraction->sift->max_num_features = 4096;
+  options_write.Write(config_path);
+
+  OptionManager options;
+  options.AddDatabaseOptions();
+  options.AddImageOptions();
+  options.AddFeatureExtractionOptions();
+
+  const std::vector<std::string> args = {
+      "colmap",
+      "--project_path",
+      config_path.string(),
+      "--image_path",
+      custom_image_path.string(),
+      "--FeatureExtraction.max_image_size",
+      "1024",
+  };
+
+  std::vector<char*> argv;
+  argv.reserve(args.size());
+  for (auto& arg : args) {
+    argv.push_back(const_cast<char*>(arg.c_str()));
+  }
+
+  EXPECT_TRUE(options.Parse(argv.size(), argv.data()));
+
+  EXPECT_EQ(*options.project_path, config_path);
+  EXPECT_EQ(*options.database_path, *options_write.database_path);
+  EXPECT_EQ(*options.image_path, custom_image_path);
+  EXPECT_EQ(options.feature_extraction->max_image_size, 1024);
+  EXPECT_EQ(options.feature_extraction->sift->max_num_features, 4096);
+}
+
 TEST(OptionManager, ParseEmptyArguments) {
   OptionManager options;
 


### PR DESCRIPTION
- preserve config values loaded from `--project_path` while reapplying explicit CLI overrides
- add BaseOptionManager and OptionManager regression tests for config-plus-CLI precedence
- document the precedence logic in the parser
