### PR TITLE
Fix glog color support version detection

### DIFF
--- a/src/colmap/util/logging.h
+++ b/src/colmap/util/logging.h
@@ -97,8 +97,8 @@
 
 namespace colmap {
 
-#if !defined(GLOG_VERSION_MAJOR) || GLOG_VERSION_MAJOR > 0 || \
-    GLOG_VERSION_MINOR >= 4
+#if defined(GLOG_VERSION_MAJOR) && \
+    (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 4)
 #define COLMAP_GLOG_HAS_COLOR_SUPPORT 1
 #else
 #define COLMAP_GLOG_HAS_COLOR_SUPPORT 0


### PR DESCRIPTION
The previous preprocessor condition in `logging.h` enabled `COLMAP_GLOG_HAS_COLOR_SUPPORT` when `GLOG_VERSION_MAJOR` was *undefined*, and also referenced `GLOG_VERSION_MINOR` without guarding that the version macros actually exist.

This changes the condition to require the version macros to be defined before enabling color support:

```cpp
#if defined(GLOG_VERSION_MAJOR) && \
    (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 4)
#define COLMAP_GLOG_HAS_COLOR_SUPPORT 1
#else
#define COLMAP_GLOG_HAS_COLOR_SUPPORT 0
#endif
```