### PR TITLE
Update CI cuda architecture from 50 to 75.

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,7 +70,7 @@ jobs:
           if [[ "${{ env.IS_RELEASE }}" == "true" ]]; then
             cuda_archs="50;60;70;75;90"
           else
-            cuda_archs="50"
+            cuda_archs="75"
           fi
           mkdir -p build/.ccache build/_deps
           docker_args=(

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -216,7 +216,7 @@ jobs:
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.cmakeBuildType }} \
             -DCMAKE_INSTALL_PREFIX=./install \
-            -DCMAKE_CUDA_ARCHITECTURES=50 \
+            -DCMAKE_CUDA_ARCHITECTURES=75 \
             -DTESTS_ENABLED=ON \
             -DWERROR_ENABLED=ON \
             -DCUDA_ENABLED=${{ matrix.config.cudaEnabled }} \
@@ -239,7 +239,7 @@ jobs:
           export colmap_DIR=${{ github.workspace }}/build/install/share/colmap
           cmake .. \
             -GNinja \
-            -DCMAKE_CUDA_ARCHITECTURES=50
+            -DCMAKE_CUDA_ARCHITECTURES=75
           ninja
           ./hello_world --message "world"
 


### PR DESCRIPTION
Per discussion from https://github.com/colmap/colmap/pull/4018.

However, I believe this would mean that we may not catch issues that break compilation on older arches (50, 60, 70) and may only bump into it at the release multi-arch build runs.