### PR TITLE
Fix stale usage example in IncrementalMapper doc comment

### DIFF
--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -41,8 +41,10 @@ namespace colmap {
 // Class that provides all functionality for the incremental reconstruction
 // procedure. Example usage:
 //
-//  IncrementalMapper mapper(&database_cache);
-//  mapper.BeginReconstruction(&reconstruction);
+//  auto database_cache = std::make_shared<DatabaseCache>(...);
+//  IncrementalMapper mapper(database_cache);
+//  auto reconstruction = std::make_shared<Reconstruction>();
+//  mapper.BeginReconstruction(reconstruction);
 //  TwoViewGeometry tvg;
 //  THROW_CHECK(
 //      mapper.FindInitialImagePair(options, tvg, image_id1, image_id2));


### PR DESCRIPTION
The example in the class comment passed the address of a local DatabaseCache/Reconstruction, but the constructor and BeginReconstruction now take std::shared_ptr (IncrementalMapper(std::shared_ptr<const DatabaseCache>) and BeginReconstruction(const std::shared_ptr< Reconstruction>&)). Update the example to construct and pass shared_ptrs so it matches the current API.

Fixes #2656.