### PR TITLE
Update Python dependencies in pyproject.toml

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -101,7 +101,7 @@ jobs:
         if: matrix.config.checkCodeFormat
         run: |
           set +x -euo pipefail
-          python -m pip install ruff==0.15.7 clang-format==22.1.1
+          python -m pip install ruff==0.15.20 clang-format==22.1.5
           ./scripts/format/c++.sh --all
           ./scripts/format/python.sh --all
           git diff --name-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.3.3",
-    "pybind11==3.0.2",
+    "pybind11==3.0.4",
     "pybind11_stubgen @ git+https://github.com/sarlinpe/pybind11-stubgen@sarlinpe/fix-2025-08-20",
     "numpy",
-    "ruff==0.15.7",
-    "clang-format==22.1.1",
+    "ruff==0.15.20",
+    "clang-format==22.1.5",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -41,7 +41,7 @@ wheel.packages = ["python/pycolmap"]
 [tool.cibuildwheel]
 build = "cp3{10,11,12,13,14}-{macosx,manylinux,win}*"
 archs = ["auto64"]
-test-requires = "pytest>=8.0 mypy==1.19.1 enlighten==1.14.1"
+test-requires = "pytest>=8.0 mypy==2.1.0 enlighten==1.14.1"
 test-command = """\
     python -c "import pycolmap; print(pycolmap.__version__)" && \
     cd {project} && \

--- a/scripts/format/c++.sh
+++ b/scripts/format/c++.sh
@@ -6,7 +6,7 @@
 
 # Check version
 version_string=$(clang-format --version | sed -E 's/^.*(\d+\.\d+\.\d+-.*).*$/\1/')
-expected_version_string='22.1.1'
+expected_version_string='22.1.5'
 if [[ "$version_string" =~ "$expected_version_string" ]]; then
     echo "clang-format version '$version_string' matches '$expected_version_string'"
 else

--- a/scripts/format/python.sh
+++ b/scripts/format/python.sh
@@ -6,7 +6,7 @@
 
 # Check version
 version_string=$(ruff --version | sed -E 's/^.*(\d+\.\d+-.*).*$/\1/')
-expected_version_string='0.15.7'
+expected_version_string='0.15.20'
 if [[ "$version_string" =~ "$expected_version_string" ]]; then
     echo "ruff version '$version_string' matches '$expected_version_string'"
 else


### PR DESCRIPTION
## Summary

Bumps pinned Python build/test dependencies in `pyproject.toml` to their latest releases:

- `pybind11` 3.0.2 → 3.0.4
- `ruff` 0.15.7 → 0.15.20
- `clang-format` 22.1.1 → 22.1.5
- `mypy` 1.19.1 → 2.1.0 (major version bump)

`enlighten` is already at its latest version (1.14.1); unpinned/minimum-version deps (`numpy`, `pytest`, `scikit-build-core`) are left as-is.

## Notes

The `mypy` bump is a major version jump and may surface new type-check errors in CI. Watching the pipeline to confirm the type-checking steps still pass.