### PR TITLE
Fix: Apply refine_sensor_from_rig to all stages of the global mapper

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -788,9 +788,8 @@ void OptionManager::AddGlobalMapperOptions() {
   AddDefaultOption(
       "GlobalMapper.ba_refine_extra_params",
       &global_mapper->mapper.bundle_adjustment.refine_extra_params);
-  AddDefaultOption(
-      "GlobalMapper.ba_refine_sensor_from_rig",
-      &global_mapper->mapper.bundle_adjustment.refine_sensor_from_rig);
+  AddDefaultOption("GlobalMapper.refine_sensor_from_rig",
+                   &global_mapper->mapper.refine_sensor_from_rig);
   AddDefaultOption(
       "GlobalMapper.ba_refine_rig_from_world",
       &global_mapper->mapper.bundle_adjustment.refine_rig_from_world);

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -246,7 +246,8 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
         // re-estimated, which requires refine_sensor_from_rig=true.
         THROW_CHECK(options_.refine_sensor_from_rig)
             << "sensor_from_rig has NaN translation but "
-               "refine_sensor_from_rig=false";
+               "refine_sensor_from_rig=false (image_id="
+            << observation.image_id << ")";
         const sensor_t sensor_id = image.CameraPtr()->SensorId();
         if (cams_in_rig_.find(sensor_id) == cams_in_rig_.end()) {
           // Will be initialized to random values in ParameterizeVariables().

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -227,10 +227,16 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
       Rig& rig = reconstruction.Rig(rig_id);
       Rigid3d& cam_from_rig = rig.SensorFromRig(image.CameraPtr()->SensorId());
 
-      if (!cam_from_rig.translation().hasNaN()) {
+      const bool keep_rig_fixed =
+          !cam_from_rig.translation().hasNaN() ||
+          !options_.refine_sensor_from_rig;
+      if (keep_rig_fixed) {
+        Eigen::Vector3d cam_in_rig = cam_from_rig.translation();
+        if (cam_in_rig.hasNaN()) {
+          cam_in_rig.setZero();
+        }
         const Eigen::Vector3d cam_from_rig_dir =
-            image.CamFromWorld().rotation().inverse() *
-            cam_from_rig.translation();
+            image.CamFromWorld().rotation().inverse() * cam_in_rig;
 
         ceres::CostFunction* cost_function =
             RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
@@ -426,17 +432,19 @@ void GlobalPositioner::ConvertBackResults(Reconstruction& reconstruction) {
     rig_from_world.translation() = rig_from_world.rotation() * -center;
   }
 
-  // Convert optimized cam_in_rig back to sensor_from_rig translations.
-  for (const auto& [sensor_id, center] : cams_in_rig_) {
-    // Find the rig containing this sensor.
-    for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
-      if (!rig.HasSensor(sensor_id)) {
-        continue;
+  if (options_.refine_sensor_from_rig) {
+    // Convert optimized cam_in_rig back to sensor_from_rig translations.
+    for (const auto& [sensor_id, center] : cams_in_rig_) {
+      // Find the rig containing this sensor.
+      for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+        if (!rig.HasSensor(sensor_id)) {
+          continue;
+        }
+        Rigid3d& sensor_from_rig =
+            reconstruction.Rig(rig_id).SensorFromRig(sensor_id);
+        sensor_from_rig.translation() = sensor_from_rig.rotation() * -center;
+        break;
       }
-      Rigid3d& sensor_from_rig =
-          reconstruction.Rig(rig_id).SensorFromRig(sensor_id);
-      sensor_from_rig.translation() = sensor_from_rig.rotation() * -center;
-      break;
     }
   }
 }

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -227,16 +227,10 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
       Rig& rig = reconstruction.Rig(rig_id);
       Rigid3d& cam_from_rig = rig.SensorFromRig(image.CameraPtr()->SensorId());
 
-      const bool keep_rig_fixed =
-          !cam_from_rig.translation().hasNaN() ||
-          !options_.refine_sensor_from_rig;
-      if (keep_rig_fixed) {
-        Eigen::Vector3d cam_in_rig = cam_from_rig.translation();
-        if (cam_in_rig.hasNaN()) {
-          cam_in_rig.setZero();
-        }
+      if (!cam_from_rig.translation().hasNaN()) {
         const Eigen::Vector3d cam_from_rig_dir =
-            image.CamFromWorld().rotation().inverse() * cam_in_rig;
+            image.CamFromWorld().rotation().inverse() *
+            cam_from_rig.translation();
 
         ceres::CostFunction* cost_function =
             RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
@@ -248,8 +242,11 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
                                    frame_centers_[image.FrameId()].data(),
                                    &scale);
       } else {
-        // If the cam_from_rig contains nan values, it needs to be re-estimated.
-        // Initialize cams_in_rig_ if not already done.
+        // NaN translation means the sensor's cam_from_rig must be
+        // re-estimated, which requires refine_sensor_from_rig=true.
+        THROW_CHECK(options_.refine_sensor_from_rig)
+            << "sensor_from_rig has NaN translation but "
+               "refine_sensor_from_rig=false";
         const sensor_t sensor_id = image.CameraPtr()->SensorId();
         if (cams_in_rig_.find(sensor_id) == cams_in_rig_.end()) {
           // Will be initialized to random values in ParameterizeVariables().
@@ -432,19 +429,16 @@ void GlobalPositioner::ConvertBackResults(Reconstruction& reconstruction) {
     rig_from_world.translation() = rig_from_world.rotation() * -center;
   }
 
-  if (options_.refine_sensor_from_rig) {
-    // Convert optimized cam_in_rig back to sensor_from_rig translations.
-    for (const auto& [sensor_id, center] : cams_in_rig_) {
-      // Find the rig containing this sensor.
-      for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
-        if (!rig.HasSensor(sensor_id)) {
-          continue;
-        }
-        Rigid3d& sensor_from_rig =
-            reconstruction.Rig(rig_id).SensorFromRig(sensor_id);
-        sensor_from_rig.translation() = sensor_from_rig.rotation() * -center;
-        break;
+  for (const auto& [sensor_id, center] : cams_in_rig_) {
+    // Find the rig containing this sensor.
+    for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+      if (!rig.HasSensor(sensor_id)) {
+        continue;
       }
+      Rigid3d& sensor_from_rig =
+          reconstruction.Rig(rig_id).SensorFromRig(sensor_id);
+      sensor_from_rig.translation() = sensor_from_rig.rotation() * -center;
+      break;
     }
   }
 }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -22,7 +22,7 @@ struct GlobalPositionerOptions {
   bool optimize_points = true;
   bool optimize_scales = true;
 
-  // When false, treat sensor_from_rig as a fixed (pre-calibrated)
+  // When false, treat sensor_from_rig as a fixed (pre-calibrated) parameter.
   bool refine_sensor_from_rig = true;
 
   bool use_gpu = true;

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -22,6 +22,9 @@ struct GlobalPositionerOptions {
   bool optimize_points = true;
   bool optimize_scales = true;
 
+  // When false, treat sensor_from_rig as a fixed (pre-calibrated)
+  bool refine_sensor_from_rig = true;
+
   bool use_gpu = true;
   std::string gpu_index = "-1";
   int min_num_images_gpu_solver = 50;

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -196,10 +196,10 @@ TEST(GlobalPositioning, RefineSensorFromRigFalsePreservesRig) {
   for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
     for (const auto& [sensor_id, sensor_from_rig_after] : rig.NonRefSensors()) {
       ASSERT_TRUE(sensor_from_rig_after.has_value())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
       const auto& sensor_from_rig_before = snapshot.at({rig_id, sensor_id});
       EXPECT_EQ(*sensor_from_rig_after, sensor_from_rig_before)
-          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
     }
   }
 }

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -177,9 +177,9 @@ TEST(GlobalPositioning, RefineSensorFromRigFalsePreservesRig) {
   // Snapshot the rig BEFORE GP.
   std::map<std::pair<rig_t, sensor_t>, Rigid3d> snapshot;
   for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
-    for (const auto& [sensor_id, sfr] : rig.NonRefSensors()) {
-      ASSERT_TRUE(sfr.has_value());
-      snapshot[{rig_id, sensor_id}] = *sfr;
+    for (const auto& [sensor_id, sensor_from_rig] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig.has_value());
+      snapshot[{rig_id, sensor_id}] = *sensor_from_rig;
     }
   }
   ASSERT_GT(snapshot.size(), 0u);
@@ -194,18 +194,12 @@ TEST(GlobalPositioning, RefineSensorFromRigFalsePreservesRig) {
 
   // Every sensor_from_rig must match the snapshot exactly.
   for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
-    for (const auto& [sensor_id, sfr_after] : rig.NonRefSensors()) {
-      ASSERT_TRUE(sfr_after.has_value())
+    for (const auto& [sensor_id, sensor_from_rig_after] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig_after.has_value())
           << "rig=" << rig_id << " sensor=" << sensor_id.id;
-      const auto& sfr_before = snapshot.at({rig_id, sensor_id});
-      EXPECT_EQ(sfr_after->rotation().coeffs(), sfr_before.rotation().coeffs())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id
-          << ": rotation modified";
-      EXPECT_EQ(sfr_after->translation(), sfr_before.translation())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id
-          << ": translation modified (was "
-          << sfr_before.translation().transpose() << ", got "
-          << sfr_after->translation().transpose() << ")";
+      const auto& sensor_from_rig_before = snapshot.at({rig_id, sensor_id});
+      EXPECT_EQ(*sensor_from_rig_after, sensor_from_rig_before)
+          << "rig=" << rig_id << " sensor=" << sensor_id.id;
     }
   }
 }

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -36,6 +36,9 @@
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 
+#include <map>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -135,6 +138,76 @@ TEST(GlobalPositioning, MultiCameraRig) {
                                  /*max_proj_center_error=*/0.5,
                                  /*max_scale_error=*/std::nullopt,
                                  /*num_obs_tolerance=*/0.0));
+}
+
+TEST(GlobalPositioning, RefineSensorFromRigFalsePreservesRig) {
+  SetPRNGSeed(0);
+
+  const auto database_path = CreateTestDir() / "database.db";
+
+  auto database = Database::Open(database_path);
+  Reconstruction gt_reconstruction;
+  // Multi-camera rig so the sensor offsets are non-trivial — both
+  // rotation and translation must round-trip.
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 3;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 200;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  SynthesizeDataset(
+      synthetic_dataset_options, &gt_reconstruction, database.get());
+
+  DatabaseCache database_cache;
+  DatabaseCache::Options cache_options;
+  database_cache.Load(*database, cache_options);
+
+  PoseGraph pose_graph;
+  pose_graph.Load(*database_cache.CorrespondenceGraph());
+
+  // Copy GT reconstruction and keep only rotations on frames (reset
+  // their translations); leave the rig calibration as-is.
+  Reconstruction reconstruction = gt_reconstruction;
+  for (const auto& [frame_id, _] : reconstruction.Frames()) {
+    Frame& frame = reconstruction.Frame(frame_id);
+    frame.SetRigFromWorld(
+        Rigid3d(frame.RigFromWorld().rotation(), Eigen::Vector3d::Zero()));
+  }
+
+  // Snapshot the rig BEFORE GP.
+  std::map<std::pair<rig_t, sensor_t>, Rigid3d> snapshot;
+  for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sfr] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sfr.has_value());
+      snapshot[{rig_id, sensor_id}] = *sfr;
+    }
+  }
+  ASSERT_GT(snapshot.size(), 0u);
+
+  GlobalPositionerOptions options;
+  options.use_gpu = false;
+  options.random_seed = 42;
+  options.solver_options.minimizer_progress_to_stdout = false;
+  options.refine_sensor_from_rig = false;
+
+  ASSERT_TRUE(RunGlobalPositioning(options, pose_graph, reconstruction));
+
+  // Every sensor_from_rig must match the snapshot exactly.
+  for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sfr_after] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sfr_after.has_value())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+      const auto& sfr_before = snapshot.at({rig_id, sensor_id});
+      EXPECT_EQ(sfr_after->rotation().coeffs(), sfr_before.rotation().coeffs())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id
+          << ": rotation modified";
+      EXPECT_EQ(sfr_after->translation(), sfr_before.translation())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id
+          << ": translation modified (was "
+          << sfr_before.translation().transpose() << ", got "
+          << sfr_after->translation().transpose() << ")";
+    }
+  }
 }
 
 }  // namespace

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -531,13 +531,9 @@ bool InitializeRigRotationsFromImages(
       const auto sensor_id = sensor_t(SensorType::CAMERA, camera_id);
       const auto existing =
           reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
-      // If sensor_from_rig rotation is already known (translation is valid),
-      // preserve the known rotation instead of overwriting with MST-derived
-      // approximation. Reset translation to NaN so downstream code (global
-      // positioning) still estimates it using the variable-rig formulation.
+      // If sensor_from_rig is already fully calibrated, preserve it rather
+      // than overwriting with MST-derived approximation.
       if (existing.has_value() && !existing->translation().hasNaN()) {
-        reconstruction.Rig(rig_id).SetSensorFromRig(
-            sensor_id, Rigid3d(existing->rotation(), kUnknownTranslation));
         continue;
       }
       weights.resize(samples.size(), 1.0);
@@ -545,6 +541,17 @@ bool InitializeRigRotationsFromImages(
           AverageQuaternions(samples, weights);
       reconstruction.Rig(rig_id).SetSensorFromRig(
           sensor_id, Rigid3d(cam_from_rig, kUnknownTranslation));
+    }
+  } else {
+    // Check if rotations are valid.
+    for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+      for (const auto& [sensor_id, sensor_from_rig] : rig.NonRefSensors()) {
+        THROW_CHECK(sensor_from_rig.has_value() &&
+                    !sensor_from_rig->rotation().coeffs().hasNaN())
+            << "sensor_from_rig has NaN rotation but "
+               "refine_sensor_from_rig=false (rig="
+            << rig_id << " sensor=" << sensor_id.id << ")";
+      }
     }
   }
 

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -387,13 +387,15 @@ bool RotationEstimator::MaybeSolveGravityAlignedSubset(
           .SetRigFromWorld(gravity_frame.RigFromWorld());
     }
 
-    for (const auto& [gravity_rig_id, gravity_rig] :
-         gravity_reconstruction.Rigs()) {
-      for (const auto& [sensor_id, sensor_from_rig] :
-           gravity_rig.NonRefSensors()) {
-        if (!gravity_rig.HasSensorFromRig(sensor_id)) continue;
-        reconstruction.Rig(gravity_rig_id)
-            .SetSensorFromRig(sensor_id, sensor_from_rig);
+    if (options_.refine_sensor_from_rig) {
+      for (const auto& [gravity_rig_id, gravity_rig] :
+           gravity_reconstruction.Rigs()) {
+        for (const auto& [sensor_id, sensor_from_rig] :
+             gravity_rig.NonRefSensors()) {
+          if (!gravity_rig.HasSensorFromRig(sensor_id)) continue;
+          reconstruction.Rig(gravity_rig_id)
+              .SetSensorFromRig(sensor_id, sensor_from_rig);
+        }
       }
     }
   }
@@ -470,12 +472,14 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
         (edge.cam2_from_cam1 * cams_from_world[parents[curr]]).rotation();
   }
 
-  InitializeRigRotationsFromImages(cams_from_world, reconstruction);
+  InitializeRigRotationsFromImages(
+      cams_from_world, reconstruction, options_.refine_sensor_from_rig);
 }
 
 bool InitializeRigRotationsFromImages(
     const std::unordered_map<image_t, Rigid3d>& cams_from_world,
-    Reconstruction& reconstruction) {
+    Reconstruction& reconstruction,
+    bool refine_sensor_from_rig) {
   // Step 1: Estimate cam_from_rig for cameras with unknown calibration.
   // Collect samples across frames, then average.
   std::unordered_map<camera_t,
@@ -521,25 +525,27 @@ bool InitializeRigRotationsFromImages(
       Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN());
 
   std::vector<double> weights;
-  for (auto& [camera_id, rig_id_and_samples] : cam_from_rig_samples) {
-    auto& [rig_id, samples] = rig_id_and_samples;
-    const auto sensor_id = sensor_t(SensorType::CAMERA, camera_id);
-    const auto existing =
-        reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
-    // If sensor_from_rig rotation is already known (translation is valid),
-    // preserve the known rotation instead of overwriting with MST-derived
-    // approximation. Reset translation to NaN so downstream code (global
-    // positioning) still estimates it using the variable-rig formulation.
-    if (existing.has_value() && !existing->translation().hasNaN()) {
+  if (refine_sensor_from_rig) {
+    for (auto& [camera_id, rig_id_and_samples] : cam_from_rig_samples) {
+      auto& [rig_id, samples] = rig_id_and_samples;
+      const auto sensor_id = sensor_t(SensorType::CAMERA, camera_id);
+      const auto existing =
+          reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
+      // If sensor_from_rig rotation is already known (translation is valid),
+      // preserve the known rotation instead of overwriting with MST-derived
+      // approximation. Reset translation to NaN so downstream code (global
+      // positioning) still estimates it using the variable-rig formulation.
+      if (existing.has_value() && !existing->translation().hasNaN()) {
+        reconstruction.Rig(rig_id).SetSensorFromRig(
+            sensor_id, Rigid3d(existing->rotation(), kUnknownTranslation));
+        continue;
+      }
+      weights.resize(samples.size(), 1.0);
+      const Eigen::Quaterniond cam_from_rig =
+          AverageQuaternions(samples, weights);
       reconstruction.Rig(rig_id).SetSensorFromRig(
-          sensor_id, Rigid3d(existing->rotation(), kUnknownTranslation));
-      continue;
+          sensor_id, Rigid3d(cam_from_rig, kUnknownTranslation));
     }
-    weights.resize(samples.size(), 1.0);
-    const Eigen::Quaterniond cam_from_rig =
-        AverageQuaternions(samples, weights);
-    reconstruction.Rig(rig_id).SetSensorFromRig(
-        sensor_id, Rigid3d(cam_from_rig, kUnknownTranslation));
   }
 
   // Step 2: Compute rig_from_world for each frame by averaging across images.
@@ -649,7 +655,9 @@ bool RunRotationAveraging(const RotationEstimatorOptions& options,
 
     LOG(INFO)
         << "Initializing cam_from_rig from preliminary rotation estimates";
-    InitializeRigRotationsFromImages(expanded_cams_from_world, reconstruction);
+    InitializeRigRotationsFromImages(expanded_cams_from_world,
+                                     reconstruction,
+                                     options.refine_sensor_from_rig);
 
     // Step 1c: Solve on original reconstruction with initialized cam_from_rig.
     active_image_ids = ComputeLargestConnectedComponentImageIds(

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -549,8 +549,8 @@ bool InitializeRigRotationsFromImages(
         THROW_CHECK(sensor_from_rig.has_value() &&
                     !sensor_from_rig->rotation().coeffs().hasNaN())
             << "sensor_from_rig has NaN rotation but "
-               "refine_sensor_from_rig=false (rig="
-            << rig_id << " sensor=" << sensor_id.id << ")";
+               "refine_sensor_from_rig=false (rig_id="
+            << rig_id << ", sensor_id=" << sensor_id.id << ")";
       }
     }
   }

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -66,6 +66,10 @@ struct RotationEstimatorOptions {
   // If > 0, filter image pairs with rotation error exceeding this threshold
   // after solving, then recompute active set.
   double max_rotation_error_deg = 10.0;
+
+  // When false, treat each non-ref sensor's cam_from_rig rotation as a
+  // pre-calibrated constant
+  bool refine_sensor_from_rig = true;
 };
 
 // High-level interface for rotation averaging.
@@ -114,9 +118,12 @@ class RotationEstimator {
 // Initialize rig rotations by averaging per-image rotations.
 // Estimates cam_from_rig for cameras with unknown calibration,
 // then computes rig_from_world for each frame.
+// When refine_sensor_from_rig is false, the per-sensor cam_from_rig
+// values are left untouched.
 bool InitializeRigRotationsFromImages(
     const std::unordered_map<image_t, Rigid3d>& cams_from_world,
-    Reconstruction& reconstruction);
+    Reconstruction& reconstruction,
+    bool refine_sensor_from_rig = true);
 
 // High-level rotation averaging solver that handles rig expansion.
 // For cameras with unknown cam_from_rig, first estimates their orientations

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -115,10 +115,10 @@ size_t RotationAveragingProblem::AllocateParameters(
   std::unordered_map<camera_t, Eigen::AngleAxisd> cam_from_rig_rotations;
   if (options_.refine_sensor_from_rig) {
     for (const auto& [camera_id, rig_id] : camera_id_to_rig_id_) {
-      sensor_t sensor_id(SensorType::CAMERA, camera_id);
+      const sensor_t sensor_id(SensorType::CAMERA, camera_id);
       if (reconstruction.Rig(rig_id).IsRefSensor(sensor_id)) continue;
 
-      auto cam_from_rig =
+      const auto cam_from_rig =
           reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
       if (!cam_from_rig.has_value() ||
           cam_from_rig.value().translation().hasNaN()) {

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -113,21 +113,23 @@ size_t RotationAveragingProblem::AllocateParameters(
   // Identify cameras that need cam_from_rig estimation
   // (non-reference cameras without calibrated extrinsics).
   std::unordered_map<camera_t, Eigen::AngleAxisd> cam_from_rig_rotations;
-  for (const auto& [camera_id, rig_id] : camera_id_to_rig_id_) {
-    sensor_t sensor_id(SensorType::CAMERA, camera_id);
-    if (reconstruction.Rig(rig_id).IsRefSensor(sensor_id)) continue;
+  if (options_.refine_sensor_from_rig) {
+    for (const auto& [camera_id, rig_id] : camera_id_to_rig_id_) {
+      sensor_t sensor_id(SensorType::CAMERA, camera_id);
+      if (reconstruction.Rig(rig_id).IsRefSensor(sensor_id)) continue;
 
-    auto cam_from_rig =
-        reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
-    if (!cam_from_rig.has_value() ||
-        cam_from_rig.value().translation().hasNaN()) {
-      if (camera_id_to_param_idx_.find(camera_id) ==
-          camera_id_to_param_idx_.end()) {
-        // Mark for later allocation (actual index set below).
-        camera_id_to_param_idx_[camera_id] = -1;
-        if (cam_from_rig.has_value()) {
-          cam_from_rig_rotations[camera_id] =
-              Eigen::AngleAxisd(cam_from_rig->rotation());
+      auto cam_from_rig =
+          reconstruction.Rig(rig_id).MaybeSensorFromRig(sensor_id);
+      if (!cam_from_rig.has_value() ||
+          cam_from_rig.value().translation().hasNaN()) {
+        if (camera_id_to_param_idx_.find(camera_id) ==
+            camera_id_to_param_idx_.end()) {
+          // Mark for later allocation (actual index set below).
+          camera_id_to_param_idx_[camera_id] = -1;
+          if (cam_from_rig.has_value()) {
+            cam_from_rig_rotations[camera_id] =
+                Eigen::AngleAxisd(cam_from_rig->rotation());
+          }
         }
       }
     }
@@ -614,20 +616,21 @@ void RotationAveragingProblem::ApplyResultsToReconstruction(
     }
   }
 
-  // Add the estimated cam_from_rig rotations.
-  for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
-    for (const auto& [sensor_id, sensor] : rig.NonRefSensors()) {
-      if (camera_id_to_param_idx_.find(sensor_id.id) ==
-          camera_id_to_param_idx_.end()) {
-        continue;  // Skip cameras that are not estimated.
+  if (options_.refine_sensor_from_rig) {
+    for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+      for (const auto& [sensor_id, sensor] : rig.NonRefSensors()) {
+        if (camera_id_to_param_idx_.find(sensor_id.id) ==
+            camera_id_to_param_idx_.end()) {
+          continue;  // Skip cameras that are not estimated.
+        }
+        Rigid3d cam_from_rig;
+        cam_from_rig.rotation() =
+            AngleAxisToRotationMatrix(estimated_rotations_.segment<3>(
+                camera_id_to_param_idx_.at(sensor_id.id)));
+        cam_from_rig.translation().setConstant(
+            std::numeric_limits<double>::quiet_NaN());  // No translation yet.
+        reconstruction.Rig(rig_id).SetSensorFromRig(sensor_id, cam_from_rig);
       }
-      Rigid3d cam_from_rig;
-      cam_from_rig.rotation() =
-          AngleAxisToRotationMatrix(estimated_rotations_.segment<3>(
-              camera_id_to_param_idx_.at(sensor_id.id)));
-      cam_from_rig.translation().setConstant(
-          std::numeric_limits<double>::quiet_NaN());  // No translation yet.
-      reconstruction.Rig(rig_id).SetSensorFromRig(sensor_id, cam_from_rig);
     }
   }
 }

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -407,10 +407,8 @@ TEST(RotationAveraging, RefineSensorFromRigFalsePreservesRig) {
   // Run RA with refine_sensor_from_rig=false.
   RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/true);
   options.refine_sensor_from_rig = false;
-  ASSERT_TRUE(RunRotationAveraging(options,
-                                   data.pose_graph,
-                                   data.reconstruction,
-                                   data.pose_priors));
+  ASSERT_TRUE(RunRotationAveraging(
+      options, data.pose_graph, data.reconstruction, data.pose_priors));
 
   // Every sensor_from_rig must match the snapshot exactly.
   for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -415,10 +415,10 @@ TEST(RotationAveraging, InitializeSensorFromRigPreservesCalibratedRig) {
   for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
     for (const auto& [sensor_id, sensor_from_rig_after] : rig.NonRefSensors()) {
       ASSERT_TRUE(sensor_from_rig_after.has_value())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
       const auto& sensor_from_rig_before = snapshot.at({rig_id, sensor_id});
       EXPECT_EQ(*sensor_from_rig_after, sensor_from_rig_before)
-          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
     }
   }
 }
@@ -458,21 +458,12 @@ TEST(RotationAveraging, RefineSensorFromRigFalsePreservesRig) {
 
   // Every sensor_from_rig must match the snapshot exactly.
   for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
-    for (const auto& [sensor_id, sfr_after] : rig.NonRefSensors()) {
-      ASSERT_TRUE(sfr_after.has_value())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id;
-      const auto& sfr_before = snapshot.at({rig_id, sensor_id});
-      // Rotation: quaternion components match exactly. Use coeffs() for
-      // a single 4-vector compare with EXPECT_EQ semantics.
-      EXPECT_EQ(sfr_after->rotation().coeffs(), sfr_before.rotation().coeffs())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id
-          << ": rotation modified";
-      // Translation: must match exactly (no NaN-poisoning, no zero-reset).
-      EXPECT_EQ(sfr_after->translation(), sfr_before.translation())
-          << "rig=" << rig_id << " sensor=" << sensor_id.id
-          << ": translation modified (was "
-          << sfr_before.translation().transpose() << ", got "
-          << sfr_after->translation().transpose() << ")";
+    for (const auto& [sensor_id, sensor_from_rig_after] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig_after.has_value())
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
+      const auto& sensor_from_rig_before = snapshot.at({rig_id, sensor_id});
+      EXPECT_EQ(*sensor_from_rig_after, sensor_from_rig_before)
+          << "rig_id=" << rig_id << ", sensor_id=" << sensor_id.id;
     }
   }
 }

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -36,6 +36,9 @@
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/synthetic.h"
 
+#include <map>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -370,6 +373,62 @@ TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
                         .SensorFromRig(sensor_id)
                         .rotation()),
                 1e-6);
+    }
+  }
+}
+
+TEST(RotationAveraging, RefineSensorFromRigFalsePreservesRig) {
+  SetPRNGSeed(1);
+
+  // A non-trivial multi-camera rig so both rotation AND translation are
+  // non-zero
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 4;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.sensor_from_rig_rotation_stddev = 20.;
+  synthetic_dataset_options.prior_gravity = true;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  // Snapshot the rig BEFORE RA so we can compare element-wise.
+  std::map<std::pair<rig_t, sensor_t>, Rigid3d> snapshot;
+  for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sfr] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sfr.has_value());
+      snapshot[{rig_id, sensor_id}] = *sfr;
+    }
+  }
+  // Sanity check: at least one sensor should have a non-zero translation
+  // so the test would actually catch the old "reset to zero" behaviour.
+  ASSERT_GT(snapshot.size(), 0u);
+
+  // Run RA with refine_sensor_from_rig=false.
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/true);
+  options.refine_sensor_from_rig = false;
+  ASSERT_TRUE(RunRotationAveraging(options,
+                                   data.pose_graph,
+                                   data.reconstruction,
+                                   data.pose_priors));
+
+  // Every sensor_from_rig must match the snapshot exactly.
+  for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sfr_after] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sfr_after.has_value())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+      const auto& sfr_before = snapshot.at({rig_id, sensor_id});
+      // Rotation: quaternion components match exactly. Use coeffs() for
+      // a single 4-vector compare with EXPECT_EQ semantics.
+      EXPECT_EQ(sfr_after->rotation().coeffs(), sfr_before.rotation().coeffs())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id
+          << ": rotation modified";
+      // Translation: must match exactly (no NaN-poisoning, no zero-reset).
+      EXPECT_EQ(sfr_after->translation(), sfr_before.translation())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id
+          << ": translation modified (was "
+          << sfr_before.translation().transpose() << ", got "
+          << sfr_after->translation().transpose() << ")";
     }
   }
 }

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -377,6 +377,52 @@ TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
   }
 }
 
+// When a sensor_from_rig is already fully calibrated (valid rotation AND
+// translation), InitializeRigRotationsFromImages must preserve it rather than
+// resetting the translation to NaN.
+TEST(RotationAveraging, InitializeSensorFromRigPreservesCalibratedRig) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 4;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.sensor_from_rig_rotation_stddev = 20.;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  std::unordered_map<image_t, Rigid3d> cams_from_world;
+  for (const auto& [image_id, image] : data.gt_reconstruction.Images()) {
+    if (image.HasPose()) {
+      cams_from_world[image_id] = image.CamFromWorld();
+    }
+  }
+
+  // Snapshot the (already-calibrated) rig BEFORE initialization.
+  std::map<std::pair<rig_t, sensor_t>, Rigid3d> snapshot;
+  for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sensor_from_rig] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig.has_value());
+      snapshot[{rig_id, sensor_id}] = *sensor_from_rig;
+    }
+  }
+  ASSERT_GT(snapshot.size(), 0u);
+
+  EXPECT_TRUE(
+      InitializeRigRotationsFromImages(cams_from_world, data.reconstruction));
+
+  for (const auto& [rig_id, rig] : data.reconstruction.Rigs()) {
+    for (const auto& [sensor_id, sensor_from_rig_after] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig_after.has_value())
+          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+      const auto& sensor_from_rig_before = snapshot.at({rig_id, sensor_id});
+      EXPECT_EQ(*sensor_from_rig_after, sensor_from_rig_before)
+          << "rig=" << rig_id << " sensor=" << sensor_id.id;
+    }
+  }
+}
+
 TEST(RotationAveraging, RefineSensorFromRigFalsePreservesRig) {
   SetPRNGSeed(1);
 

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -38,23 +38,44 @@ bool RunBundleAdjustment(const BundleAdjustmentOptions& options,
   return ba->Solve()->IsSolutionUsable();
 }
 
-GlobalMapperOptions InitializeOptions(const GlobalMapperOptions& options) {
-  // Propagate random seed and num_threads to component options.
-  GlobalMapperOptions opts = options;
-  if (opts.random_seed >= 0) {
-    opts.rotation_averaging.random_seed = opts.random_seed;
-    opts.global_positioning.random_seed = opts.random_seed;
-    opts.global_positioning.use_parameter_block_ordering = false;
-    opts.retriangulation.random_seed = opts.random_seed;
-  }
-  opts.global_positioning.solver_options.num_threads = opts.num_threads;
-  if (opts.bundle_adjustment.ceres) {
-    opts.bundle_adjustment.ceres->solver_options.num_threads = opts.num_threads;
+}  // namespace
+
+RotationEstimatorOptions GlobalMapperOptions::RotationAveraging() const {
+  RotationEstimatorOptions opts = rotation_averaging;
+  opts.refine_sensor_from_rig = refine_sensor_from_rig;
+  if (random_seed >= 0) {
+    opts.random_seed = random_seed;
   }
   return opts;
 }
 
-}  // namespace
+GlobalPositionerOptions GlobalMapperOptions::GlobalPositioning() const {
+  GlobalPositionerOptions opts = global_positioning;
+  opts.refine_sensor_from_rig = refine_sensor_from_rig;
+  opts.solver_options.num_threads = num_threads;
+  if (random_seed >= 0) {
+    opts.random_seed = random_seed;
+    opts.use_parameter_block_ordering = false;
+  }
+  return opts;
+}
+
+BundleAdjustmentOptions GlobalMapperOptions::BundleAdjustment() const {
+  BundleAdjustmentOptions opts = bundle_adjustment;
+  opts.refine_sensor_from_rig = refine_sensor_from_rig;
+  if (opts.ceres) {
+    opts.ceres->solver_options.num_threads = num_threads;
+  }
+  return opts;
+}
+
+IncrementalTriangulator::Options GlobalMapperOptions::Retriangulation() const {
+  IncrementalTriangulator::Options opts = retriangulation;
+  if (random_seed >= 0) {
+    opts.random_seed = random_seed;
+  }
+  return opts;
+}
 
 GlobalMapper::GlobalMapper(std::shared_ptr<const DatabaseCache> database_cache)
     : database_cache_(std::move(THROW_CHECK_NOTNULL(database_cache))) {}
@@ -457,15 +478,12 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
     return false;
   }
 
-  // Propagate random seed and num_threads to component options.
-  GlobalMapperOptions opts = InitializeOptions(options);
-
   // Run rotation averaging
-  if (!opts.skip_rotation_averaging) {
+  if (!options.skip_rotation_averaging) {
     LOG_HEADING1("Running rotation averaging");
     Timer run_timer;
     run_timer.Start();
-    if (!RotationAveraging(opts.rotation_averaging)) {
+    if (!RotationAveraging(options.RotationAveraging())) {
       return false;
     }
     LOG(INFO) << "Rotation averaging done in " << run_timer.ElapsedSeconds()
@@ -473,24 +491,24 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
   }
 
   // Track establishment and selection
-  if (!opts.skip_track_establishment) {
+  if (!options.skip_track_establishment) {
     LOG_HEADING1("Running track establishment");
     Timer run_timer;
     run_timer.Start();
-    EstablishTracks(opts);
+    EstablishTracks(options);
     LOG(INFO) << "Track establishment done in " << run_timer.ElapsedSeconds()
               << " seconds";
   }
 
   // Global positioning
-  if (!opts.skip_global_positioning) {
+  if (!options.skip_global_positioning) {
     LOG_HEADING1("Running global positioning");
     Timer run_timer;
     run_timer.Start();
-    if (!GlobalPositioning(opts.global_positioning,
-                           opts.max_angular_reproj_error_deg,
-                           opts.max_normalized_reproj_error,
-                           opts.min_tri_angle_deg)) {
+    if (!GlobalPositioning(options.GlobalPositioning(),
+                           options.max_angular_reproj_error_deg,
+                           options.max_normalized_reproj_error,
+                           options.min_tri_angle_deg)) {
       return false;
     }
     LOG(INFO) << "Global positioning done in " << run_timer.ElapsedSeconds()
@@ -498,16 +516,16 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
   }
 
   // Bundle adjustment
-  if (!opts.skip_bundle_adjustment) {
+  if (!options.skip_bundle_adjustment) {
     LOG_HEADING1("Running iterative bundle adjustment");
     Timer run_timer;
     run_timer.Start();
-    if (!IterativeBundleAdjustment(opts.bundle_adjustment,
-                                   opts.max_normalized_reproj_error,
-                                   opts.min_tri_angle_deg,
-                                   opts.ba_num_iterations,
-                                   opts.ba_skip_fixed_rotation_stage,
-                                   opts.ba_skip_joint_optimization_stage)) {
+    if (!IterativeBundleAdjustment(options.BundleAdjustment(),
+                                   options.max_normalized_reproj_error,
+                                   options.min_tri_angle_deg,
+                                   options.ba_num_iterations,
+                                   options.ba_skip_fixed_rotation_stage,
+                                   options.ba_skip_joint_optimization_stage)) {
       return false;
     }
     LOG(INFO) << "Iterative bundle adjustment done in "
@@ -515,14 +533,14 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
   }
 
   // Retriangulation
-  if (!opts.skip_retriangulation) {
+  if (!options.skip_retriangulation) {
     LOG_HEADING1("Running iterative retriangulation and refinement");
     Timer run_timer;
     run_timer.Start();
-    if (!IterativeRetriangulateAndRefine(opts.retriangulation,
-                                         opts.bundle_adjustment,
-                                         opts.max_normalized_reproj_error,
-                                         opts.min_tri_angle_deg)) {
+    if (!IterativeRetriangulateAndRefine(options.Retriangulation(),
+                                         options.BundleAdjustment(),
+                                         options.max_normalized_reproj_error,
+                                         options.min_tri_angle_deg)) {
       return false;
     }
     LOG(INFO) << "Iterative retriangulation and refinement done in "

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -27,12 +27,14 @@ struct GlobalMapperOptions {
   // If not specified, all point colors will be black.
   std::filesystem::path image_path;
 
+  // When false, treat each non-ref sensor's cam_from_rig as a pre-calibrated
+  bool refine_sensor_from_rig = true;
+
   // Options for each component
   RotationEstimatorOptions rotation_averaging;
   GlobalPositionerOptions global_positioning;
   BundleAdjustmentOptions bundle_adjustment = [] {
     BundleAdjustmentOptions options;
-    options.refine_sensor_from_rig = false;
     options.min_track_length = 3;
     options.print_summary = false;
     if (options.ceres) {
@@ -93,6 +95,11 @@ struct GlobalMapperOptions {
   bool skip_global_positioning = false;
   bool skip_bundle_adjustment = false;
   bool skip_retriangulation = false;
+
+  RotationEstimatorOptions RotationAveraging() const;
+  GlobalPositionerOptions GlobalPositioning() const;
+  BundleAdjustmentOptions BundleAdjustment() const;
+  IncrementalTriangulator::Options Retriangulation() const;
 };
 
 class GlobalMapper {

--- a/src/colmap/sfm/global_mapper_test.cc
+++ b/src/colmap/sfm/global_mapper_test.cc
@@ -152,5 +152,18 @@ TEST(GlobalMapper, WithNoiseAndOutliers) {
                                  /*num_obs_tolerance=*/0.02));
 }
 
+TEST(GlobalMapperOptions, RefineSensorFromRigPropagatesToSubOptions) {
+  GlobalMapperOptions options;
+  options.refine_sensor_from_rig = false;
+  // Sub-options keep their own defaults (true) until accessed.
+  EXPECT_TRUE(options.rotation_averaging.refine_sensor_from_rig);
+  EXPECT_TRUE(options.global_positioning.refine_sensor_from_rig);
+  EXPECT_TRUE(options.bundle_adjustment.refine_sensor_from_rig);
+  // Accessors return resolved sub-options with the top-level flag applied.
+  EXPECT_FALSE(options.RotationAveraging().refine_sensor_from_rig);
+  EXPECT_FALSE(options.GlobalPositioning().refine_sensor_from_rig);
+  EXPECT_FALSE(options.BundleAdjustment().refine_sensor_from_rig);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/estimators/ceres_bindings.cc
+++ b/src/pycolmap/estimators/ceres_bindings.cc
@@ -123,6 +123,8 @@ void BindCeresTypes(py::module& m) {
                  ceres::SparseLinearAlgebraLibraryType::EIGEN_SPARSE)
           .value("ACCELERATE_SPARSE",
                  ceres::SparseLinearAlgebraLibraryType::ACCELERATE_SPARSE)
+          .value("CUDA_SPARSE",
+                 ceres::SparseLinearAlgebraLibraryType::CUDA_SPARSE)
           .value("NO_SPARSE", ceres::SparseLinearAlgebraLibraryType::NO_SPARSE);
   AddStringToEnumConstructor(slalt);
 

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -35,6 +35,11 @@ void BindGlobalPositioner(py::module& m) {
           .def_readwrite("optimize_scales",
                          &GlobalPositionerOptions::optimize_scales,
                          "Whether to optimize scales.")
+          .def_readwrite(
+              "refine_sensor_from_rig",
+              &GlobalPositionerOptions::refine_sensor_from_rig,
+              "When False, treat sensor_from_rig as a fixed pre-calibrated "
+              "parameter.")
           .def_readwrite("use_gpu",
                          &GlobalPositionerOptions::use_gpu,
                          "Whether to use GPU for optimization.")
@@ -165,7 +170,12 @@ void BindRotationEstimator(py::module& m) {
               "max_rotation_error_deg",
               &RotationEstimatorOptions::max_rotation_error_deg,
               "Filter pairs with rotation error exceeding this threshold "
-              "(degrees).");
+              "(degrees).")
+          .def_readwrite(
+              "refine_sensor_from_rig",
+              &RotationEstimatorOptions::refine_sensor_from_rig,
+              "When False, treat each non-ref sensor's cam_from_rig as a "
+              "pre-calibrated constant.");
   MakeDataclass(PyRotationEstimatorOptions);
 
   m.def(

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -180,6 +180,12 @@ void BindSfM(py::module& m) {
             .def(py::init<>())
             .def_readwrite("num_threads", &Opts::num_threads)
             .def_readwrite("random_seed", &Opts::random_seed)
+            .def_readwrite("refine_sensor_from_rig",
+                           &Opts::refine_sensor_from_rig,
+                           "When False, treat each non-ref sensor's "
+                           "cam_from_rig as a pre-calibrated constant across "
+                           "rotation averaging, global positioning and "
+                           "bundle adjustment.")
             .def_readwrite("rotation_averaging", &Opts::rotation_averaging)
             .def_readwrite("global_positioning", &Opts::global_positioning)
             .def_readwrite("bundle_adjustment", &Opts::bundle_adjustment)


### PR DESCRIPTION
## Changes                                                                                                                                                    
                                                                                                                                                              
**Fix: `refine_sensor_from_rig=False` now honored by the global mapper**                                                                                      
Previously, the flag was respected only in incremental BA. In the global SfM , both rotation averaging and global positioning silently overwrote per-sensor `cam_from_rig` data — RA reset translations, GP NaN-poisoned them for re-estimation — even when callers had explicitly opted out of refinement.

This PR plumbs the flag through both stages so a pre-calibrated rig stays exactly as provided when `refine_sensor_from_rig=False`:                                                                                                      
- `RotationEstimatorOptions::refine_sensor_from_rig` (new, default `true`) → when `false`, only `rig_from_world` is updated; `sensor_from_rig` is left untouched.                                                                                                                                             
- `GlobalPositionerOptions::refine_sensor_from_rig` (new, default `true`) → when `false`, the `cam_in_rig` direction term uses the provided translation (zeroing only on NaN) and `ConvertBackResults` skips the sensor-from-rig writeback.                                                                                                                                  
- pycolmap bindings exposed for both.                                                                                                                         
                                                                                                                                                              
**Tests**                                              
                                                                                                                                                              
- `global_positioning_test`: new case verifies sensor_from_rig is preserved end-to-end through global positioning when the flag is `false`.                                                                                             
- `rotation_averaging_test`: matching case for rotation averaging — exact equality of both rotation (quaternion coeffs) and translation against a pre-RA snapshot.                                                                                                                                            
                                                                                                                                                              
## Discussion / follow-up                              
                                                                                                                                                              
`refine_sensor_from_rig` now exists as three independent fields on `BundleAdjustmentOptions`, `RotationEstimatorOptions` and `GlobalPositionerOptions`. Should this be a single field instead?