### PR TITLE
Fix Caspar CUDA build with MSVC forced includes

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -134,9 +134,13 @@ if(CASPAR_ENABLED AND CUDA_ENABLED)
     )
     if(IS_MSVC)
         set(_MSVC_COMPACT_HEADER "${CASPAR_GEN_DIR}/../../msvc_compact.h")
+        set(_MSVC_CUDA_COMPACT_HEADER "${CASPAR_GEN_DIR}/../../msvc_cuda_compact.h")
         target_compile_options(caspar_lib_core PRIVATE
             $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/FI"${_MSVC_COMPACT_HEADER}">
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler /FI"${_MSVC_COMPACT_HEADER}">
+            # Keep CUDA pre-includes minimal and use NVCC's native pre-include
+            # option to avoid forcing C++ standard library headers into NVCC's
+            # MSVC host pass.
+            $<$<COMPILE_LANGUAGE:CUDA>:--pre-include="${_MSVC_CUDA_COMPACT_HEADER}">
         )
     endif()
     message(STATUS "Configuring Caspar... done")

--- a/src/thirdparty/Symforce-Caspar/msvc_cuda_compact.h
+++ b/src/thirdparty/Symforce-Caspar/msvc_cuda_compact.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#ifdef _MSC_VER
+// Caspar CUDA sources use 'uint', which is not defined by MSVC.
+typedef unsigned int uint;
+#endif


### PR DESCRIPTION
### Background

COLMAP's Caspar integration uses a small MSVC compatibility header for generated sources. This works for regular C/C++ compilation, but the same header was also force-included for CUDA sources through `-Xcompiler /FI`.

That is too broad for NVCC builds on Windows: the compatibility header pulls in C++ standard library / MSVC headers during CUDA compilation, which can trigger MSVC/UCRT header redefinition errors with newer CUDA + Visual Studio toolchains.

The CUDA sources only need a much smaller compatibility shim for MSVC, currently just the missing `uint` typedef used by generated Caspar CUDA code. This PR separates the CUDA pre-include path from the regular C/C++ forced include path and uses NVCC's native `--pre-include` option for CUDA files.

### Fix
Keep the existing forced MSVC compact header for C/C++ sources, but use
NVCC's native --pre-include with a CUDA-only compatibility header for
Caspar CUDA sources.

This avoids pulling C++ standard library headers into NVCC's MSVC host
pass and fixes UCRT/MSVC header redefinition failures across supported
CUDA + Visual Studio toolchains.


### Validation

Tested on Windows with CUDA 12.5 and MSVC 19.44:

- `caspar_lib_core` builds successfully in Release
- `INSTALL` target completes successfully
- Installed `COLMAP.bat help` runs successfully and reports CUDA support