### PR TITLE
Allow disabling covisibility filtering in reconstruction benchmark

### DIFF
--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -399,8 +399,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--filter_covisibility",
         default=True,
-        action="store_true",
-        help="Filter out non-covisible image pairs based on GT camera poses.",
+        action=argparse.BooleanOptionalAction,
+        help="Filter out non-covisible image pairs based on GT camera poses. "
+        "Use --no-filter_covisibility to disable.",
     )
     parser.add_argument(
         "--covisibility_frustum_near",


### PR DESCRIPTION
## Summary
- The benchmark eval `--filter_covisibility` flag used `action="store_true"` with `default=True`, so it was impossible to disable covisibility filtering from the CLI.
- Switched it to `argparse.BooleanOptionalAction`, which keeps the `True` default but adds a `--no-filter_covisibility` flag to turn it off.
