### PR TITLE
Remove std::pair hash specialization and make PairHash pack integral pairs losslessly

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -70,7 +70,8 @@ FeatureMatches ExtractOutlierMatches(const FeatureMatches& matches,
                                      const FeatureMatches& inlier_matches) {
   THROW_CHECK_GE(matches.size(), inlier_matches.size());
 
-  std::unordered_set<std::pair<point2D_t, point2D_t>> inlier_matches_set;
+  std::unordered_set<std::pair<point2D_t, point2D_t>, PairHash>
+      inlier_matches_set;
   inlier_matches_set.reserve(inlier_matches.size());
   for (const auto& match : inlier_matches) {
     inlier_matches_set.emplace(match.point2D_idx1, match.point2D_idx2);

--- a/src/colmap/math/union_find.h
+++ b/src/colmap/math/union_find.h
@@ -30,13 +30,16 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <optional>
 #include <unordered_map>
 
 namespace colmap {
 
-// Helper class to perform union-find operations.
-template <typename T>
+// Helper class to perform union-find operations. The optional Hash parameter
+// allows keying on types without a std::hash specialization (e.g., std::pair,
+// via colmap::PairHash).
+template <typename T, typename Hash = std::hash<T>>
 class UnionFind {
  public:
   void Reserve(size_t capacity) { parent_.reserve(capacity); }
@@ -84,11 +87,11 @@ class UnionFind {
   }
 
   // Access all elements and their parents in the union-find structure.
-  const std::unordered_map<T, T>& Parents() const { return parent_; }
+  const std::unordered_map<T, T, Hash>& Parents() const { return parent_; }
 
  private:
   // Map to store the parent of each element.
-  std::unordered_map<T, T> parent_;
+  std::unordered_map<T, T, Hash> parent_;
 };
 
 }  // namespace colmap

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -155,7 +155,7 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
   auto corr_graph = database_cache_->CorrespondenceGraph();
 
   // Union all matching observations.
-  UnionFind<Observation> uf;
+  UnionFind<Observation, PairHash> uf;
   FeatureMatches matches;
   for (const auto& [pair_id, edge] : pose_graph_->ValidEdges()) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
@@ -177,7 +177,7 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
 
   // Group observations by their root.
   uf.Compress();
-  std::unordered_map<Observation, std::vector<Observation>> track_map;
+  std::unordered_map<Observation, std::vector<Observation>, PairHash> track_map;
   for (const auto& [obs, root] : uf.Parents()) {
     track_map[root].push_back(obs);
   }

--- a/src/colmap/sfm/incremental_triangulator.h
+++ b/src/colmap/sfm/incremental_triangulator.h
@@ -219,10 +219,8 @@ class IncrementalTriangulator {
   std::vector<TrackElement> complete_next_queue_;
   // Dedupes (image_id, point2D_idx) pairs reached by Complete()'s BFS so
   // the inner reprojection-error check is not redone for correspondences
-  // shared across multiple parents at the same transitivity level. Uses
-  // the std::hash<std::pair<uint32_t, uint32_t>> specialization in
-  // colmap/util/types.h.
-  std::unordered_set<std::pair<image_t, point2D_t>> complete_visited_;
+  // shared across multiple parents at the same transitivity level.
+  std::unordered_set<std::pair<image_t, point2D_t>, PairHash> complete_visited_;
 
   // Number of trials to retriangulate image pair.
   std::unordered_map<image_pair_t, int> re_num_trials_;

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -31,6 +31,8 @@
 
 #include <functional>
 #include <iterator>
+#include <type_traits>
+#include <utility>
 
 #ifdef _MSC_VER
 #if _MSC_VER >= 1600
@@ -349,6 +351,11 @@ struct filter_view {
 template <typename>
 struct always_false : std::false_type {};
 
+// Folds `value` into `seed`, following the classic boost::hash_combine spread.
+inline std::size_t HashCombine(std::size_t seed, std::size_t value) {
+  return seed ^ (value + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
 // Hash functor for std::pair, e.g., for use with unordered containers keyed on
 // e.g., std::pair<point3D_t, point3D_t>. Provided as an explicit functor
 // (passed to the container) rather than a std::hash<std::pair<...>>
@@ -356,12 +363,19 @@ struct always_false : std::false_type {};
 // is a global ODR hazard: a downstream translation unit that implicitly
 // instantiates the primary template first would make the later explicit
 // specialization ill-formed.
+//
+// Packs both halves into disjoint bits when they fit in a size_t (collision-
+// free), else mixes them with HashCombine.
 struct PairHash {
   template <typename T1, typename T2>
   std::size_t operator()(const std::pair<T1, T2>& p) const {
-    const std::size_t h1 = std::hash<T1>{}(p.first);
-    const std::size_t h2 = std::hash<T2>{}(p.second);
-    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+    if constexpr (std::is_unsigned_v<T1> && std::is_unsigned_v<T2> &&
+                  sizeof(T1) + sizeof(T2) <= sizeof(std::size_t)) {
+      return (static_cast<std::size_t>(p.first) << (8 * sizeof(T2))) |
+             static_cast<std::size_t>(p.second);
+    } else {
+      return HashCombine(std::hash<T1>{}(p.first), std::hash<T2>{}(p.second));
+    }
   }
 };
 
@@ -370,20 +384,11 @@ struct PairHash {
 // This file provides specializations of the templated hash function for
 // custom types. These are used for comparison in unordered sets/maps.
 namespace std {
-// Hash function specialization for uint32_t pairs, e.g., image_t or camera_t.
-template <>
-struct hash<std::pair<uint32_t, uint32_t>> {
-  std::size_t operator()(const std::pair<uint32_t, uint32_t>& p) const {
-    const uint64_t s = (static_cast<uint64_t>(p.first) << 32) +
-                       static_cast<uint64_t>(p.second);
-    return std::hash<uint64_t>()(s);
-  }
-};
 
 template <>
 struct hash<colmap::sensor_t> {
   std::size_t operator()(const colmap::sensor_t& s) const noexcept {
-    return std::hash<std::pair<uint32_t, uint32_t>>{}(
+    return colmap::PairHash{}(
         std::make_pair(static_cast<uint32_t>(s.type), s.id));
   }
 };
@@ -391,10 +396,8 @@ struct hash<colmap::sensor_t> {
 template <>
 struct hash<colmap::data_t> {
   std::size_t operator()(const colmap::data_t& d) const noexcept {
-    const size_t h1 =
-        std::hash<uint64_t>{}(std::hash<colmap::sensor_t>{}(d.sensor_id));
-    const size_t h2 = std::hash<uint64_t>{}(d.id);
-    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+    return colmap::HashCombine(std::hash<colmap::sensor_t>{}(d.sensor_id),
+                               std::hash<uint64_t>{}(d.id));
   }
 };
 

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -371,10 +371,18 @@ struct PairHash {
   std::size_t operator()(const std::pair<T1, T2>& p) const {
     // Pack into disjoint bits when possible (collision-free, unlike
     // HashCombine); otherwise fall back to mixing.
-    if constexpr (std::is_unsigned_v<T1> && std::is_unsigned_v<T2> &&
+    if constexpr (std::is_integral_v<T1> && std::is_integral_v<T2> &&
+                  !std::is_same_v<T1, bool> && !std::is_same_v<T2, bool> &&
                   sizeof(T1) + sizeof(T2) <= sizeof(std::size_t)) {
-      return (static_cast<std::size_t>(p.first) << (8 * sizeof(T2))) |
-             static_cast<std::size_t>(p.second);
+      // Convert through the unsigned counterpart: the signed->unsigned cast
+      // is a bijection modulo 2^n, so negatives map losslessly into exactly
+      // their low 8*sizeof(T) bits. Both halves then occupy disjoint bit
+      // ranges, making the pack collision-free (unlike HashCombine).
+      return (static_cast<std::size_t>(
+                  static_cast<std::make_unsigned_t<T1>>(p.first))
+              << (8 * sizeof(T2))) |
+             static_cast<std::size_t>(
+                 static_cast<std::make_unsigned_t<T2>>(p.second));
     } else {
       return HashCombine(std::hash<T1>{}(p.first), std::hash<T2>{}(p.second));
     }

--- a/src/colmap/util/types.h
+++ b/src/colmap/util/types.h
@@ -369,6 +369,8 @@ inline std::size_t HashCombine(std::size_t seed, std::size_t value) {
 struct PairHash {
   template <typename T1, typename T2>
   std::size_t operator()(const std::pair<T1, T2>& p) const {
+    // Pack into disjoint bits when possible (collision-free, unlike
+    // HashCombine); otherwise fall back to mixing.
     if constexpr (std::is_unsigned_v<T1> && std::is_unsigned_v<T2> &&
                   sizeof(T1) + sizeof(T2) <= sizeof(std::size_t)) {
       return (static_cast<std::size_t>(p.first) << (8 * sizeof(T2))) |

--- a/src/colmap/util/types_test.cc
+++ b/src/colmap/util/types_test.cc
@@ -125,7 +125,7 @@ TEST(FilterView, RangeExpression) {
 }
 
 TEST(FeatureMatchHashing, Nominal) {
-  std::unordered_set<std::pair<point2D_t, point2D_t>> set;
+  std::unordered_set<std::pair<point2D_t, point2D_t>, PairHash> set;
   set.emplace(1, 2);
   EXPECT_EQ(set.size(), 1);
   set.emplace(1, 2);
@@ -143,7 +143,7 @@ TEST(FeatureMatchHashing, Nominal) {
 TEST(FeatureMatchHashing, LargeValues) {
   const point2D_t hi = std::numeric_limits<point2D_t>::max();
   const point2D_t lo = 1;
-  std::unordered_set<std::pair<point2D_t, point2D_t>> set;
+  std::unordered_set<std::pair<point2D_t, point2D_t>, PairHash> set;
   set.emplace(hi, lo);
   set.emplace(lo, hi);
   set.emplace(hi, hi);
@@ -156,7 +156,7 @@ TEST(FeatureMatchHashing, LargeValues) {
 }
 
 TEST(FeatureMatchHashing, Deterministic) {
-  std::hash<std::pair<point2D_t, point2D_t>> h;
+  PairHash h;
   EXPECT_EQ(h(std::make_pair<point2D_t, point2D_t>(42, 99)),
             h(std::make_pair<point2D_t, point2D_t>(42, 99)));
   EXPECT_NE(h(std::make_pair<point2D_t, point2D_t>(42, 99)),

--- a/src/colmap/util/types_test.cc
+++ b/src/colmap/util/types_test.cc
@@ -164,6 +164,32 @@ TEST(FeatureMatchHashing, Deterministic) {
             h(std::make_pair<point2D_t, point2D_t>(99, 42)));
 }
 
+TEST(SignedPairHashing, LargeValues) {
+  const int32_t hi = std::numeric_limits<int32_t>::max();
+  const int32_t lo = std::numeric_limits<int32_t>::min();
+  FlatHashSet<std::pair<int32_t, int32_t>, PairHash> set;
+  set.emplace(hi, lo);
+  set.emplace(lo, hi);
+  set.emplace(hi, hi);
+  set.emplace(lo, lo);
+  EXPECT_EQ(set.size(), 4);
+  EXPECT_EQ(set.count(std::make_pair(hi, lo)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(hi, hi)), 1);
+  EXPECT_EQ(set.count(std::make_pair(lo, lo)), 1);
+}
+
+TEST(SignedPairHashing, Deterministic) {
+  PairHash h;
+  EXPECT_EQ(h(std::make_pair<int32_t, int32_t>(-42, 99)),
+            h(std::make_pair<int32_t, int32_t>(-42, 99)));
+  EXPECT_NE(h(std::make_pair<int32_t, int32_t>(-42, 99)),
+            h(std::make_pair<int32_t, int32_t>(99, -42)));
+  // Distinct negatives that share low bits with positives must not collide.
+  EXPECT_NE(h(std::make_pair<int32_t, int32_t>(-1, 0)),
+            h(std::make_pair<int32_t, int32_t>(0, -1)));
+}
+
 TEST(Point3DPairHashing, Nominal) {
   FlatHashSet<std::pair<point3D_t, point3D_t>, PairHash> set;
   set.emplace(1, 2);


### PR DESCRIPTION
There was still a std::hash specialization of std::pair<uint32_t, uint32_t> in the codebase, which had the same hazard that PairHash was aimed to avoid. 

Removed and consolidated with PairHash. Now PairHash packs std::pair<uint32_t, uint32_t> in a lossless way.
