### PR TITLE
Add benchmark option to clear two-view geometries

### DIFF
--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -341,6 +341,14 @@ def parse_args() -> argparse.Namespace:
         "--overwrite_matches", default=False, action="store_true"
     )
     parser.add_argument(
+        "--overwrite_two_view_geometries",
+        default=False,
+        action="store_true",
+        help="Clear two-view geometries (inlier matches) but keep raw matches, "
+        "so geometric verification is recomputed from the cached matches. "
+        "Useful for re-tuning geometric verification without re-matching.",
+    )
+    parser.add_argument(
         "--overwrite_reconstruction", default=False, action="store_true"
     )
     parser.add_argument(
@@ -477,6 +485,11 @@ def parse_args() -> argparse.Namespace:
             "Overwriting matches also overwrites reconstruction"
         )
         args.overwrite_reconstruction = True
+    if args.overwrite_two_view_geometries:
+        pycolmap.logging.info(
+            "Overwriting two-view geometries also overwrites reconstruction"
+        )
+        args.overwrite_reconstruction = True
     if args.overwrite_reconstruction:
         pycolmap.logging.info(
             "Overwriting reconstruction also overwrites alignment"
@@ -539,7 +552,15 @@ def colmap_reconstruction(
         pycolmap.logging.info("Skipping reconstruction, as it already exists")
         return
 
+    # Clearing matches also clears two-view geometries, so there is no need to
+    # clear the latter separately when both flags are set.
     if args.overwrite_matches:
+        cleaner_type = "matches"
+    elif args.overwrite_two_view_geometries:
+        cleaner_type = "two_view_geometries"
+    else:
+        cleaner_type = None
+    if cleaner_type is not None:
         subprocess.check_call(
             [
                 args.colmap_path,
@@ -547,7 +568,7 @@ def colmap_reconstruction(
                 "--database_path",
                 database_path,
                 "--type",
-                "matches",
+                cleaner_type,
             ],
             cwd=workspace_path,
             preexec_fn=_set_pdeathsig,


### PR DESCRIPTION
Adds an option to the reconstruction benchmark script (`benchmark/reconstruction/evaluation/utils.py`):

- `--overwrite_two_view_geometries`: clears cached two-view geometries (inlier matches) while keeping the raw matches, so geometric verification is recomputed from the cached matches without re-matching. Useful for re-tuning geometric verification without paying the cost of re-matching. Like `--overwrite_matches`, it also triggers overwriting the reconstruction.

When both `--overwrite_matches` and `--overwrite_two_view_geometries` are set, clearing matches already clears two-view geometries, so only the `matches` cleaner runs.