### PR TITLE
Set a default identity covariance to pose priors extracted from exif metadata.

### DIFF
--- a/src/colmap/controllers/image_reader.cc
+++ b/src/colmap/controllers/image_reader.cc
@@ -304,6 +304,7 @@ ImageReader::Status ImageReader::Next(Rig* rig,
     const std::optional<double> altitude = bitmap->ExifAltitude();
     if (latitude.has_value() && longitude.has_value() && altitude.has_value()) {
       pose_prior->position = Eigen::Vector3d(*latitude, *longitude, *altitude);
+      pose_prior->position_covariance = Eigen::Matrix3d::Identity();
       pose_prior->coordinate_system = PosePrior::CoordinateSystem::WGS84;
     }
 


### PR DESCRIPTION
Current behavior does not set any covariance on the priors extracted from exif metadata.  This leads to undefined covariance matrix for the created priors.  It feels cleaner to define a default identity covariance here.  Note that there is no direct impact with this modification as the PosePriorBundleAdjuster currently falls back to a ``prior_position_fallback_stddev`` value (set to 1.0) when no valid covariance is defined for a prior.