### PR TITLE
Only set manifold if there are residuals in pose refinement, test for unit quaternion + cov

### DIFF
--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -168,8 +168,8 @@ TEST(IncrementalPipeline, WithNonTrivialFramesAndConstantRigsAndCameras) {
         sensor_from_rig.value(),
         Rigid3dNear(
             gt_reconstruction.Rig(kConstantRigId).SensorFromRig(sensor_id),
-            /*rtol=*/1e-5,
-            /*ttol=*/1e-5));
+            /*rtol=*/1e-4,
+            /*ttol=*/1e-4));
   }
   EXPECT_EQ(reconstruction.Camera(kConstantCameraId).params,
             gt_reconstruction.Camera(kConstantCameraId).params);

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -407,6 +407,7 @@ bool RefineGeneralizedAbsolutePose(const AbsolutePoseRefinementOptions& options,
         }
       }
     }
+
     SetManifold(&problem,
                 rig_from_world->params.data(),
                 CreateProductManifold(CreateEigenQuaternionManifold(),

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -166,6 +166,7 @@ TEST(RefineGeneralizedAbsolutePose, Nominal) {
   EXPECT_THAT(
       rig_from_world,
       Rigid3dNear(problem.gt_rig_from_world, /*rtol=*/1e-6, /*ttol=*/1e-6));
+  EXPECT_NEAR(rig_from_world.rotation().norm(), 1.0, 1e-6);
 }
 
 TEST(RefineGeneralizedAbsolutePose, PositionPrior) {
@@ -196,6 +197,7 @@ TEST(RefineGeneralizedAbsolutePose, PositionPrior) {
                                             &rig_from_world,
                                             &problem.cameras));
   EXPECT_LT(compute_position_error(rig_from_world), initial_error);
+  EXPECT_NEAR(rig_from_world.rotation().norm(), 1.0, 1e-6);
 }
 
 TEST(RefineGeneralizedAbsolutePose, PositionPriorCovariance) {
@@ -238,6 +240,7 @@ TEST(RefineGeneralizedAbsolutePose, PositionPriorCovariance) {
                                             problem.cams_from_rig,
                                             &weak_prior_rig_from_world,
                                             &weak_prior_cameras));
+  EXPECT_NEAR(weak_prior_rig_from_world.rotation().norm(), 1.0, 1e-6);
   EXPECT_TRUE(RefineGeneralizedAbsolutePose(strong_prior_options,
                                             inlier_mask,
                                             problem.points2D,
@@ -246,6 +249,7 @@ TEST(RefineGeneralizedAbsolutePose, PositionPriorCovariance) {
                                             problem.cams_from_rig,
                                             &strong_prior_rig_from_world,
                                             &strong_prior_cameras));
+  EXPECT_NEAR(strong_prior_rig_from_world.rotation().norm(), 1.0, 1e-6);
 
   auto compute_position_error = [&](const Rigid3d& rig_from_world_to_check) {
     return (Inverse(rig_from_world_to_check).translation() -

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -155,6 +155,7 @@ TEST(RefineGeneralizedAbsolutePose, Nominal) {
   AbsolutePoseRefinementOptions options;
   options.refine_focal_length = false;
   options.refine_extra_params = false;
+  Eigen::Matrix6d rig_from_world_cov = Eigen::Matrix6d::Zero();
   EXPECT_TRUE(RefineGeneralizedAbsolutePose(options,
                                             gt_inlier_mask,
                                             problem.points2D,
@@ -162,11 +163,13 @@ TEST(RefineGeneralizedAbsolutePose, Nominal) {
                                             problem.camera_idxs,
                                             problem.cams_from_rig,
                                             &rig_from_world,
-                                            &problem.cameras));
+                                            &problem.cameras,
+                                            &rig_from_world_cov));
   EXPECT_THAT(
       rig_from_world,
       Rigid3dNear(problem.gt_rig_from_world, /*rtol=*/1e-6, /*ttol=*/1e-6));
   EXPECT_NEAR(rig_from_world.rotation().norm(), 1.0, 1e-6);
+  EXPECT_NE(rig_from_world_cov, Eigen::Matrix6d::Zero());
 }
 
 TEST(RefineGeneralizedAbsolutePose, PositionPrior) {

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -241,12 +241,12 @@ bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
         }
       }
     }
-  }
 
-  SetManifold(&problem,
-              cam_from_world->params.data(),
-              CreateProductManifold(CreateEigenQuaternionManifold(),
-                                    CreateEuclideanManifold<3>()));
+    SetManifold(&problem,
+                cam_from_world->params.data(),
+                CreateProductManifold(CreateEigenQuaternionManifold(),
+                                      CreateEuclideanManifold<3>()));
+  }
 
   ceres::Solver::Options solver_options;
   solver_options.gradient_tolerance = options.gradient_tolerance;

--- a/src/colmap/estimators/pose_test.cc
+++ b/src/colmap/estimators/pose_test.cc
@@ -174,6 +174,7 @@ TEST(RefineAbsolutePose, Nominal) {
   EXPECT_THAT(
       cam_from_world,
       Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-6, /*ttol=*/1e-6));
+  EXPECT_NEAR(cam_from_world.rotation().norm(), 1.0, 1e-6);
   EXPECT_EQ(camera, problem.camera);
   EXPECT_NE(cam_from_world_cov, Eigen::Matrix6d::Zero());
 }
@@ -198,6 +199,7 @@ TEST(RefineAbsolutePose, RefineFocalLength) {
   EXPECT_THAT(
       cam_from_world,
       Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
+  EXPECT_NEAR(cam_from_world.rotation().norm(), 1.0, 1e-6);
   EXPECT_NEAR(camera.FocalLength(), problem.camera.FocalLength(), 5);
   camera.SetFocalLength(problem.camera.FocalLength());
   EXPECT_EQ(camera, problem.camera);
@@ -224,6 +226,7 @@ TEST(RefineAbsolutePose, RefineExtraParams) {
   EXPECT_THAT(
       cam_from_world,
       Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-3));
+  EXPECT_NEAR(cam_from_world.rotation().norm(), 1.0, 1e-6);
   EXPECT_NEAR(camera.params.at(3), problem.camera.params.at(3), 1e-3);
   camera.params.at(3) = problem.camera.params.at(3);
   EXPECT_EQ(camera, problem.camera);
@@ -256,6 +259,7 @@ TEST(RefineAbsolutePose, PositionPrior) {
                                  &cam_from_world,
                                  &camera));
   EXPECT_LT(compute_position_error(cam_from_world), initial_error);
+  EXPECT_NEAR(cam_from_world.rotation().norm(), 1.0, 1e-6);
 }
 
 TEST(RefineAbsolutePose, PositionPriorCovariance) {
@@ -290,12 +294,14 @@ TEST(RefineAbsolutePose, PositionPriorCovariance) {
                                  problem.points3D,
                                  &weak_prior_cam_from_world,
                                  &weak_prior_camera));
+  EXPECT_NEAR(weak_prior_cam_from_world.rotation().norm(), 1.0, 1e-6);
   EXPECT_TRUE(RefineAbsolutePose(strong_prior_options,
                                  inlier_mask,
                                  problem.points2D,
                                  problem.points3D,
                                  &strong_prior_cam_from_world,
                                  &strong_prior_camera));
+  EXPECT_NEAR(strong_prior_cam_from_world.rotation().norm(), 1.0, 1e-6);
 
   auto compute_position_error = [&](const Rigid3d& cam_from_world_to_check) {
     return (Inverse(cam_from_world_to_check).translation() -


### PR DESCRIPTION
Minor follow-up to @nushakrishnan by also only setting the manifold logic, if there are residuals, as well as adding some checks to catch the previous bug.