### PR TITLE
Handle directory output_path for stereo_fusion PLY output

### DIFF
--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -352,6 +352,20 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
       << "Invalid `output_type` " << output_type
       << " - supported values are 'bin', 'ply' and 'txt'.";
 
+  std::filesystem::path resolved_output_path = output_path;
+  if (output_type == "ply") {
+    if (ExistsDir(resolved_output_path)) {
+      resolved_output_path /= "fused.ply";
+    }
+    const std::filesystem::path parent_path =
+        resolved_output_path.parent_path();
+    THROW_CHECK(parent_path.empty() || ExistsDir(parent_path))
+        << "Parent directory of `output_path` " << parent_path
+        << " is not a directory.";
+  } else {
+    THROW_CHECK_DIR_EXISTS(resolved_output_path);
+  }
+
   mvs::StereoFusion fuser(
       options, workspace_path, workspace_format, pmvs_option_name, input_type);
 
@@ -367,16 +381,16 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
   // overwrite sparse point cloud with dense point cloud from fuser
   reconstruction.ImportPLY(fuser.GetFusedPoints());
 
-  LOG(INFO) << "Writing output: " << output_path;
+  LOG(INFO) << "Writing output: " << resolved_output_path;
 
   // write output
   if (output_type == "bin") {
-    reconstruction.WriteBinary(output_path);
+    reconstruction.WriteBinary(resolved_output_path);
   } else if (output_type == "txt") {
-    reconstruction.WriteText(output_path);
+    reconstruction.WriteText(resolved_output_path);
   } else if (output_type == "ply") {
-    WriteBinaryPlyPoints(output_path, fuser.GetFusedPoints());
-    mvs::WritePointsVisibility(AddFileExtension(output_path, ".vis"),
+    WriteBinaryPlyPoints(resolved_output_path, fuser.GetFusedPoints());
+    mvs::WritePointsVisibility(AddFileExtension(resolved_output_path, ".vis"),
                                fuser.GetFusedPointsVisibility());
   } else {
     LOG(FATAL_THROW) << "Invalid output_type: " << output_type;

--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -352,18 +352,17 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
       << "Invalid `output_type` " << output_type
       << " - supported values are 'bin', 'ply' and 'txt'.";
 
-  std::filesystem::path resolved_output_path = output_path;
   if (output_type == "ply") {
-    if (ExistsDir(resolved_output_path)) {
-      resolved_output_path /= "fused.ply";
-    }
-    const std::filesystem::path parent_path =
-        resolved_output_path.parent_path();
+    THROW_CHECK(!ExistsDir(output_path))
+        << "Path " << output_path
+        << " is a directory, but a PLY file path is expected.";
+    THROW_CHECK_HAS_FILE_EXTENSION(output_path, ".ply");
+    const std::filesystem::path parent_path = output_path.parent_path();
     THROW_CHECK(parent_path.empty() || ExistsDir(parent_path))
         << "Parent directory of `output_path` " << parent_path
-        << " is not a directory.";
+        << " does not exist or is not a directory.";
   } else {
-    THROW_CHECK_DIR_EXISTS(resolved_output_path);
+    THROW_CHECK_DIR_EXISTS(output_path);
   }
 
   mvs::StereoFusion fuser(
@@ -381,16 +380,16 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
   // overwrite sparse point cloud with dense point cloud from fuser
   reconstruction.ImportPLY(fuser.GetFusedPoints());
 
-  LOG(INFO) << "Writing output: " << resolved_output_path;
+  LOG(INFO) << "Writing output: " << output_path;
 
   // write output
   if (output_type == "bin") {
-    reconstruction.WriteBinary(resolved_output_path);
+    reconstruction.WriteBinary(output_path);
   } else if (output_type == "txt") {
-    reconstruction.WriteText(resolved_output_path);
+    reconstruction.WriteText(output_path);
   } else if (output_type == "ply") {
-    WriteBinaryPlyPoints(resolved_output_path, fuser.GetFusedPoints());
-    mvs::WritePointsVisibility(AddFileExtension(resolved_output_path, ".vis"),
+    WriteBinaryPlyPoints(output_path, fuser.GetFusedPoints());
+    mvs::WritePointsVisibility(AddFileExtension(output_path, ".vis"),
                                fuser.GetFusedPointsVisibility());
   } else {
     LOG(FATAL_THROW) << "Invalid output_type: " << output_type;


### PR DESCRIPTION
## Summary

This PR makes `stereo_fusion` fail early when `output_type` is `PLY` and `output_path` is invalid.

Previously, passing a directory as `output_path` made COLMAP run stereo fusion first and then crash in the PLY writer.

## Changes

- Reject directory paths for PLY output before running stereo fusion.
- Validate the `.ply` extension and parent directory early.
- Preserve BIN/TXT directory output semantics, but validate invalid directories before running stereo fusion.

## Validation

- Reproduced the original crash with `--output_type PLY` and `--output_path` set to the dense workspace directory.
- Verified that the same invalid `output_path` now fails immediately with a clear error.
- Verified that an explicit `.ply` output path still writes the PLY and visibility files.

## Related issues

Fixes #3117.
