### PR TITLE
Validate stereo fusion output path before running fusion

### DIFF
--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -352,6 +352,26 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
       << "Invalid `output_type` " << output_type
       << " - supported values are 'bin', 'ply' and 'txt'.";
 
+  // Validate the output path up front, before the expensive fusion, so that a
+  // misspecified path fails immediately rather than after fusion completes
+  // (see issue #3117). For 'bin'/'txt' the output is a directory of files; for
+  // 'ply' it is a single file.
+  if (output_type == "ply") {
+    THROW_CHECK(!ExistsDir(output_path))
+        << "Invalid `output_path` " << output_path
+        << " - for output_type 'PLY' this must be a file path, but an "
+           "existing directory was given.";
+    const std::filesystem::path output_parent_dir = GetParentDir(output_path);
+    THROW_CHECK(output_parent_dir.empty() || ExistsDir(output_parent_dir))
+        << "Invalid `output_path` " << output_path
+        << " - the parent directory " << output_parent_dir
+        << " does not exist.";
+  } else {
+    THROW_CHECK(ExistsDir(output_path))
+        << "Invalid `output_path` " << output_path << " - for output_type '"
+        << output_type << "' this must be an existing directory.";
+  }
+
   mvs::StereoFusion fuser(
       options, workspace_path, workspace_format, pmvs_option_name, input_type);
 

--- a/src/colmap/exe/mvs.cc
+++ b/src/colmap/exe/mvs.cc
@@ -353,6 +353,27 @@ Reconstruction RunStereoFuserImpl(const std::filesystem::path& output_path,
       << "Invalid `output_type` " << output_type
       << " - supported values are 'bin', 'ply' and 'txt'.";
 
+  // Validate the output path up front, before the expensive fusion, so that a
+  // misspecified path fails immediately rather than after fusion completes
+  // (see issue #3117). For 'bin'/'txt' the output is a directory of files; for
+  // 'ply' it is a single file.
+  if (output_type == "ply") {
+    THROW_CHECK(!ExistsDir(output_path))
+        << "Invalid `output_path` " << output_path
+        << " - for output_type 'PLY' this must be a file path, but an "
+           "existing directory was given.";
+    THROW_CHECK_HAS_FILE_EXTENSION(output_path, ".ply");
+    const std::filesystem::path output_parent_dir = GetParentDir(output_path);
+    THROW_CHECK(output_parent_dir.empty() || ExistsDir(output_parent_dir))
+        << "Invalid `output_path` " << output_path
+        << " - the parent directory " << output_parent_dir
+        << " does not exist.";
+  } else {
+    THROW_CHECK(ExistsDir(output_path))
+        << "Invalid `output_path` " << output_path << " - for output_type '"
+        << output_type << "' this must be an existing directory.";
+  }
+
   mvs::StereoFusion fuser(
       options, workspace_path, workspace_format, pmvs_option_name, input_type);
   fuser.SetCheckIfStoppedFunc(std::move(check_if_stopped));

--- a/src/colmap/util/ply_test.cc
+++ b/src/colmap/util/ply_test.cc
@@ -245,6 +245,16 @@ TEST(Ply, RoundTripBinaryPlyPointsXYZOnly) {
   EXPECT_EQ(loaded_points[0].b, 0);
 }
 
+TEST(Ply, WritePlyPointsToDirectoryFails) {
+  // Writing to a path that is an existing directory (rather than a file) must
+  // fail cleanly instead of succeeding silently (see issue #3117).
+  const auto test_dir = CreateTestDir();
+
+  std::vector<PlyPoint> points(1);
+  EXPECT_ANY_THROW(WriteTextPlyPoints(test_dir, points, false, false));
+  EXPECT_ANY_THROW(WriteBinaryPlyPoints(test_dir, points, false, false));
+}
+
 TEST(Ply, RoundTripTextPlyMesh) {
   const auto test_dir = CreateTestDir();
   const auto test_file = test_dir / "mesh.ply";


### PR DESCRIPTION
RunStereoFuserImpl validated workspace_format, input_type and output_type up front, but never checked output_path until the results were written by WriteBinaryPlyPoints / Reconstruction::Write* after fusion completed. On large datasets fusion can run for hours, so a misspecified output_path (e.g. an existing directory when output_type is PLY, or a non-existent parent directory) aborted the whole run at the very end with a deferred THROW_CHECK_FILE_OPEN, discarding all the fusion work (issue #3117).

Add an early, output-type-aware validation of output_path in RunStereoFuserImpl before constructing the fuser:
  - PLY writes a single file, so reject an existing directory and require the parent directory to exist.
  - BIN/TXT write a directory of files, so require it to already exist (matching the THROW_CHECK_DIR_EXISTS in Reconstruction::Write*).

Also add a ply_test case asserting that WriteTextPlyPoints / WriteBinaryPlyPoints on a directory path fail cleanly, documenting the underlying deferred-failure behavior the early check guards against.

Fixes #3117
