### PR TITLE
Avoid forced copy in mvs::Image::SetBitmap

### DIFF
--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/exe/mvs.h"
 
+#include <utility>
+
 #include "colmap/controllers/option_manager.h"
 #include "colmap/mvs/fusion.h"
 #include "colmap/mvs/mesh_simplification.h"
@@ -158,7 +160,7 @@ int RunMeshTexturer(int argc, char** argv) {
       bitmap.Rescale(static_cast<int>(image.GetWidth()),
                      static_cast<int>(image.GetHeight()));
     }
-    image.SetBitmap(bitmap);
+    image.SetBitmap(std::move(bitmap));
   }
 
   LOG(INFO) << "Reading input mesh from " << input_path << "...";

--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -29,8 +29,6 @@
 
 #include "colmap/exe/mvs.h"
 
-#include <utility>
-
 #include "colmap/controllers/option_manager.h"
 #include "colmap/mvs/fusion.h"
 #include "colmap/mvs/mesh_simplification.h"
@@ -42,6 +40,8 @@
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/file.h"
 #include "colmap/util/ply.h"
+
+#include <utility>
 
 namespace colmap {
 

--- a/src/colmap/mvs/image.cc
+++ b/src/colmap/mvs/image.cc
@@ -32,6 +32,8 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
+#include <utility>
+
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
@@ -54,8 +56,8 @@ Image::Image(const std::filesystem::path& path,
   ComposeInverseProjectionMatrix(K_, R_, T_, inv_P_);
 }
 
-void Image::SetBitmap(const Bitmap& bitmap) {
-  bitmap_ = bitmap;
+void Image::SetBitmap(Bitmap bitmap) {
+  bitmap_ = std::move(bitmap);
   THROW_CHECK_EQ(width_, bitmap_.Width());
   THROW_CHECK_EQ(height_, bitmap_.Height());
 }

--- a/src/colmap/mvs/image.cc
+++ b/src/colmap/mvs/image.cc
@@ -57,9 +57,9 @@ Image::Image(const std::filesystem::path& path,
 }
 
 void Image::SetBitmap(Bitmap bitmap) {
+  THROW_CHECK_EQ(width_, bitmap.Width());
+  THROW_CHECK_EQ(height_, bitmap.Height());
   bitmap_ = std::move(bitmap);
-  THROW_CHECK_EQ(width_, bitmap_.Width());
-  THROW_CHECK_EQ(height_, bitmap_.Height());
 }
 
 void Image::Rescale(const float factor) { Rescale(factor, factor); }

--- a/src/colmap/mvs/image.h
+++ b/src/colmap/mvs/image.h
@@ -49,7 +49,7 @@ class Image {
   inline size_t GetWidth() const;
   inline size_t GetHeight() const;
 
-  void SetBitmap(const Bitmap& bitmap);
+  void SetBitmap(Bitmap bitmap);
   inline const Bitmap& GetBitmap() const;
 
   inline const std::filesystem::path& GetPath() const;

--- a/src/colmap/mvs/texture_mapping_test.cc
+++ b/src/colmap/mvs/texture_mapping_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/mvs/texture_mapping.h"
 
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -85,7 +86,7 @@ Image MakeTestImage(int width, int height, const BitmapColor<uint8_t>& color) {
 
   Bitmap bitmap(width, height, /*as_rgb=*/true);
   bitmap.Fill(color);
-  image.SetBitmap(bitmap);
+  image.SetBitmap(std::move(bitmap));
 
   return image;
 }
@@ -115,7 +116,7 @@ Image MakeBehindCameraImage(int width, int height) {
 
   Bitmap bitmap(width, height, /*as_rgb=*/true);
   bitmap.Fill(BitmapColor<uint8_t>(0));
-  image.SetBitmap(bitmap);
+  image.SetBitmap(std::move(bitmap));
 
   return image;
 }
@@ -145,7 +146,7 @@ Image MakeGrazingAngleImage(int width, int height) {
 
   Bitmap bitmap(width, height, /*as_rgb=*/true);
   bitmap.Fill(BitmapColor<uint8_t>(128));
-  image.SetBitmap(bitmap);
+  image.SetBitmap(std::move(bitmap));
 
   return image;
 }
@@ -328,7 +329,7 @@ TEST(MeshTextureMapping, SingleFaceTwoViews) {
   Image img_far("far.png", 256, 256, K, R, T);
   Bitmap bitmap(256, 256, /*as_rgb=*/true);
   bitmap.Fill(BitmapColor<uint8_t>(0, 255, 0));
-  img_far.SetBitmap(bitmap);
+  img_far.SetBitmap(std::move(bitmap));
 
   std::vector<Image> images = {img_close, img_far};
 


### PR DESCRIPTION
- Change `mvs::Image::SetBitmap` to take `Bitmap` by value and `std::move` into the member, so callers with an owned `Bitmap` can move instead of being forced to copy.
- Update callsites in `exe/mvs.cc` and `texture_mapping_test.cc` to `std::move` the local `Bitmap` into the call.
- `patch_match.cc` passes a `const Bitmap&` returned from `Workspace::GetBitmap`, so it still copies (same as before).