### PR TITLE
Add cheirality check for calculating sampson error at E estimation

### DIFF
--- a/src/colmap/estimators/solvers/essential_matrix.cc
+++ b/src/colmap/estimators/solvers/essential_matrix.cc
@@ -153,7 +153,7 @@ void EssentialMatrixFivePointEstimator::Residuals(
     const std::vector<Y_t>& cam_rays2,
     const M_t& E,
     std::vector<double>* residuals) {
-  ComputeSquaredSampsonError(cam_rays1, cam_rays2, E, residuals);
+  ComputeSquaredSampsonErrorWithCheirality(cam_rays1, cam_rays2, E, residuals);
 }
 
 void EssentialMatrixEightPointEstimator::Estimate(
@@ -206,7 +206,7 @@ void EssentialMatrixEightPointEstimator::Residuals(
     const std::vector<Y_t>& cam_rays2,
     const M_t& E,
     std::vector<double>* residuals) {
-  ComputeSquaredSampsonError(cam_rays1, cam_rays2, E, residuals);
+  ComputeSquaredSampsonErrorWithCheirality(cam_rays1, cam_rays2, E, residuals);
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -39,13 +39,6 @@
 namespace colmap {
 namespace {
 
-// Rejection thresholds used by RandomEpipolarCorrespondences to condition a
-// minimal sample: minimum depth in front of either camera, and minimum parallax
-// between the two rays as sin^2 of their angle (1 - a^2 in the cheirality
-// form).
-constexpr double kMinDepth = 0.2;
-constexpr double kMinParallax = 1e-2;  // ~5.7 degrees.
-
 // Generates a random relative pose with a unit-norm baseline. Bounding the
 // baseline away from zero avoids the (near) pure-rotation degeneracy, where the
 // essential matrix vanishes and the cheirality of every correspondence becomes
@@ -55,29 +48,15 @@ Rigid3d TestCam2FromCam1() {
                  Eigen::Vector3d::Random().normalized());
 }
 
-// When reject_degenerate is set, resamples correspondences that make a minimal
-// 5-point solve ill-conditioned (near-zero depth or near-parallel rays). Only
-// the minimal case needs this; larger samples are robust to such points.
 void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    size_t num_rays,
-                                   bool reject_degenerate,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    Eigen::Vector3d ray1;
-    Eigen::Vector3d point_in_cam2;
-    bool degenerate;
-    do {
-      ray1 = Eigen::Vector3d::Random().normalized();
-      const double random_depth = RandomUniformReal<double>(kMinDepth, 2.0);
-      point_in_cam2 = cam2_from_cam1 * (random_depth * ray1);
-      const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1.rotation() * ray1;
-      const double cos_parallax = ray1_in_cam2.dot(point_in_cam2.normalized());
-      degenerate = point_in_cam2.norm() < kMinDepth ||
-                   1.0 - cos_parallax * cos_parallax < kMinParallax;
-    } while (reject_degenerate && degenerate);
-    rays1.push_back(ray1);
-    rays2.push_back(point_in_cam2.normalized());
+    rays1.push_back(Eigen::Vector3d::Random().normalized());
+    const double random_depth = RandomUniformReal<double>(0.2, 2.0);
+    rays2.push_back(
+        (cam2_from_cam1 * (random_depth * rays1.back())).normalized());
   }
 }
 
@@ -113,9 +92,8 @@ class EssentialMatrixFivePointEstimatorTests
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
   SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
-  // The minimal case has no redundancy, so it conditions its sample to stay
-  // well-posed and accepts the solver's numerical accuracy with a looser
-  // tolerance.
+  // The minimal case has no redundancy, so its recovered E is only accurate to
+  // the solver's numerical limit and is checked with a looser tolerance.
   const bool is_minimal =
       kNumRays == EssentialMatrixFivePointEstimator::kMinNumSamples;
   for (size_t k = 0; k < 100; ++k) {
@@ -123,11 +101,7 @@ TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(cam2_from_cam1,
-                                  kNumRays,
-                                  /*reject_degenerate=*/is_minimal,
-                                  rays1,
-                                  rays2);
+    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
@@ -157,8 +131,7 @@ TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(
-        cam2_from_cam1, kNumRays, /*reject_degenerate=*/false, rays1, rays2);
+    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
 
     EssentialMatrixEightPointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -44,7 +44,7 @@ void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    rays1.push_back(Eigen::Vector3d::Random());
+    rays1.push_back(Eigen::Vector3d::Random().normalized());
     const double random_depth = RandomUniformReal<double>(0.2, 2.0);
     rays2.push_back(
         (cam2_from_cam1 * (random_depth * rays1.back())).normalized());

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -44,7 +44,7 @@ void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    rays1.push_back(Eigen::Vector3d::Random().normalized());
+    rays1.push_back(Eigen::Vector3d::Random());
     const double random_depth = RandomUniformReal<double>(0.2, 2.0);
     rays2.push_back(
         (cam2_from_cam1 * (random_depth * rays1.back())).normalized());

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -39,6 +39,13 @@
 namespace colmap {
 namespace {
 
+// Rejection thresholds used by RandomEpipolarCorrespondences to condition a
+// minimal sample: minimum depth in front of either camera, and minimum parallax
+// between the two rays as sin^2 of their angle (1 - a^2 in the cheirality
+// form).
+constexpr double kMinDepth = 0.2;
+constexpr double kMinParallax = 1e-2;  // ~5.7 degrees.
+
 // Generates a random relative pose with a unit-norm baseline. Bounding the
 // baseline away from zero avoids the (near) pure-rotation degeneracy, where the
 // essential matrix vanishes and the cheirality of every correspondence becomes
@@ -48,15 +55,29 @@ Rigid3d TestCam2FromCam1() {
                  Eigen::Vector3d::Random().normalized());
 }
 
+// When reject_degenerate is set, resamples correspondences that make a minimal
+// 5-point solve ill-conditioned (near-zero depth or near-parallel rays). Only
+// the minimal case needs this; larger samples are robust to such points.
 void RandomEpipolarCorrespondences(const Rigid3d& cam2_from_cam1,
                                    size_t num_rays,
+                                   bool reject_degenerate,
                                    std::vector<Eigen::Vector3d>& rays1,
                                    std::vector<Eigen::Vector3d>& rays2) {
   for (size_t i = 0; i < num_rays; ++i) {
-    rays1.push_back(Eigen::Vector3d::Random().normalized());
-    const double random_depth = RandomUniformReal<double>(0.2, 2.0);
-    rays2.push_back(
-        (cam2_from_cam1 * (random_depth * rays1.back())).normalized());
+    Eigen::Vector3d ray1;
+    Eigen::Vector3d point_in_cam2;
+    bool degenerate;
+    do {
+      ray1 = Eigen::Vector3d::Random().normalized();
+      const double random_depth = RandomUniformReal<double>(kMinDepth, 2.0);
+      point_in_cam2 = cam2_from_cam1 * (random_depth * ray1);
+      const Eigen::Vector3d ray1_in_cam2 = cam2_from_cam1.rotation() * ray1;
+      const double cos_parallax = ray1_in_cam2.dot(point_in_cam2.normalized());
+      degenerate = point_in_cam2.norm() < kMinDepth ||
+                   1.0 - cos_parallax * cos_parallax < kMinParallax;
+    } while (reject_degenerate && degenerate);
+    rays1.push_back(ray1);
+    rays2.push_back(point_in_cam2.normalized());
   }
 }
 
@@ -92,8 +113,9 @@ class EssentialMatrixFivePointEstimatorTests
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
   SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
-  // The minimal case has no redundancy, so its recovered E is only accurate to
-  // the solver's numerical limit and is checked with a looser tolerance.
+  // The minimal case has no redundancy, so it conditions its sample to stay
+  // well-posed and accepts the solver's numerical accuracy with a looser
+  // tolerance.
   const bool is_minimal =
       kNumRays == EssentialMatrixFivePointEstimator::kMinNumSamples;
   for (size_t k = 0; k < 100; ++k) {
@@ -101,7 +123,11 @@ TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
+    RandomEpipolarCorrespondences(cam2_from_cam1,
+                                  kNumRays,
+                                  /*reject_degenerate=*/is_minimal,
+                                  rays1,
+                                  rays2);
 
     EssentialMatrixFivePointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;
@@ -131,7 +157,8 @@ TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
     Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
     std::vector<Eigen::Vector3d> rays1;
     std::vector<Eigen::Vector3d> rays2;
-    RandomEpipolarCorrespondences(cam2_from_cam1, kNumRays, rays1, rays2);
+    RandomEpipolarCorrespondences(
+        cam2_from_cam1, kNumRays, /*reject_degenerate=*/false, rays1, rays2);
 
     EssentialMatrixEightPointEstimator estimator;
     std::vector<Eigen::Matrix3d> models;

--- a/src/colmap/geometry/essential_matrix.cc
+++ b/src/colmap/geometry/essential_matrix.cc
@@ -206,4 +206,33 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& ray1,
   }
 }
 
+void ComputeSquaredSampsonErrorWithCheirality(
+    const std::vector<Eigen::Vector3d>& ray1,
+    const std::vector<Eigen::Vector3d>& ray2,
+    const Eigen::Matrix3d& E,
+    std::vector<double>* residuals) {
+  const size_t num_ray1 = ray1.size();
+  THROW_CHECK_EQ(num_ray1, ray2.size());
+  residuals->resize(num_ray1);
+
+  // Recover the relative pose from E (resolving the four-fold decomposition
+  // ambiguity by cheirality voting) and flag which correspondences triangulate
+  // in front of both cameras.
+  Rigid3d cam2_from_cam1;
+  std::vector<int> valid_indices;
+  PoseFromEssentialMatrix(E, ray1, ray2, &cam2_from_cam1, &valid_indices);
+  std::vector<bool> is_cheiral(num_ray1, false);
+  for (const int idx : valid_indices) {
+    is_cheiral[idx] = true;
+  }
+
+  // Correspondences behind either camera are not valid inliers for the relative
+  // pose regardless of their Sampson error, so they get an infinite residual.
+  for (size_t i = 0; i < num_ray1; ++i) {
+    (*residuals)[i] = is_cheiral[i]
+                          ? ComputeSquaredSampsonError(ray1[i], ray2[i], E)
+                          : std::numeric_limits<double>::max();
+  }
+}
+
 }  // namespace colmap

--- a/src/colmap/geometry/essential_matrix.h
+++ b/src/colmap/geometry/essential_matrix.h
@@ -169,4 +169,26 @@ void ComputeSquaredSampsonError(const std::vector<Eigen::Vector3d>& rays1,
                                 const Eigen::Matrix3d& E,
                                 std::vector<double>* residuals);
 
+// Calculate the residuals of a set of corresponding rays and a given essential
+// matrix, additionally enforcing the cheirality constraint.
+//
+// Residuals are the squared Sampson error, except that correspondences which
+// triangulate behind either camera are assigned an infinite residual. The
+// relative pose is recovered from E (resolving the four-fold decomposition
+// ambiguity by cheirality voting), so an epipolar-consistent correspondence
+// with the wrong depth sign is rejected even when its Sampson error is small.
+//
+// Only meaningful for essential matrices (calibrated rays); the plain
+// ComputeSquaredSampsonError should be used for fundamental matrices.
+//
+// @param rays1       Corresponding rays.
+// @param rays2       Corresponding rays.
+// @param E           3x3 essential matrix.
+// @param residuals   Output vector of residuals.
+void ComputeSquaredSampsonErrorWithCheirality(
+    const std::vector<Eigen::Vector3d>& rays1,
+    const std::vector<Eigen::Vector3d>& rays2,
+    const Eigen::Matrix3d& E,
+    std::vector<double>* residuals);
+
 }  // namespace colmap

--- a/src/colmap/geometry/essential_matrix_test.cc
+++ b/src/colmap/geometry/essential_matrix_test.cc
@@ -34,6 +34,8 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/eigen_matchers.h"
 
+#include <limits>
+
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
@@ -194,6 +196,81 @@ TEST(ComputeSquaredSampsonError, Nominal) {
   EXPECT_EQ(residuals[0], 0);
   EXPECT_EQ(residuals[1], 0.5);
   EXPECT_EQ(residuals[2], 2);
+}
+
+TEST(ComputeSquaredSampsonErrorWithCheirality, AllCorrespondencesInFront) {
+  const Rigid3d cam1_from_world;
+  const Rigid3d cam2_from_world(Eigen::Quaterniond::Identity(),
+                                Eigen::Vector3d(1, 0, 0).normalized());
+  const Eigen::Matrix3d E =
+      EssentialMatrixFromPose(cam2_from_world * Inverse(cam1_from_world));
+
+  std::vector<Eigen::Vector3d> points3D(4);
+  points3D[0] = Eigen::Vector3d(0, 0, 1);
+  points3D[1] = Eigen::Vector3d(0, 0.1, 1);
+  points3D[2] = Eigen::Vector3d(0.1, 0, 1);
+  points3D[3] = Eigen::Vector3d(0.1, 0.1, 1);
+
+  std::vector<Eigen::Vector3d> rays1(points3D.size());
+  std::vector<Eigen::Vector3d> rays2(points3D.size());
+  for (size_t i = 0; i < points3D.size(); ++i) {
+    rays1[i] = (cam1_from_world * points3D[i]).normalized();
+    rays2[i] = (cam2_from_world * points3D[i]).normalized();
+  }
+
+  // All correspondences triangulate in front of both cameras, so enforcing
+  // cheirality must leave every residual identical to the plain Sampson error.
+  std::vector<double> sampson_residuals;
+  ComputeSquaredSampsonError(rays1, rays2, E, &sampson_residuals);
+  std::vector<double> cheiral_residuals;
+  ComputeSquaredSampsonErrorWithCheirality(rays1, rays2, E, &cheiral_residuals);
+
+  ASSERT_EQ(cheiral_residuals.size(), sampson_residuals.size());
+  for (size_t i = 0; i < sampson_residuals.size(); ++i) {
+    EXPECT_EQ(cheiral_residuals[i], sampson_residuals[i]);
+  }
+}
+
+TEST(ComputeSquaredSampsonErrorWithCheirality, CorrespondenceBehindCamera) {
+  const Rigid3d cam1_from_world;
+  const Rigid3d cam2_from_world(Eigen::Quaterniond::Identity(),
+                                Eigen::Vector3d(1, 0, 0).normalized());
+  const Eigen::Matrix3d E =
+      EssentialMatrixFromPose(cam2_from_world * Inverse(cam1_from_world));
+
+  std::vector<Eigen::Vector3d> points3D(4);
+  points3D[0] = Eigen::Vector3d(0, 0, 1);
+  points3D[1] = Eigen::Vector3d(0, 0.1, 1);
+  points3D[2] = Eigen::Vector3d(0.1, 0, 1);
+  points3D[3] = Eigen::Vector3d(0.1, 0.1, 1);
+
+  std::vector<Eigen::Vector3d> rays1(points3D.size());
+  std::vector<Eigen::Vector3d> rays2(points3D.size());
+  for (size_t i = 0; i < points3D.size(); ++i) {
+    rays1[i] = (cam1_from_world * points3D[i]).normalized();
+    rays2[i] = (cam2_from_world * points3D[i]).normalized();
+  }
+
+  // Negating a ray keeps it on the same epipolar line (the Sampson error is
+  // invariant to the sign of the ray) but flips its triangulated depth, so it
+  // ends up behind the cameras.
+  rays2[1] = -rays2[1];
+
+  // The plain Sampson error stays finite (and near zero) for the flipped
+  // correspondence because it ignores cheirality.
+  std::vector<double> sampson_residuals;
+  ComputeSquaredSampsonError(rays1, rays2, E, &sampson_residuals);
+  EXPECT_LT(sampson_residuals[1], 1e-10);
+
+  // Enforcing cheirality rejects the flipped correspondence with an infinite
+  // residual while leaving the remaining ones equal to the Sampson error.
+  std::vector<double> cheiral_residuals;
+  ComputeSquaredSampsonErrorWithCheirality(rays1, rays2, E, &cheiral_residuals);
+  ASSERT_EQ(cheiral_residuals.size(), 4);
+  EXPECT_EQ(cheiral_residuals[1], std::numeric_limits<double>::max());
+  EXPECT_EQ(cheiral_residuals[0], sampson_residuals[0]);
+  EXPECT_EQ(cheiral_residuals[2], sampson_residuals[2]);
+  EXPECT_EQ(cheiral_residuals[3], sampson_residuals[3]);
 }
 
 }  // namespace


### PR DESCRIPTION
The cheirality check at residual evaluation is crucial for accuracy when there is a large presence of outliers, according to the numbers at https://github.com/colmap/colmap/pull/4497#issuecomment-4876271485