### PR TITLE
Load mapper database lazily instead of at GUI startup

### DIFF
--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -1393,6 +1393,9 @@ void MainWindow::ReconstructionStep() {
 }
 
 void MainWindow::ReconstructionPause() {
+  if (!mapper_controller_) {
+    return;
+  }
   timer_.Pause();
   mapper_controller_->Pause();
   EnableBlockingActions();

--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -183,7 +183,10 @@ MainWindow::MainWindow(OptionManager options)
   CreateMenus();
   CreateToolbar();
   CreateStatusbar();
-  CreateControllers();
+  // The mapper controller (and its database cache) is created lazily when a
+  // reconstruction is actually started, so opening the GUI does not read the
+  // database. Just initialize the control states here.
+  UpdateMapperControls();
 
   ShowLog();
 
@@ -844,11 +847,8 @@ void MainWindow::CreateStatusbar() {
   statusBar()->addWidget(model_viewer_widget_->statusbar_status_label, 1);
 }
 
-void MainWindow::CreateControllers() {
-  if (mapper_controller_) {
-    mapper_controller_->Stop();
-    mapper_controller_->Wait();
-  }
+void MainWindow::CreateMapperController() {
+  StopMapperController();
 
   options_.mapper->image_path = *options_.image_path;
 
@@ -925,6 +925,22 @@ void MainWindow::CreateControllers() {
     }
   });
 
+  UpdateMapperControls();
+}
+
+void MainWindow::StopMapperController() {
+  if (mapper_controller_) {
+    mapper_controller_->Stop();
+    mapper_controller_->Wait();
+    mapper_controller_.reset();
+  }
+}
+
+void MainWindow::ResetMapperController() {
+  // Tear down any existing controller without building a new one (which would
+  // eagerly read the database). A fresh controller is created lazily in
+  // ReconstructionStart().
+  StopMapperController();
   UpdateMapperControls();
 }
 
@@ -1326,24 +1342,27 @@ void MainWindow::AutomaticReconstruction() {
 }
 
 void MainWindow::ReconstructionStart() {
-  if (!mapper_controller_->IsStarted() && !options_.Check()) {
+  const bool started = mapper_controller_ && mapper_controller_->IsStarted();
+  const bool finished = mapper_controller_ && mapper_controller_->IsFinished();
+
+  if (!started && !options_.Check()) {
     ShowInvalidProjectError();
     return;
   }
 
-  if (mapper_controller_->IsFinished() && HasSelectedReconstruction()) {
+  if (finished && HasSelectedReconstruction()) {
     QMessageBox::critical(
         this, "", tr("Reset reconstruction before starting."));
     return;
   }
 
-  if (mapper_controller_->IsStarted()) {
+  if (started) {
     // Resume existing reconstruction.
     timer_.Resume();
     mapper_controller_->Resume();
   } else {
     // Start new reconstruction.
-    CreateControllers();
+    CreateMapperController();
     timer_.Restart();
     mapper_controller_->Start();
     action_reconstruction_start_->setText(tr("Resume reconstruction"));
@@ -1360,7 +1379,8 @@ void MainWindow::ReconstructionStep() {
     return;
   }
 
-  if (mapper_controller_->IsFinished() && HasSelectedReconstruction()) {
+  if (mapper_controller_ && mapper_controller_->IsFinished() &&
+      HasSelectedReconstruction()) {
     QMessageBox::critical(
         this, "", tr("Reset reconstruction before starting."));
     return;
@@ -1394,7 +1414,7 @@ void MainWindow::ReconstructionFinish() {
 }
 
 void MainWindow::ReconstructionReset() {
-  CreateControllers();
+  ResetMapperController();
 
   reconstruction_manager_->Clear();
   reconstruction_manager_widget_->Update();

--- a/src/colmap/ui/main_window.h
+++ b/src/colmap/ui/main_window.h
@@ -79,7 +79,9 @@ class MainWindow : public QMainWindow {
   void CreateMenus();
   void CreateToolbar();
   void CreateStatusbar();
-  void CreateControllers();
+  void CreateMapperController();
+  void StopMapperController();
+  void ResetMapperController();
 
   void HandleDragEvent(QDropEvent* event);
 


### PR DESCRIPTION
## Problem

Starting the COLMAP GUI (with no mapping requested) reads the entire database into a `DatabaseCache`, emitting logs like:

```
incremental_pipeline.cc:278] Loading database
database_cache.cc:72] Loading rigs...
database_cache.cc:90] Loading cameras...
...
```

The `MainWindow` constructor called `CreateControllers()`, which eagerly constructed an `IncrementalPipeline` whose constructor loads the database. This also fired on every New/Open Project and Import (via `ReconstructionReset()`). The work is redundant since the pipeline is rebuilt anyway in `ReconstructionStart()` right before running.

## Fix

Construct the mapper controller lazily — only when a reconstruction is actually started:

- The constructor now just initializes control states via `UpdateMapperControls()` (already null-safe).
- `ReconstructionReset()` calls the new `ResetMapperController()`, which tears down any running controller **without** building a new one (no DB read).
- `CreateMapperController()` (renamed from the inaccurate plural `CreateControllers`) remains the single place that builds the pipeline, invoked from `ReconstructionStart()`.
- Shared `Stop`/`Wait`/`reset` teardown factored into `StopMapperController()`.
- `mapper_controller_` can now be null before the first start, so the relevant checks in `ReconstructionStart()`/`ReconstructionStep()` are null-guarded.

After this change, launching the GUI and opening/importing projects no longer read the database — that only happens when mapping actually starts.

## Testing

- `ninja colmap_ui` builds cleanly.