### PR TITLE
Update CI action and tool dependencies

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,10 +33,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Restore FetchContent cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-fetchcontent
         with:
           key: fetchcontent-v${{ env.FETCHCONTENT_CACHE_VERSION }}-docker-${{ hashFiles('cmake/FindDependencies.cmake', 'src/thirdparty/CMakeLists.txt') }}
@@ -44,7 +44,7 @@ jobs:
           path: ${{ env.FETCHCONTENT_CACHE_DIR }}
 
       - name: Restore compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-ccache
         with:
           key: ccache-v${{ env.COMPILER_CACHE_VERSION }}-docker-${{ github.run_id }}
@@ -52,14 +52,14 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
         if: ${{ env.IS_RELEASE == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -39,10 +39,10 @@ jobs:
       GLOG_logtostderr: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Restore compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-compiler
         with:
           key: v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ matrix.config.cmakeBuildType }}-${{ github.run_id }}-${{ github.run_number }}
@@ -50,7 +50,7 @@ jobs:
           path: ${{ env.COMPILER_CACHE_DIR }}
 
       - name: Restore FetchContent cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-fetchcontent
         with:
           key: fetchcontent-v${{ env.FETCHCONTENT_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ hashFiles('cmake/FindDependencies.cmake', 'src/thirdparty/CMakeLists.txt') }}

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -50,10 +50,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Restore compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-compiler
         with:
           key: pycolmap-v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ github.run_id }}-${{ github.run_number }}
@@ -61,7 +61,7 @@ jobs:
           path: ${{ env.COMPILER_CACHE_DIR }}
 
       - name: Restore FetchContent cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-fetchcontent
         with:
           key: pycolmap-fetchcontent-v${{ env.FETCHCONTENT_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.arch }}-cuda_${{ matrix.config.cudaEnabled }}-${{ hashFiles('cmake/FindDependencies.cmake', 'src/thirdparty/CMakeLists.txt') }}
@@ -217,7 +217,7 @@ jobs:
 
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@v4.1.0
         with:
           package-dir: ./
         env:
@@ -226,7 +226,7 @@ jobs:
             BUILD_CUDA_ENABLED=${{ matrix.config.cudaEnabled }}
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pycolmap-${{ matrix.config.os }}-${{ matrix.config.arch }}${{ matrix.config.cudaEnabled && '-CUDA' || '' }}
           path: wheelhouse/pycolmap*.whl
@@ -246,13 +246,13 @@ jobs:
     if: ${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./artifacts/
       - name: Move wheels
         run: mkdir ./wheelhouse && mv ./artifacts/**/*.whl ./wheelhouse/
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           skip-existing: true
           packages-dir: ./wheelhouse/

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -95,7 +95,7 @@ jobs:
       GLOG_logtostderr: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check code format
         if: matrix.config.checkCodeFormat
@@ -108,7 +108,7 @@ jobs:
           git diff --exit-code || (echo "Code formatting failed" && exit 1)
 
       - name: Restore Compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-compiler
         with:
           key: v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.cmakeBuildType }}-${{ matrix.config.asanEnabled }}--${{ matrix.config.cudaEnabled }}-${{ github.run_id }}-${{ github.run_number }}
@@ -116,7 +116,7 @@ jobs:
           path: ${{ env.COMPILER_CACHE_DIR }}
 
       - name: Restore FetchContent cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-fetchcontent
         with:
           key: fetchcontent-v${{ env.FETCHCONTENT_CACHE_VERSION }}-${{ matrix.config.os }}-cuda_${{ matrix.config.cudaEnabled }}-${{ hashFiles('cmake/FindDependencies.cmake', 'src/thirdparty/CMakeLists.txt') }}
@@ -133,11 +133,11 @@ jobs:
           fi
 
           set -x
-          wget https://github.com/ccache/ccache/releases/download/v4.12.2/ccache-4.12.2-linux-x86_64.tar.xz
-          echo "630c34ec94d451b200f5b14a6a25580d6a45bc80c394b7e0b93e33556eee5d32  ccache-4.12.2-linux-x86_64.tar.xz" | sha256sum --check
-          tar xfv ccache-4.12.2-linux-x86_64.tar.xz
+          wget https://github.com/ccache/ccache/releases/download/v4.13.6/ccache-4.13.6-linux-x86_64-glibc.tar.xz
+          echo "508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060  ccache-4.13.6-linux-x86_64-glibc.tar.xz" | sha256sum --check
+          tar xfv ccache-4.13.6-linux-x86_64-glibc.tar.xz
           mkdir -p "$COMPILER_CACHE_DIR/bin"
-          mv ./ccache-4.12.2-linux-x86_64/ccache "$COMPILER_CACHE_DIR/bin"
+          mv ./ccache-4.13.6-linux-x86_64-glibc/ccache "$COMPILER_CACHE_DIR/bin"
           ctcache_commit_id="66c3614175fc650591488519333c411b2eac15a3"
           wget https://github.com/matus-chochlik/ctcache/archive/${ctcache_commit_id}.zip
           echo "108b087f156a9fe7da0c796de1ef73f5855d2a33a27983769ea39061359a40fc  ${ctcache_commit_id}.zip" | sha256sum --check
@@ -300,7 +300,7 @@ jobs:
           ../scripts/shell/generate_coverage_report.sh
 
       - name: Upload coverage HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.config.coverageEnabled
         with:
           name: code-coverage

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,7 +51,7 @@ jobs:
       CUDA_PATCH_VERSION: 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # We define the vcpkg binary sources using separate variables for read and
       # write operations:
@@ -77,7 +77,7 @@ jobs:
           echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "${env:GITHUB_ENV}"
 
       - name: Restore compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-compiler
         with:
           key: v${{ env.COMPILER_CACHE_VERSION }}-${{ matrix.config.os }}-${{ matrix.config.cmakeBuildType }}-${{ matrix.config.asanEnabled }}--${{ matrix.config.cudaEnabled }}-${{ github.run_id }}-${{ github.run_number }}
@@ -85,7 +85,7 @@ jobs:
           path: ${{ env.COMPILER_CACHE_DIR }}
 
       - name: Restore FetchContent cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-fetchcontent
         with:
           key: fetchcontent-v${{ env.FETCHCONTENT_CACHE_VERSION }}-${{ matrix.config.os }}-cuda_${{ matrix.config.cudaEnabled }}-${{ hashFiles('cmake/FindDependencies.cmake', 'src/thirdparty/CMakeLists.txt') }}
@@ -219,14 +219,14 @@ jobs:
           Remove-Item -Recurse -Force -ErrorAction SilentlyContinue install/include,install/lib,install/share
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.config.exportPackage && matrix.config.cudaEnabled }}
         with:
           name: colmap-x64-windows-cuda
           path: build/install
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.config.exportPackage && !matrix.config.cudaEnabled }}
         with:
           name: colmap-x64-windows-nocuda

--- a/.github/workflows/install-ccache.ps1
+++ b/.github/workflows/install-ccache.ps1
@@ -4,10 +4,10 @@ param (
     [string] $Destination
 )
 
-$version = "4.12.1"
+$version = "4.13.6"
 $folder="ccache-$version-windows-x86_64"
 $url = "https://github.com/ccache/ccache/releases/download/v$version/$folder.zip"
-$expectedSha256 = "98AEA520D66905B8BA7A8E648A4CC0CA941D5E119D441F1E879A4A9045BF18F6"
+$expectedSha256 = "3D7CEBB05850AD704E197B3F1D3F0F924AB6C9FDFC561578E146184FE9D89380"
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary

Bumps pinned GitHub Actions and CI tools across all workflow files to their latest releases.

### GitHub Actions (major version bumps)
- `actions/checkout` v4 → v7
- `actions/cache` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `docker/setup-qemu-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4
- `docker/login-action` v3 → v4
- `pypa/cibuildwheel` v3.4.0 → v4.1.0

### Minor / patch bumps
- `pypa/gh-action-pypi-publish` v1.13.0 → v1.14.0
- `ccache` v4.12.2 → v4.13.6 (Linux)
- `ccache` v4.12.1 → v4.13.6 (Windows install script)

### Already up to date (unchanged)
- `jlumbroso/free-disk-space` v1.3.1
- `irongut/CodeCoverageSummary` v1.3.0
- `Jimver/cuda-toolkit` v0.2.35
- `lukka/get-cmake` @latest (intentionally floating)

## Notes

- **ccache asset rename**: newer ccache Linux releases renamed the archive from `ccache-<v>-linux-x86_64.tar.xz` to `ccache-<v>-linux-x86_64-glibc.tar.xz`. The download URL, extracted directory, and SHA-256 checksums were updated for both the Linux (`build-ubuntu.yml`) and Windows (`install-ccache.ps1`) paths. Checksums were computed from the official release assets.
- **cibuildwheel v3 → v4** is a major bump and the highest-risk change here — v4 may alter build/config behavior for the pycolmap wheels. Worth watching the PyCOLMAP workflow closely on this PR.
- The artifact actions (`upload-artifact` v7 / `download-artifact` v8) were bumped together to stay backend-compatible.
- All five workflow YAML files were validated to parse after the changes.