### PR TITLE
Automate documentation deployment to colmap.github.io

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -35,8 +35,10 @@ jobs:
       FETCHCONTENT_CACHE_VERSION: 1
       FETCHCONTENT_CACHE_DIR: ${{ github.workspace }}/fetchcontent-cache
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.config.deploymentTarget }}
-      # For faster builds in PRs, skip all but the oldest Python versions.
-      PULL_REQUEST_CIBW_BUILD: cp311-{macosx,manylinux,win}*
+      # For faster builds in PRs, build only a single Python version. We use
+      # cp312 (the oldest Python supported by the pinned Sphinx used in the docs
+      # job, which reuses this wheel); main builds all versions.
+      PULL_REQUEST_CIBW_BUILD: cp312-{macosx,manylinux,win}*
     steps:
       - name: Free disk space
         if: runner.os == 'Linux' && matrix.config.cudaEnabled
@@ -276,7 +278,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'   # PR runs build only cp311 wheels; main builds all
+          python-version: '3.12'   # Sphinx 9.1 needs >=3.12; matches the cp312 wheel
 
       # Wheel from the `build` job (same run) so autodoc introspects a pycolmap
       # that matches the commit.
@@ -288,7 +290,7 @@ jobs:
       - name: Install pycolmap + Sphinx deps
         run: |
           python -m pip install --upgrade pip
-          pip install wheelhouse/pycolmap-*cp311*manylinux*_x86_64.whl
+          pip install wheelhouse/pycolmap-*cp312*manylinux*_x86_64.whl
           pip install -r doc/requirements.txt
 
       - name: Build docs

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -256,3 +256,64 @@ jobs:
         with:
           skip-existing: true
           packages-dir: ./wheelhouse/
+
+  docs:
+    name: Build and deploy documentation
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7   # conf.py's get_git_revision() needs a git checkout
+
+      # Detect whether docs-relevant files changed (gates the deploy/preview steps).
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'doc/**'
+              - 'CHANGELOG.rst'
+              - 'python/**'   # pycolmap bindings feed the autodoc API pages
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'   # PR runs build only cp311 wheels; main builds all
+
+      # Wheel from the `build` job (same run) so autodoc introspects a pycolmap
+      # that matches the commit.
+      - uses: actions/download-artifact@v8
+        with:
+          name: pycolmap-ubuntu-24.04-
+          path: wheelhouse
+
+      - name: Install pycolmap + Sphinx deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheelhouse/pycolmap-*cp311*manylinux*_x86_64.whl
+          pip install -r doc/requirements.txt
+
+      - name: Build docs
+        run: make -C doc html   # -> doc/_build/html
+
+      # PR dry-run: publish the generated HTML as a downloadable artifact
+      # (no deploy) so reviewers can inspect the rendered docs.
+      - name: Upload docs preview artifact
+        if: github.event_name == 'pull_request' && steps.filter.outputs.docs == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-preview
+          path: doc/_build/html
+
+      - name: Deploy to colmap.github.io
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.filter.outputs.docs == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.COLMAP_GITHUB_IO_DEPLOY_KEY }}
+          external_repository: colmap/colmap.github.io
+          publish_branch: master
+          publish_dir: ./doc/_build/html
+          keep_files: true
+          commit_message: "Update docs from colmap@${{ github.sha }}"
+          full_commit_message: "Update docs from colmap@${{ github.sha }}"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -418,9 +418,16 @@ Documentation
         make latexpdf
         open _build/pdf/COLMAP.pdf
 
-3. Clone the website repository `colmap/colmap.github.io <https://github.com/colmap/colmap.github.io>`__.
-4. Copy the contents of the generated files at ``_build/html`` to the cloned repository root.
-5. Create a pull request to the `colmap/colmap.github.io <https://github.com/colmap/colmap.github.io>`__
-   repository with the updated files.
-6. (Optional, if main release) Copy the previous release as legacy to the "legacy" folder,
-   under a folder with the release number `see here <https://github.com/colmap/colmap.github.io/tree/master/legacy>`__.
+Publishing to the website (`colmap.github.io <https://colmap.github.io/>`__) is
+automated: whenever documentation-relevant files change on ``main``, the CI
+pipeline builds these docs and pushes the result to the ``master`` branch of the
+`colmap/colmap.github.io <https://github.com/colmap/colmap.github.io>`__
+repository. Pull requests that touch the docs build them too and upload the
+generated HTML as a downloadable ``docs-preview`` artifact for review, without
+publishing. The manual steps above are therefore only needed to preview the docs
+locally.
+
+For a main release, still copy the previous release as legacy to the "legacy"
+folder in the website repository, under a folder with the release number
+(`see here <https://github.com/colmap/colmap.github.io/tree/master/legacy>`__).
+The automated deploy preserves the existing ``legacy`` folder.


### PR DESCRIPTION
## Summary

Automates publishing the documentation to the [colmap.github.io](https://colmap.github.io/) website, which is currently a manual process (build docs locally, copy `_build/html` into a clone of `colmap/colmap.github.io`, open a PR).

Adds a `docs` job to the existing **PyCOLMAP** workflow (`build-pycolmap.yml`, `needs: build`) that:

- **Reuses the pycolmap wheel** built in the same run and installs it, so `sphinx.ext.autodoc` introspects a `pycolmap` matching the commit (the Python API pages depend on the installed module).
- Builds the Sphinx docs with `make -C doc html`.
- **On PRs touching docs** (`doc/**`, `CHANGELOG.rst`, `python/**`): uploads the generated HTML as a downloadable `docs-preview` artifact — a dry run, no publish.
- **On pushes to `main` touching docs**: pushes `doc/_build/html` to the `master` branch of `colmap/colmap.github.io` via `peaceiris/actions-gh-pages`, with `keep_files: true` so the hosted `legacy/` folder is preserved.

Docs are also built on every run (PR and push) so broken RST/autodoc is caught in CI regardless of whether a deploy happens.

Also updates `doc/install.rst` to document the automated flow.

## Prerequisite before the deploy step works

A write-enabled SSH deploy key must be provisioned (one-time, manual):

1. `ssh-keygen -t ed25519 -C "colmap-docs-deploy" -f docs_deploy -N ""`
2. Add `docs_deploy.pub` as a **deploy key with write access** on `colmap/colmap.github.io`.
3. Add the private `docs_deploy` as the **`COLMAP_GITHUB_IO_DEPLOY_KEY`** secret in `colmap/colmap`.

Until the secret exists, PR builds and the `docs-preview` artifact still work; only the `main` deploy step needs it.

## Notes / trade-offs

- Python is pinned to 3.11 because PR runs build only cp311 wheels while `main` builds all versions.
- `keep_files: true` mirrors today's manual "copy over the top" behavior (never deletes `legacy/`); a doc page removed upstream would linger as a stale file, same as today.
- Release-time `legacy/<version>/` snapshots remain manual and are preserved by the automated deploy.