### PR TITLE
Fix MSVC build for Caspar

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -132,6 +132,13 @@ if(CASPAR_ENABLED AND CUDA_ENABLED)
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--diag_suppress=550>
         $<$<COMPILE_LANGUAGE:CXX>:$<IF:$<CXX_COMPILER_ID:MSVC>,/W0,-w>>
     )
+    if(IS_MSVC)
+        set(_MSVC_COMPACT_HEADER "${CASPAR_GEN_DIR}/../../msvc_compact.h")
+        target_compile_options(caspar_lib_core PRIVATE
+            $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/FI"${_MSVC_COMPACT_HEADER}">
+            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler /FI"${_MSVC_COMPACT_HEADER}">
+        )
+    endif()
     message(STATUS "Configuring Caspar... done")
 
     message(STATUS "Caspar precision:  ${_caspar_precision}")

--- a/src/thirdparty/Symforce-Caspar/msvc_compact.h
+++ b/src/thirdparty/Symforce-Caspar/msvc_compact.h
@@ -2,8 +2,10 @@
 
 #ifdef _MSC_VER
 // Caspar uses 'uint' which is not defined in MSVC.
-using uint = unsigned int;
+typedef unsigned int uint;
 
+#ifdef __cplusplus
 // solver.cc uses std::to_string but misses the <string> header.
 #include <string>
+#endif
 #endif

--- a/src/thirdparty/Symforce-Caspar/msvc_compact.h
+++ b/src/thirdparty/Symforce-Caspar/msvc_compact.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #ifdef _MSC_VER
 // Caspar uses 'uint' which is not defined in MSVC.

--- a/src/thirdparty/Symforce-Caspar/msvc_compact.h
+++ b/src/thirdparty/Symforce-Caspar/msvc_compact.h
@@ -1,0 +1,9 @@
+﻿#pragma once
+
+#ifdef _MSC_VER
+// Caspar uses 'uint' which is not defined in MSVC.
+using uint = unsigned int;
+
+// solver.cc uses std::to_string but misses the <string> header.
+#include <string>
+#endif


### PR DESCRIPTION
Force-include a patch header that provides the missing uint typedef and includes <string>, fixing two compilation errors of caspar.

If we want to use caspar_generate.py, we’ll need additional compatibility changes for MSVC support on the SymForce side:   [symforce-org/symforce issue #145](https://github.com/symforce-org/symforce/issues/145).