### PR TITLE
Speed up cheirality test with a closed-form alternative

### DIFF
--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -137,12 +137,12 @@ bool EstimateRelativePose(const RANSACOptions& ransac_options,
     }
   }
 
-  std::vector<Eigen::Vector3d> points3D;
+  std::vector<int> inlier_idxs;
   PoseFromEssentialMatrix(report.model,
                           inlier_cam_rays1,
                           inlier_cam_rays2,
                           cam2_from_cam1,
-                          &points3D);
+                          &inlier_idxs);
 
   if (cam2_from_cam1->rotation().coeffs().array().isNaN().any() ||
       cam2_from_cam1->translation().array().isNaN().any()) {
@@ -152,7 +152,7 @@ bool EstimateRelativePose(const RANSACOptions& ransac_options,
   *num_inliers = report.support.num_inliers;
   *inlier_mask = std::move(report.inlier_mask);
 
-  return !points3D.empty();
+  return !inlier_idxs.empty();
 }
 
 bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
@@ -357,11 +357,11 @@ bool RefineEssentialMatrix(const ceres::Solver::Options& options,
 
   // Extract relative pose from essential matrix.
   Rigid3d cam2_from_cam1;
-  std::vector<Eigen::Vector3d> points3D;
+  std::vector<int> inlier_idxs;
   PoseFromEssentialMatrix(
-      *E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &points3D);
+      *E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &inlier_idxs);
 
-  if (points3D.size() == 0) {
+  if (inlier_idxs.empty()) {
     return false;
   }
 

--- a/src/colmap/estimators/pose.cc
+++ b/src/colmap/estimators/pose.cc
@@ -137,12 +137,12 @@ bool EstimateRelativePose(const RANSACOptions& ransac_options,
     }
   }
 
-  std::vector<int> inlier_idxs;
+  std::vector<int> valid_indices;
   PoseFromEssentialMatrix(report.model,
                           inlier_cam_rays1,
                           inlier_cam_rays2,
                           cam2_from_cam1,
-                          &inlier_idxs);
+                          &valid_indices);
 
   if (cam2_from_cam1->rotation().coeffs().array().isNaN().any() ||
       cam2_from_cam1->translation().array().isNaN().any()) {
@@ -152,7 +152,7 @@ bool EstimateRelativePose(const RANSACOptions& ransac_options,
   *num_inliers = report.support.num_inliers;
   *inlier_mask = std::move(report.inlier_mask);
 
-  return !inlier_idxs.empty();
+  return !valid_indices.empty();
 }
 
 bool RefineAbsolutePose(const AbsolutePoseRefinementOptions& options,
@@ -357,11 +357,11 @@ bool RefineEssentialMatrix(const ceres::Solver::Options& options,
 
   // Extract relative pose from essential matrix.
   Rigid3d cam2_from_cam1;
-  std::vector<int> inlier_idxs;
+  std::vector<int> valid_indices;
   PoseFromEssentialMatrix(
-      *E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &inlier_idxs);
+      *E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &valid_indices);
 
-  if (inlier_idxs.empty()) {
+  if (valid_indices.empty()) {
     return false;
   }
 

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -44,6 +44,7 @@
 #include "colmap/util/logging.h"
 #include "colmap/util/timer.h"
 
+#include <algorithm>
 #include <unordered_set>
 
 #include <Eigen/Geometry>
@@ -627,14 +628,15 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
   // CALIBRATED configuration (or DEGENERATE), so they are handled by the
   // CALIBRATED branch below and never reach the CalibrationMatrix() calls.
   Rigid3d cam2_from_cam1;
+  std::vector<int> inlier_idxs;
   if (geometry->config == TwoViewGeometry::ConfigurationType::CALIBRATED) {
     THROW_CHECK(geometry->E.has_value());
     PoseFromEssentialMatrix(*geometry->E,
                             inlier_cam_rays1,
                             inlier_cam_rays2,
                             &cam2_from_cam1,
-                            &points3D);
-    if (points3D.empty()) {
+                            &inlier_idxs);
+    if (inlier_idxs.empty()) {
       return false;
     }
   } else if (geometry->config ==
@@ -643,8 +645,8 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
     const Eigen::Matrix3d E = EssentialFromFundamentalMatrix(
         camera2.CalibrationMatrix(), *geometry->F, camera1.CalibrationMatrix());
     PoseFromEssentialMatrix(
-        E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &points3D);
-    if (points3D.empty()) {
+        E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &inlier_idxs);
+    if (inlier_idxs.empty()) {
       return false;
     }
   } else if (geometry->config == TwoViewGeometry::ConfigurationType::PLANAR ||
@@ -685,7 +687,22 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
 
   geometry->cam2_from_cam1 = cam2_from_cam1;
 
-  if (!points3D.empty()) {
+  if (!inlier_idxs.empty()) {
+    // Essential-matrix paths: the triangulation angle is the parallax between
+    // the surviving corresponding rays, so no explicit triangulation is needed.
+    const Eigen::Quaterniond cam1_from_cam2_rotation =
+        cam2_from_cam1.rotation().inverse();
+    std::vector<double> tri_angles;
+    tri_angles.reserve(inlier_idxs.size());
+    for (const int idx : inlier_idxs) {
+      const double angle = CalculateAngleBetweenVectors(
+          inlier_cam_rays1[idx],
+          cam1_from_cam2_rotation * inlier_cam_rays2[idx]);
+      tri_angles.push_back(
+          std::min(angle, static_cast<double>(EIGEN_PI) - angle));
+    }
+    geometry->tri_angle = Median(tri_angles);
+  } else if (!points3D.empty()) {
     const Eigen::Vector3d proj_center1 = Eigen::Vector3d::Zero();
     const Eigen::Vector3d proj_center2 = cam2_from_cam1.TgtOriginInSrc();
     geometry->tri_angle = Median(

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -628,15 +628,15 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
   // CALIBRATED configuration (or DEGENERATE), so they are handled by the
   // CALIBRATED branch below and never reach the CalibrationMatrix() calls.
   Rigid3d cam2_from_cam1;
-  std::vector<int> inlier_idxs;
+  std::vector<int> valid_indices;
   if (geometry->config == TwoViewGeometry::ConfigurationType::CALIBRATED) {
     THROW_CHECK(geometry->E.has_value());
     PoseFromEssentialMatrix(*geometry->E,
                             inlier_cam_rays1,
                             inlier_cam_rays2,
                             &cam2_from_cam1,
-                            &inlier_idxs);
-    if (inlier_idxs.empty()) {
+                            &valid_indices);
+    if (valid_indices.empty()) {
       return false;
     }
   } else if (geometry->config ==
@@ -645,8 +645,8 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
     const Eigen::Matrix3d E = EssentialFromFundamentalMatrix(
         camera2.CalibrationMatrix(), *geometry->F, camera1.CalibrationMatrix());
     PoseFromEssentialMatrix(
-        E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &inlier_idxs);
-    if (inlier_idxs.empty()) {
+        E, inlier_cam_rays1, inlier_cam_rays2, &cam2_from_cam1, &valid_indices);
+    if (valid_indices.empty()) {
       return false;
     }
   } else if (geometry->config == TwoViewGeometry::ConfigurationType::PLANAR ||
@@ -687,14 +687,15 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
 
   geometry->cam2_from_cam1 = cam2_from_cam1;
 
-  if (!inlier_idxs.empty()) {
-    // Essential-matrix paths: the triangulation angle is the parallax between
-    // the surviving corresponding rays, so no explicit triangulation is needed.
+  if (!valid_indices.empty()) {
+    // Essential-matrix paths (CALIBRATED / UNCALIBRATED): the triangulation
+    // angle is the parallax between the surviving corresponding rays, which
+    // needs no explicit triangulation.
     const Eigen::Quaterniond cam1_from_cam2_rotation =
         cam2_from_cam1.rotation().inverse();
     std::vector<double> tri_angles;
-    tri_angles.reserve(inlier_idxs.size());
-    for (const int idx : inlier_idxs) {
+    tri_angles.reserve(valid_indices.size());
+    for (const int idx : valid_indices) {
       const double angle = CalculateAngleBetweenVectors(
           inlier_cam_rays1[idx],
           cam1_from_cam2_rotation * inlier_cam_rays2[idx]);
@@ -703,6 +704,8 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
     }
     geometry->tri_angle = Median(tri_angles);
   } else if (!points3D.empty()) {
+    // Homography path (PLANAR): the triangulation angle is computed from the
+    // 3D points recovered by PoseFromHomographyMatrix.
     const Eigen::Vector3d proj_center1 = Eigen::Vector3d::Zero();
     const Eigen::Vector3d proj_center2 = cam2_from_cam1.TgtOriginInSrc();
     geometry->tri_angle = Median(

--- a/src/colmap/geometry/essential_matrix.cc
+++ b/src/colmap/geometry/essential_matrix.cc
@@ -65,7 +65,7 @@ void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                              const std::vector<Eigen::Vector3d>& cam_rays1,
                              const std::vector<Eigen::Vector3d>& cam_rays2,
                              Rigid3d* cam2_from_cam1,
-                             std::vector<int>* inlier_idxs) {
+                             std::vector<int>* valid_indices) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
 
   Eigen::Matrix3d R1;
@@ -82,14 +82,14 @@ void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                                                  Rigid3d(quat1, -t),
                                                  Rigid3d(quat2, -t)}};
 
-  inlier_idxs->clear();
-  std::vector<int> tentative_inlier_idxs;
+  valid_indices->clear();
+  std::vector<int> tentative_valid_indices;
   for (size_t i = 0; i < cams2_from_cams1.size(); ++i) {
     CheckCheirality(
-        cams2_from_cams1[i], cam_rays1, cam_rays2, &tentative_inlier_idxs);
-    if (tentative_inlier_idxs.size() >= inlier_idxs->size()) {
+        cams2_from_cams1[i], cam_rays1, cam_rays2, &tentative_valid_indices);
+    if (tentative_valid_indices.size() >= valid_indices->size()) {
       *cam2_from_cam1 = cams2_from_cams1[i];
-      std::swap(*inlier_idxs, tentative_inlier_idxs);
+      std::swap(*valid_indices, tentative_valid_indices);
     }
   }
 }

--- a/src/colmap/geometry/essential_matrix.cc
+++ b/src/colmap/geometry/essential_matrix.cc
@@ -65,7 +65,7 @@ void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                              const std::vector<Eigen::Vector3d>& cam_rays1,
                              const std::vector<Eigen::Vector3d>& cam_rays2,
                              Rigid3d* cam2_from_cam1,
-                             std::vector<Eigen::Vector3d>* points3D) {
+                             std::vector<int>* inlier_idxs) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
 
   Eigen::Matrix3d R1;
@@ -82,14 +82,14 @@ void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                                                  Rigid3d(quat1, -t),
                                                  Rigid3d(quat2, -t)}};
 
-  points3D->clear();
-  std::vector<Eigen::Vector3d> tentative_points3D;
+  inlier_idxs->clear();
+  std::vector<int> tentative_inlier_idxs;
   for (size_t i = 0; i < cams2_from_cams1.size(); ++i) {
     CheckCheirality(
-        cams2_from_cams1[i], cam_rays1, cam_rays2, &tentative_points3D);
-    if (tentative_points3D.size() >= points3D->size()) {
+        cams2_from_cams1[i], cam_rays1, cam_rays2, &tentative_inlier_idxs);
+    if (tentative_inlier_idxs.size() >= inlier_idxs->size()) {
       *cam2_from_cam1 = cams2_from_cams1[i];
-      std::swap(*points3D, tentative_points3D);
+      std::swap(*inlier_idxs, tentative_inlier_idxs);
     }
   }
 }

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -61,7 +61,7 @@ void DecomposeEssentialMatrix(const Eigen::Matrix3d& E,
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
 // @param cam2_from_cam1  Relative camera transformation.
-// @param valid_indices     Indices of correspondences in front of both cameras.
+// @param valid_indices   Indices of correspondences in front of both cameras.
 void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                              const std::vector<Eigen::Vector3d>& cam_rays1,
                              const std::vector<Eigen::Vector3d>& cam_rays2,

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -61,12 +61,12 @@ void DecomposeEssentialMatrix(const Eigen::Matrix3d& E,
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
 // @param cam2_from_cam1  Relative camera transformation.
-// @param points3D        Triangulated 3D points infront of camera.
+// @param inlier_idxs     Indices of correspondences in front of both cameras.
 void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                              const std::vector<Eigen::Vector3d>& cam_rays1,
                              const std::vector<Eigen::Vector3d>& cam_rays2,
                              Rigid3d* cam2_from_cam1,
-                             std::vector<Eigen::Vector3d>* points3D);
+                             std::vector<int>* inlier_idxs);
 
 // Compose essential matrix from relative camera poses.
 //

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -61,12 +61,12 @@ void DecomposeEssentialMatrix(const Eigen::Matrix3d& E,
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
 // @param cam2_from_cam1  Relative camera transformation.
-// @param inlier_idxs     Indices of correspondences in front of both cameras.
+// @param valid_indices     Indices of correspondences in front of both cameras.
 void PoseFromEssentialMatrix(const Eigen::Matrix3d& E,
                              const std::vector<Eigen::Vector3d>& cam_rays1,
                              const std::vector<Eigen::Vector3d>& cam_rays2,
                              Rigid3d* cam2_from_cam1,
-                             std::vector<int>* inlier_idxs);
+                             std::vector<int>* valid_indices);
 
 // Compose essential matrix from relative camera poses.
 //

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -87,12 +87,11 @@ TEST(PoseFromEssentialMatrix, Nominal) {
     rays2[i] = (cam2_from_world * points3D[i]).normalized();
   }
 
-  points3D.clear();
-
   Rigid3d cam2_from_cam1_est;
-  PoseFromEssentialMatrix(E, rays1, rays2, &cam2_from_cam1_est, &points3D);
+  std::vector<int> inlier_idxs;
+  PoseFromEssentialMatrix(E, rays1, rays2, &cam2_from_cam1_est, &inlier_idxs);
 
-  EXPECT_EQ(points3D.size(), 4);
+  EXPECT_EQ(inlier_idxs.size(), 4);
 
   EXPECT_THAT(cam2_from_cam1_est, Rigid3dNear(cam2_from_cam1));
 }

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -88,10 +88,10 @@ TEST(PoseFromEssentialMatrix, Nominal) {
   }
 
   Rigid3d cam2_from_cam1_est;
-  std::vector<int> inlier_idxs;
-  PoseFromEssentialMatrix(E, rays1, rays2, &cam2_from_cam1_est, &inlier_idxs);
+  std::vector<int> valid_indices;
+  PoseFromEssentialMatrix(E, rays1, rays2, &cam2_from_cam1_est, &valid_indices);
 
-  EXPECT_EQ(inlier_idxs.size(), 4);
+  EXPECT_EQ(valid_indices.size(), 4);
 
   EXPECT_THAT(cam2_from_cam1_est, Rigid3dNear(cam2_from_cam1));
 }

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/geometry/pose.h"
 
-#include "colmap/geometry/triangulation.h"
 #include "colmap/math/matrix.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
@@ -245,18 +244,25 @@ Eigen::Matrix3d RightJacobianFromAngleAxis(const Eigen::Vector3d& omega) {
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,
                      const std::vector<Eigen::Vector3d>& cam_rays1,
                      const std::vector<Eigen::Vector3d>& cam_rays2,
-                     std::vector<Eigen::Vector3d>* points3D) {
+                     std::vector<int>* inlier_idxs) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
-  points3D->clear();
+  inlier_idxs->clear();
+  const Eigen::Matrix3d R = cam2_from_cam1.rotation().toRotationMatrix();
+  const Eigen::Vector3d t = cam2_from_cam1.translation();
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
-    Eigen::Vector3d point3D_in_cam1;
-    if (!TriangulateMidPoint(
-            cam2_from_cam1, cam_rays1[i], cam_rays2[i], &point3D_in_cam1)) {
-      continue;
+    // Solve the 2x2 system for the depths of the point along both rays; both
+    // must be positive for the point to lie in front of both cameras. The
+    // common positive factor 1 / (1 - a^2) is dropped since it does not affect
+    // the sign (a = cos angle between the rays, so |a| <= 1).
+    const Eigen::Vector3d ray1_in_cam2 = R * cam_rays1[i];
+    const double a = -ray1_in_cam2.dot(cam_rays2[i]);
+    const double b1 = -ray1_in_cam2.dot(t);
+    const double b2 = cam_rays2[i].dot(t);
+    if (b1 - a * b2 > 0.0 && b2 - a * b1 > 0.0) {
+      inlier_idxs->push_back(static_cast<int>(i));
     }
-    points3D->push_back(point3D_in_cam1);
   }
-  return !points3D->empty();
+  return !inlier_idxs->empty();
 }
 
 Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -249,7 +249,6 @@ bool CheckCheirality(const Rigid3d& cam2_from_cam1,
   valid_indices->clear();
   const Eigen::Matrix3d cam2_from_cam1_rot =
       cam2_from_cam1.rotation().toRotationMatrix();
-  const auto& cam2_from_cam1_translation = cam2_from_cam1.translation();
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
     // Solve the 2x2 system for the depths of the point along both rays; both
     // must be positive for the point to lie in front of both cameras. The
@@ -257,8 +256,8 @@ bool CheckCheirality(const Rigid3d& cam2_from_cam1,
     // the sign (a = cos angle between the rays, so |a| <= 1).
     const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1_rot * cam_rays1[i];
     const double a = -ray1_in_cam2.dot(cam_rays2[i]);
-    const double b1 = -ray1_in_cam2.dot(cam2_from_cam1_translation);
-    const double b2 = cam_rays2[i].dot(cam2_from_cam1_translation);
+    const double b1 = -ray1_in_cam2.dot(cam2_from_cam1.translation());
+    const double b2 = cam_rays2[i].dot(cam2_from_cam1.translation());
     if (b1 - a * b2 > 0.0 && b2 - a * b1 > 0.0) {
       valid_indices->push_back(static_cast<int>(i));
     }

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -244,9 +244,9 @@ Eigen::Matrix3d RightJacobianFromAngleAxis(const Eigen::Vector3d& omega) {
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,
                      const std::vector<Eigen::Vector3d>& cam_rays1,
                      const std::vector<Eigen::Vector3d>& cam_rays2,
-                     std::vector<int>* inlier_idxs) {
+                     std::vector<int>* valid_indices) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
-  inlier_idxs->clear();
+  valid_indices->clear();
   const Eigen::Matrix3d R = cam2_from_cam1.rotation().toRotationMatrix();
   const Eigen::Vector3d t = cam2_from_cam1.translation();
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
@@ -259,10 +259,10 @@ bool CheckCheirality(const Rigid3d& cam2_from_cam1,
     const double b1 = -ray1_in_cam2.dot(t);
     const double b2 = cam_rays2[i].dot(t);
     if (b1 - a * b2 > 0.0 && b2 - a * b1 > 0.0) {
-      inlier_idxs->push_back(static_cast<int>(i));
+      valid_indices->push_back(static_cast<int>(i));
     }
   }
-  return !inlier_idxs->empty();
+  return !valid_indices->empty();
 }
 
 Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -247,17 +247,18 @@ bool CheckCheirality(const Rigid3d& cam2_from_cam1,
                      std::vector<int>* valid_indices) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
   valid_indices->clear();
-  const Eigen::Matrix3d R = cam2_from_cam1.rotation().toRotationMatrix();
-  const Eigen::Vector3d t = cam2_from_cam1.translation();
+  const Eigen::Matrix3d cam2_from_cam1_rot =
+      cam2_from_cam1.rotation().toRotationMatrix();
+  const auto& cam2_from_cam1_translation = cam2_from_cam1.translation();
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
     // Solve the 2x2 system for the depths of the point along both rays; both
     // must be positive for the point to lie in front of both cameras. The
     // common positive factor 1 / (1 - a^2) is dropped since it does not affect
     // the sign (a = cos angle between the rays, so |a| <= 1).
-    const Eigen::Vector3d ray1_in_cam2 = R * cam_rays1[i];
+    const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1_rot * cam_rays1[i];
     const double a = -ray1_in_cam2.dot(cam_rays2[i]);
-    const double b1 = -ray1_in_cam2.dot(t);
-    const double b2 = cam_rays2[i].dot(t);
+    const double b1 = -ray1_in_cam2.dot(cam2_from_cam1_translation);
+    const double b2 = cam_rays2[i].dot(cam2_from_cam1_translation);
     if (b1 - a * b2 > 0.0 && b2 - a * b1 > 0.0) {
       valid_indices->push_back(static_cast<int>(i));
     }

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -149,7 +149,7 @@ Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
 // @param cam2_from_cam1  Relative camera transformation.
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
-// @param valid_indices     Indices of correspondences in front of both cameras.
+// @param valid_indices   Indices of correspondences in front of both cameras.
 //
 // @return                Whether any correspondence lies in front of both.
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -143,17 +143,19 @@ Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
                                const Rigid3d& cam2_from_world,
                                double t);
 
-// Perform cheirality constraint test, i.e., determine which of the triangulated
-// correspondences lie in front of both cameras.
+// Perform cheirality constraint test, i.e., determine which corresponding rays
+// triangulate to a point in front of both cameras.
 //
 // @param cam2_from_cam1  Relative camera transformation.
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
-// @param points3D        Points that lie in front of both cameras.
+// @param inlier_idxs     Indices of correspondences in front of both cameras.
+//
+// @return                Whether any correspondence lies in front of both.
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,
                      const std::vector<Eigen::Vector3d>& cam_rays1,
                      const std::vector<Eigen::Vector3d>& cam_rays2,
-                     std::vector<Eigen::Vector3d>* points3D);
+                     std::vector<int>* inlier_idxs);
 
 Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,
                              const Rigid3d& cam_from_world);

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -149,13 +149,13 @@ Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
 // @param cam2_from_cam1  Relative camera transformation.
 // @param cam_rays1       First set of corresponding rays.
 // @param cam_rays2       Second set of corresponding rays.
-// @param inlier_idxs     Indices of correspondences in front of both cameras.
+// @param valid_indices     Indices of correspondences in front of both cameras.
 //
 // @return                Whether any correspondence lies in front of both.
 bool CheckCheirality(const Rigid3d& cam2_from_cam1,
                      const std::vector<Eigen::Vector3d>& cam_rays1,
                      const std::vector<Eigen::Vector3d>& cam_rays2,
-                     std::vector<int>* inlier_idxs);
+                     std::vector<int>* valid_indices);
 
 Rigid3d TransformCameraWorld(const Sim3d& new_from_old_world,
                              const Rigid3d& cam_from_world);

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -206,26 +206,26 @@ TEST(CheckCheirality, Nominal) {
 
   std::vector<Eigen::Vector3d> rays1;
   std::vector<Eigen::Vector3d> rays2;
-  std::vector<int> inlier_idxs;
+  std::vector<int> valid_indices;
 
   rays1.push_back(Eigen::Vector3d(0, 0, 1).normalized());
   rays2.push_back(Eigen::Vector3d(0.1, 0, 1).normalized());
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
-  EXPECT_EQ(inlier_idxs.size(), 1);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &valid_indices));
+  EXPECT_EQ(valid_indices.size(), 1);
 
   rays1.push_back(Eigen::Vector3d(0, 0, 1).normalized());
   rays2.push_back(Eigen::Vector3d(-0.1, 0, 1).normalized());
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
-  EXPECT_EQ(inlier_idxs.size(), 1);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &valid_indices));
+  EXPECT_EQ(valid_indices.size(), 1);
 
   rays2[1][0] = 0.2;
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
-  EXPECT_EQ(inlier_idxs.size(), 2);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &valid_indices));
+  EXPECT_EQ(valid_indices.size(), 2);
 
   rays2[0][0] = -0.2;
   rays2[1][0] = -0.2;
-  EXPECT_FALSE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
-  EXPECT_EQ(inlier_idxs.size(), 0);
+  EXPECT_FALSE(CheckCheirality(cam2_from_cam1, rays1, rays2, &valid_indices));
+  EXPECT_EQ(valid_indices.size(), 0);
 }
 
 TEST(AverageUnitVectors, Nominal) {

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -206,26 +206,26 @@ TEST(CheckCheirality, Nominal) {
 
   std::vector<Eigen::Vector3d> rays1;
   std::vector<Eigen::Vector3d> rays2;
-  std::vector<Eigen::Vector3d> points3D;
+  std::vector<int> inlier_idxs;
 
   rays1.push_back(Eigen::Vector3d(0, 0, 1).normalized());
   rays2.push_back(Eigen::Vector3d(0.1, 0, 1).normalized());
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &points3D));
-  EXPECT_EQ(points3D.size(), 1);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
+  EXPECT_EQ(inlier_idxs.size(), 1);
 
   rays1.push_back(Eigen::Vector3d(0, 0, 1).normalized());
   rays2.push_back(Eigen::Vector3d(-0.1, 0, 1).normalized());
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &points3D));
-  EXPECT_EQ(points3D.size(), 1);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
+  EXPECT_EQ(inlier_idxs.size(), 1);
 
   rays2[1][0] = 0.2;
-  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &points3D));
-  EXPECT_EQ(points3D.size(), 2);
+  EXPECT_TRUE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
+  EXPECT_EQ(inlier_idxs.size(), 2);
 
   rays2[0][0] = -0.2;
   rays2[1][0] = -0.2;
-  EXPECT_FALSE(CheckCheirality(cam2_from_cam1, rays1, rays2, &points3D));
-  EXPECT_EQ(points3D.size(), 0);
+  EXPECT_FALSE(CheckCheirality(cam2_from_cam1, rays1, rays2, &inlier_idxs));
+  EXPECT_EQ(inlier_idxs.size(), 0);
 }
 
 TEST(AverageUnitVectors, Nominal) {

--- a/src/pycolmap/estimators/essential_matrix.cc
+++ b/src/pycolmap/estimators/essential_matrix.cc
@@ -78,19 +78,18 @@ py::typing::Optional<py::dict> PyEstimateAndDecomposeEssentialMatrix(
   }
 
   Rigid3d cam2_from_cam1;
-  std::vector<Eigen::Vector3d> inlier_points3D;
+  std::vector<int> valid_indices;
   PoseFromEssentialMatrix(report.model,
                           inlier_cam_rays1,
                           inlier_cam_rays2,
                           &cam2_from_cam1,
-                          &inlier_points3D);
+                          &valid_indices);
 
   py::gil_scoped_acquire acquire;
   return py::dict("E"_a = report.model,
                   "cam2_from_cam1"_a = cam2_from_cam1,
                   "num_inliers"_a = report.support.num_inliers,
-                  "inlier_mask"_a = ToPythonMask(report.inlier_mask),
-                  "inlier_points3D"_a = inlier_points3D);
+                  "inlier_mask"_a = ToPythonMask(report.inlier_mask));
 }
 
 void BindEssentialMatrixEstimator(py::module& m) {


### PR DESCRIPTION
In preparation for wiring the cheirality test into the sampson error residual computation. 