### PR TITLE
Replace std::hash<std::pair<uint64_t,uint64_t>> with colmap::PairHash functor

### DIFF
--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -207,9 +207,8 @@ class IncrementalTriangulator {
   // Cache for tried track merges to avoid duplicate merge trials. Keyed on
   // a canonical (min, max) pair of 3D-point ids so each attempted merge is
   // recorded once with a single hashmap operation in either direction.
-  // Uses the std::hash<std::pair<uint64_t, uint64_t>> specialization in
-  // colmap/util/types.h.
-  std::unordered_set<std::pair<point3D_t, point3D_t>> merge_trials_;
+  // Uses the colmap::PairHash functor from colmap/util/types.h.
+  std::unordered_set<std::pair<point3D_t, point3D_t>, PairHash> merge_trials_;
 
   // Cache for found correspondences in the graph.
   std::vector<CorrespondenceGraph::Correspondence> found_corrs_;

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -339,6 +339,22 @@ struct filter_view {
 template <typename>
 struct always_false : std::false_type {};
 
+// Hash functor for std::pair, e.g., for use with unordered containers keyed on
+// e.g., std::pair<point3D_t, point3D_t>. Provided as an explicit functor
+// (passed to the container) rather than a std::hash<std::pair<...>>
+// specialization, since specializing std::hash for the std-owned std::pair type
+// is a global ODR hazard: a downstream translation unit that implicitly
+// instantiates the primary template first would make the later explicit
+// specialization ill-formed.
+struct PairHash {
+  template <typename T1, typename T2>
+  std::size_t operator()(const std::pair<T1, T2>& p) const {
+    const std::size_t h1 = std::hash<T1>{}(p.first);
+    const std::size_t h2 = std::hash<T2>{}(p.second);
+    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+  }
+};
+
 }  // namespace colmap
 
 // This file provides specializations of the templated hash function for
@@ -351,16 +367,6 @@ struct hash<std::pair<uint32_t, uint32_t>> {
     const uint64_t s = (static_cast<uint64_t>(p.first) << 32) +
                        static_cast<uint64_t>(p.second);
     return std::hash<uint64_t>()(s);
-  }
-};
-
-// Hash function specialization for uint64_t pairs, e.g., point3D_t.
-template <>
-struct hash<std::pair<uint64_t, uint64_t>> {
-  std::size_t operator()(const std::pair<uint64_t, uint64_t>& p) const {
-    const std::size_t h1 = std::hash<uint64_t>{}(p.first);
-    const std::size_t h2 = std::hash<uint64_t>{}(p.second);
-    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
   }
 };
 

--- a/src/colmap/util/types_test.cc
+++ b/src/colmap/util/types_test.cc
@@ -164,7 +164,7 @@ TEST(FeatureMatchHashing, Deterministic) {
 }
 
 TEST(Point3DPairHashing, Nominal) {
-  std::unordered_set<std::pair<point3D_t, point3D_t>> set;
+  std::unordered_set<std::pair<point3D_t, point3D_t>, PairHash> set;
   set.emplace(1, 2);
   EXPECT_EQ(set.size(), 1);
   set.emplace(1, 2);
@@ -182,7 +182,7 @@ TEST(Point3DPairHashing, Nominal) {
 TEST(Point3DPairHashing, LargeValues) {
   const point3D_t hi = std::numeric_limits<point3D_t>::max();
   const point3D_t lo = 1;
-  std::unordered_set<std::pair<point3D_t, point3D_t>> set;
+  std::unordered_set<std::pair<point3D_t, point3D_t>, PairHash> set;
   set.emplace(hi, lo);
   set.emplace(lo, hi);
   set.emplace(hi, hi);
@@ -195,7 +195,7 @@ TEST(Point3DPairHashing, LargeValues) {
 }
 
 TEST(Point3DPairHashing, Deterministic) {
-  std::hash<std::pair<point3D_t, point3D_t>> h;
+  PairHash h;
   EXPECT_EQ(h(std::make_pair<point3D_t, point3D_t>(42, 99)),
             h(std::make_pair<point3D_t, point3D_t>(42, 99)));
   EXPECT_NE(h(std::make_pair<point3D_t, point3D_t>(42, 99)),


### PR DESCRIPTION
## Problem

4.1.0 newly added an explicit `std::hash<std::pair<uint64_t, uint64_t>>` specialization in `colmap/util/types.h` (4.0.3 only had the `uint32_t` pair). Specializing `std::hash` for the std-owned `std::pair` type is a **global ODR hazard**: any downstream translation unit that includes a header keying an unordered container on `std::pair<uint64_t, uint64_t>` (with the default `std::hash`) *before* `colmap/util/types.h` will implicitly instantiate the primary template first, making the later explicit specialization ill-formed ("explicit specialization after instantiation").

## Fix

- Remove the `std::hash<std::pair<uint64_t, uint64_t>>` specialization.
- Add a `colmap::PairHash` functor, passed explicitly to colmap's own `std::unordered_set<std::pair<point3D_t, point3D_t>, PairHash>` in the incremental triangulator and the corresponding tests.
- The `std::hash<std::pair<uint32_t, uint32_t>>` specialization (present since 4.0.3) is left untouched.

This restores 4.0.3 behavior where colmap did not own that global specialization.

## Testing

`colmap_util_types_test` builds clean and all `Point3DPairHashing` tests pass; `colmap_sfm` (including `incremental_triangulator.cc`) builds clean.