### PR TITLE
Estimate separate fx/fy in p4pf for two-focal camera models

### DIFF
--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -66,14 +66,17 @@ bool EstimateAbsolutePose(const AbsolutePoseEstimationOptions& options,
     for (size_t i = 0; i < points2D.size(); ++i) {
       points2D_centered[i] = points2D[i] - principal_point;
     }
-    RANSAC<P4PFEstimator> ransac(options.ransac_options);
+    const span<const size_t> focal_length_idxs = camera->FocalLengthIdxs();
+    RANSAC<P4PFEstimator> ransac(
+        options.ransac_options,
+        P4PFEstimator(/*share_focal_length=*/focal_length_idxs.size() == 1));
     auto report = ransac.Estimate(points2D_centered, points3D);
     if (report.success) {
       *cam_from_world =
           Rigid3d(Eigen::Quaterniond(report.model.cam_from_world.leftCols<3>()),
                   report.model.cam_from_world.col(3));
-      for (const size_t idx : camera->FocalLengthIdxs()) {
-        camera->params[idx] = report.model.focal_length;
+      for (size_t k = 0; k < focal_length_idxs.size(); ++k) {
+        camera->params[focal_length_idxs[k]] = report.model.focal_lengths[k];
       }
       *num_inliers = report.support.num_inliers;
       *inlier_mask = std::move(report.inlier_mask);

--- a/src/colmap/estimators/pose_test.cc
+++ b/src/colmap/estimators/pose_test.cc
@@ -47,18 +47,22 @@ struct AbsolutePoseProblem {
   std::vector<Eigen::Vector3d> points3D;
 };
 
-AbsolutePoseProblem CreateAbsolutePoseTestData() {
+AbsolutePoseProblem CreateAbsolutePoseTestData(
+    CameraModelId camera_model_id = CameraModelId::kSimpleRadial,
+    const std::vector<double>& camera_params = {1280, 512, 384, 0.05}) {
   AbsolutePoseProblem problem;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
   synthetic_dataset_options.num_frames_per_rig = 2;
   synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.camera_model_id = camera_model_id;
+  synthetic_dataset_options.camera_params = camera_params;
   SynthesizeDataset(synthetic_dataset_options, &problem.reconstruction);
 
   problem.image = problem.reconstruction.Image(1);
   problem.camera = *problem.image.CameraPtr();
-  CHECK_EQ(problem.camera.model_id, CameraModelId::kSimpleRadial);
+  CHECK_EQ(problem.camera.model_id, camera_model_id);
   for (const auto& point2D : problem.image.Points2D()) {
     if (point2D.HasPoint3D()) {
       problem.points2D.push_back(point2D.xy);
@@ -115,6 +119,33 @@ TEST(EstimateAbsolutePose, EstimateFocalLength) {
   EXPECT_NEAR(camera.FocalLength(), problem.camera.FocalLength(), 5);
   camera.SetFocalLength(problem.camera.FocalLength());
   EXPECT_EQ(camera, problem.camera);
+  EXPECT_EQ(num_inliers, problem.points2D.size());
+  EXPECT_THAT(inlier_mask, testing::Each(testing::Eq(true)));
+}
+
+TEST(EstimateAbsolutePose, EstimateSeparateFocalLengths) {
+  // PINHOLE camera with distinct fx and fy (fx, fy, cx, cy).
+  const AbsolutePoseProblem problem = CreateAbsolutePoseTestData(
+      CameraModelId::kPinhole, {1280, 1000, 512, 384});
+
+  AbsolutePoseEstimationOptions options;
+  options.estimate_focal_length = true;
+  Rigid3d cam_from_world;
+  size_t num_inliers = 0;
+  std::vector<char> inlier_mask;
+  Camera camera = problem.camera;
+  EXPECT_TRUE(EstimateAbsolutePose(options,
+                                   problem.points2D,
+                                   problem.points3D,
+                                   &cam_from_world,
+                                   &camera,
+                                   &num_inliers,
+                                   &inlier_mask));
+  EXPECT_THAT(
+      cam_from_world,
+      Rigid3dNear(problem.image.CamFromWorld(), /*rtol=*/1e-3, /*ttol=*/1e-2));
+  EXPECT_NEAR(camera.FocalLengthX(), problem.camera.FocalLengthX(), 5);
+  EXPECT_NEAR(camera.FocalLengthY(), problem.camera.FocalLengthY(), 5);
   EXPECT_EQ(num_inliers, problem.points2D.size());
   EXPECT_THAT(inlier_mask, testing::Each(testing::Eq(true)));
 }

--- a/src/colmap/estimators/pose_test.cc
+++ b/src/colmap/estimators/pose_test.cc
@@ -308,7 +308,7 @@ TEST(RefineAbsolutePose, PositionPriorCovariance) {
   AbsolutePoseRefinementOptions strong_prior_options = weak_prior_options;
   // Small covariance = strong prior (low uncertainty).
   strong_prior_options.position_prior_covariance =
-      0.01 * Eigen::Matrix3d::Identity();
+      0.0001 * Eigen::Matrix3d::Identity();
 
   const Rigid3d initial_cam_from_world(
       Eigen::Quaterniond(Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitX())),

--- a/src/colmap/estimators/solvers/absolute_pose.cc
+++ b/src/colmap/estimators/solvers/absolute_pose.cc
@@ -72,9 +72,12 @@ void P3PEstimator::Residuals(const std::vector<X_t>& points2D,
       points2D, points3D, cam_from_world, img_from_cam_func_, residuals);
 }
 
+P4PFEstimator::P4PFEstimator(bool share_focal_length)
+    : share_focal_length_(share_focal_length) {}
+
 void P4PFEstimator::Estimate(const std::vector<X_t>& points2D,
                              const std::vector<Y_t>& points3D,
-                             std::vector<M_t>* models) {
+                             std::vector<M_t>* models) const {
   THROW_CHECK_EQ(points2D.size(), 4);
   THROW_CHECK_EQ(points3D.size(), 4);
   THROW_CHECK_NOTNULL(models);
@@ -82,14 +85,30 @@ void P4PFEstimator::Estimate(const std::vector<X_t>& points2D,
   models->clear();
 
   std::vector<poselib::CameraPose> poses;
-  std::vector<double> focals;
-  const int num_poses = poselib::p4pf(
-      points2D, points3D, &poses, &focals, /*filter_solutions=*/true);
+  std::vector<double> focals_x;
+  std::vector<double> focals_y;
+  int num_poses;
+  if (share_focal_length_) {
+    // Estimate a single shared focal length. filter_solutions additionally
+    // removes solutions whose aspect ratio (fx/fy) is far from 1.
+    num_poses = poselib::p4pf(
+        points2D, points3D, &poses, &focals_x, /*filter_solutions=*/true);
+    focals_y = focals_x;
+  } else {
+    // Estimate separate focal lengths for x and y. filter_solutions only
+    // removes solutions with non-positive focal lengths.
+    num_poses = poselib::p4pf(points2D,
+                              points3D,
+                              &poses,
+                              &focals_x,
+                              &focals_y,
+                              /*filter_solutions=*/true);
+  }
 
   models->resize(num_poses);
   for (int i = 0; i < num_poses; ++i) {
     (*models)[i].cam_from_world = poses[i].Rt();
-    (*models)[i].focal_length = focals[i];
+    (*models)[i].focal_lengths = Eigen::Vector2d(focals_x[i], focals_y[i]);
   }
 }
 
@@ -106,7 +125,8 @@ void P4PFEstimator::Residuals(const std::vector<X_t>& points2D,
     // Check if 3D point is in front of camera.
     if (point3D_in_cam.z() > std::numeric_limits<double>::epsilon()) {
       (*residuals)[i] =
-          (model.focal_length * point3D_in_cam.hnormalized() - points2D[i])
+          (model.focal_lengths.cwiseProduct(point3D_in_cam.hnormalized()) -
+           points2D[i])
               .squaredNorm();
     } else {
       (*residuals)[i] = std::numeric_limits<double>::max();

--- a/src/colmap/estimators/solvers/absolute_pose.h
+++ b/src/colmap/estimators/solvers/absolute_pose.h
@@ -103,20 +103,29 @@ class P4PFEstimator {
   struct M_t {
     // The transformation from the world to the camera frame.
     Eigen::Matrix3x4d cam_from_world;
-    // The focal length of the camera.
-    double focal_length = 0.;
+    // The focal lengths (fx, fy) of the camera. Equal when the focal length is
+    // shared (e.g. single-focal camera models).
+    Eigen::Vector2d focal_lengths = Eigen::Vector2d::Zero();
   };
 
   static const int kMinNumSamples = 4;
 
-  static void Estimate(const std::vector<X_t>& points2D,
-                       const std::vector<Y_t>& points3D,
-                       std::vector<M_t>* models);
+  // If share_focal_length is true, a single shared focal length is estimated
+  // (suitable for single-focal camera models, e.g. SIMPLE_PINHOLE). Otherwise,
+  // separate focal lengths for x and y are estimated (e.g. PINHOLE, OPENCV).
+  explicit P4PFEstimator(bool share_focal_length = true);
+
+  void Estimate(const std::vector<X_t>& points2D,
+                const std::vector<Y_t>& points3D,
+                std::vector<M_t>* models) const;
 
   static void Residuals(const std::vector<X_t>& points2D,
                         const std::vector<Y_t>& points3D,
                         const M_t& model,
                         std::vector<double>* residuals);
+
+ private:
+  const bool share_focal_length_;
 };
 
 // EPNP solver for the PNP (Perspective-N-Point) problem. The solver needs a

--- a/src/colmap/estimators/solvers/absolute_pose_test.cc
+++ b/src/colmap/estimators/solvers/absolute_pose_test.cc
@@ -107,7 +107,7 @@ TEST(AbsolutePose, P3P) {
   }
 }
 
-TEST(AbsolutePose, P4PF) {
+TEST(AbsolutePose, P4PFSharedFocalLength) {
   const std::vector<Eigen::Vector3d> points3D = {
       Eigen::Vector3d(1, 1, 1),
       Eigen::Vector3d(0, 1, 1),
@@ -148,7 +148,78 @@ TEST(AbsolutePose, P4PF) {
         const auto report = ransac.Estimate(points2D, points3D);
 
         EXPECT_TRUE(report.success);
-        EXPECT_NEAR(report.model.focal_length, f, 1e-3);
+        // In shared mode both focal lengths must be identical.
+        EXPECT_EQ(report.model.focal_lengths.x(),
+                  report.model.focal_lengths.y());
+        EXPECT_NEAR(report.model.focal_lengths.x(), f, 1e-3);
+        EXPECT_LT(
+            (expected_cam_from_world.ToMatrix() - report.model.cam_from_world)
+                .norm(),
+            1e-3);
+
+        // Test residuals of exact points.
+        std::vector<double> residuals;
+        P4PFEstimator::Residuals(points2D, points3D, report.model, &residuals);
+        for (size_t i = 0; i < residuals.size(); ++i) {
+          EXPECT_LT(residuals[i], 1e-3);
+        }
+
+        // Test residuals of faulty points.
+        P4PFEstimator::Residuals(
+            points2D, points3D_faulty, report.model, &residuals);
+        for (size_t i = 0; i < residuals.size(); ++i) {
+          EXPECT_GT(residuals[i], 0.1);
+        }
+      }
+    }
+  }
+}
+
+TEST(AbsolutePose, P4PFSeparateFocalLengths) {
+  const std::vector<Eigen::Vector3d> points3D = {
+      Eigen::Vector3d(1, 1, 1),
+      Eigen::Vector3d(0, 1, 1),
+      Eigen::Vector3d(3, 1.0, 4),
+      Eigen::Vector3d(3, 1.1, 4),
+      Eigen::Vector3d(3, 1.2, 4),
+      Eigen::Vector3d(3, 1.3, 4),
+      Eigen::Vector3d(3, 1.4, 4),
+      Eigen::Vector3d(2, 1, 7),
+  };
+
+  auto points3D_faulty = points3D;
+  for (size_t i = 0; i < points3D.size(); ++i) {
+    points3D_faulty[i](0) = 20;
+  }
+
+  // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
+  for (double qx = 0; qx < 1; qx += 0.2) {
+    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
+    for (double tx = 0; tx < 1; tx += 0.1) {
+      // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
+      for (double f = 0.5; f < 20; f += 2) {
+        const Eigen::Vector2d focal_lengths(f, 1.5 * f);
+        const Rigid3d expected_cam_from_world(
+            Eigen::Quaterniond(1, qx, 0, 0).normalized(),
+            Eigen::Vector3d(tx, 0, 0));
+
+        // Project points using separate focal lengths for x and y.
+        std::vector<Eigen::Vector2d> points2D;
+        points2D.reserve(points3D.size());
+        for (size_t i = 0; i < points3D.size(); ++i) {
+          points2D.push_back(focal_lengths.cwiseProduct(
+              (expected_cam_from_world * points3D[i]).hnormalized()));
+        }
+
+        RANSACOptions options;
+        options.max_error = 1e-5;
+        RANSAC<P4PFEstimator> ransac(
+            options, P4PFEstimator(/*share_focal_length=*/false));
+        const auto report = ransac.Estimate(points2D, points3D);
+
+        EXPECT_TRUE(report.success);
+        EXPECT_NEAR(report.model.focal_lengths.x(), focal_lengths.x(), 1e-3);
+        EXPECT_NEAR(report.model.focal_lengths.y(), focal_lengths.y(), 1e-3);
         EXPECT_LT(
             (expected_cam_from_world.ToMatrix() - report.model.cam_from_world)
                 .norm(),


### PR DESCRIPTION
EstimateAbsolutePose previously broadcast a single P4PF focal length to all focal indices, forcing fx == fy as the seed even for models with independent focal lengths (e.g., PINHOLE, OPENCV, OPENCV_FISHEYE). This used PoseLib's averaging p4pf overload, whose aspect-ratio filter also rejected exactly the non-square-pixel solutions wanted for such models.

Make P4PFEstimator model-aware: keep the shared-focal overload for single-focal models (unchanged behavior) and use PoseLib's separate-fx/fy overload for two-focal models, assigning each focal length to its corresponding parameter index. The estimator now carries a share_focal_length flag and stores fx/fy as a vector; residuals scale per axis accordingly.

cc: @vlarsson 