### PR TITLE
Fix missing SVG icons in Windows binaries

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -196,7 +196,22 @@ jobs:
           ../vcpkg/vcpkg.exe export --raw --output-dir vcpkg_export --output colmap
           cp vcpkg_export/colmap/installed/x64-windows/bin/*.dll install/bin
           cp vcpkg_export/colmap/installed/x64-windows-release/bin/*.dll install/bin
-          cp -r vcpkg_export/colmap/installed/x64-windows/Qt6/plugins install
+          # Deploy the Qt plugins from the x64-windows-release triplet, which is
+          # the triplet COLMAP is actually built against. qtsvg is only installed
+          # for that triplet, so copying from x64-windows would miss the SVG
+          # plugins (imageformats/qsvg.dll and iconengines/qsvgicon.dll) that Qt
+          # needs to render the SVG toolbar/menu icons, leaving them blank.
+          cp -r vcpkg_export/colmap/installed/x64-windows-release/Qt6/plugins install
+
+          # Fail loudly if the SVG plugins are missing: without them Qt cannot
+          # render the SVG icons and the toolbar/menu icons show up blank, but
+          # the build itself succeeds, so the regression is otherwise silent.
+          if (-not (Test-Path install/plugins/iconengines/qsvgicon.dll)) {
+              throw "Missing Qt SVG icon engine plugin (iconengines/qsvgicon.dll); SVG icons would not render."
+          }
+          if (-not (Test-Path install/plugins/imageformats/qsvg.dll)) {
+              throw "Missing Qt SVG image format plugin (imageformats/qsvg.dll); SVG icons would not render."
+          }
           if ($${{ matrix.config.cudaEnabled }}) {
               cp "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/bin/cudart64_*.dll" install/bin
               cp "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/bin/curand64_*.dll" install/bin


### PR DESCRIPTION
Fixes: #4490

## Problem

The SVG toolbar/menu icons do not render in the distributed Windows binaries produced by CI — they show up blank.

The GUI loads all icons via `QIcon(":/media/*.svg")` (embedded Qt resources). For Qt to rasterize an SVG at runtime it needs two plugins deployed alongside the executable:
- `iconengines/qsvgicon.dll` (icon engine used by `QIcon` for `.svg`)
- `imageformats/qsvg.dll`

Inspecting the artifact from a recent `main` run confirmed:
- `bin/Qt6Svg.dll` ✅ present
- `plugins/imageformats/` had only `qgif/qico/qjpeg` — **`qsvg.dll` missing**
- `plugins/iconengines/` — **directory did not exist at all**

## Root cause

A vcpkg triplet mismatch in `build-windows.yml`. The export contains `qtbase:x64-windows`, `qtbase:x64-windows-release`, and `qtsvg:x64-windows-release` — i.e. `qtsvg` is installed **only** for `x64-windows-release`. But the packaging step copied plugins from `x64-windows`:

```
cp -r vcpkg_export/colmap/installed/x64-windows/Qt6/plugins install
```

That grabs qtbase's base plugins but silently misses both qtsvg plugins. The DLLs were already copied from `x64-windows-release`, which is why `Qt6Svg.dll` was present but orphaned.

## Fix

- Copy plugins from `x64-windows-release` — the triplet COLMAP is actually built against and where qtsvg lives (consistent with the DLL copy). This is a strict superset of what was copied before, plus the missing SVG plugins.
- Add a fail-fast guard asserting both SVG plugins exist after the copy. The bug was invisible at build time (blank icons only appear at runtime), so the check prevents a silent regression.

No C++ or `vcpkg.json` changes were needed — `qtsvg` was already a `gui` dependency; the defect was purely in packaging.