### PR TITLE
Fix sequential matching hang with loop detection verification (#4456)

### DIFF
--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -389,20 +389,32 @@ void VocabTreePairGenerator::IndexImages(
 }
 
 void VocabTreePairGenerator::Query(const image_t image_id) {
-  auto keypoints = *cache_->GetKeypoints(image_id);
-  auto descriptors = *cache_->GetDescriptors(image_id);
-  if (options_.max_num_features > 0 &&
-      descriptors.data.rows() > options_.max_num_features) {
-    ExtractTopScaleFeatures(
-        &keypoints, &descriptors, options_.max_num_features);
-  }
-
   Retrieval retrieval;
   retrieval.image_id = image_id;
-  visual_index_->Query(query_options_,
-                       keypoints,
-                       descriptors.ToFloat(),
-                       &retrieval.image_scores);
+
+  // Each query must push exactly one result, because the consuming Next() pops
+  // exactly one result per query. If a query fails (e.g., due to corrupt
+  // features or an out-of-memory error during spatial verification), we still
+  // push an empty result and skip retrieval for this image. Otherwise, the
+  // consumer would block indefinitely waiting for a result that never arrives.
+  try {
+    auto keypoints = *cache_->GetKeypoints(image_id);
+    auto descriptors = *cache_->GetDescriptors(image_id);
+    if (options_.max_num_features > 0 &&
+        descriptors.data.rows() > options_.max_num_features) {
+      ExtractTopScaleFeatures(
+          &keypoints, &descriptors, options_.max_num_features);
+    }
+
+    visual_index_->Query(query_options_,
+                         keypoints,
+                         descriptors.ToFloat(),
+                         &retrieval.image_scores);
+  } catch (const std::exception& error) {
+    LOG(ERROR) << "Failed to query image " << image_id
+               << " against vocabulary tree, skipping: " << error.what();
+    retrieval.image_scores.clear();
+  }
 
   THROW_CHECK(queue_.Push(std::move(retrieval)));
 }

--- a/src/colmap/controllers/pairing_test.cc
+++ b/src/colmap/controllers/pairing_test.cc
@@ -129,6 +129,39 @@ TEST(VocabTreePairGenerator, Nominal) {
   }
 }
 
+TEST(VocabTreePairGenerator, DoesNotDeadlockOnFailedQuery) {
+  constexpr int kNumImages = 5;
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+  CreateSyntheticDatabase(kNumImages, *database);
+  std::vector<Image> images = database->ReadAllImages();
+  CHECK_EQ(images.size(), kNumImages);
+
+  VocabTreePairingOptions options;
+  options.vocab_tree_path = CreateTestDir() / "vocab_tree.txt";
+  CreateSyntheticVisualIndex()->Write(options.vocab_tree_path);
+  options.num_images = 3;
+
+  // Query a set of images that includes an invalid image identifier. Querying
+  // the invalid image fails inside the worker thread. Even so, the generator
+  // must not deadlock and must produce one result per query image. Regression
+  // test for a hang where a failing query never pushed a result and the
+  // consumer blocked indefinitely on the result queue (GH #4456).
+  std::vector<image_t> query_image_ids;
+  query_image_ids.reserve(images.size() + 1);
+  for (const auto& image : images) {
+    query_image_ids.push_back(image.ImageId());
+  }
+  const image_t kInvalidQueryImageId = 1000;
+  query_image_ids.push_back(kInvalidQueryImageId);
+
+  VocabTreePairGenerator generator(options, database, query_image_ids);
+  for (size_t i = 0; i < query_image_ids.size(); ++i) {
+    generator.Next();
+  }
+  EXPECT_TRUE(generator.Next().empty());
+  EXPECT_TRUE(generator.HasFinished());
+}
+
 TEST(SequentialPairGenerator, Linear) {
   constexpr int kNumImages = 5;
   auto database = Database::Open(kInMemorySqliteDatabasePath);


### PR DESCRIPTION
## Problem

`match_sequential` can hang indefinitely when loop detection is enabled together with `loop_detection_num_images_after_verification > 0`, as reported in #4456 (observed on long sequences of 6000+ images).

## Root cause

`VocabTreePairGenerator` uses a producer/consumer pattern: worker threads run `Query()` (one per query image) and push results to a bounded `JobQueue`, while the main thread's `Next()` pops **exactly one** result per query. The futures returned by `ThreadPool::AddTask` are discarded, so when a worker `Query()` throws, the exception is silently swallowed **and** no result is pushed. The consumer's `queue_.Pop()` then blocks forever — the matcher appears stuck.

This only surfaces when `loop_detection_num_images_after_verification > 0`, which activates the heavy spatial-verification path in `VisualIndex::Query`. That path can realistically throw (e.g. `std::bad_alloc` from the all-pairs match accumulation, which blows up on long/repetitive sequences). With verification off (the default), `Query()` returns early after lightweight scoring and never throws — which is why the hang only appears once this option is set.

## Fix

Wrap the body of `VocabTreePairGenerator::Query` in a try/catch. On failure it logs the error and pushes an **empty** result, preserving the one-result-per-query invariant so the consumer can never deadlock. A failing image is simply skipped for loop detection instead of hanging the whole pipeline.

## Testing

Added `VocabTreePairGenerator.DoesNotDeadlockOnFailedQuery`, which queries a deliberately invalid image id to deterministically trigger a worker failure. Verified it **hangs without the fix** and **passes with it**.

- All 13 `pairing_test` cases pass
- All 10 `visual_index_test` cases pass

Fixes #4456