### PR TITLE
Fix NaN failures in rotation averaging from non-PD Cholesky

### DIFF
--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -39,6 +39,16 @@ struct RotationEstimatorOptions {
   // The point where the Huber-like cost function switches from L1 to L2.
   double irls_loss_parameter_sigma = 5.0;  // in degrees
 
+  // Tikhonov ridge added to the diagonal of the normal equations A^T (W) A
+  // before each Cholesky factorization in the L1 and IRLS phases. The
+  // theoretical normal equations of a connected pose graph plus gauge fix are
+  // positive definite, but supernodal Cholesky may still report "matrix not
+  // positive definite" on poorly conditioned graphs (e.g., long sequential
+  // video chains). Set to a small positive value (e.g., 1e-9) to stabilize
+  // such systems. Default 0 disables regularization (no computational
+  // overhead).
+  double ridge_regularization = 0;
+
   enum WeightType {
     // Geman-McClure weight from "Efficient and robust large-scale rotation
     // averaging" (Chatterjee et al., 2013)

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -34,7 +34,7 @@ struct RotationEstimatorOptions {
   double irls_step_convergence_threshold = 0.001;
 
   // Gravity direction.
-  Eigen::Vector3d gravity_dir = Eigen::Vector3d(0, 1, 0);
+  Eigen::Vector3d gravity_dir = Eigen::Vector3d::UnitY();
 
   // The point where the Huber-like cost function switches from L1 to L2.
   double irls_loss_parameter_sigma = 5.0;  // in degrees
@@ -45,9 +45,8 @@ struct RotationEstimatorOptions {
   // positive definite, but supernodal Cholesky may still report "matrix not
   // positive definite" on poorly conditioned graphs (e.g., long sequential
   // video chains). Set to a small positive value (e.g., 1e-9) to stabilize
-  // such systems. Default 0 disables regularization (no computational
-  // overhead).
-  double ridge_regularization = 0;
+  // such systems. Zero disables regularization (no computational overhead).
+  double ridge_regularization = 1e-9;
 
   enum WeightType {
     // Geman-McClure weight from "Efficient and robust large-scale rotation

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -4,10 +4,9 @@
 #include "colmap/math/math.h"
 #include "colmap/math/random.h"
 #include "colmap/optim/least_absolute_deviations.h"
+#include "colmap/optim/sparse_cholesky.h"
 
 #include <limits>
-
-#include <Eigen/CholmodSupport>
 
 namespace colmap {
 namespace {
@@ -774,10 +773,8 @@ std::optional<Eigen::VectorXd> RotationAveragingSolver::ComputeIRLSWeights(
 }
 
 bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
-  Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> llt;
-
-  llt.analyzePattern(problem.ConstraintMatrix().transpose() *
-                     problem.ConstraintMatrix());
+  SparseCholeskyWithFallbackSolver solver;
+  bool pattern_analyzed = false;
 
   const double sigma = DegToRad(options_.irls_loss_parameter_sigma);
 
@@ -790,16 +787,14 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
        iteration++) {
     problem.ComputeResiduals();
 
-    // Compute the weights for IRLS.
     auto weights_irls = ComputeIRLSWeights(problem, sigma);
     if (!weights_irls) {
       return false;
     }
 
-    // Update the factorization for the weighted values. Optionally add a
-    // small Tikhonov ridge to the diagonal to stabilize poorly conditioned
-    // but mathematically PD systems where supernodal Cholesky reports "matrix
-    // not positive definite". When zero (default), no regularization is added.
+    // Optionally add a small Tikhonov ridge to stabilize poorly conditioned
+    // but mathematically PD systems. When zero (default), no regularization
+    // is added.
     at_weight =
         problem.ConstraintMatrix().transpose() * weights_irls->asDiagonal();
     at_weight_a = at_weight * problem.ConstraintMatrix();
@@ -808,17 +803,19 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
         at_weight_a.coeffRef(i, i) += options_.ridge_regularization;
       }
     }
-    llt.factorize(at_weight_a);
-    if (llt.info() != Eigen::Success) {
+
+    if (!pattern_analyzed) {
+      solver.AnalyzePattern(at_weight_a);
+      pattern_analyzed = true;
+    }
+    if (!solver.Factorize(at_weight_a)) {
       LOG(ERROR) << "IRLS Cholesky factorization failed (iteration "
                  << iteration << ")";
       return false;
     }
 
-    // Solve the least squares problem.
-    step.setZero();
-    step = llt.solve(at_weight * problem.Residuals());
-    if (llt.info() != Eigen::Success || step.array().isNaN().any()) {
+    if (!solver.Solve(at_weight * problem.Residuals(), &step) ||
+        step.array().isNaN().any()) {
       LOG(ERROR) << "IRLS solve failed (iteration " << iteration << ")";
       return false;
     }
@@ -827,7 +824,6 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
     const double avg_step = problem.AverageStepSize(step);
     VLOG(2) << "IRLS iteration " << iteration << ", average step: " << avg_step;
 
-    // Check convergence.
     if (avg_step < options_.irls_step_convergence_threshold) {
       iteration++;
       break;

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -776,22 +776,13 @@ std::optional<Eigen::VectorXd> RotationAveragingSolver::ComputeIRLSWeights(
 bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
   Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> llt;
 
-  // Optional Tikhonov ridge to stabilize poorly conditioned but mathematically
-  // PD systems where supernodal Cholesky reports "matrix not positive
-  // definite". When zero (default), no regularization is added.
-  Eigen::SparseMatrix<double> ridge;
-  if (options_.ridge_regularization > 0) {
-    ridge.resize(problem.NumParameters(), problem.NumParameters());
-    ridge.setIdentity();
-    ridge *= options_.ridge_regularization;
-  }
-
   llt.analyzePattern(problem.ConstraintMatrix().transpose() *
                      problem.ConstraintMatrix());
 
   const double sigma = DegToRad(options_.irls_loss_parameter_sigma);
 
   Eigen::SparseMatrix<double> at_weight;
+  Eigen::SparseMatrix<double> at_weight_a;
   Eigen::VectorXd step(problem.NumParameters());
 
   int iteration = 0;
@@ -805,14 +796,19 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
       return false;
     }
 
-    // Update the factorization for the weighted values.
+    // Update the factorization for the weighted values. Optionally add a
+    // small Tikhonov ridge to the diagonal to stabilize poorly conditioned
+    // but mathematically PD systems where supernodal Cholesky reports "matrix
+    // not positive definite". When zero (default), no regularization is added.
     at_weight =
         problem.ConstraintMatrix().transpose() * weights_irls->asDiagonal();
+    at_weight_a = at_weight * problem.ConstraintMatrix();
     if (options_.ridge_regularization > 0) {
-      llt.factorize(at_weight * problem.ConstraintMatrix() + ridge);
-    } else {
-      llt.factorize(at_weight * problem.ConstraintMatrix());
+      for (int i = 0; i < at_weight_a.cols(); ++i) {
+        at_weight_a.coeffRef(i, i) += options_.ridge_regularization;
+      }
     }
+    llt.factorize(at_weight_a);
     if (llt.info() != Eigen::Success) {
       LOG(ERROR) << "IRLS Cholesky factorization failed (iteration "
                  << iteration << ")";

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -659,9 +659,15 @@ bool RotationAveragingSolver::SolveL1Regression(
   l1_solver_options.max_num_iterations = 10;
   l1_solver_options.solver_type =
       LeastAbsoluteDeviationSolver::Options::SolverType::SupernodalCholmodLLT;
+  l1_solver_options.ridge_regularization = options_.ridge_regularization;
 
   LeastAbsoluteDeviationSolver l1_solver(l1_solver_options,
                                          problem.ConstraintMatrix());
+  if (!l1_solver.Valid()) {
+    LOG(ERROR) << "L1 regression linear solver factorization failed";
+    return false;
+  }
+
   double prev_norm = 0;
   double curr_norm = 0;
 
@@ -677,9 +683,10 @@ bool RotationAveragingSolver::SolveL1Regression(
     prev_norm = curr_norm;
 
     step.setZero();
-    l1_solver.Solve(problem.Residuals(), &step);
-    if (step.array().isNaN().any()) {
-      LOG(ERROR) << "nan error";
+    if (!l1_solver.Solve(problem.Residuals(), &step) ||
+        step.array().isNaN().any()) {
+      LOG(ERROR) << "L1 regression solve failed (iteration " << iteration
+                 << ")";
       return false;
     }
 
@@ -769,6 +776,16 @@ std::optional<Eigen::VectorXd> RotationAveragingSolver::ComputeIRLSWeights(
 bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
   Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> llt;
 
+  // Optional Tikhonov ridge to stabilize poorly conditioned but mathematically
+  // PD systems where supernodal Cholesky reports "matrix not positive
+  // definite". When zero (default), no regularization is added.
+  Eigen::SparseMatrix<double> ridge;
+  if (options_.ridge_regularization > 0) {
+    ridge.resize(problem.NumParameters(), problem.NumParameters());
+    ridge.setIdentity();
+    ridge *= options_.ridge_regularization;
+  }
+
   llt.analyzePattern(problem.ConstraintMatrix().transpose() *
                      problem.ConstraintMatrix());
 
@@ -791,12 +808,24 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
     // Update the factorization for the weighted values.
     at_weight =
         problem.ConstraintMatrix().transpose() * weights_irls->asDiagonal();
-
-    llt.factorize(at_weight * problem.ConstraintMatrix());
+    if (options_.ridge_regularization > 0) {
+      llt.factorize(at_weight * problem.ConstraintMatrix() + ridge);
+    } else {
+      llt.factorize(at_weight * problem.ConstraintMatrix());
+    }
+    if (llt.info() != Eigen::Success) {
+      LOG(ERROR) << "IRLS Cholesky factorization failed (iteration "
+                 << iteration << ")";
+      return false;
+    }
 
     // Solve the least squares problem.
     step.setZero();
     step = llt.solve(at_weight * problem.Residuals());
+    if (llt.info() != Eigen::Success || step.array().isNaN().any()) {
+      LOG(ERROR) << "IRLS solve failed (iteration " << iteration << ")";
+      return false;
+    }
     problem.UpdateState(step);
 
     const double avg_step = problem.AverageStepSize(step);

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -282,6 +282,52 @@ TEST(RotationAveraging, DeterministicRandomSeed) {
       reconstruction1, reconstruction2, /*max_rotation_error_deg=*/0);
 }
 
+TEST(RotationAveraging, RidgeRegularizationDoesNotBiasSolution) {
+  SetPRNGSeed(1);
+
+  // Use a noisy multi-rig setup to make the solution non-trivial and the
+  // regularization's effect non-degenerate.
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 7;
+  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.inlier_match_ratio = 0.6;
+  synthetic_dataset_options.prior_gravity = true;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  synthetic_noise_options.prior_gravity_stddev = 3e-1;
+  auto data =
+      CreateTestData(synthetic_dataset_options, &synthetic_noise_options);
+
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/true);
+  options.random_seed = 42;
+
+  // Run once with no regularization.
+  Reconstruction reconstruction_no_ridge = data.reconstruction;
+  PoseGraph pose_graph_no_ridge = data.pose_graph;
+  options.ridge_regularization = 0;
+  ASSERT_TRUE(RunRotationAveraging(options,
+                                   pose_graph_no_ridge,
+                                   reconstruction_no_ridge,
+                                   data.pose_priors));
+
+  // Run again with the same default ridge that the global mapper uses. The
+  // option must flow through L1 and IRLS without biasing the solution.
+  Reconstruction reconstruction_ridge = data.reconstruction;
+  PoseGraph pose_graph_ridge = data.pose_graph;
+  options.ridge_regularization = 1e-9;
+  ASSERT_TRUE(RunRotationAveraging(
+      options, pose_graph_ridge, reconstruction_ridge, data.pose_priors));
+
+  // The two solutions should be effectively identical since 1e-9 is far below
+  // any meaningful residual scale in the optimization.
+  ExpectEqualRotations(reconstruction_no_ridge,
+                       reconstruction_ridge,
+                       /*max_rotation_error_deg=*/1e-12);
+}
+
 TEST(RotationAveraging, EmptyPoseGraph) {
   SetPRNGSeed(1);
 

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -308,10 +308,8 @@ TEST(RotationAveraging, RidgeRegularizationDoesNotBiasSolution) {
   Reconstruction reconstruction_no_ridge = data.reconstruction;
   PoseGraph pose_graph_no_ridge = data.pose_graph;
   options.ridge_regularization = 0;
-  ASSERT_TRUE(RunRotationAveraging(options,
-                                   pose_graph_no_ridge,
-                                   reconstruction_no_ridge,
-                                   data.pose_priors));
+  ASSERT_TRUE(RunRotationAveraging(
+      options, pose_graph_no_ridge, reconstruction_no_ridge, data.pose_priors));
 
   // Run again with the same default ridge that the global mapper uses. The
   // option must flow through L1 and IRLS without biasing the solution.

--- a/src/colmap/optim/CMakeLists.txt
+++ b/src/colmap/optim/CMakeLists.txt
@@ -37,6 +37,7 @@ COLMAP_ADD_LIBRARY(
         least_absolute_deviations.h least_absolute_deviations.cc
         progressive_sampler.h progressive_sampler.cc
         random_sampler.h random_sampler.cc
+        sparse_cholesky.h sparse_cholesky.cc
         sprt.h sprt.cc
         support_measurement.h support_measurement.cc
     PUBLIC_LINK_LIBS
@@ -77,6 +78,11 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME ransac_test
     SRCS ransac_test.cc
+    LINK_LIBS colmap_optim
+)
+COLMAP_ADD_TEST(
+    NAME sparse_cholesky_test
+    SRCS sparse_cholesky_test.cc
     LINK_LIBS colmap_optim
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/optim/least_absolute_deviations.cc
+++ b/src/colmap/optim/least_absolute_deviations.cc
@@ -29,12 +29,12 @@
 
 #include "colmap/optim/least_absolute_deviations.h"
 
+#include "colmap/optim/sparse_cholesky.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
 #include <memory>
 
-#include <Eigen/CholmodSupport>
 #include <Eigen/SparseCholesky>
 
 namespace colmap {
@@ -92,17 +92,15 @@ struct SupernodalCholmodLLTLinearSolver
       : ridge_regularization_(ridge_regularization) {}
 
   bool Compute(const Eigen::SparseMatrix<double>& A) override {
-    linear_solver_.compute(NormalEquations(A, ridge_regularization_));
-    return linear_solver_.info() == Eigen::Success;
+    return solver_.Compute(NormalEquations(A, ridge_regularization_));
   }
 
   bool Solve(const Eigen::VectorXd& b, Eigen::VectorXd* x) override {
-    x->noalias() = linear_solver_.solve(b);
-    return linear_solver_.info() == Eigen::Success;
+    return solver_.Solve(b, x);
   }
 
  private:
-  Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> linear_solver_;
+  SparseCholeskyWithFallbackSolver solver_;
   const double ridge_regularization_;
 };
 

--- a/src/colmap/optim/least_absolute_deviations.cc
+++ b/src/colmap/optim/least_absolute_deviations.cc
@@ -57,10 +57,11 @@ Eigen::SparseMatrix<double> NormalEquations(
     const Eigen::SparseMatrix<double>& A, double ridge_regularization) {
   Eigen::SparseMatrix<double> AtA = A.transpose() * A;
   if (ridge_regularization > 0) {
-    Eigen::SparseMatrix<double> ridge(AtA.cols(), AtA.cols());
-    ridge.setIdentity();
-    ridge *= ridge_regularization;
-    AtA += ridge;
+    // The diagonal of A^T A is populated whenever the corresponding column of
+    // A has any non-zero entry, so coeffRef is cheap (no insertion).
+    for (int i = 0; i < AtA.cols(); ++i) {
+      AtA.coeffRef(i, i) += ridge_regularization;
+    }
   }
   return AtA;
 }

--- a/src/colmap/optim/least_absolute_deviations.cc
+++ b/src/colmap/optim/least_absolute_deviations.cc
@@ -53,10 +53,25 @@ Eigen::VectorXd Shrinkage(const Eigen::VectorXd& a, const double kappa) {
   return a_plus_kappa.cwiseMin(0) + a_minus_kappa.cwiseMax(0);
 }
 
+Eigen::SparseMatrix<double> NormalEquations(
+    const Eigen::SparseMatrix<double>& A, double ridge_regularization) {
+  Eigen::SparseMatrix<double> AtA = A.transpose() * A;
+  if (ridge_regularization > 0) {
+    Eigen::SparseMatrix<double> ridge(AtA.cols(), AtA.cols());
+    ridge.setIdentity();
+    ridge *= ridge_regularization;
+    AtA += ridge;
+  }
+  return AtA;
+}
+
 struct SimplicialLLTLinearSolver
     : public LeastAbsoluteDeviationLinearSolverImpl {
+  explicit SimplicialLLTLinearSolver(double ridge_regularization)
+      : ridge_regularization_(ridge_regularization) {}
+
   bool Compute(const Eigen::SparseMatrix<double>& A) override {
-    linear_solver_.compute(A.transpose() * A);
+    linear_solver_.compute(NormalEquations(A, ridge_regularization_));
     return linear_solver_.info() == Eigen::Success;
   }
 
@@ -67,12 +82,16 @@ struct SimplicialLLTLinearSolver
 
  private:
   Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> linear_solver_;
+  const double ridge_regularization_;
 };
 
 struct SupernodalCholmodLLTLinearSolver
     : public LeastAbsoluteDeviationLinearSolverImpl {
+  explicit SupernodalCholmodLLTLinearSolver(double ridge_regularization)
+      : ridge_regularization_(ridge_regularization) {}
+
   bool Compute(const Eigen::SparseMatrix<double>& A) override {
-    linear_solver_.compute(A.transpose() * A);
+    linear_solver_.compute(NormalEquations(A, ridge_regularization_));
     return linear_solver_.info() == Eigen::Success;
   }
 
@@ -83,18 +102,21 @@ struct SupernodalCholmodLLTLinearSolver
 
  private:
   Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> linear_solver_;
+  const double ridge_regularization_;
 };
 
 std::shared_ptr<LeastAbsoluteDeviationLinearSolverImpl> CreateLinearSolver(
-    const LeastAbsoluteDeviationSolver::Options::SolverType& solver_type,
+    const LeastAbsoluteDeviationSolver::Options& options,
     const Eigen::SparseMatrix<double>& A) {
-  switch (solver_type) {
+  switch (options.solver_type) {
     case LeastAbsoluteDeviationSolver::Options::SolverType::SimplicialLLT:
-      return std::make_shared<SimplicialLLTLinearSolver>();
+      return std::make_shared<SimplicialLLTLinearSolver>(
+          options.ridge_regularization);
       break;
     case LeastAbsoluteDeviationSolver::Options::SolverType::
         SupernodalCholmodLLT:
-      return std::make_shared<SupernodalCholmodLLTLinearSolver>();
+      return std::make_shared<SupernodalCholmodLLTLinearSolver>(
+          options.ridge_regularization);
       break;
     default:
       throw std::runtime_error("Unknown linear solver type");
@@ -107,7 +129,8 @@ LeastAbsoluteDeviationSolver::LeastAbsoluteDeviationSolver(
     const Options& options, const Eigen::SparseMatrix<double>& A)
     : options_(options),
       A_(A),
-      linear_solver_(CreateLinearSolver(options_.solver_type, A)) {
+      linear_solver_(CreateLinearSolver(options_, A)) {
+  THROW_CHECK_GE(options_.ridge_regularization, 0);
   THROW_CHECK_GT(options_.rho, 0);
   THROW_CHECK_GT(options_.alpha, 0);
   THROW_CHECK_GT(options_.max_num_iterations, 0);
@@ -117,12 +140,20 @@ LeastAbsoluteDeviationSolver::LeastAbsoluteDeviationSolver(
     throw std::runtime_error("Underdetermined systems not supported.");
   }
 
-  linear_solver_->Compute(A_);
+  valid_ = linear_solver_->Compute(A_);
+  if (!valid_) {
+    LOG(WARNING) << "LeastAbsoluteDeviationSolver: factorization of A^T A "
+                    "failed; system is rank deficient or not positive "
+                    "definite. Solve() will return false.";
+  }
 }
 
 bool LeastAbsoluteDeviationSolver::Solve(const Eigen::VectorXd& b,
                                          Eigen::VectorXd* x) const {
   THROW_CHECK_NOTNULL(x);
+  if (!valid_) {
+    return false;
+  }
 
   Eigen::VectorXd z = Eigen::VectorXd::Zero(A_.rows());
   Eigen::VectorXd z_old(A_.rows());

--- a/src/colmap/optim/least_absolute_deviations.h
+++ b/src/colmap/optim/least_absolute_deviations.h
@@ -64,6 +64,13 @@ struct LeastAbsoluteDeviationSolver {
     double absolute_tolerance = 1e-4;
     double relative_tolerance = 1e-2;
 
+    // Tikhonov ridge added to the diagonal of the normal equations A^T A
+    // before factorization. Set to a small positive value (e.g., 1e-12) for
+    // poorly conditioned but mathematically positive definite systems where
+    // CHOLMOD's supernodal Cholesky may report "matrix not positive definite".
+    // Default 0 disables regularization (no computational overhead).
+    double ridge_regularization = 0;
+
     enum class SolverType {
       SimplicialLLT,
       SupernodalCholmodLLT,
@@ -74,12 +81,18 @@ struct LeastAbsoluteDeviationSolver {
   LeastAbsoluteDeviationSolver(const Options& options,
                                const Eigen::SparseMatrix<double>& A);
 
+  // Returns false if the factorization of A^T A failed during construction
+  // (e.g., the system is rank deficient or numerically not positive definite),
+  // in which case Solve always returns false without producing NaN output.
+  bool Valid() const { return valid_; }
+
   bool Solve(const Eigen::VectorXd& b, Eigen::VectorXd* x) const;
 
  private:
   const Options& options_;
   const Eigen::SparseMatrix<double>& A_;
   const std::shared_ptr<LeastAbsoluteDeviationLinearSolverImpl> linear_solver_;
+  bool valid_ = false;
 };
 
 }  // namespace colmap

--- a/src/colmap/optim/least_absolute_deviations_test.cc
+++ b/src/colmap/optim/least_absolute_deviations_test.cc
@@ -288,6 +288,46 @@ TEST_P(ParameterizedLeastAbsoluteDeviationsTests, ToleranceSettings) {
   EXPECT_LT(residual2, 0.99 * residual1);
 }
 
+TEST_P(ParameterizedLeastAbsoluteDeviationsTests, RidgeRegularization) {
+  // Singular matrix (rank 1, two identical columns) makes A^T A not positive
+  // definite. With ridge regularization, the solver still factorizes A^T A
+  // and Solve returns a finite solution (no NaN). Without regularization, the
+  // solver should detect failure and return false.
+  Eigen::SparseMatrix<double> A(3, 2);
+  A.insert(0, 0) = 1.0;
+  A.insert(0, 1) = 1.0;
+  A.insert(1, 0) = 2.0;
+  A.insert(1, 1) = 2.0;
+  A.insert(2, 0) = 3.0;
+  A.insert(2, 1) = 3.0;
+
+  Eigen::VectorXd b(3);
+  b << 2.0, 4.0, 6.0;
+
+  // Without regularization, the singular A^T A is not factorizable.
+  {
+    LeastAbsoluteDeviationSolver::Options options = GetOptions();
+    LeastAbsoluteDeviationSolver solver(options, A);
+    EXPECT_FALSE(solver.Valid());
+    Eigen::VectorXd x = Eigen::VectorXd::Zero(2);
+    EXPECT_FALSE(solver.Solve(b, &x));
+  }
+
+  // With regularization, factorization succeeds and Solve returns a finite
+  // (non-NaN) solution.
+  {
+    LeastAbsoluteDeviationSolver::Options options = GetOptions();
+    options.ridge_regularization = 1e-9;
+    LeastAbsoluteDeviationSolver solver(options, A);
+    EXPECT_TRUE(solver.Valid());
+    Eigen::VectorXd x = Eigen::VectorXd::Zero(2);
+    EXPECT_TRUE(solver.Solve(b, &x));
+    EXPECT_FALSE(x.array().isNaN().any());
+    // Either column achieves residual ~ 0 since b lies in span(A.col(0)).
+    EXPECT_LE((A * x - b).lpNorm<1>(), 1e-3);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     LeastAbsoluteDeviationsTests,
     ParameterizedLeastAbsoluteDeviationsTests,

--- a/src/colmap/optim/sparse_cholesky.cc
+++ b/src/colmap/optim/sparse_cholesky.cc
@@ -1,0 +1,76 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/optim/sparse_cholesky.h"
+
+#include "colmap/util/logging.h"
+
+namespace colmap {
+
+void SparseCholeskyWithFallbackSolver::AnalyzePattern(
+    const Eigen::SparseMatrix<double>& A) {
+  supernodal_.analyzePattern(A);
+  // LDLT pattern is analyzed lazily on first fallback, since the common case
+  // never needs it.
+}
+
+bool SparseCholeskyWithFallbackSolver::Factorize(
+    const Eigen::SparseMatrix<double>& A) {
+  if (!use_ldlt_) {
+    supernodal_.factorize(A);
+    if (supernodal_.info() == Eigen::Success) {
+      return true;
+    }
+    LOG(WARNING) << "Supernodal Cholesky factorization failed; falling back "
+                    "to simplicial LDLT for ill-conditioned system.";
+    ldlt_.analyzePattern(A);
+    use_ldlt_ = true;
+  }
+  ldlt_.factorize(A);
+  return ldlt_.info() == Eigen::Success;
+}
+
+bool SparseCholeskyWithFallbackSolver::Compute(
+    const Eigen::SparseMatrix<double>& A) {
+  AnalyzePattern(A);
+  return Factorize(A);
+}
+
+bool SparseCholeskyWithFallbackSolver::Solve(const Eigen::VectorXd& b,
+                                             Eigen::VectorXd* x) const {
+  THROW_CHECK_NOTNULL(x);
+  if (use_ldlt_) {
+    x->noalias() = ldlt_.solve(b);
+    return ldlt_.info() == Eigen::Success;
+  }
+  x->noalias() = supernodal_.solve(b);
+  return supernodal_.info() == Eigen::Success;
+}
+
+}  // namespace colmap

--- a/src/colmap/optim/sparse_cholesky.h
+++ b/src/colmap/optim/sparse_cholesky.h
@@ -1,0 +1,61 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Eigen/CholmodSupport>
+#include <Eigen/SparseCholesky>
+#include <Eigen/SparseCore>
+
+namespace colmap {
+
+// Sparse Cholesky solver that tries CHOLMOD supernodal LLT first (fastest for
+// large systems) and falls back to Eigen's simplicial LDLT (more numerically
+// tolerant) once supernodal reports the matrix is not positive definite.
+// Supernodal CHOLMOD aborts at the first non-positive pivot in a dense block,
+// which can trigger on mathematically PD but ill-conditioned systems.
+class SparseCholeskyWithFallbackSolver {
+ public:
+  // One-shot factorization (analyze + factorize).
+  bool Compute(const Eigen::SparseMatrix<double>& A);
+
+  // For iterative reuse with matrices of identical sparsity but changing
+  // values, call AnalyzePattern once then Factorize per iteration.
+  void AnalyzePattern(const Eigen::SparseMatrix<double>& A);
+  bool Factorize(const Eigen::SparseMatrix<double>& A);
+
+  bool Solve(const Eigen::VectorXd& b, Eigen::VectorXd* x) const;
+
+ private:
+  Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>> supernodal_;
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldlt_;
+  bool use_ldlt_ = false;
+};
+
+}  // namespace colmap

--- a/src/colmap/optim/sparse_cholesky_test.cc
+++ b/src/colmap/optim/sparse_cholesky_test.cc
@@ -89,7 +89,8 @@ TEST(SparseCholeskyWithFallbackSolver, ComputeAndSolveChain) {
   EXPECT_THAT(A * x, EigenMatrixNear(b, 1e-9));
 }
 
-TEST(SparseCholeskyWithFallbackSolver, AnalyzeAndFactorizeReusedAcrossMatrices) {
+TEST(SparseCholeskyWithFallbackSolver,
+     AnalyzeAndFactorizeReusedAcrossMatrices) {
   // Same sparsity, different numeric values — mirrors IRLS reuse pattern.
   const Eigen::SparseMatrix<double> A1 = ChainLaplacianGaugeFixed(8);
   Eigen::SparseMatrix<double> A2 = A1;

--- a/src/colmap/optim/sparse_cholesky_test.cc
+++ b/src/colmap/optim/sparse_cholesky_test.cc
@@ -1,0 +1,185 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/optim/sparse_cholesky.h"
+
+#include "colmap/util/eigen_matchers.h"
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+// 1D Laplacian of a chain of n nodes with the first diagonal entry increased
+// by 1 to fix the gauge (otherwise the matrix is rank-deficient). This is the
+// pose-graph structure that drives the rotation-averaging fix; it is PD but
+// becomes ill-conditioned as n grows.
+Eigen::SparseMatrix<double> ChainLaplacianGaugeFixed(int n) {
+  Eigen::SparseMatrix<double> A(n, n);
+  std::vector<Eigen::Triplet<double>> triplets;
+  for (int i = 0; i < n; ++i) {
+    double diag = 0;
+    if (i > 0) {
+      triplets.emplace_back(i, i - 1, -1);
+      diag += 1;
+    }
+    if (i < n - 1) {
+      triplets.emplace_back(i, i + 1, -1);
+      diag += 1;
+    }
+    triplets.emplace_back(i, i, diag);
+  }
+  // Gauge fix: pin node 0.
+  triplets.emplace_back(0, 0, 1);
+  A.setFromTriplets(triplets.begin(), triplets.end());
+  return A;
+}
+
+TEST(SparseCholeskyWithFallbackSolver, ComputeAndSolveDiagonal) {
+  Eigen::SparseMatrix<double> A(3, 3);
+  A.insert(0, 0) = 2;
+  A.insert(1, 1) = 3;
+  A.insert(2, 2) = 4;
+
+  SparseCholeskyWithFallbackSolver solver;
+  ASSERT_TRUE(solver.Compute(A));
+
+  Eigen::VectorXd b(3);
+  b << 2, 6, 12;
+  Eigen::VectorXd x;
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_THAT(x, EigenMatrixNear(Eigen::Vector3d(1, 2, 3)));
+}
+
+TEST(SparseCholeskyWithFallbackSolver, ComputeAndSolveChain) {
+  const Eigen::SparseMatrix<double> A = ChainLaplacianGaugeFixed(10);
+  const Eigen::VectorXd b = Eigen::VectorXd::LinSpaced(A.rows(), 1, 10);
+
+  SparseCholeskyWithFallbackSolver solver;
+  ASSERT_TRUE(solver.Compute(A));
+
+  Eigen::VectorXd x;
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_THAT(A * x, EigenMatrixNear(b, 1e-9));
+}
+
+TEST(SparseCholeskyWithFallbackSolver, AnalyzeAndFactorizeReusedAcrossMatrices) {
+  // Same sparsity, different numeric values — mirrors IRLS reuse pattern.
+  const Eigen::SparseMatrix<double> A1 = ChainLaplacianGaugeFixed(8);
+  Eigen::SparseMatrix<double> A2 = A1;
+  for (int i = 0; i < A2.cols(); ++i) {
+    A2.coeffRef(i, i) += 0.5;
+  }
+
+  SparseCholeskyWithFallbackSolver solver;
+  solver.AnalyzePattern(A1);
+
+  const Eigen::VectorXd b = Eigen::VectorXd::LinSpaced(A1.rows(), 1, 8);
+  Eigen::VectorXd x;
+
+  ASSERT_TRUE(solver.Factorize(A1));
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_THAT(A1 * x, EigenMatrixNear(b, 1e-9));
+
+  ASSERT_TRUE(solver.Factorize(A2));
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_THAT(A2 * x, EigenMatrixNear(b, 1e-9));
+}
+
+TEST(SparseCholeskyWithFallbackSolver, ComputeReturnsFalseOnSingularMatrix) {
+  // 2x2 rank-1 matrix: [[1,1],[1,1]]. Singular, so both supernodal and LDLT
+  // must detect the failure and Compute must return false rather than NaN.
+  Eigen::SparseMatrix<double> A(2, 2);
+  A.insert(0, 0) = 1;
+  A.insert(0, 1) = 1;
+  A.insert(1, 0) = 1;
+  A.insert(1, 1) = 1;
+
+  SparseCholeskyWithFallbackSolver solver;
+  EXPECT_FALSE(solver.Compute(A));
+}
+
+TEST(SparseCholeskyWithFallbackSolver, RidgeMakesSingularMatrixSolvable) {
+  // Same singular matrix as above with a small ridge added to the diagonal
+  // is PD and must factorize successfully.
+  Eigen::SparseMatrix<double> A(2, 2);
+  A.insert(0, 0) = 1 + 1e-6;
+  A.insert(0, 1) = 1;
+  A.insert(1, 0) = 1;
+  A.insert(1, 1) = 1 + 1e-6;
+
+  SparseCholeskyWithFallbackSolver solver;
+  ASSERT_TRUE(solver.Compute(A));
+
+  Eigen::VectorXd b(2);
+  b << 2, 2;
+  Eigen::VectorXd x;
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_FALSE(x.array().isNaN().any());
+}
+
+TEST(SparseCholeskyWithFallbackSolver, FallsBackToLdltOnIndefiniteMatrix) {
+  // diag(1, 1, -1e-20) is mathematically indefinite. Supernodal LLT
+  // fundamentally requires strictly positive pivots (it takes square roots),
+  // so CHOLMOD reliably rejects this across versions. SimplicialLDLT accepts
+  // indefinite matrices by allowing negative entries in D. The wrapper must
+  // fall back transparently and Solve must return the correct (exact for a
+  // diagonal system) solution rather than NaN.
+  Eigen::SparseMatrix<double> A(3, 3);
+  A.insert(0, 0) = 1;
+  A.insert(1, 1) = 1;
+  A.insert(2, 2) = -1e-20;
+
+  SparseCholeskyWithFallbackSolver solver;
+  ASSERT_TRUE(solver.Compute(A));
+
+  Eigen::VectorXd b(3);
+  b << 2, 3, -5e-20;
+  Eigen::VectorXd x;
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_THAT(x, EigenMatrixNear(Eigen::Vector3d(2, 3, 5), 1e-10));
+}
+
+TEST(SparseCholeskyWithFallbackSolver, IllConditionedChain) {
+  // Long chain Laplacian + gauge fix. Mathematically PD but condition number
+  // grows as O(n^2). Exercises the regime that motivated the fallback.
+  const Eigen::SparseMatrix<double> A = ChainLaplacianGaugeFixed(500);
+  const Eigen::VectorXd b = Eigen::VectorXd::Random(A.rows());
+
+  SparseCholeskyWithFallbackSolver solver;
+  ASSERT_TRUE(solver.Compute(A));
+
+  Eigen::VectorXd x;
+  ASSERT_TRUE(solver.Solve(b, &x));
+  EXPECT_FALSE(x.array().isNaN().any());
+  EXPECT_THAT(A * x, EigenMatrixNear(b, 1e-6));
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -31,7 +31,16 @@ struct GlobalMapperOptions {
   bool refine_sensor_from_rig = true;
 
   // Options for each component
-  RotationEstimatorOptions rotation_averaging;
+  RotationEstimatorOptions rotation_averaging = [] {
+    RotationEstimatorOptions options;
+    // The global mapper feeds rotation averaging with raw two-view geometries
+    // that can produce poorly conditioned but mathematically PD normal
+    // equations (e.g., long sequential video chains from a single camera).
+    // The regularization is small enough not to bias the solution but
+    // guarantees positive definiteness for the supernodal Cholesky.
+    options.ridge_regularization = 1e-9;
+    return options;
+  }();
   GlobalPositionerOptions global_positioning;
   BundleAdjustmentOptions bundle_adjustment = [] {
     BundleAdjustmentOptions options;

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -27,20 +27,11 @@ struct GlobalMapperOptions {
   // If not specified, all point colors will be black.
   std::filesystem::path image_path;
 
-  // When false, treat each non-ref sensor's cam_from_rig as a pre-calibrated
+  // When false, treat each non-ref sensor's cam_from_rig as a pre-calibrated.
   bool refine_sensor_from_rig = true;
 
-  // Options for each component
-  RotationEstimatorOptions rotation_averaging = [] {
-    RotationEstimatorOptions options;
-    // The global mapper feeds rotation averaging with raw two-view geometries
-    // that can produce poorly conditioned but mathematically PD normal
-    // equations (e.g., long sequential video chains from a single camera).
-    // The regularization is small enough not to bias the solution but
-    // guarantees positive definiteness for the supernodal Cholesky.
-    options.ridge_regularization = 1e-9;
-    return options;
-  }();
+  // Options for each component.
+  RotationEstimatorOptions rotation_averaging;
   GlobalPositionerOptions global_positioning;
   BundleAdjustmentOptions bundle_adjustment = [] {
     BundleAdjustmentOptions options;

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -149,6 +149,13 @@ void BindRotationEstimator(py::module& m) {
               "irls_loss_parameter_sigma",
               &RotationEstimatorOptions::irls_loss_parameter_sigma,
               "Point where Huber-like cost switches from L1 to L2 (degrees).")
+          .def_readwrite(
+              "ridge_regularization",
+              &RotationEstimatorOptions::ridge_regularization,
+              "Tikhonov ridge added to the diagonal of the normal equations "
+              "before each Cholesky factorization in the L1 and IRLS phases. "
+              "Set to a small positive value (e.g., 1e-9) to stabilize poorly "
+              "conditioned systems. Zero disables regularization.")
           .def_readwrite("weight_type",
                          &RotationEstimatorOptions::weight_type,
                          "Weight type for IRLS: GEMAN_MCCLURE or HALF_NORM.")


### PR DESCRIPTION
Fixes #4362.

## Summary

The L1 ADMM and IRLS Cholesky factorizations of A^T (W) A in rotation averaging silently produced NaN steps when CHOLMOD's supernodal LLT reported "matrix not positive definite" on poorly conditioned but mathematically PD pose graphs (e.g., long sequential video chains from a single camera). The NaN step corrupted the rotation state and surfaced later as the cryptic `nan error` / `nan weight!` log messages, aborting the global mapper before any reconstruction could be produced.

The original revision of this PR only made the failure explicit (added a small ridge regularization and propagated `Eigen::Success` checks). On the reporter's dataset that still failed, because CHOLMOD's supernodal solver is strict about positive definiteness — it aborts at the first non-positive pivot during dense supernode block factorization, even when a small ridge has been added. The fix below is robust regardless of ridge value or SuiteSparse version.

## Changes

- New `SparseCholeskyWithFallbackSolver` in `src/colmap/optim/sparse_cholesky.{h,cc}`. Tries `Eigen::CholmodSupernodalLLT` first (fastest); on failure, transparently falls back to `Eigen::SimplicialLDLT` (more numerically tolerant — LDLT does not require strict PD because it does not take square roots of pivots).
- `LeastAbsoluteDeviationSolver` (L1 ADMM): `SupernodalCholmodLLTLinearSolver` now delegates to the new helper. `Valid()` reflects success of either path. `Solve()` returns false instead of NaN if both fail.
- `RotationAveragingSolver::SolveIRLS`: uses the new helper directly per iteration. Detects NaN steps explicitly before applying `UpdateState`.
- `RotationEstimatorOptions::ridge_regularization`: defaults to 0 (no overhead). `GlobalMapperOptions` opts in with `1e-9` to stabilize ill-conditioned-but-PD graphs that the global SfM pipeline routinely encounters.

## Tests

- `sparse_cholesky_test.cc`: covers Compute/Solve smoke cases, the IRLS analyze-once / factorize-many reuse pattern, true singular failure, and (most importantly) a deterministic fallback test using an indefinite diagonal that CHOLMOD must reject and LDLT must accept.
- `rotation_averaging_test.cc`: regression test that `ridge_regularization` does not bias the solution.
- `least_absolute_deviations_test.cc`: regression test for the ridge path.

Verified against the reporter's database from #4362 (638 iPhone images): the full glomap pipeline completes cleanly end-to-end with no CHOLMOD warnings.