### PR TITLE
Set SANITIZE_PR for PoissonRecon to fix data races on aarch64

### DIFF
--- a/src/thirdparty/PoissonRecon/FEMTree.LevelSet.2D.inl
+++ b/src/thirdparty/PoissonRecon/FEMTree.LevelSet.2D.inl
@@ -687,7 +687,7 @@ public:
 									{
 										char desired = 1 , expected = 0;
 #ifdef SANITIZED_PR
-										if( edgeSet.compare_exchange_weak( expected , desired ) )
+										if( edgeSet.compare_exchange_strong( expected , desired ) )
 #else // !SANITIZED_PR
 										if( SetAtomic( edgeSet , desired , expected ) )
 #endif // SANITIZED_PR

--- a/src/thirdparty/PoissonRecon/FEMTree.LevelSet.3D.inl
+++ b/src/thirdparty/PoissonRecon/FEMTree.LevelSet.3D.inl
@@ -1060,7 +1060,7 @@ public:
 									{
 										char desired = 1 , expected = 0;
 #ifdef SANITIZED_PR
-										if( edgeSet.compare_exchange_weak( expected , desired ) )
+										if( edgeSet.compare_exchange_strong( expected , desired ) )
 #else // !SANITIZED_PR
 										if( SetAtomic( edgeSet , desired , expected ) )
 #endif // SANITIZED_PR
@@ -1201,7 +1201,7 @@ public:
 									{
 										char desired = 1 , expected = 0;
 #ifdef SANITIZED_PR
-										if( edgeSet.compare_exchange_weak( expected , desired ) )
+										if( edgeSet.compare_exchange_strong( expected , desired ) )
 #else // !SANITIZED_PR
 										if( SetAtomic( edgeSet , desired , expected ) )
 #endif // SANITIZED_PR

--- a/src/thirdparty/PoissonRecon/PreProcessor.h
+++ b/src/thirdparty/PoissonRecon/PreProcessor.h
@@ -37,7 +37,7 @@ DAMAGE.
 												// (each of which is small enough to be represented using 32-bit indexing.)
 #endif // BIG_DATA
 						
-//#define SANITIZED_PR								// If enabled, produces CLANG-sanitized code [thread/undefined/address]
+#define SANITIZED_PR								// If enabled, produces CLANG-sanitized code [thread/undefined/address]
 //#define FAST_COMPILE								// If enabled, only a single version of the code is compiled
 #undef SHOW_WARNINGS							// Display compilation warnings
 #undef ARRAY_DEBUG								// If enabled, array access is tested for validity


### PR DESCRIPTION
See: https://github.com/colmap/colmap/issues/4428

Seems to have no impact on x86_64 but fixes aarch64.