### PR TITLE
Clip extreme pixels in fisheye undistortion

### DIFF
--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -103,6 +103,18 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
   // Scale in order to match the boundary of the undistorted image.
   if (roi_enabled || (camera.model_id != SimplePinholeCameraModel::model_id &&
                       camera.model_id != PinholeCameraModel::model_id)) {
+    // For fisheye camera, CamFromImg returns perspective-normalized coords
+    // where |cam_point| = tan(theta). Near theta = pi/2, tan(theta) diverges:
+    // border pixels outside the valid fisheye circle (common with off-center
+    // principal points) produce extreme coordinates that blow up the output
+    // dimensions. Skip any cam_point whose norm exceeds the threshold.
+    THROW_CHECK(options.max_cam_point_norm < 0 ||
+                options.max_cam_point_norm > 0);
+    const double max_cam_point_norm_sq =
+        options.max_cam_point_norm < 0
+            ? -1
+            : options.max_cam_point_norm * options.max_cam_point_norm;
+
     // Determine min/max coordinates along top / bottom image border.
 
     double left_min_x = std::numeric_limits<double>::max();
@@ -114,7 +126,9 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Left border.
       if (const std::optional<Eigen::Vector2d> cam_point1 =
               camera.CamFromImg(Eigen::Vector2d(0.5, y + 0.5));
-          cam_point1.has_value()) {
+          cam_point1.has_value() &&
+          (max_cam_point_norm_sq < 0 ||
+           cam_point1->squaredNorm() < max_cam_point_norm_sq)) {
         if (const std::optional<Eigen::Vector2d> undistorted_point1 =
                 undistorted_camera.ImgFromCam(cam_point1->homogeneous());
             undistorted_point1) {
@@ -125,7 +139,9 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Right border.
       if (const std::optional<Eigen::Vector2d> cam_point2 =
               camera.CamFromImg(Eigen::Vector2d(camera.width - 0.5, y + 0.5));
-          cam_point2.has_value()) {
+          cam_point2.has_value() &&
+          (max_cam_point_norm_sq < 0 ||
+           cam_point2->squaredNorm() < max_cam_point_norm_sq)) {
         if (const std::optional<Eigen::Vector2d> undistorted_point2 =
                 undistorted_camera.ImgFromCam(cam_point2->homogeneous());
             undistorted_point2) {
@@ -146,7 +162,9 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Top border.
       if (const std::optional<Eigen::Vector2d> cam_point1 =
               camera.CamFromImg(Eigen::Vector2d(x + 0.5, 0.5));
-          cam_point1) {
+          cam_point1.has_value() &&
+          (max_cam_point_norm_sq < 0 ||
+           cam_point1->squaredNorm() < max_cam_point_norm_sq)) {
         if (const std::optional<Eigen::Vector2d> undistorted_point1 =
                 undistorted_camera.ImgFromCam(cam_point1->homogeneous());
             undistorted_point1) {
@@ -157,7 +175,9 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       // Bottom border.
       if (const std::optional<Eigen::Vector2d> cam_point2 =
               camera.CamFromImg(Eigen::Vector2d(x + 0.5, camera.height - 0.5));
-          cam_point2) {
+          cam_point2.has_value() &&
+          (max_cam_point_norm_sq < 0 ||
+           cam_point2->squaredNorm() < max_cam_point_norm_sq)) {
         if (const std::optional<Eigen::Vector2d> undistorted_point2 =
                 undistorted_camera.ImgFromCam(cam_point2->homogeneous());
             undistorted_point2) {

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -108,11 +108,10 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
     // border pixels outside the valid fisheye circle (common with off-center
     // principal points) produce extreme coordinates that blow up the output
     // dimensions. Skip any cam_point whose norm exceeds the threshold.
-    THROW_CHECK(options.max_cam_point_norm < 0 ||
-                options.max_cam_point_norm > 0);
+    THROW_CHECK_NE(options.max_cam_point_norm, 0);
     const double max_cam_point_norm_sq =
         options.max_cam_point_norm < 0
-            ? -1
+            ? std::numeric_limits<double>::infinity()
             : options.max_cam_point_norm * options.max_cam_point_norm;
 
     // Determine min/max coordinates along top / bottom image border.
@@ -127,8 +126,7 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       if (const std::optional<Eigen::Vector2d> cam_point1 =
               camera.CamFromImg(Eigen::Vector2d(0.5, y + 0.5));
           cam_point1.has_value() &&
-          (max_cam_point_norm_sq < 0 ||
-           cam_point1->squaredNorm() < max_cam_point_norm_sq)) {
+          cam_point1->squaredNorm() < max_cam_point_norm_sq) {
         if (const std::optional<Eigen::Vector2d> undistorted_point1 =
                 undistorted_camera.ImgFromCam(cam_point1->homogeneous());
             undistorted_point1) {
@@ -140,8 +138,7 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       if (const std::optional<Eigen::Vector2d> cam_point2 =
               camera.CamFromImg(Eigen::Vector2d(camera.width - 0.5, y + 0.5));
           cam_point2.has_value() &&
-          (max_cam_point_norm_sq < 0 ||
-           cam_point2->squaredNorm() < max_cam_point_norm_sq)) {
+          cam_point2->squaredNorm() < max_cam_point_norm_sq) {
         if (const std::optional<Eigen::Vector2d> undistorted_point2 =
                 undistorted_camera.ImgFromCam(cam_point2->homogeneous());
             undistorted_point2) {
@@ -163,8 +160,7 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       if (const std::optional<Eigen::Vector2d> cam_point1 =
               camera.CamFromImg(Eigen::Vector2d(x + 0.5, 0.5));
           cam_point1.has_value() &&
-          (max_cam_point_norm_sq < 0 ||
-           cam_point1->squaredNorm() < max_cam_point_norm_sq)) {
+          cam_point1->squaredNorm() < max_cam_point_norm_sq) {
         if (const std::optional<Eigen::Vector2d> undistorted_point1 =
                 undistorted_camera.ImgFromCam(cam_point1->homogeneous());
             undistorted_point1) {
@@ -176,8 +172,7 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
       if (const std::optional<Eigen::Vector2d> cam_point2 =
               camera.CamFromImg(Eigen::Vector2d(x + 0.5, camera.height - 0.5));
           cam_point2.has_value() &&
-          (max_cam_point_norm_sq < 0 ||
-           cam_point2->squaredNorm() < max_cam_point_norm_sq)) {
+          cam_point2->squaredNorm() < max_cam_point_norm_sq) {
         if (const std::optional<Eigen::Vector2d> undistorted_point2 =
                 undistorted_camera.ImgFromCam(cam_point2->homogeneous());
             undistorted_point2) {

--- a/src/colmap/image/undistortion.h
+++ b/src/colmap/image/undistortion.h
@@ -55,6 +55,15 @@ struct UndistortCameraOptions {
   double roi_min_y = 0.0;
   double roi_max_x = 1.0;
   double roi_max_y = 1.0;
+
+  // Maximum norm of the undistorted camera-space point (= tan(theta) where
+  // theta is the angle from the optical axis) used when tracing border pixels
+  // to compute the output image dimensions. For fisheye cameras with off-center
+  // principal points, border pixels outside the valid fisheye circle can have
+  // theta approaching pi/2, causing tan(theta) to diverge and producing extreme
+  // output dimensions. Points with norm exceeding this threshold are skipped.
+  // Set to -1 to disable the check (default).
+  double max_cam_point_norm = -1;
 };
 
 // Undistort camera by resizing the image and shifting the principal point.

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -103,6 +103,43 @@ TEST(UndistortCamera, Nominal) {
   EXPECT_EQ(undistorted_camera.PrincipalPointY(), 30);
 }
 
+TEST(UndistortCamera, MaxCamPointNorm) {
+  // Fisheye camera with off-center principal point: pixels far from (cx, cy)
+  // have theta close to pi/2, so CamFromImg returns very large values
+  // (|cam_point| = tan(theta)) that blow up the output dimensions.
+  Camera distorted_camera = Camera::CreateFromModelId(
+      1, CameraModelId::kSimpleFisheye, 130, 200, 100);
+  distorted_camera.SetPrincipalPointX(10);
+  distorted_camera.SetPrincipalPointY(50);
+
+  UndistortCameraOptions options;
+  // Exercise the path driven by extreme samples.
+  options.blank_pixels = 1.0;
+
+  // Default (max_cam_point_norm = -1): the extreme cam_points push the scale
+  // factor against max_scale, so the output is the maximum allowed size.
+  const Camera undistorted_camera_unbounded =
+      UndistortCamera(options, distorted_camera);
+  EXPECT_EQ(undistorted_camera_unbounded.width,
+            distorted_camera.width * options.max_scale);
+  EXPECT_EQ(undistorted_camera_unbounded.height,
+            distorted_camera.height * options.max_scale);
+
+  // With a finite threshold, extreme border samples are skipped, yielding
+  // a smaller output that is no longer hitting the max_scale clamp.
+  options.max_cam_point_norm = 2.0;
+  const Camera undistorted_camera_bounded =
+      UndistortCamera(options, distorted_camera);
+  EXPECT_LT(undistorted_camera_bounded.width,
+            undistorted_camera_unbounded.width);
+  EXPECT_LT(undistorted_camera_bounded.height,
+            undistorted_camera_unbounded.height);
+
+  // max_cam_point_norm = 0 is invalid (would skip every sample).
+  options.max_cam_point_norm = 0;
+  EXPECT_ANY_THROW(UndistortCamera(options, distorted_camera));
+}
+
 TEST(UndistortCamera, BlankPixels) {
   UndistortCameraOptions options;
   options.blank_pixels = 1;

--- a/src/pycolmap/image/undistortion.cc
+++ b/src/pycolmap/image/undistortion.cc
@@ -22,7 +22,9 @@ void BindUndistortion(py::module& m) {
           .def_readwrite("roi_min_x", &UndistortCameraOptions::roi_min_x)
           .def_readwrite("roi_min_y", &UndistortCameraOptions::roi_min_y)
           .def_readwrite("roi_max_x", &UndistortCameraOptions::roi_max_x)
-          .def_readwrite("roi_max_y", &UndistortCameraOptions::roi_max_y);
+          .def_readwrite("roi_max_y", &UndistortCameraOptions::roi_max_y)
+          .def_readwrite("max_cam_point_norm",
+                         &UndistortCameraOptions::max_cam_point_norm);
   MakeDataclass(PyUndistortCameraOptions);
 
   m.def("undistort_camera",


### PR DESCRIPTION
## Summary

Fix undistortion boundary scaling for fisheye cameras with off-center principal points.

When tracing image borders to determine the undistorted output size, some border pixels can map to camera-space rays with very large norm (`tan(theta)`), especially near the edge of the valid fisheye circle. Those extreme samples can blow up the estimated undistorted image dimensions.

This change adds an optional `max_cam_point_norm` threshold to skip such pathological rays during border tracing.

## Changes

- add `max_cam_point_norm` to `UndistortCameraOptions`
- ignore boundary samples whose camera-space norm exceeds the threshold
- expose the new option in `pycolmap`

## Notes

- the check is disabled by default (`max_cam_point_norm = -1`), so existing behavior is unchanged unless the option is set
- this is intended as a geometry-based safeguard, rather than requiring users to hand-tune an ROI crop
