### PR TITLE
Fix SiftGPU set device to include device 0

### DIFF
--- a/src/thirdparty/SiftGPU/ProgramCU.cu
+++ b/src/thirdparty/SiftGPU/ProgramCU.cu
@@ -1387,7 +1387,7 @@ int ProgramCU::CheckCudaDevice(int device)
 
 		}
     }
-    if(device >0 && device < count)
+    if(device >= 0 && device < count)
     {
         cudaSetDevice(device);
         CheckErrorCUDA("cudaSetDevice\n");


### PR DESCRIPTION
SiftGPU sets the GPU device to use based on that passed to `ProgramCU::CheckCudaDevice`. However, this function only calls `cudaSetDevice` for devices with an ID greater than 0. Fixes to allow setting to device 0.