### PR TITLE
Add nanosecond timestamp type and conversion utils

### DIFF
--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -49,6 +49,7 @@ COLMAP_ADD_LIBRARY(
         string.h string.cc
         threading.h threading.cc
         timer.h timer.cc
+        timestamp.h
         types.h
         version.h version.cc
     PUBLIC_LINK_LIBS
@@ -231,6 +232,11 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME timer_test
     SRCS timer_test.cc
+    LINK_LIBS colmap_util
+)
+COLMAP_ADD_TEST(
+    NAME timestamp_test
+    SRCS timestamp_test.cc
     LINK_LIBS colmap_util
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/util/timestamp.h
+++ b/src/colmap/util/timestamp.h
@@ -1,0 +1,53 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/util/types.h"
+
+namespace colmap {
+
+// Convert a nanosecond timestamp to seconds.
+inline double TimestampToSeconds(timestamp_t t) { return t * 1e-9; }
+
+// Convert seconds to a nanosecond timestamp. Truncates sub-nanosecond values.
+// Intended for small durations (e.g., config values), not large absolute
+// timestamps which should be parsed as int64 directly.
+inline timestamp_t SecondsToTimestamp(double s) {
+  return static_cast<timestamp_t>(s * 1e9);
+}
+
+// Compute the time difference (t1 - t0) in seconds with nanosecond precision.
+// Unlike subtracting two large doubles, differencing int64 timestamps and then
+// converting preserves full precision.
+inline double TimestampDiffSeconds(timestamp_t t1, timestamp_t t0) {
+  return (t1 - t0) * 1e-9;
+}
+
+}  // namespace colmap

--- a/src/colmap/util/timestamp.h
+++ b/src/colmap/util/timestamp.h
@@ -29,29 +29,37 @@
 
 #pragma once
 
+#include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 
 #include <cmath>
 
 namespace colmap {
 
-// Convert a nanosecond timestamp to seconds. Note that converting a large
-// absolute timestamp (magnitude > 2^53 ns) to double loses sub-nanosecond
-// precision; to difference absolute timestamps use TimestampDiffSeconds, which
-// subtracts in int64 first.
-inline double SecondsFromTimestamp(timestamp_t t) { return t * 1e-9; }
+// Convert a (non-negative) nanosecond timestamp to seconds. Note that
+// converting a large absolute timestamp (magnitude > 2^53 ns) to double loses
+// sub-nanosecond precision; to difference absolute timestamps use
+// TimestampDiffSeconds, which subtracts in int64 first.
+inline double SecondsFromTimestamp(timestamp_t t) {
+  THROW_CHECK_GE(t, 0);
+  return t * 1e-9;
+}
 
-// Convert seconds to a nanosecond timestamp, rounding to the nearest
-// nanosecond. Intended for small durations (e.g., config values), not large
-// absolute timestamps which should be parsed as int64 directly.
+// Convert (non-negative) seconds to a nanosecond timestamp, rounding to the
+// nearest nanosecond. Intended for small durations (e.g., config values), not
+// large absolute timestamps which should be parsed as int64 directly.
 inline timestamp_t TimestampFromSeconds(double s) {
+  THROW_CHECK_GE(s, 0.0);
   return static_cast<timestamp_t>(std::round(s * 1e9));
 }
 
 // Compute the time difference (t1 - t0) in seconds with nanosecond precision.
 // Unlike subtracting two large doubles, differencing int64 timestamps and then
-// converting preserves full precision.
+// converting preserves full precision. The result may be negative, but both
+// timestamps must be valid (non-negative).
 inline double TimestampDiffSeconds(timestamp_t t1, timestamp_t t0) {
+  THROW_CHECK_GE(t1, 0);
+  THROW_CHECK_GE(t0, 0);
   return (t1 - t0) * 1e-9;
 }
 

--- a/src/colmap/util/timestamp.h
+++ b/src/colmap/util/timestamp.h
@@ -34,12 +34,12 @@
 namespace colmap {
 
 // Convert a nanosecond timestamp to seconds.
-inline double TimestampToSeconds(timestamp_t t) { return t * 1e-9; }
+inline double SecondsFromTimestamp(timestamp_t t) { return t * 1e-9; }
 
 // Convert seconds to a nanosecond timestamp. Truncates sub-nanosecond values.
 // Intended for small durations (e.g., config values), not large absolute
 // timestamps which should be parsed as int64 directly.
-inline timestamp_t SecondsToTimestamp(double s) {
+inline timestamp_t TimestampFromSeconds(double s) {
   return static_cast<timestamp_t>(s * 1e9);
 }
 

--- a/src/colmap/util/timestamp.h
+++ b/src/colmap/util/timestamp.h
@@ -31,16 +31,21 @@
 
 #include "colmap/util/types.h"
 
+#include <cmath>
+
 namespace colmap {
 
-// Convert a nanosecond timestamp to seconds.
+// Convert a nanosecond timestamp to seconds. Note that converting a large
+// absolute timestamp (magnitude > 2^53 ns) to double loses sub-nanosecond
+// precision; to difference absolute timestamps use TimestampDiffSeconds, which
+// subtracts in int64 first.
 inline double SecondsFromTimestamp(timestamp_t t) { return t * 1e-9; }
 
-// Convert seconds to a nanosecond timestamp. Truncates sub-nanosecond values.
-// Intended for small durations (e.g., config values), not large absolute
-// timestamps which should be parsed as int64 directly.
+// Convert seconds to a nanosecond timestamp, rounding to the nearest
+// nanosecond. Intended for small durations (e.g., config values), not large
+// absolute timestamps which should be parsed as int64 directly.
 inline timestamp_t TimestampFromSeconds(double s) {
-  return static_cast<timestamp_t>(s * 1e9);
+  return static_cast<timestamp_t>(std::round(s * 1e9));
 }
 
 // Compute the time difference (t1 - t0) in seconds with nanosecond precision.

--- a/src/colmap/util/timestamp.h
+++ b/src/colmap/util/timestamp.h
@@ -36,31 +36,35 @@
 
 namespace colmap {
 
-// Convert a (non-negative) nanosecond timestamp to seconds. Note that
-// converting a large absolute timestamp (magnitude > 2^53 ns) to double loses
-// sub-nanosecond precision; to difference absolute timestamps use
-// TimestampDiffSeconds, which subtracts in int64 first.
+// Timestamps whose magnitude exceeds this bound (2^53 ns) can no longer be
+// represented exactly as double, so converting them to seconds loses
+// sub-nanosecond precision; differences within the bound stay exact.
+constexpr timestamp_t kMaxStableTimestamp = timestamp_t{1} << 53;
+
+// Convert a nanosecond timestamp to seconds. Note that converting a large
+// absolute timestamp (magnitude > 2^53 ns) to double loses sub-nanosecond
+// precision; to difference absolute timestamps use TimestampDiffSeconds, which
+// subtracts in int64 first.
 inline double SecondsFromTimestamp(timestamp_t t) {
-  THROW_CHECK_GE(t, 0);
+  VLOG_IF(2, t > kMaxStableTimestamp || t < -kMaxStableTimestamp)
+      << "Converting timestamp " << t
+      << " ns to seconds loses sub-nanosecond precision (magnitude > 2^53); "
+         "use TimestampDiffSeconds for precise differences.";
   return t * 1e-9;
 }
 
-// Convert (non-negative) seconds to a nanosecond timestamp, rounding to the
-// nearest nanosecond. Intended for small durations (e.g., config values), not
-// large absolute timestamps which should be parsed as int64 directly.
+// Convert seconds to a nanosecond timestamp, rounding to the nearest
+// nanosecond. Intended for small durations (e.g., config values), not large
+// absolute timestamps which should be parsed as int64 directly.
 inline timestamp_t TimestampFromSeconds(double s) {
-  THROW_CHECK_GE(s, 0.0);
   return static_cast<timestamp_t>(std::round(s * 1e9));
 }
 
 // Compute the time difference (t1 - t0) in seconds with nanosecond precision.
 // Unlike subtracting two large doubles, differencing int64 timestamps and then
-// converting preserves full precision. The result may be negative, but both
-// timestamps must be valid (non-negative).
+// converting preserves full precision. The result may be negative.
 inline double TimestampDiffSeconds(timestamp_t t1, timestamp_t t0) {
-  THROW_CHECK_GE(t1, 0);
-  THROW_CHECK_GE(t0, 0);
-  return (t1 - t0) * 1e-9;
+  return SecondsFromTimestamp(t1 - t0);
 }
 
 }  // namespace colmap

--- a/src/colmap/util/timestamp_test.cc
+++ b/src/colmap/util/timestamp_test.cc
@@ -1,0 +1,106 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/util/timestamp.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+TEST(Timestamp, TimestampToSeconds) {
+  EXPECT_DOUBLE_EQ(TimestampToSeconds(0), 0.0);
+  EXPECT_DOUBLE_EQ(TimestampToSeconds(1000000000), 1.0);
+  EXPECT_DOUBLE_EQ(TimestampToSeconds(500000000), 0.5);
+  EXPECT_DOUBLE_EQ(TimestampToSeconds(-1000000000), -1.0);
+}
+
+TEST(Timestamp, SecondsToTimestamp) {
+  EXPECT_EQ(SecondsToTimestamp(0.0), 0);
+  EXPECT_EQ(SecondsToTimestamp(1.0), 1000000000);
+  EXPECT_EQ(SecondsToTimestamp(0.5), 500000000);
+  EXPECT_EQ(SecondsToTimestamp(0.005), 5000000);  // 5ms.
+}
+
+TEST(Timestamp, TimestampDiffSeconds) {
+  timestamp_t t0 = 1000000000;  // 1s.
+  timestamp_t t1 = 1005000000;  // 1.005s.
+  EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t1, t0), 0.005);
+  EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t0, t1), -0.005);
+}
+
+TEST(Timestamp, SecondsToTimestampPrecision) {
+  // SecondsToTimestamp is only used for config durations (small values),
+  // never for large absolute timestamps (which are parsed as int64 directly).
+  // Verify nanosecond-level precision for realistic config values.
+  EXPECT_EQ(SecondsToTimestamp(0.005), 5000000);
+  EXPECT_EQ(SecondsToTimestamp(0.25), 250000000);
+  EXPECT_EQ(SecondsToTimestamp(9.81), 9810000000LL);
+
+  // Verify that the conversion truncates (not rounds) sub-nanosecond values.
+  EXPECT_EQ(SecondsToTimestamp(0.1), 100000000);
+
+  // Differences of int64 timestamps converted back to seconds preserve
+  // nanosecond precision, unlike subtracting two large doubles.
+  timestamp_t t0 = 1403636579763555584LL;
+  timestamp_t t1 = t0 + SecondsToTimestamp(0.005);
+  EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t1, t0), 0.005);
+}
+
+TEST(Timestamp, LargeNanosecondValues) {
+  // Typical EuRoC timestamp: 1403636579763555584 ns.
+  timestamp_t t = 1403636579763555584LL;
+  double s = TimestampToSeconds(t);
+  EXPECT_NEAR(s, 1403636579.763555584, 1e-3);
+
+  // Difference between two timestamps (5ms apart).
+  timestamp_t t2 = t + 5000000;  // +5ms.
+  EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t2, t), 0.005);
+}
+
+TEST(Timestamp, MapKeyExactEquality) {
+  // int64 map keys support exact lookup, unlike double keys.
+  std::map<timestamp_t, int> m;
+  timestamp_t key = 1403636579763555584LL;
+  m[key] = 42;
+  EXPECT_NE(m.find(key), m.end());
+  EXPECT_EQ(m.at(key), 42);
+  m.erase(key);
+  EXPECT_EQ(m.find(key), m.end());
+}
+
+TEST(Timestamp, InvalidTimestamp) {
+  EXPECT_EQ(kInvalidTimestamp, -1);
+  EXPECT_LT(kInvalidTimestamp, 0);
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/util/timestamp_test.cc
+++ b/src/colmap/util/timestamp_test.cc
@@ -36,18 +36,18 @@
 namespace colmap {
 namespace {
 
-TEST(Timestamp, TimestampToSeconds) {
-  EXPECT_DOUBLE_EQ(TimestampToSeconds(0), 0.0);
-  EXPECT_DOUBLE_EQ(TimestampToSeconds(1000000000), 1.0);
-  EXPECT_DOUBLE_EQ(TimestampToSeconds(500000000), 0.5);
-  EXPECT_DOUBLE_EQ(TimestampToSeconds(-1000000000), -1.0);
+TEST(Timestamp, SecondsFromTimestamp) {
+  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(0), 0.0);
+  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(1000000000), 1.0);
+  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(500000000), 0.5);
+  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(-1000000000), -1.0);
 }
 
-TEST(Timestamp, SecondsToTimestamp) {
-  EXPECT_EQ(SecondsToTimestamp(0.0), 0);
-  EXPECT_EQ(SecondsToTimestamp(1.0), 1000000000);
-  EXPECT_EQ(SecondsToTimestamp(0.5), 500000000);
-  EXPECT_EQ(SecondsToTimestamp(0.005), 5000000);  // 5ms.
+TEST(Timestamp, TimestampFromSeconds) {
+  EXPECT_EQ(TimestampFromSeconds(0.0), 0);
+  EXPECT_EQ(TimestampFromSeconds(1.0), 1000000000);
+  EXPECT_EQ(TimestampFromSeconds(0.5), 500000000);
+  EXPECT_EQ(TimestampFromSeconds(0.005), 5000000);  // 5ms.
 }
 
 TEST(Timestamp, TimestampDiffSeconds) {
@@ -57,28 +57,28 @@ TEST(Timestamp, TimestampDiffSeconds) {
   EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t0, t1), -0.005);
 }
 
-TEST(Timestamp, SecondsToTimestampPrecision) {
-  // SecondsToTimestamp is only used for config durations (small values),
+TEST(Timestamp, TimestampFromSecondsPrecision) {
+  // TimestampFromSeconds is only used for config durations (small values),
   // never for large absolute timestamps (which are parsed as int64 directly).
   // Verify nanosecond-level precision for realistic config values.
-  EXPECT_EQ(SecondsToTimestamp(0.005), 5000000);
-  EXPECT_EQ(SecondsToTimestamp(0.25), 250000000);
-  EXPECT_EQ(SecondsToTimestamp(9.81), 9810000000LL);
+  EXPECT_EQ(TimestampFromSeconds(0.005), 5000000);
+  EXPECT_EQ(TimestampFromSeconds(0.25), 250000000);
+  EXPECT_EQ(TimestampFromSeconds(9.81), 9810000000LL);
 
   // Verify that the conversion truncates (not rounds) sub-nanosecond values.
-  EXPECT_EQ(SecondsToTimestamp(0.1), 100000000);
+  EXPECT_EQ(TimestampFromSeconds(0.1), 100000000);
 
   // Differences of int64 timestamps converted back to seconds preserve
   // nanosecond precision, unlike subtracting two large doubles.
   timestamp_t t0 = 1403636579763555584LL;
-  timestamp_t t1 = t0 + SecondsToTimestamp(0.005);
+  timestamp_t t1 = t0 + TimestampFromSeconds(0.005);
   EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t1, t0), 0.005);
 }
 
 TEST(Timestamp, LargeNanosecondValues) {
   // Typical EuRoC timestamp: 1403636579763555584 ns.
   timestamp_t t = 1403636579763555584LL;
-  double s = TimestampToSeconds(t);
+  double s = SecondsFromTimestamp(t);
   EXPECT_NEAR(s, 1403636579.763555584, 1e-3);
 
   // Difference between two timestamps (5ms apart).

--- a/src/colmap/util/timestamp_test.cc
+++ b/src/colmap/util/timestamp_test.cc
@@ -29,8 +29,8 @@
 
 #include "colmap/util/timestamp.h"
 
+#include <limits>
 #include <map>
-#include <stdexcept>
 
 #include <gtest/gtest.h>
 
@@ -41,8 +41,8 @@ TEST(Timestamp, SecondsFromTimestamp) {
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(0), 0.0);
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(1000000000), 1.0);
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(500000000), 0.5);
-  // Negative timestamps are invalid.
-  EXPECT_THROW(SecondsFromTimestamp(-1000000000), std::invalid_argument);
+  // Negative timestamps are allowed.
+  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(-1000000000), -1.0);
 }
 
 TEST(Timestamp, TimestampFromSeconds) {
@@ -50,8 +50,8 @@ TEST(Timestamp, TimestampFromSeconds) {
   EXPECT_EQ(TimestampFromSeconds(1.0), 1000000000);
   EXPECT_EQ(TimestampFromSeconds(0.5), 500000000);
   EXPECT_EQ(TimestampFromSeconds(0.005), 5000000);  // 5ms.
-  // Negative durations are invalid.
-  EXPECT_THROW(TimestampFromSeconds(-1.0), std::invalid_argument);
+  // Negative durations are allowed.
+  EXPECT_EQ(TimestampFromSeconds(-1.0), -1000000000);
 }
 
 TEST(Timestamp, TimestampDiffSeconds) {
@@ -90,6 +90,18 @@ TEST(Timestamp, LargeNanosecondValues) {
   EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t2, t), 0.005);
 }
 
+TEST(Timestamp, DiffExactAboveDoublePrecision) {
+  // Both timestamps are well above 2^53, where consecutive integers are no
+  // longer exactly representable as double (the ulp is hundreds of ns near
+  // 1.4e18), yet their difference is tiny.
+  timestamp_t t0 = 1403636579763555584LL;
+  timestamp_t t1 = t0 + 1;  // 1 ns apart.
+  ASSERT_GT(t0, timestamp_t{1} << 53);
+
+  // Differencing in int64 first preserves the exact 1 ns gap.
+  EXPECT_DOUBLE_EQ(TimestampDiffSeconds(t1, t0), 1e-9);
+}
+
 TEST(Timestamp, MapKeyExactEquality) {
   // int64 map keys support exact lookup, unlike double keys.
   std::map<timestamp_t, int> m;
@@ -102,8 +114,7 @@ TEST(Timestamp, MapKeyExactEquality) {
 }
 
 TEST(Timestamp, InvalidTimestamp) {
-  EXPECT_EQ(kInvalidTimestamp, -1);
-  EXPECT_LT(kInvalidTimestamp, 0);
+  EXPECT_EQ(kInvalidTimestamp, std::numeric_limits<timestamp_t>::min());
 }
 
 }  // namespace

--- a/src/colmap/util/timestamp_test.cc
+++ b/src/colmap/util/timestamp_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/util/timestamp.h"
 
 #include <map>
+#include <stdexcept>
 
 #include <gtest/gtest.h>
 
@@ -40,7 +41,8 @@ TEST(Timestamp, SecondsFromTimestamp) {
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(0), 0.0);
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(1000000000), 1.0);
   EXPECT_DOUBLE_EQ(SecondsFromTimestamp(500000000), 0.5);
-  EXPECT_DOUBLE_EQ(SecondsFromTimestamp(-1000000000), -1.0);
+  // Negative timestamps are invalid.
+  EXPECT_THROW(SecondsFromTimestamp(-1000000000), std::invalid_argument);
 }
 
 TEST(Timestamp, TimestampFromSeconds) {
@@ -48,6 +50,8 @@ TEST(Timestamp, TimestampFromSeconds) {
   EXPECT_EQ(TimestampFromSeconds(1.0), 1000000000);
   EXPECT_EQ(TimestampFromSeconds(0.5), 500000000);
   EXPECT_EQ(TimestampFromSeconds(0.005), 5000000);  // 5ms.
+  // Negative durations are invalid.
+  EXPECT_THROW(TimestampFromSeconds(-1.0), std::invalid_argument);
 }
 
 TEST(Timestamp, TimestampDiffSeconds) {
@@ -65,8 +69,8 @@ TEST(Timestamp, TimestampFromSecondsPrecision) {
   EXPECT_EQ(TimestampFromSeconds(0.25), 250000000);
   EXPECT_EQ(TimestampFromSeconds(9.81), 9810000000LL);
 
-  // Verify that the conversion truncates (not rounds) sub-nanosecond values.
-  EXPECT_EQ(TimestampFromSeconds(0.1), 100000000);
+  // Verify rounding to the nearest nanosecond (0.666...e9 rounds up).
+  EXPECT_EQ(TimestampFromSeconds(2.0 / 3.0), 666666667);
 
   // Differences of int64 timestamps converted back to seconds preserve
   // nanosecond precision, unlike subtracting two large doubles.

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -121,6 +121,13 @@ constexpr point2D_t kInvalidPoint2DIdx = std::numeric_limits<point2D_t>::max();
 using point3D_t = uint64_t;
 constexpr point3D_t kInvalidPoint3DId = std::numeric_limits<point3D_t>::max();
 
+// Timestamp in nanoseconds. Using int64_t rather than double avoids
+// floating-point precision loss when comparing or differencing large absolute
+// timestamps (e.g., Unix epoch in nanoseconds), and enables exact equality
+// checks for use as map keys.
+using timestamp_t = int64_t;
+constexpr timestamp_t kInvalidTimestamp = -1;
+
 // Unique identifier for pose priors.
 using pose_prior_t = uint32_t;
 constexpr pose_prior_t kInvalidPosePriorId =

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -121,11 +121,12 @@ constexpr point2D_t kInvalidPoint2DIdx = std::numeric_limits<point2D_t>::max();
 using point3D_t = uint64_t;
 constexpr point3D_t kInvalidPoint3DId = std::numeric_limits<point3D_t>::max();
 
-// Timestamp in nanoseconds. Using int64_t rather than double avoids
-// floating-point precision loss when comparing or differencing large absolute
-// timestamps (e.g., Unix epoch in nanoseconds), and enables exact equality
-// checks for use as map keys.
+// Timestamp in nanoseconds. Valid timestamps are non-negative; using int64_t
+// rather than double avoids floating-point precision loss when comparing or
+// differencing large absolute timestamps (e.g., Unix epoch in nanoseconds),
+// and enables exact equality checks for use as map keys.
 using timestamp_t = int64_t;
+// Sentinel for an unset/invalid timestamp; valid timestamps are >= 0.
 constexpr timestamp_t kInvalidTimestamp = -1;
 
 // Unique identifier for pose priors.

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -121,13 +121,15 @@ constexpr point2D_t kInvalidPoint2DIdx = std::numeric_limits<point2D_t>::max();
 using point3D_t = uint64_t;
 constexpr point3D_t kInvalidPoint3DId = std::numeric_limits<point3D_t>::max();
 
-// Timestamp in nanoseconds. Valid timestamps are non-negative; using int64_t
-// rather than double avoids floating-point precision loss when comparing or
-// differencing large absolute timestamps (e.g., Unix epoch in nanoseconds),
-// and enables exact equality checks for use as map keys.
+// Timestamp in nanoseconds. Using int64_t rather than double avoids
+// floating-point precision loss when comparing or differencing large absolute
+// timestamps (e.g., Unix epoch in nanoseconds), and enables exact equality
+// checks for use as map keys.
 using timestamp_t = int64_t;
-// Sentinel for an unset/invalid timestamp; valid timestamps are >= 0.
-constexpr timestamp_t kInvalidTimestamp = -1;
+// Sentinel for an unset/invalid timestamp. Chosen as INT64_MIN so that any
+// realistic timestamp (including negative ones) remains a valid value.
+constexpr timestamp_t kInvalidTimestamp =
+    std::numeric_limits<timestamp_t>::min();
 
 // Unique identifier for pose priors.
 using pose_prior_t = uint32_t;

--- a/src/pycolmap/util/bindings.cc
+++ b/src/pycolmap/util/bindings.cc
@@ -5,6 +5,7 @@ namespace py = pybind11;
 void BindLogging(py::module& m);
 void BindOpenImageIO(py::module& m);
 void BindTimer(py::module& m);
+void BindTimestamp(py::module& m);
 void BindUtilTypes(py::module& m);
 #if defined(COLMAP_CUDA_ENABLED)
 void BindCudaUtils(py::module& m);
@@ -12,6 +13,7 @@ void BindCudaUtils(py::module& m);
 
 void BindUtil(py::module& m) {
   BindUtilTypes(m);
+  BindTimestamp(m);
   BindLogging(m);
   BindOpenImageIO(m);
   BindTimer(m);

--- a/src/pycolmap/util/timestamp.cc
+++ b/src/pycolmap/util/timestamp.cc
@@ -1,0 +1,13 @@
+#include "colmap/util/timestamp.h"
+
+#include <pybind11/pybind11.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+void BindTimestamp(py::module& m) {
+  m.def("timestamp_to_seconds", &TimestampToSeconds, "timestamp_ns"_a);
+  m.def("seconds_to_timestamp", &SecondsToTimestamp, "seconds"_a);
+  m.def("timestamp_diff_seconds", &TimestampDiffSeconds, "t1"_a, "t0"_a);
+}

--- a/src/pycolmap/util/timestamp.cc
+++ b/src/pycolmap/util/timestamp.cc
@@ -7,7 +7,7 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindTimestamp(py::module& m) {
-  m.def("seconds_from_timestamp", &SecondsFromTimestamp, "timestamp_ns"_a);
-  m.def("timestamp_from_seconds", &TimestampFromSeconds, "seconds"_a);
+  m.def("seconds_from_timestamp", &SecondsFromTimestamp, "t"_a);
+  m.def("timestamp_from_seconds", &TimestampFromSeconds, "s"_a);
   m.def("timestamp_diff_seconds", &TimestampDiffSeconds, "t1"_a, "t0"_a);
 }

--- a/src/pycolmap/util/timestamp.cc
+++ b/src/pycolmap/util/timestamp.cc
@@ -7,7 +7,7 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindTimestamp(py::module& m) {
-  m.def("timestamp_to_seconds", &TimestampToSeconds, "timestamp_ns"_a);
-  m.def("seconds_to_timestamp", &SecondsToTimestamp, "seconds"_a);
+  m.def("seconds_from_timestamp", &SecondsFromTimestamp, "timestamp_ns"_a);
+  m.def("timestamp_from_seconds", &TimestampFromSeconds, "seconds"_a);
   m.def("timestamp_diff_seconds", &TimestampDiffSeconds, "t1"_a, "t0"_a);
 }


### PR DESCRIPTION
Splitted from https://github.com/colmap/colmap/pull/2625. 

Added timestamp_t type as int64_t, in nanoseconds. 