### PR TITLE
Refit missing E/F/H in MaybeDecomposeRelativePoses for old databases

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -925,6 +925,113 @@ TwoViewGeometry TwoViewGeometryFromKnownRelativePose(
   return geometry;
 }
 
+namespace {
+
+// Fits the E/F/H matrix matching `geometry->config` from the existing
+// inlier matches when it was not persisted in the database (e.g. databases
+// from older COLMAP versions that stored only the configuration). Returns
+// false if no matrix is needed for the configuration, the relevant matrix
+// is already present, or the fit failed (insufficient inliers / degenerate
+// configuration).
+bool MaybeFitMissingTwoViewGeometryMatrix(
+    const Camera& camera1,
+    const std::vector<Eigen::Vector2d>& points1,
+    const Camera& camera2,
+    const std::vector<Eigen::Vector2d>& points2,
+    TwoViewGeometry* geometry) {
+  switch (geometry->config) {
+    case TwoViewGeometry::ConfigurationType::CALIBRATED: {
+      if (geometry->E.has_value()) {
+        return true;
+      }
+      std::vector<Eigen::Vector3d> cam_rays1;
+      std::vector<Eigen::Vector3d> cam_rays2;
+      cam_rays1.reserve(geometry->inlier_matches.size());
+      cam_rays2.reserve(geometry->inlier_matches.size());
+      for (const FeatureMatch& match : geometry->inlier_matches) {
+        const std::optional<Eigen::Vector2d> cam_point1 =
+            camera1.CamFromImg(points1[match.point2D_idx1]);
+        const std::optional<Eigen::Vector2d> cam_point2 =
+            camera2.CamFromImg(points2[match.point2D_idx2]);
+        if (cam_point1 && cam_point2) {
+          cam_rays1.push_back(cam_point1->homogeneous().normalized());
+          cam_rays2.push_back(cam_point2->homogeneous().normalized());
+        }
+      }
+      if (cam_rays1.size() <
+          static_cast<size_t>(
+              EssentialMatrixEightPointEstimator::kMinNumSamples)) {
+        return false;
+      }
+      std::vector<Eigen::Matrix3d> models;
+      EssentialMatrixEightPointEstimator::Estimate(
+          cam_rays1, cam_rays2, &models);
+      if (models.empty()) {
+        return false;
+      }
+      geometry->E = models[0];
+      return true;
+    }
+    case TwoViewGeometry::ConfigurationType::UNCALIBRATED: {
+      if (geometry->F.has_value()) {
+        return true;
+      }
+      std::vector<Eigen::Vector2d> inlier_points1;
+      std::vector<Eigen::Vector2d> inlier_points2;
+      inlier_points1.reserve(geometry->inlier_matches.size());
+      inlier_points2.reserve(geometry->inlier_matches.size());
+      for (const FeatureMatch& match : geometry->inlier_matches) {
+        inlier_points1.push_back(points1[match.point2D_idx1]);
+        inlier_points2.push_back(points2[match.point2D_idx2]);
+      }
+      if (inlier_points1.size() <
+          static_cast<size_t>(
+              FundamentalMatrixEightPointEstimator::kMinNumSamples)) {
+        return false;
+      }
+      std::vector<Eigen::Matrix3d> models;
+      FundamentalMatrixEightPointEstimator::Estimate(
+          inlier_points1, inlier_points2, &models);
+      if (models.empty()) {
+        return false;
+      }
+      geometry->F = models[0];
+      return true;
+    }
+    case TwoViewGeometry::ConfigurationType::PLANAR:
+    case TwoViewGeometry::ConfigurationType::PANORAMIC:
+    case TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC: {
+      if (geometry->H.has_value()) {
+        return true;
+      }
+      std::vector<Eigen::Vector2d> inlier_points1;
+      std::vector<Eigen::Vector2d> inlier_points2;
+      inlier_points1.reserve(geometry->inlier_matches.size());
+      inlier_points2.reserve(geometry->inlier_matches.size());
+      for (const FeatureMatch& match : geometry->inlier_matches) {
+        inlier_points1.push_back(points1[match.point2D_idx1]);
+        inlier_points2.push_back(points2[match.point2D_idx2]);
+      }
+      if (inlier_points1.size() <
+          static_cast<size_t>(HomographyMatrixEstimator::kMinNumSamples)) {
+        return false;
+      }
+      std::vector<Eigen::Matrix3d> models;
+      HomographyMatrixEstimator::Estimate(
+          inlier_points1, inlier_points2, &models);
+      if (models.empty()) {
+        return false;
+      }
+      geometry->H = models[0];
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
 void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
   Timer timer;
   timer.Start();
@@ -975,6 +1082,16 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
     }
 
     decompose_count++;
+
+    // Older COLMAP databases stored the two-view geometry configuration
+    // without persisting the underlying E/F/H matrix. Refit it here from
+    // the inlier matches so EstimateTwoViewGeometryPose can decompose it.
+    if (!MaybeFitMissingTwoViewGeometryMatrix(
+            camera1, points1, camera2, points2, &two_view_geom)) {
+      decompose_failed_count++;
+      continue;
+    }
+
     const bool success = EstimateTwoViewGeometryPose(
         camera1, points1, camera2, points2, &two_view_geom);
 

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -480,47 +480,42 @@ EstimateRigTwoViewGeometries(
   return two_view_geometries;
 }
 
-bool EstimateTwoViewGeometryPose(const Camera& camera1,
-                                 const std::vector<Eigen::Vector2d>& points1,
-                                 const Camera& camera2,
-                                 const std::vector<Eigen::Vector2d>& points2,
-                                 TwoViewGeometry* geometry) {
-  // We need a valid epopolar geometry to estimate the relative pose.
-  if (geometry->config != TwoViewGeometry::ConfigurationType::CALIBRATED &&
-      geometry->config != TwoViewGeometry::ConfigurationType::UNCALIBRATED &&
-      geometry->config != TwoViewGeometry::ConfigurationType::PLANAR &&
-      geometry->config != TwoViewGeometry::ConfigurationType::PANORAMIC &&
-      geometry->config !=
-          TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC) {
-    return false;
-  }
+namespace {
 
-  // Extract normalized inlier points.
-  const size_t num_inlier_matches = geometry->inlier_matches.size();
-  if (num_inlier_matches == 0) {
-    return false;
-  }
-
-  std::vector<Eigen::Vector3d> inlier_cam_rays1(num_inlier_matches);
-  std::vector<Eigen::Vector3d> inlier_cam_rays2(num_inlier_matches);
-  for (size_t i = 0; i < num_inlier_matches; ++i) {
-    const FeatureMatch& match = geometry->inlier_matches[i];
+void ExtractInlierCamRays(const Camera& camera1,
+                          const std::vector<Eigen::Vector2d>& points1,
+                          const Camera& camera2,
+                          const std::vector<Eigen::Vector2d>& points2,
+                          const FeatureMatches& inlier_matches,
+                          std::vector<Eigen::Vector3d>* inlier_cam_rays1,
+                          std::vector<Eigen::Vector3d>* inlier_cam_rays2) {
+  inlier_cam_rays1->resize(inlier_matches.size());
+  inlier_cam_rays2->resize(inlier_matches.size());
+  for (size_t i = 0; i < inlier_matches.size(); ++i) {
+    const FeatureMatch& match = inlier_matches[i];
     if (const std::optional<Eigen::Vector2d> cam_point1 =
             camera1.CamFromImg(points1[match.point2D_idx1]);
         cam_point1) {
-      inlier_cam_rays1[i] = cam_point1->homogeneous().normalized();
+      (*inlier_cam_rays1)[i] = cam_point1->homogeneous().normalized();
     } else {
-      inlier_cam_rays1[i].setZero();
+      (*inlier_cam_rays1)[i].setZero();
     }
     if (const std::optional<Eigen::Vector2d> cam_point2 =
             camera2.CamFromImg(points2[match.point2D_idx2]);
         cam_point2) {
-      inlier_cam_rays2[i] = cam_point2->homogeneous().normalized();
+      (*inlier_cam_rays2)[i] = cam_point2->homogeneous().normalized();
     } else {
-      inlier_cam_rays2[i].setZero();
+      (*inlier_cam_rays2)[i].setZero();
     }
   }
+}
 
+bool EstimateTwoViewGeometryPoseFromCamRays(
+    const Camera& camera1,
+    const Camera& camera2,
+    const std::vector<Eigen::Vector3d>& inlier_cam_rays1,
+    const std::vector<Eigen::Vector3d>& inlier_cam_rays2,
+    TwoViewGeometry* geometry) {
   std::vector<Eigen::Vector3d> points3D;
 
   Rigid3d cam2_from_cam1;
@@ -590,6 +585,39 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
   }
 
   return true;
+}
+
+}  // namespace
+
+bool EstimateTwoViewGeometryPose(const Camera& camera1,
+                                 const std::vector<Eigen::Vector2d>& points1,
+                                 const Camera& camera2,
+                                 const std::vector<Eigen::Vector2d>& points2,
+                                 TwoViewGeometry* geometry) {
+  // We need a valid epipolar geometry to estimate the relative pose.
+  if (geometry->config != TwoViewGeometry::ConfigurationType::CALIBRATED &&
+      geometry->config != TwoViewGeometry::ConfigurationType::UNCALIBRATED &&
+      geometry->config != TwoViewGeometry::ConfigurationType::PLANAR &&
+      geometry->config != TwoViewGeometry::ConfigurationType::PANORAMIC &&
+      geometry->config !=
+          TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC) {
+    return false;
+  }
+  if (geometry->inlier_matches.empty()) {
+    return false;
+  }
+
+  std::vector<Eigen::Vector3d> inlier_cam_rays1;
+  std::vector<Eigen::Vector3d> inlier_cam_rays2;
+  ExtractInlierCamRays(camera1,
+                       points1,
+                       camera2,
+                       points2,
+                       geometry->inlier_matches,
+                       &inlier_cam_rays1,
+                       &inlier_cam_rays2);
+  return EstimateTwoViewGeometryPoseFromCamRays(
+      camera1, camera2, inlier_cam_rays1, inlier_cam_rays2, geometry);
 }
 
 TwoViewGeometry EstimateCalibratedTwoViewGeometry(
@@ -929,43 +957,41 @@ namespace {
 
 // Fits the E/F/H matrix matching `geometry->config` from the existing
 // inlier matches when it was not persisted in the database (e.g. databases
-// from older COLMAP versions that stored only the configuration). Returns
-// false if no matrix is needed for the configuration, the relevant matrix
-// is already present, or the fit failed (insufficient inliers / degenerate
-// configuration).
+// from older COLMAP versions that stored only the configuration). The 8-point
+// estimators are used because the inlier matches have already been filtered
+// by RANSAC at storage time (inlier counts are typically well above 8); pairs
+// with fewer inliers would yield unreliable geometry and are returned as a
+// failed fit. Returns false if the relevant matrix is already present, the
+// inlier set is too small, or the fit returned no model.
 bool MaybeFitMissingTwoViewGeometryMatrix(
-    const Camera& camera1,
     const std::vector<Eigen::Vector2d>& points1,
-    const Camera& camera2,
     const std::vector<Eigen::Vector2d>& points2,
+    const std::vector<Eigen::Vector3d>& inlier_cam_rays1,
+    const std::vector<Eigen::Vector3d>& inlier_cam_rays2,
     TwoViewGeometry* geometry) {
   switch (geometry->config) {
     case TwoViewGeometry::ConfigurationType::CALIBRATED: {
       if (geometry->E.has_value()) {
         return true;
       }
-      std::vector<Eigen::Vector3d> cam_rays1;
-      std::vector<Eigen::Vector3d> cam_rays2;
-      cam_rays1.reserve(geometry->inlier_matches.size());
-      cam_rays2.reserve(geometry->inlier_matches.size());
-      for (const FeatureMatch& match : geometry->inlier_matches) {
-        const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[match.point2D_idx1]);
-        const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[match.point2D_idx2]);
-        if (cam_point1 && cam_point2) {
-          cam_rays1.push_back(cam_point1->homogeneous().normalized());
-          cam_rays2.push_back(cam_point2->homogeneous().normalized());
+      std::vector<Eigen::Vector3d> valid_cam_rays1;
+      std::vector<Eigen::Vector3d> valid_cam_rays2;
+      valid_cam_rays1.reserve(inlier_cam_rays1.size());
+      valid_cam_rays2.reserve(inlier_cam_rays2.size());
+      for (size_t i = 0; i < inlier_cam_rays1.size(); ++i) {
+        if (!inlier_cam_rays1[i].isZero() && !inlier_cam_rays2[i].isZero()) {
+          valid_cam_rays1.push_back(inlier_cam_rays1[i]);
+          valid_cam_rays2.push_back(inlier_cam_rays2[i]);
         }
       }
-      if (cam_rays1.size() <
+      if (valid_cam_rays1.size() <
           static_cast<size_t>(
               EssentialMatrixEightPointEstimator::kMinNumSamples)) {
         return false;
       }
       std::vector<Eigen::Matrix3d> models;
       EssentialMatrixEightPointEstimator::Estimate(
-          cam_rays1, cam_rays2, &models);
+          valid_cam_rays1, valid_cam_rays2, &models);
       if (models.empty()) {
         return false;
       }
@@ -1047,19 +1073,19 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
   for (const image_pair_t pair_id : correspondence_graph->ImagePairs()) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
 
-    TwoViewGeometry two_view_geom =
+    TwoViewGeometry two_view_geometry =
         correspondence_graph->ExtractTwoViewGeometry(
             image_id1, image_id2, /*extract_inlier_matches=*/true);
 
-    if (two_view_geom.cam2_from_cam1.has_value()) {
+    if (two_view_geometry.cam2_from_cam1.has_value()) {
       continue;
     }
 
     const bool is_invalid =
-        two_view_geom.config == TwoViewGeometry::UNDEFINED ||
-        two_view_geom.config == TwoViewGeometry::DEGENERATE ||
-        two_view_geom.config == TwoViewGeometry::WATERMARK ||
-        two_view_geom.config == TwoViewGeometry::MULTIPLE;
+        two_view_geometry.config == TwoViewGeometry::UNDEFINED ||
+        two_view_geometry.config == TwoViewGeometry::DEGENERATE ||
+        two_view_geometry.config == TwoViewGeometry::WATERMARK ||
+        two_view_geometry.config == TwoViewGeometry::MULTIPLE;
 
     if (is_invalid) {
       continue;
@@ -1083,25 +1109,48 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
 
     decompose_count++;
 
-    // Older COLMAP databases stored the two-view geometry configuration
-    // without persisting the underlying E/F/H matrix. Refit it here from
-    // the inlier matches so EstimateTwoViewGeometryPose can decompose it.
-    if (!MaybeFitMissingTwoViewGeometryMatrix(
-            camera1, points1, camera2, points2, &two_view_geom)) {
+    if (two_view_geometry.inlier_matches.empty()) {
       decompose_failed_count++;
       continue;
     }
 
-    const bool success = EstimateTwoViewGeometryPose(
-        camera1, points1, camera2, points2, &two_view_geom);
+    std::vector<Eigen::Vector3d> inlier_cam_rays1;
+    std::vector<Eigen::Vector3d> inlier_cam_rays2;
+    ExtractInlierCamRays(camera1,
+                         points1,
+                         camera2,
+                         points2,
+                         two_view_geometry.inlier_matches,
+                         &inlier_cam_rays1,
+                         &inlier_cam_rays2);
 
-    if (success && two_view_geom.cam2_from_cam1.has_value()) {
-      const double norm = two_view_geom.cam2_from_cam1->translation().norm();
+    // Older COLMAP databases stored the two-view geometry configuration
+    // without persisting the underlying E/F/H matrix. Refit it here from
+    // the inlier matches so EstimateTwoViewGeometryPose can decompose it.
+    if (!MaybeFitMissingTwoViewGeometryMatrix(points1,
+                                              points2,
+                                              inlier_cam_rays1,
+                                              inlier_cam_rays2,
+                                              &two_view_geometry)) {
+      decompose_failed_count++;
+      continue;
+    }
+
+    const bool success =
+        EstimateTwoViewGeometryPoseFromCamRays(camera1,
+                                               camera2,
+                                               inlier_cam_rays1,
+                                               inlier_cam_rays2,
+                                               &two_view_geometry);
+
+    if (success && two_view_geometry.cam2_from_cam1.has_value()) {
+      const double norm =
+          two_view_geometry.cam2_from_cam1->translation().norm();
       if (norm > 1e-12) {
-        two_view_geom.cam2_from_cam1->translation() /= norm;
+        two_view_geometry.cam2_from_cam1->translation() /= norm;
       }
       correspondence_graph->UpdateTwoViewGeometry(
-          image_id1, image_id2, two_view_geom);
+          image_id1, image_id2, two_view_geometry);
     } else {
       decompose_failed_count++;
     }

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -903,27 +903,15 @@ TwoViewGeometry TwoViewGeometryFromKnownRelativePose(
     return geometry;
   }
 
-  // Extract corresponding points.
-  std::vector<Eigen::Vector3d> matched_cam_rays1(num_matches);
-  std::vector<Eigen::Vector3d> matched_cam_rays2(num_matches);
-  for (size_t i = 0; i < num_matches; ++i) {
-    const point2D_t idx1 = matches[i].point2D_idx1;
-    const point2D_t idx2 = matches[i].point2D_idx2;
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[idx1]);
-        cam_point1) {
-      matched_cam_rays1[i] = cam_point1->homogeneous().normalized();
-    } else {
-      matched_cam_rays1[i].setZero();
-    }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[idx2]);
-        cam_point2) {
-      matched_cam_rays2[i] = cam_point2->homogeneous().normalized();
-    } else {
-      matched_cam_rays2[i].setZero();
-    }
-  }
+  std::vector<Eigen::Vector3d> matched_cam_rays1;
+  std::vector<Eigen::Vector3d> matched_cam_rays2;
+  ExtractInlierCamRays(camera1,
+                       points1,
+                       camera2,
+                       points2,
+                       matches,
+                       &matched_cam_rays1,
+                       &matched_cam_rays2);
 
   // For now, we use the average threshold from cameras following the design of
   // EstimateCalibratedTwoViewGeometry.
@@ -954,6 +942,19 @@ TwoViewGeometry TwoViewGeometryFromKnownRelativePose(
 }
 
 namespace {
+
+void ExtractInlierImagePoints(const std::vector<Eigen::Vector2d>& points1,
+                              const std::vector<Eigen::Vector2d>& points2,
+                              const FeatureMatches& inlier_matches,
+                              std::vector<Eigen::Vector2d>* inlier_points1,
+                              std::vector<Eigen::Vector2d>* inlier_points2) {
+  inlier_points1->resize(inlier_matches.size());
+  inlier_points2->resize(inlier_matches.size());
+  for (size_t i = 0; i < inlier_matches.size(); ++i) {
+    (*inlier_points1)[i] = points1[inlier_matches[i].point2D_idx1];
+    (*inlier_points2)[i] = points2[inlier_matches[i].point2D_idx2];
+  }
+}
 
 // Fits the E/F/H matrix matching `geometry->config` from the existing
 // inlier matches when it was not persisted in the database (e.g. databases
@@ -1004,12 +1005,11 @@ bool MaybeFitMissingTwoViewGeometryMatrix(
       }
       std::vector<Eigen::Vector2d> inlier_points1;
       std::vector<Eigen::Vector2d> inlier_points2;
-      inlier_points1.reserve(geometry->inlier_matches.size());
-      inlier_points2.reserve(geometry->inlier_matches.size());
-      for (const FeatureMatch& match : geometry->inlier_matches) {
-        inlier_points1.push_back(points1[match.point2D_idx1]);
-        inlier_points2.push_back(points2[match.point2D_idx2]);
-      }
+      ExtractInlierImagePoints(points1,
+                               points2,
+                               geometry->inlier_matches,
+                               &inlier_points1,
+                               &inlier_points2);
       if (inlier_points1.size() <
           static_cast<size_t>(
               FundamentalMatrixEightPointEstimator::kMinNumSamples)) {
@@ -1032,12 +1032,11 @@ bool MaybeFitMissingTwoViewGeometryMatrix(
       }
       std::vector<Eigen::Vector2d> inlier_points1;
       std::vector<Eigen::Vector2d> inlier_points2;
-      inlier_points1.reserve(geometry->inlier_matches.size());
-      inlier_points2.reserve(geometry->inlier_matches.size());
-      for (const FeatureMatch& match : geometry->inlier_matches) {
-        inlier_points1.push_back(points1[match.point2D_idx1]);
-        inlier_points2.push_back(points2[match.point2D_idx2]);
-      }
+      ExtractInlierImagePoints(points1,
+                               points2,
+                               geometry->inlier_matches,
+                               &inlier_points1,
+                               &inlier_points2);
       if (inlier_points1.size() <
           static_cast<size_t>(HomographyMatrixEstimator::kMinNumSamples)) {
         return false;
@@ -1091,6 +1090,12 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
       continue;
     }
 
+    if (two_view_geometry.inlier_matches.empty()) {
+      decompose_count++;
+      decompose_failed_count++;
+      continue;
+    }
+
     const Image& image1 = images.at(image_id1);
     const Image& image2 = images.at(image_id2);
     const Camera& camera1 = cameras.at(image1.CameraId());
@@ -1109,11 +1114,6 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
 
     decompose_count++;
 
-    if (two_view_geometry.inlier_matches.empty()) {
-      decompose_failed_count++;
-      continue;
-    }
-
     std::vector<Eigen::Vector3d> inlier_cam_rays1;
     std::vector<Eigen::Vector3d> inlier_cam_rays2;
     ExtractInlierCamRays(camera1,
@@ -1124,9 +1124,6 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
                          &inlier_cam_rays1,
                          &inlier_cam_rays2);
 
-    // Older COLMAP databases stored the two-view geometry configuration
-    // without persisting the underlying E/F/H matrix. Refit it here from
-    // the inlier matches so EstimateTwoViewGeometryPose can decompose it.
     if (!MaybeFitMissingTwoViewGeometryMatrix(points1,
                                               points2,
                                               inlier_cam_rays1,

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -933,5 +933,47 @@ TEST(MaybeDecomposeRelativePoses, Nominal) {
             geometry_second.cam2_from_cam1->translation());
 }
 
+// Regression test for https://github.com/colmap/colmap/issues/4387: older
+// COLMAP databases stored the two-view geometry config without persisting
+// the E/F/H matrices. MaybeDecomposeRelativePoses must refit the missing
+// matrix from the inlier matches instead of crashing in
+// EstimateTwoViewGeometryPose's THROW_CHECK on geometry->E/F/H.
+TEST(MaybeDecomposeRelativePoses, MissingMatrixFromOldDatabase) {
+  SetPRNGSeed(42);
+
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction, database.get());
+
+  // Simulate an older database that has the configuration but no E matrix.
+  TwoViewGeometry geometry_legacy = database->ReadTwoViewGeometry(1, 2);
+  ASSERT_EQ(geometry_legacy.config,
+            TwoViewGeometry::ConfigurationType::CALIBRATED);
+  ASSERT_TRUE(geometry_legacy.E.has_value());
+  geometry_legacy.E.reset();
+  database->UpdateTwoViewGeometry(1, 2, geometry_legacy);
+
+  DatabaseCache::Options cache_options;
+  auto cache = DatabaseCache::Create(*database, cache_options);
+
+  const auto corr_graph = cache->CorrespondenceGraph();
+  TwoViewGeometry geometry_before = corr_graph->ExtractTwoViewGeometry(
+      1, 2, /*extract_inlier_matches=*/false);
+  EXPECT_FALSE(geometry_before.cam2_from_cam1.has_value());
+
+  MaybeDecomposeRelativePoses(cache.get());
+
+  TwoViewGeometry geometry_after = corr_graph->ExtractTwoViewGeometry(
+      1, 2, /*extract_inlier_matches=*/false);
+  EXPECT_TRUE(geometry_after.cam2_from_cam1.has_value());
+}
+
 }  // namespace
 }  // namespace colmap


### PR DESCRIPTION
- Fixes #4387: `global_mapper` crashed on databases written by older COLMAP versions, which stored the two-view geometry `config` (CALIBRATED / UNCALIBRATED / PLANAR / ...) but persisted the corresponding `E`/`F`/`H` matrix as NULL. `EstimateTwoViewGeometryPose` then `THROW_CHECK`ed the missing matrix and aborted.
- `MaybeDecomposeRelativePoses` now refits the missing matrix from the cached inlier matches before calling `EstimateTwoViewGeometryPose`:
  - `CALIBRATED` → `EssentialMatrixEightPointEstimator` on inlier camera rays
  - `UNCALIBRATED` → `FundamentalMatrixEightPointEstimator` on inlier image points
  - `PLANAR` / `PANORAMIC` / `PLANAR_OR_PANORAMIC` → `HomographyMatrixEstimator` (DLT) on inlier image points
- If the inlier set is too small for the estimator's `kMinNumSamples` or the fit returns no model, the pair is counted as a failed decomposition and skipped (no crash).
- Leaves `EstimateTwoViewGeometryPose`'s `THROW_CHECK`s in place: they still catch programmer errors at non-old-DB call sites such as `incremental_mapper_impl.cc`.