### PR TITLE
Fix: rescale already-undistorted images when max_image_size is provided.

### DIFF
--- a/src/colmap/controllers/undistorters.cc
+++ b/src/colmap/controllers/undistorters.cc
@@ -234,10 +234,12 @@ bool COLMAPUndistorter::Undistort(const image_t image_id) const {
   const auto output_image_path = output_path_ / "images" / image.Name();
 
   // Non-perspective cameras (e.g. EQUIRECTANGULAR) have no pinhole image plane
-  // to undistort to and are left unchanged by UndistortReconstruction, so copy
-  // their images through unchanged (they cannot be rescaled to a pinhole image
-  // for MVS).
-  if (!camera.IsPerspective() && ExistsFile(input_image_path)) {
+  // to undistort to. Without a size limit they are copied through unchanged
+  // (they cannot be rescaled to a pinhole image for MVS); with a max_image_size
+  // they still go through UndistortImage below, which resizes them to a smaller
+  // image of the same model.
+  if (!camera.IsPerspective() && camera_options_.max_image_size < 0 &&
+      ExistsFile(input_image_path)) {
     LOG(WARNING) << "Cannot undistort image " << image.Name()
                  << " with non-perspective camera model " << camera.ModelName()
                  << "; copying the original image.";

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -300,7 +300,7 @@ void UndistortImage(const UndistortCameraOptions& options,
 
 void UndistortReconstruction(const UndistortCameraOptions& options,
                              Reconstruction* reconstruction) {
-  const std::unordered_map<camera_t, Camera> distorted_cameras =
+  const NodeHashMap<camera_t, Camera> distorted_cameras =
       reconstruction->Cameras();
   // Leave a camera unchanged exactly when the image undistortion also copies
   // its images through unchanged, so that the reconstruction stays consistent
@@ -314,18 +314,18 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
   const auto keep_unchanged = [&options](const Camera& camera) {
     return camera.IsUndistorted() && options.max_image_size < 0;
   };
-  for (const auto& camera : distorted_cameras) {
-    if (keep_unchanged(camera.second)) {
+  for (const auto& [camera_id, distorted_camera] : distorted_cameras) {
+    if (keep_unchanged(distorted_camera)) {
       continue;
     }
-    Camera& undistorted_camera = reconstruction->Camera(camera.first);
-    if (camera.second.IsSpherical()) {
+    Camera& undistorted_camera = reconstruction->Camera(camera_id);
+    if (distorted_camera.IsSpherical()) {
       // Only reached with a max_image_size: resize the spherical camera in
       // place, keeping its model.
-      undistorted_camera = camera.second;
+      undistorted_camera = distorted_camera;
       RescaleToMaxImageSize(options, &undistorted_camera);
     } else {
-      undistorted_camera = UndistortCamera(options, camera.second);
+      undistorted_camera = UndistortCamera(options, distorted_camera);
     }
   }
 

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -273,11 +273,20 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
                              Reconstruction* reconstruction) {
   const std::unordered_map<camera_t, Camera> distorted_cameras =
       reconstruction->Cameras();
+  // Leave a camera unchanged exactly when the image undistortion also copies
+  // its images through unchanged, so that the reconstruction stays consistent
+  // with the output images (see COLMAPUndistorter::Undistort):
+  //  * Spherical cameras (e.g. EQUIRECTANGULAR) have no pinhole image plane to
+  //    undistort to.
+  //  * Already-undistorted perspective cameras are copied through as-is, unless
+  //    a max_image_size is requested, in which case they are still rescaled to
+  //    match the resized images.
+  const auto keep_unchanged = [&options](const Camera& camera) {
+    return camera.IsSpherical() ||
+           (camera.IsUndistorted() && options.max_image_size < 0);
+  };
   for (const auto& camera : distorted_cameras) {
-    // IsUndistorted() is true for non-perspective cameras (e.g.
-    // EQUIRECTANGULAR), which cannot be undistorted to a pinhole, so they are
-    // left unchanged.
-    if (camera.second.IsUndistorted()) {
+    if (keep_unchanged(camera.second)) {
       continue;
     }
     reconstruction->Camera(camera.first) =
@@ -287,10 +296,8 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
   for (const auto& distorted_image : reconstruction->Images()) {
     Image& image = reconstruction->Image(distorted_image.first);
     const Camera& distorted_camera = distorted_cameras.at(image.CameraId());
-    // Cameras left unchanged above (undistorted perspective cameras and all
-    // non-perspective cameras, e.g. EQUIRECTANGULAR) need no observation
-    // rewrite.
-    if (distorted_camera.IsUndistorted()) {
+    // Cameras left unchanged above need no observation rewrite.
+    if (keep_unchanged(distorted_camera)) {
       continue;
     }
     const Camera& undistorted_camera = *image.CameraPtr();

--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -34,6 +34,25 @@
 #include "colmap/sensor/models.h"
 
 namespace colmap {
+namespace {
+
+// Rescale a camera in place so that neither dimension exceeds
+// options.max_image_size, keeping its model. A no-op when no size limit is
+// requested or the camera already fits within it.
+void RescaleToMaxImageSize(const UndistortCameraOptions& options,
+                           Camera* camera) {
+  if (options.max_image_size < 0) {
+    return;
+  }
+  const double max_image_scale =
+      std::min(options.max_image_size / static_cast<double>(camera->width),
+               options.max_image_size / static_cast<double>(camera->height));
+  if (max_image_scale < 1.0) {
+    camera->Rescale(max_image_scale);
+  }
+}
+
+}  // namespace
 
 Camera UndistortCamera(const UndistortCameraOptions& options,
                        const Camera& camera) {
@@ -237,15 +256,7 @@ Camera UndistortCamera(const UndistortCameraOptions& options,
   }
 
   if (options.max_image_size > 0) {
-    const double max_image_scale_x =
-        options.max_image_size / static_cast<double>(undistorted_camera.width);
-    const double max_image_scale_y =
-        options.max_image_size / static_cast<double>(undistorted_camera.height);
-    const double max_image_scale =
-        std::min(max_image_scale_x, max_image_scale_y);
-    if (max_image_scale < 1.0) {
-      undistorted_camera.Rescale(max_image_scale);
-    }
+    RescaleToMaxImageSize(options, &undistorted_camera);
   }
 
   return undistorted_camera;
@@ -258,6 +269,24 @@ void UndistortImage(const UndistortCameraOptions& options,
                     Camera* undistorted_camera) {
   THROW_CHECK_EQ(distorted_camera.width, distorted_bitmap.Width());
   THROW_CHECK_EQ(distorted_camera.height, distorted_bitmap.Height());
+
+  if (distorted_camera.IsSpherical()) {
+    // Spherical cameras (e.g. EQUIRECTANGULAR) have no pinhole image plane to
+    // undistort to, so keep the model and only apply the max_image_size limit.
+    // The equirectangular pixel<->angle map is linear in the image dimensions,
+    // so this is a plain downscale. The per-pixel bearing warp used below
+    // cannot be reused: CamFromImg has no forward normalized coordinates for
+    // the back hemisphere and would blank out those pixels.
+    *undistorted_camera = distorted_camera;
+    RescaleToMaxImageSize(options, undistorted_camera);
+    *undistorted_bitmap = distorted_bitmap.Clone();
+    if (undistorted_camera->width != distorted_camera.width ||
+        undistorted_camera->height != distorted_camera.height) {
+      undistorted_bitmap->Rescale(static_cast<int>(undistorted_camera->width),
+                                  static_cast<int>(undistorted_camera->height));
+    }
+    return;
+  }
 
   *undistorted_camera = UndistortCamera(options, distorted_camera);
 
@@ -275,22 +304,29 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
       reconstruction->Cameras();
   // Leave a camera unchanged exactly when the image undistortion also copies
   // its images through unchanged, so that the reconstruction stays consistent
-  // with the output images (see COLMAPUndistorter::Undistort):
-  //  * Spherical cameras (e.g. EQUIRECTANGULAR) have no pinhole image plane to
-  //    undistort to.
-  //  * Already-undistorted perspective cameras are copied through as-is, unless
-  //    a max_image_size is requested, in which case they are still rescaled to
-  //    match the resized images.
+  // with the output images (see COLMAPUndistorter::Undistort). Both spherical
+  // cameras (e.g. EQUIRECTANGULAR, which have no pinhole image plane to
+  // undistort to) and already-undistorted perspective cameras are otherwise
+  // copied through as-is. When a max_image_size is requested, they are still
+  // resized to match the rescaled output images: perspective cameras through
+  // undistortion, spherical cameras by resizing to a smaller image of the same
+  // model.
   const auto keep_unchanged = [&options](const Camera& camera) {
-    return camera.IsSpherical() ||
-           (camera.IsUndistorted() && options.max_image_size < 0);
+    return camera.IsUndistorted() && options.max_image_size < 0;
   };
   for (const auto& camera : distorted_cameras) {
     if (keep_unchanged(camera.second)) {
       continue;
     }
-    reconstruction->Camera(camera.first) =
-        UndistortCamera(options, camera.second);
+    Camera& undistorted_camera = reconstruction->Camera(camera.first);
+    if (camera.second.IsSpherical()) {
+      // Only reached with a max_image_size: resize the spherical camera in
+      // place, keeping its model.
+      undistorted_camera = camera.second;
+      RescaleToMaxImageSize(options, &undistorted_camera);
+    } else {
+      undistorted_camera = UndistortCamera(options, camera.second);
+    }
   }
 
   for (const auto& distorted_image : reconstruction->Images()) {
@@ -301,6 +337,26 @@ void UndistortReconstruction(const UndistortCameraOptions& options,
       continue;
     }
     const Camera& undistorted_camera = *image.CameraPtr();
+
+    if (distorted_camera.IsSpherical()) {
+      // Spherical models are only resized (see above). The equirectangular
+      // pixel<->angle map is linear in the image dimensions, so observations
+      // scale linearly. Unlike the perspective round-trip below, this stays
+      // valid for back-hemisphere observations, whose bearing has no forward
+      // normalized (CamFromImg) representation.
+      const double scale_x = static_cast<double>(undistorted_camera.width) /
+                             static_cast<double>(distorted_camera.width);
+      const double scale_y = static_cast<double>(undistorted_camera.height) /
+                             static_cast<double>(distorted_camera.height);
+      for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();
+           ++point2D_idx) {
+        Eigen::Vector2d& xy = image.Point2D(point2D_idx).xy;
+        xy.x() *= scale_x;
+        xy.y() *= scale_y;
+      }
+      continue;
+    }
+
     for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();
          ++point2D_idx) {
       auto& point2D = image.Point2D(point2D_idx);

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -270,6 +270,64 @@ TEST(UndistortReconstruction, Nominal) {
   }
 }
 
+TEST(UndistortReconstruction, RescalesAlreadyUndistortedCameras) {
+  constexpr size_t kNumImages = 3;
+
+  Reconstruction reconstruction;
+
+  // Already-undistorted (PINHOLE) camera at a high resolution. focal=100,
+  // width=height=100 => principal point at (50, 50).
+  Camera camera =
+      Camera::CreateFromModelId(1, CameraModelId::kPinhole, 100, 100, 100);
+  ASSERT_TRUE(camera.IsUndistorted());
+  reconstruction.AddCamera(camera);
+  Rig rig;
+  rig.SetRigId(1);
+  rig.AddRefSensor(sensor_t(SensorType::CAMERA, 1));
+  reconstruction.AddRig(rig);
+
+  const Eigen::Vector2d point_xy(60, 40);
+  for (image_t image_id = 1; image_id <= kNumImages; ++image_id) {
+    Frame frame;
+    frame.SetRigId(1);
+    frame.SetFrameId(image_id);
+    frame.SetRigFromWorld(Rigid3d());
+    Image image;
+    image.SetImageId(image_id);
+    image.SetCameraId(1);
+    image.SetFrameId(frame.FrameId());
+    image.SetName("image" + std::to_string(image_id));
+    image.SetPoints2D(std::vector<Eigen::Vector2d>(1, point_xy));
+    frame.AddDataId(image.DataId());
+    reconstruction.AddFrame(frame);
+    reconstruction.AddImage(image);
+    reconstruction.RegisterFrame(frame.FrameId());
+  }
+
+  UndistortCameraOptions options;
+  options.max_image_size = 50;
+  UndistortReconstruction(options, &reconstruction);
+
+  // The camera resolution and intrinsics are rescaled to match max_image_size.
+  const Camera& undistorted_camera = reconstruction.Camera(1);
+  EXPECT_EQ(undistorted_camera.ModelName(), "PINHOLE");
+  EXPECT_EQ(undistorted_camera.width, 50);
+  EXPECT_EQ(undistorted_camera.height, 50);
+  EXPECT_NEAR(undistorted_camera.FocalLengthX(), 50, 1e-6);
+  EXPECT_NEAR(undistorted_camera.FocalLengthY(), 50, 1e-6);
+  EXPECT_NEAR(undistorted_camera.PrincipalPointX(), 25, 1e-6);
+  EXPECT_NEAR(undistorted_camera.PrincipalPointY(), 25, 1e-6);
+
+  // The observations are rescaled consistently with the camera: (60, 40) maps
+  // to normalized (0.1, -0.1) and back through the halved intrinsics to
+  // (0.1 * 50 + 25, -0.1 * 50 + 25) = (30, 20).
+  for (const auto& image : reconstruction.Images()) {
+    ASSERT_EQ(image.second.NumPoints2D(), 1);
+    EXPECT_THAT(image.second.Point2D(0).xy,
+                EigenMatrixNear(Eigen::Vector2d(30, 20), 1e-6));
+  }
+}
+
 TEST(RectifyStereoCameras, Nominal) {
   Camera camera1;
   camera1 = Camera::CreateFromModelId(1, CameraModelId::kPinhole, 1, 1, 1);

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -328,6 +328,69 @@ TEST(UndistortReconstruction, RescalesAlreadyUndistortedCameras) {
   }
 }
 
+TEST(UndistortReconstruction, RescalesSphericalCameras) {
+  constexpr size_t kNumImages = 3;
+
+  Reconstruction reconstruction;
+
+  // Spherical (EQUIRECTANGULAR) camera at a high resolution. It has no pinhole
+  // plane to undistort to, but can still be resized to a smaller image of the
+  // same model.
+  Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kEquirectangular, /*focal_length=*/0.0, 1000, 500);
+  ASSERT_TRUE(camera.IsSpherical());
+  reconstruction.AddCamera(camera);
+  Rig rig;
+  rig.SetRigId(1);
+  rig.AddRefSensor(sensor_t(SensorType::CAMERA, 1));
+  reconstruction.AddRig(rig);
+
+  // A front-hemisphere pixel (azimuth 36 deg) and a back-hemisphere pixel
+  // (azimuth -144 deg, behind the camera). The back-hemisphere observation has
+  // no forward normalized (CamFromImg) representation, so it must be handled by
+  // plain linear scaling rather than a bearing round-trip.
+  const std::vector<Eigen::Vector2d> points_xy = {Eigen::Vector2d(600, 200),
+                                                  Eigen::Vector2d(100, 400)};
+  for (image_t image_id = 1; image_id <= kNumImages; ++image_id) {
+    Frame frame;
+    frame.SetRigId(1);
+    frame.SetFrameId(image_id);
+    frame.SetRigFromWorld(Rigid3d());
+    Image image;
+    image.SetImageId(image_id);
+    image.SetCameraId(1);
+    image.SetFrameId(frame.FrameId());
+    image.SetName("image" + std::to_string(image_id));
+    image.SetPoints2D(points_xy);
+    frame.AddDataId(image.DataId());
+    reconstruction.AddFrame(frame);
+    reconstruction.AddImage(image);
+    reconstruction.RegisterFrame(frame.FrameId());
+  }
+
+  UndistortCameraOptions options;
+  options.max_image_size = 250;
+  UndistortReconstruction(options, &reconstruction);
+
+  // The camera keeps its model but is resized so its larger dimension (width)
+  // matches max_image_size: scale = 250 / 1000 = 0.25.
+  const Camera& undistorted_camera = reconstruction.Camera(1);
+  EXPECT_EQ(undistorted_camera.ModelName(), "EQUIRECTANGULAR");
+  EXPECT_EQ(undistorted_camera.width, 250);
+  EXPECT_EQ(undistorted_camera.height, 125);
+
+  // The observations are rescaled consistently with the camera: the fractional
+  // position within the image is preserved (a plain 0.25 scaling here), so both
+  // the front- and back-hemisphere points map through without loss.
+  for (const auto& image : reconstruction.Images()) {
+    ASSERT_EQ(image.second.NumPoints2D(), 2);
+    EXPECT_THAT(image.second.Point2D(0).xy,
+                EigenMatrixNear(Eigen::Vector2d(150, 50), 1e-6));
+    EXPECT_THAT(image.second.Point2D(1).xy,
+                EigenMatrixNear(Eigen::Vector2d(25, 100), 1e-6));
+  }
+}
+
 TEST(RectifyStereoCameras, Nominal) {
   Camera camera1;
   camera1 = Camera::CreateFromModelId(1, CameraModelId::kPinhole, 1, 1, 1);


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/4508