### PR TITLE
Add mapper selection (incremental/global/hierarchical) to the GUI

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -326,7 +326,7 @@ void AutomaticReconstructionController::RunSparseMapper() {
       break;
     }
     case Mapper::HIERARCHICAL: {
-      HierarchicalPipeline::Options options;
+      HierarchicalPipelineOptions options;
       options.image_path = *option_manager_.image_path;
       options.incremental_options = *option_manager_.mapper;
       mapper = std::make_unique<HierarchicalPipeline>(

--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -84,6 +84,8 @@ GlobalPipeline::GlobalPipeline(
   if (options_.decompose_relative_pose) {
     MaybeDecomposeRelativePoses(database_cache_.get());
   }
+
+  RegisterCallback(MODEL_UPDATE_CALLBACK);
 }
 
 void GlobalPipeline::Run() {
@@ -93,7 +95,10 @@ void GlobalPipeline::Run() {
     WarnInsufficientPriorFocalLengths();
   }
 
-  auto reconstruction = std::make_shared<Reconstruction>();
+  // Add the reconstruction to the manager up front so that intermediate states
+  // can be rendered while the global mapper is running.
+  auto reconstruction =
+      reconstruction_manager_->Get(reconstruction_manager_->Add());
 
   // Prepare mapper options with top-level options.
   GlobalMapperOptions mapper_options = options_.mapper;
@@ -106,7 +111,10 @@ void GlobalPipeline::Run() {
 
   Timer run_timer;
   run_timer.Start();
-  global_mapper.Solve(mapper_options);
+  global_mapper.Solve(mapper_options, [this]() {
+    Callback(MODEL_UPDATE_CALLBACK);
+    return CheckIfStopped();
+  });
   LOG(INFO) << "Reconstruction done in " << run_timer.ElapsedSeconds()
             << " seconds";
 
@@ -114,14 +122,10 @@ void GlobalPipeline::Run() {
   AlignReconstructionToOrigRigScales(database_cache_->Rigs(),
                                      reconstruction.get());
 
-  // Output the reconstruction.
-  Reconstruction& output_reconstruction =
-      *reconstruction_manager_->Get(reconstruction_manager_->Add());
-  output_reconstruction = *reconstruction;
   if (!options_.image_path.empty()) {
     LOG(INFO) << "Extracting colors ...";
-    output_reconstruction.ExtractColorsForAllImages(options_.image_path,
-                                                    options_.num_threads);
+    reconstruction->ExtractColorsForAllImages(options_.image_path,
+                                              options_.num_threads);
   }
 
   if (has_insufficient_prior_focal_lengths) {

--- a/src/colmap/controllers/global_pipeline.h
+++ b/src/colmap/controllers/global_pipeline.h
@@ -67,6 +67,13 @@ struct GlobalPipelineOptions {
 
 class GlobalPipeline : public BaseController {
  public:
+  enum CallbackType {
+    // Triggered after global positioning, after each global refinement
+    // iteration, and after retriangulation, so the in-progress reconstruction
+    // can be rendered.
+    MODEL_UPDATE_CALLBACK,
+  };
+
   GlobalPipeline(GlobalPipelineOptions options,
                  std::shared_ptr<Database> database,
                  std::shared_ptr<ReconstructionManager> reconstruction_manager);

--- a/src/colmap/controllers/hierarchical_pipeline.cc
+++ b/src/colmap/controllers/hierarchical_pipeline.cc
@@ -102,7 +102,7 @@ void MergeClusters(const SceneClustering::Cluster& cluster,
 
 }  // namespace
 
-bool HierarchicalPipeline::Options::Check() const {
+bool HierarchicalPipelineOptions::Check() const {
   CHECK_OPTION_GT(init_num_trials, -1);
   CHECK_OPTION_GE(num_threads, -1);
   CHECK_OPTION_GE(num_workers, -1);
@@ -113,7 +113,7 @@ bool HierarchicalPipeline::Options::Check() const {
 }
 
 HierarchicalPipeline::HierarchicalPipeline(
-    const Options& options,
+    const HierarchicalPipelineOptions& options,
     std::shared_ptr<Database> database,
     std::shared_ptr<ReconstructionManager> reconstruction_manager)
     : options_(options),

--- a/src/colmap/controllers/hierarchical_pipeline.h
+++ b/src/colmap/controllers/hierarchical_pipeline.h
@@ -39,6 +39,30 @@
 
 namespace colmap {
 
+struct HierarchicalPipelineOptions {
+  // The image path at which to find the images to extract point colors.
+  // If not specified, all point colors will be black.
+  std::filesystem::path image_path;
+
+  // The maximum number of trials to initialize a cluster.
+  int init_num_trials = 10;
+
+  // The total number of threads for the hierarchical pipeline. This budget
+  // is divided across workers to avoid thread oversubscription.
+  int num_threads = -1;
+
+  // The number of workers used to reconstruct clusters in parallel.
+  int num_workers = -1;
+
+  // Options for clustering the scene graph.
+  SceneClustering::Options clustering_options;
+
+  // Options used to reconstruction each cluster individually.
+  IncrementalPipelineOptions incremental_options;
+
+  bool Check() const;
+};
+
 // Hierarchical mapping first hierarchically partitions the scene into multiple
 // overlapping clusters, then reconstructs them separately using incremental
 // mapping, and finally merges them all into a globally consistent
@@ -46,39 +70,15 @@ namespace colmap {
 // incremental mapping becomes slow with an increasing number of images.
 class HierarchicalPipeline : public BaseController {
  public:
-  struct Options {
-    // The image path at which to find the images to extract point colors.
-    // If not specified, all point colors will be black.
-    std::filesystem::path image_path;
-
-    // The maximum number of trials to initialize a cluster.
-    int init_num_trials = 10;
-
-    // The total number of threads for the hierarchical pipeline. This budget
-    // is divided across workers to avoid thread oversubscription.
-    int num_threads = -1;
-
-    // The number of workers used to reconstruct clusters in parallel.
-    int num_workers = -1;
-
-    // Options for clustering the scene graph.
-    SceneClustering::Options clustering_options;
-
-    // Options used to reconstruction each cluster individually.
-    IncrementalPipelineOptions incremental_options;
-
-    bool Check() const;
-  };
-
   HierarchicalPipeline(
-      const Options& options,
+      const HierarchicalPipelineOptions& options,
       std::shared_ptr<Database> database,
       std::shared_ptr<ReconstructionManager> reconstruction_manager);
 
   void Run() override;
 
  private:
-  const Options options_;
+  const HierarchicalPipelineOptions options_;
   std::shared_ptr<DatabaseCache> database_cache_;
   std::shared_ptr<ReconstructionManager> reconstruction_manager_;
 };

--- a/src/colmap/controllers/hierarchical_pipeline_test.cc
+++ b/src/colmap/controllers/hierarchical_pipeline_test.cc
@@ -81,7 +81,7 @@ TEST(HierarchicalPipeline, WithoutNoise) {
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  HierarchicalPipeline::Options mapper_options;
+  HierarchicalPipelineOptions mapper_options;
   mapper_options.clustering_options.leaf_max_num_images = 5;
   mapper_options.clustering_options.image_overlap = 3;
   HierarchicalPipeline mapper(mapper_options, database, reconstruction_manager);
@@ -122,7 +122,7 @@ TEST(HierarchicalPipeline, WithoutNoiseAndNonTrivialFrames) {
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  HierarchicalPipeline::Options mapper_options;
+  HierarchicalPipelineOptions mapper_options;
   mapper_options.clustering_options.leaf_max_num_images = 10;
   mapper_options.clustering_options.image_overlap = 3;
   // Note that the hierarchical mapper does not work well when the
@@ -158,7 +158,7 @@ TEST(HierarchicalPipeline, WithoutNoiseAndPanoramicNonTrivialFrames) {
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  HierarchicalPipeline::Options mapper_options;
+  HierarchicalPipelineOptions mapper_options;
   mapper_options.clustering_options.leaf_max_num_images = 10;
   mapper_options.clustering_options.image_overlap = 3;
   // Note that the hierarchical mapper does not work well when the
@@ -196,7 +196,7 @@ TEST(HierarchicalPipeline, MultiReconstruction) {
       synthetic_dataset_options, &gt_reconstruction2, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  HierarchicalPipeline::Options mapper_options;
+  HierarchicalPipelineOptions mapper_options;
   mapper_options.clustering_options.leaf_max_num_images = 5;
   mapper_options.clustering_options.image_overlap = 3;
   HierarchicalPipeline mapper(mapper_options, database, reconstruction_manager);

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -30,6 +30,7 @@
 #include "colmap/controllers/option_manager.h"
 
 #include "colmap/controllers/global_pipeline.h"
+#include "colmap/controllers/hierarchical_pipeline.h"
 #include "colmap/controllers/image_reader.h"
 #include "colmap/controllers/incremental_pipeline.h"
 #include "colmap/controllers/pairing.h"
@@ -75,6 +76,7 @@ OptionManager::OptionManager(bool add_project_options)
   bundle_adjustment = std::make_shared<BundleAdjustmentOptions>();
   mapper = std::make_shared<IncrementalPipelineOptions>();
   global_mapper = std::make_shared<GlobalPipelineOptions>();
+  hierarchical_mapper = std::make_shared<HierarchicalPipelineOptions>();
   gravity_refiner = std::make_shared<GravityRefinerOptions>();
   reconstruction_clusterer =
       std::make_shared<ReconstructionClusteringOptions>();
@@ -850,6 +852,34 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.min_tri_angle_deg);
 }
 
+void OptionManager::AddHierarchicalMapperOptions() {
+  if (added_hierarchical_mapper_options_) {
+    return;
+  }
+  added_hierarchical_mapper_options_ = true;
+
+  // The per-cluster reconstruction is configured through the incremental mapper
+  // options (Mapper.*), so only the hierarchical-specific options are added
+  // here. The incremental_options member is populated from `mapper` by callers.
+  AddDefaultOption("HierarchicalMapper.init_num_trials",
+                   &hierarchical_mapper->init_num_trials);
+  AddDefaultOption("HierarchicalMapper.num_threads",
+                   &hierarchical_mapper->num_threads);
+  AddDefaultOption("HierarchicalMapper.num_workers",
+                   &hierarchical_mapper->num_workers);
+  AddDefaultOption("HierarchicalMapper.is_hierarchical",
+                   &hierarchical_mapper->clustering_options.is_hierarchical);
+  AddDefaultOption("HierarchicalMapper.branching",
+                   &hierarchical_mapper->clustering_options.branching);
+  AddDefaultOption("HierarchicalMapper.image_overlap",
+                   &hierarchical_mapper->clustering_options.image_overlap);
+  AddDefaultOption("HierarchicalMapper.num_image_matches",
+                   &hierarchical_mapper->clustering_options.num_image_matches);
+  AddDefaultOption(
+      "HierarchicalMapper.leaf_max_num_images",
+      &hierarchical_mapper->clustering_options.leaf_max_num_images);
+}
+
 void OptionManager::AddGravityRefinerOptions() {
   if (added_gravity_refiner_options_) {
     return;
@@ -1128,6 +1158,7 @@ void OptionManager::ResetOptions(const bool reset_paths) {
   *bundle_adjustment = BundleAdjustmentOptions();
   *mapper = IncrementalPipelineOptions();
   *global_mapper = GlobalPipelineOptions();
+  *hierarchical_mapper = HierarchicalPipelineOptions();
   *gravity_refiner = GravityRefinerOptions();
   *reconstruction_clusterer = ReconstructionClusteringOptions();
 #if defined(COLMAP_MVS_ENABLED)

--- a/src/colmap/controllers/option_manager.h
+++ b/src/colmap/controllers/option_manager.h
@@ -50,6 +50,7 @@ struct ExistingMatchedPairingOptions;
 struct BundleAdjustmentOptions;
 struct IncrementalPipelineOptions;
 struct GlobalPipelineOptions;
+struct HierarchicalPipelineOptions;
 struct RenderOptions;
 struct ReconstructionClusteringOptions;
 
@@ -101,6 +102,7 @@ class OptionManager : public BaseOptionManager {
   void AddBundleAdjustmentOptions();
   void AddMapperOptions();
   void AddGlobalMapperOptions();
+  void AddHierarchicalMapperOptions();
   void AddGravityRefinerOptions();
   void AddReconstructionClustererOptions();
 #if defined(COLMAP_MVS_ENABLED)
@@ -134,6 +136,7 @@ class OptionManager : public BaseOptionManager {
   std::shared_ptr<BundleAdjustmentOptions> bundle_adjustment;
   std::shared_ptr<IncrementalPipelineOptions> mapper;
   std::shared_ptr<GlobalPipelineOptions> global_mapper;
+  std::shared_ptr<HierarchicalPipelineOptions> hierarchical_mapper;
   std::shared_ptr<ReconstructionClusteringOptions> reconstruction_clusterer;
   std::shared_ptr<GravityRefinerOptions> gravity_refiner;
 
@@ -170,6 +173,7 @@ class OptionManager : public BaseOptionManager {
   bool added_ba_options_ = false;
   bool added_mapper_options_ = false;
   bool added_global_mapper_options_ = false;
+  bool added_hierarchical_mapper_options_ = false;
   bool added_gravity_refiner_options_ = false;
   bool added_reconstruction_clusterer_options_ = false;
 #if defined(COLMAP_MVS_ENABLED)

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -423,20 +423,14 @@ int RunGlobalMapper(int argc, char** argv) {
 }
 
 int RunHierarchicalMapper(int argc, char** argv) {
-  HierarchicalPipeline::Options mapper_options;
   std::filesystem::path output_path;
 
   OptionManager options;
   options.AddDatabaseOptions();
-  options.AddRequiredOption("image_path", &mapper_options.image_path);
+  options.AddRequiredOption("image_path",
+                            &options.hierarchical_mapper->image_path);
   options.AddRequiredOption("output_path", &output_path);
-  options.AddDefaultOption("num_threads", &mapper_options.num_threads);
-  options.AddDefaultOption("num_workers", &mapper_options.num_workers);
-  options.AddDefaultOption("image_overlap",
-                           &mapper_options.clustering_options.image_overlap);
-  options.AddDefaultOption(
-      "leaf_max_num_images",
-      &mapper_options.clustering_options.leaf_max_num_images);
+  options.AddHierarchicalMapperOptions();
   options.AddMapperOptions();
   if (!options.Parse(argc, argv)) {
     return EXIT_FAILURE;
@@ -447,10 +441,10 @@ int RunHierarchicalMapper(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  mapper_options.incremental_options = *options.mapper;
+  options.hierarchical_mapper->incremental_options = *options.mapper;
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
   HierarchicalPipeline hierarchical_mapper(
-      mapper_options,
+      *options.hierarchical_mapper,
       Database::Open(*options.database_path),
       reconstruction_manager);
   hierarchical_mapper.Run();

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -340,7 +340,8 @@ bool GlobalMapper::IterativeBundleAdjustment(
     double min_tri_angle_deg,
     int num_iterations,
     bool skip_fixed_rotation_stage,
-    bool skip_joint_optimization_stage) {
+    bool skip_joint_optimization_stage,
+    const std::function<bool()>& on_progress) {
   for (int ite = 0; ite < num_iterations; ite++) {
     // Optional fixed-rotation stage: optimize positions only
     if (!skip_fixed_rotation_stage) {
@@ -366,6 +367,12 @@ bool GlobalMapper::IterativeBundleAdjustment(
     // TODO: Skip normalization when position priors are used (similar to
     // incremental mapper's !use_prior_position condition).
     reconstruction_->Normalize();
+
+    // Report progress for this refinement iteration and stop early if
+    // requested.
+    if (on_progress && on_progress()) {
+      break;
+    }
 
     // Filter tracks based on the estimation
     // For the filtering, in each round, the criteria for outlier is
@@ -475,7 +482,8 @@ bool GlobalMapper::IterativeRetriangulateAndRefine(
   return true;
 }
 
-bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
+bool GlobalMapper::Solve(const GlobalMapperOptions& options,
+                         const std::function<bool()>& on_progress) {
   THROW_CHECK_NOTNULL(reconstruction_);
   THROW_CHECK_NOTNULL(pose_graph_);
 
@@ -483,6 +491,17 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
     LOG(ERROR) << "Cannot continue with empty pose graph";
     return false;
   }
+
+  // Reports the current reconstruction and returns whether a stop was
+  // requested. On stop, point errors are recomputed in pixels for consistent
+  // reporting.
+  const auto report_and_check_stop = [&]() {
+    if (on_progress && on_progress()) {
+      reconstruction_->UpdatePoint3DErrors();
+      return true;
+    }
+    return false;
+  };
 
   // Run rotation averaging
   if (!options.skip_rotation_averaging) {
@@ -519,6 +538,12 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
     }
     LOG(INFO) << "Global positioning done in " << run_timer.ElapsedSeconds()
               << " seconds";
+
+    // Report the first 3D view after global positioning and stop early if
+    // requested.
+    if (report_and_check_stop()) {
+      return true;
+    }
   }
 
   // Bundle adjustment
@@ -531,7 +556,8 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
                                    options.min_tri_angle_deg,
                                    options.ba_num_iterations,
                                    options.ba_skip_fixed_rotation_stage,
-                                   options.ba_skip_joint_optimization_stage)) {
+                                   options.ba_skip_joint_optimization_stage,
+                                   on_progress)) {
       return false;
     }
     LOG(INFO) << "Iterative bundle adjustment done in "
@@ -551,6 +577,11 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options) {
     }
     LOG(INFO) << "Iterative retriangulation and refinement done in "
               << run_timer.ElapsedSeconds() << " seconds";
+
+    // Report the result after retriangulation and stop early if requested.
+    if (report_and_check_stop()) {
+      return true;
+    }
   }
 
   // Filter passes here use NORMALIZED/ANGULAR error, so point3D.error is

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -369,9 +369,14 @@ bool GlobalMapper::IterativeBundleAdjustment(
     reconstruction_->Normalize();
 
     // Report progress for this refinement iteration and stop early if
-    // requested.
-    if (on_progress && on_progress()) {
-      break;
+    // requested. The filter passes above leave point3D.error in normalized
+    // units, so recompute it in pixels first to keep intermediate
+    // visualizations consistent with the final reconstruction.
+    if (on_progress) {
+      reconstruction_->UpdatePoint3DErrors();
+      if (on_progress()) {
+        break;
+      }
     }
 
     // Filter tracks based on the estimation
@@ -493,14 +498,16 @@ bool GlobalMapper::Solve(const GlobalMapperOptions& options,
   }
 
   // Reports the current reconstruction and returns whether a stop was
-  // requested. On stop, point errors are recomputed in pixels for consistent
-  // reporting.
+  // requested. Point errors are recomputed in pixels before reporting because
+  // the preceding filter passes leave point3D.error in normalized units, which
+  // would otherwise make intermediate visualizations inconsistent with the
+  // final reconstruction.
   const auto report_and_check_stop = [&]() {
-    if (on_progress && on_progress()) {
-      reconstruction_->UpdatePoint3DErrors();
-      return true;
+    if (!on_progress) {
+      return false;
     }
-    return false;
+    reconstruction_->UpdatePoint3DErrors();
+    return on_progress();
   };
 
   // Run rotation averaging

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -9,6 +9,7 @@
 #include "colmap/sfm/incremental_triangulator.h"
 
 #include <filesystem>
+#include <functional>
 #include <limits>
 
 namespace colmap {
@@ -113,8 +114,12 @@ class GlobalMapper {
   void BeginReconstruction(
       const std::shared_ptr<Reconstruction>& reconstruction);
 
-  // Run the global SfM pipeline.
-  bool Solve(const GlobalMapperOptions& options);
+  // Run the global SfM pipeline. The optional `on_progress` callback is invoked
+  // after global positioning, after each bundle-adjustment iteration, and after
+  // retriangulation/refinement; it returns true if a stop has been requested,
+  // in which case the pipeline terminates early and keeps the current result.
+  bool Solve(const GlobalMapperOptions& options,
+             const std::function<bool()>& on_progress = {});
 
   // Run rotation averaging to estimate global rotations.
   bool RotationAveraging(const RotationEstimatorOptions& options);
@@ -128,13 +133,16 @@ class GlobalMapper {
                          double max_normalized_reproj_error,
                          double min_tri_angle_deg);
 
-  // Run iterative bundle adjustment to refine poses and structure.
+  // Run iterative bundle adjustment to refine poses and structure. The optional
+  // `on_progress` callback is invoked after each iteration and returns true if
+  // a stop has been requested, in which case the iteration terminates early.
   bool IterativeBundleAdjustment(const BundleAdjustmentOptions& options,
                                  double max_normalized_reproj_error,
                                  double min_tri_angle_deg,
                                  int num_iterations,
                                  bool skip_fixed_rotation_stage = false,
-                                 bool skip_joint_optimization_stage = false);
+                                 bool skip_joint_optimization_stage = false,
+                                 const std::function<bool()>& on_progress = {});
 
   // Iteratively retriangulate tracks and refine to improve structure.
   bool IterativeRetriangulateAndRefine(

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/ui/main_window.h"
 
+#include "colmap/controllers/global_pipeline.h"
+#include "colmap/controllers/hierarchical_pipeline.h"
 #include "colmap/scene/reconstruction_io.h"
 #include "colmap/sensor/bitmap.h"
 #include "colmap/ui/render_options.h"
@@ -349,8 +351,8 @@ void MainWindow::CreateWidgets() {
   feature_matching_widget_ = new FeatureMatchingWidget(this, &options_);
   database_management_widget_ = new DatabaseManagementWidget(this, &options_);
   automatic_reconstruction_widget_ = new AutomaticReconstructionWidget(this);
-  reconstruction_options_widget_ =
-      new ReconstructionOptionsWidget(this, &options_);
+  reconstruction_options_widget_ = new ReconstructionOptionsWidget(
+      this, &options_, &mapper_type_, [this]() { UpdateMapperControls(); });
   bundle_adjustment_widget_ = new BundleAdjustmentWidget(this, &options_);
   dense_reconstruction_widget_ = new DenseReconstructionWidget(this, &options_);
   render_options_widget_ =
@@ -850,39 +852,80 @@ void MainWindow::CreateControllers() {
 
   options_.mapper->image_path = *options_.image_path;
 
-  mapper_controller_ = std::make_unique<ControllerThread<IncrementalPipeline>>(
-      std::make_shared<IncrementalPipeline>(
-          options_.mapper,
-          Database::Open(*options_.database_path),
-          reconstruction_manager_));
-  mapper_controller_->GetController()->AddCallback(
-      IncrementalPipeline::INITIAL_IMAGE_PAIR_REG_CALLBACK, [this]() {
-        if (!mapper_controller_->IsStopped()) {
-          action_render_now_->trigger();
-        }
-      });
-  mapper_controller_->GetController()->AddCallback(
-      IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK, [this]() {
-        if (!mapper_controller_->IsStopped()) {
-          action_render_->trigger();
-        }
-      });
-  mapper_controller_->GetController()->AddCallback(
-      IncrementalPipeline::LAST_IMAGE_REG_CALLBACK, [this]() {
-        if (!mapper_controller_->IsStopped()) {
-          action_render_now_->trigger();
-        }
-      });
-  mapper_controller_->AddCallback(
-      ControllerThread<IncrementalPipeline>::FINISHED_CALLBACK, [this]() {
-        if (!mapper_controller_->IsStopped()) {
-          action_render_now_->trigger();
-          action_reconstruction_finish_->trigger();
-        }
-        if (reconstruction_manager_->Size() == 0) {
-          action_reconstruction_reset_->trigger();
-        }
-      });
+  // Triggers an immediate render of the current reconstruction, unless the
+  // mapper is being stopped.
+  const auto render_now = [this]() {
+    if (!mapper_controller_->IsStopped()) {
+      action_render_now_->trigger();
+    }
+  };
+  // Triggers a rate-limited render of the current reconstruction.
+  const auto render = [this]() {
+    if (!mapper_controller_->IsStopped()) {
+      action_render_->trigger();
+    }
+  };
+
+  switch (mapper_type_) {
+    case MapperType::INCREMENTAL: {
+      auto controller = std::make_unique<ControllerThread<IncrementalPipeline>>(
+          std::make_shared<IncrementalPipeline>(
+              options_.mapper,
+              Database::Open(*options_.database_path),
+              reconstruction_manager_));
+      controller->GetController()->AddCallback(
+          IncrementalPipeline::INITIAL_IMAGE_PAIR_REG_CALLBACK, render_now);
+      controller->GetController()->AddCallback(
+          IncrementalPipeline::NEXT_IMAGE_REG_CALLBACK, render);
+      controller->GetController()->AddCallback(
+          IncrementalPipeline::LAST_IMAGE_REG_CALLBACK, render_now);
+      mapper_controller_ = std::move(controller);
+      break;
+    }
+    case MapperType::GLOBAL: {
+      GlobalPipelineOptions global_options = *options_.global_mapper;
+      global_options.image_path = *options_.image_path;
+      auto controller = std::make_unique<ControllerThread<GlobalPipeline>>(
+          std::make_shared<GlobalPipeline>(
+              std::move(global_options),
+              Database::Open(*options_.database_path),
+              reconstruction_manager_));
+      // The global mapper only renders after global positioning and each
+      // refinement, via this callback.
+      controller->GetController()->AddCallback(
+          GlobalPipeline::MODEL_UPDATE_CALLBACK, render_now);
+      mapper_controller_ = std::move(controller);
+      break;
+    }
+    case MapperType::HIERARCHICAL: {
+      HierarchicalPipelineOptions hierarchical_options =
+          *options_.hierarchical_mapper;
+      hierarchical_options.image_path = *options_.image_path;
+      hierarchical_options.incremental_options = *options_.mapper;
+      // The hierarchical mapper reconstructs clusters in separate managers and
+      // only populates the main reconstruction at the end, so no intermediate
+      // render callback is wired; only the finished callback below renders.
+      mapper_controller_ =
+          std::make_unique<ControllerThread<HierarchicalPipeline>>(
+              std::make_shared<HierarchicalPipeline>(
+                  hierarchical_options,
+                  Database::Open(*options_.database_path),
+                  reconstruction_manager_));
+      break;
+    }
+  }
+
+  mapper_controller_->AddCallback(Thread::FINISHED_CALLBACK, [this]() {
+    if (!mapper_controller_->IsStopped()) {
+      action_render_now_->trigger();
+      action_reconstruction_finish_->trigger();
+    }
+    if (reconstruction_manager_->Size() == 0) {
+      action_reconstruction_reset_->trigger();
+    }
+  });
+
+  UpdateMapperControls();
 }
 
 void MainWindow::HandleDragEvent(QDropEvent* event) {
@@ -1308,9 +1351,15 @@ void MainWindow::ReconstructionStart() {
 
   DisableBlockingActions();
   action_reconstruction_pause_->setEnabled(true);
+  UpdateMapperControls();
 }
 
 void MainWindow::ReconstructionStep() {
+  // Stepping is only supported for the incremental and global mappers.
+  if (mapper_type_ == MapperType::HIERARCHICAL) {
+    return;
+  }
+
   if (mapper_controller_->IsFinished() && HasSelectedReconstruction()) {
     QMessageBox::critical(
         this, "", tr("Reset reconstruction before starting."));
@@ -1730,6 +1779,17 @@ void MainWindow::EnableBlockingActions() {
   for (auto& action : blocking_actions_) {
     action->setEnabled(true);
   }
+  UpdateMapperControls();
+}
+
+void MainWindow::UpdateMapperControls() {
+  // The hierarchical mapper runs as a single solve that cannot be stepped or
+  // paused, so disable both controls when it is selected.
+  const bool supports_stepping = mapper_type_ != MapperType::HIERARCHICAL;
+  action_reconstruction_step_->setEnabled(
+      supports_stepping && action_reconstruction_step_->isEnabled());
+  action_reconstruction_pause_->setEnabled(
+      supports_stepping && action_reconstruction_pause_->isEnabled());
 }
 
 void MainWindow::DisableBlockingActions() {

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -1783,13 +1783,25 @@ void MainWindow::EnableBlockingActions() {
 }
 
 void MainWindow::UpdateMapperControls() {
+  // Derive the enabled state of the step/pause controls from the reconstruction
+  // lifecycle rather than from the controls' current state. This keeps them
+  // correct when the user toggles the mapper type back and forth (e.g. switch
+  // to hierarchical and back to incremental), which the previous
+  // preserve-current-state logic got wrong by permanently disabling stepping.
+  const bool started = mapper_controller_ && mapper_controller_->IsStarted();
+  const bool finished = mapper_controller_ && mapper_controller_->IsFinished();
+  const bool paused = mapper_controller_ && mapper_controller_->IsPaused();
+  const bool running = started && !paused && !finished;
+
   // The hierarchical mapper runs as a single solve that cannot be stepped or
-  // paused, so disable both controls when it is selected.
+  // paused, so both controls stay disabled while it is selected.
   const bool supports_stepping = mapper_type_ != MapperType::HIERARCHICAL;
-  action_reconstruction_step_->setEnabled(
-      supports_stepping && action_reconstruction_step_->isEnabled());
-  action_reconstruction_pause_->setEnabled(
-      supports_stepping && action_reconstruction_pause_->isEnabled());
+
+  // Stepping is available while the reconstruction is idle or paused (but not
+  // while running or finished); pausing is only available while running.
+  action_reconstruction_step_->setEnabled(supports_stepping && !running &&
+                                          !finished);
+  action_reconstruction_pause_->setEnabled(supports_stepping && running);
 }
 
 void MainWindow::DisableBlockingActions() {

--- a/src/colmap/ui/main_window.h
+++ b/src/colmap/ui/main_window.h
@@ -47,6 +47,7 @@
 #include "colmap/ui/render_options_widget.h"
 #include "colmap/ui/undistortion_widget.h"
 #include "colmap/util/controller_thread.h"
+#include "colmap/util/threading.h"
 
 #include <QtCore>
 #include <QtGui>
@@ -107,6 +108,10 @@ class MainWindow : public QMainWindow {
   void ReconstructionReset();
   void ReconstructionOptions();
   void ReconstructionFinish();
+  // Enables/disables the Step and Pause controls based on the selected mapper:
+  // both are usable for incremental and global mapping (the latter pausing
+  // between stages), but disabled for hierarchical mapping.
+  void UpdateMapperControls();
   void ReconstructionNormalize();
   bool ReconstructionOverwrite();
 
@@ -152,7 +157,8 @@ class MainWindow : public QMainWindow {
   OptionManager options_;
 
   std::shared_ptr<ReconstructionManager> reconstruction_manager_;
-  std::unique_ptr<ControllerThread<IncrementalPipeline>> mapper_controller_;
+  std::unique_ptr<Thread> mapper_controller_;
+  MapperType mapper_type_ = MapperType::INCREMENTAL;
 
   Timer timer_;
 

--- a/src/colmap/ui/options_widget.cc
+++ b/src/colmap/ui/options_widget.cc
@@ -29,7 +29,23 @@
 
 #include "colmap/ui/options_widget.h"
 
+#include <limits>
+
 namespace colmap {
+namespace {
+
+// Maps the stored "unlimited" sentinel (INT_MAX) to the displayed value -1.
+int UnlimitedOptionToSpinbox(int option, int max) {
+  return option >= max ? -1 : option;
+}
+
+// Maps the displayed value -1 back to the stored "unlimited" sentinel
+// (INT_MAX).
+int UnlimitedSpinboxToOption(int value) {
+  return value < 0 ? std::numeric_limits<int>::max() : value;
+}
+
+}  // namespace
 
 OptionsWidget::OptionsWidget(QWidget* parent) : QWidget(parent) {
   QFont font;
@@ -98,6 +114,22 @@ QSpinBox* OptionsWidget::AddOptionInt(int* option,
   AddOptionRow(label_text, spinbox, option);
 
   options_int_.emplace_back(spinbox, option);
+
+  return spinbox;
+}
+
+QSpinBox* OptionsWidget::AddOptionIntUnlimited(int* option,
+                                               const std::string& label_text,
+                                               const int max) {
+  QSpinBox* spinbox = new QSpinBox(this);
+  spinbox->setMinimum(-1);
+  spinbox->setMaximum(max);
+  spinbox->setSpecialValueText(tr("unlimited"));
+  spinbox->setValue(UnlimitedOptionToSpinbox(*option, max));
+
+  AddOptionRow(label_text, spinbox, option);
+
+  options_int_unlimited_.emplace_back(spinbox, option);
 
   return spinbox;
 }
@@ -228,6 +260,11 @@ void OptionsWidget::ReadOptions() {
     option.first->setValue(*option.second);
   }
 
+  for (auto& option : options_int_unlimited_) {
+    option.first->setValue(
+        UnlimitedOptionToSpinbox(*option.second, option.first->maximum()));
+  }
+
   for (auto& option : options_double_) {
     option.first->setValue(*option.second);
   }
@@ -252,6 +289,10 @@ void OptionsWidget::ReadOptions() {
 void OptionsWidget::WriteOptions() {
   for (auto& option : options_int_) {
     *option.second = option.first->value();
+  }
+
+  for (auto& option : options_int_unlimited_) {
+    *option.second = UnlimitedSpinboxToOption(option.first->value());
   }
 
   for (auto& option : options_double_) {

--- a/src/colmap/ui/options_widget.h
+++ b/src/colmap/ui/options_widget.h
@@ -50,6 +50,13 @@ class OptionsWidget : public QWidget {
                          const std::string& label_text,
                          int min = 0,
                          int max = static_cast<int>(1e7));
+  // Like AddOptionInt, but for options whose "unlimited" sentinel
+  // (std::numeric_limits<int>::max()) is shown and edited as -1, displayed as
+  // "unlimited". A plain QSpinBox capped at INT_MAX overflows when stepped, so
+  // the editable range is capped below INT_MAX.
+  QSpinBox* AddOptionIntUnlimited(int* option,
+                                  const std::string& label_text,
+                                  int max = static_cast<int>(2e9));
   QDoubleSpinBox* AddOptionDouble(double* option,
                                   const std::string& label_text,
                                   double min = 0,
@@ -96,6 +103,7 @@ class OptionsWidget : public QWidget {
   std::unordered_map<QLayout*, std::pair<QLabel*, QWidget*>> layout_rows_;
 
   std::vector<std::pair<QSpinBox*, int*>> options_int_;
+  std::vector<std::pair<QSpinBox*, int*>> options_int_unlimited_;
   std::vector<std::pair<QDoubleSpinBox*, double*>> options_double_;
   std::vector<std::pair<QDoubleSpinBox*, double*>> options_double_log_;
   std::vector<std::pair<QCheckBox*, bool*>> options_bool_;

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -29,14 +29,16 @@
 
 #include "colmap/ui/reconstruction_options_widget.h"
 
+#include "colmap/controllers/global_pipeline.h"
+#include "colmap/controllers/hierarchical_pipeline.h"
 #include "colmap/controllers/incremental_pipeline.h"
 
 namespace colmap {
 namespace {
 
-class MapperGeneralOptionsWidget : public OptionsWidget {
+class IncrementalMapperGeneralOptionsWidget : public OptionsWidget {
  public:
-  MapperGeneralOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperGeneralOptionsWidget(QWidget* parent, OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionBool(&options->mapper->multiple_models, "multiple_models");
     AddOptionInt(&options->mapper->max_num_models, "max_num_models");
@@ -53,9 +55,10 @@ class MapperGeneralOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperTriangulationOptionsWidget : public OptionsWidget {
+class IncrementalMapperTriangulationOptionsWidget : public OptionsWidget {
  public:
-  MapperTriangulationOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperTriangulationOptionsWidget(QWidget* parent,
+                                              OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionInt(&options->mapper->triangulation.max_transitivity,
                  "max_transitivity");
@@ -82,9 +85,10 @@ class MapperTriangulationOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperRegistrationOptionsWidget : public OptionsWidget {
+class IncrementalMapperRegistrationOptionsWidget : public OptionsWidget {
  public:
-  MapperRegistrationOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperRegistrationOptionsWidget(QWidget* parent,
+                                             OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionDouble(&options->mapper->mapper.abs_pose_max_error,
                     "abs_pose_max_error [px]");
@@ -100,9 +104,10 @@ class MapperRegistrationOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperInitializationOptionsWidget : public OptionsWidget {
+class IncrementalMapperInitializationOptionsWidget : public OptionsWidget {
  public:
-  MapperInitializationOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperInitializationOptionsWidget(QWidget* parent,
+                                               OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionInt(&options->mapper->init_image_id1,
                  "init_image_id1",
@@ -125,9 +130,10 @@ class MapperInitializationOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperBundleAdjustmentOptionsWidget : public OptionsWidget {
+class IncrementalMapperBundleAdjustmentOptionsWidget : public OptionsWidget {
  public:
-  MapperBundleAdjustmentOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperBundleAdjustmentOptionsWidget(QWidget* parent,
+                                                 OptionManager* options)
       : OptionsWidget(parent) {
     AddSection("Rig/Camera parameters");
     AddOptionBool(&options->mapper->ba_refine_focal_length,
@@ -211,9 +217,10 @@ class MapperBundleAdjustmentOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperFilteringOptionsWidget : public OptionsWidget {
+class IncrementalMapperFilteringOptionsWidget : public OptionsWidget {
  public:
-  MapperFilteringOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperFilteringOptionsWidget(QWidget* parent,
+                                          OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionDouble(&options->mapper->min_focal_length_ratio,
                     "min_focal_length_ratio");
@@ -228,9 +235,9 @@ class MapperFilteringOptionsWidget : public OptionsWidget {
   }
 };
 
-class MapperPriorsOptionsWidget : public OptionsWidget {
+class IncrementalMapperPriorsOptionsWidget : public OptionsWidget {
  public:
-  MapperPriorsOptionsWidget(QWidget* parent, OptionManager* options)
+  IncrementalMapperPriorsOptionsWidget(QWidget* parent, OptionManager* options)
       : OptionsWidget(parent) {
     AddOptionBool(&options->mapper->use_prior_position, "use_prior_position");
     AddOptionBool(&options->mapper->use_robust_loss_on_prior_position,
@@ -240,10 +247,187 @@ class MapperPriorsOptionsWidget : public OptionsWidget {
   }
 };
 
+// Hierarchical-specific options. The per-cluster reconstruction itself is
+// configured through the shared incremental mapper options.
+class HierarchicalMapperOptionsWidget : public OptionsWidget {
+ public:
+  HierarchicalMapperOptionsWidget(QWidget* parent, OptionManager* options)
+      : OptionsWidget(parent) {
+    auto& hierarchical = *options->hierarchical_mapper;
+    AddOptionInt(&hierarchical.num_threads, "num_threads", -1);
+    AddOptionInt(&hierarchical.num_workers, "num_workers", -1);
+    AddOptionInt(&hierarchical.init_num_trials, "init_num_trials");
+
+    AddSpacer();
+
+    AddSection("Clustering");
+    AddOptionBool(&hierarchical.clustering_options.is_hierarchical,
+                  "is_hierarchical");
+    AddOptionInt(&hierarchical.clustering_options.branching, "branching");
+    AddOptionInt(&hierarchical.clustering_options.image_overlap,
+                 "image_overlap");
+    AddOptionInt(&hierarchical.clustering_options.num_image_matches,
+                 "num_image_matches");
+    AddOptionInt(&hierarchical.clustering_options.leaf_max_num_images,
+                 "leaf_max_num_images");
+  }
+};
+
+class GlobalMapperGeneralOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperGeneralOptionsWidget(QWidget* parent, OptionManager* options)
+      : OptionsWidget(parent) {
+    AddOptionInt(&options->global_mapper->min_num_matches, "min_num_matches");
+    AddOptionBool(&options->global_mapper->ignore_watermarks,
+                  "ignore_watermarks");
+    AddOptionInt(&options->global_mapper->num_threads, "num_threads", -1);
+    AddOptionInt(&options->global_mapper->random_seed, "random_seed", -1);
+    AddOptionBool(&options->global_mapper->decompose_relative_pose,
+                  "decompose_relative_pose");
+    AddOptionBool(&options->global_mapper->mapper.refine_sensor_from_rig,
+                  "refine_sensor_from_rig");
+    AddOptionInt(&options->global_mapper->mapper.ba_num_iterations,
+                 "ba_num_iterations");
+    AddOptionDouble(
+        &options->global_mapper->mapper.max_angular_reproj_error_deg,
+        "max_angular_reproj_error [deg]");
+    AddOptionDouble(&options->global_mapper->mapper.max_normalized_reproj_error,
+                    "max_normalized_reproj_error",
+                    0,
+                    1e7,
+                    1e-4,
+                    6);
+    AddOptionDouble(&options->global_mapper->mapper.min_tri_angle_deg,
+                    "min_tri_angle [deg]",
+                    0,
+                    180);
+
+    AddSpacer();
+
+    AddSection("Stages");
+    AddOptionBool(&options->global_mapper->mapper.skip_rotation_averaging,
+                  "skip_rotation_averaging");
+    AddOptionBool(&options->global_mapper->mapper.skip_track_establishment,
+                  "skip_track_establishment");
+    AddOptionBool(&options->global_mapper->mapper.skip_global_positioning,
+                  "skip_global_positioning");
+    AddOptionBool(&options->global_mapper->mapper.skip_bundle_adjustment,
+                  "skip_bundle_adjustment");
+    AddOptionBool(&options->global_mapper->mapper.skip_retriangulation,
+                  "skip_retriangulation");
+  }
+};
+
+class GlobalMapperTrackOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperTrackOptionsWidget(QWidget* parent, OptionManager* options)
+      : OptionsWidget(parent) {
+    AddOptionDouble(
+        &options->global_mapper->mapper.track_intra_image_consistency_threshold,
+        "intra_image_consistency_threshold [px]");
+    // These options default to INT_MAX ("no limit"), which is shown and edited
+    // as -1 ("unlimited").
+    AddOptionIntUnlimited(
+        &options->global_mapper->mapper.track_required_tracks_per_view,
+        "required_tracks_per_view");
+    AddOptionInt(&options->global_mapper->mapper.track_min_num_views_per_track,
+                 "min_num_views_per_track");
+    AddOptionIntUnlimited(&options->global_mapper->mapper.keep_max_num_tracks,
+                          "keep_max_num_tracks");
+  }
+};
+
+class GlobalMapperRotationAveragingOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperRotationAveragingOptionsWidget(QWidget* parent,
+                                             OptionManager* options)
+      : OptionsWidget(parent) {
+    AddOptionBool(
+        &options->global_mapper->mapper.rotation_averaging.use_gravity,
+        "use_gravity");
+    AddOptionBool(
+        &options->global_mapper->mapper.rotation_averaging.use_stratified,
+        "use_stratified");
+    AddOptionDouble(&options->global_mapper->mapper.rotation_averaging
+                         .max_rotation_error_deg,
+                    "max_rotation_error [deg]");
+  }
+};
+
+class GlobalMapperPositioningOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperPositioningOptionsWidget(QWidget* parent, OptionManager* options)
+      : OptionsWidget(parent) {
+    auto& global_positioning =
+        options->global_mapper->mapper.global_positioning;
+    AddOptionBool(&global_positioning.use_gpu, "use_gpu");
+    AddOptionText(&global_positioning.gpu_index, "gpu_index");
+    AddOptionBool(&global_positioning.optimize_positions, "optimize_positions");
+    AddOptionBool(&global_positioning.optimize_points, "optimize_points");
+    AddOptionBool(&global_positioning.optimize_scales, "optimize_scales");
+    AddOptionDouble(&global_positioning.loss_function_scale,
+                    "loss_function_scale");
+    AddOptionInt(&global_positioning.solver_options.max_num_iterations,
+                 "max_num_iterations");
+  }
+};
+
+class GlobalMapperBundleAdjustmentOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperBundleAdjustmentOptionsWidget(QWidget* parent,
+                                            OptionManager* options)
+      : OptionsWidget(parent) {
+    auto& bundle_adjustment = options->global_mapper->mapper.bundle_adjustment;
+    AddOptionBool(&bundle_adjustment.refine_focal_length,
+                  "refine_focal_length");
+    AddOptionBool(&bundle_adjustment.refine_principal_point,
+                  "refine_principal_point");
+    AddOptionBool(&bundle_adjustment.refine_extra_params,
+                  "refine_extra_params");
+    AddOptionBool(&bundle_adjustment.refine_rig_from_world,
+                  "refine_rig_from_world");
+    AddOptionBool(&bundle_adjustment.refine_points3D, "refine_points3D");
+    AddOptionInt(&bundle_adjustment.min_track_length, "min_track_length");
+    AddOptionBool(&options->global_mapper->mapper.ba_skip_fixed_rotation_stage,
+                  "skip_fixed_rotation_stage");
+    AddOptionBool(
+        &options->global_mapper->mapper.ba_skip_joint_optimization_stage,
+        "skip_joint_optimization_stage");
+
+    if (bundle_adjustment.ceres) {
+      AddSpacer();
+      AddSection("Ceres");
+      AddOptionBool(&bundle_adjustment.ceres->use_gpu, "use_gpu");
+      AddOptionText(&bundle_adjustment.ceres->gpu_index, "gpu_index");
+      AddOptionDouble(&bundle_adjustment.ceres->loss_function_scale,
+                      "loss_function_scale");
+      AddOptionInt(&bundle_adjustment.ceres->solver_options.max_num_iterations,
+                   "max_num_iterations");
+    }
+  }
+};
+
+class GlobalMapperTriangulationOptionsWidget : public OptionsWidget {
+ public:
+  GlobalMapperTriangulationOptionsWidget(QWidget* parent,
+                                         OptionManager* options)
+      : OptionsWidget(parent) {
+    auto& retriangulation = options->global_mapper->mapper.retriangulation;
+    AddOptionDouble(&retriangulation.complete_max_reproj_error,
+                    "complete_max_reproj_error [px]");
+    AddOptionDouble(&retriangulation.merge_max_reproj_error,
+                    "merge_max_reproj_error [px]");
+    AddOptionDouble(&retriangulation.min_angle, "min_angle [deg]", 0, 180);
+  }
+};
+
 }  // namespace
 
-ReconstructionOptionsWidget::ReconstructionOptionsWidget(QWidget* parent,
-                                                         OptionManager* options)
+ReconstructionOptionsWidget::ReconstructionOptionsWidget(
+    QWidget* parent,
+    OptionManager* options,
+    MapperType* mapper_type,
+    std::function<void()> on_mapper_type_changed)
     : QWidget(parent) {
   setWindowFlags(Qt::Dialog);
   setWindowModality(Qt::ApplicationModal);
@@ -251,24 +435,96 @@ ReconstructionOptionsWidget::ReconstructionOptionsWidget(QWidget* parent,
 
   QGridLayout* grid = new QGridLayout(this);
 
-  QTabWidget* tab_widget = new QTabWidget(this);
-  tab_widget->setElideMode(Qt::TextElideMode::ElideRight);
-  tab_widget->addTab(new MapperGeneralOptionsWidget(this, options),
-                     tr("General"));
-  tab_widget->addTab(new MapperInitializationOptionsWidget(this, options),
-                     tr("Init"));
-  tab_widget->addTab(new MapperRegistrationOptionsWidget(this, options),
-                     tr("Registration"));
-  tab_widget->addTab(new MapperTriangulationOptionsWidget(this, options),
-                     tr("Triangulation"));
-  tab_widget->addTab(new MapperBundleAdjustmentOptionsWidget(this, options),
-                     tr("Bundle"));
-  tab_widget->addTab(new MapperFilteringOptionsWidget(this, options),
-                     tr("Filter"));
-  tab_widget->addTab(new MapperPriorsOptionsWidget(this, options),
-                     tr("Priors"));
+  // Mapper selection drop-down, kept above the option tabs so it stays visible
+  // regardless of which mapper's options are shown.
+  auto* mapper_combo = new QComboBox(this);
+  mapper_combo->addItem("incremental");
+  mapper_combo->addItem("hierarchical");
+  mapper_combo->addItem("global");
+  mapper_combo->setCurrentIndex(static_cast<int>(*mapper_type));
+  auto* mapper_layout = new QHBoxLayout();
+  mapper_layout->addWidget(new QLabel(tr("mapper"), this));
+  mapper_layout->addWidget(mapper_combo);
+  mapper_layout->addStretch(1);
+  grid->addLayout(mapper_layout, 0, 0);
 
-  grid->addWidget(tab_widget, 0, 0);
+  // Builds the incremental mapper option tabs. These drive both the incremental
+  // mapper and, per cluster, the hierarchical mapper, so a separate set is
+  // built for each page (all bound to the same shared options).
+  const auto make_incremental_tabs = [this, options]() {
+    QTabWidget* tabs = new QTabWidget(this);
+    tabs->setElideMode(Qt::TextElideMode::ElideRight);
+    tabs->addTab(new IncrementalMapperGeneralOptionsWidget(this, options),
+                 tr("General"));
+    tabs->addTab(
+        new IncrementalMapperInitializationOptionsWidget(this, options),
+        tr("Init"));
+    tabs->addTab(new IncrementalMapperRegistrationOptionsWidget(this, options),
+                 tr("Registration"));
+    tabs->addTab(new IncrementalMapperTriangulationOptionsWidget(this, options),
+                 tr("Triangulation"));
+    tabs->addTab(
+        new IncrementalMapperBundleAdjustmentOptionsWidget(this, options),
+        tr("Bundle"));
+    tabs->addTab(new IncrementalMapperFilteringOptionsWidget(this, options),
+                 tr("Filter"));
+    tabs->addTab(new IncrementalMapperPriorsOptionsWidget(this, options),
+                 tr("Priors"));
+    return tabs;
+  };
+
+  // Incremental mapper option tabs.
+  QTabWidget* incremental_tabs = make_incremental_tabs();
+
+  // Hierarchical mapper option tabs: the shared incremental tabs plus a tab for
+  // the hierarchical-specific clustering and worker options.
+  QTabWidget* hierarchical_tabs = make_incremental_tabs();
+  hierarchical_tabs->addTab(new HierarchicalMapperOptionsWidget(this, options),
+                            tr("Hierarchical"));
+
+  // Global mapper option tabs.
+  QTabWidget* global_tabs = new QTabWidget(this);
+  global_tabs->setElideMode(Qt::TextElideMode::ElideRight);
+  global_tabs->addTab(new GlobalMapperGeneralOptionsWidget(this, options),
+                      tr("General"));
+  global_tabs->addTab(new GlobalMapperTrackOptionsWidget(this, options),
+                      tr("Tracks"));
+  global_tabs->addTab(
+      new GlobalMapperRotationAveragingOptionsWidget(this, options),
+      tr("Rotation"));
+  global_tabs->addTab(new GlobalMapperPositioningOptionsWidget(this, options),
+                      tr("Positioning"));
+  global_tabs->addTab(
+      new GlobalMapperBundleAdjustmentOptionsWidget(this, options),
+      tr("Bundle"));
+  global_tabs->addTab(new GlobalMapperTriangulationOptionsWidget(this, options),
+                      tr("Triangulation"));
+
+  // Show the option tabs for the selected mapper. The pages are added in the
+  // same order as the MapperType enum (and the combo items above), so the stack
+  // index matches the enum value.
+  static_assert(static_cast<int>(MapperType::INCREMENTAL) == 0);
+  static_assert(static_cast<int>(MapperType::HIERARCHICAL) == 1);
+  static_assert(static_cast<int>(MapperType::GLOBAL) == 2);
+  auto* stack = new QStackedWidget(this);
+  stack->addWidget(incremental_tabs);
+  stack->addWidget(hierarchical_tabs);
+  stack->addWidget(global_tabs);
+  stack->setCurrentIndex(static_cast<int>(*mapper_type));
+  grid->addWidget(stack, 1, 0);
+
+  connect(
+      mapper_combo,
+      QOverload<int>::of(&QComboBox::currentIndexChanged),
+      [mapper_type,
+       stack,
+       on_mapper_type_changed = std::move(on_mapper_type_changed)](int idx) {
+        *mapper_type = static_cast<MapperType>(idx);
+        stack->setCurrentIndex(idx);
+        if (on_mapper_type_changed) {
+          on_mapper_type_changed();
+        }
+      });
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -443,6 +443,7 @@ ReconstructionOptionsWidget::ReconstructionOptionsWidget(
   mapper_combo->addItem("global");
   mapper_combo->setCurrentIndex(static_cast<int>(*mapper_type));
   auto* mapper_layout = new QHBoxLayout();
+  mapper_layout->addStretch(1);
   mapper_layout->addWidget(new QLabel(tr("mapper"), this));
   mapper_layout->addWidget(mapper_combo);
   mapper_layout->addStretch(1);

--- a/src/colmap/ui/reconstruction_options_widget.h
+++ b/src/colmap/ui/reconstruction_options_widget.h
@@ -34,12 +34,19 @@
 
 #include <QtCore>
 #include <QtWidgets>
+#include <functional>
 
 namespace colmap {
 
+// Selects which mapper the GUI runs when starting a reconstruction.
+enum class MapperType { INCREMENTAL, HIERARCHICAL, GLOBAL };
+
 class ReconstructionOptionsWidget : public QWidget {
  public:
-  ReconstructionOptionsWidget(QWidget* parent, OptionManager* options);
+  ReconstructionOptionsWidget(QWidget* parent,
+                              OptionManager* options,
+                              MapperType* mapper_type,
+                              std::function<void()> on_mapper_type_changed);
 };
 
 }  // namespace colmap


### PR DESCRIPTION
## Summary

Previously the COLMAP GUI could only run the **incremental** mapper. This PR adds a drop-down in the reconstruction options to select the **incremental**, **global**, or **hierarchical** mapper, with rendering behavior appropriate to each.

## Behavior

- **Incremental** — unchanged live rendering (per initial pair / image / sub-model).
- **Global** — renders after global positioning and after each refinement (each bundle-adjustment iteration and retriangulation). Pause/Step are supported *between stages*.
- **Hierarchical** — renders only the final merged reconstruction (clusters reconstruct in separate managers). Pause/Step are disabled.

The reconstruction options dialog now switches the displayed option tabs based on the selected mapper, exposing dedicated **global** and **hierarchical** option panels (the hierarchical page reuses the incremental tabs, since each cluster is reconstructed with the incremental options, plus a tab for the clustering/worker options).

## Implementation notes

- `MainWindow::mapper_controller_` is now a polymorphic `std::unique_ptr<Thread>`; `CreateControllers()` builds the selected pipeline and wires the appropriate render callbacks.
- Added an optional progress callback to `GlobalMapper::Solve` / `IterativeBundleAdjustment`, and a `GlobalPipeline::MODEL_UPDATE_CALLBACK`. The global pipeline now adds its reconstruction to the manager up front and renders intermediate states (this also removes a full reconstruction copy that previously happened at the end).
- Promoted `HierarchicalPipeline::Options` to a top-level `HierarchicalPipelineOptions` (mirroring `GlobalPipelineOptions`) and registered it in `OptionManager` via `AddHierarchicalMapperOptions()`, shared by the GUI and the `hierarchical_mapper` CLI. **Note:** the `hierarchical_mapper` CLI flags are now `HierarchicalMapper.*`-prefixed (was `--num_workers`, `--image_overlap`, `--leaf_max_num_images`), consistent with `Mapper.*` / `GlobalMapper.*`.
- Added `OptionsWidget::AddOptionIntUnlimited` to handle `INT_MAX` "unlimited" sentinels (e.g. `track_required_tracks_per_view`, `keep_max_num_tracks`), shown/edited as `-1`, fixing a `QSpinBox` overflow.

The mapper selection itself is a GUI-session setting (not written to the project `.ini`), consistent with how the global mapper options are handled.

## Testing

<img width="743" height="717" alt="image" src="https://github.com/user-attachments/assets/1aac83a2-a0c5-4dc1-afd2-a47f6cefa470" />
