### PR TITLE
Modify the FAQ Reconstruction with pose priors (GPS) section

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -140,10 +140,10 @@ the ``pose_prior_mapper``::
         --output_path $PROJECT_PATH/sparse
 
 The ``pose_prior_mapper`` is essentially the incremental mapper with prior
-position constraints enabled. You can control the prior covariance (uncertainty)
-using ``--prior_position_std_x``, ``--prior_position_std_y``, and
-``--prior_position_std_z`` (default: 1.0 meter each), or override all priors'
-covariance with ``--overwrite_priors_covariance``.
+position constraints enabled. You can override the priors covariance (uncertainty)
+using ``--overwrite_priors_covariance``.  The new covariance will be built based 
+on the values of ``--prior_position_std_x``, ``--prior_position_std_y``, and
+``--prior_position_std_z`` (default: 1.0 meter each).
 
 For geo-registration of an already reconstructed model (without using priors
 during mapping), see the `Geo-registration`_ section.


### PR DESCRIPTION
Current behavior of pose_prior_mapper requires to set the ``--overwrite_priors_covariance`` option to enable using the ``--prior_position_std_XXX`` args value for updating the current priors covariance.  FAQ was inaccurate here.  This PR fixes this.