### PR TITLE
Show camera up vector in the viewer

### DIFF
--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -185,17 +185,32 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                    plane_color(3)));
 
     if (show_camera_up_arrow) {
+      const Eigen::Matrix3f world_from_cam_rot =
+          world_from_cam_mat.block<3, 3>(0, 0);
+
+      const Eigen::Vector3f right_dir = world_from_cam_rot.col(0);
+      const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
+      const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
+
       const Eigen::Vector3f plane_normal =
           (tr - tl).cross(bl - tl).normalized();
+
+      Eigen::Vector3f right =
+          right_dir - right_dir.dot(plane_normal) * plane_normal;
+      Eigen::Vector3f up = up_dir - up_dir.dot(plane_normal) * plane_normal;
+
+      right.normalize();
+      up.normalize();
+
       const float size = 0.08f * std::max(image_width, image_height);
 
-      // Forward offset to avoid z-fighting
+      // forward offset (avoid z-fighting)
       const float eps = 0.01f * image_extent;
       const Eigen::Vector3f offset = eps * plane_normal;
 
       const Eigen::Vector3f c0 = tl + offset;
-      const Eigen::Vector3f c1 = c0 + size * (tr - tl).normalized();
-      const Eigen::Vector3f c2 = c0 + size * (bl - tl).normalized();
+      const Eigen::Vector3f c1 = c0 + size * right;
+      const Eigen::Vector3f c2 = c0 + size * (-up);
 
       triangle_data->emplace_back(PointPainter::Data(c0(0),
                                                      c0(1),
@@ -214,6 +229,28 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                   PointPainter::Data(c2(0),
                                                      c2(1),
                                                      c2(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)));
+
+      triangle_data->emplace_back(PointPainter::Data(c0(0),
+                                                     c0(1),
+                                                     c0(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)),
+                                  PointPainter::Data(c2(0),
+                                                     c2(1),
+                                                     c2(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)),
+                                  PointPainter::Data(c1(0),
+                                                     c1(1),
+                                                     c1(2),
                                                      frame_color(0),
                                                      frame_color(1),
                                                      frame_color(2),
@@ -277,7 +314,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
       add_line(tip, head_right);
     }
   }
-}
+}  // namespace
 
 }  // namespace
 

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -192,25 +192,13 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
       const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
       const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
 
-      const Eigen::Vector3f plane_normal =
-          (tr - tl).cross(bl - tl).normalized();
+      // Size + offset
+      const float size = 0.08f * image_extent;
+      const float offset = 0.01f * image_extent;
 
-      Eigen::Vector3f right =
-          right_dir - right_dir.dot(plane_normal) * plane_normal;
-      Eigen::Vector3f up = up_dir - up_dir.dot(plane_normal) * plane_normal;
-
-      right.normalize();
-      up.normalize();
-
-      const float size = 0.08f * std::max(image_width, image_height);
-
-      // forward offset (avoid z-fighting)
-      const float eps = 0.01f * image_extent;
-      const Eigen::Vector3f offset = eps * plane_normal;
-
-      const Eigen::Vector3f c0 = tl + offset;
-      const Eigen::Vector3f c1 = c0 + size * right;
-      const Eigen::Vector3f c2 = c0 + size * (-up);
+      const Eigen::Vector3f c0 = tl + forward_dir * offset;
+      const Eigen::Vector3f c1 = c0 + size * right_dir;
+      const Eigen::Vector3f c2 = c0 - size * up_dir;
 
       triangle_data->emplace_back(PointPainter::Data(c0(0),
                                                      c0(1),

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -127,122 +127,53 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
   const Eigen::Vector3f pc = world_from_cam_mat.rightCols<1>();
   const Eigen::Vector3f tl =
       world_from_cam_mat *
-      Eigen::Vector4f(-image_width, image_height, focal_length, 1);
+      Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
   const Eigen::Vector3f tr =
       world_from_cam_mat *
-      Eigen::Vector4f(image_width, image_height, focal_length, 1);
+      Eigen::Vector4f(image_width, -image_height, focal_length, 1);
   const Eigen::Vector3f br =
       world_from_cam_mat *
-      Eigen::Vector4f(image_width, -image_height, focal_length, 1);
+      Eigen::Vector4f(image_width, image_height, focal_length, 1);
   const Eigen::Vector3f bl =
       world_from_cam_mat *
-      Eigen::Vector4f(-image_width, -image_height, focal_length, 1);
+      Eigen::Vector4f(-image_width, image_height, focal_length, 1);
 
   // Image plane as two triangles.
   if (triangle_data != nullptr) {
-    triangle_data->emplace_back(PointPainter::Data(tl(0),
-                                                   tl(1),
-                                                   tl(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)),
-                                PointPainter::Data(tr(0),
-                                                   tr(1),
-                                                   tr(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)),
-                                PointPainter::Data(bl(0),
-                                                   bl(1),
-                                                   bl(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)));
-
-    triangle_data->emplace_back(PointPainter::Data(bl(0),
-                                                   bl(1),
-                                                   bl(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)),
-                                PointPainter::Data(tr(0),
-                                                   tr(1),
-                                                   tr(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)),
-                                PointPainter::Data(br(0),
-                                                   br(1),
-                                                   br(2),
-                                                   plane_color(0),
-                                                   plane_color(1),
-                                                   plane_color(2),
-                                                   plane_color(3)));
+    const auto add_triangle = [&](const Eigen::Vector3f& p1,
+                                  const Eigen::Vector3f& p2,
+                                  const Eigen::Vector3f& p3,
+                                  const RGBAColor& color) {
+      triangle_data->emplace_back(
+          PointPainter::Data(
+              p1(0), p1(1), p1(2), color(0), color(1), color(2), color(3)),
+          PointPainter::Data(
+              p2(0), p2(1), p2(2), color(0), color(1), color(2), color(3)),
+          PointPainter::Data(
+              p3(0), p3(1), p3(2), color(0), color(1), color(2), color(3)));
+    };
+    add_triangle(tl, tr, bl, plane_color);
+    add_triangle(bl, tr, br, plane_color);
 
     if (show_camera_up_arrow) {
       const Eigen::Matrix3f world_from_cam_rot =
           world_from_cam_mat.block<3, 3>(0, 0);
 
       const Eigen::Vector3f right_dir = world_from_cam_rot.col(0);
-      const Eigen::Vector3f up_dir = world_from_cam_rot.col(1);
+      const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
       const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
 
       // Size + offset
-      const float size = 0.3f * image_extent;
+      const float size = 0.5f * image_extent;
       const float offset = 0.01f * image_extent;
-
-      const Eigen::Vector3f c0 = tl + forward_dir * offset;
+      const Eigen::Vector3f offset_vec = forward_dir * offset;
+      const Eigen::Vector3f c0 = tl;
       const Eigen::Vector3f c1 = c0 + size * right_dir;
       const Eigen::Vector3f c2 = c0 - size * up_dir;
-
-      triangle_data->emplace_back(PointPainter::Data(c0(0),
-                                                     c0(1),
-                                                     c0(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)),
-                                  PointPainter::Data(c1(0),
-                                                     c1(1),
-                                                     c1(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)),
-                                  PointPainter::Data(c2(0),
-                                                     c2(1),
-                                                     c2(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)));
-
-      triangle_data->emplace_back(PointPainter::Data(c0(0),
-                                                     c0(1),
-                                                     c0(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)),
-                                  PointPainter::Data(c2(0),
-                                                     c2(1),
-                                                     c2(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)),
-                                  PointPainter::Data(c1(0),
-                                                     c1(1),
-                                                     c1(2),
-                                                     frame_color(0),
-                                                     frame_color(1),
-                                                     frame_color(2),
-                                                     frame_color(3)));
+      add_triangle(
+          c0 + offset_vec, c1 + offset_vec, c2 + offset_vec, frame_color);
+      add_triangle(
+          c0 - offset_vec, c2 - offset_vec, c1 - offset_vec, frame_color);
     }
   }
 

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -189,11 +189,11 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
           world_from_cam_mat.block<3, 3>(0, 0);
 
       const Eigen::Vector3f right_dir = world_from_cam_rot.col(0);
-      const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
+      const Eigen::Vector3f up_dir = world_from_cam_rot.col(1);
       const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
 
       // Size + offset
-      const float size = 0.08f * image_extent;
+      const float size = 0.3f * image_extent;
       const float offset = 0.01f * image_extent;
 
       const Eigen::Vector3f c0 = tl + forward_dir * offset;

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -91,7 +91,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                       const RGBAColor& frame_color,
                       const Eigen::Vector3d& model_origin,
                       const double model_scale,
-                      const bool show_camera_up_arrow,
+                      const bool show_camera_orientation,
                       std::vector<TrianglePainter::Data>* triangle_data,
                       std::vector<LinePainter::Data>* line_data) {
   // Updating the reconstruction in the viewer (e.g., deleting an image or a
@@ -155,7 +155,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
     add_triangle(tl, tr, bl, plane_color);
     add_triangle(bl, tr, br, plane_color);
 
-    if (show_camera_up_arrow) {
+    if (show_camera_orientation) {
       const Eigen::Matrix3f world_from_cam_rot =
           world_from_cam_mat.block<3, 3>(0, 0);
 
@@ -1130,7 +1130,7 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
                      frame_color,
                      model_origin_,
                      model_scale_,
-                     options_->render->show_camera_up_arrow,
+                     options_->render->show_camera_orientation,
                      &triangle_data,
                      selection_mode ? nullptr : &line_data);
   }
@@ -1279,7 +1279,7 @@ void ModelViewerWidget::UploadMovieGrabberData() {
                        frame_color,
                        /*model_origin=*/Eigen::Vector3d::Zero(),
                        /*model_scale=*/1.,
-                       /*show_arrow=*/false,
+                       /*show_camera_orientation=*/false,
                        &triangle_data,
                        &line_data);
     }

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -185,14 +185,17 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                    plane_color(3)));
 
     if (show_camera_up_arrow) {
-      const float inset = 0.08f;  // how far from top-left corner
+      const Eigen::Vector3f plane_normal =
+          (tr - tl).cross(bl - tl).normalized();
+      const float size = 0.08f * std::max(image_width, image_height);
 
-      const Eigen::Vector3f right_step = inset * (tr - tl);
-      const Eigen::Vector3f down_step = inset * (bl - tl);
+      // Forward offset to avoid z-fighting
+      const float eps = 0.01f * image_extent;
+      const Eigen::Vector3f offset = eps * plane_normal;
 
-      const Eigen::Vector3f c0 = tl + right_step + down_step;
-      const Eigen::Vector3f c1 = c0 + 0.6f * right_step;
-      const Eigen::Vector3f c2 = c0 + 0.6f * down_step;
+      const Eigen::Vector3f c0 = tl + offset;
+      const Eigen::Vector3f c1 = c0 + size * (tr - tl).normalized();
+      const Eigen::Vector3f c2 = c0 + size * (bl - tl).normalized();
 
       triangle_data->emplace_back(PointPainter::Data(c0(0),
                                                      c0(1),
@@ -220,21 +223,20 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
 
   const auto add_line = [&](const Eigen::Vector3f& p1,
                             const Eigen::Vector3f& p2) {
-    line_data->emplace_back(
-        PointPainter::Data(p1(0),
-                           p1(1),
-                           p1(2),
-                           frame_color(0),
-                           frame_color(1),
-                           frame_color(2),
-                           frame_color(3)),
-        PointPainter::Data(p2(0),
-                           p2(1),
-                           p2(2),
-                           frame_color(0),
-                           frame_color(1),
-                           frame_color(2),
-                           frame_color(3)));
+    line_data->emplace_back(PointPainter::Data(p1(0),
+                                               p1(1),
+                                               p1(2),
+                                               frame_color(0),
+                                               frame_color(1),
+                                               frame_color(2),
+                                               frame_color(3)),
+                            PointPainter::Data(p2(0),
+                                               p2(1),
+                                               p2(2),
+                                               frame_color(0),
+                                               frame_color(1),
+                                               frame_color(2),
+                                               frame_color(3)));
   };
   if (line_data != nullptr) {
     // Frame around image plane and connecting lines to projection center.
@@ -269,7 +271,6 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
       const Eigen::Vector3f head_base = tip - up_dir * head_len;
       const Eigen::Vector3f head_left = head_base - right_dir * head_width;
       const Eigen::Vector3f head_right = head_base + right_dir * head_width;
-
 
       add_line(base, tip);
       add_line(tip, head_left);

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -177,24 +177,24 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
     }
   }
 
-  const auto add_line = [&](const Eigen::Vector3f& p1,
-                            const Eigen::Vector3f& p2) {
-    line_data->emplace_back(PointPainter::Data(p1(0),
-                                               p1(1),
-                                               p1(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(p2(0),
-                                               p2(1),
-                                               p2(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-  };
   if (line_data != nullptr) {
+    const auto add_line = [&](const Eigen::Vector3f& p1,
+                              const Eigen::Vector3f& p2) {
+      line_data->emplace_back(PointPainter::Data(p1(0),
+                                                 p1(1),
+                                                 p1(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)),
+                              PointPainter::Data(p2(0),
+                                                 p2(1),
+                                                 p2(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)));
+    };
     // Frame around image plane and connecting lines to projection center.
 
     add_line(pc, tl);
@@ -206,32 +206,6 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
     add_line(tr, br);
     add_line(br, bl);
     add_line(bl, tl);
-
-    if (show_camera_up_arrow) {
-      const Eigen::Matrix3f world_from_cam_rot =
-          world_from_cam_mat.block<3, 3>(0, 0);
-      const Eigen::Vector3f right_dir = world_from_cam_rot.col(0);
-      const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
-      const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
-
-      const float arrow_len = 0.3f * image_extent;
-      const float head_len = 0.35f * arrow_len;
-      const float head_width = 0.25f * arrow_len;
-      const float offset = 0.01f * image_extent;
-
-      const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
-
-      const Eigen::Vector3f arrow_center = center + forward_dir * offset;
-      const Eigen::Vector3f tip = arrow_center + up_dir * (0.5f * arrow_len);
-      const Eigen::Vector3f base = arrow_center - up_dir * (0.5f * arrow_len);
-      const Eigen::Vector3f head_base = tip - up_dir * head_len;
-      const Eigen::Vector3f head_left = head_base - right_dir * head_width;
-      const Eigen::Vector3f head_right = head_base + right_dir * head_width;
-
-      add_line(base, tip);
-      add_line(tip, head_left);
-      add_line(tip, head_right);
-    }
   }
 }  // namespace
 

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -183,6 +183,39 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                    plane_color(1),
                                                    plane_color(2),
                                                    plane_color(3)));
+
+    if (show_camera_up_arrow) {
+      const float inset = 0.08f;  // how far from top-left corner
+
+      const Eigen::Vector3f right_step = inset * (tr - tl);
+      const Eigen::Vector3f down_step = inset * (bl - tl);
+
+      const Eigen::Vector3f c0 = tl + right_step + down_step;
+      const Eigen::Vector3f c1 = c0 + 0.6f * right_step;
+      const Eigen::Vector3f c2 = c0 + 0.6f * down_step;
+
+      triangle_data->emplace_back(PointPainter::Data(c0(0),
+                                                     c0(1),
+                                                     c0(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)),
+                                  PointPainter::Data(c1(0),
+                                                     c1(1),
+                                                     c1(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)),
+                                  PointPainter::Data(c2(0),
+                                                     c2(1),
+                                                     c2(2),
+                                                     frame_color(0),
+                                                     frame_color(1),
+                                                     frame_color(2),
+                                                     frame_color(3)));
+    }
   }
 
   const auto add_line = [&](const Eigen::Vector3f& p1,

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -306,6 +306,61 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                frame_color(1),
                                                frame_color(2),
                                                frame_color(3)));
+
+    // ---- Up arrow on image plane ----
+
+    // Center of image plane
+    const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
+
+    // Directions on the plane
+    const Eigen::Vector3f right_dir = (tr - tl).normalized();
+    const Eigen::Vector3f up_dir = ((0.5f * (tl + tr)) - center).normalized();
+
+    // Size of the arrow
+    const float arrow_len = 0.3f * image_extent;
+    const float head_len  = 0.35f * arrow_len;
+    const float head_width = 0.25f * arrow_len;
+
+    // Slight offset forward to avoid z-fighting
+    const Eigen::Vector3f forward_dir = (center - pc).normalized();
+    const float offset = 0.01f * image_extent;
+
+    // Points
+    const Eigen::Vector3f base = center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
+    const Eigen::Vector3f tip  = center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
+
+    // Arrowhead points
+    const Eigen::Vector3f head_left =
+        tip - up_dir * head_len - right_dir * head_width + forward_dir * offset;
+    const Eigen::Vector3f head_right =
+        tip - up_dir * head_len + right_dir * head_width + forward_dir * offset;
+
+    // Shaft
+    line_data->emplace_back(
+        PointPainter::Data(base(0), base(1), base(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(tip(0), tip(1), tip(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
+
+    // Head left
+    line_data->emplace_back(
+        PointPainter::Data(tip(0), tip(1), tip(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(head_left(0), head_left(1), head_left(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
+
+    // Head right
+    line_data->emplace_back(
+        PointPainter::Data(tip(0), tip(1), tip(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)),
+        PointPainter::Data(head_right(0), head_right(1), head_right(2),
+                           frame_color(0), frame_color(1),
+                           frame_color(2), frame_color(3)));
   }
 }
 

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -185,208 +185,62 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                    plane_color(3)));
   }
 
+  const auto add_line = [&](const Eigen::Vector3f& p1,
+                            const Eigen::Vector3f& p2) {
+    line_data->emplace_back(
+        PointPainter::Data(p1(0),
+                           p1(1),
+                           p1(2),
+                           frame_color(0),
+                           frame_color(1),
+                           frame_color(2),
+                           frame_color(3)),
+        PointPainter::Data(p2(0),
+                           p2(1),
+                           p2(2),
+                           frame_color(0),
+                           frame_color(1),
+                           frame_color(2),
+                           frame_color(3)));
+  };
   if (line_data != nullptr) {
     // Frame around image plane and connecting lines to projection center.
 
-    line_data->emplace_back(PointPainter::Data(pc(0),
-                                               pc(1),
-                                               pc(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(tl(0),
-                                               tl(1),
-                                               tl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
+    add_line(pc, tl);
+    add_line(pc, tr);
+    add_line(pc, br);
+    add_line(pc, bl);
 
-    line_data->emplace_back(PointPainter::Data(pc(0),
-                                               pc(1),
-                                               pc(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(tr(0),
-                                               tr(1),
-                                               tr(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
+    add_line(tl, tr);
+    add_line(tr, br);
+    add_line(br, bl);
+    add_line(bl, tl);
 
-    line_data->emplace_back(PointPainter::Data(pc(0),
-                                               pc(1),
-                                               pc(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(br(0),
-                                               br(1),
-                                               br(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-
-    line_data->emplace_back(PointPainter::Data(pc(0),
-                                               pc(1),
-                                               pc(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(bl(0),
-                                               bl(1),
-                                               bl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-
-    line_data->emplace_back(PointPainter::Data(tl(0),
-                                               tl(1),
-                                               tl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(tr(0),
-                                               tr(1),
-                                               tr(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-
-    line_data->emplace_back(PointPainter::Data(tr(0),
-                                               tr(1),
-                                               tr(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(br(0),
-                                               br(1),
-                                               br(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-
-    line_data->emplace_back(PointPainter::Data(br(0),
-                                               br(1),
-                                               br(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(bl(0),
-                                               bl(1),
-                                               bl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
-
-    line_data->emplace_back(PointPainter::Data(bl(0),
-                                               bl(1),
-                                               bl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)),
-                            PointPainter::Data(tl(0),
-                                               tl(1),
-                                               tl(2),
-                                               frame_color(0),
-                                               frame_color(1),
-                                               frame_color(2),
-                                               frame_color(3)));
     if (show_camera_up_arrow) {
-      // ---- Up arrow on image plane ----
+      const Eigen::Matrix3f world_from_cam_rot =
+          world_from_cam_mat.block<3, 3>(0, 0);
+      const Eigen::Vector3f right_dir = world_from_cam_rot.col(0);
+      const Eigen::Vector3f up_dir = -world_from_cam_rot.col(1);
+      const Eigen::Vector3f forward_dir = world_from_cam_rot.col(2);
 
-      // Center of image plane
-      const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
-
-      // Directions on the plane
-      const Eigen::Vector3f right_dir = (tr - tl).normalized();
-      const Eigen::Vector3f up_dir = (center - (0.5f * (tl + tr))).normalized();
-
-      // Size of the arrow
       const float arrow_len = 0.3f * image_extent;
       const float head_len = 0.35f * arrow_len;
       const float head_width = 0.25f * arrow_len;
-
-      // Slight offset forward to avoid z-fighting
-      const Eigen::Vector3f forward_dir = (center - pc).normalized();
       const float offset = 0.01f * image_extent;
 
-      // Points
-      const Eigen::Vector3f base =
-          center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
-      const Eigen::Vector3f tip =
-          center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
+      const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
 
-      // Arrowhead points
-      const Eigen::Vector3f head_left = tip - up_dir * head_len -
-                                        right_dir * head_width +
-                                        forward_dir * offset;
-      const Eigen::Vector3f head_right = tip - up_dir * head_len +
-                                         right_dir * head_width +
-                                         forward_dir * offset;
+      const Eigen::Vector3f arrow_center = center + forward_dir * offset;
+      const Eigen::Vector3f tip = arrow_center + up_dir * (0.5f * arrow_len);
+      const Eigen::Vector3f base = arrow_center - up_dir * (0.5f * arrow_len);
+      const Eigen::Vector3f head_base = tip - up_dir * head_len;
+      const Eigen::Vector3f head_left = head_base - right_dir * head_width;
+      const Eigen::Vector3f head_right = head_base + right_dir * head_width;
 
-      // Shaft
-      line_data->emplace_back(PointPainter::Data(base(0),
-                                                 base(1),
-                                                 base(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)),
-                              PointPainter::Data(tip(0),
-                                                 tip(1),
-                                                 tip(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)));
 
-      // Head left
-      line_data->emplace_back(PointPainter::Data(tip(0),
-                                                 tip(1),
-                                                 tip(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)),
-                              PointPainter::Data(head_left(0),
-                                                 head_left(1),
-                                                 head_left(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)));
-
-      // Head right
-      line_data->emplace_back(PointPainter::Data(tip(0),
-                                                 tip(1),
-                                                 tip(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)),
-                              PointPainter::Data(head_right(0),
-                                                 head_right(1),
-                                                 head_right(2),
-                                                 frame_color(0),
-                                                 frame_color(1),
-                                                 frame_color(2),
-                                                 frame_color(3)));
+      add_line(base, tip);
+      add_line(tip, head_left);
+      add_line(tip, head_right);
     }
   }
 }

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -315,7 +315,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
 
       // Directions on the plane
       const Eigen::Vector3f right_dir = (tr - tl).normalized();
-      const Eigen::Vector3f up_dir = ((0.5f * (tl + tr)) - center).normalized();
+      const Eigen::Vector3f up_dir = (center - (0.5f * (tl + tr))).normalized();
 
       // Size of the arrow
       const float arrow_len = 0.3f * image_extent;

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -1312,7 +1312,7 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
                      frame_color,
                      model_origin_,
                      model_scale_,
-                     options_->render->show_camera_up,
+                     options_->render->show_camera_up_arrow,
                      &triangle_data,
                      selection_mode ? nullptr : &line_data);
   }

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -319,7 +319,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
 
       // Size of the arrow
       const float arrow_len = 0.3f * image_extent;
-      const float head_len  = 0.35f * arrow_len;
+      const float head_len = 0.35f * arrow_len;
       const float head_width = 0.25f * arrow_len;
 
       // Slight offset forward to avoid z-fighting
@@ -327,41 +327,66 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
       const float offset = 0.01f * image_extent;
 
       // Points
-      const Eigen::Vector3f base = center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
-      const Eigen::Vector3f tip  = center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
+      const Eigen::Vector3f base =
+          center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
+      const Eigen::Vector3f tip =
+          center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
 
       // Arrowhead points
-      const Eigen::Vector3f head_left =
-          tip - up_dir * head_len - right_dir * head_width + forward_dir * offset;
-      const Eigen::Vector3f head_right =
-          tip - up_dir * head_len + right_dir * head_width + forward_dir * offset;
+      const Eigen::Vector3f head_left = tip - up_dir * head_len -
+                                        right_dir * head_width +
+                                        forward_dir * offset;
+      const Eigen::Vector3f head_right = tip - up_dir * head_len +
+                                         right_dir * head_width +
+                                         forward_dir * offset;
 
       // Shaft
-      line_data->emplace_back(
-          PointPainter::Data(base(0), base(1), base(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)),
-          PointPainter::Data(tip(0), tip(1), tip(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)));
+      line_data->emplace_back(PointPainter::Data(base(0),
+                                                 base(1),
+                                                 base(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)),
+                              PointPainter::Data(tip(0),
+                                                 tip(1),
+                                                 tip(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)));
 
       // Head left
-      line_data->emplace_back(
-          PointPainter::Data(tip(0), tip(1), tip(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)),
-          PointPainter::Data(head_left(0), head_left(1), head_left(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)));
+      line_data->emplace_back(PointPainter::Data(tip(0),
+                                                 tip(1),
+                                                 tip(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)),
+                              PointPainter::Data(head_left(0),
+                                                 head_left(1),
+                                                 head_left(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)));
 
       // Head right
-      line_data->emplace_back(
-          PointPainter::Data(tip(0), tip(1), tip(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)),
-          PointPainter::Data(head_right(0), head_right(1), head_right(2),
-                             frame_color(0), frame_color(1),
-                             frame_color(2), frame_color(3)));
+      line_data->emplace_back(PointPainter::Data(tip(0),
+                                                 tip(1),
+                                                 tip(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)),
+                              PointPainter::Data(head_right(0),
+                                                 head_right(1),
+                                                 head_right(2),
+                                                 frame_color(0),
+                                                 frame_color(1),
+                                                 frame_color(2),
+                                                 frame_color(3)));
     }
   }
 }

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -91,6 +91,7 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                       const RGBAColor& frame_color,
                       const Eigen::Vector3d& model_origin,
                       const double model_scale,
+                      const bool show_camera_up_arrow,
                       std::vector<TrianglePainter::Data>* triangle_data,
                       std::vector<LinePainter::Data>* line_data) {
   // Updating the reconstruction in the viewer (e.g., deleting an image or a
@@ -306,61 +307,62 @@ void BuildCameraModel(const std::optional<Rigid3d>& cam_from_world,
                                                frame_color(1),
                                                frame_color(2),
                                                frame_color(3)));
+    if (show_camera_up_arrow) {
+      // ---- Up arrow on image plane ----
 
-    // ---- Up arrow on image plane ----
+      // Center of image plane
+      const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
 
-    // Center of image plane
-    const Eigen::Vector3f center = 0.25f * (tl + tr + br + bl);
+      // Directions on the plane
+      const Eigen::Vector3f right_dir = (tr - tl).normalized();
+      const Eigen::Vector3f up_dir = ((0.5f * (tl + tr)) - center).normalized();
 
-    // Directions on the plane
-    const Eigen::Vector3f right_dir = (tr - tl).normalized();
-    const Eigen::Vector3f up_dir = ((0.5f * (tl + tr)) - center).normalized();
+      // Size of the arrow
+      const float arrow_len = 0.3f * image_extent;
+      const float head_len  = 0.35f * arrow_len;
+      const float head_width = 0.25f * arrow_len;
 
-    // Size of the arrow
-    const float arrow_len = 0.3f * image_extent;
-    const float head_len  = 0.35f * arrow_len;
-    const float head_width = 0.25f * arrow_len;
+      // Slight offset forward to avoid z-fighting
+      const Eigen::Vector3f forward_dir = (center - pc).normalized();
+      const float offset = 0.01f * image_extent;
 
-    // Slight offset forward to avoid z-fighting
-    const Eigen::Vector3f forward_dir = (center - pc).normalized();
-    const float offset = 0.01f * image_extent;
+      // Points
+      const Eigen::Vector3f base = center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
+      const Eigen::Vector3f tip  = center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
 
-    // Points
-    const Eigen::Vector3f base = center - up_dir * (0.5f * arrow_len) + forward_dir * offset;
-    const Eigen::Vector3f tip  = center + up_dir * (0.5f * arrow_len) + forward_dir * offset;
+      // Arrowhead points
+      const Eigen::Vector3f head_left =
+          tip - up_dir * head_len - right_dir * head_width + forward_dir * offset;
+      const Eigen::Vector3f head_right =
+          tip - up_dir * head_len + right_dir * head_width + forward_dir * offset;
 
-    // Arrowhead points
-    const Eigen::Vector3f head_left =
-        tip - up_dir * head_len - right_dir * head_width + forward_dir * offset;
-    const Eigen::Vector3f head_right =
-        tip - up_dir * head_len + right_dir * head_width + forward_dir * offset;
+      // Shaft
+      line_data->emplace_back(
+          PointPainter::Data(base(0), base(1), base(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)),
+          PointPainter::Data(tip(0), tip(1), tip(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)));
 
-    // Shaft
-    line_data->emplace_back(
-        PointPainter::Data(base(0), base(1), base(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)),
-        PointPainter::Data(tip(0), tip(1), tip(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)));
+      // Head left
+      line_data->emplace_back(
+          PointPainter::Data(tip(0), tip(1), tip(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)),
+          PointPainter::Data(head_left(0), head_left(1), head_left(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)));
 
-    // Head left
-    line_data->emplace_back(
-        PointPainter::Data(tip(0), tip(1), tip(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)),
-        PointPainter::Data(head_left(0), head_left(1), head_left(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)));
-
-    // Head right
-    line_data->emplace_back(
-        PointPainter::Data(tip(0), tip(1), tip(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)),
-        PointPainter::Data(head_right(0), head_right(1), head_right(2),
-                           frame_color(0), frame_color(1),
-                           frame_color(2), frame_color(3)));
+      // Head right
+      line_data->emplace_back(
+          PointPainter::Data(tip(0), tip(1), tip(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)),
+          PointPainter::Data(head_right(0), head_right(1), head_right(2),
+                             frame_color(0), frame_color(1),
+                             frame_color(2), frame_color(3)));
+    }
   }
 }
 
@@ -1285,6 +1287,7 @@ void ModelViewerWidget::UploadImageData(const bool selection_mode) {
                      frame_color,
                      model_origin_,
                      model_scale_,
+                     options_->render->show_camera_up,
                      &triangle_data,
                      selection_mode ? nullptr : &line_data);
   }
@@ -1433,6 +1436,7 @@ void ModelViewerWidget::UploadMovieGrabberData() {
                        frame_color,
                        /*model_origin=*/Eigen::Vector3d::Zero(),
                        /*model_scale=*/1.,
+                       /*show_arrow=*/false,
                        &triangle_data,
                        &line_data);
     }

--- a/src/colmap/ui/render_options.h
+++ b/src/colmap/ui/render_options.h
@@ -54,8 +54,8 @@ struct RenderOptions {
   // reconstruction gets, the less frequently the scene is rendered.
   bool adapt_refresh_rate = true;
 
-  // Whether to show camera up arrows.
-  bool show_camera_up_arrow = false;
+  // Whether to show camera orientation (triangle in top-left corner).
+  bool show_camera_orientation = false;
 
   // Whether to visualize image connections.
   bool image_connections = false;

--- a/src/colmap/ui/render_options.h
+++ b/src/colmap/ui/render_options.h
@@ -54,6 +54,9 @@ struct RenderOptions {
   // reconstruction gets, the less frequently the scene is rendered.
   bool adapt_refresh_rate = true;
 
+  // Whether to show camera up arrows.
+  bool show_camera_up_arrow = false;
+
   // Whether to visualize image connections.
   bool image_connections = false;
 

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -148,7 +148,7 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
   });
   AddWidgetRow("Image frame", select_image_frame_color_);
 
-  AddOptionBool(&options->render->show_camera_up_arrow, "Camera up arrow");
+  AddOptionBool(&options->render->show_camera_orientation, "Camera orientation (top-left corner)");
 
   image_colormap_name_filter_layout_ = new QHBoxLayout();
   QPushButton* image_colormap_add_word = new QPushButton("Add", this);

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -148,7 +148,8 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
   });
   AddWidgetRow("Image frame", select_image_frame_color_);
 
-  AddOptionBool(&options->render->show_camera_orientation, "Camera orientation\n(top-left corner)");
+  AddOptionBool(&options->render->show_camera_orientation,
+                "Camera orientation\n(top-left corner)");
 
   image_colormap_name_filter_layout_ = new QHBoxLayout();
   QPushButton* image_colormap_add_word = new QPushButton("Add", this);

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -148,7 +148,7 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
   });
   AddWidgetRow("Image frame", select_image_frame_color_);
 
-  AddOptionBool(&options->render->show_camera_orientation, "Camera orientation (top-left corner)");
+  AddOptionBool(&options->render->show_camera_orientation, "Camera orientation\n(top-left corner)");
 
   image_colormap_name_filter_layout_ = new QHBoxLayout();
   QPushButton* image_colormap_add_word = new QPushButton("Add", this);

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -148,6 +148,8 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
   });
   AddWidgetRow("Image frame", select_image_frame_color_);
 
+  AddOptionBool(&options->render->show_camera_up_arrow, "Camera up arrow");
+
   image_colormap_name_filter_layout_ = new QHBoxLayout();
   QPushButton* image_colormap_add_word = new QPushButton("Add", this);
   connect(image_colormap_add_word,


### PR DESCRIPTION
Currently it's impossible to visually distinguish the camera up/down orientation.
This would be useful when debugging camera transforms added externally e.g. pycolmap, hloc and image orientation metadata.

I added a GUI toggle to show/hide the arrows.
Is the RenderOptions the right place for this variable (show_camera_up_arrow) or should I put it directly in the render_options_widget.h besides the camera color setting?

<img width="388" height="638" alt="image" src="https://github.com/user-attachments/assets/3e4d1569-4b76-4dc2-951b-559240b5ea9a" />

Image orientation:
<img width="1873" height="1318" alt="image" src="https://github.com/user-attachments/assets/1adccef1-1cd2-4432-a21e-d4cc05839539" />

Cubemap rigs:
<img width="1697" height="1153" alt="image" src="https://github.com/user-attachments/assets/46c24cbc-5080-480e-96d2-5d8a867664e6" />
