### PR TITLE
Centralize and enrich analytical rotation utilities

### DIFF
--- a/src/colmap/estimators/cost_functions/CMakeLists.txt
+++ b/src/colmap/estimators/cost_functions/CMakeLists.txt
@@ -38,6 +38,7 @@ COLMAP_ADD_LIBRARY(
         manifold.h
         motion_averaging.h
         pose_prior.h
+        quaternion_utils.h
         reprojection_error.h
         sampson_error.h
         utils.h
@@ -82,4 +83,9 @@ COLMAP_ADD_TEST(
     NAME motion_averaging_test
     SRCS motion_averaging_test.cc
     LINK_LIBS colmap_estimators_cost_functions
+)
+COLMAP_ADD_TEST(
+    NAME quaternion_utils_test
+    SRCS quaternion_utils_test.cc
+    LINK_LIBS colmap_estimators_cost_functions colmap_math
 )

--- a/src/colmap/estimators/cost_functions/alignment.h
+++ b/src/colmap/estimators/cost_functions/alignment.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
 #include "colmap/estimators/cost_functions/utils.h"
 
 #include <Eigen/Core>

--- a/src/colmap/estimators/cost_functions/pose_prior.h
+++ b/src/colmap/estimators/cost_functions/pose_prior.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
 #include "colmap/estimators/cost_functions/utils.h"
 #include "colmap/geometry/rigid3.h"
 
@@ -37,16 +38,6 @@
 #include <ceres/rotation.h>
 
 namespace colmap {
-
-template <typename T>
-inline void EigenQuaternionToAngleAxis(const T* eigen_quaternion,
-                                       T* angle_axis) {
-  const T quaternion[4] = {eigen_quaternion[3],
-                           eigen_quaternion[0],
-                           eigen_quaternion[1],
-                           eigen_quaternion[2]};
-  ceres::QuaternionToAngleAxis(quaternion, angle_axis);
-}
 
 // 6-DoF error on the absolute sensor pose. The residual is the log of the error
 // pose, splitting SE(3) into SO(3) x R^3. The residual is computed in the

--- a/src/colmap/estimators/cost_functions/pose_prior.h
+++ b/src/colmap/estimators/cost_functions/pose_prior.h
@@ -54,8 +54,8 @@ struct AbsolutePosePriorCostFunctor
     const Eigen::Quaternion<T> param_from_prior_rotation =
         EigenQuaternionMap<T>(sensor_from_world) *
         world_from_sensor_prior_.rotation().cast<T>();
-    EigenQuaternionToAngleAxis(param_from_prior_rotation.coeffs().data(),
-                               residuals_ptr);
+    AngleAxisFromEigenQuaternion(param_from_prior_rotation.coeffs().data(),
+                                 residuals_ptr);
 
     Eigen::Map<Eigen::Matrix<T, 3, 1>> param_from_prior_translation(
         residuals_ptr + 3);
@@ -151,8 +151,8 @@ struct RelativePosePriorCostFunctor
         EigenQuaternionMap<T>(j_from_world).inverse();
     const Eigen::Quaternion<T> param_from_prior_rotation =
         i_from_j_rotation * j_from_i_prior_.rotation().template cast<T>();
-    EigenQuaternionToAngleAxis(param_from_prior_rotation.coeffs().data(),
-                               residuals_ptr);
+    AngleAxisFromEigenQuaternion(param_from_prior_rotation.coeffs().data(),
+                                 residuals_ptr);
 
     const Eigen::Matrix<T, 3, 1> j_from_i_prior_translation =
         j_from_i_prior_.translation().cast<T>() -

--- a/src/colmap/estimators/cost_functions/quaternion_utils.h
+++ b/src/colmap/estimators/cost_functions/quaternion_utils.h
@@ -1,0 +1,155 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <ceres/rotation.h>
+
+namespace colmap {
+
+template <typename T>
+using EigenVector3Map = Eigen::Map<const Eigen::Matrix<T, 3, 1>>;
+template <typename T>
+using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
+
+template <typename T>
+inline void EigenQuaternionToAngleAxis(const T* eigen_quaternion,
+                                       T* angle_axis) {
+  const T quaternion[4] = {eigen_quaternion[3],
+                           eigen_quaternion[0],
+                           eigen_quaternion[1],
+                           eigen_quaternion[2]};
+  ceres::QuaternionToAngleAxis(quaternion, angle_axis);
+}
+
+template <typename T>
+inline void AngleAxisToEigenQuaternion(const T* angle_axis,
+                                       T* eigen_quaternion) {
+  T quaternion[4];
+  ceres::AngleAxisToQuaternion(angle_axis, quaternion);
+  eigen_quaternion[0] = quaternion[1];
+  eigen_quaternion[1] = quaternion[2];
+  eigen_quaternion[2] = quaternion[3];
+  eigen_quaternion[3] = quaternion[0];
+}
+
+// Quaternion utilities for analytical Jacobian computation in cost functions.
+//
+// Convention: Eigen quaternion storage order (x, y, z, w), Hamilton product.
+// A quaternion q = (x, y, z, w) represents the rotation matrix:
+//   R(q) = (w^2 - ||v||^2) I + 2 v v^T + 2 w [v]_x
+// where v = (x, y, z) is the vector part.
+//
+// The 4-vector representation used in matrices is [x, y, z, w] (Eigen order).
+// Eigen::Quaterniond::coeffs() returns [x, y, z, w].
+
+// Hamilton quaternion left-multiplication matrix (xyzw storage):
+// QuaternionLeftMultMatrix(q) * p = q * p  (as 4-vectors).
+inline Eigen::Matrix4d QuaternionLeftMultMatrix(const Eigen::Quaterniond& q) {
+  Eigen::Matrix4d Q;
+  const double x = q.x(), y = q.y(), z = q.z(), w = q.w();
+  // clang-format off
+  Q << w, -z,  y, x,
+       z,  w, -x, y,
+      -y,  x,  w, z,
+      -x, -y, -z, w;
+  // clang-format on
+  return Q;
+}
+
+// Hamilton quaternion right-multiplication matrix (xyzw storage):
+// QuaternionRightMultMatrix(p) * q = q * p  (as 4-vectors).
+inline Eigen::Matrix4d QuaternionRightMultMatrix(const Eigen::Quaterniond& q) {
+  Eigen::Matrix4d Q;
+  const double x = q.x(), y = q.y(), z = q.z(), w = q.w();
+  // clang-format off
+  Q <<  w,  z, -y, x,
+       -z,  w,  x, y,
+        y, -x,  w, z,
+       -x, -y, -z, w;
+  // clang-format on
+  return Q;
+}
+
+// Rotates the point and optionally computes the Jacobian of R(q) * p
+// w.r.t. Eigen quaternion q (xyzw storage). J_out is a 3x4 row-major matrix.
+// Pass nullptr for J_out to skip the Jacobian computation.
+inline Eigen::Vector3d QuaternionRotatePointWithJac(const double* q,
+                                                    const double* pt,
+                                                    double* J_out) {
+  const double qx = q[0], qy = q[1], qz = q[2], qw = q[3];
+  const double px = pt[0], py = pt[1], pz = pt[2];
+
+  const double qx_py = qx * py, qx_pz = qx * pz;
+  const double qy_px = qy * px, qy_pz = qy * pz;
+  const double qz_px = qz * px, qz_py = qz * py;
+
+  // R(q) * p = p + 2*w*(v x p) + 2*(v x (v x p))
+  const double v_x_p0 = qy_pz - qz_py;
+  const double v_x_p1 = qz_px - qx_pz;
+  const double v_x_p2 = qx_py - qy_px;
+
+  const double v_x_v_x_p0 = qy * v_x_p2 - qz * v_x_p1;
+  const double v_x_v_x_p1 = qz * v_x_p0 - qx * v_x_p2;
+  const double v_x_v_x_p2 = qx * v_x_p1 - qy * v_x_p0;
+
+  Eigen::Vector3d pt_out(px + 2.0 * (qw * v_x_p0 + v_x_v_x_p0),
+                         py + 2.0 * (qw * v_x_p1 + v_x_v_x_p1),
+                         pz + 2.0 * (qw * v_x_p2 + v_x_v_x_p2));
+
+  if (J_out) {
+    const double qx_px = qx * px;
+    const double qy_py = qy * py;
+    const double qz_pz = qz * pz;
+    const double qw_px = qw * px;
+    const double qw_py = qw * py;
+    const double qw_pz = qw * pz;
+
+    J_out[0] = 2.0 * (qy_py + qz_pz);
+    J_out[1] = 2.0 * (-2.0 * qy_px + qx_py + qw_pz);
+    J_out[2] = 2.0 * (-2.0 * qz_px - qw_py + qx_pz);
+    J_out[3] = 2.0 * (-qz_py + qy_pz);
+
+    J_out[4] = 2.0 * (qy_px - 2.0 * qx_py - qw_pz);
+    J_out[5] = 2.0 * (qx_px + qz_pz);
+    J_out[6] = 2.0 * (qw_px - 2.0 * qz_py + qy_pz);
+    J_out[7] = 2.0 * (qz_px - qx_pz);
+
+    J_out[8] = 2.0 * (qz_px + qw_py - 2.0 * qx_pz);
+    J_out[9] = 2.0 * (-qw_px + qz_py - 2.0 * qy_pz);
+    J_out[10] = 2.0 * (qx_px + qy_py);
+    J_out[11] = 2.0 * (-qy_px + qx_py);
+  }
+
+  return pt_out;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/cost_functions/quaternion_utils.h
+++ b/src/colmap/estimators/cost_functions/quaternion_utils.h
@@ -41,8 +41,8 @@ template <typename T>
 using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
 
 template <typename T>
-inline void EigenQuaternionToAngleAxis(const T* eigen_quaternion,
-                                       T* angle_axis) {
+inline void AngleAxisFromEigenQuaternion(const T* eigen_quaternion,
+                                         T* angle_axis) {
   const T quaternion[4] = {eigen_quaternion[3],
                            eigen_quaternion[0],
                            eigen_quaternion[1],
@@ -51,8 +51,8 @@ inline void EigenQuaternionToAngleAxis(const T* eigen_quaternion,
 }
 
 template <typename T>
-inline void AngleAxisToEigenQuaternion(const T* angle_axis,
-                                       T* eigen_quaternion) {
+inline void EigenQuaternionFromAngleAxis(const T* angle_axis,
+                                         T* eigen_quaternion) {
   T quaternion[4];
   ceres::AngleAxisToQuaternion(angle_axis, quaternion);
   eigen_quaternion[0] = quaternion[1];

--- a/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
+++ b/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
@@ -1,0 +1,138 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
+
+#include "colmap/math/random.h"
+#include "colmap/util/eigen_matchers.h"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+TEST(QuaternionLeftMultMatrix, Nominal) {
+  SetPRNGSeed(42);
+  constexpr double kEps = 1e-7;
+
+  for (int i = 0; i < 100; ++i) {
+    Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
+    Eigen::Quaterniond p = Eigen::Quaterniond::UnitRandom();
+    Eigen::Vector4d p_vec(p.x(), p.y(), p.z(), p.w());
+
+    // L(q) * p = q * p.
+    Eigen::Vector4d result = QuaternionLeftMultMatrix(q) * p_vec;
+    Eigen::Quaterniond qp = q * p;
+    Eigen::Vector4d expected(qp.x(), qp.y(), qp.z(), qp.w());
+    EXPECT_THAT(result, EigenMatrixNear(expected, 1e-12));
+
+    // L(q) = d(q*p)/dp (Jacobian w.r.t. second argument).
+    Eigen::Matrix4d J_numeric;
+    for (int k = 0; k < 4; ++k) {
+      Eigen::Vector4d p_plus = p_vec, p_minus = p_vec;
+      p_plus(k) += kEps;
+      p_minus(k) -= kEps;
+      Eigen::Quaterniond pp(p_plus(3), p_plus(0), p_plus(1), p_plus(2));
+      Eigen::Quaterniond pm(p_minus(3), p_minus(0), p_minus(1), p_minus(2));
+      Eigen::Quaterniond rp = q * pp, rm = q * pm;
+      J_numeric.col(k) = (Eigen::Vector4d(rp.x(), rp.y(), rp.z(), rp.w()) -
+                          Eigen::Vector4d(rm.x(), rm.y(), rm.z(), rm.w())) /
+                         (2.0 * kEps);
+    }
+    EXPECT_THAT(QuaternionLeftMultMatrix(q), EigenMatrixNear(J_numeric, 1e-5));
+  }
+}
+
+TEST(QuaternionRightMultMatrix, Nominal) {
+  SetPRNGSeed(42);
+  constexpr double kEps = 1e-7;
+
+  for (int i = 0; i < 100; ++i) {
+    Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
+    Eigen::Quaterniond p = Eigen::Quaterniond::UnitRandom();
+    Eigen::Vector4d q_vec(q.x(), q.y(), q.z(), q.w());
+
+    // R(p) * q = q * p.
+    Eigen::Vector4d result = QuaternionRightMultMatrix(p) * q_vec;
+    Eigen::Quaterniond qp = q * p;
+    Eigen::Vector4d expected(qp.x(), qp.y(), qp.z(), qp.w());
+    EXPECT_THAT(result, EigenMatrixNear(expected, 1e-12));
+
+    // R(p) = d(q*p)/dq (Jacobian w.r.t. first argument).
+    Eigen::Matrix4d J_numeric;
+    for (int k = 0; k < 4; ++k) {
+      Eigen::Vector4d q_plus = q_vec, q_minus = q_vec;
+      q_plus(k) += kEps;
+      q_minus(k) -= kEps;
+      Eigen::Quaterniond qp_p(q_plus(3), q_plus(0), q_plus(1), q_plus(2));
+      Eigen::Quaterniond qm_p(q_minus(3), q_minus(0), q_minus(1), q_minus(2));
+      Eigen::Quaterniond rp = qp_p * p, rm = qm_p * p;
+      J_numeric.col(k) = (Eigen::Vector4d(rp.x(), rp.y(), rp.z(), rp.w()) -
+                          Eigen::Vector4d(rm.x(), rm.y(), rm.z(), rm.w())) /
+                         (2.0 * kEps);
+    }
+    EXPECT_THAT(QuaternionRightMultMatrix(p), EigenMatrixNear(J_numeric, 1e-5));
+  }
+}
+
+TEST(QuaternionRotatePointWithJac, Nominal) {
+  SetPRNGSeed(42);
+  constexpr double kEps = 1e-7;
+
+  for (int i = 0; i < 100; ++i) {
+    Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
+    Eigen::Vector3d pt = Eigen::Vector3d::Random();
+    double q_arr[4] = {q.x(), q.y(), q.z(), q.w()};
+
+    // R(q) * pt matches Eigen.
+    Eigen::Matrix<double, 3, 4, Eigen::RowMajor> J_analytical;
+    Eigen::Vector3d result =
+        QuaternionRotatePointWithJac(q_arr, pt.data(), J_analytical.data());
+    EXPECT_THAT(result, EigenMatrixNear(Eigen::Vector3d(q * pt), 1e-12));
+
+    // Jacobian d(R(q)*pt)/dq matches numeric.
+    Eigen::Matrix<double, 3, 4> J_numeric;
+    for (int k = 0; k < 4; ++k) {
+      double q_plus[4] = {q_arr[0], q_arr[1], q_arr[2], q_arr[3]};
+      double q_minus[4] = {q_arr[0], q_arr[1], q_arr[2], q_arr[3]};
+      q_plus[k] += kEps;
+      q_minus[k] -= kEps;
+      J_numeric.col(k) =
+          (QuaternionRotatePointWithJac(q_plus, pt.data(), nullptr) -
+           QuaternionRotatePointWithJac(q_minus, pt.data(), nullptr)) /
+          (2.0 * kEps);
+    }
+    EXPECT_THAT(J_analytical, EigenMatrixNear(J_numeric, 1e-5));
+  }
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
+++ b/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
@@ -142,9 +142,9 @@ TEST(EigenQuaternionAngleAxis, Roundtrip) {
 
     // quaternion -> angle-axis -> quaternion recovers the original rotation.
     double angle_axis[3];
-    EigenQuaternionToAngleAxis(q_arr, angle_axis);
+    AngleAxisFromEigenQuaternion(q_arr, angle_axis);
     double q_out[4];
-    AngleAxisToEigenQuaternion(angle_axis, q_out);
+    EigenQuaternionFromAngleAxis(angle_axis, q_out);
 
     // Compare as rotations to avoid the quaternion double-cover sign ambiguity.
     const Eigen::Quaterniond q_recovered(

--- a/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
+++ b/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
@@ -134,5 +134,24 @@ TEST(QuaternionRotatePointWithJac, Nominal) {
   }
 }
 
+TEST(EigenQuaternionAngleAxis, Roundtrip) {
+  SetPRNGSeed(42);
+  for (int i = 0; i < 100; ++i) {
+    const Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
+    const double q_arr[4] = {q.x(), q.y(), q.z(), q.w()};
+
+    // quaternion -> angle-axis -> quaternion recovers the original rotation.
+    double angle_axis[3];
+    EigenQuaternionToAngleAxis(q_arr, angle_axis);
+    double q_out[4];
+    AngleAxisToEigenQuaternion(angle_axis, q_out);
+
+    // Compare as rotations to avoid the quaternion double-cover sign ambiguity.
+    const Eigen::Quaterniond q_recovered(
+        q_out[3], q_out[0], q_out[1], q_out[2]);
+    EXPECT_NEAR(q.angularDistance(q_recovered), 0.0, 1e-10);
+  }
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/estimators/cost_functions/reprojection_error.h
+++ b/src/colmap/estimators/cost_functions/reprojection_error.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
 #include "colmap/estimators/cost_functions/utils.h"
 #include "colmap/geometry/rigid3.h"
 #include "colmap/sensor/models.h"
@@ -53,76 +54,6 @@ inline void WrapEquirectangularHorizontalSeam(const T* camera_params,
     const T width = camera_params[0];
     residuals[0] -= width * ceres::floor(residuals[0] / width + T(0.5));
   }
-}
-
-// Rotates the point and computes the Jacobian of R(q) * p with respect to Eigen
-// quaternions. J_out is a 3x4 matrix in row-major order.
-inline Eigen::Vector3d QuaternionRotatePointWithJac(const double* q,
-                                                    const double* pt,
-                                                    double* J_out) {
-  const double qx = q[0], qy = q[1], qz = q[2], qw = q[3];
-  const double px = pt[0], py = pt[1], pz = pt[2];
-
-  // Common sub-expressions.
-  const double qx_py = qx * py;
-  const double qx_pz = qx * pz;
-  const double qy_px = qy * px;
-  const double qy_pz = qy * pz;
-  const double qz_px = qz * px;
-  const double qz_py = qz * py;
-
-  // R(q) * p using the formula: p' = p + 2*w*(v x p) + 2*(v x (v x p)),
-  // where v = (qx, qy, qz) is the imaginary part and w = qw is the scalar.
-
-  // First compute v  x  p.
-  const double v_x_p0 = qy_pz - qz_py;
-  const double v_x_p1 = qz_px - qx_pz;
-  const double v_x_p2 = qx_py - qy_px;
-
-  // Then compute v  x  (v  x  p).
-  const double v_x_v_x_p0 = qy * v_x_p2 - qz * v_x_p1;
-  const double v_x_v_x_p1 = qz * v_x_p0 - qx * v_x_p2;
-  const double v_x_v_x_p2 = qx * v_x_p1 - qy * v_x_p0;
-
-  // p' = p + 2*w*(v x p) + 2*(v x (v x p)).
-  Eigen::Vector3d pt_out(px + 2.0 * (qw * v_x_p0 + v_x_v_x_p0),
-                         py + 2.0 * (qw * v_x_p1 + v_x_v_x_p1),
-                         pz + 2.0 * (qw * v_x_p2 + v_x_v_x_p2));
-
-  if (J_out) {
-    // Jacobian d(R*p) / dq for Eigen quaternions (x, y, z, w).
-    // Must use the ORIGINAL point (px, py, pz), not the rotated point.
-
-    // Common sub-expressions.
-    const double qx_px = qx * px;
-    const double qx_pz = qx * pz;
-    const double qy_px = qy * px;
-    const double qy_py = qy * py;
-    const double qz_pz = qz * pz;
-    const double qw_px = qw * px;
-    const double qw_py = qw * py;
-    const double qw_pz = qw * pz;
-
-    // d(R*p)_x / d(x,y,z,w)
-    J_out[0] = 2.0 * (qy_py + qz_pz);
-    J_out[1] = 2.0 * (-2.0 * qy_px + qx_py + qw_pz);
-    J_out[2] = 2.0 * (-2.0 * qz_px - qw_py + qx_pz);
-    J_out[3] = 2.0 * (-qz_py + qy_pz);
-
-    // d(R*p)_y / d(x,y,z,w)
-    J_out[4] = 2.0 * (qy_px - 2.0 * qx_py - qw_pz);
-    J_out[5] = 2.0 * (qx_px + qz_pz);
-    J_out[6] = 2.0 * (qw_px - 2.0 * qz_py + qy_pz);
-    J_out[7] = 2.0 * (qz_px - qx_pz);
-
-    // d(R*p)_z / d(x,y,z,w)
-    J_out[8] = 2.0 * (qz_px + qw_py - 2.0 * qx_pz);
-    J_out[9] = 2.0 * (-qw_px + qz_py - 2.0 * qy_pz);
-    J_out[10] = 2.0 * (qx_px + qy_py);
-    J_out[11] = 2.0 * (-qy_px + qx_py);
-  }
-
-  return pt_out;
 }
 
 // Full reprojection error cost function with analytical Jacobians.

--- a/src/colmap/estimators/cost_functions/sampson_error.h
+++ b/src/colmap/estimators/cost_functions/sampson_error.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
 #include "colmap/estimators/cost_functions/utils.h"
 
 #include <Eigen/Core>

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -36,11 +36,6 @@
 
 namespace colmap {
 
-template <typename T>
-using EigenVector3Map = Eigen::Map<const Eigen::Matrix<T, 3, 1>>;
-template <typename T>
-using EigenQuaternionMap = Eigen::Map<const Eigen::Quaternion<T>>;
-
 template <typename CostFunctor, int kNumResiduals, int... kParameterDims>
 ceres::CostFunction* CreateAutoDiffCostFunction(
     CostFunctor* functor, std::integer_sequence<int, kParameterDims...>) {

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -34,6 +34,9 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
+#include <Eigen/Eigenvalues>
+#include <Eigen/Geometry>
+
 namespace colmap {
 
 Eigen::VectorXd AverageUnitVectors(const Eigen::MatrixXd& vectors,
@@ -205,6 +208,37 @@ Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
   return Rigid3d(
       cam1_from_world.rotation().slerp(t, cam2_from_world.rotation()),
       cam1_from_world.translation() + translation12 * t);
+}
+
+namespace {
+constexpr double kSmallAngleThreshold = 1e-10;
+}  // namespace
+
+Eigen::Quaterniond QuaternionFromAngleAxis(const Eigen::Vector3d& omega) {
+  const double theta = omega.norm();
+  if (theta < kSmallAngleThreshold) {
+    // First-order Taylor expansion preserving rotation direction.
+    return Eigen::Quaterniond(
+               1.0, 0.5 * omega.x(), 0.5 * omega.y(), 0.5 * omega.z())
+        .normalized();
+  }
+  return Eigen::Quaterniond(Eigen::AngleAxisd(theta, omega / theta));
+}
+
+Eigen::Matrix3d LeftJacobianFromAngleAxis(const Eigen::Vector3d& omega) {
+  const double theta = omega.norm();
+  if (theta < kSmallAngleThreshold) {
+    return Eigen::Matrix3d::Identity() + 0.5 * CrossProductMatrix(omega);
+  }
+  const Eigen::Vector3d a = omega / theta;
+  const Eigen::Matrix3d a_x = CrossProductMatrix(a);
+  return std::sin(theta) / theta * Eigen::Matrix3d::Identity() +
+         (1.0 - std::sin(theta) / theta) * a * a.transpose() +
+         ((1.0 - std::cos(theta)) / theta) * a_x;
+}
+
+Eigen::Matrix3d RightJacobianFromAngleAxis(const Eigen::Vector3d& omega) {
+  return LeftJacobianFromAngleAxis(-omega);
 }
 
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -34,7 +34,6 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
-#include <Eigen/Eigenvalues>
 #include <Eigen/Geometry>
 
 namespace colmap {
@@ -232,8 +231,10 @@ Eigen::Matrix3d LeftJacobianFromAngleAxis(const Eigen::Vector3d& omega) {
   }
   const Eigen::Vector3d a = omega / theta;
   const Eigen::Matrix3d a_x = CrossProductMatrix(a);
-  return std::sin(theta) / theta * Eigen::Matrix3d::Identity() +
-         (1.0 - std::sin(theta) / theta) * a * a.transpose() +
+  const double sin_theta = std::sin(theta);
+  const double sinc_theta = sin_theta / theta;
+  return sinc_theta * Eigen::Matrix3d::Identity() +
+         (1.0 - sinc_theta) * a * a.transpose() +
          ((1.0 - std::cos(theta)) / theta) * a_x;
 }
 

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -115,6 +115,29 @@ Eigen::Quaterniond AverageQuaternions(
     const std::vector<Eigen::Quaterniond>& quats,
     const std::vector<double>& weights);
 
+// Compute a quaternion from Lie algebra.
+//
+// @param omega         The angles in so(3).
+//
+// @return              The quaternion corresponding to omega in so(3).
+Eigen::Quaterniond QuaternionFromAngleAxis(const Eigen::Vector3d& omega);
+
+// Compute the left Jacobian J_l from lie algebra.
+// Used for bias Jacobian propagation in IMU preintegration.
+//
+// @param omega         The angles in so(3)
+//
+// @return              The left jacobian of the angle J_l(omega)
+Eigen::Matrix3d LeftJacobianFromAngleAxis(const Eigen::Vector3d& omega);
+
+// Compute the right Jacobian J_r from lie algebra.
+// Defined as J_r(omega) = J_l(-omega).
+//
+// @param omega         The angles in so(3)
+//
+// @return              The right jacobian of the angle J_r(omega)
+Eigen::Matrix3d RightJacobianFromAngleAxis(const Eigen::Vector3d& omega);
+
 // Linearly interpolate camera pose.
 Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
                                const Rigid3d& cam2_from_world,

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -325,5 +325,91 @@ TEST(RotationFromYAxisAngle, Nominal) {
       EigenMatrixNear(Eigen::Vector3d(-Eigen::Vector3d::UnitZ()), 1e-6));
 }
 
+TEST(QuaternionFromAngleAxis, Zero) {
+  const Eigen::Quaterniond q = QuaternionFromAngleAxis(Eigen::Vector3d::Zero());
+  EXPECT_NEAR(q.w(), 1.0, 1e-12);
+  EXPECT_NEAR(q.vec().norm(), 0.0, 1e-12);
+}
+
+TEST(QuaternionFromAngleAxis, SmallAngle) {
+  // Just above and below the threshold — results should be continuous.
+  const Eigen::Vector3d axis = Eigen::Vector3d(1, 2, 3).normalized();
+  const double theta_small = 1e-11;
+  const double theta_medium = 1e-9;
+  const Eigen::Quaterniond q_small =
+      QuaternionFromAngleAxis(axis * theta_small);
+  const Eigen::Quaterniond q_medium =
+      QuaternionFromAngleAxis(axis * theta_medium);
+  // Both should be near identity but preserve direction.
+  EXPECT_NEAR(q_small.angularDistance(q_medium), 0.0, 1e-8);
+  // Small angle should NOT snap to identity — it should preserve direction.
+  const Eigen::Vector3d recovered =
+      Eigen::AngleAxisd(q_small).axis().normalized();
+  EXPECT_NEAR(std::abs(recovered.dot(axis)), 1.0, 1e-6);
+}
+
+TEST(QuaternionFromAngleAxis, Roundtrip) {
+  SetPRNGSeed(0);
+  for (int i = 0; i < 100; ++i) {
+    const Eigen::AngleAxisd aa(Eigen::Quaterniond::UnitRandom());
+    const Eigen::Vector3d omega = aa.angle() * aa.axis();
+    const Eigen::Quaterniond q = QuaternionFromAngleAxis(omega);
+    const Eigen::Matrix3d R_expected = aa.toRotationMatrix();
+    const Eigen::Matrix3d R_actual = q.toRotationMatrix();
+    EXPECT_THAT(R_actual, EigenMatrixNear(R_expected, 1e-10));
+  }
+}
+
+TEST(LeftJacobianFromAngleAxis, IdentityAtZero) {
+  const Eigen::Matrix3d Jl = LeftJacobianFromAngleAxis(Eigen::Vector3d::Zero());
+  const Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+  EXPECT_THAT(Jl, EigenMatrixNear(I, 1e-10));
+}
+
+TEST(LeftJacobianFromAngleAxis, RelationToRight) {
+  // Jr(w) = Jl(-w) for all w.
+  SetPRNGSeed(0);
+  for (int i = 0; i < 100; ++i) {
+    const Eigen::AngleAxisd aa(Eigen::Quaterniond::UnitRandom());
+    const Eigen::Vector3d omega = aa.angle() * aa.axis();
+    const Eigen::Matrix3d Jr = RightJacobianFromAngleAxis(omega);
+    const Eigen::Matrix3d Jl_neg = LeftJacobianFromAngleAxis(-omega);
+    EXPECT_THAT(Jr, EigenMatrixNear(Jl_neg, 1e-10));
+  }
+}
+
+TEST(RightJacobianFromAngleAxis, SmallAngle) {
+  // Near zero, Jr ≈ I - 0.5 * [w]_x.
+  const Eigen::Vector3d omega(1e-12, 2e-12, 3e-12);
+  const Eigen::Matrix3d Jr = RightJacobianFromAngleAxis(omega);
+  Eigen::Matrix3d expected = Eigen::Matrix3d::Identity();
+  expected -= 0.5 * CrossProductMatrix(omega);
+  EXPECT_THAT(Jr, EigenMatrixNear(expected, 1e-10));
+}
+
+TEST(RightJacobianFromAngleAxis, NumericDerivative) {
+  // Verify Jr by numeric differentiation of Exp(w + dw) ≈ Exp(w) * Exp(Jr*dw).
+  SetPRNGSeed(0);
+  const double eps = 1e-7;
+  for (int i = 0; i < 50; ++i) {
+    const Eigen::AngleAxisd aa(Eigen::Quaterniond::UnitRandom());
+    const Eigen::Vector3d omega = aa.angle() * aa.axis();
+    const Eigen::Matrix3d Jr = RightJacobianFromAngleAxis(omega);
+    const Eigen::Matrix3d R = AngleAxisToRotationMatrix(omega);
+    // Numeric: d/dw_k Exp(w) ≈ (Exp(w + eps*e_k) - Exp(w)) / eps
+    Eigen::Matrix3d Jr_numeric;
+    for (int k = 0; k < 3; ++k) {
+      Eigen::Vector3d dw = Eigen::Vector3d::Zero();
+      dw(k) = eps;
+      const Eigen::Matrix3d R_perturbed = AngleAxisToRotationMatrix(omega + dw);
+      // R_perturbed ≈ R * Exp(Jr * dw), so Exp(Jr*dw) ≈ R^T * R_perturbed
+      const Eigen::Matrix3d dR = R.transpose() * R_perturbed;
+      const Eigen::Vector3d log_dR = RotationMatrixToAngleAxis(dR);
+      Jr_numeric.col(k) = log_dR / eps;
+    }
+    EXPECT_THAT(Jr, EigenMatrixNear(Jr_numeric, 1e-5));
+  }
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -411,5 +411,28 @@ TEST(RightJacobianFromAngleAxis, NumericDerivative) {
   }
 }
 
+TEST(LeftJacobianFromAngleAxis, NumericDerivative) {
+  // Verify Jl by numeric differentiation of Exp(w + dw) ≈ Exp(Jl*dw) * Exp(w).
+  SetPRNGSeed(0);
+  const double eps = 1e-7;
+  for (int i = 0; i < 50; ++i) {
+    const Eigen::AngleAxisd aa(Eigen::Quaterniond::UnitRandom());
+    const Eigen::Vector3d omega = aa.angle() * aa.axis();
+    const Eigen::Matrix3d Jl = LeftJacobianFromAngleAxis(omega);
+    const Eigen::Matrix3d R = AngleAxisToRotationMatrix(omega);
+    Eigen::Matrix3d Jl_numeric;
+    for (int k = 0; k < 3; ++k) {
+      Eigen::Vector3d dw = Eigen::Vector3d::Zero();
+      dw(k) = eps;
+      const Eigen::Matrix3d R_perturbed = AngleAxisToRotationMatrix(omega + dw);
+      // R_perturbed ≈ Exp(Jl * dw) * R, so Exp(Jl*dw) ≈ R_perturbed * R^T.
+      const Eigen::Matrix3d dR = R_perturbed * R.transpose();
+      const Eigen::Vector3d log_dR = RotationMatrixToAngleAxis(dR);
+      Jl_numeric.col(k) = log_dR / eps;
+    }
+    EXPECT_THAT(Jl, EigenMatrixNear(Jl_numeric, 1e-5));
+  }
+}
+
 }  // namespace
 }  // namespace colmap


### PR DESCRIPTION
Splitted from https://github.com/colmap/colmap/pull/2625, a first step to help reduce reviewing burdon towards full integration of inertial optimization. 

Added a bunch of utilities on rotation analysis and centralize to a single file. 