### PR TITLE
Tint UI icons to palette for dark theme legibility

### DIFF
--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -374,37 +374,39 @@ void MainWindow::CreateActions() {
   // File actions
   //////////////////////////////////////////////////////////////////////////////
 
-  action_project_new_ =
-      new QAction(ThemedIcon(":/media/project-new.svg"), tr("New project"), this);
+  action_project_new_ = new QAction(
+      ThemedIcon(":/media/project-new.svg"), tr("New project"), this);
   action_project_new_->setShortcuts(QKeySequence::New);
   connect(
       action_project_new_, &QAction::triggered, this, &MainWindow::ProjectNew);
 
-  action_project_open_ =
-      new QAction(ThemedIcon(":/media/project-open.svg"), tr("Open project"), this);
+  action_project_open_ = new QAction(
+      ThemedIcon(":/media/project-open.svg"), tr("Open project"), this);
   action_project_open_->setShortcuts(QKeySequence::Open);
   connect(action_project_open_,
           &QAction::triggered,
           this,
           &MainWindow::ProjectOpen);
 
-  action_project_edit_ =
-      new QAction(ThemedIcon(":/media/project-edit.svg"), tr("Edit project"), this);
+  action_project_edit_ = new QAction(
+      ThemedIcon(":/media/project-edit.svg"), tr("Edit project"), this);
   connect(action_project_edit_,
           &QAction::triggered,
           this,
           &MainWindow::ProjectEdit);
 
-  action_project_save_ =
-      new QAction(ThemedIcon(":/media/project-save.svg"), tr("Save project"), this);
+  action_project_save_ = new QAction(
+      ThemedIcon(":/media/project-save.svg"), tr("Save project"), this);
   action_project_save_->setShortcuts(QKeySequence::Save);
   connect(action_project_save_,
           &QAction::triggered,
           this,
           &MainWindow::ProjectSave);
 
-  action_project_save_as_ = new QAction(
-      ThemedIcon(":/media/project-save-as.svg"), tr("Save project as..."), this);
+  action_project_save_as_ =
+      new QAction(ThemedIcon(":/media/project-save-as.svg"),
+                  tr("Save project as..."),
+                  this);
   action_project_save_as_->setShortcuts(QKeySequence::SaveAs);
   connect(action_project_save_as_,
           &QAction::triggered,
@@ -442,8 +444,9 @@ void MainWindow::CreateActions() {
   connect(action_export_as_, &QAction::triggered, this, &MainWindow::ExportAs);
   blocking_actions_.push_back(action_export_as_);
 
-  action_export_as_text_ = new QAction(
-      ThemedIcon(":/media/export-as-text.svg"), tr("Export model as text"), this);
+  action_export_as_text_ = new QAction(ThemedIcon(":/media/export-as-text.svg"),
+                                       tr("Export model as text"),
+                                       this);
   connect(action_export_as_text_,
           &QAction::triggered,
           this,
@@ -457,8 +460,10 @@ void MainWindow::CreateActions() {
   // Processing action
   //////////////////////////////////////////////////////////////////////////////
 
-  action_feature_extraction_ = new QAction(
-      ThemedIcon(":/media/feature-extraction.svg"), tr("Feature extraction"), this);
+  action_feature_extraction_ =
+      new QAction(ThemedIcon(":/media/feature-extraction.svg"),
+                  tr("Feature extraction"),
+                  this);
   connect(action_feature_extraction_,
           &QAction::triggered,
           this,
@@ -556,8 +561,10 @@ void MainWindow::CreateActions() {
           &MainWindow::ReconstructionOptions);
   blocking_actions_.push_back(action_reconstruction_options_);
 
-  action_bundle_adjustment_ = new QAction(
-      ThemedIcon(":/media/bundle-adjustment.svg"), tr("Bundle adjustment"), this);
+  action_bundle_adjustment_ =
+      new QAction(ThemedIcon(":/media/bundle-adjustment.svg"),
+                  tr("Bundle adjustment"),
+                  this);
   connect(action_bundle_adjustment_,
           &QAction::triggered,
           this,
@@ -641,8 +648,8 @@ void MainWindow::CreateActions() {
           model_viewer_widget_,
           &ModelViewerWidget::GrabMovie);
 
-  action_undistort_ =
-      new QAction(ThemedIcon(":/media/undistort.svg"), tr("Undistortion"), this);
+  action_undistort_ = new QAction(
+      ThemedIcon(":/media/undistort.svg"), tr("Undistortion"), this);
   connect(action_undistort_,
           &QAction::triggered,
           this,

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -31,6 +31,7 @@
 
 #include "colmap/scene/reconstruction_io.h"
 #include "colmap/sensor/bitmap.h"
+#include "colmap/ui/qt_utils.h"
 #include "colmap/ui/render_options.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/ply.h"
@@ -374,13 +375,13 @@ void MainWindow::CreateActions() {
   //////////////////////////////////////////////////////////////////////////////
 
   action_project_new_ =
-      new QAction(QIcon(":/media/project-new.svg"), tr("New project"), this);
+      new QAction(ThemedIcon(":/media/project-new.svg"), tr("New project"), this);
   action_project_new_->setShortcuts(QKeySequence::New);
   connect(
       action_project_new_, &QAction::triggered, this, &MainWindow::ProjectNew);
 
   action_project_open_ =
-      new QAction(QIcon(":/media/project-open.svg"), tr("Open project"), this);
+      new QAction(ThemedIcon(":/media/project-open.svg"), tr("Open project"), this);
   action_project_open_->setShortcuts(QKeySequence::Open);
   connect(action_project_open_,
           &QAction::triggered,
@@ -388,14 +389,14 @@ void MainWindow::CreateActions() {
           &MainWindow::ProjectOpen);
 
   action_project_edit_ =
-      new QAction(QIcon(":/media/project-edit.svg"), tr("Edit project"), this);
+      new QAction(ThemedIcon(":/media/project-edit.svg"), tr("Edit project"), this);
   connect(action_project_edit_,
           &QAction::triggered,
           this,
           &MainWindow::ProjectEdit);
 
   action_project_save_ =
-      new QAction(QIcon(":/media/project-save.svg"), tr("Save project"), this);
+      new QAction(ThemedIcon(":/media/project-save.svg"), tr("Save project"), this);
   action_project_save_->setShortcuts(QKeySequence::Save);
   connect(action_project_save_,
           &QAction::triggered,
@@ -403,7 +404,7 @@ void MainWindow::CreateActions() {
           &MainWindow::ProjectSave);
 
   action_project_save_as_ = new QAction(
-      QIcon(":/media/project-save-as.svg"), tr("Save project as..."), this);
+      ThemedIcon(":/media/project-save-as.svg"), tr("Save project as..."), this);
   action_project_save_as_->setShortcuts(QKeySequence::SaveAs);
   connect(action_project_save_as_,
           &QAction::triggered,
@@ -411,13 +412,13 @@ void MainWindow::CreateActions() {
           &MainWindow::ProjectSaveAs);
 
   action_import_ =
-      new QAction(QIcon(":/media/import.svg"), tr("Import model"), this);
+      new QAction(ThemedIcon(":/media/import.svg"), tr("Import model"), this);
   action_import_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_I));
   connect(action_import_, &QAction::triggered, this, &MainWindow::Import);
   blocking_actions_.push_back(action_import_);
 
   action_import_from_ = new QAction(
-      QIcon(":/media/import-from.svg"), tr("Import from ..."), this);
+      ThemedIcon(":/media/import-from.svg"), tr("Import from ..."), this);
   connect(action_import_from_,
           &QAction::triggered,
           this,
@@ -425,24 +426,24 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_import_from_);
 
   action_export_ =
-      new QAction(QIcon(":/media/export.svg"), tr("Export model"), this);
+      new QAction(ThemedIcon(":/media/export.svg"), tr("Export model"), this);
   action_export_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_E));
   connect(action_export_, &QAction::triggered, this, &MainWindow::Export);
   blocking_actions_.push_back(action_export_);
 
   action_export_all_ = new QAction(
-      QIcon(":/media/export-all.svg"), tr("Export all models"), this);
+      ThemedIcon(":/media/export-all.svg"), tr("Export all models"), this);
   connect(
       action_export_all_, &QAction::triggered, this, &MainWindow::ExportAll);
   blocking_actions_.push_back(action_export_all_);
 
   action_export_as_ = new QAction(
-      QIcon(":/media/export-as.svg"), tr("Export model as..."), this);
+      ThemedIcon(":/media/export-as.svg"), tr("Export model as..."), this);
   connect(action_export_as_, &QAction::triggered, this, &MainWindow::ExportAs);
   blocking_actions_.push_back(action_export_as_);
 
   action_export_as_text_ = new QAction(
-      QIcon(":/media/export-as-text.svg"), tr("Export model as text"), this);
+      ThemedIcon(":/media/export-as-text.svg"), tr("Export model as text"), this);
   connect(action_export_as_text_,
           &QAction::triggered,
           this,
@@ -457,7 +458,7 @@ void MainWindow::CreateActions() {
   //////////////////////////////////////////////////////////////////////////////
 
   action_feature_extraction_ = new QAction(
-      QIcon(":/media/feature-extraction.svg"), tr("Feature extraction"), this);
+      ThemedIcon(":/media/feature-extraction.svg"), tr("Feature extraction"), this);
   connect(action_feature_extraction_,
           &QAction::triggered,
           this,
@@ -465,7 +466,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_feature_extraction_);
 
   action_feature_matching_ = new QAction(
-      QIcon(":/media/feature-matching.svg"), tr("Feature matching"), this);
+      ThemedIcon(":/media/feature-matching.svg"), tr("Feature matching"), this);
   connect(action_feature_matching_,
           &QAction::triggered,
           this,
@@ -473,7 +474,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_feature_matching_);
 
   action_database_management_ =
-      new QAction(QIcon(":/media/database-management.svg"),
+      new QAction(ThemedIcon(":/media/database-management.svg"),
                   tr("Database management"),
                   this);
   connect(action_database_management_,
@@ -487,7 +488,7 @@ void MainWindow::CreateActions() {
   //////////////////////////////////////////////////////////////////////////////
 
   action_automatic_reconstruction_ =
-      new QAction(QIcon(":/media/automatic-reconstruction.svg"),
+      new QAction(ThemedIcon(":/media/automatic-reconstruction.svg"),
                   tr("Automatic reconstruction"),
                   this);
   connect(action_automatic_reconstruction_,
@@ -496,7 +497,7 @@ void MainWindow::CreateActions() {
           &MainWindow::AutomaticReconstruction);
 
   action_reconstruction_start_ =
-      new QAction(QIcon(":/media/reconstruction-start.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-start.svg"),
                   tr("Start reconstruction"),
                   this);
   connect(action_reconstruction_start_,
@@ -506,7 +507,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_reconstruction_start_);
 
   action_reconstruction_step_ =
-      new QAction(QIcon(":/media/reconstruction-step.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-step.svg"),
                   tr("Reconstruct next image"),
                   this);
   connect(action_reconstruction_step_,
@@ -516,7 +517,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_reconstruction_step_);
 
   action_reconstruction_pause_ =
-      new QAction(QIcon(":/media/reconstruction-pause.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-pause.svg"),
                   tr("Pause reconstruction"),
                   this);
   connect(action_reconstruction_pause_,
@@ -527,7 +528,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_reconstruction_pause_);
 
   action_reconstruction_reset_ =
-      new QAction(QIcon(":/media/reconstruction-reset.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-reset.svg"),
                   tr("Reset reconstruction"),
                   this);
   connect(action_reconstruction_reset_,
@@ -536,7 +537,7 @@ void MainWindow::CreateActions() {
           &MainWindow::ReconstructionOverwrite);
 
   action_reconstruction_normalize_ =
-      new QAction(QIcon(":/media/reconstruction-normalize.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-normalize.svg"),
                   tr("Normalize reconstruction"),
                   this);
   connect(action_reconstruction_normalize_,
@@ -546,7 +547,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_reconstruction_normalize_);
 
   action_reconstruction_options_ =
-      new QAction(QIcon(":/media/reconstruction-options.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-options.svg"),
                   tr("Reconstruction options"),
                   this);
   connect(action_reconstruction_options_,
@@ -556,7 +557,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_reconstruction_options_);
 
   action_bundle_adjustment_ = new QAction(
-      QIcon(":/media/bundle-adjustment.svg"), tr("Bundle adjustment"), this);
+      ThemedIcon(":/media/bundle-adjustment.svg"), tr("Bundle adjustment"), this);
   connect(action_bundle_adjustment_,
           &QAction::triggered,
           this,
@@ -565,7 +566,7 @@ void MainWindow::CreateActions() {
   blocking_actions_.push_back(action_bundle_adjustment_);
 
   action_dense_reconstruction_ =
-      new QAction(QIcon(":/media/dense-reconstruction.svg"),
+      new QAction(ThemedIcon(":/media/dense-reconstruction.svg"),
                   tr("Dense reconstruction"),
                   this);
   connect(action_dense_reconstruction_,
@@ -578,21 +579,21 @@ void MainWindow::CreateActions() {
   //////////////////////////////////////////////////////////////////////////////
 
   action_render_toggle_ = new QAction(
-      QIcon(":/media/render-enabled.svg"), tr("Disable rendering"), this);
+      ThemedIcon(":/media/render-enabled.svg"), tr("Disable rendering"), this);
   connect(action_render_toggle_,
           &QAction::triggered,
           this,
           &MainWindow::RenderToggle);
 
   action_render_reset_view_ = new QAction(
-      QIcon(":/media/render-reset-view.svg"), tr("Reset view"), this);
+      ThemedIcon(":/media/render-reset-view.svg"), tr("Reset view"), this);
   connect(action_render_reset_view_,
           &QAction::triggered,
           model_viewer_widget_,
           &ModelViewerWidget::ResetView);
 
   action_render_options_ = new QAction(
-      QIcon(":/media/render-options.svg"), tr("Render options"), this);
+      ThemedIcon(":/media/render-options.svg"), tr("Render options"), this);
   connect(action_render_options_,
           &QAction::triggered,
           this,
@@ -609,7 +610,7 @@ void MainWindow::CreateActions() {
   //////////////////////////////////////////////////////////////////////////////
 
   action_reconstruction_stats_ =
-      new QAction(QIcon(":/media/reconstruction-stats.svg"),
+      new QAction(ThemedIcon(":/media/reconstruction-stats.svg"),
                   tr("Show model statistics"),
                   this);
   connect(action_reconstruction_stats_,
@@ -618,30 +619,30 @@ void MainWindow::CreateActions() {
           &MainWindow::ReconstructionStats);
 
   action_match_matrix_ = new QAction(
-      QIcon(":/media/match-matrix.svg"), tr("Show match matrix"), this);
+      ThemedIcon(":/media/match-matrix.svg"), tr("Show match matrix"), this);
   connect(action_match_matrix_,
           &QAction::triggered,
           this,
           &MainWindow::MatchMatrix);
 
   action_log_show_ =
-      new QAction(QIcon(":/media/log.svg"), tr("Show log"), this);
+      new QAction(ThemedIcon(":/media/log.svg"), tr("Show log"), this);
   connect(action_log_show_, &QAction::triggered, this, &MainWindow::ShowLog);
 
   action_grab_image_ =
-      new QAction(QIcon(":/media/grab-image.svg"), tr("Grab image"), this);
+      new QAction(ThemedIcon(":/media/grab-image.svg"), tr("Grab image"), this);
   connect(
       action_grab_image_, &QAction::triggered, this, &MainWindow::GrabImage);
 
   action_grab_movie_ =
-      new QAction(QIcon(":/media/grab-movie.svg"), tr("Grab movie"), this);
+      new QAction(ThemedIcon(":/media/grab-movie.svg"), tr("Grab movie"), this);
   connect(action_grab_movie_,
           &QAction::triggered,
           model_viewer_widget_,
           &ModelViewerWidget::GrabMovie);
 
   action_undistort_ =
-      new QAction(QIcon(":/media/undistort.svg"), tr("Undistortion"), this);
+      new QAction(ThemedIcon(":/media/undistort.svg"), tr("Undistortion"), this);
   connect(action_undistort_,
           &QAction::triggered,
           this,
@@ -1698,13 +1699,13 @@ void MainWindow::RenderToggle() {
   if (render_options_widget_->automatic_update) {
     render_options_widget_->automatic_update = false;
     render_options_widget_->counter = 0;
-    action_render_toggle_->setIcon(QIcon(":/media/render-disabled.svg"));
+    action_render_toggle_->setIcon(ThemedIcon(":/media/render-disabled.svg"));
     action_render_toggle_->setText(tr("Enable rendering"));
   } else {
     render_options_widget_->automatic_update = true;
     render_options_widget_->counter = 0;
     RenderNow();
-    action_render_toggle_->setIcon(QIcon(":/media/render-enabled.svg"));
+    action_render_toggle_->setIcon(ThemedIcon(":/media/render-enabled.svg"));
     action_render_toggle_->setText(tr("Disable rendering"));
   }
 }

--- a/src/colmap/ui/qt_utils.cc
+++ b/src/colmap/ui/qt_utils.cc
@@ -32,7 +32,35 @@
 #include "colmap/sensor/models.h"
 #include "colmap/util/misc.h"
 
+#include <QApplication>
+#include <QPainter>
+#include <QPalette>
+#include <QPixmap>
+#include <QtSvg/QSvgRenderer>
+
 namespace colmap {
+
+QIcon ThemedIcon(const QString& resource_path) {
+  QSvgRenderer renderer(resource_path);
+  if (!renderer.isValid()) {
+    return QIcon(resource_path);
+  }
+
+  // Render at a generous base size so that QIcon produces crisp icons at any
+  // toolbar/menu size, including on high-DPI displays.
+  QPixmap pixmap(64, 64);
+  pixmap.fill(Qt::transparent);
+  QPainter painter(&pixmap);
+  renderer.render(&painter);
+  // The :/media SVGs are flat black silhouettes; recolor them to the palette
+  // foreground color so they stay legible under both light and dark themes.
+  // Qt derives the disabled appearance from this pixmap automatically.
+  painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+  painter.fillRect(pixmap.rect(),
+                   QApplication::palette().color(QPalette::WindowText));
+  painter.end();
+  return QIcon(pixmap);
+}
 
 Eigen::Matrix4f QMatrixToEigen(const QMatrix4x4& matrix) {
   Eigen::Matrix4f eigen;

--- a/src/colmap/ui/qt_utils.cc
+++ b/src/colmap/ui/qt_utils.cc
@@ -36,6 +36,7 @@
 #include <QPainter>
 #include <QPalette>
 #include <QPixmap>
+
 #include <QtSvg/QSvgRenderer>
 
 namespace colmap {

--- a/src/colmap/ui/qt_utils.h
+++ b/src/colmap/ui/qt_utils.h
@@ -35,11 +35,21 @@
 #include "colmap/util/types.h"
 
 #include <QtCore>
+#include <QtGui>
 #include <QtOpenGL>
 
 #include <Eigen/Core>
 
 namespace colmap {
+
+// Loads a monochrome SVG icon from a Qt resource path and tints it to match
+// the current application palette, so that icons remain legible under both
+// light and dark themes. The icons under :/media are flat silhouettes without
+// an explicit fill color (which defaults to black per the SVG spec), so a
+// solid tint to the palette foreground color is exact. The tint is baked in
+// when the icon is created, so a theme change at runtime is only reflected
+// once icons are recreated.
+QIcon ThemedIcon(const QString& resource_path);
 
 Eigen::Matrix4f QMatrixToEigen(const QMatrix4x4& matrix);
 


### PR DESCRIPTION
## Problem

Fixes #4477. The Material Symbols SVG icons under `src/colmap/ui/media/` (introduced in #4343) are flat silhouettes whose `<path>` elements have no `fill` attribute. Per the SVG spec, fill then defaults to **solid black**, independent of the Qt palette. On dark themes (e.g. Ubuntu's Yaru-dark) the toolbar/menu icons render black-on-dark and are nearly unreadable.

## Fix

Add a `ThemedIcon()` helper in `qt_utils` that loads the SVG with `QSvgRenderer` and recolors the silhouette to the palette's `WindowText` color via a `CompositionMode_SourceIn` fill, then use it at all icon load sites in `main_window.cc` (replacing `QIcon(":/media/*.svg")`).

This auto-adapts to any theme (light, dark, high-contrast, macOS/Windows dark mode) from a single helper, with no duplicate assets and no new dependencies (QtSvg was already linked). Icons are rendered at 64×64 so `QIcon` stays crisp at toolbar/menu sizes including on high-DPI displays.

## Notes

- The tint is baked in at icon-creation time; a runtime theme switch is only reflected once icons are recreated (documented in the header). This covers the reported scenario, where the theme is set before launch.