### PR TITLE
Fix Windows Unicode path handling in Bitmap::Read/Bitmap::Write

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -64,6 +64,16 @@ OIIO::string_view OIIOFromStdStringView(std::string_view value) {
   return {value.data(), value.size()};
 }
 
+// Convert a filesystem path to a UTF-8 std::string. On Windows,
+// path.string() returns a locale-dependent narrow string, which mangles
+// non-ASCII characters before they reach OIIO. path.u8string() always yields
+// UTF-8 bytes, but its return type changes from std::string in C++17 to
+// std::u8string in C++20; the reinterpret_cast keeps this portable.
+std::string PathToUtf8(const std::filesystem::path& path) {
+  const auto u8 = path.u8string();
+  return std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
+}
+
 std::vector<uint8_t> ConvertColorSpace(const uint8_t* src_data,
                                        int width,
                                        int height,
@@ -457,9 +467,7 @@ bool Bitmap::Read(const std::filesystem::path& path,
   OIIO::ImageSpec config;
   config["oiio:reorient"] = 0;
 
-  // Use u8string() so non-ASCII paths are passed to OIIO as UTF-8 on Windows
-  // (path.string() returns a locale-dependent narrow string there).
-  const auto input = OIIO::ImageInput::open(path.u8string(), &config);
+  const auto input = OIIO::ImageInput::open(PathToUtf8(path), &config);
   if (!input) {
     // Always retrieve the error to clear OIIO's pending error state.
     const std::string error = OIIO::geterror();
@@ -514,9 +522,7 @@ bool Bitmap::Read(const std::filesystem::path& path,
 
 bool Bitmap::Write(const std::filesystem::path& path,
                    const bool delinearize_colorspace) const {
-  // Use u8string() so non-ASCII paths are passed to OIIO as UTF-8 on Windows
-  // (path.string() returns a locale-dependent narrow string there).
-  const std::string utf8_path = path.u8string();
+  const std::string utf8_path = PathToUtf8(path);
   const auto output = OIIO::ImageOutput::create(utf8_path);
   if (!output) {
     std::cerr << "Could not create an ImageOutput for " << path

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -457,7 +457,9 @@ bool Bitmap::Read(const std::filesystem::path& path,
   OIIO::ImageSpec config;
   config["oiio:reorient"] = 0;
 
-  const auto input = OIIO::ImageInput::open(path.string(), &config);
+  // Use u8string() so non-ASCII paths are passed to OIIO as UTF-8 on Windows
+  // (path.string() returns a locale-dependent narrow string there).
+  const auto input = OIIO::ImageInput::open(path.u8string(), &config);
   if (!input) {
     // Always retrieve the error to clear OIIO's pending error state.
     const std::string error = OIIO::geterror();
@@ -512,7 +514,10 @@ bool Bitmap::Read(const std::filesystem::path& path,
 
 bool Bitmap::Write(const std::filesystem::path& path,
                    const bool delinearize_colorspace) const {
-  const auto output = OIIO::ImageOutput::create(path.string());
+  // Use u8string() so non-ASCII paths are passed to OIIO as UTF-8 on Windows
+  // (path.string() returns a locale-dependent narrow string there).
+  const std::string utf8_path = path.u8string();
+  const auto output = OIIO::ImageOutput::create(utf8_path);
   if (!output) {
     std::cerr << "Could not create an ImageOutput for " << path
               << ", error = " << OIIO::geterror() << "\n";
@@ -545,7 +550,7 @@ bool Bitmap::Write(const std::filesystem::path& path,
     }
   }
 
-  if (!output->open(path.string(), meta_data.image_spec)) {
+  if (!output->open(utf8_path, meta_data.image_spec)) {
     VLOG(3) << "Could not open " << path << ", error = " << output->geterror()
             << "\n";
     return false;

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -797,6 +797,27 @@ TEST(Bitmap, ReadWriteAsRGB) {
   EXPECT_EQ(read_bitmap.RowMajorData(), bitmap.CloneAsGrey().RowMajorData());
 }
 
+TEST(Bitmap, ReadWriteUnicodePath) {
+  Bitmap bitmap(2, 3, /*as_rgb=*/true);
+  bitmap.SetPixel(0, 0, BitmapColor<uint8_t>(10, 20, 30));
+  bitmap.SetPixel(1, 2, BitmapColor<uint8_t>(40, 50, 60));
+
+  // Use a non-ASCII filename to ensure the path is round-tripped through OIIO
+  // as UTF-8. On Windows, path.string() would mangle these characters using
+  // the system locale and the read/write would fail.
+  const std::filesystem::path filename =
+      CreateTestDir() /
+      std::filesystem::u8path(u8"éü中文-bitmap.png");
+
+  EXPECT_TRUE(bitmap.Write(filename));
+
+  Bitmap read_bitmap;
+  EXPECT_TRUE(read_bitmap.Read(filename));
+  EXPECT_EQ(read_bitmap.Width(), bitmap.Width());
+  EXPECT_EQ(read_bitmap.Height(), bitmap.Height());
+  EXPECT_EQ(read_bitmap.RowMajorData(), bitmap.RowMajorData());
+}
+
 TEST(Bitmap, ReadWriteAsGrey) {
   Bitmap bitmap(2, 3, /*as_rgb=*/false);
   bitmap.SetPixel(0, 0, BitmapColor<uint8_t>(0));

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -806,8 +806,7 @@ TEST(Bitmap, ReadWriteUnicodePath) {
   // as UTF-8. On Windows, path.string() would mangle these characters using
   // the system locale and the read/write would fail.
   const std::filesystem::path filename =
-      CreateTestDir() /
-      std::filesystem::u8path(u8"éü中文-bitmap.png");
+      CreateTestDir() / std::filesystem::u8path(u8"éü中文-bitmap.png");
 
   EXPECT_TRUE(bitmap.Write(filename));
 


### PR DESCRIPTION
- Replace `path.string()` with `path.u8string()` in `Bitmap::Read` and `Bitmap::Write` when handing filenames to OpenImageIO. On Windows, `path.string()` returns a locale-dependent narrow string rather than UTF-8, which caused image I/O to fail for non-ASCII paths. OIIO expects UTF-8 for its `std::string` filename parameters on all platforms, and in C++17 `path.u8string()` returns `std::string` containing UTF-8 bytes.
- Add a `Bitmap.ReadWriteUnicodePath` test that round-trips a bitmap through a path containing non-ASCII characters (`éü中文`).

Fixes #4418.