### PR TITLE
doc: add Fedora build instructions to install.rst

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -27,13 +27,6 @@ find_package(OpenImageIO ${COLMAP_FIND_TYPE})
 
 find_package(Metis ${COLMAP_FIND_TYPE})
 
-find_package(Glog ${COLMAP_FIND_TYPE})
-if(DEFINED glog_VERSION_MAJOR)
-  # Older versions of glog don't export version variables.
-  list(APPEND COLMAP_COMPILE_DEFINITIONS GLOG_VERSION_MAJOR=${glog_VERSION_MAJOR})
-  list(APPEND COLMAP_COMPILE_DEFINITIONS GLOG_VERSION_MINOR=${glog_VERSION_MINOR})
-endif()
-
 find_package(SQLite3 ${COLMAP_FIND_TYPE})
 # Older CMake versions define SQLite::SQLite3 instead of SQLite3::SQLite3.
 if(NOT TARGET SQLite3::SQLite3 AND TARGET SQLite::SQLite3)
@@ -49,6 +42,12 @@ find_package(Git)
 
 find_package(CHOLMOD REQUIRED)
 
+# Ceres is found before Glog on purpose. Some distributions (e.g. Fedora) ship a
+# Ceres whose bundled FindGlog.cmake unconditionally calls add_library(glog::glog)
+# in module mode. If we created the glog::glog target first, that call collides
+# with a "target already exists" error (see issue #3347). By finding Ceres first,
+# Ceres creates glog::glog itself, and our subsequent find_package(Glog) reuses
+# the existing target instead.
 find_package(Ceres ${COLMAP_FIND_TYPE})
 if(NOT TARGET Ceres::ceres)
     # Older Ceres versions don't come with an imported interface target.
@@ -57,6 +56,13 @@ if(NOT TARGET Ceres::ceres)
         Ceres::ceres INTERFACE ${CERES_INCLUDE_DIRS})
     target_link_libraries(
         Ceres::ceres INTERFACE ${CERES_LIBRARIES})
+endif()
+
+find_package(Glog ${COLMAP_FIND_TYPE})
+if(DEFINED glog_VERSION_MAJOR)
+  # Older versions of glog don't export version variables.
+  list(APPEND COLMAP_COMPILE_DEFINITIONS GLOG_VERSION_MAJOR=${glog_VERSION_MAJOR})
+  list(APPEND COLMAP_COMPILE_DEFINITIONS GLOG_VERSION_MINOR=${glog_VERSION_MINOR})
 endif()
 
 if(TESTS_ENABLED)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -148,6 +148,112 @@ implementation of BLAS. If you decide to compile against OpenBLAS instead of
 MKL, you must install and select the OpenMP version under Debian/Ubuntu because
 of `this issue <https://github.com/facebookresearch/faiss/wiki/Troubleshooting#surprising-faiss-openmp-and-openblas-interaction>`__.
 
+Fedora
+------
+
+*Recommended dependencies:* CUDA (at least version 11.X)
+
+Dependencies from the default Fedora repositories::
+
+    sudo dnf install -y \
+        git \
+        cmake \
+        ninja-build \
+        gcc-c++ \
+        boost-devel \
+        eigen3-devel \
+        flann-devel \
+        freeimage-devel \
+        OpenImageIO-devel \
+        metis-devel \
+        glog-devel \
+        gflags-devel \
+        sqlite-devel \
+        lz4-devel \
+        glew-devel \
+        qt5-qtbase-devel \
+        qt5-qtsvg-devel \
+        CGAL-devel \
+        ceres-solver-devel \
+        suitesparse-devel \
+        suitesparse-static \
+        blas-devel \
+        lapack-devel
+
+A few Fedora-specific notes on the above:
+
+- CGAL is packaged as ``CGAL-devel`` (capitalized), unlike Debian/Ubuntu's
+  ``libcgal-dev``.
+- COLMAP 4.1.0+ requires OpenImageIO instead of FreeImage; on Fedora this is
+  ``OpenImageIO-devel``.
+- ``suitesparse-static`` is required even for a dynamic build. Fedora splits
+  static libraries into separate ``-static`` subpackages, but the SuiteSparse
+  CMake config shipped on Fedora unconditionally references the static
+  targets file regardless of link type, causing a CMake configure error
+  (``CAMDTargets_static.cmake`` / ``CCOLAMDTargets_static.cmake`` not found)
+  if the subpackage isn't installed. This should be resolved as Fedora's
+  package catches up with SuiteSparse >= 7.11.0's separated static config.
+
+To compile with **CUDA support**, install the CUDA toolkit from NVIDIA's
+official Fedora repository (this preserves an existing NVIDIA driver
+installation, unlike the plain ``cuda`` meta-package)::
+
+    sudo dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/fedora<VERSION>/x86_64/cuda-fedora<VERSION>.repo
+    sudo dnf clean expire-cache
+    sudo dnf install -y cuda-toolkit
+
+    echo 'export PATH=/usr/local/cuda/bin:$PATH' >> ~/.bashrc
+    echo 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH' >> ~/.bashrc
+    source ~/.bashrc
+
+Replace ``<VERSION>`` with your Fedora release number (e.g. ``43``). During
+CMake configuration, specify ``-DCMAKE_CUDA_ARCHITECTURES=native`` to target
+only your current GPU, or a specific compute capability such as ``89``.
+
+**Known issue:** Ceres 2.2's bundled ``FindGlog.cmake`` module can fail with::
+
+    CMake Error at /usr/lib64/cmake/Ceres/FindGlog.cmake:349 (add_library):
+      add_library cannot create imported target "glog::glog" because another
+      target with the same name already exists.
+
+This happens because glog's own exported CMake config already creates the
+``glog::glog`` target before Ceres's bundled module unconditionally tries to
+create it again. Until this is fixed upstream in Ceres, patch the file to
+guard the ``add_library`` call::
+
+    sudo cp /usr/lib64/cmake/Ceres/FindGlog.cmake /usr/lib64/cmake/Ceres/FindGlog.cmake.bak
+
+Change::
+
+      add_library(glog::glog INTERFACE IMPORTED)
+      target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
+      target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
+      glog_reset_find_library_prefix()
+
+to::
+
+      if (NOT TARGET glog::glog)
+      add_library(glog::glog INTERFACE IMPORTED)
+      target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
+      target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
+      endif()
+      glog_reset_find_library_prefix()
+
+Configure and compile COLMAP::
+
+    git clone https://github.com/colmap/colmap.git
+    cd colmap
+    mkdir build
+    cd build
+    cmake .. -GNinja -DCMAKE_CUDA_ARCHITECTURES=native
+    ninja
+    sudo ninja install
+
+Run COLMAP::
+
+    colmap -h
+    colmap gui
+
 Mac
 ---
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -162,82 +162,43 @@ Dependencies from the default Fedora repositories::
         gcc-c++ \
         boost-devel \
         eigen3-devel \
-        flann-devel \
-        freeimage-devel \
         OpenImageIO-devel \
+        OpenImageIO-utils \
         metis-devel \
         glog-devel \
-        gflags-devel \
+        gtest-devel \
+        gmock-devel \
         sqlite-devel \
-        lz4-devel \
         glew-devel \
-        qt5-qtbase-devel \
-        qt5-qtsvg-devel \
+        qt6-qtbase-devel \
+        qt6-qtsvg-devel \
         CGAL-devel \
         ceres-solver-devel \
         suitesparse-devel \
         suitesparse-static \
-        blas-devel \
-        lapack-devel
+        libcurl-devel \
+        openssl-devel \
+        openblas-devel
+    # suitesparse-static is required even for a dynamic build, because Fedora's
+    # SuiteSparse CMake config references the static targets file regardless of
+    # link type. This can be dropped once Fedora ships SuiteSparse >= 7.11.0 with
+    # its separated static config.
 
-A few Fedora-specific notes on the above:
+Alternatively, you can also build against Qt 5 instead of Qt 6 using::
 
-- CGAL is packaged as ``CGAL-devel`` (capitalized), unlike Debian/Ubuntu's
-  ``libcgal-dev``.
-- COLMAP 4.1.0+ requires OpenImageIO instead of FreeImage; on Fedora this is
-  ``OpenImageIO-devel``.
-- ``suitesparse-static`` is required even for a dynamic build. Fedora splits
-  static libraries into separate ``-static`` subpackages, but the SuiteSparse
-  CMake config shipped on Fedora unconditionally references the static
-  targets file regardless of link type, causing a CMake configure error
-  (``CAMDTargets_static.cmake`` / ``CCOLAMDTargets_static.cmake`` not found)
-  if the subpackage isn't installed. This should be resolved as Fedora's
-  package catches up with SuiteSparse >= 7.11.0's separated static config.
+    qt5-qtbase-devel qt5-qtsvg-devel
 
-To compile with **CUDA support**, install the CUDA toolkit from NVIDIA's
-official Fedora repository (this preserves an existing NVIDIA driver
-installation, unlike the plain ``cuda`` meta-package)::
+To compile with **CUDA support**, install the CUDA toolkit from NVIDIA's official
+Fedora repository, which (unlike the plain ``cuda`` meta-package) preserves an
+existing NVIDIA driver. Replace ``<VERSION>`` with your Fedora release, e.g.
+``43``::
 
     sudo dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/fedora<VERSION>/x86_64/cuda-fedora<VERSION>.repo
-    sudo dnf clean expire-cache
     sudo dnf install -y cuda-toolkit
 
-    echo 'export PATH=/usr/local/cuda/bin:$PATH' >> ~/.bashrc
-    echo 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH' >> ~/.bashrc
-    source ~/.bashrc
-
-Replace ``<VERSION>`` with your Fedora release number (e.g. ``43``). During
-CMake configuration, specify ``-DCMAKE_CUDA_ARCHITECTURES=native`` to target
-only your current GPU, or a specific compute capability such as ``89``.
-
-**Known issue:** Ceres 2.2's bundled ``FindGlog.cmake`` module can fail with::
-
-    CMake Error at /usr/lib64/cmake/Ceres/FindGlog.cmake:349 (add_library):
-      add_library cannot create imported target "glog::glog" because another
-      target with the same name already exists.
-
-This happens because glog's own exported CMake config already creates the
-``glog::glog`` target before Ceres's bundled module unconditionally tries to
-create it again. Until this is fixed upstream in Ceres, patch the file to
-guard the ``add_library`` call::
-
-    sudo cp /usr/lib64/cmake/Ceres/FindGlog.cmake /usr/lib64/cmake/Ceres/FindGlog.cmake.bak
-
-Change::
-
-      add_library(glog::glog INTERFACE IMPORTED)
-      target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
-      target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
-      glog_reset_find_library_prefix()
-
-to::
-
-      if (NOT TARGET glog::glog)
-      add_library(glog::glog INTERFACE IMPORTED)
-      target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
-      target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
-      endif()
-      glog_reset_find_library_prefix()
+During CMake configuration, specify ``-DCMAKE_CUDA_ARCHITECTURES=native``, if you
+want to run COLMAP only on your current machine (default), "all"/"all-major" to be
+able to distribute to other machines, or a specific CUDA architecture like "89", etc.
 
 Configure and compile COLMAP::
 


### PR DESCRIPTION
Adds a Fedora section to doc/install.rst, covering the full set of build issues encountered on a fresh Fedora 43 system: package name differences (CGAL, OpenImageIO), CUDA toolkit setup via NVIDIA's official Fedora repo, the suitesparse-static packaging quirk, and the Ceres/FindGlog.cmake target-collision fix mentioned in #3347.