### PR TITLE
Fail Caspar build early on CUDA arch < 7.0

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -189,6 +189,34 @@ if(CUDA_ENABLED AND CUDA_FOUND)
         set(CMAKE_CUDA_ARCHITECTURES "native")
     endif()
 
+    # Caspar's Symforce-generated kernels use cooperative_groups::labeled_partition
+    # and atomicAdd_block, which require compute capability >= 7.0. Fail early with
+    # a clear message instead of a cryptic nvcc error deep in the kernel build. The
+    # numeric check handles list entries and -real/-virtual suffixes; the special
+    # values native/all/all-major cannot be resolved statically here, so they only
+    # get a warning (nvcc may fall back to an older default arch in build
+    # environments without a visible GPU >= 7.0, e.g. containerized builds).
+    if(CASPAR_ENABLED)
+        foreach(_caspar_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+            string(REGEX MATCH "^([0-9]+)" _caspar_arch_num "${_caspar_arch}")
+            if(_caspar_arch_num AND _caspar_arch_num LESS 70)
+                message(FATAL_ERROR
+                    "CASPAR_ENABLED requires CUDA architecture >= 70 (compute "
+                    "capability 7.0), but CMAKE_CUDA_ARCHITECTURES contains "
+                    "'${_caspar_arch}'. Set -DCMAKE_CUDA_ARCHITECTURES to 70+.")
+            endif()
+        endforeach()
+        if(CMAKE_CUDA_ARCHITECTURES MATCHES "native|all|all-major")
+            message(WARNING
+                "CASPAR_ENABLED with CMAKE_CUDA_ARCHITECTURES='${CMAKE_CUDA_ARCHITECTURES}': "
+                "Caspar requires compute capability >= 7.0, which cannot be "
+                "verified statically for this value. In an environment without a "
+                "visible GPU >= 7.0 (e.g. containerized builds) nvcc may fall back "
+                "to an older default arch and fail with cryptic kernel errors. "
+                "Set -DCMAKE_CUDA_ARCHITECTURES explicitly (e.g. 75, 86).")
+        endif()
+    endif()
+
     list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_CUDA_ENABLED)
 
     # Do not show warnings if the architectures are deprecated.


### PR DESCRIPTION
## Problem

Building with `-DCASPAR_ENABLED=ON` fails during Caspar kernel compilation when the target CUDA architecture is below compute capability 7.0. Caspar's Symforce-generated kernels use `cooperative_groups::labeled_partition` and `atomicAdd_block`, which require SM >= 7.0. The failure surfaces as low-level `nvcc` errors deep in the kernel build rather than a clear message, and is especially easy to hit in containerized / no-GPU builds where `CMAKE_CUDA_ARCHITECTURES` defaults to `native` and `nvcc` falls back to an older default arch.

## Fix

Add a configure-time guard in `cmake/FindDependencies.cmake`, right after the arch list is finalized (i.e. after the `native` default is applied):

- **FATAL_ERROR** when `CASPAR_ENABLED` and any resolved arch entry is `< 70`. The numeric check handles list entries and `-real`/`-virtual` suffixes.
- **WARNING** for `native`/`all`/`all-major`, which cannot be resolved statically (the containerized/no-GPU case).

This fails early with an actionable message instead of a cryptic kernel-compile error.

## Verification

Tested the regex/comparison logic with `cmake -P`:

| archs | result |
|---|---|
| `52`, `60;75`, `75;61` | FATAL |
| `70`, `86`, `86-real`, `75;80;86;89;75-virtual` | pass |
| `native`, `all`, `all-major` | warn |

Fixes #4494