### PR TITLE
Upgrade ONNX Runtime to 1.27.1 on all platforms

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -328,8 +328,10 @@ if(ONNX_ENABLED)
 
         message(STATUS "Configuring onnxruntime...")
 
-        set(ONNX_VERSION "1.24.4")
-        # ONNX Runtime >= 1.22 GPU binaries are built with CUDA >= 12
+        set(ONNX_VERSION "1.27.1")
+        # ONNX Runtime now ships separate GPU binaries per CUDA major version
+        # (gpu_cuda12 / gpu_cuda13). We consume the CUDA 12 build below, so CUDA
+        # >= 12 is required for the GPU execution provider.
         if(ONNX_VERSION VERSION_GREATER_EQUAL "1.22"
            AND CUDA_ENABLED AND CUDA_FOUND AND CUDAToolkit_VERSION VERSION_LESS "12.0")
             message(WARNING
@@ -350,7 +352,7 @@ if(ONNX_ENABLED)
             else()
                 FetchContent_Declare(onnxruntime
                     URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-osx-arm64-${ONNX_VERSION}.tgz
-                    URL_HASH SHA256=93787795f47e1eee369182e43ed51b9e5da0878ab0346aecf4258979b8bba989
+                    URL_HASH SHA256=e42b77a7281cc6e55141bf44fcfbac2c782b823a491bbb6ac33c781dd991f8a6
                     ${_fetch_content_declare_args}
                 )
             endif()
@@ -358,28 +360,28 @@ if(ONNX_ENABLED)
             if(IS_ARM64)
                 FetchContent_Declare(onnxruntime
                     URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-aarch64-${ONNX_VERSION}.tgz
-                    URL_HASH SHA256=866109a9248d057671a039b9d725be4bd86888e3754140e6701ec621be9d4d7e
+                    URL_HASH SHA256=33c67e33d1e25b816878366ea276589a024f71f000e7ff955c4b33224d639edd
                     ${_fetch_content_declare_args}
                 )
             else()
                 if(CUDA_ENABLED)
                     FetchContent_Declare(onnxruntime
-                        URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-gpu-${ONNX_VERSION}.tgz
-                        URL_HASH SHA256=c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808
+                        URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-gpu_cuda12-${ONNX_VERSION}.tgz
+                        URL_HASH SHA256=08b568bd69500c36606aff7c3896ee4fa7d3531719f6b00f43e6a34db41dc4bf
                         ${_fetch_content_declare_args}
                     )
                 else()
                     FetchContent_Declare(onnxruntime
                         URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-${ONNX_VERSION}.tgz
-                        URL_HASH SHA256=3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747
+                        URL_HASH SHA256=25b1ef1fea1acd210d63f8f24dc870ad6e077795ce1f54876252c6d3803c15af
                         ${_fetch_content_declare_args}
                     )
                 endif()
             endif()
         elseif(IS_WINDOWS)
             FetchContent_Declare(onnxruntime
-                URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-win-x64-gpu-${ONNX_VERSION}.zip
-                URL_HASH SHA256=ef3337a0b8184eb8beec310f7c83bd50376b3eefc43aab84ac8e452f6987df0a
+                URL https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-win-x64-gpu_cuda12-${ONNX_VERSION}.zip
+                URL_HASH SHA256=78d4de5ab262f79ac5dd59f08ff0d049b1cea605497f375f8df5ba1a52f26111
                 ${_fetch_content_declare_args}
             )
         endif()


### PR DESCRIPTION
## Summary

Upgrades the fetched ONNX Runtime binaries from **1.24.4 → 1.27.1** across all platforms (macOS osx-arm64, Linux aarch64 / x64 / x64-GPU, Windows x64-GPU) and updates the SHA256 hashes accordingly.

## Packaging change

ONNX Runtime now publishes GPU binaries split by CUDA major version, so the single `-gpu-` archive no longer exists. The Linux x64 GPU and Windows x64 GPU downloads switch to the **CUDA 12** build (`-gpu_cuda12-`), which preserves the existing "CUDA ≥ 12" requirement (the compatibility warning is unchanged). CPU-only archives (osx-arm64, linux-aarch64, linux-x64) keep their names.

> Note: CUDA 12 packages are marked deprecated upstream (a CUDA 13 build, `gpu_cuda13`, is also available). Staying on CUDA 12 keeps the current minimum-CUDA behavior; moving to CUDA 13 can be a later follow-up.

## Validation

- Reconfigured on macOS arm64: FetchContent downloads onnxruntime 1.27.1 and validates the new SHA256 (a wrong hash fails configure).
- The feature library builds against the 1.27.1 C++ API with no code changes, and `aliked_test` passes end-to-end.

## Relevant upstream changes (1.24.4 → 1.27.1)

- **CUDA minimum raised to 12.0** (1.25); CUDA 11.x no longer supported.
- **GPU packages split per CUDA major version** and CUDA 12 marked deprecated (1.26/1.27) — handled here.
- Numerous **security / robustness hardening** fixes in CPU kernels COLMAP's models exercise (Attention overflow, GridSample float→int cast hardening, Pad/Tile/Expand bounds checks, transpose-optimizer fix).
- **MLAS CPU improvements** (FP16 Gelu, Arm64 BF16 conv fast-math) benefiting CPU inference.
- C API version bumped to 25; ArmNN EP removed (unused by COLMAP).