### PR TITLE
Add GlobalMapper.keep_max_num_tracks option to bound established tracks

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -760,6 +760,8 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.track_required_tracks_per_view);
   AddDefaultOption("GlobalMapper.track_min_num_views_per_track",
                    &global_mapper->mapper.track_min_num_views_per_track);
+  AddDefaultOption("GlobalMapper.keep_max_num_tracks",
+                   &global_mapper->mapper.keep_max_num_tracks);
 
   // Global positioning options.
   AddDefaultOption("GlobalMapper.gp_use_gpu",

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -235,7 +235,13 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
 
   std::unordered_map<image_t, size_t> tracks_per_image;
   size_t images_left = image_id_to_keypoints.size();
+  const size_t max_num_tracks =
+      static_cast<size_t>(options.keep_max_num_tracks);
   for (const auto& [track_length, point3D_id] : track_lengths) {
+    // Stop once the global track budget is exhausted. As tracks are sorted by
+    // decreasing length, this keeps the longest tracks and bounds memory usage.
+    if (reconstruction_->NumPoints3D() >= max_num_tracks) break;
+
     auto& point3D = candidate_points3D.at(point3D_id);
 
     // Check if any image in this track still needs more observations.

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -66,6 +66,10 @@ struct GlobalMapperOptions {
   int track_required_tracks_per_view = std::numeric_limits<int>::max();
   // Minimum number of views per track.
   int track_min_num_views_per_track = 3;
+  // Maximum total number of tracks to establish. Tracks are selected in order
+  // of decreasing length, so the longest tracks are kept. Use this to bound
+  // memory usage on large datasets. By default, there is no limit.
+  int keep_max_num_tracks = std::numeric_limits<int>::max();
 
   // Thresholds for each component.
   double max_angular_reproj_error_deg = 1.;   // for global positioning

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -196,6 +196,8 @@ void BindSfM(py::module& m) {
                            &Opts::track_required_tracks_per_view)
             .def_readwrite("track_min_num_views_per_track",
                            &Opts::track_min_num_views_per_track)
+            .def_readwrite("keep_max_num_tracks",
+                           &Opts::keep_max_num_tracks)
             .def_readwrite("max_angular_reproj_error_deg",
                            &Opts::max_angular_reproj_error_deg)
             .def_readwrite("max_normalized_reproj_error",

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -196,8 +196,7 @@ void BindSfM(py::module& m) {
                            &Opts::track_required_tracks_per_view)
             .def_readwrite("track_min_num_views_per_track",
                            &Opts::track_min_num_views_per_track)
-            .def_readwrite("keep_max_num_tracks",
-                           &Opts::keep_max_num_tracks)
+            .def_readwrite("keep_max_num_tracks", &Opts::keep_max_num_tracks)
             .def_readwrite("max_angular_reproj_error_deg",
                            &Opts::max_angular_reproj_error_deg)
             .def_readwrite("max_normalized_reproj_error",


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/4438

## Problem

When migrating from standalone GLOMAP to COLMAP 4's `global_mapper`, there was no equivalent of the old `--TrackEstablishment.max_num_tracks` flag, which capped the total number of established tracks to bound memory usage and avoid OOM on large datasets. The existing `GlobalMapper.track_required_tracks_per_view` option only controls per-view early stopping and defaults to no capping.

## Change

Adds a new `GlobalMapper.keep_max_num_tracks` option (default: unlimited). During track establishment, tracks are already sorted by decreasing length; the selection loop now stops once this budget is reached, keeping the longest (most valuable) tracks. The option is exposed via the C++ `GlobalMapperOptions` struct, the CLI option manager, and the pycolmap bindings.