### PR TITLE
Fix mesh_texturer occlusion check edge case

### DIFF
--- a/src/colmap/mvs/texture_mapping.cc
+++ b/src/colmap/mvs/texture_mapping.cc
@@ -236,10 +236,12 @@ struct OcclusionTester {
     const Eigen::Vector3f dir = vertex - camera_center;
     const float dist = dir.norm();
     if (dist < kEps) return false;
+    const Eigen::Vector3f target_offset = vertex - dir.normalized() * kEps;
 
     const CGALPoint origin(
         camera_center.x(), camera_center.y(), camera_center.z());
-    const CGALPoint target(vertex.x(), vertex.y(), vertex.z());
+    const CGALPoint target(
+        target_offset.x(), target_offset.y(), target_offset.z());
     const CGALSegment segment(origin, target);
 
     const auto intersection = tree.any_intersection(segment);

--- a/src/colmap/mvs/texture_mapping.cc
+++ b/src/colmap/mvs/texture_mapping.cc
@@ -236,7 +236,7 @@ struct OcclusionTester {
     const Eigen::Vector3f dir = vertex - camera_center;
     const float dist = dir.norm();
     if (dist < kEps) return false;
-    const Eigen::Vector3f target_offset = vertex - dir.normalized() * kEps;
+    const Eigen::Vector3f target_offset = vertex - (kEps / dist) * dir;
 
     const CGALPoint origin(
         camera_center.x(), camera_center.y(), camera_center.z());

--- a/src/colmap/mvs/texture_mapping_test.cc
+++ b/src/colmap/mvs/texture_mapping_test.cc
@@ -183,24 +183,24 @@ PlyMesh MakeCubeMesh() {
       PlyMeshVertex(0, 1, 1),
   };
   mesh.faces = {
-      // Front (Z=0): 0,1,2 and 0,2,3
-      PlyMeshFace(0, 1, 2),
-      PlyMeshFace(0, 2, 3),
-      // Back (Z=1): 4,6,5 and 4,7,6
-      PlyMeshFace(4, 6, 5),
-      PlyMeshFace(4, 7, 6),
-      // Left (X=0): 0,3,7 and 0,7,4
-      PlyMeshFace(0, 3, 7),
-      PlyMeshFace(0, 7, 4),
-      // Right (X=1): 1,5,6 and 1,6,2
-      PlyMeshFace(1, 5, 6),
-      PlyMeshFace(1, 6, 2),
-      // Bottom (Y=0): 0,4,5 and 0,5,1
-      PlyMeshFace(0, 4, 5),
-      PlyMeshFace(0, 5, 1),
-      // Top (Y=1): 3,2,6 and 3,6,7
-      PlyMeshFace(3, 2, 6),
-      PlyMeshFace(3, 6, 7),
+      // Front (Z=0): 0,2,1 and 0,3,2
+      PlyMeshFace(0, 2, 1),
+      PlyMeshFace(0, 3, 2),
+      // Back (Z=1): 4,5,6 and 4,6,7
+      PlyMeshFace(4, 5, 6),
+      PlyMeshFace(4, 6, 7),
+      // Left (X=0): 0,7,3 and 0,4,7
+      PlyMeshFace(0, 7, 3),
+      PlyMeshFace(0, 4, 7),
+      // Right (X=1): 1,6,5 and 1,2,6
+      PlyMeshFace(1, 6, 5),
+      PlyMeshFace(1, 2, 6),
+      // Bottom (Y=0): 0,5,4 and 0,1,5
+      PlyMeshFace(0, 5, 4),
+      PlyMeshFace(0, 1, 5),
+      // Top (Y=1): 3,6,2 and 3,7,6
+      PlyMeshFace(3, 6, 2),
+      PlyMeshFace(3, 7, 6),
   };
   return mesh;
 }


### PR DESCRIPTION
The occlusion check in the texturing code has a bug causing texture projected "behind" objects. (Wall behind chair)

The current implementation incorrectly assumes that if the intersection between camera and target triangle is the target triangle, there is no occlusion possible. This is false because the intersection check used is `any_intersection` which is not ordered and another intersection could occur between the camera and triangle.

https://github.com/colmap/colmap/blob/1169d14d98a8d09bf8dd87ce3df44a186043068f/src/colmap/mvs/texture_mapping.cc#L247-L254

I added a small offset to exclude the target triangle from the checked range. This potentially has some numerical issues but doesn't have an effect on performance.

The numerically correct option would be to check the first intersection in this case but that adds complexity and impacts runtime.

Current implementation:
<img width="1938" height="1500" alt="texturing_bug" src="https://github.com/user-attachments/assets/4989c857-0c0b-4d55-93c0-a996e9494f3b" />

Fix with offset:
<img width="1938" height="1500" alt="texturing_offset" src="https://github.com/user-attachments/assets/c60d26fa-8e31-4d38-b76e-d06c03ff4e86" />

Fix with first_intersection:
<img width="1938" height="1500" alt="texturing_first_intersection" src="https://github.com/user-attachments/assets/0dfaa88b-8459-42cd-99dc-342794ccf9bf" />


There are some minor differences but I propose to use the simple offset based fix until other major issues are encountered.