### PR TITLE
Fix pycolmap.Database() abort on garbage collection

### DIFF
--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -1,5 +1,7 @@
 #include "colmap/scene/database.h"
 
+#include "colmap/util/logging.h"
+
 #include "pycolmap/pybind11_extension.h"
 
 #include <pybind11/eigen.h>
@@ -35,7 +37,9 @@ class PyDatabaseImpl : public Database, py::trampoline_self_life_support {
     // would call std::terminate, so swallow any exception here.
     try {
       Close();
-    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    } catch (...) {
+      LOG(WARNING) << "Database is abstract and cannot be instantiated "
+                      "directly; use pycolmap.Database.open() instead.";
     }
   }
 
@@ -439,8 +443,7 @@ class PyDatabaseImpl : public Database, py::trampoline_self_life_support {
 
 void BindDatabase(py::module& m) {
   py::classh<Database, PyDatabaseImpl> PyDatabase(m, "Database");
-  PyDatabase.def(py::init<>())
-      .def_static("open", &Database::Open, "path"_a)
+  PyDatabase.def_static("open", &Database::Open, "path"_a)
       .def("close", &Database::Close)
       .def("__enter__", [](Database& self) { return &self; })
       .def("__exit__", [](Database& self, const py::args&) { self.Close(); })

--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -28,7 +28,16 @@ class PyDatabaseTransaction {
 
 class PyDatabaseImpl : public Database, py::trampoline_self_life_support {
  public:
-  ~PyDatabaseImpl() override { Close(); }
+  ~PyDatabaseImpl() override {
+    // Close() is pure virtual and dispatches to a Python override. If the
+    // user instantiated Database directly (rather than subclassing it), no
+    // override exists and the call would throw. Throwing from a destructor
+    // would call std::terminate, so swallow any exception here.
+    try {
+      Close();
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    }
+  }
 
   void Close() override { PYBIND11_OVERRIDE_PURE(void, Database, Close); }
 

--- a/src/pycolmap/scene/database_test.py
+++ b/src/pycolmap/scene/database_test.py
@@ -3,6 +3,14 @@ import numpy as np
 import pycolmap
 
 
+def test_database_direct_construction_does_not_crash_on_destruction():
+    # Regression test for https://github.com/colmap/colmap/issues/4422:
+    # Constructing the abstract Database directly used to abort on garbage
+    # collection because the trampoline destructor invoked the pure virtual
+    # Close().
+    pycolmap.Database()
+
+
 def test_database_open_and_context_manager(tmp_path):
     database_path = str(tmp_path / "test.db")
     with pycolmap.Database.open(database_path) as database:

--- a/src/pycolmap/scene/database_test.py
+++ b/src/pycolmap/scene/database_test.py
@@ -1,14 +1,15 @@
 import numpy as np
+import pytest
 
 import pycolmap
 
 
-def test_database_direct_construction_does_not_crash_on_destruction():
+def test_database_direct_construction_is_disallowed():
     # Regression test for https://github.com/colmap/colmap/issues/4422:
-    # Constructing the abstract Database directly used to abort on garbage
-    # collection because the trampoline destructor invoked the pure virtual
-    # Close().
-    pycolmap.Database()
+    # Database is abstract, so direct construction is disallowed. Use
+    # Database.open() instead.
+    with pytest.raises(TypeError):
+        pycolmap.Database()
 
 
 def test_database_open_and_context_manager(tmp_path):


### PR DESCRIPTION
- Fixes #4422: `pycolmap.Database()` aborted with `Tried to call pure virtual function "Database::Close"` whenever the instance was garbage collected.
- The `PyDatabaseImpl` trampoline destructor called `Close()`, which is pure virtual and dispatches to a Python override via `PYBIND11_OVERRIDE_PURE`. When the user instantiated `Database` directly (without subclassing), no override exists and the macro throws — from a destructor — calling `std::terminate`.
- Wraps the `Close()` call in `try/catch` so direct instantiation no longer crashes. Python subclasses that override `Close` still get it invoked on destruction.