### PR TITLE
Expose INVALID_TIMESTAMP in pycolmap and add timestamp binding tests.

### DIFF
--- a/src/pycolmap/scene/constants.cc
+++ b/src/pycolmap/scene/constants.cc
@@ -14,4 +14,5 @@ void BindConstants(py::module& m) {
   m.attr("INVALID_POSE_PRIOR_ID") = colmap::kInvalidPosePriorId;
   m.attr("INVALID_SENSOR_ID") = colmap::kInvalidSensorId;
   m.attr("INVALID_DATA_ID") = colmap::kInvalidDataId;
+  m.attr("INVALID_TIMESTAMP") = colmap::kInvalidTimestamp;
 }

--- a/src/pycolmap/scene/constants_test.py
+++ b/src/pycolmap/scene/constants_test.py
@@ -31,3 +31,7 @@ def test_invalid_sensor_id():
 
 def test_invalid_data_id():
     assert pycolmap.INVALID_DATA_ID is not None
+
+
+def test_invalid_timestamp():
+    assert pycolmap.INVALID_TIMESTAMP is not None

--- a/src/pycolmap/util/timestamp_test.py
+++ b/src/pycolmap/util/timestamp_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+import pycolmap
+
+
+def test_timestamp_from_seconds():
+    # Timestamps are integer nanoseconds.
+    assert pycolmap.timestamp_from_seconds(1.5) == 1_500_000_000
+    # Rounds to the nearest nanosecond.
+    assert pycolmap.timestamp_from_seconds(1e-9) == 1
+    assert pycolmap.timestamp_from_seconds(0.4e-9) == 0
+
+
+def test_seconds_from_timestamp():
+    assert pycolmap.seconds_from_timestamp(1_500_000_000) == pytest.approx(1.5)
+    assert pycolmap.seconds_from_timestamp(0) == 0.0
+
+
+def test_timestamp_roundtrip():
+    for seconds in [0.0, 0.001, 1.25, 10.0]:
+        t = pycolmap.timestamp_from_seconds(seconds)
+        assert pycolmap.seconds_from_timestamp(t) == pytest.approx(seconds)
+
+
+def test_timestamp_diff_seconds():
+    t0 = pycolmap.timestamp_from_seconds(1.0)
+    t1 = pycolmap.timestamp_from_seconds(2.5)
+    assert pycolmap.timestamp_diff_seconds(t1, t0) == pytest.approx(1.5)
+    # The difference may be negative.
+    assert pycolmap.timestamp_diff_seconds(t0, t1) == pytest.approx(-1.5)


### PR DESCRIPTION
Splitted from https://github.com/colmap/colmap/pull/2625