### PR TITLE
Add CamRayFromImg bearing-vector unprojection interface

### DIFF
--- a/src/colmap/estimators/generalized_pose.cc
+++ b/src/colmap/estimators/generalized_pose.cc
@@ -153,13 +153,9 @@ bool EstimateGeneralizedAbsolutePose(
   std::vector<GP3PEstimator::X_t> rig_points2D(points2D.size());
   for (size_t i = 0; i < points2D.size(); i++) {
     const size_t camera_idx = camera_idxs[i];
-    if (const std::optional<Eigen::Vector2d> cam_point =
-            cameras[camera_idx].CamFromImg(points2D[i]);
-        cam_point) {
-      rig_points2D[i].ray_in_cam = cam_point->homogeneous().normalized();
-    } else {
-      rig_points2D[i].ray_in_cam.setZero();
-    }
+    rig_points2D[i].ray_in_cam = cameras[camera_idx]
+                                     .CamRayFromImg(points2D[i])
+                                     .value_or(Eigen::Vector3d::Zero());
     rig_points2D[i].cam_from_rig = cams_from_rig_matrices[camera_idx];
   }
 
@@ -229,24 +225,16 @@ bool EstimateGeneralizedRelativePose(
     std::vector<Eigen::Vector3d> cam_rays2(num_points);
     for (size_t i = 0; i < num_points; ++i) {
       const size_t camera_idx1 = camera_idxs1[i];
-      if (const std::optional<Eigen::Vector2d> cam_point1 =
-              cameras[camera_idx1].CamFromImg(points2D1[i]);
-          cam_point1.has_value()) {
-        cam_rays1[i] = cams_from_rig[camera_idx1].rotation().inverse() *
-                       cam_point1->homogeneous().normalized();
-      } else {
-        cam_rays1[i].setZero();
-      }
+      cam_rays1[i] = cams_from_rig[camera_idx1].rotation().inverse() *
+                     cameras[camera_idx1]
+                         .CamRayFromImg(points2D1[i])
+                         .value_or(Eigen::Vector3d::Zero());
 
       const size_t camera_idx2 = camera_idxs2[i];
-      if (const std::optional<Eigen::Vector2d> cam_point2 =
-              cameras[camera_idxs2[i]].CamFromImg(points2D2[i]);
-          cam_point2.has_value()) {
-        cam_rays2[i] = cams_from_rig[camera_idx2].rotation().inverse() *
-                       cam_point2->homogeneous().normalized();
-      } else {
-        cam_rays2[i].setZero();
-      }
+      cam_rays2[i] = cams_from_rig[camera_idx2].rotation().inverse() *
+                     cameras[camera_idx2]
+                         .CamRayFromImg(points2D2[i])
+                         .value_or(Eigen::Vector3d::Zero());
     }
     if (EstimateRelativePose(normalized_ransac_options,
                              cam_rays1,
@@ -264,22 +252,14 @@ bool EstimateGeneralizedRelativePose(
   std::vector<GRNPObservation> points2(num_points);
   for (size_t i = 0; i < num_points; ++i) {
     points1[i].cam_from_rig = cams_from_rig[camera_idxs1[i]];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            cameras[camera_idxs1[i]].CamFromImg(points2D1[i]);
-        cam_point1.has_value()) {
-      points1[i].ray_in_cam = cam_point1->homogeneous().normalized();
-    } else {
-      points1[i].ray_in_cam.setZero();
-    }
+    points1[i].ray_in_cam = cameras[camera_idxs1[i]]
+                                .CamRayFromImg(points2D1[i])
+                                .value_or(Eigen::Vector3d::Zero());
 
     points2[i].cam_from_rig = cams_from_rig[camera_idxs2[i]];
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            cameras[camera_idxs2[i]].CamFromImg(points2D2[i]);
-        cam_point2.has_value()) {
-      points2[i].ray_in_cam = cam_point2->homogeneous().normalized();
-    } else {
-      points2[i].ray_in_cam.setZero();
-    }
+    points2[i].ray_in_cam = cameras[camera_idxs2[i]]
+                                .CamRayFromImg(points2D2[i])
+                                .value_or(Eigen::Vector3d::Zero());
   }
 
   LORANSAC<GR6PEstimator, GR8PEstimator> ransac(normalized_ransac_options);
@@ -475,22 +455,13 @@ bool EstimateStructureLessAbsolutePose(
   for (size_t i = 0; i < num_points; ++i) {
     const size_t world_camera_idx = world_camera_idxs[i];
     world_obs[i].cam_from_rig = world_cams_from_world[world_camera_idx];
-    if (const std::optional<Eigen::Vector2d> world_cam_point =
-            world_cameras[world_camera_idx].CamFromImg(world_points2D[i]);
-        world_cam_point.has_value()) {
-      world_obs[i].ray_in_cam = world_cam_point->homogeneous().normalized();
-    } else {
-      world_obs[i].ray_in_cam.setZero();
-    }
+    world_obs[i].ray_in_cam = world_cameras[world_camera_idx]
+                                  .CamRayFromImg(world_points2D[i])
+                                  .value_or(Eigen::Vector3d::Zero());
 
     query_obs[i].cam_from_rig = Rigid3d();
-    if (const std::optional<Eigen::Vector2d> query_cam_point =
-            query_camera.CamFromImg(query_points2D[i]);
-        query_cam_point.has_value()) {
-      query_obs[i].ray_in_cam = query_cam_point->homogeneous().normalized();
-    } else {
-      query_obs[i].ray_in_cam.setZero();
-    }
+    query_obs[i].ray_in_cam = query_camera.CamRayFromImg(query_points2D[i])
+                                  .value_or(Eigen::Vector3d::Zero());
   }
 
   auto custom_ransac_options = options.ransac_options;

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -174,10 +174,10 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     Image& image = reconstruction.Image(observation.image_id);
     if (!image.HasPose()) continue;
 
-    const std::optional<Eigen::Vector2d> cam_point =
-        image.CameraPtr()->CamFromImg(
+    const std::optional<Eigen::Vector3d> cam_ray =
+        image.CameraPtr()->CamRayFromImg(
             image.Point2D(observation.point2D_idx).xy);
-    if (!cam_point.has_value()) {
+    if (!cam_ray.has_value()) {
       LOG(WARNING)
           << "Ignoring feature because it failed to project: point3D_id="
           << point3D_id << ", image_id=" << observation.image_id
@@ -186,8 +186,7 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     }
 
     const Eigen::Vector3d cam_from_point3D_dir =
-        image.CamFromWorld().rotation().inverse() *
-        cam_point->homogeneous().normalized();
+        image.CamFromWorld().rotation().inverse() * (*cam_ray);
 
     CHECK_GE(scales_.capacity(), scales_.size())
         << "Not enough capacity was reserved for the scales.";

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -83,14 +83,8 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
     std::vector<P3PEstimator::X_t> points2D_with_rays(points2D.size());
     for (size_t i = 0; i < points2D.size(); ++i) {
       points2D_with_rays[i].image_point = points2D[i];
-      if (const std::optional<Eigen::Vector2d> cam_point =
-              camera->CamFromImg(points2D[i]);
-          cam_point) {
-        points2D_with_rays[i].camera_ray =
-            cam_point->homogeneous().normalized();
-      } else {
-        points2D_with_rays[i].camera_ray.setZero();
-      }
+      points2D_with_rays[i].camera_ray =
+          camera->CamRayFromImg(points2D[i]).value_or(Eigen::Vector3d::Zero());
     }
 
     ImgFromCamFunc img_from_cam_func =

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -493,20 +493,10 @@ void ExtractInlierCamRays(const Camera& camera1,
   inlier_cam_rays2->resize(inlier_matches.size());
   for (size_t i = 0; i < inlier_matches.size(); ++i) {
     const FeatureMatch& match = inlier_matches[i];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[match.point2D_idx1]);
-        cam_point1) {
-      (*inlier_cam_rays1)[i] = cam_point1->homogeneous().normalized();
-    } else {
-      (*inlier_cam_rays1)[i].setZero();
-    }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[match.point2D_idx2]);
-        cam_point2) {
-      (*inlier_cam_rays2)[i] = cam_point2->homogeneous().normalized();
-    } else {
-      (*inlier_cam_rays2)[i].setZero();
-    }
+    (*inlier_cam_rays1)[i] = camera1.CamRayFromImg(points1[match.point2D_idx1])
+                                 .value_or(Eigen::Vector3d::Zero());
+    (*inlier_cam_rays2)[i] = camera2.CamRayFromImg(points2[match.point2D_idx2])
+                                 .value_or(Eigen::Vector3d::Zero());
   }
 }
 
@@ -647,20 +637,10 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
     const point2D_t idx2 = matches[i].point2D_idx2;
     matched_img_points1[i] = points1[idx1];
     matched_img_points2[i] = points2[idx2];
-    if (const std::optional<Eigen::Vector2d> cam_point1 =
-            camera1.CamFromImg(points1[idx1]);
-        cam_point1) {
-      matched_cam_rays1[i] = cam_point1->homogeneous().normalized();
-    } else {
-      matched_cam_rays1[i].setZero();
-    }
-    if (const std::optional<Eigen::Vector2d> cam_point2 =
-            camera2.CamFromImg(points2[idx2]);
-        cam_point2) {
-      matched_cam_rays2[i] = cam_point2->homogeneous().normalized();
-    } else {
-      matched_cam_rays2[i].setZero();
-    }
+    matched_cam_rays1[i] =
+        camera1.CamRayFromImg(points1[idx1]).value_or(Eigen::Vector3d::Zero());
+    matched_cam_rays2[i] =
+        camera2.CamRayFromImg(points2[idx2]).value_or(Eigen::Vector3d::Zero());
   }
 
   // Estimate epipolar models.

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -131,6 +131,15 @@ struct Camera {
   inline std::optional<Eigen::Vector2d> CamFromImg(
       const Eigen::Vector2d& image_point) const;
 
+  // Unproject a pixel to a unit 3D bearing vector in the camera frame.
+  //
+  // Unlike CamFromImg (which returns a 2D normalized coordinate and is
+  // therefore limited to the forward hemisphere), this works for any pixel
+  // the camera model can unproject — including back-facing rays on
+  // omnidirectional cameras.
+  inline std::optional<Eigen::Vector3d> CamRayFromImg(
+      const Eigen::Vector2d& image_point) const;
+
   // Convert pixel threshold in image plane to camera frame.
   inline double CamFromImgThreshold(double threshold) const;
 
@@ -262,6 +271,11 @@ bool Camera::HasBogusParams(const double min_focal_length_ratio,
 std::optional<Eigen::Vector2d> Camera::CamFromImg(
     const Eigen::Vector2d& image_point) const {
   return CameraModelCamFromImg(model_id, params, image_point);
+}
+
+std::optional<Eigen::Vector3d> Camera::CamRayFromImg(
+    const Eigen::Vector2d& image_point) const {
+  return CameraModelCamRayFromImg(model_id, params, image_point);
 }
 
 double Camera::CamFromImgThreshold(const double threshold) const {

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -242,6 +242,34 @@ struct BaseCameraModel {
                                            double* u,
                                            double* v);
 
+  // Unproject a pixel to a unit bearing vector in the camera frame.
+  //
+  // Default implementation: delegates to CameraModel::CamFromImg and
+  // normalizes the resulting homogeneous coordinate. Correct for perspective
+  // and fisheye-with-FOV<=180° cameras — the returned ray always has rz > 0.
+  //
+  // Omnidirectional camera models override this to produce rays in any
+  // direction of the full sphere. Downstream geometry code should prefer
+  // CamRayFromImg over the 2D CamFromImg whenever a 3D bearing is needed,
+  // since the 2D (u, v, 1) representation cannot encode rays with rz <= 0.
+  static inline bool CamRayFromImg(const double* params,
+                                   double x,
+                                   double y,
+                                   double* rx,
+                                   double* ry,
+                                   double* rz) {
+    double u = 0;
+    double v = 0;
+    if (!CameraModel::CamFromImg(params, x, y, &u, &v)) {
+      return false;
+    }
+    const double norm = std::sqrt(u * u + v * v + 1.0);
+    *rx = u / norm;
+    *ry = v / norm;
+    *rz = 1.0 / norm;
+    return true;
+  }
+
  private:
   BaseCameraModel() = default;
   friend CameraModel;
@@ -674,6 +702,27 @@ inline std::optional<Eigen::Vector2d> CameraModelImgFromCam(
 //
 // @return              Output ray in camera frame (u, v, w).
 inline std::optional<Eigen::Vector2d> CameraModelCamFromImg(
+    CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector2d& xy);
+
+// Unproject a pixel to a unit 3D bearing vector in the camera frame.
+//
+// Unlike `CameraModelCamFromImg` (limited to the forward hemisphere via the
+// 2D normalized-coordinate representation), this function returns a valid
+// bearing for any pixel the camera model can unproject — including back-
+// facing rays for omnidirectional cameras.
+//
+// Prefer this over `CameraModelCamFromImg` followed by homogeneous +
+// normalize when downstream code needs a 3D ray.
+//
+// @param model_id      Unique identifier of camera model.
+// @param params        Array of camera parameters.
+// @param xy            Image coordinates in pixels.
+//
+// @return              Unit bearing vector in camera frame, or std::nullopt
+//                      if unprojection fails.
+inline std::optional<Eigen::Vector3d> CameraModelCamRayFromImg(
     CameraModelId model_id,
     const std::vector<double>& params,
     const Eigen::Vector2d& xy);
@@ -2499,6 +2548,36 @@ std::optional<Eigen::Vector2d> CameraModelCamFromImg(
             params.data(), xy.x(), xy.y(), &uv.x(), &uv.y())) { \
       return uv;                                                \
     }                                                           \
+    break;
+
+    CAMERA_MODEL_SWITCH_CASES
+
+#undef CAMERA_MODEL_CASE
+  }
+  return std::nullopt;
+}
+
+// Unproject a pixel to a unit bearing vector in camera coordinates.
+//
+// Unlike CameraModelCamFromImg (which is limited to the forward hemisphere
+// via the 2D normalized-coordinate representation), this function returns a
+// valid 3D unit ray for any pixel on the camera model's image plane,
+// including back-facing rays on omnidirectional cameras.
+//
+// Downstream geometry code (two-view geometry, absolute/relative pose,
+// triangulation) should prefer this function when a 3D bearing is needed.
+std::optional<Eigen::Vector3d> CameraModelCamRayFromImg(
+    const CameraModelId model_id,
+    const std::vector<double>& params,
+    const Eigen::Vector2d& xy) {
+  Eigen::Vector3d ray;
+  switch (model_id) {
+#define CAMERA_MODEL_CASE(CameraModel)                                      \
+  case CameraModel::model_id:                                               \
+    if (CameraModel::CamRayFromImg(                                         \
+            params.data(), xy.x(), xy.y(), &ray.x(), &ray.y(), &ray.z())) { \
+      return ray;                                                           \
+    }                                                                       \
     break;
 
     CAMERA_MODEL_SWITCH_CASES

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -104,6 +104,26 @@ void TestCamFromImgToImg(const std::vector<double>& params,
   }
 }
 
+// Round-trip a pixel through the 3D bearing interface: CamRayFromImg yields a
+// unit ray, ImgFromCam must project it back to the same pixel.
+template <typename CameraModel>
+void TestCamRayFromImgToImg(const std::vector<double>& params,
+                            const double x0,
+                            const double y0) {
+  const std::optional<Eigen::Vector3d> ray = CameraModelCamRayFromImg(
+      CameraModel::model_id, params, Eigen::Vector2d(x0, y0));
+  ASSERT_TRUE(ray.has_value());
+  EXPECT_NEAR(ray->norm(), 1.0, 1e-12);
+  const std::optional<Eigen::Vector2d> xy =
+      CameraModelImgFromCam(CameraModel::model_id, params, *ray);
+  ASSERT_TRUE(xy.has_value());
+  // The pixel round-trip is floored by the iterative Newton undistortion in
+  // CamFromImg (~1e-7 worst case); matches the tolerance of the sibling
+  // CamFromImg/ImgFromCam round-trip in TestCamFromImgToImg.
+  EXPECT_NEAR(xy->x(), x0, 1e-6);
+  EXPECT_NEAR(xy->y(), y0, 1e-6);
+}
+
 // Validate ImgFromCamWithJac against ImgFromCam using Ceres Jets.
 template <typename CameraModel>
 void TestImgFromCamWithJac(const std::vector<double>& params,
@@ -236,11 +256,14 @@ void TestModel(const std::vector<double>& params) {
         continue;
       }
       TestCamFromImgToImg<CameraModel>(params, x, y);
+      TestCamRayFromImgToImg<CameraModel>(params, x, y);
     }
   }
 
   const auto pp_idxs = CameraModel::principal_point_idxs;
   TestCamFromImgToImg<CameraModel>(
+      params, params[pp_idxs.at(0)], params[pp_idxs.at(1)]);
+  TestCamRayFromImgToImg<CameraModel>(
       params, params[pp_idxs.at(0)], params[pp_idxs.at(1)]);
 
   if constexpr (CameraModel::has_img_from_cam_with_jac) {

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -163,6 +163,51 @@ void BindCamera(py::module& m) {
           },
           "image_points"_a,
           "Unproject list of points in image plane to camera frame.")
+      .def("cam_ray_from_img",
+           &Camera::CamRayFromImg,
+           "image_point"_a,
+           "Unproject point in image plane to a unit bearing vector in the "
+           "camera frame. Unlike cam_from_img, this supports back-facing rays "
+           "of omnidirectional cameras.")
+      .def(
+          "cam_ray_from_img",
+          [](const Camera& self,
+             const py::EigenDRef<const Eigen::MatrixX2d>& image_points) {
+            std::vector<Eigen::Vector3d> cam_rays(image_points.rows());
+            for (Eigen::Index i = 0; i < image_points.rows(); ++i) {
+              const std::optional<Eigen::Vector3d> cam_ray =
+                  self.CamRayFromImg(image_points.row(i));
+              if (cam_ray) {
+                cam_rays[i] = *cam_ray;
+              } else {
+                cam_rays[i].setConstant(
+                    std::numeric_limits<double>::quiet_NaN());
+              }
+            }
+            return cam_rays;
+          },
+          "image_points"_a,
+          "Unproject list of points in image plane to unit bearing vectors in "
+          "the camera frame.")
+      .def(
+          "cam_ray_from_img",
+          [](const Camera& self, const Point2DVector& image_points) {
+            std::vector<Eigen::Vector3d> cam_rays(image_points.size());
+            for (size_t i = 0; i < image_points.size(); ++i) {
+              const std::optional<Eigen::Vector3d> cam_ray =
+                  self.CamRayFromImg(image_points[i].xy);
+              if (cam_ray) {
+                cam_rays[i] = *cam_ray;
+              } else {
+                cam_rays[i].setConstant(
+                    std::numeric_limits<double>::quiet_NaN());
+              }
+            }
+            return cam_rays;
+          },
+          "image_points"_a,
+          "Unproject list of points in image plane to unit bearing vectors in "
+          "the camera frame.")
       .def("cam_from_img_threshold",
            &Camera::CamFromImgThreshold,
            "threshold"_a,

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -158,6 +158,22 @@ def test_camera_cam_from_img_matrix(simple_camera):
     assert len(result) == 2
 
 
+def test_camera_cam_ray_from_img_point2d(simple_camera):
+    point2d = np.array([512.0, 384.0])
+    result = simple_camera.cam_ray_from_img(point2d)
+    assert result is not None
+    assert result.shape == (3,)
+    assert np.isclose(np.linalg.norm(result), 1.0)
+
+
+def test_camera_cam_ray_from_img_matrix(simple_camera):
+    points = np.array([[512.0, 384.0], [100.0, 200.0]])
+    result = simple_camera.cam_ray_from_img(points)
+    assert len(result) == 2
+    for ray in result:
+        assert np.isclose(np.linalg.norm(ray), 1.0)
+
+
 def test_camera_img_from_cam_point3d(simple_camera):
     point3d = np.array([0.0, 0.0, 1.0])
     result = simple_camera.img_from_cam(point3d)


### PR DESCRIPTION
## Summary

Extracts the bearing-vector unprojection interface from #4433 into a standalone, behavior-preserving change. Adds a 3D unit-ray unprojection method (`CamRayFromImg`) alongside the existing 2D `CamFromImg`, and migrates the geometry estimators to use it.

This is a pure refactor for all existing camera models — the default implementation is bit-identical to the `CamFromImg(p)->homogeneous().normalized()` pattern that was previously open-coded at every ray-conversion site. It establishes the hook that omnidirectional camera models (e.g. a future SPHERE model) need to return bearings the 2D `(u, v, 1)` representation cannot encode (rays with `rz <= 0`).

## Changes

- **`BaseCameraModel::CamRayFromImg`** — default implementation delegating to `CamFromImg` followed by `homogeneous().normalized()`. Correct for perspective and `<=180°`-fisheye cameras; the returned ray always has `rz > 0`. Omnidirectional models can override it.
- **`CameraModelCamRayFromImg`** top-level dispatch + **`Camera::CamRayFromImg`** wrapper, both returning `std::optional<Eigen::Vector3d>`.
- **Geometry estimator migration** — replaces the `CamFromImg(p)->homogeneous().normalized()` pattern with a direct `CamRayFromImg` call at every 2D→3D ray conversion site:
  - `two_view_geometry.cc` (essential-matrix + pose, via `ExtractInlierCamRays` and the calibrated path)
  - `generalized_pose.cc` (rig-aware absolute + relative pose, visual localization)
  - `pose.cc` (P3P ray preparation)
  - `global_positioning.cc` (global translation averaging ingress)

## Tests

- New `Perspective.CamRayFromImgMatchesLegacy` in `models_test.cc` asserts the default delegate is bit-equivalent to the pre-existing pattern across SimplePinhole, Pinhole, SimpleRadial, and OpenCV.
- Existing estimator tests pass unchanged (`two_view_geometry_test`, `pose_test`, `generalized_pose_test`).

## Notes

Split out from #4433. The SPHERE camera model, its `CamRayFromImg` override, the non-perspective guard in `EstimateTwoViewGeometryPose`, bearing-vector triangulation, and `sphere_to_cubic` remain in that PR / future follow-ups; this PR is intentionally limited to the ray interface and its no-op migration. The method is named `CamRayFromImg` (vs. `CamFromImgRay` in #4433).