### PR TITLE
Simplify merge_trials_ and reuse Complete() BFS allocations in IncrementalTriangulator

### DIFF
--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -601,8 +601,7 @@ size_t IncrementalTriangulator::Merge(const Options& options,
       }
 
       const Point2D& corr_point2D = image.Point2D(corr->point2D_idx);
-      if (!corr_point2D.HasPoint3D() ||
-          corr_point2D.point3D_id == point3D_id) {
+      if (!corr_point2D.HasPoint3D() || corr_point2D.point3D_id == point3D_id) {
         continue;
       }
 
@@ -751,8 +750,7 @@ size_t IncrementalTriangulator::Complete(const Options& options,
 
         // Recursively complete track for this new correspondence.
         if (transitivity < max_transitivity) {
-          complete_next_queue_.emplace_back(corr->image_id,
-                                            corr->point2D_idx);
+          complete_next_queue_.emplace_back(corr->image_id, corr->point2D_idx);
         }
 
         num_completed += 1;

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -691,8 +691,7 @@ size_t IncrementalTriangulator::Complete(const Options& options,
 
   // Reuse member-held BFS scratch buffers across Complete() invocations to
   // avoid per-call heap allocations.
-  complete_curr_queue_.assign(point3D.track.Elements().begin(),
-                              point3D.track.Elements().end());
+  complete_curr_queue_ = point3D.track.Elements();
   complete_next_queue_.clear();
   complete_visited_.clear();
 

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -601,8 +601,18 @@ size_t IncrementalTriangulator::Merge(const Options& options,
       }
 
       const Point2D& corr_point2D = image.Point2D(corr->point2D_idx);
-      if (!corr_point2D.HasPoint3D() || corr_point2D.point3D_id == point3D_id ||
-          merge_trials_[point3D_id].count(corr_point2D.point3D_id) > 0) {
+      if (!corr_point2D.HasPoint3D() ||
+          corr_point2D.point3D_id == point3D_id) {
+        continue;
+      }
+
+      // Canonical (min, max) pair so this merge is keyed identically
+      // regardless of which side of the pair we are visiting from.
+      const std::pair<point3D_t, point3D_t> merge_trial_key =
+          point3D_id < corr_point2D.point3D_id
+              ? std::pair{point3D_id, corr_point2D.point3D_id}
+              : std::pair{corr_point2D.point3D_id, point3D_id};
+      if (merge_trials_.count(merge_trial_key) > 0) {
         continue;
       }
 
@@ -611,8 +621,7 @@ size_t IncrementalTriangulator::Merge(const Options& options,
       const Point3D& corr_point3D =
           reconstruction_.Point3D(corr_point2D.point3D_id);
 
-      merge_trials_[point3D_id].insert(corr_point2D.point3D_id);
-      merge_trials_[corr_point2D.point3D_id].insert(point3D_id);
+      merge_trials_.insert(merge_trial_key);
 
       // Weighted average of point locations, depending on track length.
       const Eigen::Vector3d merged_xyz =
@@ -683,18 +692,37 @@ size_t IncrementalTriangulator::Complete(const Options& options,
 
   const Point3D& point3D = reconstruction_.Point3D(point3D_id);
 
-  std::vector<TrackElement> curr_queue = point3D.track.Elements();
-  std::vector<TrackElement> next_queue;
+  // Reuse member-held BFS scratch buffers across Complete() invocations to
+  // avoid per-call heap allocations.
+  complete_curr_queue_.assign(point3D.track.Elements().begin(),
+                              point3D.track.Elements().end());
+  complete_next_queue_.clear();
+  complete_visited_.clear();
+
+  // Seed visited with the existing track members so the BFS never tries to
+  // re-add them.
+  for (const TrackElement& el : complete_curr_queue_) {
+    complete_visited_.insert(std::make_pair(el.image_id, el.point2D_idx));
+  }
 
   const int max_transitivity = options.complete_max_transitivity;
   for (int transitivity = 1; transitivity <= max_transitivity; ++transitivity) {
-    while (!curr_queue.empty()) {
-      const TrackElement queue_elem = curr_queue.back();
-      curr_queue.pop_back();
+    while (!complete_curr_queue_.empty()) {
+      const TrackElement queue_elem = complete_curr_queue_.back();
+      complete_curr_queue_.pop_back();
 
       const auto corr_range = correspondence_graph_->FindCorrespondences(
           queue_elem.image_id, queue_elem.point2D_idx);
       for (const auto* corr = corr_range.beg; corr < corr_range.end; ++corr) {
+        // Two queue entries at the same transitivity level can share
+        // correspondences. Dedupe before the (more expensive) reprojection
+        // check below so we don't redo it for each parent.
+        if (!complete_visited_
+                 .insert(std::make_pair(corr->image_id, corr->point2D_idx))
+                 .second) {
+          continue;
+        }
+
         const Image& image = reconstruction_.Image(corr->image_id);
         if (!image.HasPose()) {
           continue;
@@ -723,18 +751,19 @@ size_t IncrementalTriangulator::Complete(const Options& options,
 
         // Recursively complete track for this new correspondence.
         if (transitivity < max_transitivity) {
-          next_queue.emplace_back(corr->image_id, corr->point2D_idx);
+          complete_next_queue_.emplace_back(corr->image_id,
+                                            corr->point2D_idx);
         }
 
         num_completed += 1;
       }
     }
 
-    if (next_queue.empty()) {
+    if (complete_next_queue_.empty()) {
       break;
     }
 
-    std::swap(curr_queue, next_queue);
+    std::swap(complete_curr_queue_, complete_next_queue_);
   }
 
   return num_completed;

--- a/src/colmap/sfm/incremental_triangulator.cc
+++ b/src/colmap/sfm/incremental_triangulator.cc
@@ -611,7 +611,7 @@ size_t IncrementalTriangulator::Merge(const Options& options,
           point3D_id < corr_point2D.point3D_id
               ? std::pair{point3D_id, corr_point2D.point3D_id}
               : std::pair{corr_point2D.point3D_id, point3D_id};
-      if (merge_trials_.count(merge_trial_key) > 0) {
+      if (!merge_trials_.insert(merge_trial_key).second) {
         continue;
       }
 
@@ -619,8 +619,6 @@ size_t IncrementalTriangulator::Merge(const Options& options,
 
       const Point3D& corr_point3D =
           reconstruction_.Point3D(corr_point2D.point3D_id);
-
-      merge_trials_.insert(merge_trial_key);
 
       // Weighted average of point locations, depending on track length.
       const Eigen::Vector3d merged_xyz =

--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -204,11 +204,26 @@ class IncrementalTriangulator {
   // Cache for cameras with bogus parameters.
   std::unordered_map<camera_t, bool> camera_has_bogus_params_;
 
-  // Cache for tried track merges to avoid duplicate merge trials.
-  std::unordered_map<point3D_t, std::unordered_set<point3D_t>> merge_trials_;
+  // Cache for tried track merges to avoid duplicate merge trials. Keyed on
+  // a canonical (min, max) pair of 3D-point ids so each attempted merge is
+  // recorded once with a single hashmap operation in either direction.
+  // Uses the std::hash<std::pair<uint64_t, uint64_t>> specialization in
+  // colmap/util/types.h.
+  std::unordered_set<std::pair<point3D_t, point3D_t>> merge_trials_;
 
   // Cache for found correspondences in the graph.
   std::vector<CorrespondenceGraph::Correspondence> found_corrs_;
+
+  // Reusable BFS scratch buffers for Complete(). Held as members so each
+  // invocation swap+clears instead of heap-allocating fresh vectors.
+  std::vector<TrackElement> complete_curr_queue_;
+  std::vector<TrackElement> complete_next_queue_;
+  // Dedupes (image_id, point2D_idx) pairs reached by Complete()'s BFS so
+  // the inner reprojection-error check is not redone for correspondences
+  // shared across multiple parents at the same transitivity level. Uses
+  // the std::hash<std::pair<uint32_t, uint32_t>> specialization in
+  // colmap/util/types.h.
+  std::unordered_set<std::pair<image_t, point2D_t>> complete_visited_;
 
   // Number of trials to retriangulate image pair.
   std::unordered_map<image_pair_t, int> re_num_trials_;

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -353,6 +353,16 @@ struct hash<std::pair<uint32_t, uint32_t>> {
   }
 };
 
+// Hash function specialization for uint64_t pairs, e.g., point3D_t.
+template <>
+struct hash<std::pair<uint64_t, uint64_t>> {
+  std::size_t operator()(const std::pair<uint64_t, uint64_t>& p) const {
+    const std::size_t h1 = std::hash<uint64_t>{}(p.first);
+    const std::size_t h2 = std::hash<uint64_t>{}(p.second);
+    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+  }
+};
+
 template <>
 struct hash<colmap::sensor_t> {
   std::size_t operator()(const colmap::sensor_t& s) const noexcept {

--- a/src/colmap/util/types_test.cc
+++ b/src/colmap/util/types_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/util/types.h"
 
+#include <limits>
 #include <unordered_set>
 
 #include <gmock/gmock.h>
@@ -126,6 +127,68 @@ TEST(FeatureMatchHashing, Nominal) {
   EXPECT_EQ(set.count(std::make_pair(0, 0)), 0);
   EXPECT_EQ(set.count(std::make_pair(1, 2)), 1);
   EXPECT_EQ(set.count(std::make_pair(2, 1)), 1);
+}
+
+TEST(FeatureMatchHashing, LargeValues) {
+  const point2D_t hi = std::numeric_limits<point2D_t>::max();
+  const point2D_t lo = 1;
+  std::unordered_set<std::pair<point2D_t, point2D_t>> set;
+  set.emplace(hi, lo);
+  set.emplace(lo, hi);
+  set.emplace(hi, hi);
+  set.emplace(lo, lo);
+  EXPECT_EQ(set.size(), 4);
+  EXPECT_EQ(set.count(std::make_pair(hi, lo)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(hi, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, lo)), 1);
+}
+
+TEST(FeatureMatchHashing, Deterministic) {
+  std::hash<std::pair<point2D_t, point2D_t>> h;
+  EXPECT_EQ(h(std::make_pair<point2D_t, point2D_t>(42, 99)),
+            h(std::make_pair<point2D_t, point2D_t>(42, 99)));
+  EXPECT_NE(h(std::make_pair<point2D_t, point2D_t>(42, 99)),
+            h(std::make_pair<point2D_t, point2D_t>(99, 42)));
+}
+
+TEST(Point3DPairHashing, Nominal) {
+  std::unordered_set<std::pair<point3D_t, point3D_t>> set;
+  set.emplace(1, 2);
+  EXPECT_EQ(set.size(), 1);
+  set.emplace(1, 2);
+  EXPECT_EQ(set.size(), 1);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(0, 0)), 0);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(1, 2)), 1);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(2, 1)), 0);
+  set.emplace(2, 1);
+  EXPECT_EQ(set.size(), 2);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(0, 0)), 0);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(1, 2)), 1);
+  EXPECT_EQ(set.count(std::make_pair<point3D_t, point3D_t>(2, 1)), 1);
+}
+
+TEST(Point3DPairHashing, LargeValues) {
+  const point3D_t hi = std::numeric_limits<point3D_t>::max();
+  const point3D_t lo = 1;
+  std::unordered_set<std::pair<point3D_t, point3D_t>> set;
+  set.emplace(hi, lo);
+  set.emplace(lo, hi);
+  set.emplace(hi, hi);
+  set.emplace(lo, lo);
+  EXPECT_EQ(set.size(), 4);
+  EXPECT_EQ(set.count(std::make_pair(hi, lo)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(hi, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, lo)), 1);
+}
+
+TEST(Point3DPairHashing, Deterministic) {
+  std::hash<std::pair<point3D_t, point3D_t>> h;
+  EXPECT_EQ(h(std::make_pair<point3D_t, point3D_t>(42, 99)),
+            h(std::make_pair<point3D_t, point3D_t>(42, 99)));
+  EXPECT_NE(h(std::make_pair<point3D_t, point3D_t>(42, 99)),
+            h(std::make_pair<point3D_t, point3D_t>(99, 42)));
 }
 
 }  // namespace


### PR DESCRIPTION

- `IncrementalTriangulator::merge_trials_` switched from `unordered_map<point3D_t, unordered_set<point3D_t>>` to a flat `unordered_set<pair<point3D_t, point3D_t>>` keyed on the canonical (min, max) pair. Each attempted merge is recorded once instead of twice and every check/insert is a single hashmap operation instead of two.
- `IncrementalTriangulator::Complete()` now reuses three triangulator-owned scratch buffers (`complete_curr_queue_`, `complete_next_queue_`, `complete_visited_`) across invocations instead of heap-allocating fresh vectors per call, and dedupes correspondences via a `visited` set so the inner reprojection-error check isn't repeated for correspondences shared across multiple parents at the same BFS transitivity level.
- Added a `std::hash<std::pair<uint64_t, uint64_t>>` specialization to `colmap/util/types.h` next to the existing `<uint32_t, uint32_t>` one, so the new flat sets get a deterministic hash for free without a per-site custom hasher. The visited-set in `Complete()` reuses the existing `<uint32_t, uint32_t>` specialization for `(image_t, point2D_t)`.