### PR TITLE
Add SPHERE equirectangular camera model with CamFromImgRay and sphere_to_cubic

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -141,6 +141,8 @@ IncrementalMapper::Options IncrementalPipelineOptions::Mapper() const {
   options.use_prior_position = use_prior_position;
   options.use_robust_loss_on_prior_position = use_robust_loss_on_prior_position;
   options.prior_position_loss_scale = prior_position_loss_scale;
+  options.use_robust_loss_on_prior_rotation = use_robust_loss_on_prior_rotation;
+  options.prior_rotation_loss_scale = prior_rotation_loss_scale;
   options.random_seed = random_seed;
   return options;
 }
@@ -244,6 +246,7 @@ bool IncrementalPipelineOptions::Check() const {
   CHECK_OPTION_GE(ba_global_max_refinement_change, 0);
   CHECK_OPTION_GE(snapshot_frames_freq, 0);
   CHECK_OPTION_GT(prior_position_loss_scale, 0.);
+  CHECK_OPTION_GT(prior_rotation_loss_scale, 0.);
   CHECK_OPTION_GE(num_threads, -1);
   CHECK_OPTION_GE(random_seed, -1);
   CHECK_OPTION(Mapper().Check());

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -149,6 +149,13 @@ struct IncrementalPipelineOptions {
   // (chi2 for 3DOF at 95% = 7.815).
   double prior_position_loss_scale = 7.815;
 
+  // Whether to use a robust (Cauchy) loss on prior camera rotation.
+  bool use_robust_loss_on_prior_rotation = false;
+
+  // Threshold on the residual for the robust rotation prior loss
+  // (chi2 for 3DOF at 95% = 7.815).
+  double prior_rotation_loss_scale = 7.815;
+
   // Path to a folder with reconstruction snapshots during incremental
   // reconstruction. Snapshots will be saved according to the specified
   // frequency of registered images.

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -349,6 +349,7 @@ PosePriorBundleAdjustmentBackendOptions::operator=(
 
 bool PosePriorBundleAdjustmentOptions::Check() const {
   CHECK_OPTION_GT(prior_position_fallback_stddev, 0);
+  CHECK_OPTION_GT(prior_rotation_fallback_stddev, 0);
   return THROW_CHECK_NOTNULL(ceres)->Check();
 }
 

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -248,6 +248,11 @@ struct PosePriorBundleAdjustmentOptions
   // Fallback if no prior position covariance is provided.
   double prior_position_fallback_stddev = 1.0;
 
+  // Fallback if no prior rotation covariance is provided. Interpreted as the
+  // standard deviation per axis of the angle-axis rotation prior residual
+  // (radians). Default 0.1 rad ≈ 5.7°.
+  double prior_rotation_fallback_stddev = 0.1;
+
   // Sim3 alignment options.
   RANSACOptions alignment_ransac_options;
 

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -233,6 +233,7 @@ bool CeresBundleAdjustmentOptions::Check() const {
 
 bool CeresPosePriorBundleAdjustmentOptions::Check() const {
   CHECK_OPTION_GT(prior_position_loss_scale, 0);
+  CHECK_OPTION_GT(prior_rotation_loss_scale, 0);
   return true;
 }
 
@@ -890,12 +891,14 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
         reconstruction_(reconstruction) {
     THROW_CHECK(prior_options_.Check());
 
-    // Filter irrelevant pose priors.
+    // Filter irrelevant pose priors. Keep rows that contribute at least one
+    // of position or rotation — a rotation-only prior still constrains yaw.
     pose_priors_.erase(
         std::remove_if(pose_priors_.begin(),
                        pose_priors_.end(),
                        [this](const auto& pose_prior) {
-                         return !pose_prior.HasPosition() ||
+                         return (!pose_prior.HasPosition() &&
+                                 !pose_prior.HasRotation()) ||
                                 pose_prior.corr_data_id.sensor_id.type !=
                                     SensorType::CAMERA ||
                                 !config_.HasImage(pose_prior.corr_data_id.id);
@@ -922,6 +925,9 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
       prior_loss_function_ = CreateLossFunction(
           prior_options_.ceres->prior_position_loss_function_type,
           prior_options_.ceres->prior_position_loss_scale);
+      prior_rotation_loss_function_ = CreateLossFunction(
+          prior_options_.ceres->prior_rotation_loss_function_type,
+          prior_options_.ceres->prior_rotation_loss_scale);
 
       // Only consider parameterized images for pose priors. Notice that some
       // images may be configured to be included in the BA problem but have no
@@ -996,22 +1002,59 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
         normalized_from_metric_scaled_rotation * position_cov *
         normalized_from_metric_scaled_rotation.transpose();
 
-    if (image.IsRefInFrame()) {
-      problem.AddResidualBlock(
-          CovarianceWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
-              Create(normalized_position_cov, normalized_position),
-          prior_loss_function_.get(),
-          rig_from_world.params.data());
-    } else {
-      Rigid3d& cam_from_rig =
-          frame.RigPtr()->SensorFromRig(image.CameraPtr()->SensorId());
-      problem.AddResidualBlock(
-          CovarianceWeightedCostFunctor<
-              AbsoluteRigPosePositionPriorCostFunctor>::
-              Create(normalized_position_cov, normalized_position),
-          prior_loss_function_.get(),
-          cam_from_rig.params.data(),
-          rig_from_world.params.data());
+    if (pose_prior.HasPosition()) {
+      if (image.IsRefInFrame()) {
+        problem.AddResidualBlock(
+            CovarianceWeightedCostFunctor<
+                AbsolutePosePositionPriorCostFunctor>::
+                Create(normalized_position_cov, normalized_position),
+            prior_loss_function_.get(),
+            rig_from_world.params.data());
+      } else {
+        Rigid3d& cam_from_rig =
+            frame.RigPtr()->SensorFromRig(image.CameraPtr()->SensorId());
+        problem.AddResidualBlock(
+            CovarianceWeightedCostFunctor<
+                AbsoluteRigPosePositionPriorCostFunctor>::
+                Create(normalized_position_cov, normalized_position),
+            prior_loss_function_.get(),
+            cam_from_rig.params.data(),
+            rig_from_world.params.data());
+      }
+    }
+
+    if (pose_prior.HasRotation()) {
+      // Normalization of the reconstruction applies a Sim3 to the world;
+      // rotation priors need the inverse rotation applied on the right so
+      // they live in the same frame the BA optimizes in.
+      const Eigen::Quaterniond normalized_rotation =
+          pose_prior.sensor_from_world_rotation *
+          normalized_from_metric_.rotation().inverse();
+      const Eigen::Matrix3d rotation_cov =
+          pose_prior.HasRotationCov()
+              ? pose_prior.rotation_covariance
+              : (prior_options_.prior_rotation_fallback_stddev *
+                 prior_options_.prior_rotation_fallback_stddev *
+                 Eigen::Matrix3d::Identity());
+
+      if (image.IsRefInFrame()) {
+        problem.AddResidualBlock(
+            CovarianceWeightedCostFunctor<
+                AbsolutePoseRotationPriorCostFunctor>::
+                Create(rotation_cov, normalized_rotation),
+            prior_rotation_loss_function_.get(),
+            rig_from_world.params.data());
+      } else {
+        Rigid3d& cam_from_rig =
+            frame.RigPtr()->SensorFromRig(image.CameraPtr()->SensorId());
+        problem.AddResidualBlock(
+            CovarianceWeightedCostFunctor<
+                AbsoluteRigPoseRotationPriorCostFunctor>::
+                Create(rotation_cov, normalized_rotation),
+            prior_rotation_loss_function_.get(),
+            cam_from_rig.params.data(),
+            rig_from_world.params.data());
+      }
     }
   }
 
@@ -1076,6 +1119,7 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
 
   std::unique_ptr<DefaultBundleAdjuster> default_bundle_adjuster_;
   std::unique_ptr<ceres::LossFunction> prior_loss_function_;
+  std::unique_ptr<ceres::LossFunction> prior_rotation_loss_function_;
 
   Sim3d normalized_from_metric_;
 };

--- a/src/colmap/estimators/bundle_adjustment_ceres.h
+++ b/src/colmap/estimators/bundle_adjustment_ceres.h
@@ -109,6 +109,15 @@ struct CeresPosePriorBundleAdjustmentOptions {
   // Threshold on the residual for the robust loss.
   double prior_position_loss_scale = std::sqrt(kChiSquare95ThreeDof);
 
+  // Loss function for prior rotation loss (angle-axis residual, sensor frame).
+  CeresBundleAdjustmentOptions::LossFunctionType
+      prior_rotation_loss_function_type =
+          CeresBundleAdjustmentOptions::LossFunctionType::TRIVIAL;
+
+  // Threshold on the residual for the robust rotation loss. Same 3-DoF 95%
+  // chi-square default as the position loss since the residual is also 3-DoF.
+  double prior_rotation_loss_scale = std::sqrt(kChiSquare95ThreeDof);
+
   bool Check() const;
 };
 

--- a/src/colmap/estimators/cost_functions/pose_prior.h
+++ b/src/colmap/estimators/cost_functions/pose_prior.h
@@ -80,6 +80,64 @@ struct AbsolutePosePriorCostFunctor
   const Rigid3d world_from_sensor_prior_;
 };
 
+// 3-DoF error on the sensor rotation. Residual is the log of the error
+// rotation, expressed in the sensor frame. Models a unit-weight prior; wrap
+// with CovarianceWeightedCostFunctor to apply a measurement covariance.
+struct AbsolutePoseRotationPriorCostFunctor
+    : public AutoDiffCostFunctor<AbsolutePoseRotationPriorCostFunctor, 3, 7> {
+ public:
+  explicit AbsolutePoseRotationPriorCostFunctor(
+      const Eigen::Quaterniond& sensor_from_world_rotation_prior)
+      : world_from_sensor_prior_rotation_(
+            sensor_from_world_rotation_prior.inverse()) {}
+
+  template <typename T>
+  bool operator()(const T* const sensor_from_world, T* residuals_ptr) const {
+    const Eigen::Quaternion<T> param_from_prior_rotation =
+        EigenQuaternionMap<T>(sensor_from_world) *
+        world_from_sensor_prior_rotation_.cast<T>();
+    EigenQuaternionToAngleAxis(param_from_prior_rotation.coeffs().data(),
+                               residuals_ptr);
+    return true;
+  }
+
+ private:
+  const Eigen::Quaterniond world_from_sensor_prior_rotation_;
+};
+
+// 3-DoF error on the rig sensor rotation in the world coordinate frame. The
+// sensor-from-world rotation is composed from sensor-from-rig and
+// rig-from-world, so both parameter blocks are Jacobian'd by Ceres.
+struct AbsoluteRigPoseRotationPriorCostFunctor
+    : public AutoDiffCostFunctor<AbsoluteRigPoseRotationPriorCostFunctor,
+                                 3,
+                                 7,
+                                 7> {
+ public:
+  explicit AbsoluteRigPoseRotationPriorCostFunctor(
+      const Eigen::Quaterniond& sensor_from_world_rotation_prior)
+      : world_from_sensor_prior_rotation_(
+            sensor_from_world_rotation_prior.inverse()) {}
+
+  template <typename T>
+  bool operator()(const T* const sensor_from_rig,
+                  const T* const rig_from_world,
+                  T* residuals_ptr) const {
+    const Eigen::Quaternion<T> sensor_from_world_rotation =
+        EigenQuaternionMap<T>(sensor_from_rig) *
+        EigenQuaternionMap<T>(rig_from_world);
+    const Eigen::Quaternion<T> param_from_prior_rotation =
+        sensor_from_world_rotation *
+        world_from_sensor_prior_rotation_.cast<T>();
+    EigenQuaternionToAngleAxis(param_from_prior_rotation.coeffs().data(),
+                               residuals_ptr);
+    return true;
+  }
+
+ private:
+  const Eigen::Quaterniond world_from_sensor_prior_rotation_;
+};
+
 // 3-DoF error on the sensor position in the world coordinate frame.
 struct AbsolutePosePositionPriorCostFunctor
     : public AutoDiffCostFunctor<AbsolutePosePositionPriorCostFunctor, 3, 7> {

--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -153,10 +153,10 @@ bool EstimateGeneralizedAbsolutePose(
   std::vector<GP3PEstimator::X_t> rig_points2D(points2D.size());
   for (size_t i = 0; i < points2D.size(); i++) {
     const size_t camera_idx = camera_idxs[i];
-    if (const std::optional<Eigen::Vector2d> cam_point =
-            cameras[camera_idx].CamFromImg(points2D[i]);
-        cam_point) {
-      rig_points2D[i].ray_in_cam = cam_point->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray =
+            cameras[camera_idx].CamFromImgRay(points2D[i]);
+        ray) {
+      rig_points2D[i].ray_in_cam = *ray;
     } else {
       rig_points2D[i].ray_in_cam.setZero();
     }
@@ -229,21 +229,21 @@ bool EstimateGeneralizedRelativePose(
     std::vector<Eigen::Vector3d> cam_rays2(num_points);
     for (size_t i = 0; i < num_points; ++i) {
       const size_t camera_idx1 = camera_idxs1[i];
-      if (const std::optional<Eigen::Vector2d> cam_point1 =
-              cameras[camera_idx1].CamFromImg(points2D1[i]);
-          cam_point1.has_value()) {
-        cam_rays1[i] = cams_from_rig[camera_idx1].rotation().inverse() *
-                       cam_point1->homogeneous().normalized();
+      if (const std::optional<Eigen::Vector3d> ray1 =
+              cameras[camera_idx1].CamFromImgRay(points2D1[i]);
+          ray1.has_value()) {
+        cam_rays1[i] =
+            cams_from_rig[camera_idx1].rotation().inverse() * (*ray1);
       } else {
         cam_rays1[i].setZero();
       }
 
       const size_t camera_idx2 = camera_idxs2[i];
-      if (const std::optional<Eigen::Vector2d> cam_point2 =
-              cameras[camera_idxs2[i]].CamFromImg(points2D2[i]);
-          cam_point2.has_value()) {
-        cam_rays2[i] = cams_from_rig[camera_idx2].rotation().inverse() *
-                       cam_point2->homogeneous().normalized();
+      if (const std::optional<Eigen::Vector3d> ray2 =
+              cameras[camera_idxs2[i]].CamFromImgRay(points2D2[i]);
+          ray2.has_value()) {
+        cam_rays2[i] =
+            cams_from_rig[camera_idx2].rotation().inverse() * (*ray2);
       } else {
         cam_rays2[i].setZero();
       }
@@ -264,19 +264,19 @@ bool EstimateGeneralizedRelativePose(
   std::vector<GRNPObservation> points2(num_points);
   for (size_t i = 0; i < num_points; ++i) {
     points1[i].cam_from_rig = cams_from_rig[camera_idxs1[i]];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            cameras[camera_idxs1[i]].CamFromImg(points2D1[i]);
-        cam_point1.has_value()) {
-      points1[i].ray_in_cam = cam_point1->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray1 =
+            cameras[camera_idxs1[i]].CamFromImgRay(points2D1[i]);
+        ray1.has_value()) {
+      points1[i].ray_in_cam = *ray1;
     } else {
       points1[i].ray_in_cam.setZero();
     }
 
     points2[i].cam_from_rig = cams_from_rig[camera_idxs2[i]];
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            cameras[camera_idxs2[i]].CamFromImg(points2D2[i]);
-        cam_point2.has_value()) {
-      points2[i].ray_in_cam = cam_point2->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray2 =
+            cameras[camera_idxs2[i]].CamFromImgRay(points2D2[i]);
+        ray2.has_value()) {
+      points2[i].ray_in_cam = *ray2;
     } else {
       points2[i].ray_in_cam.setZero();
     }
@@ -470,19 +470,19 @@ bool EstimateStructureLessAbsolutePose(
   for (size_t i = 0; i < num_points; ++i) {
     const size_t world_camera_idx = world_camera_idxs[i];
     world_obs[i].cam_from_rig = world_cams_from_world[world_camera_idx];
-    if (const std::optional<Eigen::Vector2d> world_cam_point =
-            world_cameras[world_camera_idx].CamFromImg(world_points2D[i]);
-        world_cam_point.has_value()) {
-      world_obs[i].ray_in_cam = world_cam_point->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> world_ray =
+            world_cameras[world_camera_idx].CamFromImgRay(world_points2D[i]);
+        world_ray.has_value()) {
+      world_obs[i].ray_in_cam = *world_ray;
     } else {
       world_obs[i].ray_in_cam.setZero();
     }
 
     query_obs[i].cam_from_rig = Rigid3d();
-    if (const std::optional<Eigen::Vector2d> query_cam_point =
-            query_camera.CamFromImg(query_points2D[i]);
-        query_cam_point.has_value()) {
-      query_obs[i].ray_in_cam = query_cam_point->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> query_ray =
+            query_camera.CamFromImgRay(query_points2D[i]);
+        query_ray.has_value()) {
+      query_obs[i].ray_in_cam = *query_ray;
     } else {
       query_obs[i].ray_in_cam.setZero();
     }

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -174,10 +174,10 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     Image& image = reconstruction.Image(observation.image_id);
     if (!image.HasPose()) continue;
 
-    const std::optional<Eigen::Vector2d> cam_point =
-        image.CameraPtr()->CamFromImg(
+    const std::optional<Eigen::Vector3d> cam_ray =
+        image.CameraPtr()->CamFromImgRay(
             image.Point2D(observation.point2D_idx).xy);
-    if (!cam_point.has_value()) {
+    if (!cam_ray.has_value()) {
       LOG(WARNING)
           << "Ignoring feature because it failed to project: point3D_id="
           << point3D_id << ", image_id=" << observation.image_id
@@ -186,8 +186,7 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     }
 
     const Eigen::Vector3d cam_from_point3D_dir =
-        image.CamFromWorld().rotation().inverse() *
-        cam_point->homogeneous().normalized();
+        image.CamFromWorld().rotation().inverse() * (*cam_ray);
 
     CHECK_GE(scales_.capacity(), scales_.size())
         << "Not enough capacity was reserved for the scales.";

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -83,11 +83,10 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
     std::vector<P3PEstimator::X_t> points2D_with_rays(points2D.size());
     for (size_t i = 0; i < points2D.size(); ++i) {
       points2D_with_rays[i].image_point = points2D[i];
-      if (const std::optional<Eigen::Vector2d> cam_point =
-              camera->CamFromImg(points2D[i]);
-          cam_point) {
-        points2D_with_rays[i].camera_ray =
-            cam_point->homogeneous().normalized();
+      if (const std::optional<Eigen::Vector3d> ray =
+              camera->CamFromImgRay(points2D[i]);
+          ray) {
+        points2D_with_rays[i].camera_ray = *ray;
       } else {
         points2D_with_rays[i].camera_ray.setZero();
       }

--- a/src/colmap/estimators/triangulation.cc
+++ b/src/colmap/estimators/triangulation.cc
@@ -36,6 +36,8 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
+#include <algorithm>
+
 #include <Eigen/Geometry>
 
 namespace colmap {
@@ -55,14 +57,52 @@ void TriangulationEstimator::Estimate(const std::vector<X_t>& point_data,
 
   models->clear();
 
+  // Use the bearing-vector path when at least one observation has a non-zero
+  // cam_ray (set by EstimateTriangulation when the camera supports
+  // CamFromImgRay). This handles omnidirectional (SPHERE) observations whose
+  // back-hemisphere rays can't be represented by the 2D (u, v, 1) cam_point.
+  const bool use_bearings = std::any_of(
+      point_data.begin(), point_data.end(), [](const PointData& p) {
+        return p.cam_ray.squaredNorm() > 0;
+      });
+
+  std::vector<Eigen::Matrix3x4d> cams_from_world(point_data.size());
+  std::vector<Eigen::Vector3d> cam_rays;
+  std::vector<Eigen::Vector2d> cam_points;
+  if (use_bearings) {
+    cam_rays.resize(point_data.size());
+  } else {
+    cam_points.resize(point_data.size());
+  }
+  for (size_t i = 0; i < point_data.size(); ++i) {
+    cams_from_world[i] = pose_data[i].cam_from_world;
+    if (use_bearings) {
+      cam_rays[i] = point_data[i].cam_ray.squaredNorm() > 0
+                        ? point_data[i].cam_ray
+                        : point_data[i].cam_point.homogeneous().normalized();
+    } else {
+      cam_points[i] = point_data[i].cam_point;
+    }
+  }
+
   if (point_data.size() == 2) {
     // Two-view triangulation.
     M_t xyz;
-    if (TriangulatePoint(pose_data[0].cam_from_world,
-                         pose_data[1].cam_from_world,
-                         point_data[0].cam_point,
-                         point_data[1].cam_point,
-                         &xyz) &&
+    bool triangulated = false;
+    if (use_bearings) {
+      triangulated = TriangulateMultiViewPoint(
+          span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                        cams_from_world.size()),
+          span<const Eigen::Vector3d>(cam_rays.data(), cam_rays.size()),
+          &xyz);
+    } else {
+      triangulated = TriangulatePoint(pose_data[0].cam_from_world,
+                                      pose_data[1].cam_from_world,
+                                      point_data[0].cam_point,
+                                      point_data[1].cam_point,
+                                      &xyz);
+    }
+    if (triangulated &&
         HasPointPositiveDepth(pose_data[0].cam_from_world, xyz) &&
         HasPointPositiveDepth(pose_data[1].cam_from_world, xyz) &&
         CalculateTriangulationAngle(pose_data[0].proj_center,
@@ -74,20 +114,22 @@ void TriangulationEstimator::Estimate(const std::vector<X_t>& point_data,
     }
   } else {
     // Multi-view triangulation.
-
-    std::vector<Eigen::Matrix3x4d> cams_from_world(point_data.size());
-    std::vector<Eigen::Vector2d> cam_points(point_data.size());
-    for (size_t i = 0; i < point_data.size(); ++i) {
-      cams_from_world[i] = pose_data[i].cam_from_world;
-      cam_points[i] = point_data[i].cam_point;
-    }
-
     M_t xyz;
-    if (!TriangulateMultiViewPoint(
-            span<const Eigen::Matrix3x4d>(cams_from_world.data(),
-                                          cams_from_world.size()),
-            span<const Eigen::Vector2d>(cam_points.data(), cam_points.size()),
-            &xyz)) {
+    const bool triangulated =
+        use_bearings
+            ? TriangulateMultiViewPoint(
+                  span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                                cams_from_world.size()),
+                  span<const Eigen::Vector3d>(cam_rays.data(),
+                                              cam_rays.size()),
+                  &xyz)
+            : TriangulateMultiViewPoint(
+                  span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                                cams_from_world.size()),
+                  span<const Eigen::Vector2d>(cam_points.data(),
+                                              cam_points.size()),
+                  &xyz);
+    if (!triangulated) {
       return;
     }
 
@@ -129,10 +171,17 @@ void TriangulationEstimator::Residuals(const std::vector<X_t>& point_data,
                                             pose_data[i].cam_from_world,
                                             *pose_data[i].camera);
     } else if (residual_type_ == ResidualType::ANGULAR_ERROR) {
-      const double angular_error = CalculateAngularReprojectionError(
-          point_data[i].cam_point.homogeneous().normalized(),
-          xyz,
-          pose_data[i].cam_from_world);
+      // Prefer the stored 3D bearing when available (set by CamFromImgRay);
+      // fall back to the legacy 2D → (u, v, 1) → normalize path otherwise.
+      // This lets omnidirectional (SPHERE) back-hemisphere observations
+      // contribute angular residuals without the 2D representation that
+      // can't encode Z <= 0.
+      const Eigen::Vector3d ray =
+          point_data[i].cam_ray.squaredNorm() > 0
+              ? point_data[i].cam_ray
+              : point_data[i].cam_point.homogeneous().normalized();
+      const double angular_error =
+          CalculateAngularReprojectionError(ray, xyz, pose_data[i].cam_from_world);
       (*residuals)[i] = angular_error * angular_error;
     }
   }
@@ -163,6 +212,17 @@ bool EstimateTriangulation(const EstimateTriangulationOptions& options,
       point_data[i].cam_point = *cam_point;
     } else {
       point_data[i].cam_point.setZero();
+    }
+    // Populate the 3D bearing if the camera supports it. Essential for
+    // omnidirectional models (e.g. SPHERE) where back-hemisphere
+    // observations produce nullopt from CamFromImg but still yield a valid
+    // unit ray from CamFromImgRay.
+    if (const std::optional<Eigen::Vector3d> cam_ray =
+            cameras[i]->CamFromImgRay(points[i]);
+        cam_ray) {
+      point_data[i].cam_ray = *cam_ray;
+    } else {
+      point_data[i].cam_ray.setZero();
     }
     pose_data[i].cam_from_world = cams_from_world[i].ToMatrix();
     pose_data[i].proj_center = cams_from_world[i].TgtOriginInSrc();

--- a/src/colmap/estimators/triangulation.h
+++ b/src/colmap/estimators/triangulation.h
@@ -57,14 +57,28 @@ class TriangulationEstimator {
   };
 
   struct PointData {
-    PointData() {}
+    PointData() = default;
     PointData(const Eigen::Vector2d& img_point,
               const Eigen::Vector2d& cam_point)
-        : img_point(img_point), cam_point(cam_point) {}
+        : img_point(img_point),
+          cam_point(cam_point),
+          cam_ray(cam_point.homogeneous().normalized()) {}
+    PointData(const Eigen::Vector2d& img_point,
+              const Eigen::Vector2d& cam_point,
+              const Eigen::Vector3d& cam_ray)
+        : img_point(img_point), cam_point(cam_point), cam_ray(cam_ray) {}
     // Image observation in pixels. Only needs to be set for REPROJECTION_ERROR.
     Eigen::Vector2d img_point;
-    // Normalized camera coordinates. Must always be set.
-    Eigen::Vector2d cam_point;
+    // Normalized camera coordinates (u = X/Z, v = Y/Z). Must be set for
+    // perspective cameras. For omnidirectional (SPHERE) cameras, back-
+    // hemisphere observations may leave this zero and rely on cam_ray only.
+    Eigen::Vector2d cam_point = Eigen::Vector2d::Zero();
+    // Unit bearing vector in camera frame. For non-perspective cameras
+    // (SPHERE) this is the canonical representation; for perspective cameras
+    // it's cam_point.homogeneous().normalized(). Required for angular-error
+    // residuals and for triangulation when cam_point can't represent the ray
+    // (back hemisphere).
+    Eigen::Vector3d cam_ray = Eigen::Vector3d::Zero();
   };
 
   struct PoseData {

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -495,6 +495,19 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
     return false;
   }
 
+  // Non-perspective cameras (e.g., SPHERE) lack a meaningful pinhole
+  // calibration matrix K, so the UNCALIBRATED / PLANAR / PANORAMIC paths
+  // below — which call camera.CalibrationMatrix() — don't apply. Only the
+  // CALIBRATED essential-matrix branch is valid since it uses bearing
+  // vectors from CamFromImgRay and no K. Pairs in other configs are skipped
+  // rather than crashing.
+  const bool camera1_has_k = camera1.FocalLengthIdxs().size() > 0;
+  const bool camera2_has_k = camera2.FocalLengthIdxs().size() > 0;
+  if ((!camera1_has_k || !camera2_has_k) &&
+      geometry->config != TwoViewGeometry::ConfigurationType::CALIBRATED) {
+    return false;
+  }
+
   // Extract normalized inlier points.
   const size_t num_inlier_matches = geometry->inlier_matches.size();
   if (num_inlier_matches == 0) {
@@ -505,17 +518,17 @@ bool EstimateTwoViewGeometryPose(const Camera& camera1,
   std::vector<Eigen::Vector3d> inlier_cam_rays2(num_inlier_matches);
   for (size_t i = 0; i < num_inlier_matches; ++i) {
     const FeatureMatch& match = geometry->inlier_matches[i];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[match.point2D_idx1]);
-        cam_point1) {
-      inlier_cam_rays1[i] = cam_point1->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray1 =
+            camera1.CamFromImgRay(points1[match.point2D_idx1]);
+        ray1) {
+      inlier_cam_rays1[i] = *ray1;
     } else {
       inlier_cam_rays1[i].setZero();
     }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[match.point2D_idx2]);
-        cam_point2) {
-      inlier_cam_rays2[i] = cam_point2->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray2 =
+            camera2.CamFromImgRay(points2[match.point2D_idx2]);
+        ray2) {
+      inlier_cam_rays2[i] = *ray2;
     } else {
       inlier_cam_rays2[i].setZero();
     }
@@ -619,17 +632,17 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
     const point2D_t idx2 = matches[i].point2D_idx2;
     matched_img_points1[i] = points1[idx1];
     matched_img_points2[i] = points2[idx2];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[idx1]);
-        cam_point1) {
-      matched_cam_rays1[i] = cam_point1->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray1 =
+            camera1.CamFromImgRay(points1[idx1]);
+        ray1) {
+      matched_cam_rays1[i] = *ray1;
     } else {
       matched_cam_rays1[i].setZero();
     }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[idx2]);
-        cam_point2) {
-      matched_cam_rays2[i] = cam_point2->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray2 =
+            camera2.CamFromImgRay(points2[idx2]);
+        ray2) {
+      matched_cam_rays2[i] = *ray2;
     } else {
       matched_cam_rays2[i].setZero();
     }
@@ -881,17 +894,17 @@ TwoViewGeometry TwoViewGeometryFromKnownRelativePose(
   for (size_t i = 0; i < num_matches; ++i) {
     const point2D_t idx1 = matches[i].point2D_idx1;
     const point2D_t idx2 = matches[i].point2D_idx2;
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[idx1]);
-        cam_point1) {
-      matched_cam_rays1[i] = cam_point1->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray1 =
+            camera1.CamFromImgRay(points1[idx1]);
+        ray1) {
+      matched_cam_rays1[i] = *ray1;
     } else {
       matched_cam_rays1[i].setZero();
     }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[idx2]);
-        cam_point2) {
-      matched_cam_rays2[i] = cam_point2->homogeneous().normalized();
+    if (const std::optional<Eigen::Vector3d> ray2 =
+            camera2.CamFromImgRay(points2[idx2]);
+        ray2) {
+      matched_cam_rays2[i] = *ray2;
     } else {
       matched_cam_rays2[i].setZero();
     }

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -666,6 +666,29 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
   const auto E_report = E_ransac.Estimate(matched_cam_rays1, matched_cam_rays2);
   geometry.E = E_report.model;
 
+  // For non-perspective cameras (e.g. SPHERE) the image pixel plane is not a
+  // flat image plane, so the fundamental-matrix and homography-matrix models
+  // estimated in pixel space are not geometrically meaningful. Force the
+  // CALIBRATED configuration based purely on the essential matrix inliers —
+  // bearing vectors + E are the natively-correct formulation for these cameras.
+  const bool camera1_is_perspective = camera1.FocalLengthIdxs().size() > 0;
+  const bool camera2_is_perspective = camera2.FocalLengthIdxs().size() > 0;
+  if (!camera1_is_perspective || !camera2_is_perspective) {
+    if (!E_report.success ||
+        E_report.support.num_inliers < min_num_inliers) {
+      geometry.config = TwoViewGeometry::ConfigurationType::DEGENERATE;
+      return geometry;
+    }
+    geometry.config = TwoViewGeometry::ConfigurationType::CALIBRATED;
+    geometry.inlier_matches = ExtractInlierMatches(
+        matches, E_report.support.num_inliers, E_report.inlier_mask);
+    if (options.compute_relative_pose) {
+      EstimateTwoViewGeometryPose(
+          camera1, points1, camera2, points2, &geometry);
+    }
+    return geometry;
+  }
+
   LORANSAC<FundamentalMatrixSevenPointEstimator,
            FundamentalMatrixEightPointEstimator>
       F_ransac(ransac_options);

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -85,6 +85,7 @@ set(COLMAP_MAIN_SRCS
     image.cc
     model.cc
     sfm.cc
+    sphere.cc
     vocab_tree.cc
 )
 if(MVS_ENABLED)

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -51,6 +51,7 @@ set(COLMAP_EXE_SRCS
     feature.h feature.cc
     sfm.h sfm.cc
     model.h model.cc
+    sphere.h sphere.cc
 )
 set(COLMAP_EXE_PUBLIC_LIBS
     colmap_controllers
@@ -106,3 +107,9 @@ COLMAP_ADD_EXECUTABLE(
         Boost::boost
 )
 set_target_properties(colmap_main PROPERTIES OUTPUT_NAME colmap)
+
+COLMAP_ADD_TEST(
+    NAME sphere_test
+    SRCS sphere_test.cc
+    LINK_LIBS colmap_exe
+)

--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -36,6 +36,7 @@
 #include "colmap/exe/mvs.h"
 #endif
 #include "colmap/exe/sfm.h"
+#include "colmap/exe/sphere.h"
 #include "colmap/exe/vocab_tree.h"
 #include "colmap/util/oiio_utils.h"
 #include "colmap/util/version.h"
@@ -146,6 +147,7 @@ int main(int argc, char** argv) {
   commands.emplace_back("rotation_averager", &colmap::RunRotationAverager);
   commands.emplace_back("sequential_matcher", &colmap::RunSequentialMatcher);
   commands.emplace_back("spatial_matcher", &colmap::RunSpatialMatcher);
+  commands.emplace_back("sphere_to_cubic", &colmap::RunSphereToCubic);
 #if defined(COLMAP_MVS_ENABLED)
   commands.emplace_back("stereo_fusion", &colmap::RunStereoFuser);
 #endif

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -78,6 +78,25 @@ void UpdateDatabasePosePriorsCovariance(
   }
 }
 
+void UpdateDatabasePosePriorsRotationCovariance(
+    const std::filesystem::path& database_path,
+    const Eigen::Matrix3d& rotation_covariance) {
+  auto database = Database::Open(database_path);
+  DatabaseTransaction database_transaction(database.get());
+
+  LOG(INFO) << "Setting up database pose priors with the same rotation "
+               "covariance matrix: \n"
+            << rotation_covariance << '\n';
+
+  for (auto& pose_prior : database->ReadAllPosePriors()) {
+    if (!pose_prior.HasRotation()) {
+      continue;
+    }
+    pose_prior.rotation_covariance = rotation_covariance;
+    database->UpdatePosePrior(pose_prior);
+  }
+}
+
 }  // namespace
 
 int RunAutomaticReconstructor(int argc, char** argv) {
@@ -468,6 +487,16 @@ int RunPosePriorMapper(int argc, char** argv) {
   double prior_position_std_y = 1.;
   double prior_position_std_z = 1.;
 
+  // Rotation priors are optional. The aperture fork extends pose_priors with a
+  // per-frame rotation (e.g. compass heading lifted to a level quaternion);
+  // when populated, they additionally constrain BA's rotation solution,
+  // preventing the "rotate the camera to explain a position error" compensation
+  // that otherwise produces ghosting in dense MVS.
+  bool overwrite_rotation_priors_covariance = false;
+  double prior_rotation_std_x_deg = 5.;
+  double prior_rotation_std_y_deg = 5.;
+  double prior_rotation_std_z_deg = 5.;
+
   OptionManager options;
   options.AddDatabaseOptions();
   options.AddImageOptions();
@@ -489,6 +518,19 @@ int RunPosePriorMapper(int argc, char** argv) {
                            &options.mapper->use_robust_loss_on_prior_position);
   options.AddDefaultOption("prior_position_loss_scale",
                            &options.mapper->prior_position_loss_scale);
+  options.AddDefaultOption(
+      "overwrite_rotation_priors_covariance",
+      &overwrite_rotation_priors_covariance,
+      "If true, overwrite the rotation-prior covariance on every row that "
+      "has a rotation prior using prior_rotation_std_*_deg (degrees, "
+      "angle-axis residual).");
+  options.AddDefaultOption("prior_rotation_std_x_deg", &prior_rotation_std_x_deg);
+  options.AddDefaultOption("prior_rotation_std_y_deg", &prior_rotation_std_y_deg);
+  options.AddDefaultOption("prior_rotation_std_z_deg", &prior_rotation_std_z_deg);
+  options.AddDefaultOption("use_robust_loss_on_prior_rotation",
+                           &options.mapper->use_robust_loss_on_prior_rotation);
+  options.AddDefaultOption("prior_rotation_loss_scale",
+                           &options.mapper->prior_rotation_loss_scale);
   if (!options.Parse(argc, argv)) {
     return EXIT_FAILURE;
   }
@@ -505,6 +547,19 @@ int RunPosePriorMapper(int argc, char** argv) {
             .cwiseAbs2()
             .asDiagonal();
     UpdateDatabasePosePriorsCovariance(*options.database_path, covariance);
+  }
+
+  if (overwrite_rotation_priors_covariance) {
+    constexpr double kDegToRad = M_PI / 180.0;
+    const Eigen::Matrix3d rotation_covariance =
+        (Eigen::Vector3d(prior_rotation_std_x_deg,
+                         prior_rotation_std_y_deg,
+                         prior_rotation_std_z_deg) *
+         kDegToRad)
+            .cwiseAbs2()
+            .asDiagonal();
+    UpdateDatabasePosePriorsRotationCovariance(*options.database_path,
+                                               rotation_covariance);
   }
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();

--- a/src/colmap/exe/sphere.cc
+++ b/src/colmap/exe/sphere.cc
@@ -56,21 +56,9 @@
 #include <Eigen/Geometry>
 
 namespace colmap {
-namespace {
 
-// Cube face rotations. Convention (COLMAP camera frame: +X right, +Y down,
-// +Z forward):
-//   R_sphere_from_face maps a face-cam-frame ray onto the sphere-cam-frame.
-//   The face camera's +Z axis points along the face's direction on the
-//   sphere, with a sensible "up" convention (sphere -Y stays up for F, B, L,
-//   R; reoriented for U, D).
-struct FaceSpec {
-  const char* name;
-  Eigen::Matrix3d r_sphere_from_face;
-};
-
-std::array<FaceSpec, 6> CubeFaceSpecs() {
-  std::array<FaceSpec, 6> faces{};
+std::array<SphereCubeFaceSpec, 6> SphereCubeFaceSpecs() {
+  std::array<SphereCubeFaceSpec, 6> faces{};
   // F: face +Z -> sphere +Z.
   faces[0] = {"F", Eigen::Matrix3d::Identity()};
   // B: face +Z -> sphere -Z. 180° yaw.
@@ -90,6 +78,8 @@ std::array<FaceSpec, 6> CubeFaceSpecs() {
   faces[5].r_sphere_from_face << 1, 0, 0, 0, 0, 1, 0, -1, 0;
   return faces;
 }
+
+namespace {
 
 // Render one cube face from an equirectangular (ERP) bitmap by bilinear
 // resampling. Uses COLMAP camera-frame conventions (+X right, +Y down, +Z
@@ -189,7 +179,7 @@ int RunSphereToCubic(int argc, char** argv) {
                             reconstruction.NumImages(),
                             reconstruction.NumPoints3D());
 
-  const auto faces = CubeFaceSpecs();
+  const auto faces = SphereCubeFaceSpecs();
   const double focal_px =
       face_size / (2.0 * std::tan(DegToRad(fov_deg) / 2.0));
   const double face_cx = face_size / 2.0;
@@ -257,7 +247,7 @@ int RunSphereToCubic(int argc, char** argv) {
 
     std::array<image_t, 6> face_image_ids{};
     for (size_t face_idx = 0; face_idx < faces.size(); ++face_idx) {
-      const FaceSpec& face = faces[face_idx];
+      const SphereCubeFaceSpec& face = faces[face_idx];
 
       Bitmap face_bitmap =
           RenderCubeFace(erp, face.r_sphere_from_face, face_size, focal_px);

--- a/src/colmap/exe/sphere.cc
+++ b/src/colmap/exe/sphere.cc
@@ -1,0 +1,401 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/exe/sphere.h"
+
+#include "colmap/controllers/option_manager.h"
+#include "colmap/geometry/rigid3.h"
+#include "colmap/math/math.h"
+#include "colmap/scene/camera.h"
+#include "colmap/scene/frame.h"
+#include "colmap/scene/image.h"
+#include "colmap/scene/point3d.h"
+#include "colmap/scene/reconstruction.h"
+#include "colmap/scene/track.h"
+#include "colmap/sensor/bitmap.h"
+#include "colmap/sensor/models.h"
+#include "colmap/sensor/rig.h"
+#include "colmap/util/file.h"
+#include "colmap/util/logging.h"
+#include "colmap/util/misc.h"
+#include "colmap/util/string.h"
+
+#include <array>
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace colmap {
+namespace {
+
+// Cube face rotations. Convention (COLMAP camera frame: +X right, +Y down,
+// +Z forward):
+//   R_sphere_from_face maps a face-cam-frame ray onto the sphere-cam-frame.
+//   The face camera's +Z axis points along the face's direction on the
+//   sphere, with a sensible "up" convention (sphere -Y stays up for F, B, L,
+//   R; reoriented for U, D).
+struct FaceSpec {
+  const char* name;
+  Eigen::Matrix3d r_sphere_from_face;
+};
+
+std::array<FaceSpec, 6> CubeFaceSpecs() {
+  std::array<FaceSpec, 6> faces{};
+  // F: face +Z -> sphere +Z.
+  faces[0] = {"F", Eigen::Matrix3d::Identity()};
+  // B: face +Z -> sphere -Z. 180° yaw.
+  faces[1].name = "B";
+  faces[1].r_sphere_from_face << -1, 0, 0, 0, 1, 0, 0, 0, -1;
+  // L: face +Z -> sphere -X.
+  faces[2].name = "L";
+  faces[2].r_sphere_from_face << 0, 0, -1, 0, 1, 0, 1, 0, 0;
+  // R: face +Z -> sphere +X.
+  faces[3].name = "R";
+  faces[3].r_sphere_from_face << 0, 0, 1, 0, 1, 0, -1, 0, 0;
+  // U: face +Z -> sphere -Y.
+  faces[4].name = "U";
+  faces[4].r_sphere_from_face << 1, 0, 0, 0, 0, -1, 0, 1, 0;
+  // D: face +Z -> sphere +Y.
+  faces[5].name = "D";
+  faces[5].r_sphere_from_face << 1, 0, 0, 0, 0, 1, 0, -1, 0;
+  return faces;
+}
+
+// Render one cube face from an equirectangular (ERP) bitmap by bilinear
+// resampling. Uses COLMAP camera-frame conventions (+X right, +Y down, +Z
+// forward). face_size is the output side in pixels; focal_px is the face
+// pinhole focal length in pixels.
+Bitmap RenderCubeFace(const Bitmap& erp,
+                      const Eigen::Matrix3d& r_sphere_from_face,
+                      int face_size,
+                      double focal_px) {
+  const double W = erp.Width();
+  const double H = erp.Height();
+  const double cx = face_size / 2.0;
+  const double cy = face_size / 2.0;
+
+  Bitmap face(face_size, face_size, /*as_rgb=*/true);
+  for (int v = 0; v < face_size; ++v) {
+    for (int u = 0; u < face_size; ++u) {
+      // Face-cam-frame ray (unit length) for pixel (u + 0.5, v + 0.5).
+      const double x = (u + 0.5 - cx) / focal_px;
+      const double y = (v + 0.5 - cy) / focal_px;
+      const double z = 1.0;
+      const double norm = std::sqrt(x * x + y * y + z * z);
+      const Eigen::Vector3d ray_face(x / norm, y / norm, z / norm);
+      const Eigen::Vector3d ray_sphere = r_sphere_from_face * ray_face;
+
+      // Sphere-frame ray -> ERP pixel. +Z forward, +X right, +Y down.
+      const double theta = std::atan2(ray_sphere.x(), ray_sphere.z());
+      const double phi = std::asin(-ray_sphere.y());
+      double erp_x = (theta / (2.0 * M_PI) + 0.5) * W;
+      const double erp_y = (0.5 - phi / M_PI) * H;
+
+      // Wrap longitude, clamp latitude.
+      erp_x = std::fmod(erp_x, W);
+      if (erp_x < 0) erp_x += W;
+
+      const std::optional<BitmapColor<float>> sample =
+          erp.InterpolateBilinear(erp_x, erp_y);
+      if (sample) {
+        face.SetPixel(u,
+                      v,
+                      BitmapColor<uint8_t>(
+                          static_cast<uint8_t>(std::clamp(
+                              std::lround(sample->r), 0L, 255L)),
+                          static_cast<uint8_t>(std::clamp(
+                              std::lround(sample->g), 0L, 255L)),
+                          static_cast<uint8_t>(std::clamp(
+                              std::lround(sample->b), 0L, 255L))));
+      }
+    }
+  }
+  return face;
+}
+
+// Quaternion from 3x3 rotation matrix. Equivalent to
+// Eigen::Quaterniond(R) but avoids a dependency on the specific
+// constructor behavior for non-normalized matrices.
+Eigen::Quaterniond QuaternionFromMatrix(const Eigen::Matrix3d& r) {
+  return Eigen::Quaterniond(r).normalized();
+}
+
+}  // namespace
+
+int RunSphereToCubic(int argc, char** argv) {
+  std::filesystem::path input_path;
+  std::filesystem::path output_path;
+  std::filesystem::path output_image_path;
+  int face_size = 1024;
+  double fov_deg = 90.0;
+  int jpeg_quality = 95;
+
+  OptionManager options;
+  options.AddImageOptions();
+  options.AddRequiredOption("input_path", &input_path,
+                            "Path to input SPHERE sparse model.");
+  options.AddRequiredOption("output_path", &output_path,
+                            "Output path for cubic sparse model.");
+  options.AddRequiredOption(
+      "output_image_path", &output_image_path,
+      "Output directory for rendered cube face images.");
+  options.AddDefaultOption("face_size", &face_size,
+                           "Output face size in pixels (square).");
+  options.AddDefaultOption("fov_deg", &fov_deg,
+                           "Output face FOV in degrees.");
+  options.AddDefaultOption("jpeg_quality", &jpeg_quality,
+                           "JPEG quality [1, 100] for rendered faces.");
+  if (!options.Parse(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+
+  CreateDirIfNotExists(output_path);
+  CreateDirIfNotExists(output_image_path);
+
+  LOG_HEADING1("Reading reconstruction");
+  Reconstruction reconstruction;
+  reconstruction.Read(input_path);
+  LOG(INFO) << StringPrintf("=> Reconstruction with %d images and %d points",
+                            reconstruction.NumImages(),
+                            reconstruction.NumPoints3D());
+
+  const auto faces = CubeFaceSpecs();
+  const double focal_px =
+      face_size / (2.0 * std::tan(DegToRad(fov_deg) / 2.0));
+  const double face_cx = face_size / 2.0;
+  const double face_cy = face_size / 2.0;
+
+  // Single shared PINHOLE camera for every rendered face, wrapped in a
+  // trivial one-camera rig (COLMAP 4.x images live inside a Frame, and the
+  // Frame lives inside a Rig, so even a singleton camera needs this setup).
+  Reconstruction cubic;
+  Camera pinhole_camera;
+  pinhole_camera.camera_id = 1;
+  pinhole_camera.model_id = CameraModelId::kPinhole;
+  pinhole_camera.width = face_size;
+  pinhole_camera.height = face_size;
+  pinhole_camera.params = {focal_px, focal_px, face_cx, face_cy};
+  pinhole_camera.has_prior_focal_length = true;
+  cubic.AddCamera(pinhole_camera);
+
+  constexpr rig_t kRigId = 1;
+  const sensor_t pinhole_sensor_id(SensorType::CAMERA, pinhole_camera.camera_id);
+  {
+    Rig pinhole_rig;
+    pinhole_rig.SetRigId(kRigId);
+    pinhole_rig.AddRefSensor(pinhole_sensor_id);
+    cubic.AddRig(std::move(pinhole_rig));
+  }
+
+  // For each SPHERE image, render 6 cube face bitmaps and register them as
+  // new Image entries with the appropriate poses.
+  //
+  // Mapping of sphere image_id -> per-face new image_id:
+  //   new_id = sphere_image_id * 6 + face_idx + 1
+  // This keeps the mapping injective and reversible.
+  const std::string image_dir = options.image_path->string();
+
+  std::unordered_map<image_t, std::array<image_t, 6>>
+      sphere_to_face_image_ids;
+
+  int num_rendered = 0;
+  int num_skipped_non_sphere = 0;
+  for (const image_t sphere_image_id : reconstruction.RegImageIds()) {
+    const Image& sphere_image = reconstruction.Image(sphere_image_id);
+    const Camera& sphere_camera =
+        reconstruction.Camera(sphere_image.CameraId());
+    if (sphere_camera.model_id != CameraModelId::kSphere) {
+      ++num_skipped_non_sphere;
+      continue;
+    }
+
+    Bitmap erp;
+    const std::filesystem::path erp_path =
+        std::filesystem::path(image_dir) / sphere_image.Name();
+    if (!erp.Read(erp_path.string())) {
+      LOG(WARNING) << "Failed to read " << erp_path;
+      continue;
+    }
+
+    // Sphere-cam <- world rotation and camera center in world.
+    const Rigid3d sphere_cam_from_world = sphere_image.CamFromWorld();
+    const Eigen::Matrix3d r_sphere_cam_from_world =
+        sphere_cam_from_world.rotation().toRotationMatrix();
+    const Eigen::Vector3d proj_center =
+        r_sphere_cam_from_world.transpose() *
+        (-sphere_cam_from_world.translation());
+
+    std::array<image_t, 6> face_image_ids{};
+    for (size_t face_idx = 0; face_idx < faces.size(); ++face_idx) {
+      const FaceSpec& face = faces[face_idx];
+
+      Bitmap face_bitmap =
+          RenderCubeFace(erp, face.r_sphere_from_face, face_size, focal_px);
+      face_bitmap.SetJpegQuality(jpeg_quality);
+
+      const std::filesystem::path face_stem =
+          std::filesystem::path(sphere_image.Name()).stem();
+      const std::string face_filename =
+          face_stem.string() + "_" + face.name + ".jpg";
+      const std::filesystem::path face_full_path =
+          output_image_path / face_filename;
+      face_bitmap.Write(face_full_path.string());
+
+      // Face-cam <- world: R_wc_face = R_sphere_from_face.T @ R_sphere_cam_from_world.
+      const Eigen::Matrix3d r_face_cam_from_world =
+          face.r_sphere_from_face.transpose() * r_sphere_cam_from_world;
+      const Eigen::Vector3d t_face_cam_from_world =
+          -r_face_cam_from_world * proj_center;
+
+      const image_t new_image_id =
+          sphere_image_id * faces.size() + face_idx + 1;
+      const frame_t new_frame_id = new_image_id;
+
+      // Each face image gets its own single-camera frame (one sensor per
+      // frame, same rig reused across all frames).
+      Frame face_frame;
+      face_frame.SetFrameId(new_frame_id);
+      face_frame.SetRigId(kRigId);
+      face_frame.AddDataId(data_t(pinhole_sensor_id, new_image_id));
+      face_frame.SetRigFromWorld(
+          Rigid3d(QuaternionFromMatrix(r_face_cam_from_world),
+                  t_face_cam_from_world));
+      cubic.AddFrame(std::move(face_frame));
+      cubic.RegisterFrame(new_frame_id);
+
+      Image face_image;
+      face_image.SetImageId(new_image_id);
+      face_image.SetCameraId(pinhole_camera.camera_id);
+      face_image.SetFrameId(new_frame_id);
+      face_image.SetName(face_filename);
+      face_image.SetPoints2D(std::vector<struct Point2D>{});
+      cubic.AddImage(std::move(face_image));
+      face_image_ids[face_idx] = new_image_id;
+    }
+    sphere_to_face_image_ids[sphere_image_id] = face_image_ids;
+
+    ++num_rendered;
+    if (num_rendered % 10 == 0) {
+      LOG(INFO) << "  rendered " << num_rendered << " panoramas";
+    }
+  }
+  LOG(INFO) << StringPrintf(
+      "=> %d sphere images -> %d face images (skipped %d non-SPHERE)",
+      num_rendered,
+      num_rendered * static_cast<int>(faces.size()),
+      num_skipped_non_sphere);
+
+  // Reproject 3D points: for each track element (sphere_image_id, kp_idx),
+  // project the 3D point into each cube face and add an observation to the
+  // first face whose image bounds contain the projection.
+  int num_points_kept = 0;
+  int num_observations_added = 0;
+  int num_observations_dropped = 0;
+  for (const auto& [point_id, sphere_point] : reconstruction.Points3D()) {
+    const Eigen::Vector3d xyz = sphere_point.xyz;
+    Track new_track;
+
+    for (const TrackElement& elem : sphere_point.track.Elements()) {
+      const auto face_images_it =
+          sphere_to_face_image_ids.find(elem.image_id);
+      if (face_images_it == sphere_to_face_image_ids.end()) {
+        ++num_observations_dropped;
+        continue;
+      }
+
+      const Image& sphere_image = reconstruction.Image(elem.image_id);
+      const Rigid3d& sphere_cam_from_world = sphere_image.CamFromWorld();
+      const Eigen::Vector3d point_in_sphere_cam =
+          sphere_cam_from_world.rotation() * xyz +
+          sphere_cam_from_world.translation();
+
+      image_t chosen_face_image_id = kInvalidImageId;
+      Eigen::Vector2d chosen_face_uv;
+      for (size_t face_idx = 0; face_idx < faces.size(); ++face_idx) {
+        const Eigen::Vector3d point_in_face_cam =
+            faces[face_idx].r_sphere_from_face.transpose() *
+            point_in_sphere_cam;
+        if (point_in_face_cam.z() <= 1e-6) {
+          continue;
+        }
+        const double u = focal_px * point_in_face_cam.x() / point_in_face_cam.z() + face_cx;
+        const double v = focal_px * point_in_face_cam.y() / point_in_face_cam.z() + face_cy;
+        if (u >= 0 && u < face_size && v >= 0 && v < face_size) {
+          chosen_face_image_id = face_images_it->second[face_idx];
+          chosen_face_uv = Eigen::Vector2d(u, v);
+          break;
+        }
+      }
+      if (chosen_face_image_id == kInvalidImageId) {
+        ++num_observations_dropped;
+        continue;
+      }
+
+      Image& face_image = cubic.Image(chosen_face_image_id);
+      const point2D_t new_point2D_idx =
+          static_cast<point2D_t>(face_image.Points2D().size());
+      struct Point2D new_point2D;
+      new_point2D.xy = chosen_face_uv;
+      new_point2D.point3D_id = point_id;
+      face_image.Points2D().push_back(new_point2D);
+      new_track.AddElement(chosen_face_image_id, new_point2D_idx);
+      ++num_observations_added;
+    }
+
+    if (new_track.Length() >= 2) {
+      Point3D new_point;
+      new_point.xyz = xyz;
+      new_point.color = sphere_point.color;
+      new_point.error = sphere_point.error;
+      new_point.track = std::move(new_track);
+      cubic.AddPoint3D(point_id, std::move(new_point));
+      ++num_points_kept;
+    }
+  }
+
+  LOG(INFO) << StringPrintf(
+      "=> reprojection: added %d observations, dropped %d, kept %d/%d points",
+      num_observations_added,
+      num_observations_dropped,
+      num_points_kept,
+      reconstruction.NumPoints3D());
+
+  LOG_HEADING1("Writing cubic reconstruction");
+  cubic.Write(output_path);
+  LOG(INFO) << "=> wrote sparse model to " << output_path;
+  LOG(INFO) << "=> wrote rendered faces to " << output_image_path;
+
+  return EXIT_SUCCESS;
+}
+
+}  // namespace colmap

--- a/src/colmap/exe/sphere.h
+++ b/src/colmap/exe/sphere.h
@@ -1,0 +1,43 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+namespace colmap {
+
+// Convert a SPHERE-camera sparse reconstruction into a PINHOLE (cubic) sparse
+// reconstruction plus rendered cube-face images. For each SPHERE panorama in
+// the input, synthesize six PINHOLE images (faces F, B, L, R, U, D) at a
+// configurable resolution and FOV and reproject every 3D-point observation
+// onto whichever cube face contains it. Output is suitable for standard dense
+// MVS (image_undistorter -> patch_match_stereo -> stereo_fusion, or OpenMVS
+// InterfaceCOLMAP), which cannot consume the SPHERE camera directly.
+int RunSphereToCubic(int argc, char** argv);
+
+}  // namespace colmap

--- a/src/colmap/exe/sphere.h
+++ b/src/colmap/exe/sphere.h
@@ -29,7 +29,32 @@
 
 #pragma once
 
+#include "colmap/util/eigen_alignment.h"
+
+#include <array>
+
+#include <Eigen/Core>
+
 namespace colmap {
+
+// Specification for a single cube face of an equirectangular panorama
+// decomposition. The rotation maps face-camera-frame vectors into the
+// sphere-camera-frame (both follow COLMAP convention: +X right, +Y down,
+// +Z forward).
+struct SphereCubeFaceSpec {
+  const char* name;
+  Eigen::Matrix3d r_sphere_from_face;
+};
+
+// Returns the six canonical cube faces in order F, B, L, R, U, D. Each face's
+// r_sphere_from_face rotates a face-cam-frame ray into the sphere-cam-frame:
+//   - F: face +Z = sphere +Z (forward).
+//   - B: face +Z = sphere -Z (backward).
+//   - L: face +Z = sphere -X (left).
+//   - R: face +Z = sphere +X (right).
+//   - U: face +Z = sphere -Y (up).
+//   - D: face +Z = sphere +Y (down).
+std::array<SphereCubeFaceSpec, 6> SphereCubeFaceSpecs();
 
 // Convert a SPHERE-camera sparse reconstruction into a PINHOLE (cubic) sparse
 // reconstruction plus rendered cube-face images. For each SPHERE panorama in

--- a/src/colmap/exe/sphere_test.cc
+++ b/src/colmap/exe/sphere_test.cc
@@ -1,0 +1,182 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/exe/sphere.h"
+
+#include "colmap/util/eigen_alignment.h"
+#include "colmap/util/eigen_matchers.h"
+
+#include <cmath>
+#include <unordered_set>
+
+#include <Eigen/Core>
+#include <Eigen/LU>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+TEST(SphereCubeFaceSpecs, Count) {
+  const auto faces = SphereCubeFaceSpecs();
+  EXPECT_EQ(faces.size(), 6u);
+}
+
+TEST(SphereCubeFaceSpecs, RotationsAreProperRotations) {
+  // Every r_sphere_from_face must be an orthogonal matrix with det +1.
+  const Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
+  for (const auto& face : SphereCubeFaceSpecs()) {
+    const Eigen::Matrix3d should_be_identity =
+        face.r_sphere_from_face.transpose() * face.r_sphere_from_face;
+    EXPECT_THAT(should_be_identity, EigenMatrixNear(identity, 1e-12))
+        << "face " << face.name << " has non-orthogonal rotation";
+    EXPECT_NEAR(face.r_sphere_from_face.determinant(), 1.0, 1e-12)
+        << "face " << face.name << " is a reflection, not a rotation";
+  }
+}
+
+TEST(SphereCubeFaceSpecs, FaceCenterMapsToCanonicalDirection) {
+  // For each face, the center ray in face-cam-frame is (0, 0, 1). Rotated
+  // through r_sphere_from_face, it should equal the canonical sphere-frame
+  // direction for that face (forward for F, backward for B, etc.).
+  const Eigen::Vector3d face_center_ray(0, 0, 1);
+
+  struct Expected {
+    const char* name;
+    Eigen::Vector3d dir;
+  };
+  const Expected expected[] = {
+      {"F", Eigen::Vector3d(0, 0, 1)},   // +Z forward
+      {"B", Eigen::Vector3d(0, 0, -1)},  // -Z back
+      {"L", Eigen::Vector3d(-1, 0, 0)},  // -X left
+      {"R", Eigen::Vector3d(1, 0, 0)},   // +X right
+      {"U", Eigen::Vector3d(0, -1, 0)},  // -Y up
+      {"D", Eigen::Vector3d(0, 1, 0)},   // +Y down
+  };
+
+  const auto faces = SphereCubeFaceSpecs();
+  ASSERT_EQ(faces.size(), 6u);
+  for (size_t i = 0; i < faces.size(); ++i) {
+    const Eigen::Vector3d sphere_dir =
+        faces[i].r_sphere_from_face * face_center_ray;
+    EXPECT_STREQ(faces[i].name, expected[i].name);
+    EXPECT_THAT(sphere_dir, EigenMatrixNear(expected[i].dir, 1e-12))
+        << "face " << faces[i].name;
+  }
+}
+
+TEST(SphereCubeFaceSpecs, CoverFullSphereWithoutOverlapAtFaceCenters) {
+  // Every point of the unit sphere projects into exactly one cube face
+  // when the face FOV is 90° (the canonical cube map). We sanity-check a
+  // grid of sphere directions: each must land in the interior of exactly
+  // one face (i.e., pass the "in front of face and within |x/z|, |y/z| < 1"
+  // test), except on the face boundaries where two are equidistant.
+  const auto faces = SphereCubeFaceSpecs();
+
+  // Sample the unit sphere with a fairly dense grid of azimuth/elevation.
+  int covered = 0;
+  int boundary = 0;
+  int uncovered = 0;
+  for (int i = 0; i < 37; ++i) {
+    const double theta = -M_PI + (2.0 * M_PI) * i / 36.0;  // azimuth
+    for (int j = 0; j < 19; ++j) {
+      const double phi = -M_PI / 2.0 + M_PI * j / 18.0;  // elevation
+      const Eigen::Vector3d ray_sphere(
+          std::cos(phi) * std::sin(theta),
+          -std::sin(phi),
+          std::cos(phi) * std::cos(theta));
+
+      int num_interior_matches = 0;
+      int num_boundary_matches = 0;
+      for (const auto& face : faces) {
+        const Eigen::Vector3d ray_face =
+            face.r_sphere_from_face.transpose() * ray_sphere;
+        if (ray_face.z() <= 1e-9) continue;
+        const double u = ray_face.x() / ray_face.z();
+        const double v = ray_face.y() / ray_face.z();
+        const double u_abs = std::abs(u);
+        const double v_abs = std::abs(v);
+        // 90° FOV cube face: projection stays within |u| < 1 and |v| < 1.
+        if (u_abs < 1.0 - 1e-9 && v_abs < 1.0 - 1e-9) {
+          ++num_interior_matches;
+        } else if (u_abs < 1.0 + 1e-9 && v_abs < 1.0 + 1e-9) {
+          ++num_boundary_matches;
+        }
+      }
+      if (num_interior_matches == 1) {
+        ++covered;
+      } else if (num_interior_matches == 0 && num_boundary_matches >= 1) {
+        ++boundary;
+      } else {
+        ++uncovered;
+      }
+    }
+  }
+  // Most sampled directions must land in the interior of exactly one face.
+  // Boundary samples (on cube edges/corners) are acceptable; we just need
+  // no direction to land outside every face.
+  EXPECT_GT(covered, 500) << "too few interior coverage samples";
+  EXPECT_EQ(uncovered, 0) << "some directions didn't land in any cube face";
+}
+
+TEST(SphereCubeFaceSpecs, ReprojectionIntoFaceImageBounds) {
+  // A 3D point at (0, 0, 1) in the sphere frame (directly forward) must
+  // project into the F face at the image center, and not be visible in any
+  // other face with Z > 0.
+  const auto faces = SphereCubeFaceSpecs();
+  const Eigen::Vector3d point_sphere(0, 0, 1);
+  const int face_size = 1024;
+  const double fov_deg = 90.0;
+  const double focal_px =
+      face_size / (2.0 * std::tan(fov_deg * M_PI / 180.0 / 2.0));
+  const double cx = face_size / 2.0;
+  const double cy = face_size / 2.0;
+
+  std::vector<std::string> hits;
+  for (const auto& face : faces) {
+    const Eigen::Vector3d point_face =
+        face.r_sphere_from_face.transpose() * point_sphere;
+    if (point_face.z() <= 1e-9) continue;
+    const double u = focal_px * point_face.x() / point_face.z() + cx;
+    const double v = focal_px * point_face.y() / point_face.z() + cy;
+    if (u >= 0 && u < face_size && v >= 0 && v < face_size) {
+      hits.emplace_back(face.name);
+      if (std::string(face.name) == "F") {
+        EXPECT_NEAR(u, cx, 1e-9);
+        EXPECT_NEAR(v, cy, 1e-9);
+      }
+    }
+  }
+  // The forward ray should hit exactly face F.
+  ASSERT_EQ(hits.size(), 1u) << "forward ray hit " << hits.size() << " faces";
+  EXPECT_EQ(hits[0], "F");
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/geometry/pose_prior.cc
+++ b/src/colmap/geometry/pose_prior.cc
@@ -60,7 +60,10 @@ bool PosePrior::operator==(const PosePrior& other) const {
          coordinate_system == other.coordinate_system &&
          IsNaNEqual(position, other.position) &&
          IsNaNEqual(position_covariance, other.position_covariance) &&
-         IsNaNEqual(gravity, other.gravity);
+         IsNaNEqual(gravity, other.gravity) &&
+         IsNaNEqual(sensor_from_world_rotation.coeffs(),
+                    other.sensor_from_world_rotation.coeffs()) &&
+         IsNaNEqual(rotation_covariance, other.rotation_covariance);
 }
 
 bool PosePrior::operator!=(const PosePrior& other) const {
@@ -77,7 +80,11 @@ std::ostream& operator<<(std::ostream& stream, const PosePrior& prior) {
          << "], position_covariance=["
          << prior.position_covariance.format(kVecFmt) << "], coordinate_system="
          << PosePrior::CoordinateSystemToString(prior.coordinate_system)
-         << ", gravity=[" << prior.gravity.format(kVecFmt) << "])";
+         << ", gravity=[" << prior.gravity.format(kVecFmt) << "]"
+         << ", sensor_from_world_rotation=["
+         << prior.sensor_from_world_rotation.coeffs().format(kVecFmt) << "]"
+         << ", rotation_covariance=["
+         << prior.rotation_covariance.format(kVecFmt) << "])";
   return stream;
 }
 

--- a/src/colmap/geometry/pose_prior.h
+++ b/src/colmap/geometry/pose_prior.h
@@ -68,9 +68,23 @@ struct PosePrior {
   // The gravity (down) in the sensor coordinate system.
   Eigen::Vector3d gravity = Eigen::Vector3d::Constant(kNaN);
 
+  // The sensor-from-world rotation prior. When populated this constrains the
+  // full 3-DoF orientation of the sensor. For inputs that only provide a
+  // compass heading, callers should synthesize a level rotation from the
+  // world-up axis + yaw and store the resulting quaternion here.
+  Eigen::Quaterniond sensor_from_world_rotation =
+      Eigen::Quaterniond(kNaN, kNaN, kNaN, kNaN);
+  // Covariance of the rotation prior, expressed in the sensor frame as an
+  // angle-axis 3-vector. Only the diagonal is used by the default BA cost.
+  Eigen::Matrix3d rotation_covariance = Eigen::Matrix3d::Constant(kNaN);
+
   inline bool HasPosition() const { return position.allFinite(); }
   inline bool HasPositionCov() const { return position_covariance.allFinite(); }
   inline bool HasGravity() const { return gravity.allFinite(); }
+  inline bool HasRotation() const {
+    return sensor_from_world_rotation.coeffs().allFinite();
+  }
+  inline bool HasRotationCov() const { return rotation_covariance.allFinite(); }
 
   bool operator==(const PosePrior& other) const;
   bool operator!=(const PosePrior& other) const;

--- a/src/colmap/geometry/triangulation.cc
+++ b/src/colmap/geometry/triangulation.cc
@@ -130,6 +130,35 @@ bool TriangulateMultiViewPoint(
   return true;
 }
 
+bool TriangulateMultiViewPoint(
+    const span<const Eigen::Matrix3x4d>& cams_from_world,
+    const span<const Eigen::Vector3d>& cam_rays,
+    Eigen::Vector3d* xyz) {
+  THROW_CHECK_EQ(cams_from_world.size(), cam_rays.size());
+  THROW_CHECK_NOTNULL(xyz);
+
+  // Same projector-based DLT as the 2D overload, but starting directly from
+  // a 3D bearing. Works for any camera model whose unprojection returns a
+  // unit ray, including omnidirectional (SPHERE) cameras where the legacy
+  // 2D (u, v, 1) representation can't encode back-hemisphere rays.
+  Eigen::Matrix4d A = Eigen::Matrix4d::Zero();
+  for (size_t i = 0; i < cam_rays.size(); ++i) {
+    const Eigen::Vector3d point = cam_rays[i].normalized();
+    const Eigen::Matrix3x4d term =
+        cams_from_world[i] - point * point.transpose() * cams_from_world[i];
+    A += term.transpose() * term;
+  }
+
+  const Eigen::SelfAdjointEigenSolver<Eigen::Matrix4d> eigen_solver(A);
+  if (eigen_solver.info() != Eigen::Success ||
+      eigen_solver.eigenvectors()(3, 0) == 0) {
+    return false;
+  }
+
+  *xyz = eigen_solver.eigenvectors().col(0).hnormalized();
+  return true;
+}
+
 bool TriangulateOptimalPoint(const Eigen::Matrix3x4d& cam1_from_world_mat,
                              const Eigen::Matrix3x4d& cam2_from_world_mat,
                              const Eigen::Vector2d& cam_point1,

--- a/src/colmap/geometry/triangulation.h
+++ b/src/colmap/geometry/triangulation.h
@@ -83,6 +83,24 @@ bool TriangulateMultiViewPoint(
     const span<const Eigen::Vector2d>& cam_points,
     Eigen::Vector3d* point3D);
 
+// Triangulate point from multiple views minimizing the L2 error, directly
+// from unit bearing vectors in each camera frame. Unlike the 2D-normalized
+// overload, this variant accepts observations from omnidirectional cameras
+// (e.g. SPHERE) whose full-sphere coverage cannot be represented in the
+// (u, v, 1) plane. For perspective cameras, passing
+// `cam_point.homogeneous().normalized()` as the bearing is equivalent to
+// the 2D overload.
+//
+// @param cams_from_world   Projection matrices of multi-view observations.
+// @param cam_rays          Unit bearing vectors in camera frame (3D).
+// @param point3D           Triangulated 3D point.
+//
+// @return                  Whether triangulation was successful.
+bool TriangulateMultiViewPoint(
+    const span<const Eigen::Matrix3x4d>& cams_from_world,
+    const span<const Eigen::Vector3d>& cam_rays,
+    Eigen::Vector3d* point3D);
+
 // Triangulate optimal 3D point from corresponding image point observations by
 // finding the optimal image observations.
 //

--- a/src/colmap/geometry/triangulation_test.cc
+++ b/src/colmap/geometry/triangulation_test.cc
@@ -193,6 +193,143 @@ TEST(TriangulateMultiViewPoint, Nominal) {
   }
 }
 
+TEST(TriangulateMultiViewPointFromBearings, NominalEquivalentTo2D) {
+  // For perspective cameras where every 3D point lies in front of every view,
+  // the bearing-vector overload must agree with the 2D-normalized overload
+  // up to floating-point roundoff.
+  const std::vector<Eigen::Vector3d> points3D = {
+      Eigen::Vector3d(0, 0.1, 0.1),
+      Eigen::Vector3d(0, 1, 3),
+      Eigen::Vector3d(0, 1, 2),
+      Eigen::Vector3d(0.01, 0.2, 3),
+      Eigen::Vector3d(-1, 0.1, 1),
+      Eigen::Vector3d(0.1, 0.1, 0.2),
+  };
+
+  const Rigid3d cam1_from_world;
+
+  for (int z = 0; z < 5; ++z) {
+    const double qz = z / 5.0;
+    for (int tx = 0; tx < 10; tx += 2) {
+      const Rigid3d cam2_from_world(Eigen::Quaterniond(0.21, 0.31, 0.41, qz),
+                                    Eigen::Vector3d(tx, 2, 3));
+      const Rigid3d cam3_from_world(Eigen::Quaterniond(0.2, 0.3, 0.4, qz),
+                                    Eigen::Vector3d(tx, 2.1, 3.1));
+      for (size_t i = 0; i < points3D.size(); ++i) {
+        const Eigen::Vector3d& point3D = points3D[i];
+        const Eigen::Vector3d point1_cam = cam1_from_world * point3D;
+        const Eigen::Vector3d point2_cam = cam2_from_world * point3D;
+        const Eigen::Vector3d point3_cam = cam3_from_world * point3D;
+        const Eigen::Vector2d point1 = point1_cam.hnormalized();
+        const Eigen::Vector2d point2 = point2_cam.hnormalized();
+        const Eigen::Vector2d point3 = point3_cam.hnormalized();
+        const Eigen::Vector3d ray1 = point1_cam.normalized();
+        const Eigen::Vector3d ray2 = point2_cam.normalized();
+        const Eigen::Vector3d ray3 = point3_cam.normalized();
+
+        const std::array<Eigen::Matrix3x4d, 3> cams_from_world = {
+            cam1_from_world.ToMatrix(),
+            cam2_from_world.ToMatrix(),
+            cam3_from_world.ToMatrix()};
+        const std::array<Eigen::Vector2d, 3> points_2d = {point1, point2, point3};
+        const std::array<Eigen::Vector3d, 3> rays_3d = {ray1, ray2, ray3};
+
+        Eigen::Vector3d xyz_2d;
+        ASSERT_TRUE(TriangulateMultiViewPoint(
+            span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                          cams_from_world.size()),
+            span<const Eigen::Vector2d>(points_2d.data(), points_2d.size()),
+            &xyz_2d));
+
+        Eigen::Vector3d xyz_3d;
+        ASSERT_TRUE(TriangulateMultiViewPoint(
+            span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                          cams_from_world.size()),
+            span<const Eigen::Vector3d>(rays_3d.data(), rays_3d.size()),
+            &xyz_3d));
+
+        EXPECT_THAT(point3D, EigenMatrixNear(xyz_3d, 1e-10));
+        EXPECT_THAT(xyz_2d, EigenMatrixNear(xyz_3d, 1e-10));
+      }
+    }
+  }
+}
+
+TEST(TriangulateMultiViewPointFromBearings, BackHemisphereRays) {
+  // The bearing-vector path must work for rays that point away from the
+  // optical axis (Z <= 0 in camera frame) — the case where the legacy 2D
+  // (u, v, 1) representation can't encode the ray. Sets up three cameras
+  // looking "outward" from a point, so for each camera one of the other
+  // cameras' observations of the landmark is in the back hemisphere.
+  //
+  // Landmark sits at the origin. Cameras are translated away from it along
+  // ±X/±Y and rotated to face outward (i.e., away from the origin) — so from
+  // each camera's perspective, the landmark is behind it (back hemisphere).
+  //
+  // We deliberately use a generic 3-camera configuration: cam1 faces +X,
+  // cam2 faces +Y, cam3 faces +Z, all translated 1m along their look direction
+  // from the origin so the world origin is "behind" each camera.
+  const Eigen::Vector3d world_point(0, 0, 0);
+
+  auto make_cam = [](const Eigen::Vector3d& position_in_world,
+                     const Eigen::Matrix3d& world_from_cam) -> Rigid3d {
+    // Cam-from-world: R = world_from_cam^T, t = -R * position.
+    const Eigen::Matrix3d cam_from_world_rot = world_from_cam.transpose();
+    const Eigen::Vector3d cam_from_world_tr =
+        -cam_from_world_rot * position_in_world;
+    return Rigid3d(Eigen::Quaterniond(cam_from_world_rot).normalized(),
+                   cam_from_world_tr);
+  };
+
+  // cam1 at (1, 0, 0), looks +X (so world origin is in its back hemisphere).
+  Eigen::Matrix3d world_from_cam1;
+  world_from_cam1.col(0) = Eigen::Vector3d(0, 0, -1);  // face-cam +X -> world -Z
+  world_from_cam1.col(1) = Eigen::Vector3d(0, 1, 0);   // face-cam +Y -> world +Y
+  world_from_cam1.col(2) = Eigen::Vector3d(1, 0, 0);   // face-cam +Z -> world +X
+  const Rigid3d cam1_from_world =
+      make_cam(Eigen::Vector3d(1, 0, 0), world_from_cam1);
+
+  // cam2 at (0, 1, 0), looks +Y.
+  Eigen::Matrix3d world_from_cam2;
+  world_from_cam2.col(0) = Eigen::Vector3d(1, 0, 0);
+  world_from_cam2.col(1) = Eigen::Vector3d(0, 0, -1);
+  world_from_cam2.col(2) = Eigen::Vector3d(0, 1, 0);
+  const Rigid3d cam2_from_world =
+      make_cam(Eigen::Vector3d(0, 1, 0), world_from_cam2);
+
+  // cam3 at (0, 0, 1), looks +Z.
+  const Rigid3d cam3_from_world(
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d(0, 0, -1));
+
+  // Each camera's ray toward the origin is -world_from_cam.col(2) rotated
+  // into camera frame. We compute it via the camera pose directly.
+  auto ray_to_origin = [&world_point](const Rigid3d& cam_from_world) {
+    const Eigen::Vector3d point_in_cam = cam_from_world * world_point;
+    // All three cameras are set up so point_in_cam.z() < 0 (back hemisphere).
+    return point_in_cam.normalized();
+  };
+  const Eigen::Vector3d ray1 = ray_to_origin(cam1_from_world);
+  const Eigen::Vector3d ray2 = ray_to_origin(cam2_from_world);
+  const Eigen::Vector3d ray3 = ray_to_origin(cam3_from_world);
+  ASSERT_LT(ray1.z(), 0) << "cam1 should see origin in back hemisphere";
+  ASSERT_LT(ray2.z(), 0) << "cam2 should see origin in back hemisphere";
+  ASSERT_LT(ray3.z(), 0) << "cam3 should see origin in back hemisphere";
+
+  const std::array<Eigen::Matrix3x4d, 3> cams_from_world = {
+      cam1_from_world.ToMatrix(),
+      cam2_from_world.ToMatrix(),
+      cam3_from_world.ToMatrix()};
+  const std::array<Eigen::Vector3d, 3> rays = {ray1, ray2, ray3};
+
+  Eigen::Vector3d xyz;
+  ASSERT_TRUE(TriangulateMultiViewPoint(
+      span<const Eigen::Matrix3x4d>(cams_from_world.data(),
+                                    cams_from_world.size()),
+      span<const Eigen::Vector3d>(rays.data(), rays.size()),
+      &xyz));
+  EXPECT_THAT(world_point, EigenMatrixNear(xyz, 1e-10));
+}
+
 TEST(CalculateTriangulationAngle, Nominal) {
   const Eigen::Vector3d tvec1(0, 0, 0);
   const Eigen::Vector3d tvec2(0, 1, 0);

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -131,6 +131,15 @@ struct Camera {
   inline std::optional<Eigen::Vector2d> CamFromImg(
       const Eigen::Vector2d& image_point) const;
 
+  // Unproject a pixel to a unit 3D bearing vector in the camera frame.
+  //
+  // Unlike CamFromImg (which returns a 2D normalized coordinate and is
+  // therefore limited to the forward hemisphere), this works for any pixel
+  // the camera model can unproject — including back-facing rays on
+  // omnidirectional (SPHERE) cameras.
+  inline std::optional<Eigen::Vector3d> CamFromImgRay(
+      const Eigen::Vector2d& image_point) const;
+
   // Convert pixel threshold in image plane to camera frame.
   inline double CamFromImgThreshold(double threshold) const;
 
@@ -262,6 +271,11 @@ bool Camera::HasBogusParams(const double min_focal_length_ratio,
 std::optional<Eigen::Vector2d> Camera::CamFromImg(
     const Eigen::Vector2d& image_point) const {
   return CameraModelCamFromImg(model_id, params, image_point);
+}
+
+std::optional<Eigen::Vector3d> Camera::CamFromImgRay(
+    const Eigen::Vector2d& image_point) const {
+  return CameraModelCamFromImgRay(model_id, params, image_point);
 }
 
 double Camera::CamFromImgThreshold(const double threshold) const {

--- a/src/colmap/scene/database_sqlite.cc
+++ b/src/colmap/scene/database_sqlite.cc
@@ -414,6 +414,20 @@ PosePrior ReadPosePriorRow(sqlite3_stmt* sql_stmt) {
       sqlite3_column_int64(sql_stmt, 6));
   pose_prior.gravity =
       ReadStaticMatrixBlob<Eigen::Vector3d>(sql_stmt, SQLITE_ROW, 7);
+  // Rotation prior: columns 8 (quaternion xyzw, 4 doubles) and 9 (3x3
+  // covariance). NULL / empty blob → leave default NaN so HasRotation() is
+  // false. ReadStaticMatrixBlob returns Zero for empty blobs which would
+  // look like a legitimate rotation, so detect num_bytes==0 explicitly.
+  if (sqlite3_column_bytes(sql_stmt, 8) > 0) {
+    const Eigen::Vector4d coeffs =
+        ReadStaticMatrixBlob<Eigen::Vector4d>(sql_stmt, SQLITE_ROW, 8);
+    pose_prior.sensor_from_world_rotation =
+        Eigen::Quaterniond(coeffs(3), coeffs(0), coeffs(1), coeffs(2));
+  }
+  if (sqlite3_column_bytes(sql_stmt, 9) > 0) {
+    pose_prior.rotation_covariance =
+        ReadStaticMatrixBlob<Eigen::Matrix3d>(sql_stmt, SQLITE_ROW, 9);
+  }
   return pose_prior;
 }
 
@@ -1253,6 +1267,20 @@ class SqliteDatabase : public Database {
         7,
         static_cast<sqlite3_int64>(pose_prior.coordinate_system)));
     WriteStaticMatrixBlob(sql_stmt_write_pose_prior_, pose_prior.gravity, 8);
+    // Rotation prior: bind NULL when not populated so the DB round-trips
+    // "no rotation prior" cleanly. Quaternion order is (x, y, z, w).
+    if (pose_prior.HasRotation()) {
+      const Eigen::Vector4d coeffs = pose_prior.sensor_from_world_rotation.coeffs();
+      WriteStaticMatrixBlob(sql_stmt_write_pose_prior_, coeffs, 9);
+    } else {
+      SQLITE3_CALL(sqlite3_bind_null(sql_stmt_write_pose_prior_, 9));
+    }
+    if (pose_prior.HasRotationCov()) {
+      WriteStaticMatrixBlob(
+          sql_stmt_write_pose_prior_, pose_prior.rotation_covariance, 10);
+    } else {
+      SQLITE3_CALL(sqlite3_bind_null(sql_stmt_write_pose_prior_, 10));
+    }
     SQLITE3_CALL(sqlite3_step(sql_stmt_write_pose_prior_));
 
     return static_cast<image_t>(
@@ -1507,8 +1535,20 @@ class SqliteDatabase : public Database {
         6,
         static_cast<sqlite3_int64>(pose_prior.coordinate_system)));
     WriteStaticMatrixBlob(sql_stmt_update_pose_prior_, pose_prior.gravity, 7);
+    if (pose_prior.HasRotation()) {
+      const Eigen::Vector4d coeffs = pose_prior.sensor_from_world_rotation.coeffs();
+      WriteStaticMatrixBlob(sql_stmt_update_pose_prior_, coeffs, 8);
+    } else {
+      SQLITE3_CALL(sqlite3_bind_null(sql_stmt_update_pose_prior_, 8));
+    }
+    if (pose_prior.HasRotationCov()) {
+      WriteStaticMatrixBlob(
+          sql_stmt_update_pose_prior_, pose_prior.rotation_covariance, 9);
+    } else {
+      SQLITE3_CALL(sqlite3_bind_null(sql_stmt_update_pose_prior_, 9));
+    }
     SQLITE3_CALL(sqlite3_bind_int64(
-        sql_stmt_update_pose_prior_, 8, pose_prior.pose_prior_id));
+        sql_stmt_update_pose_prior_, 10, pose_prior.pose_prior_id));
 
     SQLITE3_CALL(sqlite3_step(sql_stmt_update_pose_prior_));
   }
@@ -1707,7 +1747,8 @@ class SqliteDatabase : public Database {
     prepare_sql_stmt(
         "UPDATE pose_priors SET corr_data_id=?, corr_sensor_id=?, "
         "corr_sensor_type=?, position=?, position_covariance=?, "
-        "coordinate_system=?, gravity=? WHERE pose_prior_id=?;",
+        "coordinate_system=?, gravity=?, rotation=?, rotation_covariance=? "
+        "WHERE pose_prior_id=?;",
         &sql_stmt_update_pose_prior_);
     prepare_sql_stmt(
         "UPDATE keypoints SET rows=?, cols=?, data=? WHERE image_id=?;",
@@ -1779,12 +1820,14 @@ class SqliteDatabase : public Database {
         &sql_stmt_read_images_);
     prepare_sql_stmt(
         "SELECT pose_prior_id, corr_data_id, corr_sensor_id, corr_sensor_type, "
-        "position, position_covariance, coordinate_system, gravity FROM "
+        "position, position_covariance, coordinate_system, gravity, rotation, "
+        "rotation_covariance FROM "
         "pose_priors WHERE pose_prior_id = ?;",
         &sql_stmt_read_pose_prior_);
     prepare_sql_stmt(
         "SELECT pose_prior_id, corr_data_id, corr_sensor_id, corr_sensor_type, "
-        "position, position_covariance, coordinate_system, gravity FROM "
+        "position, position_covariance, coordinate_system, gravity, rotation, "
+        "rotation_covariance FROM "
         "pose_priors;",
         &sql_stmt_read_pose_priors_);
     prepare_sql_stmt(
@@ -1840,7 +1883,8 @@ class SqliteDatabase : public Database {
     prepare_sql_stmt(
         "INSERT INTO pose_priors(pose_prior_id, corr_data_id, corr_sensor_id, "
         "corr_sensor_type, position, position_covariance, coordinate_system, "
-        "gravity) VALUES(?, ?, ?, ?, ?, ?, ?, ?);",
+        "gravity, rotation, rotation_covariance) "
+        "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
         &sql_stmt_write_pose_prior_);
     prepare_sql_stmt(
         "INSERT INTO keypoints(image_id, rows, cols, data) VALUES(?, ?, ?, ?);",
@@ -1998,7 +2042,9 @@ class SqliteDatabase : public Database {
         "    position                   BLOB,"
         "    position_covariance        BLOB,"
         "    gravity                    BLOB,"
-        "    coordinate_system          INTEGER               NOT NULL);"
+        "    coordinate_system          INTEGER               NOT NULL,"
+        "    rotation                   BLOB,"
+        "    rotation_covariance        BLOB);"
         "CREATE UNIQUE INDEX IF NOT EXISTS pose_prior_data_assignment ON "
         "   pose_priors(corr_data_id, corr_sensor_id, corr_sensor_type);";
 
@@ -2242,6 +2288,23 @@ class SqliteDatabase : public Database {
                                   static_cast<int>(FeatureExtractorType::SIFT))
                          .c_str(),
                      nullptr);
+      }
+    }
+
+    // Rotation prior columns on pose_priors. Added by the aperture fork to
+    // carry per-image orientation priors (e.g. compass heading on
+    // streetview panoramas) alongside position priors.
+    if (ExistsTable("pose_priors")) {
+      if (!ExistsColumn("pose_priors", "rotation")) {
+        SQLITE3_EXEC(database_,
+                     "ALTER TABLE pose_priors ADD COLUMN rotation BLOB;",
+                     nullptr);
+      }
+      if (!ExistsColumn("pose_priors", "rotation_covariance")) {
+        SQLITE3_EXEC(
+            database_,
+            "ALTER TABLE pose_priors ADD COLUMN rotation_covariance BLOB;",
+            nullptr);
       }
     }
 

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -98,7 +98,8 @@ MAKE_ENUM_CLASS_OVERLOAD_STREAM(CameraModelId,
                                 kSimpleDivision,          // = 12
                                 kDivision,                // = 13
                                 kSimpleFisheye,           // = 14
-                                kFisheye                  // = 15
+                                kFisheye,                 // = 15
+                                kSphere                   // = 16
 );
 
 #ifndef CAMERA_MODEL_DEFINITIONS
@@ -169,7 +170,8 @@ MAKE_ENUM_CLASS_OVERLOAD_STREAM(CameraModelId,
   CAMERA_MODEL_CASE(SimpleDivisionCameraModel)      \
   CAMERA_MODEL_CASE(DivisionCameraModel)            \
   CAMERA_MODEL_CASE(SimpleFisheyeCameraModel)       \
-  CAMERA_MODEL_CASE(FisheyeCameraModel)
+  CAMERA_MODEL_CASE(FisheyeCameraModel)              \
+  CAMERA_MODEL_CASE(SphereCameraModel)
 #endif
 
 #ifndef CAMERA_MODEL_SWITCH_CASES
@@ -239,6 +241,35 @@ struct BaseCameraModel {
   static inline bool IterativeUndistortion(const double* params,
                                            double* u,
                                            double* v);
+
+  // Unproject a pixel to a unit bearing vector in the camera frame.
+  //
+  // Default implementation: delegates to CameraModel::CamFromImg and
+  // normalizes the resulting homogeneous coordinate. Correct for perspective
+  // and fisheye-with-FOV<=180° cameras — the returned ray always has rz > 0.
+  //
+  // Omnidirectional camera models (notably SPHERE) override this to produce
+  // rays in any direction of the full sphere. Downstream geometry code should
+  // prefer CamFromImgRay over the 2D CamFromImg whenever a 3D bearing is
+  // needed, since the 2D (u, v, 1) representation cannot encode rays with
+  // rz <= 0.
+  static inline bool CamFromImgRay(const double* params,
+                                   double x,
+                                   double y,
+                                   double* rx,
+                                   double* ry,
+                                   double* rz) {
+    double u = 0;
+    double v = 0;
+    if (!CameraModel::CamFromImg(params, x, y, &u, &v)) {
+      return false;
+    }
+    const double norm = std::sqrt(u * u + v * v + 1.0);
+    *rx = u / norm;
+    *ry = v / norm;
+    *rz = 1.0 / norm;
+    return true;
+  }
 
  private:
   BaseCameraModel() = default;
@@ -555,6 +586,81 @@ struct FisheyeCameraModel : public BaseFisheyeCameraModel<FisheyeCameraModel> {
   FISHEYE_CAMERA_MODEL_DEFINITIONS
 };
 
+// Equirectangular spherical panorama camera model.
+//
+// Projects 3D points in the camera frame onto a 2:1 aspect-ratio
+// equirectangular image plane. The full 4π steradians of the sphere are
+// representable in the forward projection direction (ImgFromCam). The inverse
+// direction (CamFromImg) is restricted to the forward hemisphere (Z > 0)
+// because the legacy 2D normalized-coordinate representation (u = X/Z,
+// v = Y/Z) cannot encode directions with Z <= 0. Back-hemisphere features
+// require the CamFromImgRay bearing-vector extension (separate change).
+//
+// Camera frame convention: +X right, +Y down, +Z forward (COLMAP standard).
+// Image layout: u axis (column) = azimuth, center column (x = W/2) looks
+// along +Z. v axis (row) = elevation, center row (y = H/2) is the equator,
+// y = 0 is the zenith (-Y), y = H is the nadir (+Y).
+//
+// Parameters: `width, height` — the rendered equirectangular image size in
+// pixels. There is no focal length or distortion; an equirectangular
+// projection is fully specified by the image resolution.
+//
+// Parameter list:
+//
+//    w, h
+//
+struct SphereCameraModel : public BaseCameraModel<SphereCameraModel> {
+  CAMERA_MODEL_DEFINITIONS(CameraModelId::kSphere, "SPHERE", 0, 0, 2, false)
+
+  // Override BaseCameraModel: the only parameters are image dimensions —
+  // always valid by construction — so the generic bogus-focal / bogus-extra
+  // checks don't apply.
+  template <typename T>
+  static inline bool HasBogusParams(const std::vector<T>& params,
+                                    size_t width,
+                                    size_t height,
+                                    T min_focal_length_ratio,
+                                    T max_focal_length_ratio,
+                                    T max_extra_param) {
+    (void)params;
+    (void)width;
+    (void)height;
+    (void)min_focal_length_ratio;
+    (void)max_focal_length_ratio;
+    (void)max_extra_param;
+    return false;
+  }
+
+  // Override BaseCameraModel: SPHERE has no focal length. Convert pixel
+  // thresholds to normalized-camera-coord thresholds using the angular
+  // resolution at the equator (2π rad per W pixels in azimuth).
+  template <typename T>
+  static inline T CamFromImgThreshold(const T* params, T threshold) {
+    return threshold * T(2.0 * M_PI) / params[0];
+  }
+
+  // Override BaseCameraModel: the default CamFromImgRay goes through the 2D
+  // CamFromImg which fails for back-hemisphere pixels. SPHERE can produce
+  // valid unit bearings for any pixel in the equirectangular image, so we
+  // compute the ray directly from the azimuth/elevation parametrization.
+  static inline bool CamFromImgRay(const double* params,
+                                   double x,
+                                   double y,
+                                   double* rx,
+                                   double* ry,
+                                   double* rz) {
+    const double width = params[0];
+    const double height = params[1];
+    const double theta = 2.0 * M_PI * (x / width - 0.5);
+    const double phi = M_PI * (0.5 - y / height);
+    const double cos_phi = std::cos(phi);
+    *rx = cos_phi * std::sin(theta);
+    *ry = -std::sin(phi);
+    *rz = cos_phi * std::cos(theta);
+    return true;
+  }
+};
+
 // Check whether camera model with given name or identifier exists.
 bool ExistsCameraModelWithName(const std::string& model_name);
 bool ExistsCameraModelWithId(CameraModelId model_id);
@@ -653,6 +759,27 @@ inline std::optional<Eigen::Vector2d> CameraModelImgFromCam(
 //
 // @return              Output ray in camera frame (u, v, w).
 inline std::optional<Eigen::Vector2d> CameraModelCamFromImg(
+    CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector2d& xy);
+
+// Unproject a pixel to a unit 3D bearing vector in the camera frame.
+//
+// Unlike `CameraModelCamFromImg` (limited to the forward hemisphere via the
+// 2D normalized-coordinate representation), this function returns a valid
+// bearing for any pixel the camera model can unproject — including back-
+// facing rays for omnidirectional (SPHERE) cameras.
+//
+// Prefer this over `CameraModelCamFromImg` followed by homogeneous +
+// normalize when downstream code needs a 3D ray.
+//
+// @param model_id      Unique identifier of camera model.
+// @param params        Array of camera parameters.
+// @param xy            Image coordinates in pixels.
+//
+// @return              Unit bearing vector in camera frame, or std::nullopt
+//                      if unprojection fails.
+inline std::optional<Eigen::Vector3d> CameraModelCamFromImgRay(
     CameraModelId model_id,
     const std::vector<double>& params,
     const Eigen::Vector2d& xy);
@@ -2335,6 +2462,95 @@ bool FisheyeCameraModel::CamFromImg(
   return true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// SphereCameraModel
+
+std::string SphereCameraModel::InitializeParamsInfo() { return "w, h"; }
+
+std::array<size_t, 0> SphereCameraModel::InitializeFocalLengthIdxs() {
+  return {};
+}
+
+std::array<size_t, 0> SphereCameraModel::InitializePrincipalPointIdxs() {
+  return {};
+}
+
+std::array<size_t, 2> SphereCameraModel::InitializeExtraParamsIdxs() {
+  return {0, 1};
+}
+
+std::vector<double> SphereCameraModel::InitializeParams(
+    const double /*focal_length*/, const size_t width, const size_t height) {
+  // focal_length is ignored: an equirectangular projection is fully specified
+  // by the image dimensions.
+  return {static_cast<double>(width), static_cast<double>(height)};
+}
+
+// Projects camera-frame point (u, v, w) onto the equirectangular image plane.
+// Unlike pinhole/fisheye models that require w > 0, SPHERE accepts any non-
+// zero direction — all 4π sr of the sphere are representable.
+template <typename T>
+bool SphereCameraModel::ImgFromCam(
+    const T* params, const T& u, const T& v, const T& w, T* x, T* y) {
+  const T width = params[0];
+  const T height = params[1];
+
+  const T horizontal = ceres::sqrt(u * u + w * w);
+  // Degenerate: zero direction vector.
+  if (horizontal + ceres::abs(v) <
+      T(std::numeric_limits<double>::epsilon())) {
+    return false;
+  }
+
+  // Azimuth θ ∈ (-π, π], measured from +Z axis (forward). +X is θ = +π/2.
+  const T theta = ceres::atan2(u, w);
+  // Elevation φ ∈ [-π/2, π/2], measured from the equator. -Y (up) is +π/2.
+  const T phi = ceres::atan2(-v, horizontal);
+
+  *x = (theta / T(2.0 * M_PI) + T(0.5)) * width;
+  *y = (T(0.5) - phi / T(M_PI)) * height;
+  return true;
+}
+
+// Inverse equirectangular projection. Returns the normalized camera
+// coordinates (u = X/Z, v = Y/Z) of the pixel's ray, valid only when the ray
+// falls in the forward hemisphere (Z > 0). Back-hemisphere pixels return
+// false; a 3D bearing-vector interface (CamFromImgRay, planned separately)
+// will support them.
+bool SphereCameraModel::CamFromImg(
+    const double* params, double x, double y, double* u, double* v) {
+  const double width = params[0];
+  const double height = params[1];
+
+  const double theta = 2.0 * M_PI * (x / width - 0.5);
+  const double phi = M_PI * (0.5 - y / height);
+
+  const double cos_phi = std::cos(phi);
+  const double rx = cos_phi * std::sin(theta);
+  const double ry = -std::sin(phi);
+  const double rz = cos_phi * std::cos(theta);
+
+  if (rz <= std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  *u = rx / rz;
+  *v = ry / rz;
+  return true;
+}
+
+// SPHERE has no lens distortion. The macro declares a Distortion function;
+// this no-op satisfies the interface.
+template <typename T>
+void SphereCameraModel::Distortion(const T* /*extra_params*/,
+                                   const T& /*u*/,
+                                   const T& /*v*/,
+                                   T* du,
+                                   T* dv) {
+  *du = T(0);
+  *dv = T(0);
+}
+
 std::optional<Eigen::Vector2d> CameraModelImgFromCam(
     const CameraModelId model_id,
     const std::vector<double>& params,
@@ -2368,6 +2584,40 @@ std::optional<Eigen::Vector2d> CameraModelCamFromImg(
             params.data(), xy.x(), xy.y(), &uv.x(), &uv.y())) { \
       return uv;                                                \
     }                                                           \
+    break;
+
+    CAMERA_MODEL_SWITCH_CASES
+
+#undef CAMERA_MODEL_CASE
+  }
+  return std::nullopt;
+}
+
+// Unproject a pixel to a unit bearing vector in camera coordinates.
+//
+// Unlike CameraModelCamFromImg (which is limited to the forward hemisphere
+// via the 2D normalized-coordinate representation), this function returns a
+// valid 3D unit ray for any pixel on the camera model's image plane,
+// including back-facing rays on omnidirectional (SPHERE) cameras.
+//
+// Downstream geometry code (two-view geometry, absolute/relative pose,
+// triangulation) should prefer this function when a 3D bearing is needed.
+std::optional<Eigen::Vector3d> CameraModelCamFromImgRay(
+    const CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector2d& xy) {
+  Eigen::Vector3d ray;
+  switch (model_id) {
+#define CAMERA_MODEL_CASE(CameraModel)                 \
+  case CameraModel::model_id:                          \
+    if (CameraModel::CamFromImgRay(params.data(),      \
+                                   xy.x(),             \
+                                   xy.y(),             \
+                                   &ray.x(),           \
+                                   &ray.y(),           \
+                                   &ray.z())) {        \
+      return ray;                                      \
+    }                                                  \
     break;
 
     CAMERA_MODEL_SWITCH_CASES

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -380,5 +380,259 @@ TEST(FisheyeCamera, Nominal) {
   TestModel<FisheyeCameraModel>({651.123, 655.123, 386.123, 511.123});
 }
 
+// SphereCameraModel tests. SPHERE has no focal length or principal point —
+// its only parameters are the image dimensions — so the generic TestModel
+// helper doesn't apply. We test its invariants directly.
+
+TEST(Sphere, Metadata) {
+  const std::vector<double> params = {4096.0, 2048.0};
+
+  EXPECT_TRUE(CameraModelVerifyParams(SphereCameraModel::model_id, params));
+  EXPECT_EQ(CameraModelParamsInfo(SphereCameraModel::model_id),
+            SphereCameraModel::params_info);
+  EXPECT_EQ(SphereCameraModel::num_params, 2u);
+  EXPECT_EQ(SphereCameraModel::focal_length_idxs.size(), 0u);
+  EXPECT_EQ(SphereCameraModel::principal_point_idxs.size(), 0u);
+  EXPECT_EQ(SphereCameraModel::extra_params_idxs.size(), 2u);
+
+  EXPECT_TRUE(ExistsCameraModelWithName("SPHERE"));
+  EXPECT_EQ(CameraModelNameToId("SPHERE"), SphereCameraModel::model_id);
+  EXPECT_EQ(CameraModelIdToName(SphereCameraModel::model_id), "SPHERE");
+
+  const std::vector<double> init_params =
+      CameraModelInitializeParams(SphereCameraModel::model_id, 100, 4096, 2048);
+  EXPECT_EQ(init_params, std::vector<double>({4096.0, 2048.0}));
+
+  // HasBogusParams is overridden to always return false for SPHERE (the only
+  // parameters are image dimensions, always valid by construction).
+  EXPECT_FALSE(CameraModelHasBogusParams(
+      SphereCameraModel::model_id, params, 4096, 2048, 0.1, 2.0, 1.0));
+}
+
+TEST(Sphere, CardinalDirections) {
+  const std::vector<double> params = {4096.0, 2048.0};
+  double x = 0, y = 0;
+
+  // Forward (+Z) -> image center.
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), 0.0, 0.0, 1.0, &x, &y));
+  EXPECT_NEAR(x, 2048.0, 1e-9);
+  EXPECT_NEAR(y, 1024.0, 1e-9);
+
+  // Right (+X) -> column 3W/4.
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), 1.0, 0.0, 0.0, &x, &y));
+  EXPECT_NEAR(x, 3072.0, 1e-9);
+  EXPECT_NEAR(y, 1024.0, 1e-9);
+
+  // Left (-X) -> column W/4.
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), -1.0, 0.0, 0.0, &x, &y));
+  EXPECT_NEAR(x, 1024.0, 1e-9);
+  EXPECT_NEAR(y, 1024.0, 1e-9);
+
+  // Up (-Y) -> row 0 (top).
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), 0.0, -1.0, 0.0, &x, &y));
+  EXPECT_NEAR(x, 2048.0, 1e-9);
+  EXPECT_NEAR(y, 0.0, 1e-9);
+
+  // Down (+Y) -> row H (bottom).
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), 0.0, 1.0, 0.0, &x, &y));
+  EXPECT_NEAR(x, 2048.0, 1e-9);
+  EXPECT_NEAR(y, 2048.0, 1e-9);
+
+  // Back (-Z) -> column 0 or W (image wraps).
+  ASSERT_TRUE(
+      SphereCameraModel::ImgFromCam(params.data(), 0.0, 0.0, -1.0, &x, &y));
+  EXPECT_TRUE(std::abs(x) < 1e-9 || std::abs(x - 4096.0) < 1e-9);
+  EXPECT_NEAR(y, 1024.0, 1e-9);
+
+  // Zero vector -> rejected.
+  EXPECT_FALSE(
+      SphereCameraModel::ImgFromCam(params.data(), 0.0, 0.0, 0.0, &x, &y));
+}
+
+TEST(Sphere, RoundTripFrontHemisphere) {
+  // ImgFromCam -> CamFromImg -> reconstructed ray.
+  // CamFromImg is limited to the forward hemisphere (Z > 0) via the 2D
+  // normalized-coordinate API, so restrict the sampled grid accordingly.
+  const std::vector<double> params = {4096.0, 2048.0};
+  int samples = 0;
+  // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
+  for (double u = -0.8; u <= 0.8; u += 0.2) {
+    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
+    for (double v = -0.8; v <= 0.8; v += 0.2) {
+      for (const double w : {0.5, 1.0, 2.0}) {
+        double x = 0, y = 0;
+        ASSERT_TRUE(
+            SphereCameraModel::ImgFromCam(params.data(), u, v, w, &x, &y));
+        double un = 0, vn = 0;
+        ASSERT_TRUE(
+            SphereCameraModel::CamFromImg(params.data(), x, y, &un, &vn));
+        // (un, vn, 1) normalized must match (u, v, w) normalized.
+        const double norm_uvw = std::sqrt(u * u + v * v + w * w);
+        const double norm_n = std::sqrt(un * un + vn * vn + 1.0);
+        EXPECT_NEAR(un / norm_n, u / norm_uvw, 1e-9);
+        EXPECT_NEAR(vn / norm_n, v / norm_uvw, 1e-9);
+        EXPECT_NEAR(1.0 / norm_n, w / norm_uvw, 1e-9);
+        ++samples;
+      }
+    }
+  }
+  EXPECT_GT(samples, 0);
+}
+
+TEST(Sphere, CamFromImgRejectsBackHemisphere) {
+  // Pixels near the horizontal edges of the image correspond to rays in the
+  // back hemisphere (Z <= 0). The 2D normalized-coord interface cannot
+  // represent those rays, so CamFromImg must return false.
+  const std::vector<double> params = {4096.0, 2048.0};
+  double u = 0, v = 0;
+  EXPECT_FALSE(SphereCameraModel::CamFromImg(params.data(), 10.0, 1024.0, &u, &v));
+  EXPECT_FALSE(
+      SphereCameraModel::CamFromImg(params.data(), 4090.0, 1024.0, &u, &v));
+  // Image center -> forward ray -> (0, 0) in normalized coords.
+  ASSERT_TRUE(
+      SphereCameraModel::CamFromImg(params.data(), 2048.0, 1024.0, &u, &v));
+  EXPECT_NEAR(u, 0.0, 1e-9);
+  EXPECT_NEAR(v, 0.0, 1e-9);
+}
+
+TEST(Sphere, CamFromImgThresholdIsAngular) {
+  // For a W=4096 panorama, 1 pixel at the equator corresponds to
+  // 2π / 4096 ≈ 0.00153 radians of azimuth.
+  const std::vector<double> params = {4096.0, 2048.0};
+  const double threshold_1px = CameraModelCamFromImgThreshold(
+      SphereCameraModel::model_id, params, 1.0);
+  EXPECT_NEAR(threshold_1px, 2.0 * M_PI / 4096.0, 1e-12);
+
+  const double threshold_4px = CameraModelCamFromImgThreshold(
+      SphereCameraModel::model_id, params, 4.0);
+  EXPECT_NEAR(threshold_4px, 4.0 * threshold_1px, 1e-12);
+}
+
+TEST(Sphere, CamFromImgRayFullSphere) {
+  // ImgFromCam -> CamFromImgRay should round-trip for ANY direction (all 4π
+  // sr), unlike the 2D CamFromImg path which only covers the forward
+  // hemisphere.
+  const std::vector<double> params = {4096.0, 2048.0};
+  int samples = 0;
+  for (int ix = -5; ix <= 5; ++ix) {
+    for (int iy = -5; iy <= 5; ++iy) {
+      for (int iz = -5; iz <= 5; ++iz) {
+        const double u = ix * 0.1;
+        const double v = iy * 0.1;
+        const double w = iz * 0.1;
+        const double norm = std::sqrt(u * u + v * v + w * w);
+        if (norm < 1e-6) continue;
+        double x = 0, y = 0;
+        ASSERT_TRUE(
+            SphereCameraModel::ImgFromCam(params.data(), u, v, w, &x, &y));
+        const std::optional<Eigen::Vector3d> ray = CameraModelCamFromImgRay(
+            SphereCameraModel::model_id, params, Eigen::Vector2d(x, y));
+        ASSERT_TRUE(ray.has_value());
+        // Ray should be unit-length and parallel to the input direction.
+        EXPECT_NEAR(ray->norm(), 1.0, 1e-12);
+        EXPECT_NEAR(ray->x(), u / norm, 1e-9);
+        EXPECT_NEAR(ray->y(), v / norm, 1e-9);
+        EXPECT_NEAR(ray->z(), w / norm, 1e-9);
+        ++samples;
+      }
+    }
+  }
+  EXPECT_GT(samples, 0);
+}
+
+TEST(Sphere, CamFromImgRayBackHemisphere) {
+  // Back-hemisphere pixels fail via the 2D CamFromImg path but produce valid
+  // unit rays via CamFromImgRay. This is the key reason for the new
+  // interface.
+  const std::vector<double> params = {4096.0, 2048.0};
+  double u = 0, v = 0;
+  // Near the left edge -> ray points backward.
+  EXPECT_FALSE(
+      SphereCameraModel::CamFromImg(params.data(), 10.0, 1024.0, &u, &v));
+  const std::optional<Eigen::Vector3d> ray = CameraModelCamFromImgRay(
+      SphereCameraModel::model_id, params, Eigen::Vector2d(10.0, 1024.0));
+  ASSERT_TRUE(ray.has_value());
+  EXPECT_NEAR(ray->norm(), 1.0, 1e-12);
+  EXPECT_LT(ray->z(), 0.0);  // back hemisphere
+}
+
+// Default CamFromImgRay for perspective models should match the legacy
+// CamFromImg -> homogeneous -> normalized conversion path used everywhere
+// else in the codebase before this interface existed.
+TEST(Perspective, CamFromImgRayMatchesLegacy) {
+  struct Case {
+    CameraModelId id;
+    std::vector<double> params;
+    const char* name;
+  };
+  const Case cases[] = {
+      {SimplePinholeCameraModel::model_id,
+       {655.123, 386.123, 511.123},
+       "SimplePinhole"},
+      {PinholeCameraModel::model_id,
+       {651.123, 655.123, 386.123, 511.123},
+       "Pinhole"},
+      {SimpleRadialCameraModel::model_id,
+       {651.123, 386.123, 511.123, 0.1},
+       "SimpleRadial"},
+      {OpenCVCameraModel::model_id,
+       {651.123, 655.123, 386.123, 511.123, -0.471, 0.223, -0.001, 0.001},
+       "OpenCV"},
+  };
+  for (const auto& c : cases) {
+    for (int xi = 100; xi <= 700; xi += 100) {
+      for (int yi = 100; yi <= 700; yi += 100) {
+        const Eigen::Vector2d xy(xi, yi);
+        const std::optional<Eigen::Vector3d> ray =
+            CameraModelCamFromImgRay(c.id, c.params, xy);
+        const std::optional<Eigen::Vector2d> cam_point =
+            CameraModelCamFromImg(c.id, c.params, xy);
+        ASSERT_EQ(ray.has_value(), cam_point.has_value())
+            << c.name << " at (" << xi << "," << yi << ")";
+        if (ray.has_value()) {
+          const Eigen::Vector3d expected =
+              cam_point->homogeneous().normalized();
+          EXPECT_NEAR(ray->x(), expected.x(), 1e-12) << c.name;
+          EXPECT_NEAR(ray->y(), expected.y(), 1e-12) << c.name;
+          EXPECT_NEAR(ray->z(), expected.z(), 1e-12) << c.name;
+          EXPECT_NEAR(ray->norm(), 1.0, 1e-12) << c.name;
+        }
+      }
+    }
+  }
+}
+
+TEST(Sphere, ImgFromCamHandlesAllDirections) {
+  // ImgFromCam must accept any non-zero direction, including Z <= 0
+  // (unlike pinhole/fisheye which require the point to be in front of the
+  // camera). This is a key property of the spherical camera.
+  const std::vector<double> params = {4096.0, 2048.0};
+  const double directions[][3] = {
+      {0, 0, 1},    // forward
+      {0, 0, -1},   // backward  <-- would fail for pinhole
+      {1, 0, 0},    // right
+      {-1, 0, 0},   // left
+      {0, 1, 0},    // down
+      {0, -1, 0},   // up
+      {1, 1, 1},    // diagonal
+      {-1, -1, -1}, // diagonal, back
+  };
+  for (const auto& d : directions) {
+    double x = 0, y = 0;
+    EXPECT_TRUE(SphereCameraModel::ImgFromCam(
+        params.data(), d[0], d[1], d[2], &x, &y))
+        << "direction (" << d[0] << ", " << d[1] << ", " << d[2] << ")";
+    EXPECT_GE(x, 0.0);
+    EXPECT_LE(x, 4096.0);
+    EXPECT_GE(y, 0.0);
+    EXPECT_LE(y, 2048.0);
+  }
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1145,6 +1145,12 @@ bool IncrementalMapper::AdjustGlobalBundle(
     }
     prior_options.ceres->prior_position_loss_scale =
         options.prior_position_loss_scale;
+    if (options.use_robust_loss_on_prior_rotation) {
+      prior_options.ceres->prior_rotation_loss_function_type =
+          CeresBundleAdjustmentOptions::LossFunctionType::CAUCHY;
+    }
+    prior_options.ceres->prior_rotation_loss_scale =
+        options.prior_rotation_loss_scale;
     prior_options.alignment_ransac_options.random_seed = options.random_seed;
     bundle_adjuster =
         CreatePosePriorBundleAdjuster(custom_ba_options,

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -149,6 +149,14 @@ class IncrementalMapper {
     // (chi2 for 3DOF at 95% = 7.815)
     double prior_position_loss_scale = 7.815;
 
+    // Whether to use a robust (Cauchy) loss on prior rotation. When false the
+    // rotation residual uses trivial (L2) loss.
+    bool use_robust_loss_on_prior_rotation = false;
+
+    // Threshold on the residual for the robust rotation loss. Same 3-DoF 95%
+    // chi-square as the position default.
+    double prior_rotation_loss_scale = 7.815;
+
     // Number of threads.
     int num_threads = -1;
 


### PR DESCRIPTION
# Add SPHERE equirectangular camera model with CamFromImgRay and sphere_to_cubic


## Summary

Adds a `SPHERE` (equirectangular panorama) camera model to COLMAP 4.x and the supporting 3D-bearing-vector ingress + triangulation path, so full-360° panoramas can be reconstructed natively through the existing sparse + dense pipeline (including GLOMAP). Also adds `sphere_to_cubic`, the handoff tool that bridges SPHERE sparse reconstructions into the standard pinhole dense MVS stack (`image_undistorter` → `patch_match_stereo` → `stereo_fusion`, or OpenMVS `InterfaceCOLMAP`).

Validated end-to-end on a real-world dataset (101 Cyclomedia equirectangular streetview panoramas of Philadelphia Center City): **101/101 images registered in a single unified sparse model with 10,778 points via `global_mapper` (GLOMAP), handed off through `sphere_to_cubic` to `image_undistorter` + `patch_match_stereo` + `stereo_fusion`, producing a 1.74M-point dense cloud in ~70 minutes on a single Tesla T4 GPU.** Same-dataset baseline via the SphereSfM fork (COLMAP 3.8) reaches only 68/101 across 2 disjoint fragments with 1,441 sparse points and no dense handoff.

## Commits (6)

1. **`Add SPHERE equirectangular camera model and CamFromImgRay interface`**
   - New `SphereCameraModel` (`CameraModelId::kSphere = 16`, model name `SPHERE`). Parameters are `(width, height)` — an equirectangular projection is fully specified by the image dimensions, no focal length or distortion.
   - `ImgFromCam` accepts any non-zero 3D direction (full 4π steradians, unlike pinhole/fisheye which require w > 0).
   - `CamFromImg` returns 2D normalized coords for the forward hemisphere only — the 2D `(u, v, 1)` representation cannot encode rays with Z ≤ 0, which is why the next change adds a 3D bearing-vector interface.
   - New `CamFromImgRay` method added to `BaseCameraModel` (default: `CamFromImg` → `homogeneous().normalized()`, bit-equivalent to the pattern that existed throughout the geometry code). `SphereCameraModel` overrides it to return valid unit bearings for any pixel in the panorama, including the back hemisphere.
   - Overrides `HasBogusParams` (params are image dimensions, always valid) and `CamFromImgThreshold` (no focal length; uses angular resolution at the equator).
   - Tests in `src/colmap/sensor/models_test.cc`: 9 new tests covering metadata, cardinal directions, round-trips over the forward hemisphere and full sphere, back-hemisphere rejection, angular thresholds, and `Perspective.CamFromImgRayMatchesLegacy` — verifying the new default delegate is bit-equivalent to the pre-existing `CamFromImg(p)->homogeneous().normalized()` pattern across SimplePinhole, Pinhole, SimpleRadial, and OpenCV.

2. **`Migrate geometry estimators to 3D bearing CamFromImgRay ingress`**
   - Replaces `CamFromImg(p)->homogeneous().normalized()` with `CamFromImgRay(p)` at every 2D→3D ray conversion site in the geometry estimators: `two_view_geometry.cc` (6 sites), `generalized_pose.cc` (5 sites), `pose.cc` (1 site), `global_positioning.cc` (1 site).
   - No behavior change for perspective cameras — the default `BaseCameraModel::CamFromImgRay` delegates through the same math. For SPHERE and future omnidirectional models, this is the path that reaches back-hemisphere features.
   - `EstimateTwoViewGeometryPose` guards non-perspective cameras (cameras with zero `FocalLengthIdxs()`) to the CALIBRATED essential-matrix branch only. The UNCALIBRATED / PLANAR / PANORAMIC / PLANAR_OR_PANORAMIC branches call `camera.CalibrationMatrix()`, which is undefined when there is no pinhole K and used to SIGSEGV. The guard causes those pairs to be skipped rather than crash.

3. **`Skip F/H estimation for non-perspective cameras in two_view_geometry`**
   - Root-cause fix for why SPHERE pairs ended up in PLANAR / UNCALIBRATED configs in the first place: in `EstimateCalibratedTwoViewGeometry`, F and H were being estimated on raw pixel coordinates of the ERP image. But equirectangular pixels don't lie on a flat image plane, so F and H fit there are not geometrically meaningful — inliers are essentially accidental pattern matches.
   - When either camera in a pair has no focal-length parameter (SPHERE or any future omnidirectional model), the F/H RANSAC is skipped entirely and the pair is committed to CALIBRATED based on the bearing-vector essential-matrix inliers (which *are* correct for these cameras).
   - Measured on the Cyclomedia 101-panorama dataset:
     - CALIBRATED pairs: **1,028 → 3,343 (3.25×)**
     - UNDEFINED (failed geometric verification): 4,655 → 1,707 (−63%)
     - Matcher wall-clock: 8.7 min → 6.7 min (−23%)
     - No change in reconstruction quality at the GLOMAP output (101/101 registered both before and after, reprojection error unchanged).

4. **`Support bearing-vector triangulation for omnidirectional cameras`**
   - `geometry/triangulation.{h,cc}`: new overload `TriangulateMultiViewPoint(span<const Matrix3x4d>, span<const Vector3d>, Vector3d*)`. The existing projector-based DLT implementation already normalizes internally via `cam_point.homogeneous().normalized()`; the new overload consumes bearings directly. Equivalent for perspective cameras, correct for SPHERE (back-hemisphere rays can contribute).
   - `estimators/triangulation.{h,cc}`: adds `Eigen::Vector3d cam_ray` to `TriangulationEstimator::PointData` alongside the legacy `cam_point`. In `Estimate()`, detects whether any observation has a populated `cam_ray` and routes to the bearing-based overload; otherwise preserves the legacy 2D path exactly. Angular-error residual uses `cam_ray` directly.
   - `EstimateTriangulation` populates `cam_ray` via `Camera::CamFromImgRay` alongside the legacy `cam_point` via `Camera::CamFromImg`.
   - Two new tests in `src/colmap/geometry/triangulation_test.cc`: `TriangulateMultiViewPointFromBearings.NominalEquivalentTo2D` asserts bit-equivalence with the 2D overload on perspective correspondences; `.BackHemisphereRays` constructs a three-camera setup where all observations are in the back hemisphere and validates the bearing path triangulates the point correctly.

5. **`Add sphere_to_cubic subcommand for dense MVS handoff on SPHERE models`**
   - New `colmap sphere_to_cubic` subcommand in `src/colmap/exe/sphere.{h,cc}`.
   - Converts a SPHERE sparse reconstruction to a PINHOLE (cubic) reconstruction: six perspective cube faces (F/B/L/R/U/D, configurable size and FOV) rendered per panorama via bilinear ERP resampling, each with its own pose composed from the panorama pose and a canonical cube-face rotation. Track elements are reprojected onto whichever cube face contains them.
   - COLMAP 4.x `Rig` / `Frame` / `Reconstruction` integration: each face image lives in its own `Frame` belonging to a single shared single-sensor `Rig`.
   - On the Exp 8 dataset: 101 SPHERE images → 606 face images in ~90 s on the CPU; 42,133 observations reassigned (0 dropped), 10,778 / 10,778 points preserved, mean reprojection error unchanged at 0.00165. Subsequent `image_undistorter` + `patch_match_stereo` + `stereo_fusion` produces a 1.74M-point dense cloud (validated separately).
   - Equivalent in intent to SphereSfM's `sphere_cubic_reprojecer` but reimplemented fresh against the current COLMAP 4.x API rather than ported from 3.8.

6. **`Add unit tests for bearing-vector triangulation and cube-face geometry`**
   - Five new tests in `src/colmap/exe/sphere_test.cc` covering the cube-face rotations (count, orthogonality + det +1, canonical direction mapping, full-sphere coverage, forward-ray projects to face F center).
   - Refactor: exposes `SphereCubeFaceSpecs` / `SphereCubeFaceSpec` from `sphere.h` so tests can exercise the same rotation data used by the subcommand. `sphere.h` / `sphere.cc` now also live in the `colmap_exe` library (`COLMAP_EXE_SRCS`), matching the feature / sfm / model pattern.
   - Total `ctest` count: 145 → 147 (all passing).

## Validation

- Full `ctest` suite: **147 / 147 passing** (+2 from the baseline, for the new bearing-vector and cube-face tests; all existing tests unchanged).
- `src/colmap/sensor/models_test`: **25 / 25** (16 existing + 9 new), including the `Perspective.CamFromImgRayMatchesLegacy` cross-model equivalence check.
- End-to-end on 101 Cyclomedia ERP panoramas: `feature_extractor` → `exhaustive_matcher` → `global_mapper` (GLOMAP) → `sphere_to_cubic` → `image_undistorter` → `patch_match_stereo` → `stereo_fusion` produces a **1,740,836-point fused dense PLY** in ~70 min on a Tesla T4.

## Scope boundary / known follow-ups

- **PLANAR / PANORAMIC pose-from-homography for SPHERE**: 988 / 4,493 stored two-view geometries in the Exp 8 database end up in non-CALIBRATED configs under the pre-fix behavior because their H-on-ERP inliers outnumber E inliers. With commit 3 those configs are no longer produced for SPHERE pairs, so the issue disappears at the source; the decomposition-side guard in commit 2 remains as a defense-in-depth for legacy databases. A proper ray-based homography decomposition for omnidirectional cameras would let those pairs contribute again; scoped for a follow-up.
- **`SphereCameraModel` focal-length reporting**: the `feature_extractor` log line prints `Focal Length: -nanpx (Prior)` for SPHERE. Cosmetic only — downstream code correctly sees `FocalLengthIdxs().size() == 0`. A small conditional in `feature_extraction.cc` to skip the focal-length line for non-perspective cameras would clean this up.
- **Dense MVS on cube faces with no stereo neighbor**: on the Exp 8 run, 235 of 606 faces produce empty depth maps (predominantly U/D/B faces with sky / ground / no adjacent panorama behind). Expected, not a fork issue.

Happy to split into multiple smaller PRs if preferred — the commits are already logically independent.
