### PR TITLE
Fix Windows MSVC test issues

### DIFF
--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -38,6 +38,7 @@
 #include "colmap/feature/sift.h"
 #include "colmap/feature/utils.h"
 #include "colmap/geometry/essential_matrix.h"
+#include "colmap/math/math.h"
 #include "colmap/math/random.h"
 #include "colmap/util/opengl_utils.h"
 

--- a/src/colmap/util/file_test.cc
+++ b/src/colmap/util/file_test.cc
@@ -196,7 +196,11 @@ TEST(FileCopy, Nominal) {
   EXPECT_TRUE(ExistsFile(dst_hard_link_path));
 
   const auto dst_soft_link_path = dir / "destination_soft_link.txt";
-  FileCopy(src_path, dst_soft_link_path, FileCopyType::SOFT_LINK);
+  try {
+    FileCopy(src_path, dst_soft_link_path, FileCopyType::SOFT_LINK);
+  } catch (const std::filesystem::filesystem_error& e) {
+    GTEST_SKIP() << "Could not create symlink: " << e.what();
+  }
   EXPECT_TRUE(ExistsFile(dst_soft_link_path));
 }
 


### PR DESCRIPTION
## Summary

Two small Windows MSVC test fixes extracted from a downstream migration branch.

## Changes

- `src/colmap/feature/sift_test.cc`: include `colmap/math/math.h` so `M_PI` is available under MSVC without relying on `_USE_MATH_DEFINES`.
- `src/colmap/util/file_test.cc`: skip the soft-link portion of `FileCopy.Nominal` when the host Windows environment lacks symlink privileges, mirroring the existing skip in `GetNormalizedRelativePath.PreservesSymlinkStructure`.

## Validation

Built and tested on Windows with vcpkg + MSVC 14.44 + Ninja. All affected tests pass.
