### PR TITLE
Replace libqt6svg6-dev with qt6-svg-dev

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -149,7 +149,7 @@ jobs:
           if [ "${{ matrix.config.qtVersion }}" == "5" ]; then
             qt_packages="qtbase5-dev libqt5opengl5-dev libqt5svg5-dev libcgal-qt5-dev"
           elif [ "${{ matrix.config.qtVersion }}" == "6" ]; then
-            qt_packages="qt6-base-dev libqt6opengl6-dev libqt6openglwidgets6 libqt6svg6-dev"
+            qt_packages="qt6-base-dev libqt6opengl6-dev libqt6openglwidgets6 qt6-svg-dev"
           fi
 
           sudo apt-get update && sudo apt-get install -y \

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -149,7 +149,14 @@ jobs:
           if [ "${{ matrix.config.qtVersion }}" == "5" ]; then
             qt_packages="qtbase5-dev libqt5opengl5-dev libqt5svg5-dev libcgal-qt5-dev"
           elif [ "${{ matrix.config.qtVersion }}" == "6" ]; then
-            qt_packages="qt6-base-dev libqt6opengl6-dev libqt6openglwidgets6 qt6-svg-dev"
+            qt_packages="qt6-base-dev libqt6opengl6-dev libqt6openglwidgets6"
+            # The Svg dev package is named qt6-svg-dev on Ubuntu 24.04+ but
+            # libqt6svg6-dev on Ubuntu 22.04.
+            if [ "${{ matrix.config.os }}" == "ubuntu-22.04" ]; then
+              qt_packages="$qt_packages libqt6svg6-dev"
+            else
+              qt_packages="$qt_packages qt6-svg-dev"
+            fi
           fi
 
           sudo apt-get update && sudo apt-get install -y \

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -92,7 +92,6 @@ Dependencies from the default Ubuntu repositories::
         qt6-base-dev \
         libqt6opengl6-dev \
         libqt6openglwidgets6 \
-        libqt6svg6-dev \
         qt6-svg-dev \
         libcgal-dev \
         libceres-dev \

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -93,6 +93,7 @@ Dependencies from the default Ubuntu repositories::
         libqt6opengl6-dev \
         libqt6openglwidgets6 \
         libqt6svg6-dev \
+        qt6-svg-dev \
         libcgal-dev \
         libceres-dev \
         libsuitesparse-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
         qt6-base-dev \
         libqt6opengl6-dev \
         libqt6openglwidgets6 \
-        libqt6svg6-dev \
+        qt6-svg-dev \
         libcgal-dev \
         libceres-dev \
         libcurl4-openssl-dev \


### PR DESCRIPTION
When following the installation instructions for Ubuntu 24.04, in the step `cmake .. -GNinja -DBLA_VENDOR=Intel10_64lp`, I get this error:

```
CMake Error at cmake/FindDependencies.cmake:424 (find_package):
  Found package configuration file:

    /usr/lib/x86_64-linux-gnu/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "Svg".

  Expected Config file at
  "/usr/lib/x86_64-linux-gnu/cmake/Qt6Svg/Qt6SvgConfig.cmake" does NOT exist
```

Installing `qt6-svg-dev` in addition fixes that problem.