### PR TITLE
Fix SIGABRT in RegisterNextStructureLessImage when NumRegImages < 2

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -618,7 +618,12 @@ bool IncrementalMapper::RegisterNextStructureLessImage(const Options& options,
                                                        const image_t image_id) {
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(obs_manager_);
-  THROW_CHECK_GE(reconstruction_->NumRegImages(), 2);
+  if (reconstruction_->NumRegImages() < 2) {
+    LOG(WARNING) << "Structure-less registration requires at least 2 registered "
+                    "images; only "
+                 << reconstruction_->NumRegImages() << " available";
+    return false;
+  }
 
   THROW_CHECK(options.Check());
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/colmap/colmap/issues/901

`RegisterNextStructureLessImage` crashes with `SIGABRT` (via `THROW_CHECK_GE`) when fewer than 2 images are registered. This happens in degenerate scenes where the mapper registers only 0-1 images before attempting structure-less registration of a candidate.

This PR replaces the hard `THROW_CHECK_GE` with a warning log and `return false`, following the same pattern applied to `AdjustGlobalBundle` in #4344.

## Why this is safe

- `RegisterNextStructureLessImage` returns `bool`. The caller in `incremental_pipeline.cc` (line ~540) already handles `false` returns gracefully -- it logs "Could not register, trying another image" and moves on to the next candidate or falls back to different registration strategies.
- The warning log preserves observability so users can see when the early return triggers.

## Changes

- `src/colmap/sfm/incremental_mapper.cc`: Replace `THROW_CHECK_GE(reconstruction_->NumRegImages(), 2)` with an `if` guard that logs a warning and returns `false`.