### PR TITLE
Set-based, GT-cluster-aware reconstruction evaluation metrics

### DIFF
--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -34,6 +34,7 @@ import ctypes
 import dataclasses
 import datetime
 import functools
+import itertools
 import multiprocessing
 import platform
 import shutil
@@ -1067,77 +1068,62 @@ def compute_grouped_rel_errors(
     fragmented registrations) we assign the maximum error of 180 degrees. The
     returned error array covers all pairs in A u B.
 
-    Sets A and B are never materialized: B membership is decided on the fly
-    from image_name_to_gt_recon_ids, and A is tracked with a visited set so the
-    B - A pairs can be found in a second pass.
+    A and B are materialized as flat collections and scored in a single pass.
+    A is a multiset (est_edges): an image may appear in several sub-models, so
+    the same edge can carry several estimated relative poses, each contributing
+    one error entry.
     """
     gt_cam_from_world = {
         image.name: image.cam_from_world()
         for image in sparse_gt.images.values()
     }
 
-    def same_gt_recon(name_a: str, name_b: str) -> bool:
-        recon_a = image_name_to_gt_recon_ids.get(name_a)
-        return (
-            recon_a is not None
-            and recon_a != OUTLIER_RECON_ID
-            and recon_a == image_name_to_gt_recon_ids.get(name_b)
-        )
-
-    visited: set[tuple[str, str]] = set()
-    errors: list[float] = []
-
-    # Pass 1: walk set A (ordered pairs within each estimated sub-model). An
-    # image may appear in several sub-models, so the same edge can be visited
-    # (and scored) multiple times; each estimate contributes an error.
+    # A: ordered estimated edges -> list of relative poses (one per sub-model
+    # containing both endpoints). Keeping a list makes A a multiset.
+    est_edges: dict[tuple[str, str], list[pycolmap.Rigid3d]] = (
+        collections.defaultdict(list)
+    )
     for sub_model in sub_models:
         cam_from_world = {
             image.name: image.cam_from_world()
             for image in sub_model.images.values()
         }
-        names = list(cam_from_world)
-        for name_i in names:
-            for name_j in names:
-                if name_i == name_j:
-                    continue
-                visited.add((name_i, name_j))
-                if (
-                    same_gt_recon(name_i, name_j)
-                    and name_i in gt_cam_from_world
-                    and name_j in gt_cam_from_world
-                ):
-                    # Edge in A n B: measure the relative pose error.
-                    rel_est = (
-                        cam_from_world[name_j]
-                        * cam_from_world[name_i].inverse()
-                    )
-                    rel_gt = (
-                        gt_cam_from_world[name_j]
-                        * gt_cam_from_world[name_i].inverse()
-                    )
-                    dt, dR = relative_pose_error_deg(
-                        rel_est, rel_gt, min_proj_center_dist
-                    )
-                    errors.append(max(dt, dR))
-                else:
-                    # Edge in A - B: wrong merge or registered outlier.
-                    errors.append(180.0)
+        for name_i, name_j in itertools.permutations(cam_from_world, 2):
+            rel_est = cam_from_world[name_j] * cam_from_world[name_i].inverse()
+            est_edges[(name_i, name_j)].append(rel_est)
 
-    # Pass 2: add the B - A pairs (grouped in GT but not jointly estimated).
+    # B: ordered GT edges grouped by GT reconstruction id. Outliers never
+    # belong to a GT reconstruction, and names absent from sparse_gt cannot
+    # form a measurable GT edge, so both are excluded here.
     names_by_recon: dict[int, list[str]] = collections.defaultdict(list)
     for name, recon_id in image_name_to_gt_recon_ids.items():
-        # Outliers never belong to a GT reconstruction, so they form no
-        # GT edges.
-        if recon_id == OUTLIER_RECON_ID:
+        if recon_id == OUTLIER_RECON_ID or name not in gt_cam_from_world:
             continue
         names_by_recon[recon_id].append(name)
+    gt_edges: set[tuple[str, str]] = set()
     for group_names in names_by_recon.values():
-        for name_i in group_names:
-            for name_j in group_names:
-                if name_i == name_j:
-                    continue
-                if (name_i, name_j) not in visited:
-                    errors.append(180.0)
+        gt_edges.update(itertools.permutations(group_names, 2))
+
+    errors: list[float] = []
+    for edge in set(est_edges) | gt_edges:
+        name_i, name_j = edge
+        rel_ests = est_edges.get(edge, [])
+        if edge in gt_edges:
+            rel_gt = (
+                gt_cam_from_world[name_j] * gt_cam_from_world[name_i].inverse()
+            )
+            if not rel_ests:
+                # Edge in B - A: failed / fragmented registration.
+                errors.append(180.0)
+            for rel_est in rel_ests:
+                # Edge in A n B: measure the relative pose error.
+                dt, dR = relative_pose_error_deg(
+                    rel_est, rel_gt, min_proj_center_dist
+                )
+                errors.append(max(dt, dR))
+        else:
+            # Edge in A - B: wrong merge or registered outlier.
+            errors.extend(180.0 for _ in rel_ests)
 
     if not errors:
         # No evaluable pairs (e.g. only singleton GT reconstructions). Report
@@ -1197,9 +1183,34 @@ def compute_abs_errors(
     if image_name_to_gt_recon_ids is None:
         return dts, dRs
 
-    # Mean finite translational error per cluster; outliers and images missing
-    # from the mapping never form a selectable cluster.
-    errors_by_recon: dict[int, list[float]] = collections.defaultdict(list)
+    best_recon_id = _best_gt_cluster(names, dts, image_name_to_gt_recon_ids)
+
+    # Keep only the best cluster intact; max out every other image (other
+    # clusters, outliers, or names missing from the mapping). When no cluster
+    # is selectable (best_recon_id is None) every image is maxed out.
+    for i, name in enumerate(names):
+        in_best_cluster = (
+            best_recon_id is not None
+            and image_name_to_gt_recon_ids.get(name) == best_recon_id
+        )
+        if not in_best_cluster:
+            dts[i] = np.inf
+            dRs[i] = 180
+
+    return dts, dRs
+
+
+def _best_gt_cluster(
+    names: list[str],
+    dts: npt.NDArray[np.floating],
+    image_name_to_gt_recon_ids: dict[str, int],
+) -> int | None:
+    """GT recon id with the smallest mean finite translational error.
+
+    Returns None when no image maps to a selectable cluster. Outliers and
+    names missing from the mapping never form a selectable cluster.
+    """
+    finite_dts_by_recon: dict[int, list[float]] = collections.defaultdict(list)
     for name, dt in zip(names, dts, strict=True):
         recon_id = image_name_to_gt_recon_ids.get(name)
         if (
@@ -1207,28 +1218,13 @@ def compute_abs_errors(
             and recon_id != OUTLIER_RECON_ID
             and np.isfinite(dt)
         ):
-            errors_by_recon[recon_id].append(float(dt))
-
-    best_recon_id = None
-    best_mean = np.inf
-    for recon_id, errs in errors_by_recon.items():
-        mean = float(np.mean(errs))
-        if mean < best_mean:
-            best_mean = mean
-            best_recon_id = recon_id
-
-    # Keep only the best cluster intact; max out every other image.
-    for i, name in enumerate(names):
-        recon_id = image_name_to_gt_recon_ids.get(name)
-        if not (
-            recon_id is not None
-            and recon_id != OUTLIER_RECON_ID
-            and recon_id == best_recon_id
-        ):
-            dts[i] = np.inf
-            dRs[i] = 180
-
-    return dts, dRs
+            finite_dts_by_recon[recon_id].append(float(dt))
+    if not finite_dts_by_recon:
+        return None
+    return min(
+        finite_dts_by_recon,
+        key=lambda recon_id: float(np.mean(finite_dts_by_recon[recon_id])),
+    )
 
 
 def compute_grouped_abs_errors(
@@ -1251,12 +1247,14 @@ def compute_grouped_abs_errors(
     gt_names = [image.name for image in sparse_gt.images.values()]
     gt_name_set = set(gt_names)
 
-    # Collect one error per (image, sub-model) registration. compute_abs_errors
-    # returns errors aligned to the sub-model's images that also exist in the
-    # GT, in sub_model.images.values() order, so we rebuild the matching names
-    # with the same filter/order. Registered images outside a sub-model's best
-    # cluster are maxed out (inf) yet still contribute an error.
-    errors_by_name: dict[str, list[float]] = {name: [] for name in gt_names}
+    # Flat node multiset keyed by GT image name: one translational error per
+    # (GT image, sub-model) registration. compute_abs_errors keeps each
+    # sub-model's best GT cluster intact and maxes out (inf) every other
+    # registered image, which still contributes an error. Its returned errors
+    # are aligned to the sub-model's images that also exist in the GT, in
+    # sub_model.images.values() order, so we rebuild the names with the same
+    # filter/order.
+    errors_by_name: dict[str, list[float]] = collections.defaultdict(list)
     for sub_model in sub_models:
         sub_dts, _ = compute_abs_errors(
             sparse_gt=sparse_gt,
@@ -1271,16 +1269,13 @@ def compute_grouped_abs_errors(
         for name, dt in zip(sub_names, sub_dts, strict=True):
             errors_by_name[name].append(float(dt))
 
-    # Images not registered in any sub-model count as a single failure.
+    # A GT image registered in no sub-model counts as a single failure.
     for name in gt_names:
         if not errors_by_name[name]:
             errors_by_name[name].append(np.inf)
 
-    errors: list[float] = []
-    for name in gt_names:
-        errors.extend(errors_by_name[name])
-
-    return np.array(errors)
+    # Flatten the node dict in GT image order.
+    return np.array([dt for name in gt_names for dt in errors_by_name[name]])
 
 
 def compute_auc(

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -1126,7 +1126,8 @@ def compute_grouped_rel_errors(
     # Pass 2: add the B - A pairs (grouped in GT but not jointly estimated).
     names_by_recon: dict[int, list[str]] = collections.defaultdict(list)
     for name, recon_id in image_name_to_gt_recon_ids.items():
-        # Outliers never belong to a GT reconstruction, so they form no GT edges.
+        # Outliers never belong to a GT reconstruction, so they form no
+        # GT edges.
         if recon_id == OUTLIER_RECON_ID:
             continue
         names_by_recon[recon_id].append(name)
@@ -1199,7 +1200,7 @@ def compute_abs_errors(
     # Mean finite translational error per cluster; outliers and images missing
     # from the mapping never form a selectable cluster.
     errors_by_recon: dict[int, list[float]] = collections.defaultdict(list)
-    for name, dt in zip(names, dts):
+    for name, dt in zip(names, dts, strict=True):
         recon_id = image_name_to_gt_recon_ids.get(name)
         if (
             recon_id is not None
@@ -1267,7 +1268,7 @@ def compute_grouped_abs_errors(
             for image in sub_model.images.values()
             if image.name in gt_name_set
         ]
-        for name, dt in zip(sub_names, sub_dts):
+        for name, dt in zip(sub_names, sub_dts, strict=True):
             errors_by_name[name].append(float(dt))
 
     # Images not registered in any sub-model count as a single failure.

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -53,6 +53,11 @@ import pycolmap
 from .covisibility import filter_covisibility  # noqa: F401
 from .geometry import normalize_vec, vec_angular_dist_deg  # noqa: F401
 
+# Sentinel GT reconstruction id in image_name_to_gt_recon_ids marking an
+# outlier image that does not belong to any GT reconstruction. Outliers are
+# never part of a GT edge (relative metric) or a GT cluster (absolute metric).
+OUTLIER_RECON_ID = -1
+
 _PR_SET_PDEATHSIG = 1
 _LIBC = (
     ctypes.CDLL("libc.so.6", use_errno=True)
@@ -113,6 +118,15 @@ class SceneInfo:
     has_camera_priors: bool
     # Additional arguments for the COLMAP reconstruction command.
     colmap_extra_args: list[str]
+    # Maps image name -> ground-truth reconstruction id. Images sharing an id
+    # belong to the same GT reconstruction (this defines the GT edge set for
+    # the relative metric and the cluster for the absolute metric). Empty means
+    # the scene ships a single GT reconstruction; process_scene then
+    # materializes a default {name: 0 for every sparse_gt image}. This is the
+    # case for all current datasets that ship one GT model per scene.
+    image_name_to_gt_recon_ids: dict[str, int] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -723,13 +737,11 @@ def process_scene(
 
     tracker.set("evaluation")
 
-    # Merge all sub-models into a single reconstruction. Each sub-model will be
-    # "randomly" aligned to the other sub-models. We then compute the overall
-    # error over the merged reconstruction. With this simple appraoch, there is
-    # a small chance that the randomly aligned images in one sub-model are
-    # correctly aligned with other sub-models and the error is therefore
-    # underestimated. However, this is very unlikely to happen.
-    sparse_merged = pycolmap.Reconstruction()
+    # Load all estimated sub-models. Both metrics keep the sub-models separate:
+    # the relative set-based metric forms edges within a sub-model, and the
+    # absolute metric scores each GT image against the best-aligned sub-model.
+    # For absolute errors each sub-model is aligned to the GT independently.
+    sub_models: list[pycolmap.Reconstruction] = []
     num_components = 0
     largest_component = 0
     for sparse_path in (scene_info.workspace_path / "sparse").iterdir():
@@ -740,7 +752,9 @@ def process_scene(
         if args.error_type.startswith("relative"):
             sparse = pycolmap.Reconstruction(str(sparse_path))
         elif args.error_type.startswith("absolute"):
-            sparse_aligned_path = scene_info.workspace_path / "sparse_aligned"
+            sparse_aligned_path = (
+                scene_info.workspace_path / "sparse_aligned" / sparse_path.name
+            )
             colmap_alignment(
                 args=args,
                 sparse_path=sparse_path,
@@ -753,35 +767,40 @@ def process_scene(
         else:
             raise ValueError(f"Invalid error type: {args.error_type}")
 
-        if sparse is not None:
-            largest_component = max(largest_component, sparse.num_images())
-            for image in sparse.images.values():
-                if image.image_id in sparse_merged.images:
-                    continue
-                if image.camera_id not in sparse_merged.cameras:
-                    sparse_merged.add_camera(image.camera)
-                if image.frame_id not in sparse_merged.frames:
-                    if image.frame.rig_id not in sparse_merged.rigs:
-                        sparse_merged.add_rig(image.frame.rig)
-                    image.frame.reset_rig_ptr()
-                    sparse_merged.add_frame(image.frame)
-                image.reset_camera_ptr()
-                image.reset_frame_ptr()
-                sparse_merged.add_image(image)
+        if sparse is None:
+            continue
+
+        largest_component = max(largest_component, sparse.num_images())
+        sub_models.append(sparse)
+
+    # Materialize the GT-cluster mapping, defaulting to a single reconstruction
+    # (all GT images in cluster 0) when the dataset does not provide one.
+    image_name_to_gt_recon_ids = scene_info.image_name_to_gt_recon_ids or {
+        image.name: 0 for image in sparse_gt.images.values()
+    }
+
+    # Registered images counted as the union of names across all sub-models.
+    num_reg_images = len(
+        {
+            image.name
+            for sub_model in sub_models
+            for image in sub_model.images.values()
+        }
+    )
 
     if args.error_type.startswith("relative"):
-        dts, dRs = compute_rel_errors(
+        errors = compute_grouped_rel_errors(
             sparse_gt=sparse_gt,
-            sparse=sparse_merged,
+            sub_models=sub_models,
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
             min_proj_center_dist=position_accuracy_gt,
         )
-        errors = np.maximum(dts, dRs)
     elif args.error_type.startswith("absolute"):
-        dts, dRs = compute_abs_errors(
+        errors = compute_grouped_abs_errors(
             sparse_gt=sparse_gt,
-            sparse=sparse_merged,
+            sub_models=sub_models,
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
         )
-        errors = dts
     else:
         raise ValueError(f"Invalid error type: {args.error_type}")
 
@@ -790,7 +809,7 @@ def process_scene(
         scene_info=scene_info,
         errors=errors,
         num_images=sparse_gt.num_images(),
-        num_reg_images=sparse_merged.num_images(),
+        num_reg_images=num_reg_images,
         num_components=num_components,
         largest_component=largest_component,
     )
@@ -1006,125 +1025,261 @@ def get_scores(error_type: str, metrics: Metrics) -> npt.NDArray[np.floating]:
         raise ValueError(f"Invalid error type: {error_type}")
 
 
-def compute_rel_errors(
-    sparse_gt: pycolmap.Reconstruction,
-    sparse: pycolmap.Reconstruction,
+def relative_pose_error_deg(
+    rel_est: pycolmap.Rigid3d,
+    rel_gt: pycolmap.Rigid3d,
     min_proj_center_dist: float,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Computes angular relative pose errors across all image pairs.
+) -> tuple[float, float]:
+    """Angular relative pose errors (dt, dR) in degrees.
 
-    Notice that this approach leads to a super-linear decrease in the AUC scores
-    when multiple images fail to register. Consider that we have N images in
-    total in a dataset and M images are registered in the evaluated
-    reconstruction. In this case, we can compute "finite" errors for (N-M)^2
-    pairs while the dataset has a total of N^2 pairs. In case of many
-    unregistered images, the AUC score will drop much more than the
-    (intuitively) expected (N-M) / N ratio. One could appropriately normalize by
-    computing a single score per image through a suitable normalization of all
-    pairwise errors per image. However, this becomes difficult when multiple
-    sub-components are incorrectly stitched together in the same reconstruction
-    (e.g., in the case of symmetry issues).
+    dR is the geodesic rotation error and dt is the angular distance between
+    the relative translation directions. If the GT baseline is shorter than
+    min_proj_center_dist, the translation direction is unstable and dt is set
+    to zero, so only the rotation error is measured.
     """
+    estimated_from_gt = rel_est.inverse() * rel_gt
 
-    if sparse is None:
-        pycolmap.logging.error("Reconstruction failed")
-        return len(sparse_gt.images) * [np.inf], len(sparse_gt.images) * [180]
+    if np.linalg.norm(rel_gt.translation) < min_proj_center_dist:
+        # If the cameras almost coincide, then the angular direction distance
+        # is unstable, because a small position change can cause a large
+        # rotational error. In this case, we only measure rotational error.
+        dt = 0.0
+    else:
+        dt = vec_angular_dist_deg(rel_est.translation, rel_gt.translation)
 
-    images = {}
-    for image in sparse.images.values():
-        images[image.name] = image
+    dR = np.rad2deg(estimated_from_gt.rotation.angle())
+    return dt, dR
 
-    dts = []
-    dRs = []
-    for this_image_gt in sparse_gt.images.values():
-        if this_image_gt.name not in images:
-            for _ in range(sparse_gt.num_images() - 1):
-                dts.append(np.inf)
-                dRs.append(180)
+
+def compute_grouped_rel_errors(
+    sparse_gt: pycolmap.Reconstruction,
+    sub_models: list[pycolmap.Reconstruction],
+    image_name_to_gt_recon_ids: dict[str, int],
+    min_proj_center_dist: float,
+) -> npt.NDArray[np.floating]:
+    """Set-based relative pose errors over the graph of image pairs.
+
+    Let A be the set of ordered image pairs (i, j) that share an estimated
+    sub-model and B the set of ordered pairs that share a GT reconstruction (as
+    defined by image_name_to_gt_recon_ids). For pairs in A n B we measure the
+    relative pose error; for pairs in the symmetric difference (grouped in only
+    one of the two, i.e. wrong merges / registered outliers or failed /
+    fragmented registrations) we assign the maximum error of 180 degrees. The
+    returned error array covers all pairs in A u B.
+
+    Sets A and B are never materialized: B membership is decided on the fly
+    from image_name_to_gt_recon_ids, and A is tracked with a visited set so the
+    B - A pairs can be found in a second pass.
+    """
+    gt_cam_from_world = {
+        image.name: image.cam_from_world()
+        for image in sparse_gt.images.values()
+    }
+
+    def same_gt_recon(name_a: str, name_b: str) -> bool:
+        recon_a = image_name_to_gt_recon_ids.get(name_a)
+        return (
+            recon_a is not None
+            and recon_a != OUTLIER_RECON_ID
+            and recon_a == image_name_to_gt_recon_ids.get(name_b)
+        )
+
+    visited: set[tuple[str, str]] = set()
+    errors: list[float] = []
+
+    # Pass 1: walk set A (ordered pairs within each estimated sub-model). An
+    # image may appear in several sub-models, so the same edge can be visited
+    # (and scored) multiple times; each estimate contributes an error.
+    for sub_model in sub_models:
+        cam_from_world = {
+            image.name: image.cam_from_world()
+            for image in sub_model.images.values()
+        }
+        names = list(cam_from_world)
+        for name_i in names:
+            for name_j in names:
+                if name_i == name_j:
+                    continue
+                visited.add((name_i, name_j))
+                if (
+                    same_gt_recon(name_i, name_j)
+                    and name_i in gt_cam_from_world
+                    and name_j in gt_cam_from_world
+                ):
+                    # Edge in A n B: measure the relative pose error.
+                    rel_est = (
+                        cam_from_world[name_j]
+                        * cam_from_world[name_i].inverse()
+                    )
+                    rel_gt = (
+                        gt_cam_from_world[name_j]
+                        * gt_cam_from_world[name_i].inverse()
+                    )
+                    dt, dR = relative_pose_error_deg(
+                        rel_est, rel_gt, min_proj_center_dist
+                    )
+                    errors.append(max(dt, dR))
+                else:
+                    # Edge in A - B: wrong merge or registered outlier.
+                    errors.append(180.0)
+
+    # Pass 2: add the B - A pairs (grouped in GT but not jointly estimated).
+    names_by_recon: dict[int, list[str]] = collections.defaultdict(list)
+    for name, recon_id in image_name_to_gt_recon_ids.items():
+        # Outliers never belong to a GT reconstruction, so they form no GT edges.
+        if recon_id == OUTLIER_RECON_ID:
             continue
+        names_by_recon[recon_id].append(name)
+    for group_names in names_by_recon.values():
+        for name_i in group_names:
+            for name_j in group_names:
+                if name_i == name_j:
+                    continue
+                if (name_i, name_j) not in visited:
+                    errors.append(180.0)
 
-        this_image = images[this_image_gt.name]
-
-        for other_image_gt in sparse_gt.images.values():
-            if this_image_gt.image_id == other_image_gt.image_id:
-                continue
-
-            if other_image_gt.name not in images:
-                dts.append(np.inf)
-                dRs.append(180)
-                continue
-
-            other_image = images[other_image_gt.name]
-
-            other_from_this = (
-                other_image.cam_from_world()
-                * this_image.cam_from_world().inverse()
-            )
-            other_from_this_gt = (
-                other_image_gt.cam_from_world()
-                * this_image_gt.cam_from_world().inverse()
-            )
-
-            estimated_from_gt = other_from_this.inverse() * other_from_this_gt
-
-            if (
-                np.linalg.norm(other_from_this_gt.translation)
-                < min_proj_center_dist
-            ):
-                # If the cameras almost coincide, then the angular direction
-                # distance is unstable, because a small position change can
-                # cause a large rotational error. In this case, we only measure
-                # rotational relative pose error.
-                dt = 0.0
-            else:
-                dt = vec_angular_dist_deg(
-                    other_from_this.translation, other_from_this_gt.translation
-                )
-
-            dR = np.rad2deg(estimated_from_gt.rotation.angle())
-
-            dts.append(dt)
-            dRs.append(dR)
-
-    return np.array(dts), np.array(dRs)
+    if not errors:
+        # No evaluable pairs (e.g. only singleton GT reconstructions). Report
+        # the worst case rather than raising downstream on an empty array.
+        return np.array([180.0])
+    return np.array(errors)
 
 
 def compute_abs_errors(
-    sparse_gt: pycolmap.Reconstruction, sparse: pycolmap.Reconstruction
+    sparse_gt: pycolmap.Reconstruction,
+    sparse: pycolmap.Reconstruction,
+    image_name_to_gt_recon_ids: dict[str, int] | None = None,
 ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
     """Computes rotational and translational absolute pose errors.
 
     Assumes that the input reconstructions are aligned in the same coordinate
-    system. Computes one error per ground-truth image.
-    """
+    system. Iterates over the estimated reconstruction (sparse) and computes one
+    error per sparse image that also exists in the ground truth, in
+    sparse.images.values() order; sparse images absent from the GT are skipped.
 
-    dts = np.full(len(sparse_gt.images), fill_value=np.inf, dtype=np.float64)
-    dRs = np.full(len(sparse_gt.images), fill_value=180, dtype=np.float64)
+    When image_name_to_gt_recon_ids is given, the reconstruction is treated as
+    covering a single GT cluster: the cluster with the smallest mean finite
+    translational error is kept intact and every other image (other clusters,
+    outliers, or images missing from the mapping) is set to the maximum error
+    (inf translation, 180 rotation). Without the mapping the raw per-image
+    errors are returned.
+    """
 
     if sparse is None:
         pycolmap.logging.error("Reconstruction or alignment failed")
-        return dts, dRs
+        return (
+            np.array([], dtype=np.float64),
+            np.array([], dtype=np.float64),
+        )
 
-    images = {}
+    gt_images = {image.name: image for image in sparse_gt.images.values()}
+
+    names: list[str] = []
+    dt_list: list[float] = []
+    dR_list: list[float] = []
     for image in sparse.images.values():
-        images[image.name] = image
-
-    dts = np.full(len(sparse_gt.images), fill_value=np.inf, dtype=np.float64)
-    dRs = np.full(len(sparse_gt.images), fill_value=180, dtype=np.float64)
-    for i, image_gt in enumerate(sparse_gt.images.values()):
-        if image_gt.name not in images:
+        image_gt = gt_images.get(image.name)
+        if image_gt is None:
             continue
-
-        image = images[image_gt.name]
 
         estimated_from_gt = (
             image.cam_from_world() * image_gt.cam_from_world().inverse()
         )
 
-        dts[i] = np.linalg.norm(estimated_from_gt.translation)
-        dRs[i] = np.rad2deg(estimated_from_gt.rotation.angle())
+        names.append(image.name)
+        dt_list.append(float(np.linalg.norm(estimated_from_gt.translation)))
+        dR_list.append(float(np.rad2deg(estimated_from_gt.rotation.angle())))
+
+    dts = np.array(dt_list, dtype=np.float64)
+    dRs = np.array(dR_list, dtype=np.float64)
+
+    if image_name_to_gt_recon_ids is None:
+        return dts, dRs
+
+    # Mean finite translational error per cluster; outliers and images missing
+    # from the mapping never form a selectable cluster.
+    errors_by_recon: dict[int, list[float]] = collections.defaultdict(list)
+    for name, dt in zip(names, dts):
+        recon_id = image_name_to_gt_recon_ids.get(name)
+        if (
+            recon_id is not None
+            and recon_id != OUTLIER_RECON_ID
+            and np.isfinite(dt)
+        ):
+            errors_by_recon[recon_id].append(float(dt))
+
+    best_recon_id = None
+    best_mean = np.inf
+    for recon_id, errs in errors_by_recon.items():
+        mean = float(np.mean(errs))
+        if mean < best_mean:
+            best_mean = mean
+            best_recon_id = recon_id
+
+    # Keep only the best cluster intact; max out every other image.
+    for i, name in enumerate(names):
+        recon_id = image_name_to_gt_recon_ids.get(name)
+        if not (
+            recon_id is not None
+            and recon_id != OUTLIER_RECON_ID
+            and recon_id == best_recon_id
+        ):
+            dts[i] = np.inf
+            dRs[i] = 180
 
     return dts, dRs
+
+
+def compute_grouped_abs_errors(
+    sparse_gt: pycolmap.Reconstruction,
+    sub_models: list[pycolmap.Reconstruction],
+    image_name_to_gt_recon_ids: dict[str, int],
+) -> npt.NDArray[np.floating]:
+    """GT-cluster-aware absolute pose errors.
+
+    Each estimated sub-model is assumed to be aligned to the GT. A GT image
+    that is registered in n sub-models contributes n (translational) errors,
+    one per reconstruction; a GT image registered in no sub-model contributes a
+    single infinite error (a failure). Within each sub-model only its
+    best-matching GT cluster (smallest mean finite error) is kept intact and
+    every other GT image is maxed out (see compute_abs_errors). Because the
+    selection is per sub-model, a scene with several GT clusters can credit
+    several of them, one per sub-model. With a single cluster this reduces to
+    the standard absolute metric.
+    """
+    gt_names = [image.name for image in sparse_gt.images.values()]
+    gt_name_set = set(gt_names)
+
+    # Collect one error per (image, sub-model) registration. compute_abs_errors
+    # returns errors aligned to the sub-model's images that also exist in the
+    # GT, in sub_model.images.values() order, so we rebuild the matching names
+    # with the same filter/order. Registered images outside a sub-model's best
+    # cluster are maxed out (inf) yet still contribute an error.
+    errors_by_name: dict[str, list[float]] = {name: [] for name in gt_names}
+    for sub_model in sub_models:
+        sub_dts, _ = compute_abs_errors(
+            sparse_gt=sparse_gt,
+            sparse=sub_model,
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+        sub_names = [
+            image.name
+            for image in sub_model.images.values()
+            if image.name in gt_name_set
+        ]
+        for name, dt in zip(sub_names, sub_dts):
+            errors_by_name[name].append(float(dt))
+
+    # Images not registered in any sub-model count as a single failure.
+    for name in gt_names:
+        if not errors_by_name[name]:
+            errors_by_name[name].append(np.inf)
+
+    errors: list[float] = []
+    for name in gt_names:
+        errors.extend(errors_by_name[name])
+
+    return np.array(errors)
 
 
 def compute_auc(

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -827,6 +827,29 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_real * (num_real - 1)
         np.testing.assert_allclose(errors, 180.0)
 
+    def test_gt_names_absent_from_sparse_gt_form_no_edges(self):
+        # A name in image_name_to_gt_recon_ids that does not exist in sparse_gt
+        # cannot form a measurable GT edge and must not add spurious B - A
+        # edges. Nothing is registered, so every scored pair comes from B - A.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        phantom = "phantom_not_in_sparse_gt"
+        assert phantom not in names
+        image_name_to_gt_recon_ids = {name: 0 for name in names}
+        image_name_to_gt_recon_ids[phantom] = 0
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        # Only edges among the real images count; the phantom adds none.
+        num_real = len(names)
+        assert len(errors) == num_real * (num_real - 1)
+        np.testing.assert_allclose(errors, 180.0)
+
 
 class TestComputeGroupedAbsErrors:
     def test_identical_single_cluster(self):

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -36,6 +36,7 @@ import pytest
 import pycolmap
 
 from .utils import (
+    OUTLIER_RECON_ID,
     Metrics,
     SceneInfo,
     _parse_gpu_index,
@@ -43,8 +44,9 @@ from .utils import (
     compute_abs_errors,
     compute_auc,
     compute_avg_metrics,
+    compute_grouped_abs_errors,
+    compute_grouped_rel_errors,
     compute_recall,
-    compute_rel_errors,
     diff_metrics,
     filter_smallest_scenes_per_category,
     get_scores,
@@ -506,6 +508,39 @@ def create_test_reconstruction():
     return pycolmap.synthesize_dataset(synthetic_dataset_options)
 
 
+def sub_reconstruction(reconstruction, keep_names):
+    """Build a copy of reconstruction containing only the given image names.
+
+    Mirrors what a real sub-model loaded from disk looks like: its images map
+    holds exactly the registered subset. Rebuilding from a private copy keeps
+    the source reconstruction untouched.
+    """
+    keep_names = set(keep_names)
+    source = pycolmap.Reconstruction(reconstruction)
+    keep_frame_ids = {
+        image.frame_id
+        for image in source.images.values()
+        if image.name in keep_names
+    }
+    sub = pycolmap.Reconstruction()
+    for camera in source.cameras.values():
+        sub.add_camera(camera)
+    for rig in source.rigs.values():
+        sub.add_rig(rig)
+    for frame in source.frames.values():
+        if frame.frame_id in keep_frame_ids:
+            frame.reset_rig_ptr()
+            sub.add_frame(frame)
+    for image in source.images.values():
+        if image.name in keep_names:
+            image.reset_camera_ptr()
+            image.reset_frame_ptr()
+            sub.add_image(image)
+    for frame_id in keep_frame_ids:
+        sub.register_frame(frame_id)
+    return sub
+
+
 class TestComputeAbsErrors:
     def test_identical_reconstruction(self):
         reconstruction = create_test_reconstruction()
@@ -541,26 +576,31 @@ class TestComputeAbsErrors:
         np.testing.assert_allclose(dRs, 180.0, atol=1e-10)
 
 
-class TestComputeRelErrors:
+def _single_gt_cluster(reconstruction) -> dict[str, int]:
+    """Map every image of a reconstruction to a single GT cluster (id 0)."""
+    return {image.name: 0 for image in reconstruction.images.values()}
+
+
+class TestComputeGroupedRelErrors:
     def test_identical_reconstruction(self):
         reconstruction = create_test_reconstruction()
 
-        dts, dRs = compute_rel_errors(
+        errors = compute_grouped_rel_errors(
             sparse_gt=reconstruction,
-            sparse=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=_single_gt_cluster(reconstruction),
             min_proj_center_dist=0.01,
         )
 
         num_images = reconstruction.num_images()
-        expected_num_errors = num_images * (num_images - 1)
-        assert len(dts) == expected_num_errors
-        assert len(dRs) == expected_num_errors
-        np.testing.assert_allclose(dts, 0.0, atol=1e-5)
-        np.testing.assert_allclose(dRs, 0.0, atol=1e-5)
+        # A n B covers every ordered pair; A - B and B - A are empty.
+        assert len(errors) == num_images * (num_images - 1)
+        np.testing.assert_allclose(errors, 0.0, atol=1e-5)
 
     def test_transformed_reconstruction(self):
         gt_reconstruction = create_test_reconstruction()
         reconstruction = create_test_reconstruction()
+        # A global similarity transform leaves relative poses unchanged.
         reconstruction.transform(
             pycolmap.Sim3d(
                 1.0,
@@ -569,18 +609,16 @@ class TestComputeRelErrors:
             )
         )
 
-        dts, dRs = compute_rel_errors(
+        errors = compute_grouped_rel_errors(
             sparse_gt=gt_reconstruction,
-            sparse=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=_single_gt_cluster(gt_reconstruction),
             min_proj_center_dist=0.01,
         )
 
         num_images = reconstruction.num_images()
-        expected_num_errors = num_images * (num_images - 1)
-        assert len(dts) == expected_num_errors
-        assert len(dRs) == expected_num_errors
-        np.testing.assert_allclose(dts, 0.0, atol=1e-5)
-        np.testing.assert_allclose(dRs, 0.0, atol=1e-5)
+        assert len(errors) == num_images * (num_images - 1)
+        np.testing.assert_allclose(errors, 0.0, atol=1e-5)
 
     def test_different_reconstructions(self):
         gt_reconstruction = create_test_reconstruction()
@@ -592,15 +630,426 @@ class TestComputeRelErrors:
             )
             image.frame.rig_from_world.translation += np.array([1, 2, 3])
 
-        dts, dRs = compute_rel_errors(
+        errors = compute_grouped_rel_errors(
             sparse_gt=gt_reconstruction,
-            sparse=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=_single_gt_cluster(gt_reconstruction),
             min_proj_center_dist=0.01,
         )
 
         num_images = reconstruction.num_images()
-        expected_num_errors = num_images * (num_images - 1)
-        assert len(dts) == expected_num_errors
-        assert len(dRs) == expected_num_errors
-        assert np.all(dts > 0.1)
-        assert np.all(dRs > 0.1)
+        assert len(errors) == num_images * (num_images - 1)
+        assert np.all(errors > 0.1)
+
+    def test_nothing_registered_maxes_all_gt_edges(self):
+        # No estimated sub-models: set A is empty, so every GT edge is in
+        # B - A and must be scored as the maximum (180 degrees).
+        reconstruction = create_test_reconstruction()
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[],
+            image_name_to_gt_recon_ids=_single_gt_cluster(reconstruction),
+            min_proj_center_dist=0.01,
+        )
+
+        num_images = reconstruction.num_images()
+        assert len(errors) == num_images * (num_images - 1)
+        np.testing.assert_allclose(errors, 180.0)
+
+    def test_merged_estimate_of_separate_gt_clusters_maxes_cross_edges(self):
+        # Two GT clusters, each perfectly reconstructed in its own sub-model.
+        # There are no cross-cluster edges in B, and the within-cluster edges
+        # are all in A n B with ~0 error.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        half = len(names) // 2
+        image_name_to_gt_recon_ids = {
+            name: (0 if i < half else 1) for i, name in enumerate(names)
+        }
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        # Edges within a cluster: A n B (scored). Cross-cluster edges are in
+        # A - B (the single sub-model connects everything) and set to 180.
+        n0 = half
+        n1 = len(names) - half
+        num_within = n0 * (n0 - 1) + n1 * (n1 - 1)
+        num_cross = len(names) * (len(names) - 1) - num_within
+        assert len(errors) == len(names) * (len(names) - 1)
+        np.testing.assert_allclose(np.sort(errors)[:num_within], 0.0, atol=1e-5)
+        assert int(np.sum(np.isclose(errors, 180.0))) == num_cross
+
+    def test_fragmented_estimate_of_merged_gt_maxes_cross_edges(self):
+        # One GT cluster (merged reconstruction) that the estimate splits into
+        # two disjoint sub-models (fragmented estimation). Within-fragment edges
+        # are in A n B (scored ~0); the GT edges bridging the two fragments are
+        # in B - A and set to 180.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        half = len(names) // 2
+        sub_model_0 = sub_reconstruction(reconstruction, names[:half])
+        sub_model_1 = sub_reconstruction(reconstruction, names[half:])
+        image_name_to_gt_recon_ids = {name: 0 for name in names}
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[sub_model_0, sub_model_1],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        n0 = half
+        n1 = len(names) - half
+        num_within = n0 * (n0 - 1) + n1 * (n1 - 1)
+        num_cross = len(names) * (len(names) - 1) - num_within
+        assert len(errors) == len(names) * (len(names) - 1)
+        np.testing.assert_allclose(np.sort(errors)[:num_within], 0.0, atol=1e-5)
+        assert int(np.sum(np.isclose(errors, 180.0))) == num_cross
+
+    def test_mismatched_gt_and_estimate_cluster_boundaries(self):
+        # GT splits the images 1/3 vs 2/3, but the estimate splits them 2/3 vs
+        # 1/3, so the two cluster boundaries disagree. Ordered pairs that share
+        # both an estimated sub-model and a GT cluster are scored (~0 for a
+        # perfect estimate); pairs grouped by only one of the two are maxed.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        n = len(names)
+        third = n // 3
+        two_thirds = 2 * n // 3
+        # GT: first third -> cluster 0, remaining two thirds -> cluster 1.
+        image_name_to_gt_recon_ids = {
+            name: (0 if i < third else 1) for i, name in enumerate(names)
+        }
+        # Estimate: first two thirds and remaining third form two sub-models.
+        sub_model_0 = sub_reconstruction(reconstruction, names[:two_thirds])
+        sub_model_1 = sub_reconstruction(reconstruction, names[two_thirds:])
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[sub_model_0, sub_model_1],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        # Three groups by (sub-model, GT cluster): P = names[:third] (sub 0,
+        # cluster 0), Q = names[third:two_thirds] (sub 0, cluster 1), R =
+        # names[two_thirds:] (sub 1, cluster 1). Only intra-group edges share
+        # both a sub-model and a cluster (A n B, ~0). P-Q share a sub-model but
+        # not a cluster (A - B), and Q-R share a cluster but not a sub-model
+        # (B - A); both are maxed to 180.
+        n_p = third
+        n_q = two_thirds - third
+        n_r = n - two_thirds
+        num_scored = n_p * (n_p - 1) + n_q * (n_q - 1) + n_r * (n_r - 1)
+        num_maxed = 2 * (n_p * n_q) + 2 * (n_q * n_r)
+        assert len(errors) == num_scored + num_maxed
+        np.testing.assert_allclose(np.sort(errors)[:num_scored], 0.0, atol=1e-5)
+        assert int(np.sum(np.isclose(errors, 180.0))) == num_maxed
+
+    def test_registered_outlier_edges_are_maxed(self):
+        # A single sub-model connects an outlier to every real image. The
+        # outlier is never in a GT reconstruction, so all edges touching it are
+        # in A - B and set to 180; the remaining real edges are A n B (~0).
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        outlier = names[0]
+        image_name_to_gt_recon_ids = {
+            name: (OUTLIER_RECON_ID if name == outlier else 0)
+            for name in names
+        }
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        num_images = reconstruction.num_images()
+        assert len(errors) == num_images * (num_images - 1)
+        # The 2 * (num_images - 1) ordered edges touching the outlier are maxed.
+        num_maxed = int(np.sum(np.isclose(errors, 180.0)))
+        assert num_maxed == 2 * (num_images - 1)
+
+    def test_outlier_present_in_gt_maxes_its_edges(self):
+        # An image that exists in the GT reconstruction and is perfectly
+        # registered, but is flagged as an outlier, must still have large
+        # edges: every edge touching it is in A - B and set to 180, while the
+        # edges among the real images stay in A n B (~0).
+        reconstruction = create_test_reconstruction()
+        gt_names = [image.name for image in reconstruction.images.values()]
+        outlier = sorted(gt_names)[0]
+        assert outlier in gt_names  # The outlier is present in the GT.
+        image_name_to_gt_recon_ids = {
+            name: (OUTLIER_RECON_ID if name == outlier else 0)
+            for name in gt_names
+        }
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        n = reconstruction.num_images()
+        assert len(errors) == n * (n - 1)
+        # All 2 * (n - 1) ordered edges touching the outlier are maxed; the
+        # (n - 1) * (n - 2) edges among the real images are ~0.
+        assert int(np.sum(np.isclose(errors, 180.0))) == 2 * (n - 1)
+        np.testing.assert_allclose(
+            np.sort(errors)[: (n - 1) * (n - 2)], 0.0, atol=1e-5
+        )
+
+    def test_outliers_excluded_from_gt_edges(self):
+        # Nothing is registered, so every scored pair comes from B - A. The
+        # outlier forms no GT edges, so it contributes none of them.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        outlier = names[0]
+        image_name_to_gt_recon_ids = {
+            name: (OUTLIER_RECON_ID if name == outlier else 0)
+            for name in names
+        }
+
+        errors = compute_grouped_rel_errors(
+            sparse_gt=reconstruction,
+            sub_models=[],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+            min_proj_center_dist=0.01,
+        )
+
+        num_real = len(names) - 1
+        assert len(errors) == num_real * (num_real - 1)
+        np.testing.assert_allclose(errors, 180.0)
+
+
+class TestComputeGroupedAbsErrors:
+    def test_identical_single_cluster(self):
+        reconstruction = create_test_reconstruction()
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=_single_gt_cluster(reconstruction),
+        )
+
+        assert len(errors) == reconstruction.num_images()
+        np.testing.assert_allclose(errors, 0.0, atol=1e-10)
+
+    def test_keeps_one_error_per_reconstruction(self):
+        # An image registered in n sub-models contributes n errors (not just
+        # the smallest). Here every image appears in both sub-models.
+        reconstruction = create_test_reconstruction()
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction, reconstruction],
+            image_name_to_gt_recon_ids=_single_gt_cluster(reconstruction),
+        )
+
+        assert len(errors) == 2 * reconstruction.num_images()
+        np.testing.assert_allclose(errors, 0.0, atol=1e-10)
+
+    def test_keeps_only_best_cluster(self):
+        # Cluster 0 is reconstructed perfectly; cluster 1 is offset. The
+        # best-mean cluster (0) is kept intact and cluster 1 is maxed out.
+        gt_reconstruction = create_test_reconstruction()
+        reconstruction = create_test_reconstruction()
+
+        names = sorted(image.name for image in gt_reconstruction.images.values())
+        half = len(names) // 2
+        image_name_to_gt_recon_ids = {
+            name: (0 if i < half else 1) for i, name in enumerate(names)
+        }
+        cluster1_names = {name for name in names[half:]}
+        for image in reconstruction.images.values():
+            if image.name in cluster1_names:
+                image.frame.rig_from_world.translation += np.array([5, 5, 5])
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=gt_reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        assert len(errors) == gt_reconstruction.num_images()
+        finite = errors[np.isfinite(errors)]
+        # Only the (perfect) best cluster remains finite.
+        assert len(finite) == half
+        np.testing.assert_allclose(finite, 0.0, atol=1e-10)
+        assert int(np.sum(~np.isfinite(errors))) == len(names) - half
+
+    def test_images_without_cluster_id_are_maxed(self):
+        # GT images missing from the mapping (cluster id None) are always maxed
+        # out, even when perfectly registered.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        half = len(names) // 2
+        # Only the second half is mapped (all to cluster 1); the first half is
+        # left unmapped (None).
+        image_name_to_gt_recon_ids = {name: 1 for name in names[half:]}
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        assert len(errors) == reconstruction.num_images()
+        finite = errors[np.isfinite(errors)]
+        # The mapped (best) cluster stays finite; unmapped images are maxed.
+        assert len(finite) == len(names) - half
+        np.testing.assert_allclose(finite, 0.0, atol=1e-10)
+
+    def test_outlier_cluster_is_maxed(self):
+        # An outlier is never a selectable cluster, so it is maxed out even
+        # though it is perfectly aligned; the real cluster is kept intact.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        outlier = names[0]
+        image_name_to_gt_recon_ids = {
+            name: (OUTLIER_RECON_ID if name == outlier else 0)
+            for name in names
+        }
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        assert len(errors) == reconstruction.num_images()
+        finite = errors[np.isfinite(errors)]
+        assert len(finite) == len(names) - 1
+        np.testing.assert_allclose(finite, 0.0, atol=1e-10)
+
+    def test_outlier_present_in_gt_gets_large_error(self):
+        # An image that exists in the GT reconstruction and is perfectly
+        # registered, but is flagged as an outlier, must still receive a large
+        # error: being present and well-aligned does not rescue an outlier.
+        reconstruction = create_test_reconstruction()
+        gt_names = [image.name for image in reconstruction.images.values()]
+        outlier = sorted(gt_names)[0]
+        assert outlier in gt_names  # The outlier is present in the GT.
+        image_name_to_gt_recon_ids = {
+            name: (OUTLIER_RECON_ID if name == outlier else 0)
+            for name in gt_names
+        }
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[reconstruction],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        # Every GT image is registered exactly once, so errors map 1:1 to
+        # gt_names in order.
+        assert len(errors) == reconstruction.num_images()
+        error_by_name = dict(zip(gt_names, errors))
+        assert not np.isfinite(error_by_name[outlier])
+        others = [v for n, v in error_by_name.items() if n != outlier]
+        np.testing.assert_allclose(others, 0.0, atol=1e-10)
+
+    def test_credits_multiple_clusters_across_sub_models(self):
+        # Two sub-models each perfectly reconstruct a different GT cluster and
+        # offset the other. Per-sub-model selection credits both clusters,
+        # which a single global choice could not do.
+        gt_reconstruction = create_test_reconstruction()
+        sub_model_0 = create_test_reconstruction()
+        sub_model_1 = create_test_reconstruction()
+
+        names = sorted(image.name for image in gt_reconstruction.images.values())
+        half = len(names) // 2
+        image_name_to_gt_recon_ids = {
+            name: (0 if i < half else 1) for i, name in enumerate(names)
+        }
+        cluster0_names = set(names[:half])
+        cluster1_names = set(names[half:])
+        # sub_model_0 offsets cluster 1 -> its best cluster is 0.
+        for image in sub_model_0.images.values():
+            if image.name in cluster1_names:
+                image.frame.rig_from_world.translation += np.array([5, 5, 5])
+        # sub_model_1 offsets cluster 0 -> its best cluster is 1.
+        for image in sub_model_1.images.values():
+            if image.name in cluster0_names:
+                image.frame.rig_from_world.translation += np.array([5, 5, 5])
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=gt_reconstruction,
+            sub_models=[sub_model_0, sub_model_1],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        # Each GT image is registered in both sub-models -> two errors each.
+        assert len(errors) == 2 * gt_reconstruction.num_images()
+        finite = errors[np.isfinite(errors)]
+        # Exactly one finite error per GT image: cluster 0 via sub_model_0 and
+        # cluster 1 via sub_model_1, so both clusters are credited.
+        assert len(finite) == gt_reconstruction.num_images()
+        np.testing.assert_allclose(finite, 0.0, atol=1e-10)
+
+        # The errors must map back to the right image and sub-model: they are
+        # emitted in sparse_gt image order, each image contributing its two
+        # errors in sub_model order [sub_model_0, sub_model_1]. A cluster-0
+        # image is credited only by sub_model_0 (finite, sub_model_1 maxed) and
+        # a cluster-1 image only by sub_model_1 (sub_model_0 maxed, finite).
+        gt_names = [image.name for image in gt_reconstruction.images.values()]
+        for i, name in enumerate(gt_names):
+            err_sub0, err_sub1 = errors[2 * i], errors[2 * i + 1]
+            if name in cluster0_names:
+                np.testing.assert_allclose(err_sub0, 0.0, atol=1e-10)
+                assert not np.isfinite(err_sub1)
+            else:
+                assert not np.isfinite(err_sub0)
+                np.testing.assert_allclose(err_sub1, 0.0, atol=1e-10)
+
+    def test_mismatched_gt_and_estimate_cluster_boundaries(self):
+        # GT splits the images 1/3 vs 2/3 while the estimate splits them 2/3 vs
+        # 1/3. sub_model_0 spans all of GT cluster 0 plus the cluster-1 images
+        # that leaked in; it can credit only one GT cluster, so the leaked
+        # cluster-1 images are maxed. sub_model_1 holds the rest of cluster 1
+        # and credits them.
+        reconstruction = create_test_reconstruction()
+        names = sorted(image.name for image in reconstruction.images.values())
+        n = len(names)
+        third = n // 3
+        two_thirds = 2 * n // 3
+        image_name_to_gt_recon_ids = {
+            name: (0 if i < third else 1) for i, name in enumerate(names)
+        }
+        sub_model_0 = sub_reconstruction(reconstruction, names[:two_thirds])
+        sub_model_1 = sub_reconstruction(reconstruction, names[two_thirds:])
+        # Offset the cluster-1 images that leaked into sub_model_0 so its best
+        # cluster is unambiguously cluster 0.
+        leaked_cluster1 = set(names[third:two_thirds])
+        for image in sub_model_0.images.values():
+            if image.name in leaked_cluster1:
+                image.frame.rig_from_world.translation += np.array([5, 5, 5])
+
+        errors = compute_grouped_abs_errors(
+            sparse_gt=reconstruction,
+            sub_models=[sub_model_0, sub_model_1],
+            image_name_to_gt_recon_ids=image_name_to_gt_recon_ids,
+        )
+
+        # Sub-models are disjoint, so each GT image contributes exactly one
+        # error, emitted in sparse_gt image order.
+        assert len(errors) == reconstruction.num_images()
+        gt_names = [image.name for image in reconstruction.images.values()]
+        error_by_name = dict(zip(gt_names, errors))
+        # Cluster 0 (first third) credited by sub_model_0.
+        for name in names[:third]:
+            np.testing.assert_allclose(error_by_name[name], 0.0, atol=1e-10)
+        # Cluster-1 images that leaked into sub_model_0 are maxed.
+        for name in names[third:two_thirds]:
+            assert not np.isfinite(error_by_name[name])
+        # Remaining cluster 1 credited by sub_model_1.
+        for name in names[two_thirds:]:
+            np.testing.assert_allclose(error_by_name[name], 0.0, atol=1e-10)

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -760,8 +760,7 @@ class TestComputeGroupedRelErrors:
         names = sorted(image.name for image in reconstruction.images.values())
         outlier = names[0]
         image_name_to_gt_recon_ids = {
-            name: (OUTLIER_RECON_ID if name == outlier else 0)
-            for name in names
+            name: (OUTLIER_RECON_ID if name == outlier else 0) for name in names
         }
 
         errors = compute_grouped_rel_errors(
@@ -814,8 +813,7 @@ class TestComputeGroupedRelErrors:
         names = sorted(image.name for image in reconstruction.images.values())
         outlier = names[0]
         image_name_to_gt_recon_ids = {
-            name: (OUTLIER_RECON_ID if name == outlier else 0)
-            for name in names
+            name: (OUTLIER_RECON_ID if name == outlier else 0) for name in names
         }
 
         errors = compute_grouped_rel_errors(
@@ -863,7 +861,9 @@ class TestComputeGroupedAbsErrors:
         gt_reconstruction = create_test_reconstruction()
         reconstruction = create_test_reconstruction()
 
-        names = sorted(image.name for image in gt_reconstruction.images.values())
+        names = sorted(
+            image.name for image in gt_reconstruction.images.values()
+        )
         half = len(names) // 2
         image_name_to_gt_recon_ids = {
             name: (0 if i < half else 1) for i, name in enumerate(names)
@@ -915,8 +915,7 @@ class TestComputeGroupedAbsErrors:
         names = sorted(image.name for image in reconstruction.images.values())
         outlier = names[0]
         image_name_to_gt_recon_ids = {
-            name: (OUTLIER_RECON_ID if name == outlier else 0)
-            for name in names
+            name: (OUTLIER_RECON_ID if name == outlier else 0) for name in names
         }
 
         errors = compute_grouped_abs_errors(
@@ -952,7 +951,7 @@ class TestComputeGroupedAbsErrors:
         # Every GT image is registered exactly once, so errors map 1:1 to
         # gt_names in order.
         assert len(errors) == reconstruction.num_images()
-        error_by_name = dict(zip(gt_names, errors))
+        error_by_name = dict(zip(gt_names, errors, strict=True))
         assert not np.isfinite(error_by_name[outlier])
         others = [v for n, v in error_by_name.items() if n != outlier]
         np.testing.assert_allclose(others, 0.0, atol=1e-10)
@@ -965,7 +964,9 @@ class TestComputeGroupedAbsErrors:
         sub_model_0 = create_test_reconstruction()
         sub_model_1 = create_test_reconstruction()
 
-        names = sorted(image.name for image in gt_reconstruction.images.values())
+        names = sorted(
+            image.name for image in gt_reconstruction.images.values()
+        )
         half = len(names) // 2
         image_name_to_gt_recon_ids = {
             name: (0 if i < half else 1) for i, name in enumerate(names)
@@ -1043,7 +1044,7 @@ class TestComputeGroupedAbsErrors:
         # error, emitted in sparse_gt image order.
         assert len(errors) == reconstruction.num_images()
         gt_names = [image.name for image in reconstruction.images.values()]
-        error_by_name = dict(zip(gt_names, errors))
+        error_by_name = dict(zip(gt_names, errors, strict=True))
         # Cluster 0 (first third) credited by sub_model_0.
         for name in names[:third]:
             np.testing.assert_allclose(error_by_name[name], 0.0, atol=1e-10)


### PR DESCRIPTION
## Summary

- Evaluate estimated sub-models separately instead of merging them into a single reconstruction. Merging arbitrarily aligned sub-models could under- or over-estimate errors; keeping sub-models separate avoids that.
- **Relative metric** (`compute_grouped_rel_errors`): scores over the graph of ordered image pairs. Let `A` be pairs sharing an estimated sub-model and `B` pairs sharing a GT reconstruction. Pairs in `A ∩ B` get the measured relative pose error; pairs in the symmetric difference (wrong merges / registered outliers, or failed / fragmented registrations) are maxed to 180°.
- **Absolute metric** (`compute_grouped_abs_errors`): each sub-model is aligned to the GT independently and only its best-matching GT cluster (smallest mean finite error) is kept intact; other images are maxed out. Per-sub-model selection lets a scene with multiple GT clusters credit several of them.
- Introduces `image_name_to_gt_recon_ids` on `SceneInfo` to define GT clusters, plus an `OUTLIER_RECON_ID` sentinel for images that belong to no GT reconstruction. Defaults to a single GT cluster when a scene ships one GT model.

## Test plan
New tests cover: identical / transformed / different reconstructions, nothing-registered, merged estimate of separate GT clusters, fragmented estimate of merged GT, mismatched cluster boundaries, registered outliers, multi-cluster crediting across sub-models.
