### PR TITLE
Propagate max_num_iterations to Caspar BA backend (fixes #4382)

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -188,6 +188,11 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
     options.ceres->gpu_index = ba_gpu_index;
   }
   if (options.caspar) {
+    // Caspar has different dampening and convergence criteria than Ceres, so
+    // most solver parameters are not meaningful to propagate. The maximum
+    // number of iterations is the exception: bounding it keeps the Caspar
+    // backend from running unboundedly long compared to the Ceres path.
+    options.caspar->solver_iter_max = ba_local_max_num_iterations;
     options.caspar->gpu_index = ba_gpu_index;
   }
   return options;
@@ -228,6 +233,9 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
     options.ceres->gpu_index = ba_gpu_index;
   }
   if (options.caspar) {
+    // See LocalBundleAdjustment(): only the iteration bound is propagated to
+    // the Caspar backend, whose other solver parameters do not map to Ceres.
+    options.caspar->solver_iter_max = ba_global_max_num_iterations;
     options.caspar->gpu_index = ba_gpu_index;
   }
   return options;

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -188,11 +188,16 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
     options.ceres->gpu_index = ba_gpu_index;
   }
   if (options.caspar) {
-    // Caspar has different dampening and convergence criteria than Ceres, so
-    // most solver parameters are not meaningful to propagate. The maximum
-    // number of iterations is the exception: bounding it keeps the Caspar
-    // backend from running unboundedly long compared to the Ceres path.
-    options.caspar->solver_iter_max = ba_local_max_num_iterations;
+    // Caspar has different dampening and convergence criteria than Ceres and
+    // ships its own tuned default iteration bound, so we must not clobber it
+    // with the Ceres-oriented mapper default. Only forward the iteration bound
+    // when the user explicitly overrode it (i.e. it differs from the default),
+    // leaving CasparBundleAdjustmentOptions::solver_iter_max untouched
+    // otherwise.
+    static const IncrementalPipelineOptions kDefaults;
+    if (ba_local_max_num_iterations != kDefaults.ba_local_max_num_iterations) {
+      options.caspar->solver_iter_max = ba_local_max_num_iterations;
+    }
     options.caspar->gpu_index = ba_gpu_index;
   }
   return options;
@@ -233,9 +238,13 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
     options.ceres->gpu_index = ba_gpu_index;
   }
   if (options.caspar) {
-    // See LocalBundleAdjustment(): only the iteration bound is propagated to
-    // the Caspar backend, whose other solver parameters do not map to Ceres.
-    options.caspar->solver_iter_max = ba_global_max_num_iterations;
+    // See LocalBundleAdjustment(): only forward the iteration bound to the
+    // Caspar backend when the user overrode the mapper default, so Caspar's
+    // own tuned solver_iter_max default is preserved otherwise.
+    static const IncrementalPipelineOptions kDefaults;
+    if (ba_global_max_num_iterations != kDefaults.ba_global_max_num_iterations) {
+      options.caspar->solver_iter_max = ba_global_max_num_iterations;
+    }
     options.caspar->gpu_index = ba_gpu_index;
   }
   return options;

--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -40,6 +40,13 @@
 namespace colmap {
 namespace {
 
+// Default maximum number of bundle adjustment iterations for the Ceres
+// backend, used when ba_{local,global}_max_num_iterations is -1. The Caspar
+// backend has different convergence behavior and instead falls back to its
+// own tuned default in CasparBundleAdjustmentOptions::solver_iter_max.
+constexpr int kDefaultCeresLocalMaxNumIterations = 25;
+constexpr int kDefaultCeresGlobalMaxNumIterations = 50;
+
 void CustomizeIncrementalPipelineOptions(const DatabaseCache& database_cache,
                                          IncrementalPipelineOptions& options) {
   // If the total number of images is small then do not enforce the
@@ -172,7 +179,8 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
     options.ceres->solver_options.gradient_tolerance = 10.0;
     options.ceres->solver_options.parameter_tolerance = 0.0;
     options.ceres->solver_options.max_num_iterations =
-        ba_local_max_num_iterations;
+        (ba_local_max_num_iterations >= 0) ? ba_local_max_num_iterations
+                                           : kDefaultCeresLocalMaxNumIterations;
     options.ceres->solver_options.max_linear_solver_iterations = 100;
     options.ceres->solver_options.logging_type = ceres::LoggingType::SILENT;
     options.ceres->solver_options.num_threads = num_threads;
@@ -188,14 +196,11 @@ BundleAdjustmentOptions IncrementalPipelineOptions::LocalBundleAdjustment()
     options.ceres->gpu_index = ba_gpu_index;
   }
   if (options.caspar) {
-    // Caspar has different dampening and convergence criteria than Ceres and
-    // ships its own tuned default iteration bound, so we must not clobber it
-    // with the Ceres-oriented mapper default. Only forward the iteration bound
-    // when the user explicitly overrode it (i.e. it differs from the default),
-    // leaving CasparBundleAdjustmentOptions::solver_iter_max untouched
-    // otherwise.
-    static const IncrementalPipelineOptions kDefaults;
-    if (ba_local_max_num_iterations != kDefaults.ba_local_max_num_iterations) {
+    // Only forward the iteration bound when the user explicitly set it
+    // (i.e. it is not the -1 sentinel), leaving Caspar's own tuned
+    // solver_iter_max default untouched otherwise, as Caspar has different
+    // dampening and convergence criteria than Ceres.
+    if (ba_local_max_num_iterations >= 0) {
       options.caspar->solver_iter_max = ba_local_max_num_iterations;
     }
     options.caspar->gpu_index = ba_gpu_index;
@@ -218,7 +223,9 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
     options.ceres->solver_options.gradient_tolerance = 1.0;
     options.ceres->solver_options.parameter_tolerance = 0.0;
     options.ceres->solver_options.max_num_iterations =
-        ba_global_max_num_iterations;
+        (ba_global_max_num_iterations >= 0)
+            ? ba_global_max_num_iterations
+            : kDefaultCeresGlobalMaxNumIterations;
     options.ceres->solver_options.max_linear_solver_iterations = 100;
     options.ceres->solver_options.logging_type = ceres::LoggingType::SILENT;
     if (VLOG_IS_ON(2)) {
@@ -239,15 +246,34 @@ BundleAdjustmentOptions IncrementalPipelineOptions::GlobalBundleAdjustment()
   }
   if (options.caspar) {
     // See LocalBundleAdjustment(): only forward the iteration bound to the
-    // Caspar backend when the user overrode the mapper default, so Caspar's
-    // own tuned solver_iter_max default is preserved otherwise.
-    static const IncrementalPipelineOptions kDefaults;
-    if (ba_global_max_num_iterations != kDefaults.ba_global_max_num_iterations) {
+    // Caspar backend when the user explicitly set it, so Caspar's own tuned
+    // solver_iter_max default is preserved otherwise.
+    if (ba_global_max_num_iterations >= 0) {
       options.caspar->solver_iter_max = ba_global_max_num_iterations;
     }
     options.caspar->gpu_index = ba_gpu_index;
   }
   return options;
+}
+
+int IncrementalPipelineOptions::EffBaLocalMaxNumIterations() const {
+  if (ba_local_max_num_iterations >= 0) {
+    return ba_local_max_num_iterations;
+  }
+  if (ba_local_backend == BundleAdjustmentBackend::CASPAR) {
+    return CasparBundleAdjustmentOptions().solver_iter_max;
+  }
+  return kDefaultCeresLocalMaxNumIterations;
+}
+
+int IncrementalPipelineOptions::EffBaGlobalMaxNumIterations() const {
+  if (ba_global_max_num_iterations >= 0) {
+    return ba_global_max_num_iterations;
+  }
+  if (ba_global_backend == BundleAdjustmentBackend::CASPAR) {
+    return CasparBundleAdjustmentOptions().solver_iter_max;
+  }
+  return kDefaultCeresGlobalMaxNumIterations;
 }
 
 bool IncrementalPipelineOptions::Check() const {
@@ -259,12 +285,13 @@ bool IncrementalPipelineOptions::Check() const {
   CHECK_OPTION_GT(min_focal_length_ratio, 0);
   CHECK_OPTION_GT(max_focal_length_ratio, 0);
   CHECK_OPTION_GE(max_extra_param, 0);
-  CHECK_OPTION_GE(ba_local_max_num_iterations, 0);
+  CHECK_OPTION_GE(ba_local_max_num_iterations, -1);
   CHECK_OPTION_GT(ba_global_frames_ratio, 1.0);
   CHECK_OPTION_GT(ba_global_points_ratio, 1.0);
   CHECK_OPTION_GT(ba_global_frames_freq, 0);
   CHECK_OPTION_GT(ba_global_points_freq, 0);
-  CHECK_OPTION_GT(ba_global_max_num_iterations, 0);
+  CHECK_OPTION_GE(ba_global_max_num_iterations, -1);
+  CHECK_OPTION_NE(ba_global_max_num_iterations, 0);
   CHECK_OPTION_GT(ba_local_max_refinements, 0);
   CHECK_OPTION_GE(ba_local_max_refinement_change, 0);
   CHECK_OPTION_GE(ba_global_max_refinements, 0);

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -114,8 +114,9 @@ struct IncrementalPipelineOptions {
   // Ceres solver function tolerance for local bundle adjustment
   double ba_local_function_tolerance = 0.0;
 
-  // The maximum number of local bundle adjustment iterations.
-  int ba_local_max_num_iterations = 25;
+  // The maximum number of local bundle adjustment iterations. If -1, the
+  // default of the configured bundle adjustment backend is used.
+  int ba_local_max_num_iterations = -1;
 
   // The growth rates after which to perform global bundle adjustment.
   double ba_global_frames_ratio = 1.1;
@@ -126,8 +127,9 @@ struct IncrementalPipelineOptions {
   // Ceres solver function tolerance for global bundle adjustment
   double ba_global_function_tolerance = 0.0;
 
-  // The maximum number of global bundle adjustment iterations.
-  int ba_global_max_num_iterations = 50;
+  // The maximum number of global bundle adjustment iterations. If -1, the
+  // default of the configured bundle adjustment backend is used.
+  int ba_global_max_num_iterations = -1;
 
   // The thresholds for iterative bundle adjustment refinements.
   int ba_local_max_refinements = 2;
@@ -198,6 +200,12 @@ struct IncrementalPipelineOptions {
   IncrementalTriangulator::Options Triangulation() const;
   BundleAdjustmentOptions LocalBundleAdjustment() const;
   BundleAdjustmentOptions GlobalBundleAdjustment() const;
+
+  // Returns the effective maximum number of local/global bundle adjustment
+  // iterations. If the respective option is set to -1, the default of the
+  // configured bundle adjustment backend is returned.
+  int EffBaLocalMaxNumIterations() const;
+  int EffBaGlobalMaxNumIterations() const;
 
   inline bool IsInitialPairProvided() const {
     return init_image_id1 != -1 && init_image_id2 != -1;

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -713,7 +713,7 @@ TEST(IncrementalPipeline, PriorBasedSfMWithRandomSeedStability) {
               ReconstructionEq(*reconstruction_manager1->Get(0)));
 }
 
-TEST(IncrementalPipelineOptions, PropagatesMaxNumIterationsToCaspar) {
+TEST(IncrementalPipelineOptions, PropagatesOverriddenMaxNumIterationsToCaspar) {
   IncrementalPipelineOptions options;
   options.ba_local_max_num_iterations = 7;
   options.ba_global_max_num_iterations = 13;
@@ -728,6 +728,23 @@ TEST(IncrementalPipelineOptions, PropagatesMaxNumIterationsToCaspar) {
   ASSERT_TRUE(global_options.caspar);
   EXPECT_EQ(global_options.caspar->solver_iter_max,
             options.ba_global_max_num_iterations);
+}
+
+TEST(IncrementalPipelineOptions, PreservesCasparSolverIterMaxDefault) {
+  // When the mapper iteration bounds are left at their (Ceres-oriented)
+  // defaults, Caspar's own tuned solver_iter_max default must be preserved
+  // rather than overwritten (see review discussion on #4382/PR #4527).
+  const IncrementalPipelineOptions options;
+  const int caspar_default = CasparBundleAdjustmentOptions().solver_iter_max;
+
+  const BundleAdjustmentOptions local_options = options.LocalBundleAdjustment();
+  ASSERT_TRUE(local_options.caspar);
+  EXPECT_EQ(local_options.caspar->solver_iter_max, caspar_default);
+
+  const BundleAdjustmentOptions global_options =
+      options.GlobalBundleAdjustment();
+  ASSERT_TRUE(global_options.caspar);
+  EXPECT_EQ(global_options.caspar->solver_iter_max, caspar_default);
 }
 
 }  // namespace

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -30,6 +30,7 @@
 #include "colmap/controllers/incremental_pipeline.h"
 
 #include "colmap/estimators/bundle_adjustment_caspar.h"
+#include "colmap/estimators/bundle_adjustment_ceres.h"
 #include "colmap/geometry/rigid3_matchers.h"
 #include "colmap/scene/database.h"
 #include "colmap/scene/reconstruction_matchers.h"
@@ -713,38 +714,67 @@ TEST(IncrementalPipeline, PriorBasedSfMWithRandomSeedStability) {
               ReconstructionEq(*reconstruction_manager1->Get(0)));
 }
 
-TEST(IncrementalPipelineOptions, PropagatesOverriddenMaxNumIterationsToCaspar) {
+TEST(IncrementalPipelineOptions, PropagatesExplicitMaxNumIterations) {
+  // Explicitly set iteration bounds must be forwarded to both backends,
+  // including values that coincide with the previous compiled-in defaults.
   IncrementalPipelineOptions options;
-  options.ba_local_max_num_iterations = 7;
-  options.ba_global_max_num_iterations = 13;
+  options.ba_local_max_num_iterations = 25;
+  options.ba_global_max_num_iterations = 50;
 
   const BundleAdjustmentOptions local_options = options.LocalBundleAdjustment();
+  ASSERT_TRUE(local_options.ceres);
+  EXPECT_EQ(local_options.ceres->solver_options.max_num_iterations, 25);
   ASSERT_TRUE(local_options.caspar);
-  EXPECT_EQ(local_options.caspar->solver_iter_max,
-            options.ba_local_max_num_iterations);
+  EXPECT_EQ(local_options.caspar->solver_iter_max, 25);
 
   const BundleAdjustmentOptions global_options =
       options.GlobalBundleAdjustment();
+  ASSERT_TRUE(global_options.ceres);
+  EXPECT_EQ(global_options.ceres->solver_options.max_num_iterations, 50);
   ASSERT_TRUE(global_options.caspar);
-  EXPECT_EQ(global_options.caspar->solver_iter_max,
-            options.ba_global_max_num_iterations);
+  EXPECT_EQ(global_options.caspar->solver_iter_max, 50);
 }
 
-TEST(IncrementalPipelineOptions, PreservesCasparSolverIterMaxDefault) {
-  // When the mapper iteration bounds are left at their (Ceres-oriented)
-  // defaults, Caspar's own tuned solver_iter_max default must be preserved
-  // rather than overwritten (see review discussion on #4382/PR #4527).
+TEST(IncrementalPipelineOptions, DefaultMaxNumIterationsUsesBackendDefaults) {
+  // With the -1 sentinel default, each backend must keep its own default:
+  // Ceres the previous 25/50 mapper defaults, Caspar its own tuned
+  // solver_iter_max (see review discussion on #4382/PR #4527).
   const IncrementalPipelineOptions options;
+  ASSERT_EQ(options.ba_local_max_num_iterations, -1);
+  ASSERT_EQ(options.ba_global_max_num_iterations, -1);
   const int caspar_default = CasparBundleAdjustmentOptions().solver_iter_max;
 
   const BundleAdjustmentOptions local_options = options.LocalBundleAdjustment();
+  ASSERT_TRUE(local_options.ceres);
+  EXPECT_EQ(local_options.ceres->solver_options.max_num_iterations, 25);
   ASSERT_TRUE(local_options.caspar);
   EXPECT_EQ(local_options.caspar->solver_iter_max, caspar_default);
 
   const BundleAdjustmentOptions global_options =
       options.GlobalBundleAdjustment();
+  ASSERT_TRUE(global_options.ceres);
+  EXPECT_EQ(global_options.ceres->solver_options.max_num_iterations, 50);
   ASSERT_TRUE(global_options.caspar);
   EXPECT_EQ(global_options.caspar->solver_iter_max, caspar_default);
+}
+
+TEST(IncrementalPipelineOptions, EffBaMaxNumIterations) {
+  IncrementalPipelineOptions options;
+  const int caspar_default = CasparBundleAdjustmentOptions().solver_iter_max;
+
+  // Sentinel resolves to the configured backend's default.
+  EXPECT_EQ(options.EffBaLocalMaxNumIterations(), 25);
+  EXPECT_EQ(options.EffBaGlobalMaxNumIterations(), 50);
+  options.ba_local_backend = BundleAdjustmentBackend::CASPAR;
+  options.ba_global_backend = BundleAdjustmentBackend::CASPAR;
+  EXPECT_EQ(options.EffBaLocalMaxNumIterations(), caspar_default);
+  EXPECT_EQ(options.EffBaGlobalMaxNumIterations(), caspar_default);
+
+  // Explicit values win regardless of backend.
+  options.ba_local_max_num_iterations = 7;
+  options.ba_global_max_num_iterations = 13;
+  EXPECT_EQ(options.EffBaLocalMaxNumIterations(), 7);
+  EXPECT_EQ(options.EffBaGlobalMaxNumIterations(), 13);
 }
 
 }  // namespace

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/controllers/incremental_pipeline.h"
 
+#include "colmap/estimators/bundle_adjustment_caspar.h"
 #include "colmap/geometry/rigid3_matchers.h"
 #include "colmap/scene/database.h"
 #include "colmap/scene/reconstruction_matchers.h"
@@ -710,6 +711,23 @@ TEST(IncrementalPipeline, PriorBasedSfMWithRandomSeedStability) {
       run_mapper(/*num_threads=*/1, /*random_seed=*/kRandomSeed);
   EXPECT_THAT(*reconstruction_manager0->Get(0),
               ReconstructionEq(*reconstruction_manager1->Get(0)));
+}
+
+TEST(IncrementalPipelineOptions, PropagatesMaxNumIterationsToCaspar) {
+  IncrementalPipelineOptions options;
+  options.ba_local_max_num_iterations = 7;
+  options.ba_global_max_num_iterations = 13;
+
+  const BundleAdjustmentOptions local_options = options.LocalBundleAdjustment();
+  ASSERT_TRUE(local_options.caspar);
+  EXPECT_EQ(local_options.caspar->solver_iter_max,
+            options.ba_local_max_num_iterations);
+
+  const BundleAdjustmentOptions global_options =
+      options.GlobalBundleAdjustment();
+  ASSERT_TRUE(global_options.caspar);
+  EXPECT_EQ(global_options.caspar->solver_iter_max,
+            options.ba_global_max_num_iterations);
 }
 
 }  // namespace

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -126,8 +126,10 @@ void OptionManager::ModifyForLowQuality() {
   sequential_pairing->loop_detection_num_images /= 2;
   vocab_tree_pairing->max_num_features = 256;
   vocab_tree_pairing->num_images /= 2;
-  mapper->ba_local_max_num_iterations /= 2;
-  mapper->ba_global_max_num_iterations /= 2;
+  mapper->ba_local_max_num_iterations =
+      mapper->EffBaLocalMaxNumIterations() / 2;
+  mapper->ba_global_max_num_iterations =
+      mapper->EffBaGlobalMaxNumIterations() / 2;
   mapper->ba_global_frames_ratio *= 1.2;
   mapper->ba_global_points_ratio *= 1.2;
   mapper->ba_global_max_refinements = 2;
@@ -150,8 +152,10 @@ void OptionManager::ModifyForMediumQuality() {
   sequential_pairing->loop_detection_num_images /= 1.5;
   vocab_tree_pairing->max_num_features = 1024;
   vocab_tree_pairing->num_images /= 1.5;
-  mapper->ba_local_max_num_iterations /= 1.5;
-  mapper->ba_global_max_num_iterations /= 1.5;
+  mapper->ba_local_max_num_iterations =
+      static_cast<int>(mapper->EffBaLocalMaxNumIterations() / 1.5);
+  mapper->ba_global_max_num_iterations =
+      static_cast<int>(mapper->EffBaGlobalMaxNumIterations() / 1.5);
   mapper->ba_global_frames_ratio *= 1.1;
   mapper->ba_global_points_ratio *= 1.1;
   mapper->ba_global_max_refinements = 2;

--- a/src/colmap/ui/reconstruction_options_widget.cc
+++ b/src/colmap/ui/reconstruction_options_widget.cc
@@ -150,7 +150,8 @@ class IncrementalMapperBundleAdjustmentOptionsWidget : public OptionsWidget {
     AddSection("Local Bundle Adjustment");
     AddOptionInt(&options->mapper->mapper.ba_local_num_images, "num_images");
     AddOptionInt(&options->mapper->ba_local_max_num_iterations,
-                 "max_num_iterations");
+                 "max_num_iterations",
+                 /*min=*/-1);
     AddOptionInt(
         &options->mapper->ba_local_max_refinements, "max_refinements", 1);
     AddOptionDouble(&options->mapper->ba_local_max_refinement_change,
@@ -205,7 +206,8 @@ class IncrementalMapperBundleAdjustmentOptionsWidget : public OptionsWidget {
     AddOptionDouble(&options->mapper->ba_global_points_ratio, "points_ratio");
     AddOptionInt(&options->mapper->ba_global_points_freq, "points_freq");
     AddOptionInt(&options->mapper->ba_global_max_num_iterations,
-                 "max_num_iterations");
+                 "max_num_iterations",
+                 /*min=*/-1);
     AddOptionInt(
         &options->mapper->ba_global_max_refinements, "max_refinements", 1);
     AddOptionDouble(&options->mapper->ba_global_max_refinement_change,

--- a/src/pycolmap/sfm/incremental_mapper.cc
+++ b/src/pycolmap/sfm/incremental_mapper.cc
@@ -115,7 +115,8 @@ void BindIncrementalPipeline(py::module& m) {
       .def_readwrite(
           "ba_local_max_num_iterations",
           &Opts::ba_local_max_num_iterations,
-          "The maximum number of local bundle adjustment iterations.")
+          "The maximum number of local bundle adjustment iterations. If -1, "
+          "the default of the configured bundle adjustment backend is used.")
       .def_readwrite(
           "ba_global_frames_ratio",
           &Opts::ba_global_frames_ratio,
@@ -139,7 +140,8 @@ void BindIncrementalPipeline(py::module& m) {
       .def_readwrite(
           "ba_global_max_num_iterations",
           &Opts::ba_global_max_num_iterations,
-          "The maximum number of global bundle adjustment iterations.")
+          "The maximum number of global bundle adjustment iterations. If -1, "
+          "the default of the configured bundle adjustment backend is used.")
       .def_readwrite(
           "ba_local_max_refinements",
           &Opts::ba_local_max_refinements,


### PR DESCRIPTION
## Problem

`IncrementalPipelineOptions::LocalBundleAdjustment()` and `GlobalBundleAdjustment()` build the Ceres backend options with the configured `max_num_iterations`, tolerances, thread count, loss function, etc. — but the parallel `if (options.caspar)` block only copied `gpu_index`:

```cpp
if (options.caspar) {
  options.caspar->gpu_index = ba_gpu_index;   // everything else dropped
}
```

So `ba_local_max_num_iterations` / `ba_global_max_num_iterations` were silently ignored when the Caspar backend was selected, leaving the Caspar solve effectively unbounded relative to the Ceres path. On larger scenes this manifested as a global BA running far longer than the equivalent Ceres BA (in one real case, >20 min with no per-iteration output, which a CI watchdog killed).

## Change

As discussed in the issue, Caspar solves the normal equations directly with its own dampening and convergence criteria, so most Ceres solver parameters do not map. The iteration bound is the sensible exception. This forwards the respective `max_num_iterations` to `CasparBundleAdjustmentOptions::solver_iter_max` in both builders.

Added a unit test (`IncrementalPipelineOptions.PropagatesMaxNumIterationsToCaspar`) asserting the propagation for both the local and global builders. `options.caspar` is always allocated (independent of the `CASPAR_ENABLED` build flag), so the test runs headless without the Caspar backend compiled in.

## Testing

Built with CUDA/GUI/CGAL disabled and ran the full `incremental_pipeline_test` suite — all 20 tests pass, including the new one and the existing end-to-end reconstruction tests that exercise the BA path.

Fixes #4382
