### PR TITLE
Use 5pt minimal solver from PoseLib for essential matrix

### DIFF
--- a/src/colmap/estimators/solvers/essential_matrix.cc
+++ b/src/colmap/estimators/solvers/essential_matrix.cc
@@ -58,7 +58,7 @@ void EssentialMatrixFivePointEstimator::Estimate(
     return;
   }
 
-  // Setup system of equations: [cam_rays2(i,:), 1]' * E * [cam_rays1(i,:), 1]'.
+  // Setup system of equations: cam_rays2(i)' * E * cam_rays1(i) = 0.
 
   Eigen::Matrix<double, Eigen::Dynamic, 9> Q(cam_rays1.size(), 9);
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
@@ -67,25 +67,21 @@ void EssentialMatrixFivePointEstimator::Estimate(
         cam_rays2[i].z() * cam_rays1[i].transpose();
   }
 
-  // Step 1: Extraction of the nullspace.
+  // Step 1: Extraction of the nullspace. The minimal case is handled by
+  // PoseLib above, so we always reach this with an over-determined system.
 
-  Eigen::Matrix<double, 9, 4> E;
-  if (cam_rays1.size() == 5) {
-    E = Q.transpose().fullPivHouseholderQr().matrixQ().rightCols<4>();
-  } else {
-    const Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> svd(
-        Q, Eigen::ComputeFullV);
-    E = svd.matrixV().rightCols<4>();
-  }
+  const Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> svd(
+      Q, Eigen::ComputeFullV);
+  const Eigen::Matrix<double, 9, 4> E = svd.matrixV().rightCols<4>();
 
-  // Step 3: Gauss-Jordan elimination with partial pivoting on A.
+  // Step 2: Gauss-Jordan elimination with partial pivoting on A.
 
   Eigen::Matrix<double, 10, 20> A;
 #include "colmap/estimators/solvers/essential_matrix_poly.h"
   const Eigen::Matrix<double, 10, 10> AA =
       A.block<10, 10>(0, 0).partialPivLu().solve(A.block<10, 10>(0, 10));
 
-  // Step 4: Expansion of the determinant polynomial of the 3x3 polynomial
+  // Step 3: Expansion of the determinant polynomial of the 3x3 polynomial
   //         matrix B to obtain the tenth degree polynomial.
 
   Eigen::Matrix<double, 13, 3> B;
@@ -101,7 +97,7 @@ void EssentialMatrixFivePointEstimator::Estimate(
     B.block<4, 1>(8, i) -= AA.block<1, 4>(i * 2 + 5, 6);
   }
 
-  // Step 5: Extraction of roots from the degree 10 polynomial.
+  // Step 4: Extraction of roots from the degree 10 polynomial.
   Eigen::Matrix<double, 11, 1> coeffs;
 #include "colmap/estimators/solvers/essential_matrix_coeffs.h"
 

--- a/src/colmap/estimators/solvers/essential_matrix.cc
+++ b/src/colmap/estimators/solvers/essential_matrix.cc
@@ -37,6 +37,7 @@
 #include <Eigen/Geometry>
 #include <Eigen/LU>
 #include <Eigen/SVD>
+#include <PoseLib/solvers/relpose_5pt.h>
 
 namespace colmap {
 
@@ -49,6 +50,13 @@ void EssentialMatrixFivePointEstimator::Estimate(
   THROW_CHECK(models != nullptr);
 
   models->clear();
+
+  // PoseLib's 5-point solver only supports the minimal case; the non-minimal
+  // case falls through to the SVD-based solver below.
+  if (cam_rays1.size() == 5) {
+    poselib::relpose_5pt(cam_rays1, cam_rays2, models);
+    return;
+  }
 
   // Setup system of equations: [cam_rays2(i,:), 1]' * E * [cam_rays1(i,:), 1]'.
 

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -59,11 +59,10 @@ void ExpectAtLeastOneValidModel(const Estimator& estimator,
                                 std::vector<Eigen::Matrix3d>& models,
                                 double E_eps = 1e-4,
                                 double r_eps = 1e-5) {
-  expected_E /= expected_E(2, 2);
+  expected_E.normalize();
   for (size_t i = 0; i < models.size(); ++i) {
-    Eigen::Matrix3d E = models[i];
-    E /= E(2, 2);
-    if (!E.isApprox(expected_E, E_eps)) {
+    const Eigen::Matrix3d E = models[i].normalized();
+    if (std::min((E - expected_E).norm(), (E + expected_E).norm()) > E_eps) {
       continue;
     }
 
@@ -82,6 +81,7 @@ class EssentialMatrixFivePointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
+  SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 100; ++k) {
     const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
@@ -107,6 +107,7 @@ class EssentialMatrixEightPointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
+  SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 1; ++k) {
     const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),


### PR DESCRIPTION
PoseLib s 5pt solver is much faster (>2-3x) than the one from colmap. In essential matrix estimation the minimal solver overhead is actually quite significant:

Results sweeping on number of points and inlier ratio on synthetic data. Minimum number of trials was set to 1000. colmap_pl5pt corresponds to the estimator after this change. 
```
colmap/100/100              1822 ms         1822 ms            1 fail_pct=0 items_per_second=54.8773/s num_trials_mean=1.001k rot_err_mean_deg=0.226915 rot_err_med_deg=0.186059 t_err_mean_deg=0.412922 t_err_med_deg=0.3421
colmap_pl5pt/100/100         778 ms          778 ms            1 fail_pct=0 items_per_second=128.581/s num_trials_mean=1.001k rot_err_mean_deg=0.231557 rot_err_med_deg=0.197138 t_err_mean_deg=0.423347 t_err_med_deg=0.332021
colmap/100/80               1798 ms         1798 ms            1 fail_pct=0 items_per_second=55.6209/s num_trials_mean=1.00101k rot_err_mean_deg=0.290308 rot_err_med_deg=0.245312 t_err_mean_deg=0.517667 t_err_med_deg=0.489848
colmap_pl5pt/100/80          744 ms          744 ms            1 fail_pct=0 items_per_second=134.403/s num_trials_mean=1.00101k rot_err_mean_deg=0.286034 rot_err_med_deg=0.234622 t_err_mean_deg=0.505267 t_err_med_deg=0.448965
colmap/100/50               2284 ms         2284 ms            1 fail_pct=0 items_per_second=43.7767/s num_trials_mean=1.29579k rot_err_mean_deg=0.312642 rot_err_med_deg=0.252156 t_err_mean_deg=0.638919 t_err_med_deg=0.545109
colmap_pl5pt/100/50          920 ms          920 ms            1 fail_pct=0 items_per_second=108.728/s num_trials_mean=1.29766k rot_err_mean_deg=0.317915 rot_err_med_deg=0.257494 t_err_mean_deg=0.634875 t_err_med_deg=0.540982
colmap/500/100              2966 ms         2966 ms            1 fail_pct=0 items_per_second=33.7144/s num_trials_mean=1.001k rot_err_mean_deg=0.161071 rot_err_med_deg=0.14013 t_err_mean_deg=0.328741 t_err_med_deg=0.313259
colmap_pl5pt/500/100        1927 ms         1927 ms            1 fail_pct=0 items_per_second=51.8949/s num_trials_mean=1.001k rot_err_mean_deg=0.16684 rot_err_med_deg=0.138625 t_err_mean_deg=0.339131 t_err_med_deg=0.319561
colmap/500/80               2938 ms         2938 ms            1 fail_pct=0 items_per_second=34.0424/s num_trials_mean=1.001k rot_err_mean_deg=0.160895 rot_err_med_deg=0.135946 t_err_mean_deg=0.332277 t_err_med_deg=0.302617
colmap_pl5pt/500/80         1820 ms         1820 ms            1 fail_pct=0 items_per_second=54.9407/s num_trials_mean=1.001k rot_err_mean_deg=0.158934 rot_err_med_deg=0.126382 t_err_mean_deg=0.338105 t_err_med_deg=0.310161
colmap/500/50               2931 ms         2930 ms            1 fail_pct=0 items_per_second=34.1243/s num_trials_mean=1.04047k rot_err_mean_deg=0.230951 rot_err_med_deg=0.187253 t_err_mean_deg=0.516861 t_err_med_deg=0.464692
colmap_pl5pt/500/50         1792 ms         1792 ms            1 fail_pct=0 items_per_second=55.8119/s num_trials_mean=1.0399k rot_err_mean_deg=0.229662 rot_err_med_deg=0.180381 t_err_mean_deg=0.512767 t_err_med_deg=0.464692
colmap/1000/100             4470 ms         4470 ms            1 fail_pct=0 items_per_second=22.3715/s num_trials_mean=1.001k rot_err_mean_deg=0.124274 rot_err_med_deg=0.113866 t_err_mean_deg=0.269385 t_err_med_deg=0.233073
colmap_pl5pt/1000/100       3344 ms         3344 ms            1 fail_pct=0 items_per_second=29.9047/s num_trials_mean=1.001k rot_err_mean_deg=0.121305 rot_err_med_deg=0.107805 t_err_mean_deg=0.264547 t_err_med_deg=0.214254
```