### PR TITLE
Remove unused preconditioner setting for SPARSE_SCHUR

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -416,10 +416,8 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
   // Do not use iterative solvers, for its suboptimal performance.
   if (reconstruction.NumPoints3D() > 0) {
     options_.solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
-    options_.solver_options.preconditioner_type = ceres::CLUSTER_TRIDIAGONAL;
   } else {
     options_.solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
-    options_.solver_options.preconditioner_type = ceres::JACOBI;
   }
 }
 

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -414,11 +414,9 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
 
   // Set up the options for the solver
   // Do not use iterative solvers, for its suboptimal performance.
-  if (reconstruction.NumPoints3D() > 0) {
-    options_.solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
-  } else {
-    options_.solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
-  }
+  // TODO: Investigate whether the direct solver should be chosen
+  // adaptively based on problem scale.
+  options_.solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
 }
 
 void GlobalPositioner::ConvertBackResults(Reconstruction& reconstruction) {

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -42,14 +42,12 @@ struct GlobalMapperOptions {
           CeresBundleAdjustmentOptions::LossFunctionType::HUBER;
       options.ceres->use_gpu = true;
       // TODO: Investigate whether disabling auto solver selection and using
-      // explicit SPARSE_SCHUR + CLUSTER_TRIDIAGONAL is necessary for global
-      // SfM, or if we can just rely on COLMAP's auto selection.
+      // explicit SPARSE_SCHUR is necessary for global SfM, or if we can just
+      // rely on COLMAP's auto selection.
       options.ceres->auto_select_solver_type = false;
       options.ceres->solver_options.function_tolerance = 1e-5;
       options.ceres->solver_options.max_num_iterations = 200;
       options.ceres->solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
-      options.ceres->solver_options.preconditioner_type =
-          ceres::CLUSTER_TRIDIAGONAL;
     }
     return options;
   }();


### PR DESCRIPTION
Remove the explicit `CLUSTER_TRIDIAGONAL` preconditioner setting when using `ceres::SPARSE_SCHUR`.

According to Ceres Solver documentation/comments, visibility-clustering preconditioners are only valid with `ITERATIVE_SCHUR`:

https://github.com/ceres-solver/ceres-solver/blob/0ba987acaf9e8674070f116ed624edf017d2b630/include/ceres/types.h#L100-L119

```cpp
  // Note: The following four preconditioners can only be used with
  // the ITERATIVE_SCHUR solver. They are well suited for Structure
  // from Motion problems.


  // Block diagonal of the Schur complement. This preconditioner may
  // only be used with the ITERATIVE_SCHUR solver.
  SCHUR_JACOBI,


  // Use power series expansion to approximate the inversion of Schur complement
  // as a preconditioner.
  SCHUR_POWER_SERIES_EXPANSION,


  // Visibility clustering based preconditioners.
  //
  // The following two preconditioners use the visibility structure of
  // the scene to determine the sparsity structure of the
  // preconditioner. This is done using a clustering algorithm. The
  // available visibility clustering algorithms are described below.
  CLUSTER_JACOBI,
  CLUSTER_TRIDIAGONAL,
```