### PR TITLE
Emit Caspar bundle-adjustment progress under VLOG(2)

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_caspar.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar.cc
@@ -935,7 +935,7 @@ class CasparBundleAdjuster : public BundleAdjuster {
     const bool collect_iters =
         options_.caspar && options_.caspar->collect_iteration_data;
     caspar::SolveResult result = solver.solve(
-        /*print_progress=*/false, /*verbose_logging=*/collect_iters);
+        /*print_progress=*/VLOG_IS_ON(2), /*verbose_logging=*/collect_iters);
     ReadSolverResults(solver);
     WriteResultsToReconstruction();
 


### PR DESCRIPTION
Re-opens #4515 — I accidentally closed that PR and deleted its branch (sorry for the churn). This is the **same one-line change**, now gated at **log level 2** as @ahojnnes requested (consistent with how Ceres progress is already gated).

## Problem

`BundleAdjustmentCaspar::Solve()` calls the Caspar solver with `print_progress` hardcoded to `false`:

```cpp
caspar::SolveResult result = solver.solve(
    /*print_progress=*/false, /*verbose_logging=*/collect_iters);
```

So the Caspar backend produces **no output while it runs**. On larger reconstructions the **global** BA can take many minutes, during which a slow-but-working solve is **indistinguishable from a hang** — both to a user tailing the log and to any external monitor (a CI job, or a no-output watchdog that kills wedged subprocesses).

We hit exactly this running COLMAP 4.1.0 with Caspar as the default backend: on a ~128-image scene the mapper's final global BA ran **>20 minutes silently** and our no-output watchdog killed the container (`SIGKILL`, exit 137); smaller scenes finished fine. Data point + context in #4382.

## Change

Gate `print_progress` on `VLOG_IS_ON(2)`, consistent with how Ceres' progress is gated:

```cpp
caspar::SolveResult result = solver.solve(
    /*print_progress=*/VLOG_IS_ON(2), /*verbose_logging=*/collect_iters);
```

- **No change to default output** — silent unless run with `--log_level 2` / `GLOG_v=2`.
- With verbose logging on, the Caspar solve reports progress, so a long-running BA is clearly distinguishable from a real hang.

Related: #4382 — the mapper's BA iteration limits aren't propagated to Caspar, which is *why* the global BA runs long in the first place; this PR makes that long run observable.

## Testing

One-liner substituting an existing glog macro (`VLOG_IS_ON`, already used in this file) for the hardcoded `false`; it doesn't alter control flow.
