### PR TITLE
Add cheirality check for 5-pt essential matrix solver

### DIFF
--- a/src/colmap/estimators/solvers/essential_matrix.cc
+++ b/src/colmap/estimators/solvers/essential_matrix.cc
@@ -30,6 +30,7 @@
 #include "colmap/estimators/solvers/essential_matrix.h"
 
 #include "colmap/geometry/essential_matrix.h"
+#include "colmap/geometry/rigid3.h"
 #include "colmap/math/polynomial.h"
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
@@ -54,7 +55,22 @@ void EssentialMatrixFivePointEstimator::Estimate(
   // PoseLib's 5-point solver only supports the minimal case; the non-minimal
   // case falls through to the SVD-based solver below.
   if (cam_rays1.size() == 5) {
-    poselib::relpose_5pt(cam_rays1, cam_rays2, models);
+    std::vector<M_t> candidate_models;
+    poselib::relpose_5pt(cam_rays1, cam_rays2, &candidate_models);
+    // Keep only hypotheses whose minimal sample is in front of both cameras,
+    // pruning geometrically invalid essential matrices before they are scored.
+    Rigid3d cam2_from_cam1;
+    std::vector<int> valid_indices;
+    for (const M_t& candidate_model : candidate_models) {
+      PoseFromEssentialMatrix(candidate_model,
+                              cam_rays1,
+                              cam_rays2,
+                              &cam2_from_cam1,
+                              &valid_indices);
+      if (valid_indices.size() == 5) {
+        models->push_back(candidate_model);
+      }
+    }
     return;
   }
 

--- a/src/colmap/estimators/solvers/essential_matrix.cc
+++ b/src/colmap/estimators/solvers/essential_matrix.cc
@@ -47,14 +47,14 @@ void EssentialMatrixFivePointEstimator::Estimate(
     const std::vector<Y_t>& cam_rays2,
     std::vector<M_t>* models) {
   THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
-  THROW_CHECK_GE(cam_rays1.size(), 5);
+  THROW_CHECK_GE(cam_rays1.size(), kMinNumSamples);
   THROW_CHECK(models != nullptr);
 
   models->clear();
 
   // PoseLib's 5-point solver only supports the minimal case; the non-minimal
   // case falls through to the SVD-based solver below.
-  if (cam_rays1.size() == 5) {
+  if (cam_rays1.size() == kMinNumSamples) {
     std::vector<M_t> candidate_models;
     poselib::relpose_5pt(cam_rays1, cam_rays2, &candidate_models);
     // Keep only hypotheses whose minimal sample is in front of both cameras,
@@ -67,7 +67,7 @@ void EssentialMatrixFivePointEstimator::Estimate(
                               cam_rays2,
                               &cam2_from_cam1,
                               &valid_indices);
-      if (valid_indices.size() == 5) {
+      if (valid_indices.size() == kMinNumSamples) {
         models->push_back(candidate_model);
       }
     }

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -39,15 +39,38 @@
 namespace colmap {
 namespace {
 
+// Minimum depth in front of either camera. Correspondences closer than this to
+// a camera center are numerically ill-conditioned for the cheirality check: the
+// depth collapses to ~0 and its sign becomes ambiguous, so a valid essential
+// matrix estimated from such a minimal sample may be spuriously pruned.
+constexpr double kMinDepth = 0.2;
+
+// Generates a random relative pose with a unit-norm baseline. Bounding the
+// baseline away from zero avoids the (near) pure-rotation degeneracy, where the
+// essential matrix vanishes and the cheirality of every correspondence becomes
+// ill-defined.
+Rigid3d TestCam2FromCam1() {
+  return Rigid3d(Eigen::Quaterniond::UnitRandom(),
+                 Eigen::Vector3d::Random().normalized());
+}
+
 void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    size_t num_rays,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    rays1.push_back(Eigen::Vector3d::Random().normalized());
-    const double random_depth = RandomUniformReal<double>(0.2, 2.0);
-    rays2.push_back(
-        (cam2_from_cam1 * (random_depth * rays1.back())).normalized());
+    // Reject correspondences whose 3D point lands too close to either camera
+    // center, keeping the synthesized minimal sample non-degenerate so that the
+    // true essential matrix is always cheirality-consistent.
+    Eigen::Vector3d ray1;
+    Eigen::Vector3d point_in_cam2;
+    do {
+      ray1 = Eigen::Vector3d::Random().normalized();
+      const double random_depth = RandomUniformReal<double>(kMinDepth, 2.0);
+      point_in_cam2 = cam2_from_cam1 * (random_depth * ray1);
+    } while (point_in_cam2.norm() < kMinDepth);
+    rays1.push_back(ray1);
+    rays2.push_back(point_in_cam2.normalized());
   }
 }
 
@@ -84,8 +107,7 @@ TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
   SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 100; ++k) {
-    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
-                                 Eigen::Vector3d::Random());
+    const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
@@ -110,8 +132,7 @@ TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
   SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 1; ++k) {
-    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
-                                 Eigen::Vector3d::Random());
+    const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -123,9 +123,11 @@ TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(
-        cam2_from_cam1, kNumRays, /*reject_degenerate=*/is_minimal, rays1,
-        rays2);
+    RandomEpipolarCorrespondences(cam2_from_cam1,
+                                  kNumRays,
+                                  /*reject_degenerate=*/is_minimal,
+                                  rays1,
+                                  rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -113,24 +113,30 @@ class EssentialMatrixFivePointEstimatorTests
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
   SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
+  // The minimal case has no redundancy, so it conditions its sample to stay
+  // well-posed and accepts the solver's numerical accuracy with a looser
+  // tolerance.
+  const bool is_minimal =
+      kNumRays == EssentialMatrixFivePointEstimator::kMinNumSamples;
   for (size_t k = 0; k < 100; ++k) {
     const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
     RandomEpipolarCorrespondences(
-        cam2_from_cam1,
-        kNumRays,
-        /*reject_degenerate=*/kNumRays ==
-            EssentialMatrixFivePointEstimator::kMinNumSamples,
-        rays1,
+        cam2_from_cam1, kNumRays, /*reject_degenerate=*/is_minimal, rays1,
         rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
     estimator.Estimate(rays1, rays2, &models);
 
-    ExpectAtLeastOneValidModel(estimator, rays1, rays2, expected_E, models);
+    ExpectAtLeastOneValidModel(estimator,
+                               rays1,
+                               rays2,
+                               expected_E,
+                               models,
+                               /*E_eps=*/is_minimal ? 5e-3 : 1e-4);
   }
 }
 

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -44,7 +44,7 @@ void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    rays1.push_back(Eigen::Vector3d::Random());
+    rays1.push_back(Eigen::Vector3d::Random().normalized());
     const double random_depth = RandomUniformReal<double>(0.2, 2.0);
     rays2.push_back(
         (cam2_from_cam1 * (random_depth * rays1.back())).normalized());

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -39,11 +39,12 @@
 namespace colmap {
 namespace {
 
-// Minimum depth in front of either camera. Correspondences closer than this to
-// a camera center are numerically ill-conditioned for the cheirality check: the
-// depth collapses to ~0 and its sign becomes ambiguous, so a valid essential
-// matrix estimated from such a minimal sample may be spuriously pruned.
+// Rejection thresholds used by RandomEpipolarCorrespondences to condition a
+// minimal sample: minimum depth in front of either camera, and minimum parallax
+// between the two rays as sin^2 of their angle (1 - a^2 in the cheirality
+// form).
 constexpr double kMinDepth = 0.2;
+constexpr double kMinParallax = 1e-2;  // ~5.7 degrees.
 
 // Generates a random relative pose with a unit-norm baseline. Bounding the
 // baseline away from zero avoids the (near) pure-rotation degeneracy, where the
@@ -54,21 +55,27 @@ Rigid3d TestCam2FromCam1() {
                  Eigen::Vector3d::Random().normalized());
 }
 
+// When reject_degenerate is set, resamples correspondences that make a minimal
+// 5-point solve ill-conditioned (near-zero depth or near-parallel rays). Only
+// the minimal case needs this; larger samples are robust to such points.
 void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    size_t num_rays,
+                                   bool reject_degenerate,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    // Reject correspondences whose 3D point lands too close to either camera
-    // center, keeping the synthesized minimal sample non-degenerate so that the
-    // true essential matrix is always cheirality-consistent.
     Eigen::Vector3d ray1;
     Eigen::Vector3d point_in_cam2;
+    bool degenerate;
     do {
       ray1 = Eigen::Vector3d::Random().normalized();
       const double random_depth = RandomUniformReal<double>(kMinDepth, 2.0);
       point_in_cam2 = cam2_from_cam1 * (random_depth * ray1);
-    } while (point_in_cam2.norm() < kMinDepth);
+      const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1.rotation() * ray1;
+      const double cos_parallax = ray1_in_cam2.dot(point_in_cam2.normalized());
+      degenerate = point_in_cam2.norm() < kMinDepth ||
+                   1.0 - cos_parallax * cos_parallax < kMinParallax;
+    } while (reject_degenerate && degenerate);
     rays1.push_back(ray1);
     rays2.push_back(point_in_cam2.normalized());
   }
@@ -80,7 +87,7 @@ void ExpectAtLeastOneValidModel(const Estimator& estimator,
                                 const std::vector<Eigen::Vector3d>& rays2,
                                 Eigen::Matrix3d& expected_E,
                                 std::vector<Eigen::Matrix3d>& models,
-                                double E_eps = 1e-3,
+                                double E_eps = 1e-4,
                                 double r_eps = 1e-5) {
   expected_E.normalize();
   for (size_t i = 0; i < models.size(); ++i) {
@@ -111,7 +118,13 @@ TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
+    RandomEpipolarCorrespondences(
+        cam2_from_cam1,
+        kNumRays,
+        /*reject_degenerate=*/kNumRays ==
+            EssentialMatrixFivePointEstimator::kMinNumSamples,
+        rays1,
+        rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
@@ -136,7 +149,8 @@ TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
+    RandomEpipolarCorrespondences(
+        cam2_from_cam1, kNumRays, /*reject_degenerate=*/false, rays1, rays2);
 
     EssentialMatrixEightPointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -80,7 +80,7 @@ void ExpectAtLeastOneValidModel(const Estimator& estimator,
                                 const std::vector<Eigen::Vector3d>& rays2,
                                 Eigen::Matrix3d& expected_E,
                                 std::vector<Eigen::Matrix3d>& models,
-                                double E_eps = 1e-4,
+                                double E_eps = 1e-3,
                                 double r_eps = 1e-5) {
   expected_E.normalize();
   for (size_t i = 0; i < models.size(); ++i) {

--- a/src/colmap/geometry/pose.cc
+++ b/src/colmap/geometry/pose.cc
@@ -251,9 +251,10 @@ bool CheckCheirality(const Rigid3d& cam2_from_cam1,
       cam2_from_cam1.rotation().toRotationMatrix();
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
     // Solve the 2x2 system for the depths of the point along both rays; both
-    // must be positive for the point to lie in front of both cameras. The
-    // common positive factor 1 / (1 - a^2) is dropped since it does not affect
-    // the sign (a = cos angle between the rays, so |a| <= 1).
+    // must be positive for the point to lie in front of both cameras. This
+    // assumes unit-norm rays: the common positive factor 1 / (1 - a^2) is
+    // dropped since it does not affect the sign (a = cos angle between the
+    // rays, so |a| <= 1).
     const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1_rot * cam_rays1[i];
     const double a = -ray1_in_cam2.dot(cam_rays2[i]);
     const double b1 = -ray1_in_cam2.dot(cam2_from_cam1.translation());

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -146,9 +146,12 @@ Rigid3d InterpolateCameraPoses(const Rigid3d& cam1_from_world,
 // Perform cheirality constraint test, i.e., determine which corresponding rays
 // triangulate to a point in front of both cameras.
 //
+// NOTE: The closed-form depth test assumes both rays are unit-normalized;
+// passing rays of arbitrary scale yields incorrect cheirality results.
+//
 // @param cam2_from_cam1  Relative camera transformation.
-// @param cam_rays1       First set of corresponding rays.
-// @param cam_rays2       Second set of corresponding rays.
+// @param cam_rays1       First set of corresponding rays (must be unit-norm).
+// @param cam_rays2       Second set of corresponding rays (must be unit-norm).
 // @param valid_indices   Indices of correspondences in front of both cameras.
 //
 // @return                Whether any correspondence lies in front of both.


### PR DESCRIPTION
This is the root cause of the previous speed gap against PoseLib. The impact on runtime performance is significant when there is a large presence of outliers. The overhead is marginal.

```
  `colmap` = shipping five-point LO-RANSAC (count support, no refinement).
  `colmap_gated` = same, but the minimal solver drops hypotheses whose 5 sample
  rays fail cheirality (PoseLib-style). `poselib` = reference (has LM refinement).
  `score_calls` = models scored per problem (the RANSAC scoring *volume*).

  | Points | Inliers | Method       | Time (ms) | Recovered inlier % | Rot med (°) | Trans med (°) | Score calls |
  |-------:|--------:|--------------|----------:|-------------------:|------------:|--------------:|------------:|
  | 100    | 100%    | colmap       |       788 |               99.9 |       0.197 |         0.332 |        4412 |
  | 100    | 100%    | colmap_gated |      1053 |               99.9 |       0.197 |         0.332 |        2524 |
  | 100    | 100%    | poselib      |       958 |               98.7 |       0.101 |         0.212 |        2507 |
  |        |         |              |           |                    |             |               |             |
  | 100    | 80%     | colmap       |       761 |               79.3 |       0.235 |         0.449 |        4338 |
  | 100    | 80%     | colmap_gated |       975 |               79.3 |       0.228 |         0.451 |        1319 |
  | 100    | 80%     | poselib      |       728 |               78.2 |       0.124 |         0.219 |        1303 |
  |        |         |              |           |                    |             |               |             |
  | 100    | 50%     | colmap       |       950 |               50.3 |       0.252 |         0.521 |        5550 |
  | 100    | 50%     | colmap_gated |      1192 |               50.2 |       0.257 |         0.541 |         761 |
  | 100    | 50%     | poselib      |       855 |               49.2 |       0.146 |         0.325 |         767 |
  |        |         |              |           |                    |             |               |             |
  | 500    | 100%    | colmap       |      1817 |               99.7 |       0.139 |         0.320 |        4409 |
  | 500    | 100%    | colmap_gated |      1668 |               99.7 |       0.138 |         0.322 |        2483 |
  | 500    | 100%    | poselib      |      2253 |               98.7 |       0.046 |         0.089 |        2477 |
  |        |         |              |           |                    |             |               |             |
  | 500    | 80%     | colmap       |      1737 |               79.9 |       0.126 |         0.309 |        4329 |
  | 500    | 80%     | colmap_gated |      1327 |               79.9 |       0.137 |         0.304 |        1388 |
  | 500    | 80%     | poselib      |      1327 |               79.1 |       0.055 |         0.120 |        1365 |
  |        |         |              |           |                    |             |               |             |
  | 500    | 50%     | colmap       |      1731 |               50.2 |       0.178 |         0.446 |        4458 |
  | 500    | 50%     | colmap_gated |      1126 |               50.2 |       0.187 |         0.453 |         663 |
  | 500    | 50%     | poselib      |       852 |               49.5 |       0.068 |         0.144 |         636 |
  |        |         |              |           |                    |             |               |             |
  | 1000   | 100%    | colmap       |      3105 |               99.6 |       0.108 |         0.214 |        4410 |
  | 1000   | 100%    | colmap_gated |      2476 |               99.6 |       0.097 |         0.214 |        2544 |
  | 1000   | 100%    | poselib      |      3971 |               98.7 |       0.034 |         0.072 |        2535 |
  |        |         |              |           |                    |             |               |             |
  | 1000   | 80%     | colmap       |      2953 |               79.9 |       0.096 |         0.187 |        4335 |
  | 1000   | 80%     | colmap_gated |      1749 |               79.9 |       0.104 |         0.210 |        1346 |
  | 1000   | 80%     | poselib      |      2050 |               79.1 |       0.036 |         0.071 |        1326 |
  |        |         |              |           |                    |             |               |             |
  | 1000   | 50%     | colmap       |      2886 |               50.5 |       0.121 |         0.295 |        4336 |
  | 1000   | 50%     | colmap_gated |      1303 |               50.5 |       0.121 |         0.320 |         640 |
  | 1000   | 50%     | poselib      |      1048 |               49.8 |       0.050 |         0.104 |         607 |

```