### PR TITLE
Emit Caspar bundle-adjustment progress under VLOG(1)

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_caspar.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar.cc
@@ -935,7 +935,7 @@ class CasparBundleAdjuster : public BundleAdjuster {
     const bool collect_iters =
         options_.caspar && options_.caspar->collect_iteration_data;
     caspar::SolveResult result = solver.solve(
-        /*print_progress=*/false, /*verbose_logging=*/collect_iters);
+        /*print_progress=*/VLOG_IS_ON(1), /*verbose_logging=*/collect_iters);
     ReadSolverResults(solver);
     WriteResultsToReconstruction();
 


### PR DESCRIPTION
## Problem

`BundleAdjustmentCaspar::Solve()` calls the Caspar solver with `print_progress` hardcoded to `false`:

```cpp
caspar::SolveResult result = solver.solve(
    /*print_progress=*/false, /*verbose_logging=*/collect_iters);
```

So the Caspar backend produces **no output while it runs**. On larger reconstructions the **global** BA can take many minutes, during which a slow‑but‑working solve is **indistinguishable from a hang** — both to a user tailing the log and to any external monitor (a CI job, or a no‑output watchdog that kills wedged subprocesses).

We hit exactly this running COLMAP 4.1.0 with Caspar as the default backend: on a ~128‑image scene the mapper's final global BA ran **>20 minutes silently** and our no‑output watchdog killed the container (`SIGKILL`, exit 137); smaller scenes finished fine. Data point + context in #4382.

## Change

Gate `print_progress` on `VLOG_IS_ON(1)`, consistent with the `VLOG(1)` diagnostics already used throughout this file:

```cpp
caspar::SolveResult result = solver.solve(
    /*print_progress=*/VLOG_IS_ON(1), /*verbose_logging=*/collect_iters);
```

- **No change to default output** — silent unless run with `--log_level 1` / `GLOG_v=1`.
- With verbose logging on, the Caspar solve reports progress, so a long‑running BA is clearly distinguishable from a real hang.

## Notes / alternatives

Deliberately the smallest, non‑intrusive change. Happy to adjust if you'd prefer to tie it to `BundleAdjustmentOptions::print_summary` (prints by default) or add a dedicated `print_progress` option to `CasparBundleAdjustmentOptions`.

Related: #4382 — the mapper's BA iteration limits aren't propagated to Caspar, which is *why* the global BA runs long in the first place; this PR makes that long run observable.

## Testing

One‑liner substituting an existing glog macro (`VLOG_IS_ON`, already used in this file) for the hardcoded `false`; it doesn't alter control flow. I haven't run a full CUDA+Caspar build locally — CI should confirm the build, and I'm glad to attach sample `-v 1` output from our GPU host.
