### PR TITLE
Support selecting Caspar BA backend in global mapper

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -806,11 +806,15 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.bundle_adjustment.refine_points3D);
   AddDefaultOption("GlobalMapper.ba_min_track_length",
                    &global_mapper->mapper.bundle_adjustment.min_track_length);
+  AddDefaultEnumOption("GlobalMapper.ba_backend",
+                       &global_mapper->mapper.bundle_adjustment.backend,
+                       BundleAdjustmentBackendToString,
+                       BundleAdjustmentBackendFromString);
+  AddDefaultOption("GlobalMapper.ba_gpu_index",
+                   &global_mapper->mapper.ba_gpu_index);
   // Bundle adjustment options (Ceres-specific).
   AddDefaultOption("GlobalMapper.ba_ceres_use_gpu",
                    &global_mapper->mapper.bundle_adjustment.ceres->use_gpu);
-  AddDefaultOption("GlobalMapper.ba_ceres_gpu_index",
-                   &global_mapper->mapper.bundle_adjustment.ceres->gpu_index);
   AddDefaultOption(
       "GlobalMapper.ba_ceres_loss_function_scale",
       &global_mapper->mapper.bundle_adjustment.ceres->loss_function_scale);

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -1,5 +1,6 @@
 #include "colmap/sfm/global_mapper.h"
 
+#include "colmap/estimators/bundle_adjustment_caspar.h"
 #include "colmap/estimators/rotation_averaging.h"
 #include "colmap/math/union_find.h"
 #include "colmap/scene/projection.h"
@@ -65,6 +66,10 @@ BundleAdjustmentOptions GlobalMapperOptions::BundleAdjustment() const {
   opts.refine_sensor_from_rig = refine_sensor_from_rig;
   if (opts.ceres) {
     opts.ceres->solver_options.num_threads = num_threads;
+    opts.ceres->gpu_index = ba_gpu_index;
+  }
+  if (opts.caspar) {
+    opts.caspar->gpu_index = ba_gpu_index;
   }
   return opts;
 }

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -76,6 +76,10 @@ struct GlobalMapperOptions {
   double max_normalized_reproj_error = 1e-2;  // for bundle adjustment
   double min_tri_angle_deg = 1.;              // for triangulation
 
+  // GPU device index for bundle adjustment, shared by the Ceres and Caspar
+  // backends (-1 = auto-select).
+  std::string ba_gpu_index = "-1";
+
   // Control the number of iterations for bundle adjustment.
   int ba_num_iterations = 3;
 


### PR DESCRIPTION
Exposes the bundle adjustment solver backend selection in the global mapper, so Caspar can be selected just like in the incremental mapper.

## Changes

- Add `GlobalMapper.ba_backend` option (`CERES` / `CASPAR`), bound to `GlobalMapperOptions::bundle_adjustment.backend`. The global mapper already dispatches through `CreateDefaultBundleAdjuster`, which honors the backend, so this just exposes the choice on the CLI / project file.
- Replace the Ceres-only `GlobalMapper.ba_ceres_gpu_index` with a single solver-agnostic `GlobalMapper.ba_gpu_index`, plumbed into both `ceres->gpu_index` and `caspar->gpu_index` in `GlobalMapperOptions::BundleAdjustment()`. This mirrors how `Mapper.ba_gpu_index` is shared across backends in the incremental mapper.

The hierarchical mapper already inherits backend selection via the shared `Mapper.ba_local_backend` / `Mapper.ba_global_backend` options (it feeds `IncrementalPipelineOptions` into each cluster), so no changes are needed there.

## Notes

`ba_ceres_use_gpu` remains Ceres-specific, since Caspar has no equivalent toggle (it always runs on GPU). Selecting `CASPAR` in a build without `CASPAR_ENABLED` produces a clear runtime error via the existing factory path.