### PR TITLE
Add DEGENSAC for fundamental matrix estimation robust to a dominant plane

### DIFF
--- a/benchmark/runtime/CMakeLists.txt
+++ b/benchmark/runtime/CMakeLists.txt
@@ -3,6 +3,9 @@ find_package(benchmark REQUIRED)
 add_executable(benchmark_cost_functions cost_functions.cc)
 target_link_libraries(benchmark_cost_functions PRIVATE colmap_estimators benchmark::benchmark)
 
+add_executable(benchmark_fundamental_matrix_degensac fundamental_matrix_degensac.cc)
+target_link_libraries(benchmark_fundamental_matrix_degensac PRIVATE colmap_estimators benchmark::benchmark)
+
 add_executable(benchmark_bundle_adjustment bundle_adjustment.cc)
 target_link_libraries(benchmark_bundle_adjustment PRIVATE colmap_estimators colmap_scene benchmark::benchmark)
 

--- a/benchmark/runtime/fundamental_matrix_degensac.cc
+++ b/benchmark/runtime/fundamental_matrix_degensac.cc
@@ -357,7 +357,8 @@ int main(int /*argc*/, char** /*argv*/) {
   constexpr int kNumProblems = 300;
   constexpr double kNoise = 0.5;  // Pixel std-dev of observation noise.
   const std::vector<size_t> point_counts = {200, 1000};
-  const std::vector<double> plane_fractions = {0.0, 0.5, 0.8, 0.9, 0.95, 0.98};
+  const std::vector<double> plane_fractions = {
+      0.0, 0.3, 0.5, 0.8, 0.9, 0.95, 0.98};
   const std::vector<double> outlier_fractions = {0.0, 0.2, 0.4};
 
   std::printf(

--- a/benchmark/runtime/fundamental_matrix_degensac.cc
+++ b/benchmark/runtime/fundamental_matrix_degensac.cc
@@ -1,0 +1,414 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// A/B comparison of plain LO-RANSAC vs DEGENSAC for fundamental matrix
+// estimation on synthetic two-view data with a dominant scene plane. Prints a
+// markdown table of accuracy, robustness, and runtime metrics across scene
+// configurations, in the style of the essential-matrix cheirality benchmark.
+//
+// For each configuration a number of independent problems are generated. Both
+// methods see the identical data and identical RANSAC randomness per problem,
+// so the comparison is apples-to-apples. Pose error is measured by decomposing
+// the estimated fundamental matrix into a relative pose and comparing it to
+// ground truth.
+
+#include "colmap/estimators/fundamental_matrix_degensac.h"
+
+#include "colmap/estimators/solvers/fundamental_matrix.h"
+#include "colmap/geometry/essential_matrix.h"
+#include "colmap/geometry/rigid3.h"
+#include "colmap/math/random.h"
+#include "colmap/optim/loransac.h"
+#include "colmap/optim/ransac.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+using namespace colmap;
+
+namespace {
+
+constexpr double kMaxError = 1.0;  // Inlier pixel threshold.
+
+Eigen::Matrix3d RandomCalibrationMatrix() {
+  return (Eigen::Matrix3d() << RandomUniformReal<double>(800, 1200),
+          0,
+          RandomUniformReal<double>(400, 600),
+          0,
+          RandomUniformReal<double>(800, 1200),
+          RandomUniformReal<double>(400, 600),
+          0,
+          0,
+          1)
+      .finished();
+}
+
+struct Scene {
+  Eigen::Matrix3d K;
+  Rigid3d cam2_from_cam1;
+  std::vector<Eigen::Vector2d> points1;
+  std::vector<Eigen::Vector2d> points2;
+  // True inliers are the non-outlier correspondences (on-plane or off-plane).
+  std::vector<char> true_inlier_mask;
+};
+
+// Generates a scene where `plane_fraction` of the true-inlier correspondences
+// lie on a dominant plane and `outlier_fraction` of all correspondences are
+// gross mismatches.
+Scene GenerateScene(size_t num_points,
+                    double plane_fraction,
+                    double outlier_fraction,
+                    double noise) {
+  Scene scene;
+  scene.K = RandomCalibrationMatrix();
+  // A moderate forward-facing relative pose (limited rotation and a small
+  // baseline relative to the scene depth) so that points stay in front of both
+  // cameras and pose recovery is not affected by the twisted-pair ambiguity.
+  const double angle = RandomUniformReal<double>(5.0, 30.0) * M_PI / 180.0;
+  const Eigen::Quaterniond rotation(
+      Eigen::AngleAxisd(angle, Eigen::Vector3d::Random().normalized()));
+  const Eigen::Vector3d translation = Eigen::Vector3d::Random().normalized() *
+                                      RandomUniformReal<double>(0.1, 0.4);
+  scene.cam2_from_cam1 = Rigid3d(rotation, translation);
+  const Eigen::Matrix3d K_inv = scene.K.inverse();
+  const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+  constexpr double kDistance = 2.0;
+
+  const size_t num_outliers =
+      static_cast<size_t>(std::round(outlier_fraction * num_points));
+  const size_t num_inliers = num_points - num_outliers;
+  const size_t num_on_plane =
+      static_cast<size_t>(std::round(plane_fraction * num_inliers));
+
+  for (size_t i = 0; i < num_points; ++i) {
+    const Eigen::Vector2d point1 =
+        scene.K.topRows<2>() * Eigen::Vector2d::Random().homogeneous();
+    const Eigen::Vector3d ray = K_inv * point1.homogeneous();
+
+    const bool is_outlier = i >= num_inliers;
+    const bool on_plane = !is_outlier && i < num_on_plane;
+
+    double depth;
+    if (on_plane) {
+      depth = kDistance / normal.dot(ray);
+    } else {
+      depth = RandomUniformReal<double>(0.5, 3.0);
+    }
+    const Eigen::Vector3d point3D_in_cam1 = depth * ray;
+    Eigen::Vector2d point2 =
+        (scene.K * (scene.cam2_from_cam1 * point3D_in_cam1)).hnormalized();
+    if (is_outlier) {
+      // Replace with a random mismatch somewhere in the image.
+      point2 = scene.K.topRows<2>() * Eigen::Vector2d::Random().homogeneous();
+    }
+
+    scene.points1.push_back(point1 + noise * Eigen::Vector2d::Random());
+    scene.points2.push_back(point2 + noise * Eigen::Vector2d::Random());
+    scene.true_inlier_mask.push_back(!is_outlier);
+  }
+  return scene;
+}
+
+double RotationErrorDeg(const Eigen::Matrix3d& R_gt, const Eigen::Matrix3d& R) {
+  const Eigen::Quaterniond q_gt(R_gt);
+  const Eigen::Quaterniond q(R);
+  return q_gt.angularDistance(q) * 180.0 / M_PI;
+}
+
+double TranslationErrorDeg(const Eigen::Vector3d& t_gt,
+                           const Eigen::Vector3d& t) {
+  const double cos_angle =
+      std::clamp(std::abs(t_gt.normalized().dot(t.normalized())), 0.0, 1.0);
+  return std::acos(cos_angle) * 180.0 / M_PI;
+}
+
+double Percentile(std::vector<double> values, double percentile) {
+  if (values.empty()) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  std::sort(values.begin(), values.end());
+  const double rank = percentile / 100.0 * (values.size() - 1);
+  const size_t lo = static_cast<size_t>(std::floor(rank));
+  const size_t hi = static_cast<size_t>(std::ceil(rank));
+  const double frac = rank - lo;
+  return values[lo] * (1.0 - frac) + values[hi] * frac;
+}
+
+double Mean(const std::vector<double>& values) {
+  if (values.empty()) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  double sum = 0;
+  for (double v : values) {
+    sum += v;
+  }
+  return sum / values.size();
+}
+
+struct Stats {
+  double success_rate = 0;  // Pose within 5 deg of ground truth.
+  double recall = 0;        // % of true inliers recovered as inliers.
+  double precision = 0;     // % of reported inliers that are true inliers.
+  double rot_med = 0;
+  double rot_p90 = 0;
+  double trans_med = 0;
+  double trans_p90 = 0;
+  double time_mean_ms = 0;
+  double time_p90_ms = 0;
+  double avg_trials = 0;
+};
+
+// Recovers the relative pose from a fundamental matrix and returns rotation and
+// translation-direction error in degrees.
+void PoseErrors(const Scene& scene,
+                const Eigen::Matrix3d& F,
+                double* rot_err,
+                double* trans_err) {
+  const Eigen::Matrix3d E = EssentialFromFundamentalMatrix(scene.K, F, scene.K);
+  std::vector<Eigen::Vector3d> rays1(scene.points1.size());
+  std::vector<Eigen::Vector3d> rays2(scene.points2.size());
+  const Eigen::Matrix3d K_inv = scene.K.inverse();
+  for (size_t i = 0; i < scene.points1.size(); ++i) {
+    rays1[i] = (K_inv * scene.points1[i].homogeneous()).normalized();
+    rays2[i] = (K_inv * scene.points2[i].homogeneous()).normalized();
+  }
+  Rigid3d cam2_from_cam1;
+  std::vector<int> valid;
+  PoseFromEssentialMatrix(E, rays1, rays2, &cam2_from_cam1, &valid);
+  *rot_err =
+      RotationErrorDeg(scene.cam2_from_cam1.rotation().toRotationMatrix(),
+                       cam2_from_cam1.rotation().toRotationMatrix());
+  *trans_err = TranslationErrorDeg(scene.cam2_from_cam1.translation(),
+                                   cam2_from_cam1.translation());
+}
+
+// Inlier recall (fraction of true inliers reported) and precision (fraction of
+// reported inliers that are true inliers) for the estimated inlier mask.
+void RecallPrecision(const Scene& scene,
+                     const std::vector<char>& inlier_mask,
+                     double* recall,
+                     double* precision) {
+  size_t num_true = 0;
+  size_t num_reported = 0;
+  size_t num_true_reported = 0;
+  for (size_t i = 0; i < scene.true_inlier_mask.size(); ++i) {
+    const bool is_true = scene.true_inlier_mask[i];
+    const bool is_reported = i < inlier_mask.size() && inlier_mask[i];
+    num_true += is_true;
+    num_reported += is_reported;
+    num_true_reported += is_true && is_reported;
+  }
+  *recall = num_true == 0 ? 0.0 : 100.0 * num_true_reported / num_true;
+  *precision = num_reported == 0 ? 0.0 : 100.0 * num_true_reported / num_reported;
+}
+
+enum class Method { kLoRansac, kDegensac };
+
+Stats RunConfig(Method method,
+                size_t num_points,
+                double plane_fraction,
+                double outlier_fraction,
+                double noise,
+                int num_problems) {
+  int num_success = 0;
+  std::vector<double> rot_errs;
+  std::vector<double> trans_errs;
+  std::vector<double> times_ms;
+  std::vector<double> recalls;
+  std::vector<double> precisions;
+  double sum_trials = 0;
+
+  for (int p = 0; p < num_problems; ++p) {
+    // Deterministic, distinct data per problem; identical for both methods.
+    SetPRNGSeed(1000 + p);
+    const Scene scene =
+        GenerateScene(num_points, plane_fraction, outlier_fraction, noise);
+
+    RANSACOptions ransac_options;
+    ransac_options.max_error = kMaxError;
+    ransac_options.confidence = 0.9999;
+    ransac_options.min_inlier_ratio = 0.1;
+    ransac_options.max_num_trials = 10000;
+    ransac_options.random_seed = 5000 + p;
+
+    FundamentalMatrixDegensac::Report report;
+    const auto start = std::chrono::high_resolution_clock::now();
+    if (method == Method::kDegensac) {
+      FundamentalMatrixDegensac::Options options;
+      options.ransac = ransac_options;
+      report = FundamentalMatrixDegensac(options).Estimate(scene.points1,
+                                                           scene.points2);
+    } else {
+      LORANSAC<FundamentalMatrixSevenPointEstimator,
+               FundamentalMatrixEightPointEstimator>
+          loransac(ransac_options);
+      report = loransac.Estimate(scene.points1, scene.points2);
+    }
+    const auto end = std::chrono::high_resolution_clock::now();
+    times_ms.push_back(
+        std::chrono::duration<double, std::milli>(end - start).count());
+
+    sum_trials += report.num_trials;
+    if (!report.success) {
+      // A failed estimate counts as a full pose failure with worst-case error.
+      rot_errs.push_back(180.0);
+      trans_errs.push_back(90.0);
+      recalls.push_back(0.0);
+      precisions.push_back(0.0);
+      continue;
+    }
+
+    double rot_err;
+    double trans_err;
+    PoseErrors(scene, report.model, &rot_err, &trans_err);
+    if (rot_err < 5.0 && trans_err < 5.0) {
+      ++num_success;
+    }
+    rot_errs.push_back(rot_err);
+    trans_errs.push_back(trans_err);
+
+    double recall;
+    double precision;
+    RecallPrecision(scene, report.inlier_mask, &recall, &precision);
+    recalls.push_back(recall);
+    precisions.push_back(precision);
+  }
+
+  Stats stats;
+  stats.success_rate = 100.0 * num_success / num_problems;
+  stats.recall = Mean(recalls);
+  stats.precision = Mean(precisions);
+  stats.rot_med = Percentile(rot_errs, 50);
+  stats.rot_p90 = Percentile(rot_errs, 90);
+  stats.trans_med = Percentile(trans_errs, 50);
+  stats.trans_p90 = Percentile(trans_errs, 90);
+  stats.time_mean_ms = Mean(times_ms);
+  stats.time_p90_ms = Percentile(times_ms, 90);
+  stats.avg_trials = sum_trials / num_problems;
+  return stats;
+}
+
+void PrintRow(size_t num_points,
+              double plane_fraction,
+              double outlier_fraction,
+              const char* method,
+              const Stats& stats) {
+  std::printf(
+      "| %5zu | %5.0f%% | %4.0f%% | %-8s | %7.2f | %7.2f | %6.1f | %8.1f | "
+      "%7.1f | %8.3f | %8.3f | %9.3f | %9.3f | %6.0f |\n",
+      num_points,
+      100 * plane_fraction,
+      100 * outlier_fraction,
+      method,
+      stats.time_mean_ms,
+      stats.time_p90_ms,
+      stats.success_rate,
+      stats.recall,
+      stats.precision,
+      stats.rot_med,
+      stats.rot_p90,
+      stats.trans_med,
+      stats.trans_p90,
+      stats.avg_trials);
+}
+
+}  // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  constexpr int kNumProblems = 300;
+  constexpr double kNoise = 0.5;  // Pixel std-dev of observation noise.
+  const std::vector<size_t> point_counts = {200, 1000};
+  const std::vector<double> plane_fractions = {0.0, 0.5, 0.8, 0.9, 0.95, 0.98};
+  const std::vector<double> outlier_fractions = {0.0, 0.2, 0.4};
+
+  std::printf(
+      "DEGENSAC vs plain LO-RANSAC for fundamental matrix estimation on "
+      "synthetic\ntwo-view data with a dominant plane.\n\n");
+  std::printf(
+      "- %d independent problems per configuration; both methods see identical "
+      "data\n  and identical RANSAC randomness per problem.\n"
+      "- Observation noise: %.1f px std-dev; inlier threshold max_error=%.1f "
+      "px.\n"
+      "- `success` = %% of runs whose recovered pose is within 5 deg of ground "
+      "truth.\n"
+      "- `recall` = %% of true inliers recovered; `prec` = %% of reported "
+      "inliers that\n  are true inliers (both averaged over all problems, "
+      "failures included).\n"
+      "- `rot`/`trans` errors (deg) are over ALL returned models (a "
+      "plane-corrupted\n  model contributes its large error), so medians and "
+      "p90 reflect degradation.\n\n",
+      kNumProblems,
+      kNoise,
+      kMaxError);
+  std::printf(
+      "| Pts   | Plane  | Outl | Method   | t mean  | t p90   | Succ%%  | "
+      "Recall%% | Prec%%  | Rot med  | Rot p90  | Trans med | Trans p90 | "
+      "Trials |\n");
+  std::printf(
+      "|------:|-------:|-----:|:---------|--------:|--------:|-------:|"
+      "--------:|-------:|---------:|---------:|----------:|----------:|"
+      "-------:|\n");
+
+  for (size_t num_points : point_counts) {
+    for (double plane_fraction : plane_fractions) {
+      for (double outlier_fraction : outlier_fractions) {
+        const Stats loransac_stats = RunConfig(Method::kLoRansac,
+                                               num_points,
+                                               plane_fraction,
+                                               outlier_fraction,
+                                               kNoise,
+                                               kNumProblems);
+        const Stats degensac_stats = RunConfig(Method::kDegensac,
+                                               num_points,
+                                               plane_fraction,
+                                               outlier_fraction,
+                                               kNoise,
+                                               kNumProblems);
+        PrintRow(num_points,
+                 plane_fraction,
+                 outlier_fraction,
+                 "loransac",
+                 loransac_stats);
+        PrintRow(num_points,
+                 plane_fraction,
+                 outlier_fraction,
+                 "degensac",
+                 degensac_stats);
+      }
+    }
+  }
+
+  return 0;
+}

--- a/benchmark/runtime/fundamental_matrix_degensac.cc
+++ b/benchmark/runtime/fundamental_matrix_degensac.cc
@@ -231,7 +231,8 @@ void RecallPrecision(const Scene& scene,
     num_true_reported += is_true && is_reported;
   }
   *recall = num_true == 0 ? 0.0 : 100.0 * num_true_reported / num_true;
-  *precision = num_reported == 0 ? 0.0 : 100.0 * num_true_reported / num_reported;
+  *precision =
+      num_reported == 0 ? 0.0 : 100.0 * num_true_reported / num_reported;
 }
 
 enum class Method { kLoRansac, kDegensac };
@@ -263,13 +264,19 @@ Stats RunConfig(Method method,
     ransac_options.max_num_trials = 10000;
     ransac_options.random_seed = 5000 + p;
 
-    FundamentalMatrixDegensac::Report report;
+    LORANSAC<FundamentalMatrixSevenPointEstimator,
+             FundamentalMatrixEightPointEstimator>::Report report;
     const auto start = std::chrono::high_resolution_clock::now();
     if (method == Method::kDegensac) {
-      FundamentalMatrixDegensac::Options options;
+      FundamentalMatrixDegensacOptions options;
       options.ransac = ransac_options;
-      report = FundamentalMatrixDegensac(options).Estimate(scene.points1,
-                                                           scene.points2);
+      const auto r = EstimateFundamentalMatrixDegensac(
+          scene.points1, scene.points2, options);
+      report.success = r.success;
+      report.num_trials = r.num_trials;
+      report.support = r.support;
+      report.inlier_mask = r.inlier_mask;
+      report.model = r.model;
     } else {
       LORANSAC<FundamentalMatrixSevenPointEstimator,
                FundamentalMatrixEightPointEstimator>

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -38,6 +38,7 @@ set(ESTIMATORS_SRCS
     bundle_adjustment_ceres.h bundle_adjustment_ceres.cc
     coordinate_frame.h coordinate_frame.cc
     covariance.h covariance.cc
+    fundamental_matrix_degensac.h fundamental_matrix_degensac.cc
     generalized_pose.h generalized_pose.cc
     global_positioning.h global_positioning.cc
     gravity_refinement.h gravity_refinement.cc
@@ -113,6 +114,11 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME covariance_test
     SRCS covariance_test.cc
+    LINK_LIBS colmap_estimators
+)
+COLMAP_ADD_TEST(
+    NAME fundamental_matrix_degensac_test
+    SRCS fundamental_matrix_degensac_test.cc
     LINK_LIBS colmap_estimators
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -188,20 +188,44 @@ bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
       .has_value();
 }
 
+namespace {
+
+// Squared forward transfer error of a correspondence under a homography.
+double TransferError(const Eigen::Vector2d& point1,
+                     const Eigen::Vector2d& point2,
+                     const Eigen::Matrix3d& H) {
+  return ComputeSquaredHomographyError(point1, point2, H);
+}
+
+// Draws `num` distinct entries of `src` into the front of `scratch` (a working
+// copy of `src`) via a partial Fisher-Yates shuffle.
+void SampleDistinct(size_t num, std::vector<size_t>* scratch) {
+  const size_t n = scratch->size();
+  for (size_t i = 0; i < num; ++i) {
+    const size_t j = i + RandomUniformInteger<size_t>(0, n - 1 - i);
+    const size_t tmp = (*scratch)[i];
+    (*scratch)[i] = (*scratch)[j];
+    (*scratch)[j] = tmp;
+  }
+}
+
+}  // namespace
+
 std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     const Eigen::Matrix3d& seed_H,
     const std::vector<Eigen::Vector2d>& points1,
     const std::vector<Eigen::Vector2d>& points2,
     const double sampson_max_residual,
-    const double h_max_residual,
+    const double plane_max_residual,
+    const double off_plane_min_residual,
     const int max_trials) {
   THROW_CHECK_EQ(points1.size(), points2.size());
 
   // The seed homography is built from only three sample correspondences (via
   // the plane-corrupted sample fundamental matrix), so it is only approximate.
-  // Refit it on all of its consistent correspondences to obtain an accurate
-  // dominant-plane homography; otherwise the off-plane classification below is
-  // polluted with plane points and the epipole recovery becomes unreliable.
+  // Refit it on all of its plane inliers to obtain an accurate dominant-plane
+  // homography; otherwise the off-plane classification below is polluted with
+  // plane points and the epipole recovery becomes unreliable.
   Eigen::Matrix3d H = seed_H;
   HomographyMatrixEstimator homography_estimator;
   std::vector<Eigen::Vector2d> plane_points1;
@@ -212,8 +236,7 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     plane_points1.clear();
     plane_points2.clear();
     for (size_t i = 0; i < points1.size(); ++i) {
-      if (ComputeSquaredHomographyError(points1[i], points2[i], H) <=
-          h_max_residual) {
+      if (TransferError(points1[i], points2[i], H) <= plane_max_residual) {
         plane_points1.push_back(points1[i]);
         plane_points2.push_back(points2[i]);
       }
@@ -230,12 +253,12 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     H = homographies[0];
   }
 
-  // Off-plane correspondences carry the parallax that constrains the epipole.
+  // Only correspondences well off the plane carry reliable parallax: near-plane
+  // points have tiny, noise-dominated parallax that destabilizes the epipole.
   std::vector<size_t> off_plane_idxs;
   off_plane_idxs.reserve(points1.size());
   for (size_t i = 0; i < points1.size(); ++i) {
-    if (ComputeSquaredHomographyError(points1[i], points2[i], H) >
-        h_max_residual) {
+    if (TransferError(points1[i], points2[i], H) > off_plane_min_residual) {
       off_plane_idxs.push_back(i);
     }
   }
@@ -283,6 +306,70 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     }
   }
 
+  if (!best_F.has_value()) {
+    return std::nullopt;
+  }
+
+  // Refine the recovered fundamental matrix by fitting the 8-point algorithm to
+  // mixed samples of plane and off-plane inliers, so the epipole is constrained
+  // by several off-plane points rather than just the two used above. Fitting on
+  // a balanced sample avoids the plane bias that a full-inlier fit would incur.
+  std::vector<size_t> plane_inliers;
+  std::vector<size_t> off_plane_inliers;
+  for (size_t i = 0; i < points1.size(); ++i) {
+    if (TransferError(points1[i], points2[i], H) <= plane_max_residual) {
+      plane_inliers.push_back(i);
+    }
+  }
+  ComputeSquaredSampsonError(points1, points2, *best_F, &residuals);
+  for (size_t i = 0; i < points1.size(); ++i) {
+    if (residuals[i] <= sampson_max_residual &&
+        TransferError(points1[i], points2[i], H) > off_plane_min_residual) {
+      off_plane_inliers.push_back(i);
+    }
+  }
+
+  constexpr size_t kNumPlaneSample = 6;
+  constexpr size_t kMaxNumOffPlaneSample = 4;
+  if (plane_inliers.size() >= kNumPlaneSample &&
+      off_plane_inliers.size() >= 2) {
+    const size_t num_off_sample =
+        std::min(kMaxNumOffPlaneSample, off_plane_inliers.size());
+    FundamentalMatrixEightPointEstimator eight_point;
+    std::vector<Eigen::Vector2d> sample_points1;
+    std::vector<Eigen::Vector2d> sample_points2;
+    std::vector<Eigen::Matrix3d> refined_models;
+    constexpr int kNumRefineTrials = 15;
+    for (int trial = 0; trial < kNumRefineTrials; ++trial) {
+      SampleDistinct(kNumPlaneSample, &plane_inliers);
+      SampleDistinct(num_off_sample, &off_plane_inliers);
+      sample_points1.clear();
+      sample_points2.clear();
+      for (size_t i = 0; i < kNumPlaneSample; ++i) {
+        sample_points1.push_back(points1[plane_inliers[i]]);
+        sample_points2.push_back(points2[plane_inliers[i]]);
+      }
+      for (size_t i = 0; i < num_off_sample; ++i) {
+        sample_points1.push_back(points1[off_plane_inliers[i]]);
+        sample_points2.push_back(points2[off_plane_inliers[i]]);
+      }
+
+      refined_models.clear();
+      eight_point.Estimate(sample_points1, sample_points2, &refined_models);
+      if (refined_models.empty()) {
+        continue;
+      }
+      ComputeSquaredSampsonError(
+          points1, points2, refined_models[0], &residuals);
+      const auto support =
+          support_measurer.Evaluate(residuals, sampson_max_residual);
+      if (support_measurer.IsLeftBetter(support, best_support)) {
+        best_support = support;
+        best_F = refined_models[0];
+      }
+    }
+  }
+
   return best_F;
 }
 
@@ -290,13 +377,15 @@ FundamentalMatrixDegensacEstimator::FundamentalMatrixDegensacEstimator(
     const std::vector<Eigen::Vector2d>* points1,
     const std::vector<Eigen::Vector2d>* points2,
     const double sampson_max_residual,
-    const double h_max_residual,
+    const double plane_max_residual,
+    const double off_plane_min_residual,
     const double min_sample_h_inlier_ratio,
     const int max_plane_parallax_trials)
     : points1_(THROW_CHECK_NOTNULL(points1)),
       points2_(THROW_CHECK_NOTNULL(points2)),
       sampson_max_residual_(sampson_max_residual),
-      h_max_residual_(h_max_residual),
+      plane_max_residual_(plane_max_residual),
+      off_plane_min_residual_(off_plane_min_residual),
       min_sample_h_inlier_ratio_(min_sample_h_inlier_ratio),
       max_plane_parallax_trials_(max_plane_parallax_trials) {}
 
@@ -326,7 +415,7 @@ void FundamentalMatrixDegensacEstimator::Estimate(
         DetectSampleHDegeneracy(sample_model,
                                 sample_points1,
                                 sample_points2,
-                                h_max_residual_,
+                                plane_max_residual_,
                                 min_sample_h_inlier_ratio_);
     if (!plane_H.has_value()) {
       // Non-degenerate sample: keep the fitted hypothesis as-is.
@@ -340,7 +429,8 @@ void FundamentalMatrixDegensacEstimator::Estimate(
                                         *points1_,
                                         *points2_,
                                         sampson_max_residual_,
-                                        h_max_residual_,
+                                        plane_max_residual_,
+                                        off_plane_min_residual_,
                                         max_plane_parallax_trials_);
     if (completed_model.has_value()) {
       models->push_back(*completed_model);
@@ -363,10 +453,18 @@ EstimateFundamentalMatrixDegensac(
     const FundamentalMatrixDegensacOptions& options) {
   const double sampson_max_residual =
       options.ransac.max_error * options.ransac.max_error;
-  const double h_max_error = options.h_consistency_max_error > 0
-                                 ? options.h_consistency_max_error
-                                 : options.ransac.max_error;
-  const double h_max_residual = h_max_error * h_max_error;
+  // A correspondence counts as on the dominant plane within a looser margin
+  // than the inlier threshold; only points well off the plane serve as
+  // parallax.
+  const double plane_max_error =
+      options.plane_max_error > 0 ? options.plane_max_error
+                                  : std::sqrt(3.0) * options.ransac.max_error;
+  const double off_plane_min_error = options.off_plane_min_error > 0
+                                         ? options.off_plane_min_error
+                                         : 10.0 * options.ransac.max_error;
+  const double plane_max_residual = plane_max_error * plane_max_error;
+  const double off_plane_min_residual =
+      off_plane_min_error * off_plane_min_error;
 
   // The DEGENSAC estimator is used as BOTH the hypothesis and the
   // local-optimization solver, so the local optimization also applies the
@@ -375,7 +473,8 @@ EstimateFundamentalMatrixDegensac(
       &points1,
       &points2,
       sampson_max_residual,
-      h_max_residual,
+      plane_max_residual,
+      off_plane_min_residual,
       options.min_sample_h_inlier_ratio,
       options.max_plane_parallax_trials);
   LORANSAC<FundamentalMatrixDegensacEstimator,

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -41,6 +41,7 @@
 #include <array>
 #include <cmath>
 #include <optional>
+#include <utility>
 
 #include <Eigen/Geometry>
 #include <Eigen/LU>
@@ -236,9 +237,7 @@ void SampleDistinct(size_t num, std::vector<size_t>* scratch) {
   const size_t n = scratch->size();
   for (size_t i = 0; i < num; ++i) {
     const size_t j = i + RandomUniformInteger<size_t>(0, n - 1 - i);
-    const size_t tmp = (*scratch)[i];
-    (*scratch)[i] = (*scratch)[j];
-    (*scratch)[j] = tmp;
+    std::swap((*scratch)[i], (*scratch)[j]);
   }
 }
 
@@ -299,12 +298,20 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     H = homographies[0];
   }
 
+  // The dominant-plane homography is now fixed, so the transfer error of every
+  // correspondence against it is reused below (off-plane classification here and
+  // the plane/off-plane split for the mixed-sample refit) instead of recomputed.
+  std::vector<double> plane_transfer_errors(points1.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    plane_transfer_errors[i] = TransferError(points1[i], points2[i], H);
+  }
+
   // Only correspondences well off the plane carry reliable parallax: near-plane
   // points have tiny, noise-dominated parallax that destabilizes the epipole.
   std::vector<size_t> off_plane_idxs;
   off_plane_idxs.reserve(points1.size());
   for (size_t i = 0; i < points1.size(); ++i) {
-    if (TransferError(points1[i], points2[i], H) > off_plane_min_residual) {
+    if (plane_transfer_errors[i] > off_plane_min_residual) {
       off_plane_idxs.push_back(i);
     }
   }
@@ -378,14 +385,14 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
   std::vector<size_t> plane_inliers;
   std::vector<size_t> off_plane_inliers;
   for (size_t i = 0; i < points1.size(); ++i) {
-    if (TransferError(points1[i], points2[i], H) <= plane_max_residual) {
+    if (plane_transfer_errors[i] <= plane_max_residual) {
       plane_inliers.push_back(i);
     }
   }
   ComputeSquaredSampsonError(points1, points2, *best_F, &residuals);
   for (size_t i = 0; i < points1.size(); ++i) {
     if (residuals[i] <= sampson_max_residual &&
-        TransferError(points1[i], points2[i], H) > off_plane_min_residual) {
+        plane_transfer_errors[i] > off_plane_min_residual) {
       off_plane_inliers.push_back(i);
     }
   }

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -1,0 +1,362 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/estimators/fundamental_matrix_degensac.h"
+
+#include "colmap/estimators/solvers/homography_matrix.h"
+#include "colmap/geometry/essential_matrix.h"
+#include "colmap/geometry/homography_matrix.h"
+#include "colmap/geometry/rigid3.h"
+#include "colmap/math/random.h"
+#include "colmap/optim/loransac.h"
+#include "colmap/util/logging.h"
+
+#include <array>
+#include <optional>
+
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+#include <Eigen/SVD>
+
+namespace colmap {
+namespace {
+
+// All C(7,3) = 35 triplets of the seven minimal-sample indices. Enumerated once
+// so the sample degeneracy test does not recompute them per hypothesis.
+constexpr int kNumSampleTriplets = 35;
+constexpr std::array<std::array<int, 3>, kNumSampleTriplets> kSampleTriplets = {
+    {
+        {0, 1, 2}, {0, 1, 3}, {0, 1, 4}, {0, 1, 5}, {0, 1, 6}, {0, 2, 3},
+        {0, 2, 4}, {0, 2, 5}, {0, 2, 6}, {0, 3, 4}, {0, 3, 5}, {0, 3, 6},
+        {0, 4, 5}, {0, 4, 6}, {0, 5, 6}, {1, 2, 3}, {1, 2, 4}, {1, 2, 5},
+        {1, 2, 6}, {1, 3, 4}, {1, 3, 5}, {1, 3, 6}, {1, 4, 5}, {1, 4, 6},
+        {1, 5, 6}, {2, 3, 4}, {2, 3, 5}, {2, 3, 6}, {2, 4, 5}, {2, 4, 6},
+        {2, 5, 6}, {3, 4, 5}, {3, 4, 6}, {3, 5, 6}, {4, 5, 6},
+    }};
+
+}  // namespace
+
+Eigen::Vector3d EpipoleFromFundamentalMatrix(const Eigen::Matrix3d& F) {
+  // The left epipole e2 satisfies F^T e2 = 0, i.e. it is the left null vector
+  // of F and thus the last left singular vector (last column of U).
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(F, Eigen::ComputeFullU);
+  return svd.matrixU().col(2).normalized();
+}
+
+std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
+    const Eigen::Matrix3d& F,
+    const Eigen::Vector3d& epipole2,
+    const std::array<Eigen::Vector2d, 3>& points1,
+    const std::array<Eigen::Vector2d, 3>& points2) {
+  // A = [e2]_x F is a particular homography compatible with F (H&Z
+  // Result 13.6).
+  const Eigen::Matrix3d A = CrossProductMatrix(epipole2) * F;
+
+  Eigen::Matrix3d M;
+  Eigen::Vector3d b;
+  for (int i = 0; i < 3; ++i) {
+    const Eigen::Vector3d x1 = points1[i].homogeneous();
+    const Eigen::Vector3d x2 = points2[i].homogeneous();
+    const Eigen::Vector3d x2_cross_e2 = x2.cross(epipole2);
+    const double denom = x2_cross_e2.squaredNorm();
+    if (denom < 1e-12) {
+      // The point lies (near) the epipole, so the transfer is undefined.
+      return std::nullopt;
+    }
+    b(i) = x2.cross(A * x1).dot(x2_cross_e2) / denom;
+    M.row(i) = x1.transpose();
+  }
+
+  // Reject collinear first-image points, for which M is singular.
+  Eigen::FullPivLU<Eigen::Matrix3d> lu(M);
+  if (!lu.isInvertible()) {
+    return std::nullopt;
+  }
+
+  const Eigen::Vector3d Minv_b = lu.solve(b);
+  return A - epipole2 * Minv_b.transpose();
+}
+
+std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
+    const Eigen::Matrix3d& F,
+    const std::vector<Eigen::Vector2d>& sample_points1,
+    const std::vector<Eigen::Vector2d>& sample_points2,
+    const double h_max_residual,
+    const int min_sample_h_inliers) {
+  THROW_CHECK_EQ(sample_points1.size(), 7);
+  THROW_CHECK_EQ(sample_points2.size(), 7);
+
+  const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+
+  int best_num_consistent = min_sample_h_inliers - 1;
+  std::optional<Eigen::Matrix3d> best_H;
+  for (const auto& triplet : kSampleTriplets) {
+    const std::array<Eigen::Vector2d, 3> tri_points1 = {
+        sample_points1[triplet[0]],
+        sample_points1[triplet[1]],
+        sample_points1[triplet[2]]};
+    const std::array<Eigen::Vector2d, 3> tri_points2 = {
+        sample_points2[triplet[0]],
+        sample_points2[triplet[1]],
+        sample_points2[triplet[2]]};
+
+    const std::optional<Eigen::Matrix3d> H = HomographyFromFundamentalAndPoints(
+        F, epipole2, tri_points1, tri_points2);
+    if (!H.has_value()) {
+      continue;
+    }
+
+    int num_consistent = 0;
+    for (size_t i = 0; i < sample_points1.size(); ++i) {
+      if (ComputeSquaredHomographyError(
+              sample_points1[i], sample_points2[i], *H) <= h_max_residual) {
+        ++num_consistent;
+      }
+    }
+    if (num_consistent > best_num_consistent) {
+      best_num_consistent = num_consistent;
+      best_H = H;
+    }
+  }
+
+  return best_H;
+}
+
+bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
+                         const std::vector<Eigen::Vector2d>& sample_points1,
+                         const std::vector<Eigen::Vector2d>& sample_points2,
+                         const double h_max_residual,
+                         const int min_sample_h_inliers) {
+  return DetectSampleHDegeneracy(F,
+                                 sample_points1,
+                                 sample_points2,
+                                 h_max_residual,
+                                 min_sample_h_inliers)
+      .has_value();
+}
+
+std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
+    const Eigen::Matrix3d& seed_H,
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2,
+    const double sampson_max_residual,
+    const double h_max_residual,
+    const int max_trials) {
+  THROW_CHECK_EQ(points1.size(), points2.size());
+
+  // The seed homography is built from only three sample correspondences (via
+  // the plane-corrupted sample fundamental matrix), so it is only approximate.
+  // Refit it on all of its consistent correspondences to obtain an accurate
+  // dominant-plane homography; otherwise the off-plane classification below is
+  // polluted with plane points and the epipole recovery becomes unreliable.
+  Eigen::Matrix3d H = seed_H;
+  HomographyMatrixEstimator homography_estimator;
+  std::vector<Eigen::Vector2d> plane_points1;
+  std::vector<Eigen::Vector2d> plane_points2;
+  std::vector<Eigen::Matrix3d> homographies;
+  constexpr int kNumRefitIters = 2;
+  for (int iter = 0; iter < kNumRefitIters; ++iter) {
+    plane_points1.clear();
+    plane_points2.clear();
+    for (size_t i = 0; i < points1.size(); ++i) {
+      if (ComputeSquaredHomographyError(points1[i], points2[i], H) <=
+          h_max_residual) {
+        plane_points1.push_back(points1[i]);
+        plane_points2.push_back(points2[i]);
+      }
+    }
+    if (plane_points1.size() <
+        static_cast<size_t>(HomographyMatrixEstimator::kMinNumSamples)) {
+      break;
+    }
+    homographies.clear();
+    homography_estimator.Estimate(plane_points1, plane_points2, &homographies);
+    if (homographies.empty()) {
+      break;
+    }
+    H = homographies[0];
+  }
+
+  // Off-plane correspondences carry the parallax that constrains the epipole.
+  std::vector<size_t> off_plane_idxs;
+  off_plane_idxs.reserve(points1.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    if (ComputeSquaredHomographyError(points1[i], points2[i], H) >
+        h_max_residual) {
+      off_plane_idxs.push_back(i);
+    }
+  }
+  if (off_plane_idxs.size() < 2) {
+    return std::nullopt;
+  }
+
+  // Precompute the transferred plane points H * x1 for the off-plane
+  // candidates.
+  std::vector<Eigen::Vector3d> lines(off_plane_idxs.size());
+  for (size_t i = 0; i < off_plane_idxs.size(); ++i) {
+    const size_t idx = off_plane_idxs[i];
+    lines[i] = points2[idx].homogeneous().cross(H * points1[idx].homogeneous());
+  }
+
+  InlierSupportMeasurer support_measurer;
+  InlierSupportMeasurer::Support best_support;
+  std::optional<Eigen::Matrix3d> best_F;
+  std::vector<double> residuals;
+
+  const size_t num_off_plane = off_plane_idxs.size();
+  const size_t num_pairs = num_off_plane * (num_off_plane - 1) / 2;
+  const size_t num_trials =
+      std::min<size_t>(static_cast<size_t>(std::max(max_trials, 1)), num_pairs);
+  for (size_t trial = 0; trial < num_trials; ++trial) {
+    size_t a = RandomUniformInteger<size_t>(0, num_off_plane - 1);
+    size_t b = RandomUniformInteger<size_t>(0, num_off_plane - 1);
+    if (a == b) {
+      b = (b + 1) % num_off_plane;
+    }
+
+    // The epipole is the intersection of the two parallax lines.
+    const Eigen::Vector3d epipole2 = lines[a].cross(lines[b]);
+    if (epipole2.norm() < 1e-9) {
+      continue;
+    }
+    const Eigen::Matrix3d F = CrossProductMatrix(epipole2.normalized()) * H;
+
+    ComputeSquaredSampsonError(points1, points2, F, &residuals);
+    const auto support =
+        support_measurer.Evaluate(residuals, sampson_max_residual);
+    if (support_measurer.IsLeftBetter(support, best_support)) {
+      best_support = support;
+      best_F = F;
+    }
+  }
+
+  return best_F;
+}
+
+FundamentalMatrixDegensacEstimator::FundamentalMatrixDegensacEstimator(
+    const std::vector<Eigen::Vector2d>* points1,
+    const std::vector<Eigen::Vector2d>* points2,
+    const double sampson_max_residual,
+    const double h_max_residual,
+    const int min_sample_h_inliers,
+    const int max_plane_parallax_trials)
+    : points1_(THROW_CHECK_NOTNULL(points1)),
+      points2_(THROW_CHECK_NOTNULL(points2)),
+      sampson_max_residual_(sampson_max_residual),
+      h_max_residual_(h_max_residual),
+      min_sample_h_inliers_(min_sample_h_inliers),
+      max_plane_parallax_trials_(max_plane_parallax_trials) {}
+
+void FundamentalMatrixDegensacEstimator::Estimate(
+    const std::vector<X_t>& sample_points1,
+    const std::vector<Y_t>& sample_points2,
+    std::vector<M_t>* models) const {
+  THROW_CHECK(models != nullptr);
+
+  std::vector<M_t> sample_models;
+  FundamentalMatrixSevenPointEstimator::Estimate(
+      sample_points1, sample_points2, &sample_models);
+
+  models->clear();
+  models->reserve(sample_models.size());
+  for (const auto& sample_model : sample_models) {
+    const std::optional<Eigen::Matrix3d> plane_H =
+        DetectSampleHDegeneracy(sample_model,
+                                sample_points1,
+                                sample_points2,
+                                h_max_residual_,
+                                min_sample_h_inliers_);
+    if (!plane_H.has_value()) {
+      // Non-degenerate sample: keep the minimal-solver hypothesis as-is.
+      models->push_back(sample_model);
+      continue;
+    }
+    // H-degenerate sample: replace the plane-corrupted hypothesis by a
+    // plane-and-parallax completion, or drop it if there is no usable parallax.
+    const std::optional<Eigen::Matrix3d> completed_model =
+        FundamentalFromPlaneAndParallax(*plane_H,
+                                        *points1_,
+                                        *points2_,
+                                        sampson_max_residual_,
+                                        h_max_residual_,
+                                        max_plane_parallax_trials_);
+    if (completed_model.has_value()) {
+      models->push_back(*completed_model);
+    }
+  }
+}
+
+void FundamentalMatrixDegensacEstimator::Residuals(
+    const std::vector<X_t>& points1,
+    const std::vector<Y_t>& points2,
+    const M_t& F,
+    std::vector<double>* residuals) const {
+  ComputeSquaredSampsonError(points1, points2, F, residuals);
+}
+
+FundamentalMatrixDegensac::FundamentalMatrixDegensac(Options options)
+    : options_(options) {
+  options_.ransac.Check();
+}
+
+FundamentalMatrixDegensac::Report FundamentalMatrixDegensac::Estimate(
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2) {
+  const double sampson_max_residual =
+      options_.ransac.max_error * options_.ransac.max_error;
+  const double h_max_error = options_.h_consistency_max_error > 0
+                                 ? options_.h_consistency_max_error
+                                 : options_.ransac.max_error;
+  const double h_max_residual = h_max_error * h_max_error;
+
+  // Inject the DEGENSAC minimal solver into LO-RANSAC, using the 8-point solver
+  // as the local optimizer, mirroring the plain fundamental matrix estimation.
+  FundamentalMatrixDegensacEstimator estimator(
+      &points1,
+      &points2,
+      sampson_max_residual,
+      h_max_residual,
+      options_.min_sample_h_inliers,
+      options_.max_plane_parallax_trials);
+  LORANSAC<FundamentalMatrixDegensacEstimator,
+           FundamentalMatrixEightPointEstimator>
+      ransac(options_.ransac, estimator);
+  const auto ransac_report = ransac.Estimate(points1, points2);
+
+  // Copy into the stable, estimator-agnostic report type.
+  Report report;
+  report.success = ransac_report.success;
+  report.num_trials = ransac_report.num_trials;
+  report.support = ransac_report.support;
+  report.inlier_mask = ransac_report.inlier_mask;
+  report.model = ransac_report.model;
+  return report;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -299,8 +299,9 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
   }
 
   // The dominant-plane homography is now fixed, so the transfer error of every
-  // correspondence against it is reused below (off-plane classification here and
-  // the plane/off-plane split for the mixed-sample refit) instead of recomputed.
+  // correspondence against it is reused below (off-plane classification here
+  // and the plane/off-plane split for the mixed-sample refit) instead of
+  // recomputed.
   std::vector<double> plane_transfer_errors(points1.size());
   for (size_t i = 0; i < points1.size(); ++i) {
     plane_transfer_errors[i] = TransferError(points1[i], points2[i], H);

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/fundamental_matrix_degensac.h"
 
+#include "colmap/estimators/solvers/fundamental_matrix.h"
 #include "colmap/estimators/solvers/homography_matrix.h"
 #include "colmap/geometry/essential_matrix.h"
 #include "colmap/geometry/homography_matrix.h"
@@ -38,6 +39,7 @@
 #include "colmap/util/logging.h"
 
 #include <array>
+#include <cmath>
 #include <optional>
 
 #include <Eigen/Geometry>
@@ -59,6 +61,10 @@ constexpr std::array<std::array<int, 3>, kNumSampleTriplets> kSampleTriplets = {
         {1, 5, 6}, {2, 3, 4}, {2, 3, 5}, {2, 3, 6}, {2, 4, 5}, {2, 4, 6},
         {2, 5, 6}, {3, 4, 5}, {3, 4, 6}, {3, 5, 6}, {4, 5, 6},
     }};
+
+// Number of triplets randomly sampled from a non-minimal sample when searching
+// for the dominant plane (a minimal sample enumerates all 35 exhaustively).
+constexpr int kNumSampledTriplets = 50;
 
 }  // namespace
 
@@ -108,40 +114,61 @@ std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
     const std::vector<Eigen::Vector2d>& sample_points1,
     const std::vector<Eigen::Vector2d>& sample_points2,
     const double h_max_residual,
-    const int min_sample_h_inliers) {
-  THROW_CHECK_EQ(sample_points1.size(), 7);
-  THROW_CHECK_EQ(sample_points2.size(), 7);
+    const double min_sample_h_inlier_ratio) {
+  const size_t num_samples = sample_points1.size();
+  THROW_CHECK_EQ(sample_points1.size(), sample_points2.size());
+  THROW_CHECK_GE(num_samples, 3);
 
   const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+  const int min_consistent = std::max<int>(
+      3,
+      static_cast<int>(std::llround(min_sample_h_inlier_ratio * num_samples)));
 
-  int best_num_consistent = min_sample_h_inliers - 1;
+  int best_num_consistent = min_consistent - 1;
   std::optional<Eigen::Matrix3d> best_H;
-  for (const auto& triplet : kSampleTriplets) {
-    const std::array<Eigen::Vector2d, 3> tri_points1 = {
-        sample_points1[triplet[0]],
-        sample_points1[triplet[1]],
-        sample_points1[triplet[2]]};
-    const std::array<Eigen::Vector2d, 3> tri_points2 = {
-        sample_points2[triplet[0]],
-        sample_points2[triplet[1]],
-        sample_points2[triplet[2]]};
 
+  const auto evaluate_triplet = [&](int i, int j, int k) {
+    const std::array<Eigen::Vector2d, 3> tri_points1 = {
+        sample_points1[i], sample_points1[j], sample_points1[k]};
+    const std::array<Eigen::Vector2d, 3> tri_points2 = {
+        sample_points2[i], sample_points2[j], sample_points2[k]};
     const std::optional<Eigen::Matrix3d> H = HomographyFromFundamentalAndPoints(
         F, epipole2, tri_points1, tri_points2);
     if (!H.has_value()) {
-      continue;
+      return;
     }
-
     int num_consistent = 0;
-    for (size_t i = 0; i < sample_points1.size(); ++i) {
+    for (size_t p = 0; p < num_samples; ++p) {
       if (ComputeSquaredHomographyError(
-              sample_points1[i], sample_points2[i], *H) <= h_max_residual) {
+              sample_points1[p], sample_points2[p], *H) <= h_max_residual) {
         ++num_consistent;
       }
     }
     if (num_consistent > best_num_consistent) {
       best_num_consistent = num_consistent;
       best_H = H;
+    }
+  };
+
+  if (num_samples ==
+      static_cast<size_t>(FundamentalMatrixDegensacEstimator::kMinNumSamples)) {
+    // Minimal sample: exhaustively enumerate all triplets.
+    for (const auto& triplet : kSampleTriplets) {
+      evaluate_triplet(triplet[0], triplet[1], triplet[2]);
+    }
+  } else {
+    // Non-minimal sample (e.g. a local-optimization inlier set): sample
+    // triplets. On a plane-dominated sample most triplets lie on the plane, so
+    // a modest number reliably discovers it.
+    const int last = static_cast<int>(num_samples) - 1;
+    for (int t = 0; t < kNumSampledTriplets; ++t) {
+      const int i = RandomUniformInteger<int>(0, last);
+      const int j = RandomUniformInteger<int>(0, last);
+      const int k = RandomUniformInteger<int>(0, last);
+      if (i == j || j == k || i == k) {
+        continue;
+      }
+      evaluate_triplet(i, j, k);
     }
   }
 
@@ -152,12 +179,12 @@ bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
                          const std::vector<Eigen::Vector2d>& sample_points1,
                          const std::vector<Eigen::Vector2d>& sample_points2,
                          const double h_max_residual,
-                         const int min_sample_h_inliers) {
+                         const double min_sample_h_inlier_ratio) {
   return DetectSampleHDegeneracy(F,
                                  sample_points1,
                                  sample_points2,
                                  h_max_residual,
-                                 min_sample_h_inliers)
+                                 min_sample_h_inlier_ratio)
       .has_value();
 }
 
@@ -264,13 +291,13 @@ FundamentalMatrixDegensacEstimator::FundamentalMatrixDegensacEstimator(
     const std::vector<Eigen::Vector2d>* points2,
     const double sampson_max_residual,
     const double h_max_residual,
-    const int min_sample_h_inliers,
+    const double min_sample_h_inlier_ratio,
     const int max_plane_parallax_trials)
     : points1_(THROW_CHECK_NOTNULL(points1)),
       points2_(THROW_CHECK_NOTNULL(points2)),
       sampson_max_residual_(sampson_max_residual),
       h_max_residual_(h_max_residual),
-      min_sample_h_inliers_(min_sample_h_inliers),
+      min_sample_h_inlier_ratio_(min_sample_h_inlier_ratio),
       max_plane_parallax_trials_(max_plane_parallax_trials) {}
 
 void FundamentalMatrixDegensacEstimator::Estimate(
@@ -278,10 +305,19 @@ void FundamentalMatrixDegensacEstimator::Estimate(
     const std::vector<Y_t>& sample_points2,
     std::vector<M_t>* models) const {
   THROW_CHECK(models != nullptr);
+  THROW_CHECK_GE(sample_points1.size(), kMinNumSamples);
 
+  // Fit the fundamental matrix from the sample: the 7-point solver for a
+  // minimal sample (yielding up to three roots), the 8-point solver otherwise
+  // (e.g. the local-optimization inlier set).
   std::vector<M_t> sample_models;
-  FundamentalMatrixSevenPointEstimator::Estimate(
-      sample_points1, sample_points2, &sample_models);
+  if (sample_points1.size() == static_cast<size_t>(kMinNumSamples)) {
+    FundamentalMatrixSevenPointEstimator::Estimate(
+        sample_points1, sample_points2, &sample_models);
+  } else {
+    FundamentalMatrixEightPointEstimator::Estimate(
+        sample_points1, sample_points2, &sample_models);
+  }
 
   models->clear();
   models->reserve(sample_models.size());
@@ -291,9 +327,9 @@ void FundamentalMatrixDegensacEstimator::Estimate(
                                 sample_points1,
                                 sample_points2,
                                 h_max_residual_,
-                                min_sample_h_inliers_);
+                                min_sample_h_inlier_ratio_);
     if (!plane_H.has_value()) {
-      // Non-degenerate sample: keep the minimal-solver hypothesis as-is.
+      // Non-degenerate sample: keep the fitted hypothesis as-is.
       models->push_back(sample_model);
       continue;
     }
@@ -320,43 +356,32 @@ void FundamentalMatrixDegensacEstimator::Residuals(
   ComputeSquaredSampsonError(points1, points2, F, residuals);
 }
 
-FundamentalMatrixDegensac::FundamentalMatrixDegensac(Options options)
-    : options_(options) {
-  options_.ransac.Check();
-}
-
-FundamentalMatrixDegensac::Report FundamentalMatrixDegensac::Estimate(
+RANSAC<FundamentalMatrixDegensacEstimator>::Report
+EstimateFundamentalMatrixDegensac(
     const std::vector<Eigen::Vector2d>& points1,
-    const std::vector<Eigen::Vector2d>& points2) {
+    const std::vector<Eigen::Vector2d>& points2,
+    const FundamentalMatrixDegensacOptions& options) {
   const double sampson_max_residual =
-      options_.ransac.max_error * options_.ransac.max_error;
-  const double h_max_error = options_.h_consistency_max_error > 0
-                                 ? options_.h_consistency_max_error
-                                 : options_.ransac.max_error;
+      options.ransac.max_error * options.ransac.max_error;
+  const double h_max_error = options.h_consistency_max_error > 0
+                                 ? options.h_consistency_max_error
+                                 : options.ransac.max_error;
   const double h_max_residual = h_max_error * h_max_error;
 
-  // Inject the DEGENSAC minimal solver into LO-RANSAC, using the 8-point solver
-  // as the local optimizer, mirroring the plain fundamental matrix estimation.
+  // The DEGENSAC estimator is used as BOTH the hypothesis and the
+  // local-optimization solver, so the local optimization also applies the
+  // degeneracy handling instead of re-fitting a plane-corrupted model.
   FundamentalMatrixDegensacEstimator estimator(
       &points1,
       &points2,
       sampson_max_residual,
       h_max_residual,
-      options_.min_sample_h_inliers,
-      options_.max_plane_parallax_trials);
+      options.min_sample_h_inlier_ratio,
+      options.max_plane_parallax_trials);
   LORANSAC<FundamentalMatrixDegensacEstimator,
-           FundamentalMatrixEightPointEstimator>
-      ransac(options_.ransac, estimator);
-  const auto ransac_report = ransac.Estimate(points1, points2);
-
-  // Copy into the stable, estimator-agnostic report type.
-  Report report;
-  report.success = ransac_report.success;
-  report.num_trials = ransac_report.num_trials;
-  report.support = ransac_report.support;
-  report.inlier_mask = ransac_report.inlier_mask;
-  report.model = ransac_report.model;
-  return report;
+           FundamentalMatrixDegensacEstimator>
+      ransac(options.ransac, estimator, estimator);
+  return ransac.Estimate(points1, points2);
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_degensac.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac.cc
@@ -44,7 +44,6 @@
 
 #include <Eigen/Geometry>
 #include <Eigen/LU>
-#include <Eigen/SVD>
 
 namespace colmap {
 namespace {
@@ -69,21 +68,33 @@ constexpr int kNumSampledTriplets = 50;
 }  // namespace
 
 Eigen::Vector3d EpipoleFromFundamentalMatrix(const Eigen::Matrix3d& F) {
-  // The left epipole e2 satisfies F^T e2 = 0, i.e. it is the left null vector
-  // of F and thus the last left singular vector (last column of U).
-  Eigen::JacobiSVD<Eigen::Matrix3d> svd(F, Eigen::ComputeFullU);
-  return svd.matrixU().col(2).normalized();
+  // The epipole e2 is the left null vector (F^T e2 = 0), i.e. it is orthogonal
+  // to the column space of the rank-2 matrix F and thus parallel to the cross
+  // product of two of its columns. Using the column pair with the largest cross
+  // product is numerically stable and avoids a full SVD.
+  const Eigen::Vector3d e01 = F.col(0).cross(F.col(1));
+  const Eigen::Vector3d e02 = F.col(0).cross(F.col(2));
+  const Eigen::Vector3d e12 = F.col(1).cross(F.col(2));
+  const double n01 = e01.squaredNorm();
+  const double n02 = e02.squaredNorm();
+  const double n12 = e12.squaredNorm();
+  if (n01 >= n02 && n01 >= n12) {
+    return e01.normalized();
+  }
+  return n02 >= n12 ? e02.normalized() : e12.normalized();
 }
 
-std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
-    const Eigen::Matrix3d& F,
+namespace {
+
+// Plane-induced homography compatible with the epipolar geometry from three
+// correspondences (H&Z Result 13.6), given the precomputed A = [e2]_x F and the
+// epipole e2. Splitting this out lets the degeneracy test reuse A across all
+// triplets of a sample instead of recomputing it each time.
+std::optional<Eigen::Matrix3d> HomographyFromCompatible(
+    const Eigen::Matrix3d& A,
     const Eigen::Vector3d& epipole2,
     const std::array<Eigen::Vector2d, 3>& points1,
     const std::array<Eigen::Vector2d, 3>& points2) {
-  // A = [e2]_x F is a particular homography compatible with F (H&Z
-  // Result 13.6).
-  const Eigen::Matrix3d A = CrossProductMatrix(epipole2) * F;
-
   Eigen::Matrix3d M;
   Eigen::Vector3d b;
   for (int i = 0; i < 3; ++i) {
@@ -99,14 +110,28 @@ std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
     M.row(i) = x1.transpose();
   }
 
-  // Reject collinear first-image points, for which M is singular.
-  Eigen::FullPivLU<Eigen::Matrix3d> lu(M);
-  if (!lu.isInvertible()) {
+  // Reject collinear first-image points (scale-invariant singularity check),
+  // then solve with the closed-form 3x3 inverse.
+  const double det = M.determinant();
+  const double scale = M.row(0).norm() * M.row(1).norm() * M.row(2).norm();
+  if (scale < 1e-12 || std::abs(det) < 1e-9 * scale) {
     return std::nullopt;
   }
-
-  const Eigen::Vector3d Minv_b = lu.solve(b);
+  const Eigen::Vector3d Minv_b = M.inverse() * b;
   return A - epipole2 * Minv_b.transpose();
+}
+
+}  // namespace
+
+std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
+    const Eigen::Matrix3d& F,
+    const Eigen::Vector3d& epipole2,
+    const std::array<Eigen::Vector2d, 3>& points1,
+    const std::array<Eigen::Vector2d, 3>& points2) {
+  // A = [e2]_x F is a particular homography compatible with F (H&Z
+  // Result 13.6).
+  return HomographyFromCompatible(
+      CrossProductMatrix(epipole2) * F, epipole2, points1, points2);
 }
 
 std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
@@ -120,6 +145,8 @@ std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
   THROW_CHECK_GE(num_samples, 3);
 
   const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+  // A = [e2]_x F is shared by all triplets; compute it once.
+  const Eigen::Matrix3d A = CrossProductMatrix(epipole2) * F;
   const int min_consistent = std::max<int>(
       3,
       static_cast<int>(std::llround(min_sample_h_inlier_ratio * num_samples)));
@@ -127,15 +154,16 @@ std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
   int best_num_consistent = min_consistent - 1;
   std::optional<Eigen::Matrix3d> best_H;
 
+  // Returns true if all sample points are consistent (nothing left to improve).
   const auto evaluate_triplet = [&](int i, int j, int k) {
     const std::array<Eigen::Vector2d, 3> tri_points1 = {
         sample_points1[i], sample_points1[j], sample_points1[k]};
     const std::array<Eigen::Vector2d, 3> tri_points2 = {
         sample_points2[i], sample_points2[j], sample_points2[k]};
-    const std::optional<Eigen::Matrix3d> H = HomographyFromFundamentalAndPoints(
-        F, epipole2, tri_points1, tri_points2);
+    const std::optional<Eigen::Matrix3d> H =
+        HomographyFromCompatible(A, epipole2, tri_points1, tri_points2);
     if (!H.has_value()) {
-      return;
+      return false;
     }
     int num_consistent = 0;
     for (size_t p = 0; p < num_samples; ++p) {
@@ -148,13 +176,16 @@ std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
       best_num_consistent = num_consistent;
       best_H = H;
     }
+    return best_num_consistent >= static_cast<int>(num_samples);
   };
 
   if (num_samples ==
       static_cast<size_t>(FundamentalMatrixDegensacEstimator::kMinNumSamples)) {
     // Minimal sample: exhaustively enumerate all triplets.
     for (const auto& triplet : kSampleTriplets) {
-      evaluate_triplet(triplet[0], triplet[1], triplet[2]);
+      if (evaluate_triplet(triplet[0], triplet[1], triplet[2])) {
+        break;
+      }
     }
   } else {
     // Non-minimal sample (e.g. a local-optimization inlier set): sample
@@ -168,7 +199,9 @@ std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
       if (i == j || j == k || i == k) {
         continue;
       }
-      evaluate_triplet(i, j, k);
+      if (evaluate_triplet(i, j, k)) {
+        break;
+      }
     }
   }
 
@@ -228,22 +261,35 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
   // plane points and the epipole recovery becomes unreliable.
   Eigen::Matrix3d H = seed_H;
   HomographyMatrixEstimator homography_estimator;
+  std::vector<size_t> plane_idxs;
   std::vector<Eigen::Vector2d> plane_points1;
   std::vector<Eigen::Vector2d> plane_points2;
   std::vector<Eigen::Matrix3d> homographies;
   constexpr int kNumRefitIters = 2;
+  // A homography is well determined by a modest, spatially spread subset, so
+  // cap the number of correspondences used for the DLT to avoid an O(N) SVD
+  // when the dominant plane has many inliers.
+  constexpr size_t kMaxHomographyFitPoints = 64;
   for (int iter = 0; iter < kNumRefitIters; ++iter) {
-    plane_points1.clear();
-    plane_points2.clear();
+    plane_idxs.clear();
     for (size_t i = 0; i < points1.size(); ++i) {
       if (TransferError(points1[i], points2[i], H) <= plane_max_residual) {
-        plane_points1.push_back(points1[i]);
-        plane_points2.push_back(points2[i]);
+        plane_idxs.push_back(i);
       }
     }
-    if (plane_points1.size() <
+    if (plane_idxs.size() <
         static_cast<size_t>(HomographyMatrixEstimator::kMinNumSamples)) {
       break;
+    }
+    const size_t num_fit = std::min(kMaxHomographyFitPoints, plane_idxs.size());
+    if (plane_idxs.size() > num_fit) {
+      SampleDistinct(num_fit, &plane_idxs);
+    }
+    plane_points1.clear();
+    plane_points2.clear();
+    for (size_t i = 0; i < num_fit; ++i) {
+      plane_points1.push_back(points1[plane_idxs[i]]);
+      plane_points2.push_back(points2[plane_idxs[i]]);
     }
     homographies.clear();
     homography_estimator.Estimate(plane_points1, plane_points2, &homographies);
@@ -266,20 +312,29 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     return std::nullopt;
   }
 
-  // Precompute the transferred plane points H * x1 for the off-plane
-  // candidates.
-  std::vector<Eigen::Vector3d> lines(off_plane_idxs.size());
-  for (size_t i = 0; i < off_plane_idxs.size(); ++i) {
+  // Precompute the transferred plane points H * x1 and the off-plane points, so
+  // the epipole search below scores over only the off-plane subset.
+  const size_t num_off_plane = off_plane_idxs.size();
+  std::vector<Eigen::Vector3d> lines(num_off_plane);
+  std::vector<Eigen::Vector2d> off_points1(num_off_plane);
+  std::vector<Eigen::Vector2d> off_points2(num_off_plane);
+  for (size_t i = 0; i < num_off_plane; ++i) {
     const size_t idx = off_plane_idxs[i];
     lines[i] = points2[idx].homogeneous().cross(H * points1[idx].homogeneous());
+    off_points1[i] = points1[idx];
+    off_points2[i] = points2[idx];
   }
 
   InlierSupportMeasurer support_measurer;
-  InlierSupportMeasurer::Support best_support;
-  std::optional<Eigen::Matrix3d> best_F;
   std::vector<double> residuals;
 
-  const size_t num_off_plane = off_plane_idxs.size();
+  // Plane correspondences are consistent with F = [e2]_x H for ANY epipole e2
+  // (x2^T [e2]_x H x1 ~ x2^T [e2]_x x2 = 0 when H x1 ~ x2), so among the
+  // F = [e2]_x H candidates only the off-plane correspondences discriminate.
+  // Scoring epipole candidates over just the off-plane subset ranks them
+  // correctly at a fraction of the cost of scoring all correspondences.
+  InlierSupportMeasurer::Support best_off_support;
+  std::optional<Eigen::Matrix3d> best_F;
   const size_t num_pairs = num_off_plane * (num_off_plane - 1) / 2;
   const size_t num_trials =
       std::min<size_t>(static_cast<size_t>(std::max(max_trials, 1)), num_pairs);
@@ -297,11 +352,11 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     }
     const Eigen::Matrix3d F = CrossProductMatrix(epipole2.normalized()) * H;
 
-    ComputeSquaredSampsonError(points1, points2, F, &residuals);
+    ComputeSquaredSampsonError(off_points1, off_points2, F, &residuals);
     const auto support =
         support_measurer.Evaluate(residuals, sampson_max_residual);
-    if (support_measurer.IsLeftBetter(support, best_support)) {
-      best_support = support;
+    if (support_measurer.IsLeftBetter(support, best_off_support)) {
+      best_off_support = support;
       best_F = F;
     }
   }
@@ -309,6 +364,12 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
   if (!best_F.has_value()) {
     return std::nullopt;
   }
+
+  // Seed the full-data support of the best epipole candidate, against which the
+  // mixed-sample refinement below is compared.
+  ComputeSquaredSampsonError(points1, points2, *best_F, &residuals);
+  InlierSupportMeasurer::Support best_support =
+      support_measurer.Evaluate(residuals, sampson_max_residual);
 
   // Refine the recovered fundamental matrix by fitting the 8-point algorithm to
   // mixed samples of plane and off-plane inliers, so the epipole is constrained

--- a/src/colmap/estimators/fundamental_matrix_degensac.h
+++ b/src/colmap/estimators/fundamental_matrix_degensac.h
@@ -85,8 +85,14 @@ class FundamentalMatrixDegensacEstimator {
   // @param sampson_max_residual     Squared max Sampson error used when scoring
   //                                 completion candidates (typically the RANSAC
   //                                 max_error squared).
-  // @param h_max_residual           Squared max transfer error for
-  //                                 H-consistency.
+  // @param plane_max_residual       Squared max transfer error for a
+  //                                 correspondence to count as lying on the
+  //                                 dominant plane (degeneracy detection and
+  //                                 homography refit).
+  // @param off_plane_min_residual   Squared min transfer error for a
+  //                                 correspondence to be used as an off-plane
+  //                                 parallax source when recovering the
+  //                                 epipole.
   // @param min_sample_h_inlier_ratio Fraction of a sample that must be
   //                                 consistent with a single plane homography
   //                                 for the sample to be H-degenerate.
@@ -95,7 +101,8 @@ class FundamentalMatrixDegensacEstimator {
       const std::vector<Eigen::Vector2d>* points1,
       const std::vector<Eigen::Vector2d>* points2,
       double sampson_max_residual,
-      double h_max_residual,
+      double plane_max_residual,
+      double off_plane_min_residual,
       double min_sample_h_inlier_ratio,
       int max_plane_parallax_trials);
 
@@ -117,7 +124,8 @@ class FundamentalMatrixDegensacEstimator {
   const std::vector<Eigen::Vector2d>* points1_;
   const std::vector<Eigen::Vector2d>* points2_;
   double sampson_max_residual_;
-  double h_max_residual_;
+  double plane_max_residual_;
+  double off_plane_min_residual_;
   double min_sample_h_inlier_ratio_;
   int max_plane_parallax_trials_;
 };
@@ -128,10 +136,19 @@ struct FundamentalMatrixDegensacOptions {
   // since Sampson residuals are squared errors.
   RANSACOptions ransac;
 
-  // Maximum pixel error for a sample correspondence to be considered consistent
-  // with a candidate plane homography during the sample degeneracy test.
-  // Squared internally. If <= 0, falls back to `ransac.max_error`.
-  double h_consistency_max_error = -1;
+  // Maximum pixel error for a correspondence to count as lying on the dominant
+  // plane, used for the degeneracy test and the homography refit. Squared
+  // internally. Deliberately looser than the inlier threshold so noisy plane
+  // points are still recognized as coplanar. If <= 0, derived as
+  // sqrt(3) * ransac.max_error (i.e. 3x in squared-pixel units).
+  double plane_max_error = -1;
+
+  // Minimum pixel error for a correspondence to be used as an off-plane
+  // parallax source when recovering the epipole. Squared internally.
+  // Deliberately much larger than the inlier threshold so only clean,
+  // high-parallax points constrain the epipole (near-plane, low-parallax points
+  // are ignored). If <= 0, derived as 10 * ransac.max_error (100x squared).
+  double off_plane_min_error = -1;
 
   // Fraction of a sample that must be consistent with a single plane homography
   // for the sample to be considered H-degenerate. The default corresponds to
@@ -201,12 +218,16 @@ bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
 
 // Recover the fundamental matrix from a dominant plane homography and the
 // off-plane parallax (plane-and-parallax model completion). The seed homography
-// is refit on its inlier correspondences; then correspondences whose squared
-// forward transfer error under the refit H exceeds `h_max_residual` are treated
-// as off-plane candidates, and the epipole is recovered from a pair of them as
+// is refit on its plane inliers (squared transfer error <=
+// `plane_max_residual`); then correspondences whose squared transfer error
+// exceeds `off_plane_min_residual` are treated as clean off-plane parallax
+// sources, and the epipole is recovered from a pair of them as
 // e2 = (x2_a x H x1_a) x (x2_b x H x1_b), giving F = [e2]_x H. Pairs are
-// sampled robustly and the F with the largest squared-Sampson support
-// (threshold `sampson_max_residual`) over all correspondences is returned.
+// sampled robustly and the best F is then refined by fitting the 8-point
+// algorithm to mixed samples of plane and off-plane inliers (so the epipole is
+// constrained by more than two off-plane points). The F with the largest
+// squared-Sampson support (threshold `sampson_max_residual`) over all
+// correspondences is returned.
 //
 // @return  The recovered fundamental matrix, or nullopt if there are too few
 //          off-plane correspondences.
@@ -215,7 +236,8 @@ std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
     const std::vector<Eigen::Vector2d>& points1,
     const std::vector<Eigen::Vector2d>& points2,
     double sampson_max_residual,
-    double h_max_residual,
+    double plane_max_residual,
+    double off_plane_min_residual,
     int max_trials);
 
 }  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_degensac.h
+++ b/src/colmap/estimators/fundamental_matrix_degensac.h
@@ -1,0 +1,259 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/estimators/solvers/fundamental_matrix.h"
+#include "colmap/optim/random_sampler.h"
+#include "colmap/optim/ransac.h"
+#include "colmap/optim/support_measurement.h"
+#include "colmap/util/eigen_alignment.h"
+
+#include <array>
+#include <optional>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace colmap {
+
+// DEGENSAC-based fundamental matrix estimation, robust to a dominant scene
+// plane. Based on the following paper:
+//
+//    Ondrej Chum, Tomas Werner, Jiri Matas, "Two-View Geometry Estimation
+//    Unaffected by a Dominant Plane", CVPR 2005.
+//    https://cmp.felk.cvut.cz/~werner/papers/chum-degen-cvpr05.pdf
+//
+// When the scene contains a dominant plane, a random 7-point minimal sample
+// frequently contains five or more coplanar correspondences. The fundamental
+// matrix computed from such an H-degenerate sample is compatible with the plane
+// homography but its epipole is essentially unconstrained, yet it can still
+// accrue high inlier support (all plane points fit it). The recovered epipolar
+// geometry is then wrong even though RANSAC reports a confident result.
+//
+// This detects H-degenerate minimal samples during RANSAC and, instead of
+// accepting the plane-corrupted model, completes it using plane-and-parallax:
+// the dominant plane homography is refit on the H-consistent data and the
+// epipole (hence the fundamental matrix) is recovered from the off-plane
+// parallax. The completed model explains both the plane and the off-plane
+// points, so it wins on support. If no usable off-plane parallax exists (i.e.
+// the configuration is genuinely degenerate), the sample is rejected.
+//
+// The DEGENSAC logic is implemented as a minimal solver that is injected into
+// the existing (LO-)RANSAC machinery. Because the minimal solver receives the
+// 7-point sample but the plane-and-parallax completion also needs the full
+// correspondence set, the estimator holds pointers to the full data passed to
+// RANSAC. It is a drop-in replacement for FundamentalMatrixSevenPointEstimator
+// as the hypothesis solver in LORANSAC.
+class FundamentalMatrixDegensacEstimator {
+ public:
+  using X_t = Eigen::Vector2d;
+  using Y_t = Eigen::Vector2d;
+  using M_t = Eigen::Matrix3d;
+
+  // The minimum number of samples needed to estimate a model.
+  static const int kMinNumSamples = 7;
+
+  // @param points1                  Full first-image correspondences (must
+  //                                 outlive the estimator and be the same data
+  //                                 passed to RANSAC).
+  // @param points2                  Full second-image correspondences.
+  // @param sampson_max_residual     Squared max Sampson error used when scoring
+  //                                 completion candidates (typically the RANSAC
+  //                                 max_error squared).
+  // @param h_max_residual           Squared max transfer error for
+  //                                 H-consistency.
+  // @param min_sample_h_inliers     Coplanar-count threshold for degeneracy.
+  // @param max_plane_parallax_trials Off-plane pairs sampled during completion.
+  FundamentalMatrixDegensacEstimator(
+      const std::vector<Eigen::Vector2d>* points1,
+      const std::vector<Eigen::Vector2d>* points2,
+      double sampson_max_residual,
+      double h_max_residual,
+      int min_sample_h_inliers,
+      int max_plane_parallax_trials);
+
+  // Estimate fundamental matrix hypotheses from a 7-point minimal sample. For
+  // each hypothesis whose sample is H-degenerate, the plane-corrupted model is
+  // replaced by a plane-and-parallax completion, or dropped if no usable
+  // off-plane parallax exists.
+  void Estimate(const std::vector<X_t>& sample_points1,
+                const std::vector<Y_t>& sample_points2,
+                std::vector<M_t>* models) const;
+
+  // Squared Sampson error residuals over the given correspondences.
+  void Residuals(const std::vector<X_t>& points1,
+                 const std::vector<Y_t>& points2,
+                 const M_t& F,
+                 std::vector<double>* residuals) const;
+
+ private:
+  const std::vector<Eigen::Vector2d>* points1_;
+  const std::vector<Eigen::Vector2d>* points2_;
+  double sampson_max_residual_;
+  double h_max_residual_;
+  int min_sample_h_inliers_;
+  int max_plane_parallax_trials_;
+};
+
+// Convenience driver that runs the DEGENSAC estimator inside LO-RANSAC (with
+// the 8-point solver as the local optimizer), mirroring how the plain
+// fundamental matrix is estimated. Provided so callers get a stable Report type
+// and options.
+class FundamentalMatrixDegensac {
+ public:
+  // Report type identical to the one produced by the plain LO-RANSAC estimator
+  // for the fundamental matrix, so it is a drop-in replacement.
+  using Report = RANSAC<FundamentalMatrixSevenPointEstimator,
+                        InlierSupportMeasurer,
+                        RandomSampler>::Report;
+
+  struct Options {
+    // RANSAC options that control sampling, scoring, and termination. As in
+    // RANSAC/LO-RANSAC, `max_error` is a pixel error that is squared
+    // internally, since Sampson residuals are squared errors.
+    RANSACOptions ransac;
+
+    // Maximum pixel error for a sample correspondence to be considered
+    // consistent with a candidate plane homography during the sample
+    // degeneracy test. Squared internally. If <= 0, falls back to
+    // `ransac.max_error`.
+    double h_consistency_max_error = -1;
+
+    // Minimum number of the 7 minimal-sample correspondences that must be
+    // consistent with a single plane homography for the sample to be considered
+    // H-degenerate (and thus completed via plane-and-parallax).
+    int min_sample_h_inliers = 5;
+
+    // Maximum number of off-plane correspondence pairs sampled during the
+    // plane-and-parallax model completion to recover the epipole. Only a couple
+    // of off-plane inliers are needed, so a small budget suffices; the
+    // completed model is scored and locally optimized by the surrounding RANSAC
+    // anyway.
+    int max_plane_parallax_trials = 25;
+  };
+
+  explicit FundamentalMatrixDegensac(Options options);
+
+  // Robustly estimate the fundamental matrix mapping points in image 1 to
+  // epipolar lines in image 2 from corresponding pixel observations.
+  //
+  // @param points1  First set of corresponding image points.
+  // @param points2  Second set of corresponding image points.
+  //
+  // @return         The report with the results of the estimation.
+  Report Estimate(const std::vector<Eigen::Vector2d>& points1,
+                  const std::vector<Eigen::Vector2d>& points2);
+
+ private:
+  const Options options_;
+};
+
+// Compute the epipole in the second image, i.e. the left null vector e2 of the
+// fundamental matrix with F^T e2 = 0. Returned in homogeneous coordinates and
+// normalized to unit length.
+Eigen::Vector3d EpipoleFromFundamentalMatrix(const Eigen::Matrix3d& F);
+
+// Compute the plane-induced homography compatible with the epipolar geometry F
+// from three point correspondences, following Hartley & Zisserman, "Multiple
+// View Geometry", Result 13.6:
+//
+//    H = [e2]_x F - e2 (M^{-1} b)^T
+//
+// where the rows of M are the homogeneous first-image points x1_i, and
+//
+//    b_i = (x2_i x ([e2]_x F x1_i)) . (x2_i x e2) / ||x2_i x e2||^2.
+//
+// @param F         3x3 fundamental matrix (image 1 to image 2).
+// @param epipole2  Left epipole e2 (see EpipoleFromFundamentalMatrix).
+// @param points1   Three first-image points.
+// @param points2   Three corresponding second-image points.
+//
+// @return          The homography, or nullopt if the configuration is
+//                  degenerate (collinear first-image points, or a point at the
+//                  epipole).
+std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
+    const Eigen::Matrix3d& F,
+    const Eigen::Vector3d& epipole2,
+    const std::array<Eigen::Vector2d, 3>& points1,
+    const std::array<Eigen::Vector2d, 3>& points2);
+
+// Test a 7-point minimal sample for H-degeneracy, i.e. whether five or more of
+// the seven correspondences lie on a common scene plane. For each triplet of
+// the sample, the plane homography compatible with F is constructed and the
+// number of sample correspondences consistent with it (squared forward transfer
+// error <= h_max_residual) is counted. Returns the homography of the triplet
+// with the most consistent correspondences if that count reaches
+// `min_sample_h_inliers`, otherwise nullopt.
+//
+// @param F                    3x3 fundamental matrix estimated from the sample.
+// @param sample_points1       Seven first-image sample points.
+// @param sample_points2       Seven second-image sample points.
+// @param h_max_residual       Squared max transfer error for H-consistency.
+// @param min_sample_h_inliers Threshold on the coplanar count (typically 5).
+std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
+    const Eigen::Matrix3d& F,
+    const std::vector<Eigen::Vector2d>& sample_points1,
+    const std::vector<Eigen::Vector2d>& sample_points2,
+    double h_max_residual,
+    int min_sample_h_inliers);
+
+// Convenience predicate wrapping DetectSampleHDegeneracy.
+bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
+                         const std::vector<Eigen::Vector2d>& sample_points1,
+                         const std::vector<Eigen::Vector2d>& sample_points2,
+                         double h_max_residual,
+                         int min_sample_h_inliers);
+
+// Recover the fundamental matrix from a dominant plane homography and the
+// off-plane parallax (plane-and-parallax model completion). Correspondences
+// whose squared forward transfer error under H exceeds `h_max_residual` are
+// treated as off-plane candidates; the epipole is recovered from a pair of them
+// as e2 = (x2_a x H x1_a) x (x2_b x H x1_b), giving F = [e2]_x H. Pairs are
+// sampled robustly and the F with the largest squared-Sampson support
+// (threshold `sampson_max_residual`) over all correspondences is returned.
+//
+// @param H                    Dominant plane homography (image 1 to image 2).
+// @param points1              First-image correspondences (all data).
+// @param points2              Second-image correspondences (all data).
+// @param sampson_max_residual Squared max Sampson error for scoring support.
+// @param h_max_residual       Squared max transfer error to classify off-plane.
+// @param max_trials           Maximum number of off-plane pairs to sample.
+//
+// @return                     The recovered fundamental matrix, or nullopt if
+//                             there are too few off-plane correspondences.
+std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
+    const Eigen::Matrix3d& H,
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2,
+    double sampson_max_residual,
+    double h_max_residual,
+    int max_trials);
+
+}  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_degensac.h
+++ b/src/colmap/estimators/fundamental_matrix_degensac.h
@@ -160,9 +160,9 @@ struct FundamentalMatrixDegensacOptions {
   // of off-plane inliers are needed, so a small budget suffices; the completed
   // model is scored and locally optimized by the surrounding RANSAC anyway.
   // The value 25 sits at the knee of a runtime/accuracy sweep: fewer trials
-  // erode success on the hardest >=98%-plane scenes (t=5: -3pts) with no runtime
-  // win (the inner pair loop is not the bottleneck), while more trials (or
-  // dynamic termination) yield no accuracy gain at added cost.
+  // erode success on the hardest >=98%-plane scenes (t=5: -3pts) with no
+  // runtime win (the inner pair loop is not the bottleneck), while more trials
+  // (or dynamic termination) yield no accuracy gain at added cost.
   int max_plane_parallax_trials = 25;
 };
 

--- a/src/colmap/estimators/fundamental_matrix_degensac.h
+++ b/src/colmap/estimators/fundamental_matrix_degensac.h
@@ -159,6 +159,10 @@ struct FundamentalMatrixDegensacOptions {
   // plane-and-parallax model completion to recover the epipole. Only a couple
   // of off-plane inliers are needed, so a small budget suffices; the completed
   // model is scored and locally optimized by the surrounding RANSAC anyway.
+  // The value 25 sits at the knee of a runtime/accuracy sweep: fewer trials
+  // erode success on the hardest >=98%-plane scenes (t=5: -3pts) with no runtime
+  // win (the inner pair loop is not the bottleneck), while more trials (or
+  // dynamic termination) yield no accuracy gain at added cost.
   int max_plane_parallax_trials = 25;
 };
 

--- a/src/colmap/estimators/fundamental_matrix_degensac.h
+++ b/src/colmap/estimators/fundamental_matrix_degensac.h
@@ -29,11 +29,7 @@
 
 #pragma once
 
-#include "colmap/estimators/solvers/fundamental_matrix.h"
-#include "colmap/optim/random_sampler.h"
 #include "colmap/optim/ransac.h"
-#include "colmap/optim/support_measurement.h"
-#include "colmap/util/eigen_alignment.h"
 
 #include <array>
 #include <optional>
@@ -50,27 +46,29 @@ namespace colmap {
 //    Unaffected by a Dominant Plane", CVPR 2005.
 //    https://cmp.felk.cvut.cz/~werner/papers/chum-degen-cvpr05.pdf
 //
-// When the scene contains a dominant plane, a random 7-point minimal sample
-// frequently contains five or more coplanar correspondences. The fundamental
-// matrix computed from such an H-degenerate sample is compatible with the plane
+// When the scene contains a dominant plane, a random minimal sample frequently
+// contains a majority of coplanar correspondences. The fundamental matrix
+// computed from such an H-degenerate sample is compatible with the plane
 // homography but its epipole is essentially unconstrained, yet it can still
 // accrue high inlier support (all plane points fit it). The recovered epipolar
 // geometry is then wrong even though RANSAC reports a confident result.
 //
-// This detects H-degenerate minimal samples during RANSAC and, instead of
-// accepting the plane-corrupted model, completes it using plane-and-parallax:
-// the dominant plane homography is refit on the H-consistent data and the
-// epipole (hence the fundamental matrix) is recovered from the off-plane
-// parallax. The completed model explains both the plane and the off-plane
-// points, so it wins on support. If no usable off-plane parallax exists (i.e.
-// the configuration is genuinely degenerate), the sample is rejected.
+// This is implemented as a solver that detects H-degeneracy of a sample and,
+// instead of returning the plane-corrupted model, completes it via
+// plane-and-parallax: the dominant plane homography is refit on the
+// H-consistent data and the epipole (hence the fundamental matrix) is recovered
+// from the off-plane parallax. If no usable off-plane parallax exists, the
+// sample is rejected.
 //
-// The DEGENSAC logic is implemented as a minimal solver that is injected into
-// the existing (LO-)RANSAC machinery. Because the minimal solver receives the
-// 7-point sample but the plane-and-parallax completion also needs the full
-// correspondence set, the estimator holds pointers to the full data passed to
-// RANSAC. It is a drop-in replacement for FundamentalMatrixSevenPointEstimator
-// as the hypothesis solver in LORANSAC.
+// The solver handles both minimal (7-point) and non-minimal (>= 8-point)
+// samples, so it can be used as BOTH the hypothesis and the local-optimization
+// estimator in LO-RANSAC. This is important: a plain non-minimal solver would
+// re-fit a plane-corrupted model on the (plane-dominated) inlier set during
+// local optimization, undoing the completion.
+//
+// The estimator needs the full correspondence set (not just the minimal sample)
+// for the plane-and-parallax completion, so it holds pointers to the data
+// passed to RANSAC.
 class FundamentalMatrixDegensacEstimator {
  public:
   using X_t = Eigen::Vector2d;
@@ -89,20 +87,22 @@ class FundamentalMatrixDegensacEstimator {
   //                                 max_error squared).
   // @param h_max_residual           Squared max transfer error for
   //                                 H-consistency.
-  // @param min_sample_h_inliers     Coplanar-count threshold for degeneracy.
+  // @param min_sample_h_inlier_ratio Fraction of a sample that must be
+  //                                 consistent with a single plane homography
+  //                                 for the sample to be H-degenerate.
   // @param max_plane_parallax_trials Off-plane pairs sampled during completion.
   FundamentalMatrixDegensacEstimator(
       const std::vector<Eigen::Vector2d>* points1,
       const std::vector<Eigen::Vector2d>* points2,
       double sampson_max_residual,
       double h_max_residual,
-      int min_sample_h_inliers,
+      double min_sample_h_inlier_ratio,
       int max_plane_parallax_trials);
 
-  // Estimate fundamental matrix hypotheses from a 7-point minimal sample. For
-  // each hypothesis whose sample is H-degenerate, the plane-corrupted model is
-  // replaced by a plane-and-parallax completion, or dropped if no usable
-  // off-plane parallax exists.
+  // Estimate fundamental matrix hypotheses from a sample (minimal 7-point or
+  // non-minimal >= 8-point). For each hypothesis whose sample is H-degenerate,
+  // the plane-corrupted model is replaced by a plane-and-parallax completion,
+  // or dropped if no usable off-plane parallax exists.
   void Estimate(const std::vector<X_t>& sample_points1,
                 const std::vector<Y_t>& sample_points2,
                 std::vector<M_t>* models) const;
@@ -118,62 +118,41 @@ class FundamentalMatrixDegensacEstimator {
   const std::vector<Eigen::Vector2d>* points2_;
   double sampson_max_residual_;
   double h_max_residual_;
-  int min_sample_h_inliers_;
+  double min_sample_h_inlier_ratio_;
   int max_plane_parallax_trials_;
 };
 
-// Convenience driver that runs the DEGENSAC estimator inside LO-RANSAC (with
-// the 8-point solver as the local optimizer), mirroring how the plain
-// fundamental matrix is estimated. Provided so callers get a stable Report type
-// and options.
-class FundamentalMatrixDegensac {
- public:
-  // Report type identical to the one produced by the plain LO-RANSAC estimator
-  // for the fundamental matrix, so it is a drop-in replacement.
-  using Report = RANSAC<FundamentalMatrixSevenPointEstimator,
-                        InlierSupportMeasurer,
-                        RandomSampler>::Report;
+struct FundamentalMatrixDegensacOptions {
+  // RANSAC options that control sampling, scoring, and termination. As in
+  // RANSAC/LO-RANSAC, `max_error` is a pixel error that is squared internally,
+  // since Sampson residuals are squared errors.
+  RANSACOptions ransac;
 
-  struct Options {
-    // RANSAC options that control sampling, scoring, and termination. As in
-    // RANSAC/LO-RANSAC, `max_error` is a pixel error that is squared
-    // internally, since Sampson residuals are squared errors.
-    RANSACOptions ransac;
+  // Maximum pixel error for a sample correspondence to be considered consistent
+  // with a candidate plane homography during the sample degeneracy test.
+  // Squared internally. If <= 0, falls back to `ransac.max_error`.
+  double h_consistency_max_error = -1;
 
-    // Maximum pixel error for a sample correspondence to be considered
-    // consistent with a candidate plane homography during the sample
-    // degeneracy test. Squared internally. If <= 0, falls back to
-    // `ransac.max_error`.
-    double h_consistency_max_error = -1;
+  // Fraction of a sample that must be consistent with a single plane homography
+  // for the sample to be considered H-degenerate. The default corresponds to
+  // the paper's "at least 5 of 7" criterion for a minimal sample.
+  double min_sample_h_inlier_ratio = 5.0 / 7.0;
 
-    // Minimum number of the 7 minimal-sample correspondences that must be
-    // consistent with a single plane homography for the sample to be considered
-    // H-degenerate (and thus completed via plane-and-parallax).
-    int min_sample_h_inliers = 5;
-
-    // Maximum number of off-plane correspondence pairs sampled during the
-    // plane-and-parallax model completion to recover the epipole. Only a couple
-    // of off-plane inliers are needed, so a small budget suffices; the
-    // completed model is scored and locally optimized by the surrounding RANSAC
-    // anyway.
-    int max_plane_parallax_trials = 25;
-  };
-
-  explicit FundamentalMatrixDegensac(Options options);
-
-  // Robustly estimate the fundamental matrix mapping points in image 1 to
-  // epipolar lines in image 2 from corresponding pixel observations.
-  //
-  // @param points1  First set of corresponding image points.
-  // @param points2  Second set of corresponding image points.
-  //
-  // @return         The report with the results of the estimation.
-  Report Estimate(const std::vector<Eigen::Vector2d>& points1,
-                  const std::vector<Eigen::Vector2d>& points2);
-
- private:
-  const Options options_;
+  // Maximum number of off-plane correspondence pairs sampled during the
+  // plane-and-parallax model completion to recover the epipole. Only a couple
+  // of off-plane inliers are needed, so a small budget suffices; the completed
+  // model is scored and locally optimized by the surrounding RANSAC anyway.
+  int max_plane_parallax_trials = 25;
 };
+
+// Robustly estimate the fundamental matrix from corresponding image points
+// using DEGENSAC inside LO-RANSAC (the DEGENSAC estimator is used as both the
+// hypothesis and the local-optimization solver).
+RANSAC<FundamentalMatrixDegensacEstimator>::Report
+EstimateFundamentalMatrixDegensac(
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2,
+    const FundamentalMatrixDegensacOptions& options);
 
 // Compute the epipole in the second image, i.e. the left null vector e2 of the
 // fundamental matrix with F^T e2 = 0. Returned in homogeneous coordinates and
@@ -190,66 +169,49 @@ Eigen::Vector3d EpipoleFromFundamentalMatrix(const Eigen::Matrix3d& F);
 //
 //    b_i = (x2_i x ([e2]_x F x1_i)) . (x2_i x e2) / ||x2_i x e2||^2.
 //
-// @param F         3x3 fundamental matrix (image 1 to image 2).
-// @param epipole2  Left epipole e2 (see EpipoleFromFundamentalMatrix).
-// @param points1   Three first-image points.
-// @param points2   Three corresponding second-image points.
-//
-// @return          The homography, or nullopt if the configuration is
-//                  degenerate (collinear first-image points, or a point at the
-//                  epipole).
+// Returns nullopt on degenerate input (collinear first-image points, or a point
+// at the epipole).
 std::optional<Eigen::Matrix3d> HomographyFromFundamentalAndPoints(
     const Eigen::Matrix3d& F,
     const Eigen::Vector3d& epipole2,
     const std::array<Eigen::Vector2d, 3>& points1,
     const std::array<Eigen::Vector2d, 3>& points2);
 
-// Test a 7-point minimal sample for H-degeneracy, i.e. whether five or more of
-// the seven correspondences lie on a common scene plane. For each triplet of
-// the sample, the plane homography compatible with F is constructed and the
-// number of sample correspondences consistent with it (squared forward transfer
-// error <= h_max_residual) is counted. Returns the homography of the triplet
-// with the most consistent correspondences if that count reaches
-// `min_sample_h_inliers`, otherwise nullopt.
-//
-// @param F                    3x3 fundamental matrix estimated from the sample.
-// @param sample_points1       Seven first-image sample points.
-// @param sample_points2       Seven second-image sample points.
-// @param h_max_residual       Squared max transfer error for H-consistency.
-// @param min_sample_h_inliers Threshold on the coplanar count (typically 5).
+// Test a sample for H-degeneracy, i.e. whether a fraction of at least
+// `min_sample_h_inlier_ratio` of the correspondences lie on a common scene
+// plane. Plane homographies compatible with F are constructed from triplets of
+// the sample (all C(7,3) triplets for a minimal sample, otherwise a fixed
+// number of randomly sampled triplets) and the number of sample correspondences
+// consistent with each (squared forward transfer error <= h_max_residual) is
+// counted. Returns the homography of the triplet with the most consistent
+// correspondences if that count reaches the threshold, otherwise nullopt.
 std::optional<Eigen::Matrix3d> DetectSampleHDegeneracy(
     const Eigen::Matrix3d& F,
     const std::vector<Eigen::Vector2d>& sample_points1,
     const std::vector<Eigen::Vector2d>& sample_points2,
     double h_max_residual,
-    int min_sample_h_inliers);
+    double min_sample_h_inlier_ratio);
 
 // Convenience predicate wrapping DetectSampleHDegeneracy.
 bool IsSampleHDegenerate(const Eigen::Matrix3d& F,
                          const std::vector<Eigen::Vector2d>& sample_points1,
                          const std::vector<Eigen::Vector2d>& sample_points2,
                          double h_max_residual,
-                         int min_sample_h_inliers);
+                         double min_sample_h_inlier_ratio);
 
 // Recover the fundamental matrix from a dominant plane homography and the
-// off-plane parallax (plane-and-parallax model completion). Correspondences
-// whose squared forward transfer error under H exceeds `h_max_residual` are
-// treated as off-plane candidates; the epipole is recovered from a pair of them
-// as e2 = (x2_a x H x1_a) x (x2_b x H x1_b), giving F = [e2]_x H. Pairs are
+// off-plane parallax (plane-and-parallax model completion). The seed homography
+// is refit on its inlier correspondences; then correspondences whose squared
+// forward transfer error under the refit H exceeds `h_max_residual` are treated
+// as off-plane candidates, and the epipole is recovered from a pair of them as
+// e2 = (x2_a x H x1_a) x (x2_b x H x1_b), giving F = [e2]_x H. Pairs are
 // sampled robustly and the F with the largest squared-Sampson support
 // (threshold `sampson_max_residual`) over all correspondences is returned.
 //
-// @param H                    Dominant plane homography (image 1 to image 2).
-// @param points1              First-image correspondences (all data).
-// @param points2              Second-image correspondences (all data).
-// @param sampson_max_residual Squared max Sampson error for scoring support.
-// @param h_max_residual       Squared max transfer error to classify off-plane.
-// @param max_trials           Maximum number of off-plane pairs to sample.
-//
-// @return                     The recovered fundamental matrix, or nullopt if
-//                             there are too few off-plane correspondences.
+// @return  The recovered fundamental matrix, or nullopt if there are too few
+//          off-plane correspondences.
 std::optional<Eigen::Matrix3d> FundamentalFromPlaneAndParallax(
-    const Eigen::Matrix3d& H,
+    const Eigen::Matrix3d& seed_H,
     const std::vector<Eigen::Vector2d>& points1,
     const std::vector<Eigen::Vector2d>& points2,
     double sampson_max_residual,

--- a/src/colmap/estimators/fundamental_matrix_degensac_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac_test.cc
@@ -1,0 +1,407 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/estimators/fundamental_matrix_degensac.h"
+
+#include "colmap/estimators/solvers/fundamental_matrix.h"
+#include "colmap/geometry/essential_matrix.h"
+#include "colmap/geometry/homography_matrix.h"
+#include "colmap/math/random.h"
+#include "colmap/optim/loransac.h"
+
+#include <array>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+Eigen::Matrix3d RandomCalibrationMatrix() {
+  return (Eigen::Matrix3d() << RandomUniformReal<double>(800, 1200),
+          0,
+          RandomUniformReal<double>(400, 600),
+          0,
+          RandomUniformReal<double>(800, 1200),
+          RandomUniformReal<double>(400, 600),
+          0,
+          0,
+          1)
+      .finished();
+}
+
+// Generates a two-view scene with a dominant plane. The first `num_on_plane`
+// correspondences lie on the plane `normal . X = distance` (in the first
+// camera frame); the remaining ones are at random depths off the plane. All
+// correspondences are consistent with the true epipolar geometry; only the
+// on-plane ones are additionally consistent with the plane homography.
+void GenerateDominantPlaneScene(const Rigid3d& cam2_from_cam1,
+                                const Eigen::Matrix3d& K,
+                                const Eigen::Vector3d& normal,
+                                double distance,
+                                size_t num_points,
+                                size_t num_on_plane,
+                                double noise,
+                                std::vector<Eigen::Vector2d>* points1,
+                                std::vector<Eigen::Vector2d>* points2,
+                                std::vector<char>* on_plane_mask) {
+  const Eigen::Matrix3d K_inv = K.inverse();
+  points1->clear();
+  points2->clear();
+  on_plane_mask->clear();
+  for (size_t i = 0; i < num_points; ++i) {
+    const Eigen::Vector2d point1 =
+        K.topRows<2>() * Eigen::Vector2d::Random().homogeneous();
+    const Eigen::Vector3d ray = K_inv * point1.homogeneous();
+    const bool on_plane = i < num_on_plane;
+    double depth;
+    if (on_plane) {
+      depth = distance / normal.dot(ray);
+    } else {
+      depth = RandomUniformReal<double>(0.5, 3.0);
+    }
+    const Eigen::Vector3d point3D_in_cam1 = depth * ray;
+    const Eigen::Vector2d point2 =
+        (K * (cam2_from_cam1 * point3D_in_cam1)).hnormalized();
+    points1->push_back(point1 + noise * Eigen::Vector2d::Random());
+    points2->push_back(point2 + noise * Eigen::Vector2d::Random());
+    on_plane_mask->push_back(on_plane);
+  }
+}
+
+double MeanSampsonErrorOnSubset(const std::vector<Eigen::Vector2d>& points1,
+                                const std::vector<Eigen::Vector2d>& points2,
+                                const Eigen::Matrix3d& F,
+                                const std::vector<char>& subset_mask) {
+  std::vector<double> residuals;
+  ComputeSquaredSampsonError(points1, points2, F, &residuals);
+  double sum = 0;
+  size_t count = 0;
+  for (size_t i = 0; i < residuals.size(); ++i) {
+    if (subset_mask[i]) {
+      sum += residuals[i];
+      ++count;
+    }
+  }
+  return count == 0 ? 0.0 : sum / count;
+}
+
+RANSACOptions TestRANSACOptions() {
+  RANSACOptions options;
+  options.max_error = 1.0;
+  options.confidence = 0.9999;
+  options.min_inlier_ratio = 0.1;
+  options.max_num_trials = 10000;
+  options.random_seed = 0;
+  return options;
+}
+
+TEST(EpipoleFromFundamentalMatrix, Nominal) {
+  SetPRNGSeed(0);
+  for (int k = 0; k < 20; ++k) {
+    const Eigen::Matrix3d K = RandomCalibrationMatrix();
+    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                                 Eigen::Vector3d::Random());
+    const Eigen::Matrix3d F = FundamentalFromEssentialMatrix(
+        K, EssentialMatrixFromPose(cam2_from_cam1), K);
+    const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+    EXPECT_NEAR(epipole2.norm(), 1.0, 1e-9);
+    EXPECT_LT((F.transpose() * epipole2).norm(), 1e-6);
+  }
+}
+
+TEST(HomographyFromFundamentalAndPoints, Nominal) {
+  SetPRNGSeed(0);
+  const Eigen::Matrix3d K = RandomCalibrationMatrix();
+  const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                               Eigen::Vector3d::Random());
+  const Eigen::Matrix3d F = FundamentalFromEssentialMatrix(
+      K, EssentialMatrixFromPose(cam2_from_cam1), K);
+  const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+
+  const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+  constexpr double kDistance = 2.0;
+  std::vector<Eigen::Vector2d> points1;
+  std::vector<Eigen::Vector2d> points2;
+  std::vector<char> on_plane_mask;
+  GenerateDominantPlaneScene(cam2_from_cam1,
+                             K,
+                             normal,
+                             kDistance,
+                             /*num_points=*/6,
+                             /*num_on_plane=*/6,
+                             /*noise=*/0.0,
+                             &points1,
+                             &points2,
+                             &on_plane_mask);
+
+  const std::array<Eigen::Vector2d, 3> tri_points1 = {
+      points1[0], points1[1], points1[2]};
+  const std::array<Eigen::Vector2d, 3> tri_points2 = {
+      points2[0], points2[1], points2[2]};
+  const std::optional<Eigen::Matrix3d> H =
+      HomographyFromFundamentalAndPoints(F, epipole2, tri_points1, tri_points2);
+  ASSERT_TRUE(H.has_value());
+
+  // All on-plane correspondences must be explained by the recovered homography.
+  for (size_t i = 0; i < points1.size(); ++i) {
+    EXPECT_LT(ComputeSquaredHomographyError(points1[i], points2[i], *H), 1e-6);
+  }
+}
+
+TEST(HomographyFromFundamentalAndPoints, CollinearReturnsNullopt) {
+  SetPRNGSeed(0);
+  const Eigen::Matrix3d K = RandomCalibrationMatrix();
+  const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                               Eigen::Vector3d::Random());
+  const Eigen::Matrix3d F = FundamentalFromEssentialMatrix(
+      K, EssentialMatrixFromPose(cam2_from_cam1), K);
+  const Eigen::Vector3d epipole2 = EpipoleFromFundamentalMatrix(F);
+
+  // Three collinear first-image points make M rank-deficient.
+  const std::array<Eigen::Vector2d, 3> tri_points1 = {
+      Eigen::Vector2d(100, 201),
+      Eigen::Vector2d(200, 401),
+      Eigen::Vector2d(300, 601)};
+  const std::array<Eigen::Vector2d, 3> tri_points2 = {
+      Eigen::Vector2d(110, 210),
+      Eigen::Vector2d(220, 430),
+      Eigen::Vector2d(330, 650)};
+  EXPECT_FALSE(
+      HomographyFromFundamentalAndPoints(F, epipole2, tri_points1, tri_points2)
+          .has_value());
+}
+
+TEST(IsSampleHDegenerate, DetectsAndRejects) {
+  SetPRNGSeed(0);
+  const Eigen::Matrix3d K = RandomCalibrationMatrix();
+  const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                               Eigen::Vector3d::Random());
+  const Eigen::Matrix3d F = FundamentalFromEssentialMatrix(
+      K, EssentialMatrixFromPose(cam2_from_cam1), K);
+  const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+
+  // A sample with 5 of 7 correspondences on the plane is H-degenerate.
+  {
+    std::vector<Eigen::Vector2d> points1;
+    std::vector<Eigen::Vector2d> points2;
+    std::vector<char> on_plane_mask;
+    GenerateDominantPlaneScene(cam2_from_cam1,
+                               K,
+                               normal,
+                               /*distance=*/2.0,
+                               /*num_points=*/7,
+                               /*num_on_plane=*/5,
+                               /*noise=*/0.0,
+                               &points1,
+                               &points2,
+                               &on_plane_mask);
+    EXPECT_TRUE(IsSampleHDegenerate(F,
+                                    points1,
+                                    points2,
+                                    /*h_max_residual=*/4.0,
+                                    /*min_sample_h_inliers=*/5));
+  }
+
+  // A general (non-planar) sample is not H-degenerate.
+  {
+    std::vector<Eigen::Vector2d> points1;
+    std::vector<Eigen::Vector2d> points2;
+    std::vector<char> on_plane_mask;
+    GenerateDominantPlaneScene(cam2_from_cam1,
+                               K,
+                               normal,
+                               /*distance=*/2.0,
+                               /*num_points=*/7,
+                               /*num_on_plane=*/0,
+                               /*noise=*/0.0,
+                               &points1,
+                               &points2,
+                               &on_plane_mask);
+    EXPECT_FALSE(IsSampleHDegenerate(F,
+                                     points1,
+                                     points2,
+                                     /*h_max_residual=*/4.0,
+                                     /*min_sample_h_inliers=*/5));
+  }
+}
+
+// On a general non-planar scene, DEGENSAC recovers the fundamental matrix as
+// well as the plain LO-RANSAC estimator.
+TEST(FundamentalMatrixDegensac, NonPlanarParity) {
+  SetPRNGSeed(0);
+  const Eigen::Matrix3d K = RandomCalibrationMatrix();
+  const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                               Eigen::Vector3d::Random());
+  Eigen::Matrix3d expected_F = FundamentalFromEssentialMatrix(
+      K, EssentialMatrixFromPose(cam2_from_cam1), K);
+  expected_F /= expected_F(2, 2);
+
+  const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+  std::vector<Eigen::Vector2d> points1;
+  std::vector<Eigen::Vector2d> points2;
+  std::vector<char> on_plane_mask;
+  GenerateDominantPlaneScene(cam2_from_cam1,
+                             K,
+                             normal,
+                             /*distance=*/2.0,
+                             /*num_points=*/200,
+                             /*num_on_plane=*/0,
+                             /*noise=*/0.0,
+                             &points1,
+                             &points2,
+                             &on_plane_mask);
+
+  FundamentalMatrixDegensac::Options options;
+  options.ransac = TestRANSACOptions();
+  const auto report =
+      FundamentalMatrixDegensac(options).Estimate(points1, points2);
+  ASSERT_TRUE(report.success);
+
+  Eigen::Matrix3d F = report.model / report.model(2, 2);
+  EXPECT_TRUE(F.isApprox(expected_F, 1e-3) || (-F).isApprox(expected_F, 1e-3));
+  EXPECT_GE(report.support.num_inliers, points1.size() - 2);
+}
+
+// On a dominant-plane scene with real off-plane parallax, DEGENSAC recovers the
+// correct fundamental matrix via plane-and-parallax completion, explaining the
+// off-plane points well.
+TEST(FundamentalMatrixDegensac, RecoversFOnDominantPlane) {
+  SetPRNGSeed(0);
+  const Eigen::Matrix3d K = RandomCalibrationMatrix();
+  const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                               Eigen::Vector3d::Random().normalized());
+  Eigen::Matrix3d expected_F = FundamentalFromEssentialMatrix(
+      K, EssentialMatrixFromPose(cam2_from_cam1), K);
+  expected_F /= expected_F(2, 2);
+
+  const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+  constexpr size_t kNumPoints = 200;
+  constexpr size_t kNumOnPlane = 190;  // 95% dominant plane.
+  std::vector<Eigen::Vector2d> points1;
+  std::vector<Eigen::Vector2d> points2;
+  std::vector<char> on_plane_mask;
+  GenerateDominantPlaneScene(cam2_from_cam1,
+                             K,
+                             normal,
+                             /*distance=*/2.0,
+                             kNumPoints,
+                             kNumOnPlane,
+                             /*noise=*/0.1,
+                             &points1,
+                             &points2,
+                             &on_plane_mask);
+
+  std::vector<char> off_plane_mask(kNumPoints);
+  for (size_t i = 0; i < kNumPoints; ++i) {
+    off_plane_mask[i] = !on_plane_mask[i];
+  }
+
+  FundamentalMatrixDegensac::Options degensac_options;
+  degensac_options.ransac = TestRANSACOptions();
+  const auto report =
+      FundamentalMatrixDegensac(degensac_options).Estimate(points1, points2);
+  ASSERT_TRUE(report.success);
+
+  Eigen::Matrix3d F = report.model / report.model(2, 2);
+  EXPECT_TRUE(F.isApprox(expected_F, 1e-2) || (-F).isApprox(expected_F, 1e-2));
+
+  // DEGENSAC must explain the off-plane parallax points well, which a
+  // plane-corrupted fundamental matrix cannot.
+  EXPECT_LT(
+      MeanSampsonErrorOnSubset(points1, points2, report.model, off_plane_mask),
+      1.0);
+}
+
+// Aggregated over many dominant-plane scenes, DEGENSAC recovers the correct
+// epipolar geometry at least as often as plain LO-RANSAC, which is prone to
+// terminating on a plane-corrupted model.
+TEST(FundamentalMatrixDegensac, OutperformsLoRansacOnDominantPlane) {
+  constexpr int kNumScenes = 40;
+  constexpr size_t kNumPoints = 200;
+  constexpr size_t kNumOnPlane = 190;  // 95% dominant plane.
+  constexpr double kOffPlaneErrorThreshold = 1.0;
+
+  int degensac_successes = 0;
+  int loransac_successes = 0;
+  for (int s = 0; s < kNumScenes; ++s) {
+    SetPRNGSeed(s);
+    const Eigen::Matrix3d K = RandomCalibrationMatrix();
+    const Rigid3d cam2_from_cam1(Eigen::Quaterniond::UnitRandom(),
+                                 Eigen::Vector3d::Random().normalized());
+    const Eigen::Vector3d normal = Eigen::Vector3d(0.2, -0.1, 1.0).normalized();
+    std::vector<Eigen::Vector2d> points1;
+    std::vector<Eigen::Vector2d> points2;
+    std::vector<char> on_plane_mask;
+    GenerateDominantPlaneScene(cam2_from_cam1,
+                               K,
+                               normal,
+                               /*distance=*/2.0,
+                               kNumPoints,
+                               kNumOnPlane,
+                               /*noise=*/0.1,
+                               &points1,
+                               &points2,
+                               &on_plane_mask);
+    std::vector<char> off_plane_mask(kNumPoints);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      off_plane_mask[i] = !on_plane_mask[i];
+    }
+
+    const RANSACOptions ransac_options = TestRANSACOptions();
+
+    FundamentalMatrixDegensac::Options degensac_options;
+    degensac_options.ransac = ransac_options;
+    const auto degensac_report =
+        FundamentalMatrixDegensac(degensac_options).Estimate(points1, points2);
+    if (degensac_report.success &&
+        MeanSampsonErrorOnSubset(
+            points1, points2, degensac_report.model, off_plane_mask) <
+            kOffPlaneErrorThreshold) {
+      ++degensac_successes;
+    }
+
+    LORANSAC<FundamentalMatrixSevenPointEstimator,
+             FundamentalMatrixEightPointEstimator>
+        loransac(ransac_options);
+    const auto loransac_report = loransac.Estimate(points1, points2);
+    if (loransac_report.success &&
+        MeanSampsonErrorOnSubset(
+            points1, points2, loransac_report.model, off_plane_mask) <
+            kOffPlaneErrorThreshold) {
+      ++loransac_successes;
+    }
+  }
+
+  EXPECT_GT(degensac_successes, 0);
+  EXPECT_GE(degensac_successes, loransac_successes);
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/estimators/fundamental_matrix_degensac_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac_test.cc
@@ -226,7 +226,7 @@ TEST(IsSampleHDegenerate, DetectsAndRejects) {
                                     points1,
                                     points2,
                                     /*h_max_residual=*/4.0,
-                                    /*min_sample_h_inliers=*/5));
+                                    /*min_sample_h_inlier_ratio=*/5.0 / 7.0));
   }
 
   // A general (non-planar) sample is not H-degenerate.
@@ -248,7 +248,7 @@ TEST(IsSampleHDegenerate, DetectsAndRejects) {
                                      points1,
                                      points2,
                                      /*h_max_residual=*/4.0,
-                                     /*min_sample_h_inliers=*/5));
+                                     /*min_sample_h_inlier_ratio=*/5.0 / 7.0));
   }
 }
 
@@ -278,10 +278,10 @@ TEST(FundamentalMatrixDegensac, NonPlanarParity) {
                              &points2,
                              &on_plane_mask);
 
-  FundamentalMatrixDegensac::Options options;
+  FundamentalMatrixDegensacOptions options;
   options.ransac = TestRANSACOptions();
   const auto report =
-      FundamentalMatrixDegensac(options).Estimate(points1, points2);
+      EstimateFundamentalMatrixDegensac(points1, points2, options);
   ASSERT_TRUE(report.success);
 
   Eigen::Matrix3d F = report.model / report.model(2, 2);
@@ -323,10 +323,10 @@ TEST(FundamentalMatrixDegensac, RecoversFOnDominantPlane) {
     off_plane_mask[i] = !on_plane_mask[i];
   }
 
-  FundamentalMatrixDegensac::Options degensac_options;
+  FundamentalMatrixDegensacOptions degensac_options;
   degensac_options.ransac = TestRANSACOptions();
   const auto report =
-      FundamentalMatrixDegensac(degensac_options).Estimate(points1, points2);
+      EstimateFundamentalMatrixDegensac(points1, points2, degensac_options);
   ASSERT_TRUE(report.success);
 
   Eigen::Matrix3d F = report.model / report.model(2, 2);
@@ -376,10 +376,10 @@ TEST(FundamentalMatrixDegensac, OutperformsLoRansacOnDominantPlane) {
 
     const RANSACOptions ransac_options = TestRANSACOptions();
 
-    FundamentalMatrixDegensac::Options degensac_options;
+    FundamentalMatrixDegensacOptions degensac_options;
     degensac_options.ransac = ransac_options;
     const auto degensac_report =
-        FundamentalMatrixDegensac(degensac_options).Estimate(points1, points2);
+        EstimateFundamentalMatrixDegensac(points1, points2, degensac_options);
     if (degensac_report.success &&
         MeanSampsonErrorOnSubset(
             points1, points2, degensac_report.model, off_plane_mask) <

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -53,29 +53,35 @@
 namespace colmap {
 namespace {
 
+using FundamentalMatrixReport =
+    LORANSAC<FundamentalMatrixSevenPointEstimator,
+             FundamentalMatrixEightPointEstimator>::Report;
+
+// DEGENSAC uses a different estimator type, so its report is a distinct (but
+// structurally identical) type; adapt it to the plain report type.
+FundamentalMatrixReport ToFundamentalMatrixReport(
+    const RANSAC<FundamentalMatrixDegensacEstimator>::Report& degensac_report) {
+  FundamentalMatrixReport report;
+  report.success = degensac_report.success;
+  report.num_trials = degensac_report.num_trials;
+  report.support = degensac_report.support;
+  report.inlier_mask = degensac_report.inlier_mask;
+  report.model = degensac_report.model;
+  return report;
+}
+
 // Robustly estimate the fundamental matrix, either with plain LO-RANSAC or with
 // DEGENSAC (robust to a dominant scene plane), depending on the options.
-LORANSAC<FundamentalMatrixSevenPointEstimator,
-         FundamentalMatrixEightPointEstimator>::Report
-EstimateFundamentalMatrix(const TwoViewGeometryOptions& options,
-                          const RANSACOptions& ransac_options,
-                          const std::vector<Eigen::Vector2d>& points1,
-                          const std::vector<Eigen::Vector2d>& points2) {
+FundamentalMatrixReport EstimateFundamentalMatrix(
+    const TwoViewGeometryOptions& options,
+    const RANSACOptions& ransac_options,
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2) {
   if (options.use_degensac) {
     FundamentalMatrixDegensacOptions degensac_options;
     degensac_options.ransac = ransac_options;
-    const auto degensac_report =
-        EstimateFundamentalMatrixDegensac(points1, points2, degensac_options);
-    // DEGENSAC uses a different estimator type, so its report is a distinct
-    // (but structurally identical) type; adapt it to the plain report type.
-    LORANSAC<FundamentalMatrixSevenPointEstimator,
-             FundamentalMatrixEightPointEstimator>::Report report;
-    report.success = degensac_report.success;
-    report.num_trials = degensac_report.num_trials;
-    report.support = degensac_report.support;
-    report.inlier_mask = degensac_report.inlier_mask;
-    report.model = degensac_report.model;
-    return report;
+    return ToFundamentalMatrixReport(
+        EstimateFundamentalMatrixDegensac(points1, points2, degensac_options));
   }
   return LORANSAC<FundamentalMatrixSevenPointEstimator,
                   FundamentalMatrixEightPointEstimator>(ransac_options)

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/two_view_geometry.h"
 
+#include "colmap/estimators/fundamental_matrix_degensac.h"
 #include "colmap/estimators/generalized_pose.h"
 #include "colmap/estimators/solvers/essential_matrix.h"
 #include "colmap/estimators/solvers/fundamental_matrix.h"
@@ -51,6 +52,25 @@
 
 namespace colmap {
 namespace {
+
+// Robustly estimate the fundamental matrix, either with plain LO-RANSAC or with
+// DEGENSAC (robust to a dominant scene plane), depending on the options. Both
+// paths return the same report type, so callers are agnostic to the choice.
+FundamentalMatrixDegensac::Report EstimateFundamentalMatrix(
+    const TwoViewGeometryOptions& options,
+    const RANSACOptions& ransac_options,
+    const std::vector<Eigen::Vector2d>& points1,
+    const std::vector<Eigen::Vector2d>& points2) {
+  if (options.use_degensac) {
+    FundamentalMatrixDegensac::Options degensac_options;
+    degensac_options.ransac = ransac_options;
+    return FundamentalMatrixDegensac(degensac_options)
+        .Estimate(points1, points2);
+  }
+  return LORANSAC<FundamentalMatrixSevenPointEstimator,
+                  FundamentalMatrixEightPointEstimator>(ransac_options)
+      .Estimate(points1, points2);
+}
 
 FeatureMatches ExtractInlierMatches(const FeatureMatches& matches,
                                     const size_t num_inliers,
@@ -172,11 +192,10 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
 
   // Estimate epipolar model.
 
-  LORANSAC<FundamentalMatrixSevenPointEstimator,
-           FundamentalMatrixEightPointEstimator>
-      F_ransac(options.ransac_options);
-  const auto F_report =
-      F_ransac.Estimate(matched_img_points1, matched_img_points2);
+  const auto F_report = EstimateFundamentalMatrix(options,
+                                                  options.ransac_options,
+                                                  matched_img_points1,
+                                                  matched_img_points2);
   geometry.F = F_report.model;
 
   // Estimate planar or panoramic model.
@@ -804,11 +823,8 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
   const auto E_report = E_ransac.Estimate(matched_cam_rays1, matched_cam_rays2);
   geometry.E = E_report.model;
 
-  LORANSAC<FundamentalMatrixSevenPointEstimator,
-           FundamentalMatrixEightPointEstimator>
-      F_ransac(ransac_options);
-  const auto F_report =
-      F_ransac.Estimate(matched_img_points1, matched_img_points2);
+  const auto F_report = EstimateFundamentalMatrix(
+      options, ransac_options, matched_img_points1, matched_img_points2);
   geometry.F = F_report.model;
 
   // Estimate planar or panoramic model.

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -54,18 +54,28 @@ namespace colmap {
 namespace {
 
 // Robustly estimate the fundamental matrix, either with plain LO-RANSAC or with
-// DEGENSAC (robust to a dominant scene plane), depending on the options. Both
-// paths return the same report type, so callers are agnostic to the choice.
-FundamentalMatrixDegensac::Report EstimateFundamentalMatrix(
-    const TwoViewGeometryOptions& options,
-    const RANSACOptions& ransac_options,
-    const std::vector<Eigen::Vector2d>& points1,
-    const std::vector<Eigen::Vector2d>& points2) {
+// DEGENSAC (robust to a dominant scene plane), depending on the options.
+LORANSAC<FundamentalMatrixSevenPointEstimator,
+         FundamentalMatrixEightPointEstimator>::Report
+EstimateFundamentalMatrix(const TwoViewGeometryOptions& options,
+                          const RANSACOptions& ransac_options,
+                          const std::vector<Eigen::Vector2d>& points1,
+                          const std::vector<Eigen::Vector2d>& points2) {
   if (options.use_degensac) {
-    FundamentalMatrixDegensac::Options degensac_options;
+    FundamentalMatrixDegensacOptions degensac_options;
     degensac_options.ransac = ransac_options;
-    return FundamentalMatrixDegensac(degensac_options)
-        .Estimate(points1, points2);
+    const auto degensac_report =
+        EstimateFundamentalMatrixDegensac(points1, points2, degensac_options);
+    // DEGENSAC uses a different estimator type, so its report is a distinct
+    // (but structurally identical) type; adapt it to the plain report type.
+    LORANSAC<FundamentalMatrixSevenPointEstimator,
+             FundamentalMatrixEightPointEstimator>::Report report;
+    report.success = degensac_report.success;
+    report.num_trials = degensac_report.num_trials;
+    report.support = degensac_report.support;
+    report.inlier_mask = degensac_report.inlier_mask;
+    report.model = degensac_report.model;
+    return report;
   }
   return LORANSAC<FundamentalMatrixSevenPointEstimator,
                   FundamentalMatrixEightPointEstimator>(ransac_options)

--- a/src/colmap/estimators/two_view_geometry.h
+++ b/src/colmap/estimators/two_view_geometry.h
@@ -98,6 +98,11 @@ struct TwoViewGeometryOptions {
   // between both cameras.
   bool force_H_use = false;
 
+  // Use DEGENSAC (Chum et al., CVPR 2005) for the fundamental matrix instead of
+  // plain LO-RANSAC, making estimation robust to a dominant scene plane. Off by
+  // default.
+  bool use_degensac = false;
+
   // Whether to compute the relative pose between the two views.
   bool compute_relative_pose = false;
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -731,6 +731,40 @@ TEST(EstimateTwoViewGeometry, UncalibratedDeterministic) {
   EXPECT_NE(geometry1.F, geometry3.F);
 }
 
+TEST(EstimateTwoViewGeometry, UncalibratedDegensac) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.inlier_match_ratio = 0.6;
+  synthetic_dataset_options.camera_has_prior_focal_length = false;
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 5;
+  const TwoViewGeometryTestData test_data = CreateTwoViewGeometryTestData(
+      synthetic_dataset_options, synthetic_noise_options);
+
+  // The DEGENSAC-based fundamental matrix estimation is a drop-in replacement
+  // that recovers a valid uncalibrated geometry on a general (non-planar)
+  // scene.
+  TwoViewGeometryOptions two_view_geometry_options;
+  two_view_geometry_options.ransac_options.random_seed = 42;
+  two_view_geometry_options.use_degensac = true;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::UNCALIBRATED);
+  EXPECT_GE(geometry.inlier_matches.size(),
+            static_cast<size_t>(synthetic_dataset_options.inlier_match_ratio *
+                                synthetic_dataset_options.num_points3D * 0.9));
+}
+
 TEST(EstimateTwoViewGeometry, PlanarOrPanoramicDeterministic) {
   SetPRNGSeed(1);
 

--- a/src/pycolmap/estimators/two_view_geometry.cc
+++ b/src/pycolmap/estimators/two_view_geometry.cc
@@ -47,6 +47,7 @@ void BindTwoViewGeometryEstimator(py::module& m) {
       .def_readwrite("stationary_matches_max_error",
                      &TwoViewGeometryOptions::stationary_matches_max_error)
       .def_readwrite("force_H_use", &TwoViewGeometryOptions::force_H_use)
+      .def_readwrite("use_degensac", &TwoViewGeometryOptions::use_degensac)
       .def_readwrite("compute_relative_pose",
                      &TwoViewGeometryOptions::compute_relative_pose)
       .def_readwrite("multiple_models",


### PR DESCRIPTION
## Summary

Implements **DEGENSAC** (Chum, Werner, Matas, *"Two-View Geometry Estimation Unaffected by a Dominant Plane"*, CVPR 2005) as an **opt-in** fundamental-matrix estimator that is robust to a dominant scene plane.

When the scene contains a dominant plane, a random minimal sample frequently contains a majority of coplanar correspondences. The fundamental matrix from such an *H-degenerate* sample is compatible with the plane homography but its epipole is essentially unconstrained — yet it still accrues high inlier support (all plane points fit it) and makes RANSAC terminate early on a wrong epipolar geometry. COLMAP previously only detected this *after the fact* (H/F inlier-ratio → `PLANAR_OR_PANORAMIC`) and discarded `F` rather than recovering it.

## Design

DEGENSAC is a minimal/non-minimal solver injected into the existing LO-RANSAC. It receives a sample and holds pointers to the full correspondence set, so inside `Estimate()` it can:

1. Fit `F` (7-point for a minimal sample, 8-point otherwise).
2. Detect H-degeneracy: build the plane homography compatible with `F` from triplets (all C(7,3) for a minimal sample, randomly sampled triplets otherwise) and check the coplanar fraction, using a **plane-consistency threshold** (default `sqrt(3)·max_error`) that is deliberately looser than the inlier threshold.
3. **Complete** a degenerate sample via plane-and-parallax: refit the plane homography on its plane inliers, recover the epipole from **clean, high-parallax off-plane** correspondences (those beyond an off-plane margin, default `10·max_error`, so near-plane low-parallax points don't destabilize the epipole), form `F = [e2]ₓH`, and finally **refine `F` with the 8-point algorithm on mixed samples of plane + off-plane inliers** (so the epipole is constrained by several off-plane points, not just two). If no usable off-plane parallax exists, the sample is dropped.

The DEGENSAC estimator is used as **both the hypothesis and the local-optimization solver** (`LORANSAC<DegensacEstimator, DegensacEstimator>`), so LO cannot re-fit a plane-corrupted model on the plane-dominated inlier set.

Estimation is exposed as a free function `EstimateFundamentalMatrixDegensac(points1, points2, options)`. It is enabled via `TwoViewGeometryOptions::use_degensac` (**default `false`** — the default pipeline is unchanged), wired into both the uncalibrated and calibrated two-view-geometry paths, and toggleable from Python via the pycolmap binding.

## Synthetic benchmark

Synthetic two-view data, **300 problems per configuration**, both methods seeing identical data and identical RANSAC randomness per problem. Observation noise 0.5 px, inlier `max_error` = 1.0 px. `success` = recovered pose within 5° of ground truth; `rot`/`trans` errors are over **all returned models** (a plane-corrupted model contributes its large error), so medians/p90 reflect degradation.

### Accuracy & robustness (dominant-plane regime)

| Pts | Plane | Outl | Success% (LO→DEG) | Trans median° (LO→DEG) | Trans p90° (LO→DEG) |
|----:|------:|-----:|:--|:--|:--|
| 200  | 90% | 0%  | 84.7 → **100**  | 0.14 → **0.10** | 13.3 → **0.29** |
| 200  | 95% | 0%  | 39.7 → **100**  | 12.2 → **0.18** | 66.9 → **0.60** |
| 200  | 95% | 20% | 28.7 → **98.7** | 19.7 → **0.32** | 72.9 → **1.77** |
| 200  | 98% | 0%  | 9.7  → **96.3** | 42.8 → **0.48** | 79.9 → **2.52** |
| 1000 | 95% | 0%  | 59.3 → **100**  | 0.13 → **0.065** | 52.2 → **0.17** |
| 1000 | 95% | 20% | 42.7 → **100**  | 7.68 → **0.15** | 60.5 → **0.41** |
| 1000 | 98% | 40% | 15.7 → **96.3** | 29.4 → **0.51** | 77.8 → **2.05** |

Below ~80% plane, both methods are ~100% success with identical sub-0.1° medians — **no regression on general scenes**. The **0% (no plane)** and **30% plane** configurations confirm this directly: DEGENSAC matches LO-RANSAC exactly (100% success, identical rotation/translation medians and inlier recall/precision) at every point count and outlier level, at a small constant runtime overhead. Compared with the earlier "detection + LO" version, the split thresholds and mixed-sample refit further improve the hardest rows (e.g. 200 pts / 98% / 0%: 89% → 96%; 1000 pts / 98% / 0%: 95% → 100%) and tighten pose-error tails.

### Runtime cost

Detection + completion (incl. the mixed-sample refit) run on nearly every RANSAC trial and every LO refit, so cost scales with `trials × points`. This is the main trade-off of the refinement:

| Pts | Plane | Outl | t mean ms (LO → DEG) |
|----:|------:|-----:|:--|
| 200  | 0%  | 0%  | 0.07 → 0.16 |
| 1000 | 0%  | 40% | 9.1 → 12.8 (1.4×) |
| 1000 | 80% | 40% | 10.0 → 63.7 |
| 1000 | 95% | 0%  | 0.4 → 1.8 |
| 1000 | 95% | 40% | 11.1 → 108 |
| 1000 | 98% | 40% | 10.5 → **119** |

Clean dominant planes stay cheap (converge in ~2 trials); outlier-heavy large problems are the expensive corner. The estimator's hot paths are optimized (cross-product epipole instead of SVD, closed-form 3×3 solves, hoisted `[e]ₓF`, capped homography-refit points, and off-plane-only scoring of epipole candidates), which cut ~1.6× off detection-dominated cases and ~1.3–1.4× off dominant-plane cases at unchanged accuracy. `max_plane_parallax_trials` and the refit trial count remain tunable knobs, and LO-RANSAC's OpenMP parallelism is available for free since it is an injected solver.

<details>
<summary>Full synthetic benchmark table</summary>

```
| Pts   | Plane  | Outl | Method   | t mean  | t p90   | Succ%  | Recall% | Prec%  | Rot med  | Rot p90  | Trans med | Trans p90 | Trials |
|------:|-------:|-----:|:---------|--------:|--------:|-------:|--------:|-------:|---------:|---------:|----------:|----------:|-------:|
|   200 |     0% |    0% | loransac |    0.07 |    0.09 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.033 |     0.076 |      2 |
|   200 |     0% |    0% | degensac |    0.13 |    0.17 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.033 |     0.076 |      2 |
|   200 |     0% |   20% | loransac |    0.41 |    0.45 |  100.0 |    100.0 |    99.9 |    0.009 |    0.015 |     0.036 |     0.095 |    122 |
|   200 |     0% |   20% | degensac |    0.99 |    1.33 |  100.0 |    100.0 |    99.9 |    0.009 |    0.015 |     0.035 |     0.091 |    122 |
|   200 |     0% |   40% | loransac |    2.81 |    2.94 |  100.0 |    100.0 |    99.8 |    0.010 |    0.021 |     0.041 |     0.119 |   1036 |
|   200 |     0% |   40% | degensac |    6.28 |    6.91 |  100.0 |    100.0 |    99.8 |    0.010 |    0.020 |     0.042 |     0.125 |   1035 |
|   200 |    30% |    0% | loransac |    0.07 |    0.09 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.034 |     0.073 |      2 |
|   200 |    30% |    0% | degensac |    0.16 |    0.29 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.034 |     0.073 |      2 |
|   200 |    30% |   20% | loransac |    0.48 |    0.56 |  100.0 |    100.0 |    99.9 |    0.008 |    0.017 |     0.036 |     0.117 |    123 |
|   200 |    30% |   20% | degensac |    1.55 |    2.30 |  100.0 |    100.0 |    99.9 |    0.009 |    0.018 |     0.038 |     0.124 |    122 |
|   200 |    30% |   40% | loransac |    2.88 |    3.02 |  100.0 |     99.9 |    99.8 |    0.011 |    0.022 |     0.051 |     0.128 |   1036 |
|   200 |    30% |   40% | degensac |    7.37 |    8.79 |  100.0 |    100.0 |    99.8 |    0.011 |    0.022 |     0.051 |     0.136 |   1032 |
|   200 |    50% |    0% | loransac |    0.07 |    0.09 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.039 |     0.096 |      2 |
|   200 |    50% |    0% | degensac |    0.27 |    0.58 |  100.0 |    100.0 |   100.0 |    0.007 |    0.014 |     0.039 |     0.097 |      2 |
|   200 |    50% |   20% | loransac |    0.45 |    0.52 |  100.0 |    100.0 |    99.9 |    0.009 |    0.017 |     0.043 |     0.121 |    123 |
|   200 |    50% |   20% | degensac |    3.68 |    5.23 |  100.0 |    100.0 |    99.9 |    0.008 |    0.016 |     0.042 |     0.136 |    122 |
|   200 |    50% |   40% | loransac |    3.01 |    3.21 |  100.0 |     99.9 |    99.8 |    0.011 |    0.023 |     0.058 |     0.197 |   1044 |
|   200 |    50% |   40% | degensac |   12.06 |   14.94 |  100.0 |    100.0 |    99.6 |    0.011 |    0.024 |     0.061 |     0.216 |   1023 |
|   200 |    80% |    0% | loransac |    0.10 |    0.14 |  100.0 |    100.0 |   100.0 |    0.009 |    0.017 |     0.066 |     0.187 |      4 |
|   200 |    80% |    0% | degensac |    0.96 |    1.42 |  100.0 |    100.0 |   100.0 |    0.009 |    0.018 |     0.079 |     0.196 |      2 |
|   200 |    80% |   20% | loransac |    0.49 |    0.62 |   99.0 |     99.6 |    99.9 |    0.011 |    0.031 |     0.084 |     0.336 |    130 |
|   200 |    80% |   20% | degensac |   14.44 |   17.02 |  100.0 |    100.0 |    99.8 |    0.010 |    0.026 |     0.090 |     0.324 |    121 |
|   200 |    80% |   40% | loransac |    3.48 |    4.64 |   98.7 |     99.1 |    99.6 |    0.015 |    0.083 |     0.130 |     1.563 |   1129 |
|   200 |    80% |   40% | degensac |   41.07 |   47.26 |  100.0 |    100.0 |    99.4 |    0.015 |    0.043 |     0.157 |     0.520 |   1008 |
|   200 |    90% |    0% | loransac |    0.12 |    0.17 |   84.7 |     98.8 |   100.0 |    0.013 |    0.692 |     0.142 |    13.271 |     12 |
|   200 |    90% |    0% | degensac |    1.10 |    1.52 |  100.0 |    100.0 |   100.0 |    0.010 |    0.022 |     0.107 |     0.291 |      2 |
|   200 |    90% |   20% | loransac |    0.50 |    0.65 |   77.0 |     97.9 |    99.6 |    0.024 |    1.529 |     0.302 |    23.908 |    150 |
|   200 |    90% |   20% | degensac |   20.28 |   23.28 |  100.0 |    100.0 |    99.7 |    0.014 |    0.046 |     0.174 |     0.591 |    121 |
|   200 |    90% |   40% | loransac |    3.77 |    4.94 |   69.7 |     97.4 |    99.1 |    0.066 |    2.890 |     0.984 |    36.671 |   1242 |
|   200 |    90% |   40% | degensac |   59.54 |   67.77 |  100.0 |     99.9 |    99.2 |    0.023 |    0.069 |     0.305 |     1.113 |    996 |
|   200 |    95% |    0% | loransac |    0.11 |    0.14 |   39.7 |     97.6 |   100.0 |    0.476 |    2.940 |    12.160 |    66.933 |     16 |
|   200 |    95% |    0% | degensac |    1.13 |    1.50 |  100.0 |    100.0 |   100.0 |    0.014 |    0.038 |     0.196 |     0.622 |      2 |
|   200 |    95% |   20% | loransac |    0.48 |    0.54 |   28.7 |     97.3 |    99.2 |    1.052 |    6.115 |    19.732 |    72.885 |    144 |
|   200 |    95% |   20% | degensac |   24.42 |   28.19 |   99.3 |     99.9 |    99.6 |    0.026 |    0.112 |     0.381 |     1.819 |    119 |
|   200 |    95% |   40% | loransac |    3.10 |    3.40 |   27.3 |     97.3 |    98.3 |    1.707 |    6.778 |    22.472 |    79.824 |   1137 |
|   200 |    95% |   40% | degensac |   71.64 |   81.45 |   89.3 |     99.7 |    98.7 |    0.049 |    0.269 |     0.778 |     5.224 |    974 |
|   200 |    98% |    0% | loransac |    0.09 |    0.11 |    9.7 |     98.7 |   100.0 |    1.520 |    4.061 |    42.783 |    79.866 |     13 |
|   200 |    98% |    0% | degensac |    1.24 |    1.70 |   95.3 |     99.9 |   100.0 |    0.032 |    0.139 |     0.473 |     2.415 |      4 |
|   200 |    98% |   20% | loransac |    0.40 |    0.43 |    6.0 |     98.7 |    98.9 |    3.200 |    7.199 |    54.386 |    83.959 |    126 |
|   200 |    98% |   20% | degensac |   26.25 |   30.85 |   30.0 |     99.3 |    98.4 |    1.116 |    6.240 |    17.007 |    75.201 |    114 |
|   200 |    98% |   40% | loransac |    2.65 |    2.80 |    2.7 |     98.9 |    97.8 |    3.773 |    7.530 |    52.549 |    82.750 |    968 |
|   200 |    98% |   40% | degensac |   74.34 |   83.68 |   10.0 |     99.1 |    96.8 |    3.204 |    7.349 |    43.697 |    79.854 |    883 |
|  1000 |     0% |    0% | loransac |    0.20 |    0.23 |  100.0 |    100.0 |   100.0 |    0.003 |    0.006 |     0.014 |     0.034 |      2 |
|  1000 |     0% |    0% | degensac |    0.43 |    0.50 |  100.0 |    100.0 |   100.0 |    0.003 |    0.006 |     0.014 |     0.034 |      2 |
|  1000 |     0% |   20% | loransac |    1.29 |    1.38 |  100.0 |    100.0 |   100.0 |    0.004 |    0.007 |     0.015 |     0.039 |    119 |
|  1000 |     0% |   20% | degensac |    2.19 |    2.90 |  100.0 |    100.0 |   100.0 |    0.004 |    0.007 |     0.015 |     0.038 |    120 |
|  1000 |     0% |   40% | loransac |    8.98 |    9.28 |  100.0 |    100.0 |    99.9 |    0.004 |    0.010 |     0.018 |     0.056 |    981 |
|  1000 |     0% |   40% | degensac |   12.76 |   14.04 |  100.0 |    100.0 |    99.9 |    0.004 |    0.009 |     0.018 |     0.059 |    982 |
|  1000 |    30% |    0% | loransac |    0.19 |    0.23 |  100.0 |    100.0 |   100.0 |    0.003 |    0.007 |     0.017 |     0.039 |      2 |
|  1000 |    30% |    0% | degensac |    0.47 |    0.63 |  100.0 |    100.0 |   100.0 |    0.003 |    0.007 |     0.017 |     0.039 |      2 |
|  1000 |    30% |   20% | loransac |    1.30 |    1.43 |  100.0 |    100.0 |   100.0 |    0.004 |    0.009 |     0.018 |     0.044 |    119 |
|  1000 |    30% |   20% | degensac |    3.11 |    4.44 |  100.0 |    100.0 |   100.0 |    0.004 |    0.009 |     0.019 |     0.049 |    119 |
|  1000 |    30% |   40% | loransac |    9.09 |    9.29 |  100.0 |    100.0 |    99.9 |    0.005 |    0.010 |     0.023 |     0.064 |    981 |
|  1000 |    30% |   40% | degensac |   14.82 |   17.35 |  100.0 |    100.0 |    99.9 |    0.005 |    0.011 |     0.024 |     0.086 |    980 |
|  1000 |    50% |    0% | loransac |    0.20 |    0.24 |  100.0 |    100.0 |   100.0 |    0.003 |    0.007 |     0.018 |     0.043 |      2 |
|  1000 |    50% |    0% | degensac |    0.61 |    1.04 |  100.0 |    100.0 |   100.0 |    0.003 |    0.007 |     0.018 |     0.043 |      2 |
|  1000 |    50% |   20% | loransac |    1.33 |    1.47 |  100.0 |    100.0 |   100.0 |    0.004 |    0.008 |     0.022 |     0.052 |    119 |
|  1000 |    50% |   20% | degensac |    6.67 |    9.10 |  100.0 |    100.0 |    99.9 |    0.004 |    0.010 |     0.023 |     0.076 |    119 |
|  1000 |    50% |   40% | loransac |    9.24 |   10.13 |  100.0 |    100.0 |    99.9 |    0.004 |    0.011 |     0.027 |     0.089 |    981 |
|  1000 |    50% |   40% | degensac |   22.34 |   27.03 |  100.0 |    100.0 |    99.8 |    0.005 |    0.012 |     0.030 |     0.132 |    977 |
|  1000 |    80% |    0% | loransac |    0.26 |    0.36 |  100.0 |    100.0 |   100.0 |    0.003 |    0.007 |     0.026 |     0.061 |      2 |
|  1000 |    80% |    0% | degensac |    1.50 |    2.14 |  100.0 |    100.0 |   100.0 |    0.006 |    0.012 |     0.054 |     0.141 |      2 |
|  1000 |    80% |   20% | loransac |    1.54 |    1.81 |   99.7 |     99.8 |   100.0 |    0.004 |    0.009 |     0.032 |     0.097 |    124 |
|  1000 |    80% |   20% | degensac |   22.17 |   25.74 |  100.0 |    100.0 |    99.9 |    0.008 |    0.016 |     0.072 |     0.205 |    119 |
|  1000 |    80% |   40% | loransac |   10.00 |   12.26 |   99.3 |     99.5 |    99.8 |    0.006 |    0.034 |     0.050 |     0.613 |   1063 |
|  1000 |    80% |   40% | degensac |   63.68 |   71.09 |  100.0 |    100.0 |    99.8 |    0.010 |    0.023 |     0.100 |     0.248 |    974 |
|  1000 |    90% |    0% | loransac |    0.33 |    0.52 |   93.7 |     99.5 |   100.0 |    0.004 |    0.011 |     0.042 |     0.126 |      7 |
|  1000 |    90% |    0% | degensac |    1.69 |    2.31 |  100.0 |    100.0 |   100.0 |    0.007 |    0.013 |     0.062 |     0.155 |      2 |
|  1000 |    90% |   20% | loransac |    1.79 |    2.42 |   82.0 |     98.3 |    99.9 |    0.008 |    0.550 |     0.088 |     9.116 |    146 |
|  1000 |    90% |   20% | degensac |   29.67 |   33.39 |  100.0 |    100.0 |    99.9 |    0.010 |    0.021 |     0.095 |     0.288 |    119 |
|  1000 |    90% |   40% | loransac |   11.08 |   14.84 |   79.3 |     97.7 |    99.7 |    0.034 |    0.503 |     0.550 |     9.443 |   1191 |
|  1000 |    90% |   40% | degensac |   90.24 |   99.16 |  100.0 |    100.0 |    99.8 |    0.014 |    0.033 |     0.136 |     0.359 |    973 |
|  1000 |    95% |    0% | loransac |    0.37 |    0.51 |   59.3 |     98.3 |   100.0 |    0.009 |    2.187 |     0.132 |    52.172 |     12 |
|  1000 |    95% |    0% | degensac |    1.76 |    2.40 |  100.0 |    100.0 |   100.0 |    0.008 |    0.014 |     0.081 |     0.207 |      2 |
|  1000 |    95% |   20% | loransac |    1.54 |    1.73 |   42.7 |     97.6 |    99.8 |    0.515 |    4.076 |     7.679 |    60.490 |    145 |
|  1000 |    95% |   20% | degensac |   34.21 |   38.01 |  100.0 |    100.0 |    99.9 |    0.013 |    0.030 |     0.152 |     0.412 |    119 |
|  1000 |    95% |   40% | loransac |   10.83 |   12.07 |   45.7 |     97.5 |    99.6 |    0.434 |    4.189 |     5.969 |    49.859 |   1162 |
|  1000 |    95% |   40% | degensac |  107.83 |  118.17 |  100.0 |    100.0 |    99.7 |    0.018 |    0.041 |     0.208 |     0.526 |    972 |
|  1000 |    98% |    0% | loransac |    0.30 |    0.40 |   22.3 |     98.7 |   100.0 |    0.890 |    2.893 |    31.623 |    69.137 |     12 |
|  1000 |    98% |    0% | degensac |    1.92 |    2.63 |  100.0 |    100.0 |   100.0 |    0.010 |    0.022 |     0.125 |     0.367 |      2 |
|  1000 |    98% |   20% | loransac |    1.47 |    1.61 |   15.0 |     98.6 |    99.8 |    1.881 |    7.141 |    34.667 |    78.203 |    131 |
|  1000 |    98% |   20% | degensac |   38.42 |   43.43 |   99.3 |     99.9 |    99.9 |    0.022 |    0.072 |     0.303 |     0.920 |    119 |
|  1000 |    98% |   40% | loransac |    9.91 |   10.41 |   15.7 |     98.6 |    99.5 |    2.043 |    6.153 |    29.387 |    77.764 |   1051 |
|  1000 |    98% |   40% | degensac |  118.81 |  130.19 |   99.0 |     99.9 |    99.6 |    0.038 |    0.137 |     0.540 |     2.049 |    969 |
```
</details>

## Real-data evaluation (south-building, SIFT, 128 images, exhaustive)

Geometric verification was recomputed on the pre-computed `database.db` with default vs `use_degensac=True` (identical options otherwise, fixed RANSAC seed), followed by incremental mapping (single-thread, fixed seed). **Bottom line: negligible practical difference on this dataset** — it already reconstructs perfectly without DEGENSAC, so there is no plane-dominated failure to fix.

**Verification (4210 pairs with ≥15 matches):**

| Metric | Default | DEGENSAC |
|---|--:|--:|
| Total inlier matches | 844,504 | 846,570 (**+0.24%**) |
| Pairs with more / fewer F inliers | — | 1037 / 96 (3077 unchanged) |
| Pairs with changed config | — | **109 (~2.6%)** |
| Verification wall time | 41 s | 45 s (**~1.1×**) |

Head-to-head over the 4210 pairs, DEGENSAC averages 62 ms/pair vs 36 ms/pair for plain LO-RANSAC (1.7×); after the hot-path optimizations the full geometric-verification wall time is only ~10% higher.

**Config changes explained.** DEGENSAC only changes the `F` estimate (`E` and `H` are re-seeded identically per pair), so every config flip is a threshold crossing driven by the changed number of `F` inliers moving the `E/F` and `H/F` inlier ratios across the calibrated-path decision thresholds (`min_E_F_inlier_ratio=0.95`, `max_H_inlier_ratio=0.8`, `min_num_inliers=15`):

| Transition | n | Direction / cause |
|---|--:|---|
| `CALIBRATED → UNCALIBRATED` | 53 | F gains inliers → `E/F` < 0.95, E≈F calibration test no longer holds |
| `PLANAR_OR_PANORAMIC → UNCALIBRATED` | 15 | F gains inliers → `H/F` < 0.8 (epipolar geometry recovered) |
| `DEGENERATE → UNCALIBRATED` | 15 | F gains enough inliers to pass `min_num_inliers` |
| `UNCALIBRATED → DEGENERATE` | 14 | F loses inliers → below `min_num_inliers` |
| `UNCALIBRATED → CALIBRATED` | 10 | F loses inliers → `E/F` > 0.95 |
| `UNCALIBRATED → PLANAR_OR_PANORAMIC` | 2 | F loses inliers → `H/F` > 0.8 |

83 pairs move in the intended direction (F gains inliers, recovering/keeping epipolar geometry), 26 mildly the other way. 1037 pairs gain F inliers overall vs only 96 losing — a cleaner distribution than before the completion improvements.

**Reconstruction (incremental mapping):**

| Metric | Default | DEGENSAC |
|---|--:|--:|
| Registered images | 128 / 128 | 128 / 128 |
| 3D points | 61,504 | 61,727 (**+0.36%**) |
| Observations | 327,795 | 328,205 |
| Mean track length | 5.33 | 5.32 |
| Mean reprojection error | 0.5142 px | 0.5137 px |

Both register all 128 images with statistically identical accuracy. The completion improvements raise recovered points (+0.20% → +0.36%) but the net remains negligible: south-building has enough non-planar parallax that plain LO-RANSAC already reconstructs fully. DEGENSAC's value is concentrated in the plane-dominated regime isolated by the synthetic benchmark — consistent with its opt-in, default-off design.

## Benchmark: ETH3D `dslr` A/B (DEGENSAC on vs. off)

End-to-end reconstruction benchmark on ETH3D `dslr` (25 scenes), `quality=medium`,
relative pairwise-pose AUC. Each arm is an independent full run (extraction → matching
→ mapping); `use_degensac` is the only variable. Run in both the **uncalibrated**
(self-calibration) and **calibrated** (GT camera priors) settings.

**Summary**

DEGENSAC's benefit is concentrated in **uncalibrated + global** — where the fundamental
matrix is both the primary epipolar model and the mapper is sensitive to degenerate
planar geometry. Where the essential matrix takes over (all calibrated runs), the effect
is ≈zero.

Δ (ON − OFF), AUC@5°:

| | Global overall | Global average | Incremental overall | Incremental average |
|---|---|---|---|---|
| **Uncalibrated** | **+7.38** | **+10.89** | −2.16 | −2.75 |
| **Calibrated** | −0.06 | −0.05 | +0.15 | +1.53 |

- **Uncalibrated / global — clear, large win.** +7.4 (overall) / +10.9 (average) AUC@5°,
  no meaningful per-scene regressions.
- **Uncalibrated / incremental — roughly neutral, high variance.** Net slightly negative,
  driven almost entirely by one scene (`delivery_area`) flipping into a wrongly-stitched
  model. Excluding it, ≈neutral.
- **Calibrated (both mappers) — ≈no-op.** With GT priors the 5-point essential matrix
  dominates two-view geometry, so changing F estimation barely moves anything (global
  flat; incremental marginally positive, mostly from `pipes`). No catastrophic
  regressions — `delivery_area` is stable here.

### Uncalibrated

**Overall & average AUC (ON − OFF)**

| Mapper | Metric | @0.5° | @1° | @5° | @10° | reg imgs |
|---|---|---|---|---|---|---|
| Global | overall OFF→ON | 30.97→33.81 | 50.91→55.92 | 78.05→85.43 | 83.40→90.47 | 867→868 |
| Global | Δ overall | +2.84 | +5.01 | **+7.38** | +7.07 | +1 |
| Global | Δ average | +3.88 | +7.08 | **+10.89** | +10.62 | — |
| Incremental | overall OFF→ON | 32.47→32.21 | 53.92→53.02 | 82.97→80.81 | 87.73→85.60 | 841→846 |
| Incremental | Δ overall | −0.26 | −0.90 | **−2.16** | −2.13 | +5 |
| Incremental | Δ average | −0.65 | −1.72 | **−2.75** | −2.66 | — |

**Notable per-scene movers (AUC@5°)**

Global (top wins; worst case is −1.7 on `facade`):

| Scene | OFF | ON | Δ |
|---|---|---|---|
| terrains | 25.4 | 90.4 | +65.0 |
| boulders | 16.1 | 73.7 | +57.7 |
| pipes | 49.3 | 83.8 | +34.5 |
| old_computer | 46.7 | 80.7 | +34.0 |
| courtyard | 50.1 | 77.6 | +27.5 |
| playground | 78.3 | 93.5 | +15.2 |

Incremental (one big win, one catastrophic loss):

| Scene | OFF | ON | Δ |
|---|---|---|---|
| living_room | 77.6 | 91.5 | +13.9 |
| meadow | 0.4 | 11.3 | +10.9 |
| pipes | 66.0 | 52.5 | −13.5 |
| delivery_area | 89.0 | 6.6 | −82.4 |

### Calibrated (GT camera priors)

**Overall & average AUC (ON − OFF)**

| Mapper | Metric | @0.5° | @1° | @5° | @10° | reg imgs |
|---|---|---|---|---|---|---|
| Global | overall OFF→ON | 70.56→70.21 | 82.13→82.01 | 93.79→93.73 | 95.55→95.46 | 870→868 |
| Global | Δ overall | −0.35 | −0.12 | −0.06 | −0.09 | −2 |
| Global | Δ average | +0.08 | +0.24 | −0.05 | −0.21 | — |
| Incremental | overall OFF→ON | 68.59→68.31 | 80.34→80.19 | 91.95→92.10 | 93.65→93.86 | 854→863 |
| Incremental | Δ overall | −0.28 | −0.15 | +0.15 | +0.21 | +9 |
| Incremental | Δ average | +0.29 | +0.62 | **+1.53** | +1.70 | — |

With GT priors the essential matrix dominates, so DEGENSAC (which only changes F) is
≈no-op: global is flat, incremental is marginally positive (mostly `pipes`
57.5→91.8 @5°). No catastrophic regressions; `delivery_area` is stable (97.9→97.9).

**Interpretation**

- The global mapper's averaging is sensitive to degenerate planar fundamental-matrix
  estimates; DEGENSAC cleaning those up (e.g. `terrains`, `boulders`) is exactly what
  it needs, hence the broad gains.
- Incremental's per-image PnP + retriangulation is already robust to individual bad
  pairs, so it gains less and can occasionally be tipped into a bad merge. The
  `delivery_area` collapse (2 clean components → 1 grossly misaligned model) accounts
  for essentially the entire incremental net drop; backing it out leaves incremental
  ≈neutral.

_Reproduce (medium, all dslr scenes; add `--uncalibrated` for the self-calibration
setting, omit it for the calibrated/GT-priors setting):_

```
python benchmark/reconstruction/evaluate.py \
  --datasets eth3d --categories dslr --quality medium [--uncalibrated] \
  --mapper <global|incremental> [--use_degensac] \
  --colmap_path <colmap> --run_name <arm>
```


## Testing

- `fundamental_matrix_degensac_test` — helper unit tests (`EpipoleFromFundamentalMatrix`, `HomographyFromFundamentalAndPoints` incl. collinear→nullopt, `IsSampleHDegenerate`), non-planar parity vs LO-RANSAC, dominant-plane recovery, and an aggregate contrast over many scenes. Clean under AddressSanitizer.
- `two_view_geometry_test` — added `UncalibratedDegensac` integration test; default path unchanged.
- Regression: `fundamental_matrix` (solver), `loransac`, `ransac` tests pass.

## Reference

Ondřej Chum, Tomáš Werner, Jiří Matas. *Two-View Geometry Estimation Unaffected by a Dominant Plane.* CVPR 2005. https://cmp.felk.cvut.cz/~werner/papers/chum-degen-cvpr05.pdf



