### PR TITLE
Fix mypy var-annotated error in panorama_sfm

### DIFF
--- a/python/examples/panorama_sfm.py
+++ b/python/examples/panorama_sfm.py
@@ -358,7 +358,7 @@ class PanoProcessor:
                     old_to_new_point2D[image.image_id] = {}
                     continue
                 xy = np.array([point2D.xy for point2D in image.points2D])
-                rays_in_cam = np.asarray(
+                rays_in_cam: npt.NDArray[np.floating] = np.asarray(
                     self._camera.cam_ray_from_img(image_points=xy)
                 )
                 rays_in_cam /= np.linalg.norm(


### PR DESCRIPTION
Follow-up to #4468.

`Camera.cam_ray_from_img` returns a `list` of vectors, so `np.asarray(...)` of it leaves mypy unable to infer a concrete element type, producing:

```
python/examples/panorama_sfm.py:361: error: Need type annotation for "rays_in_cam"  [var-annotated]
```

Add an explicit `npt.NDArray[np.floating]` annotation on `rays_in_cam` to resolve it.