### PR TITLE
Fix: Missing rig pose manifold in RefineGeneralizedAbsolutePose

### DIFF
--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -409,10 +409,12 @@ bool RefineGeneralizedAbsolutePose(const AbsolutePoseRefinementOptions& options,
     }
   }
 
-  SetManifold(&problem,
-              rig_from_world->params.data(),
-              CreateProductManifold(CreateEigenQuaternionManifold(),
-                                    CreateEuclideanManifold<3>()));
+  if (problem.NumResiduals() > 0) {
+    SetManifold(&problem,
+                rig_from_world->params.data(),
+                CreateProductManifold(CreateEigenQuaternionManifold(),
+                                      CreateEuclideanManifold<3>()));
+  }
 
   ceres::Solver::Options solver_options;
   solver_options.gradient_tolerance = options.gradient_tolerance;

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -407,9 +407,6 @@ bool RefineGeneralizedAbsolutePose(const AbsolutePoseRefinementOptions& options,
         }
       }
     }
-  }
-
-  if (problem.NumResiduals() > 0) {
     SetManifold(&problem,
                 rig_from_world->params.data(),
                 CreateProductManifold(CreateEigenQuaternionManifold(),

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -409,6 +409,11 @@ bool RefineGeneralizedAbsolutePose(const AbsolutePoseRefinementOptions& options,
     }
   }
 
+  SetManifold(&problem,
+              rig_from_world->params.data(),
+              CreateProductManifold(CreateEigenQuaternionManifold(),
+                                    CreateEuclideanManifold<3>()));
+
   ceres::Solver::Options solver_options;
   solver_options.gradient_tolerance = options.gradient_tolerance;
   solver_options.max_num_iterations = options.max_num_iterations;


### PR DESCRIPTION
Hi

I was facing an error with `pycolmap.estimate_and_refine_generalized_absolute_pose` when installing pycolmap via pip. 

Error:
```
*** Aborted at 1777983489 (unix time) try "date -d @1777983489" if you are using GNU date ***
PC: @     0x73ded64220cb (/local/home/akrishnan/lamar_env_fix/lib/python3.10/site-packages/pycolmap/_core.cpython-310-x86_64-linux-gnu.so+0x10220ca)
Segmentation fault
```

The breaking PR was #4041. I was able to validate this by installing pycolmap from source on the commit before (#4037). The script below should work on PR #4037.

Test data: [Rig_pose_data](https://drive.google.com/file/d/125Y-Pap9FhQUVCayLVfU6iTWXQSHJaS7/view?usp=sharing)

Testing script:

```python
import pickle, time
import numpy as np
import pycolmap
from tqdm import tqdm

PKL = '/local/home/akrishnan/Downloads/rig_pose_debug.pkl'

with open(PKL, 'rb') as f:
    all_data = pickle.load(f)

print(f'pycolmap {pycolmap.__version__} from {pycolmap.__file__}')
print(f'{len(all_data)} entries')

n_ok = 0
n_none = 0
t0 = time.time()
for i, d in enumerate(tqdm(all_data, desc='rig PnP')):
    p2d_per_cam = d['p2d']
    p3d_per_cam = d['p3d']
    camera_dicts = d['camera_dicts']
    qvecs = d['qvecs'] 
    tvecs = d['tvecs']
    thresh = float(d['thresh'])

    p2d_flat = np.concatenate(p2d_per_cam, axis=0).astype(np.float64)
    p3d_flat = np.concatenate(p3d_per_cam, axis=0).astype(np.float64)
    camera_idxs = []
    for ci, p in enumerate(p2d_per_cam):
        camera_idxs.extend([ci] * len(p))

    cams_from_rig = []
    for q_wxyz, t in zip(qvecs, tvecs):
        q_xyzw = np.array([q_wxyz[1], q_wxyz[2], q_wxyz[3], q_wxyz[0]], dtype=np.float64)
        cams_from_rig.append(pycolmap.Rigid3d(
            pycolmap.Rotation3d(q_xyzw),
            np.asarray(t, dtype=np.float64),
        ))

    # Build cameras
    cameras = [
        pycolmap.Camera(
            model=cd['model'],
            width=int(cd['width']),
            height=int(cd['height']),
            params=list(cd['params']),
        )
        for cd in camera_dicts
    ]

    opts = pycolmap.RANSACOptions()
    opts.max_error = thresh

    ret = pycolmap.estimate_and_refine_generalized_absolute_pose(
        p2d_flat, p3d_flat, camera_idxs, cams_from_rig, cameras,
        estimation_options=opts, return_covariance=True,
    )
    if ret is None:
        n_none += 1
    else:
        n_ok += 1

dt = time.time() - t0
print(f'\ndone in {dt:.1f}s — succeeded: {n_ok}/{len(all_data)}, '
      f'returned None: {n_none}/{len(all_data)}')
```