### PR TITLE
Add `PosePriorArchive` type for external pose prior import

### DIFF
--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -139,6 +139,7 @@ int main(int argc, char** argv) {
 #endif
   commands.emplace_back("point_filtering", &colmap::RunPointFiltering);
   commands.emplace_back("point_triangulator", &colmap::RunPointTriangulator);
+  commands.emplace_back("pose_prior_importer", &colmap::RunPosePriorImporter);
   commands.emplace_back("pose_prior_mapper", &colmap::RunPosePriorMapper);
 #if defined(COLMAP_MVS_ENABLED)
   commands.emplace_back("poisson_mesher", &colmap::RunPoissonMesher);

--- a/src/colmap/exe/database.cc
+++ b/src/colmap/exe/database.cc
@@ -30,10 +30,12 @@
 #include "colmap/exe/database.h"
 
 #include "colmap/controllers/option_manager.h"
+#include "colmap/geometry/pose_prior_io.h"
 #include "colmap/scene/database.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/scene/rig.h"
 #include "colmap/util/file.h"
+#include "colmap/util/hash_containers.h"
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -164,6 +166,108 @@ int RunRigConfigurator(int argc, char** argv) {
     reconstruction->Write(output_path);
   }
 
+  return EXIT_SUCCESS;
+}
+
+int RunPosePriorImporter(int argc, char** argv) {
+  std::filesystem::path pose_prior_path;
+  bool overwrite = true;
+  bool update = false;
+
+  OptionManager options;
+  options.AddDatabaseOptions();
+  options.AddRequiredOption("pose_prior_path", &pose_prior_path);
+  options.AddDefaultOption(
+      "overwrite", &overwrite, "Replace existing pose priors.");
+  options.AddDefaultOption(
+      "update",
+      &update,
+      "Merge input data into existing pose priors and add unmatched entries.");
+  if (!options.Parse(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+
+  if (overwrite && update) {
+    LOG(WARNING) << "Both --overwrite and --update specified. "
+                 << "--update takes precedence, --overwrite is ignored.";
+  }
+
+  if (!ExistsFile(pose_prior_path)) {
+    LOG(ERROR) << "`pose_prior_path` is not a file.";
+    return EXIT_FAILURE;
+  }
+
+  const auto archive = ReadPosePriorArchive(pose_prior_path);
+
+  auto database = Database::Open(*options.database_path);
+
+  const auto data_id_from_name =
+      [&database](const std::string& name) -> std::optional<data_t> {
+    const auto image = database->ReadImageWithName(name);
+    if (!image) {
+      return std::nullopt;
+    }
+    return data_t(sensor_t(SensorType::CAMERA, image->CameraId()),
+                  image->ImageId());
+  };
+
+  if (update) {
+    auto priors = database->ReadAllPosePriors();
+    const size_t num_existing = priors.size();
+    archive.UpdatePosePriors(
+        data_id_from_name, /*allow_new_priors=*/true, priors);
+
+    size_t num_updated = 0;
+    size_t num_added = 0;
+    {
+      DatabaseTransaction transaction(database.get());
+      for (size_t i = 0; i < priors.size(); ++i) {
+        if (i < num_existing) {
+          database->UpdatePosePrior(priors[i]);
+          ++num_updated;
+        } else {
+          database->WritePosePrior(priors[i]);
+          ++num_added;
+        }
+      }
+    }
+
+    LOG(INFO) << "Added " << num_added << " new and updated " << num_updated
+              << " existing pose priors.";
+    return EXIT_SUCCESS;
+  }
+
+  auto priors = archive.ToPosePriors(data_id_from_name);
+  if (priors.empty()) {
+    LOG(WARNING) << "No pose priors were imported.";
+    return EXIT_FAILURE;
+  }
+
+  // We cannot use ExistsPosePrior(pose_prior_t pose_prior_id) here
+  NodeHashMap<data_t, pose_prior_t> existing_prior_ids;
+  for (const auto& prior : database->ReadAllPosePriors()) {
+    existing_prior_ids.emplace(prior.corr_data_id, prior.pose_prior_id);
+  }
+
+  size_t num_imported = 0;
+  {
+    DatabaseTransaction transaction(database.get());
+    for (auto& prior : priors) {
+      const auto it = existing_prior_ids.find(prior.corr_data_id);
+      if (it != existing_prior_ids.end()) {
+        if (overwrite) {
+          prior.pose_prior_id = it->second;
+          database->UpdatePosePrior(prior);
+          ++num_imported;
+        }
+      } else {
+        database->WritePosePrior(prior);
+        ++num_imported;
+      }
+    }
+  }
+
+  LOG(INFO) << "Imported " << num_imported << " pose priors.";
   return EXIT_SUCCESS;
 }
 

--- a/src/colmap/exe/database.h
+++ b/src/colmap/exe/database.h
@@ -35,5 +35,6 @@ int RunDatabaseCleaner(int argc, char** argv);
 int RunDatabaseCreator(int argc, char** argv);
 int RunDatabaseMerger(int argc, char** argv);
 int RunRigConfigurator(int argc, char** argv);
+int RunPosePriorImporter(int argc, char** argv);
 
 }  // namespace colmap

--- a/src/colmap/geometry/CMakeLists.txt
+++ b/src/colmap/geometry/CMakeLists.txt
@@ -40,6 +40,7 @@ COLMAP_ADD_LIBRARY(
         normalization.h normalization.cc
         pose.h pose.cc
         pose_prior.h pose_prior.cc
+        pose_prior_io.h pose_prior_io.cc
         rigid3.h rigid3.cc
         sim3.h sim3.cc
         triangulation.h triangulation.cc
@@ -91,6 +92,11 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME pose_prior_test
     SRCS pose_prior_test.cc
+    LINK_LIBS colmap_geometry
+)
+COLMAP_ADD_TEST(
+    NAME pose_prior_io_test
+    SRCS pose_prior_io_test.cc
     LINK_LIBS colmap_geometry
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/geometry/pose_prior_io.cc
+++ b/src/colmap/geometry/pose_prior_io.cc
@@ -1,0 +1,553 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/geometry/pose_prior_io.h"
+
+#include "colmap/geometry/pose_prior.h"
+#include "colmap/util/enum_utils.h"
+#include "colmap/util/hash_containers.h"
+#include "colmap/util/logging.h"
+#include "colmap/util/string.h"
+#include "colmap/util/types.h"
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+namespace colmap {
+namespace {
+MAKE_ENUM_CLASS(ColumnGroup,
+                0,
+                NAME,
+                GEOGRAPHIC_POSITION,
+                CARTESIAN_POSITION,
+                TRANSLATION_STD,
+                TRANSLATION_COV);
+
+struct GroupPresence {
+  bool any = false;
+  bool all = false;
+  bool duplicate = false;
+};
+
+FlatHashMap<ColumnGroup, GroupPresence> AnalyzeColumnGroups(
+    const std::vector<PosePriorArchive::ColumnId>& columns) {
+  static const auto group_cols = [] {
+    FlatHashMap<ColumnGroup, std::vector<PosePriorArchive::ColumnId>> m;
+    m[ColumnGroup::NAME] = {PosePriorArchive::ColumnId::NAME};
+    m[ColumnGroup::GEOGRAPHIC_POSITION] = {PosePriorArchive::ColumnId::LAT,
+                                           PosePriorArchive::ColumnId::LON,
+                                           PosePriorArchive::ColumnId::ALT};
+    m[ColumnGroup::CARTESIAN_POSITION] = {PosePriorArchive::ColumnId::TX,
+                                          PosePriorArchive::ColumnId::TY,
+                                          PosePriorArchive::ColumnId::TZ};
+    m[ColumnGroup::TRANSLATION_STD] = {PosePriorArchive::ColumnId::STD_TX,
+                                       PosePriorArchive::ColumnId::STD_TY,
+                                       PosePriorArchive::ColumnId::STD_TZ};
+    m[ColumnGroup::TRANSLATION_COV] = {PosePriorArchive::ColumnId::COV_TXX,
+                                       PosePriorArchive::ColumnId::COV_TXY,
+                                       PosePriorArchive::ColumnId::COV_TXZ,
+                                       PosePriorArchive::ColumnId::COV_TYY,
+                                       PosePriorArchive::ColumnId::COV_TYZ,
+                                       PosePriorArchive::ColumnId::COV_TZZ};
+    return m;
+  }();
+
+  FlatHashMap<PosePriorArchive::ColumnId, int> counts;
+  for (const auto& col : columns) {
+    if (col != PosePriorArchive::ColumnId::UNKNOWN) {
+      counts[col]++;
+    }
+  }
+
+  FlatHashMap<ColumnGroup, GroupPresence> result;
+  for (const auto& [group, cols] : group_cols) {
+    int present = 0;
+    bool duplicate = false;
+    for (const auto& col : cols) {
+      auto it = counts.find(col);
+      int c = (it != counts.end()) ? it->second : 0;
+      if (c > 0) {
+        ++present;
+      }
+      if (c > 1) {
+        duplicate = true;
+      }
+    }
+    GroupPresence p;
+    p.any = present > 0;
+    p.all = present == static_cast<int>(cols.size()) && !duplicate;
+    p.duplicate = duplicate;
+    result[group] = p;
+  }
+  return result;
+}
+
+template <typename EnumT>
+bool MaybeGetEnumFromPropertyTree(const boost::property_tree::ptree& pt,
+                                  const std::string& key,
+                                  EnumT (*from_string)(std::string_view),
+                                  EnumT& output) {
+  const auto value = pt.get_optional<std::string>(key);
+  if (value) {
+    output = from_string(*value);
+    return true;
+  }
+  return false;
+}
+
+template <typename EnumT>
+bool MaybeGetEnumFromPropertyTree(const boost::property_tree::ptree& pt,
+                                  const std::string& key,
+                                  EnumT (*from_string)(std::string_view),
+                                  std::optional<EnumT>& output) {
+  EnumT value;
+  if (MaybeGetEnumFromPropertyTree(pt, key, from_string, value)) {
+    output = value;
+    return true;
+  }
+  return false;
+}
+
+template <PosePriorArchive::ColumnId Id>
+PosePriorArchive::cell_t ParseCell(const std::string& value) {
+  using T = typename PosePriorArchive::ColumnTraits<Id>::value_type;
+  if constexpr (std::is_same_v<T, std::string>) {
+    return value;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return StringToDouble(value);
+  } else {
+    return std::monostate{};
+  }
+}
+
+using cell_parser_t =
+    std::function<PosePriorArchive::cell_t(const std::string&)>;
+
+#define COLMAP_COLUMN_PARSER_ENTRY(x) \
+  {PosePriorArchive::ColumnId::x, ParseCell<PosePriorArchive::ColumnId::x>}
+
+const FlatHashMap<PosePriorArchive::ColumnId, cell_parser_t>& GetCellParsers() {
+  static const FlatHashMap<PosePriorArchive::ColumnId, cell_parser_t> parsers =
+      {
+          COLMAP_COLUMN_PARSER_ENTRY(UNKNOWN),
+          COLMAP_COLUMN_PARSER_ENTRY(NAME),
+          COLMAP_COLUMN_PARSER_ENTRY(LAT),
+          COLMAP_COLUMN_PARSER_ENTRY(LON),
+          COLMAP_COLUMN_PARSER_ENTRY(ALT),
+          COLMAP_COLUMN_PARSER_ENTRY(TX),
+          COLMAP_COLUMN_PARSER_ENTRY(TY),
+          COLMAP_COLUMN_PARSER_ENTRY(TZ),
+          COLMAP_COLUMN_PARSER_ENTRY(STD_TX),
+          COLMAP_COLUMN_PARSER_ENTRY(STD_TY),
+          COLMAP_COLUMN_PARSER_ENTRY(STD_TZ),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TXX),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TXY),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TXZ),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TYY),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TYZ),
+          COLMAP_COLUMN_PARSER_ENTRY(COV_TZZ),
+      };
+  return parsers;
+}
+
+#undef COLMAP_COLUMN_PARSER_ENTRY
+
+PosePriorArchive ReadPosePriorArchiveFromJSON(
+    const std::filesystem::path& path) {
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(path.string(), pt);
+
+  PosePriorArchive archive;
+
+  MaybeGetEnumFromPropertyTree(pt,
+                               "coordinate_system",
+                               PosePrior::CoordinateSystemFromString,
+                               archive.metadata.coordinate_system);
+  MaybeGetEnumFromPropertyTree(
+      pt, "sensor_type", SensorTypeFromString, archive.metadata.sensor_type);
+  MaybeGetEnumFromPropertyTree(pt,
+                               "translation_convention",
+                               PosePriorArchive::PoseConventionFromString,
+                               archive.metadata.translation_convention);
+  MaybeGetEnumFromPropertyTree(pt,
+                               "cartesian_frame",
+                               PosePriorArchive::CartesianFrameFromString,
+                               archive.metadata.cartesian_frame);
+
+  MaybeGetEnumFromPropertyTree(pt,
+                               "ellipsoid",
+                               GPSTransform::EllipsoidFromString,
+                               archive.metadata.ellipsoid);
+
+  const auto enu_origin_node = pt.get_child_optional("enu_origin");
+  if (enu_origin_node) {
+    THROW_CHECK_EQ(enu_origin_node->size(), 3)
+        << "enu_origin must be an array of 3 values";
+
+    Eigen::Vector3d origin;
+    int index = 0;
+    for (const auto& value : *enu_origin_node) {
+      origin(index++) = value.second.get_value<double>();
+    }
+    archive.metadata.enu_origin = origin;
+  }
+
+  // Parse schema: ordered list of column type strings.
+  const auto schema_node = pt.get_child("schema");
+  THROW_CHECK(!schema_node.empty())
+      << "PosePriorArchive JSON must contain a non-empty schema array";
+  for (const auto& item : schema_node) {
+    std::string column_name = item.second.get_value<std::string>();
+    archive.schema.columns.push_back(
+        PosePriorArchive::ColumnIdFromString(column_name));
+  }
+
+  THROW_CHECK(archive.IsValid())
+      << "PosePriorArchive metadata or schema is invalid";
+
+  // Parse data rows via the type-dispatch table.
+  const auto data_node = pt.get_child("data");
+  const auto& cell_parsers = GetCellParsers();
+  for (const auto& row_node : data_node) {
+    PosePriorArchive::row_t row;
+    size_t column_index = 0;
+    for (const auto& cell_node : row_node.second) {
+      if (column_index >= archive.schema.columns.size()) {
+        LOG(WARNING) << StringPrintf(
+            "Row %zu has more cells than the schema defines (%zu). "
+            "Extra cells will be ignored.",
+            archive.data.size(),
+            archive.schema.columns.size());
+        break;
+      }
+
+      const auto value = cell_node.second.get_value<std::string>("");
+      const auto it = cell_parsers.find(archive.schema.columns[column_index]);
+      if (it != cell_parsers.end()) {
+        row.push_back(it->second(value));
+      }
+      column_index++;
+    }
+    if (row.size() < archive.schema.columns.size()) {
+      LOG(WARNING) << StringPrintf(
+          "Row %zu has fewer cells (%zu) than the schema defines (%zu). "
+          "Missing cells will be treated as empty.",
+          archive.data.size(),
+          row.size(),
+          archive.schema.columns.size());
+    }
+
+    while (row.size() < archive.schema.columns.size()) {
+      row.push_back(std::monostate{});
+    }
+    archive.data.push_back(std::move(row));
+  }
+
+  return archive;
+}
+
+// TODO: Implement ReadPosePriorArchiveFromCSV
+
+}  // namespace
+
+bool PosePriorArchive::Metadata::IsValid() const {
+  if (sensor_type == SensorType::INVALID) {
+    return false;
+  }
+
+  if (coordinate_system == PosePrior::CoordinateSystem::UNDEFINED) {
+    return false;
+  } else if (coordinate_system == PosePrior::CoordinateSystem::WGS84) {
+    if (cartesian_frame.has_value()) {
+      return false;
+    }
+  } else if (coordinate_system == PosePrior::CoordinateSystem::CARTESIAN) {
+    if (cartesian_frame.has_value() &&
+        *cartesian_frame == PosePriorArchive::CartesianFrame::ENU) {
+      if (!enu_origin.has_value()) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool PosePriorArchive::Schema::IsValid(const Metadata& metadata) const {
+  if (columns.empty()) {
+    LOG(ERROR) << "Schema is empty";
+    return false;
+  }
+
+  // Count and skip UNKNOWN columns.
+  size_t num_skipped = 0;
+  std::vector<ColumnId> known_columns;
+  for (const auto& col : columns) {
+    if (col == ColumnId::UNKNOWN) {
+      num_skipped++;
+    } else {
+      known_columns.push_back(col);
+    }
+  }
+  LOG_IF(WARNING, num_skipped > 0)
+      << "Skipped " << num_skipped << " UNKNOWN columns";
+
+  auto groups = AnalyzeColumnGroups(known_columns);
+  const auto cs = metadata.coordinate_system;
+
+  // Reject duplicate columns within any group.
+  for (auto& [group, presence] : groups) {
+    if (presence.duplicate) {
+      LOG(ERROR) << "Duplicate columns in group " << ColumnGroupToString(group);
+      return false;
+    }
+  }
+
+  const auto& name_presence = groups.at(ColumnGroup::NAME);
+  const auto& geographic_presence = groups.at(ColumnGroup::GEOGRAPHIC_POSITION);
+  const auto& cartesian_presence = groups.at(ColumnGroup::CARTESIAN_POSITION);
+  const auto& translation_std_presence =
+      groups.at(ColumnGroup::TRANSLATION_STD);
+  const auto& translation_cov_presence =
+      groups.at(ColumnGroup::TRANSLATION_COV);
+
+  if (!name_presence.all) {
+    LOG(ERROR) << "Schema must contain a NAME column";
+    return false;
+  }
+
+  if (cs == PosePrior::CoordinateSystem::WGS84) {
+    if (geographic_presence.any && !geographic_presence.all) {
+      LOG(ERROR) << "Incomplete translation: all of LAT/LON/ALT are required";
+      return false;
+    }
+    if (cartesian_presence.any) {
+      LOG(WARNING) << "WGS84 coordinate system ignores TX/TY/TZ columns";
+    }
+  } else if (cs == PosePrior::CoordinateSystem::CARTESIAN) {
+    if (cartesian_presence.any && !cartesian_presence.all) {
+      LOG(ERROR) << "Incomplete translation: all of TX/TY/TZ are required";
+      return false;
+    }
+    if (geographic_presence.any) {
+      LOG(WARNING) << "CARTESIAN coordinate system ignores LAT/LON/ALT columns";
+    }
+  }
+
+  if (translation_std_presence.all && translation_cov_presence.all) {
+    LOG(ERROR) << "Schema must not contain both STD and COV columns";
+    return false;
+  }
+
+  if (translation_std_presence.any && !translation_std_presence.all) {
+    LOG(ERROR) << "Incomplete STD columns: all of STD_TX, STD_TY, STD_TZ "
+                  "are required";
+    return false;
+  }
+  if (translation_cov_presence.any && !translation_cov_presence.all) {
+    LOG(ERROR) << "Incomplete COV columns: all of COV_TXX, COV_TXY, "
+                  "COV_TXZ, COV_TYY, COV_TYZ, COV_TZZ are required";
+    return false;
+  }
+
+  return true;
+}
+
+size_t PosePriorArchive::NumColumns() const { return schema.columns.size(); }
+size_t PosePriorArchive::NumRows() const { return data.size(); }
+
+bool PosePriorArchive::IsValid() const {
+  return metadata.IsValid() && schema.IsValid(metadata);
+}
+
+PosePriorArchive ReadPosePriorArchive(const std::filesystem::path& path) {
+  const std::string ext = path.extension().string();
+  if (ext == ".json") {
+    return ReadPosePriorArchiveFromJSON(path);
+  }
+  LOG(FATAL_THROW) << "Unsupported pose prior archive format: " << ext;
+  // Unreachable, silence -Wreturn-type for non-MSVC compilers.
+  return {};
+}
+
+void PosePriorArchive::UpdatePosePriors(
+    const data_id_resolver_t& data_id_from_name,
+    bool allow_new_priors,
+    std::vector<PosePrior>& pose_priors) const {
+  THROW_CHECK(IsValid()) << "Invalid PosePriorArchive";
+
+  // Currently only support prior translations in world frame.
+  if (metadata.translation_convention !=
+      PosePriorArchive::PoseConvention::WORLD_FROM_CAM) {
+    LOG(FATAL_THROW)
+        << "Only PosePriorArchive::PoseConvention::WORLD_FROM_CAM is supported";
+  }
+
+  FlatHashMap<ColumnId, size_t> column_indices;
+  for (size_t i = 0; i < schema.columns.size(); ++i) {
+    column_indices[schema.columns[i]] = i;
+  }
+
+  const auto groups = AnalyzeColumnGroups(schema.columns);
+  const auto& name_presence = groups.at(ColumnGroup::NAME);
+  const auto& geographic_presence = groups.at(ColumnGroup::GEOGRAPHIC_POSITION);
+  const auto& cartesian_presence = groups.at(ColumnGroup::CARTESIAN_POSITION);
+  const auto& translation_std_presence =
+      groups.at(ColumnGroup::TRANSLATION_STD);
+  const auto& translation_cov_presence =
+      groups.at(ColumnGroup::TRANSLATION_COV);
+
+  if (!name_presence.all) {
+    LOG(ERROR) << "Schema is missing NAME column: cannot convert "
+                  "pose prior archive to PosePrior objects";
+    return;
+  }
+
+  const bool is_geographic =
+      metadata.coordinate_system == PosePrior::CoordinateSystem::WGS84;
+  const bool has_translation =
+      is_geographic ? geographic_presence.all : cartesian_presence.all;
+  const bool has_uncertainty =
+      translation_std_presence.all || translation_cov_presence.all;
+
+  const auto get_double = [](const PosePriorArchive::cell_t& cell) -> double {
+    if (std::holds_alternative<double>(cell)) {
+      return std::get<double>(cell);
+    }
+    return PosePrior::kNaN;
+  };
+
+  const size_t name_index = column_indices.at(ColumnId::NAME);
+
+  if (allow_new_priors && pose_priors.capacity() < data.size()) {
+    pose_priors.reserve(data.size());
+  }
+
+  FlatHashMap<data_t, size_t> data_id_to_index;
+  for (size_t i = 0; i < pose_priors.size(); ++i) {
+    data_id_to_index[pose_priors[i].corr_data_id] = i;
+  }
+
+  for (const auto& row : data) {
+    if (name_index >= row.size()) {
+      continue;
+    }
+    const std::string& name = std::get<std::string>(row[name_index]);
+
+    const auto data_id = data_id_from_name(name);
+    if (!data_id) {
+      LOG(WARNING) << "Cannot resolve name: " << name;
+      continue;
+    }
+
+    const bool is_prior_exist = data_id_to_index.count(*data_id);
+    if (!is_prior_exist && !allow_new_priors) {
+      LOG(WARNING) << "No existing pose prior for " << name
+                   << " and allow_new_priors is false, skipping";
+      continue;
+    }
+
+    PosePrior* prior_ptr = nullptr;
+    if (is_prior_exist) {
+      prior_ptr = &pose_priors[data_id_to_index.at(*data_id)];
+    } else {
+      pose_priors.push_back(PosePrior());
+      prior_ptr = &pose_priors.back();
+      prior_ptr->corr_data_id = *data_id;
+    }
+
+    PosePrior& prior = *prior_ptr;
+    prior.coordinate_system = metadata.coordinate_system;
+
+    if (has_translation) {
+      if (is_geographic) {
+        prior.position.x() = get_double(row[column_indices.at(ColumnId::LAT)]);
+        prior.position.y() = get_double(row[column_indices.at(ColumnId::LON)]);
+        prior.position.z() = get_double(row[column_indices.at(ColumnId::ALT)]);
+      } else {
+        prior.position.x() = get_double(row[column_indices.at(ColumnId::TX)]);
+        prior.position.y() = get_double(row[column_indices.at(ColumnId::TY)]);
+        prior.position.z() = get_double(row[column_indices.at(ColumnId::TZ)]);
+      }
+
+      if (!prior.HasPosition()) {
+        LOG(WARNING) << "Pose prior for " << name
+                     << " has no valid translation data";
+      }
+    }
+
+    // Read covariance from either STD columns (diagonal) or full COV matrix.
+    if (has_uncertainty) {
+      if (translation_std_presence.all) {
+        const double std_x =
+            get_double(row[column_indices.at(ColumnId::STD_TX)]);
+        const double std_y =
+            get_double(row[column_indices.at(ColumnId::STD_TY)]);
+        const double std_z =
+            get_double(row[column_indices.at(ColumnId::STD_TZ)]);
+        prior.position_covariance = Eigen::DiagonalMatrix<double, 3>(
+            std_x * std_x, std_y * std_y, std_z * std_z);
+      } else if (translation_cov_presence.all) {
+        const double cxx =
+            get_double(row[column_indices.at(ColumnId::COV_TXX)]);
+        const double cxy =
+            get_double(row[column_indices.at(ColumnId::COV_TXY)]);
+        const double cxz =
+            get_double(row[column_indices.at(ColumnId::COV_TXZ)]);
+        const double cyy =
+            get_double(row[column_indices.at(ColumnId::COV_TYY)]);
+        const double cyz =
+            get_double(row[column_indices.at(ColumnId::COV_TYZ)]);
+        const double czz =
+            get_double(row[column_indices.at(ColumnId::COV_TZZ)]);
+
+        prior.position_covariance << cxx, cxy, cxz, cxy, cyy, cyz, cxz, cyz,
+            czz;
+      }
+
+      if (!prior.HasPositionCov()) {
+        LOG(WARNING) << "Pose prior for " << name
+                     << " has no valid translation covariance data";
+      }
+    }
+  }
+}
+
+std::vector<PosePrior> PosePriorArchive::ToPosePriors(
+    const data_id_resolver_t& data_id_from_name) const {
+  std::vector<PosePrior> pose_priors;
+  UpdatePosePriors(data_id_from_name, /*allow_new_priors=*/true, pose_priors);
+  return pose_priors;
+}
+
+}  // namespace colmap

--- a/src/colmap/geometry/pose_prior_io.h
+++ b/src/colmap/geometry/pose_prior_io.h
@@ -1,0 +1,187 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/geometry/gps.h"
+#include "colmap/geometry/pose_prior.h"
+#include "colmap/util/enum_utils.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace colmap {
+
+// In-memory representation of a pose-prior archive loaded from a file.
+//
+// An archive consists of three parts:
+//   1. Metadata — describes the coordinate system, sensor type, reference
+//      ellipsoid, and other global properties shared by all pose priors.
+//   2. Schema — an ordered list of ColumnId values defining how each data
+//      row maps to semantic fields (name, translation, covariance).
+//   3. Data — a vector of rows, each with one cell per schema column.
+//
+// Schema flexibility:
+//   - Column order is arbitrary; each column type appears at most once.
+//   - Translation columns (LAT/LON/ALT or TX/TY/TZ) are optional. When absent,
+//     the archive carries only NAME + uncertainty data.
+//   - Uncertainty columns (STD_* or COV_*) are optional. STD and COV are
+//     mutually exclusive.
+//   - UNKNOWN columns are parsed but their values are discarded, allowing
+//     forward-compatible schema evolution.
+struct PosePriorArchive {
+  MAKE_ENUM_CLASS(CartesianFrame, 0, LOCAL, ENU);
+  MAKE_ENUM_CLASS(PoseConvention, 0, WORLD_FROM_CAM, CAM_FROM_WORLD);
+
+  using cell_t = std::variant<std::monostate, std::string, double>;
+  using row_t = std::vector<cell_t>;
+
+  // Global metadata shared by all pose priors in the archive.
+  struct Metadata {
+    SensorType sensor_type = SensorType::CAMERA;
+
+    PosePrior::CoordinateSystem coordinate_system =
+        PosePrior::CoordinateSystem::UNDEFINED;
+    std::optional<CartesianFrame> cartesian_frame = std::nullopt;
+
+    // Convention for interpreting the prior translation.
+    PoseConvention translation_convention = PoseConvention::WORLD_FROM_CAM;
+
+    // Reference ellipsoid used by geographic and derived coordinate systems.
+    std::optional<GPSTransform::Ellipsoid> ellipsoid = std::nullopt;
+    // Origin (lat, lon, alt) of the ENU local tangent plane.
+    std::optional<Eigen::Vector3d> enu_origin = std::nullopt;
+
+    bool IsValid() const;
+  };
+
+  // clang-format off
+  MAKE_ENUM_CLASS(ColumnId, -1,
+      UNKNOWN,
+      NAME,
+      // Geographic translation
+      LAT, LON, ALT,
+      // Translation
+      TX, TY, TZ,
+      // Translation standard deviation
+      STD_TX, STD_TY, STD_TZ,
+      // Translation covariance
+      COV_TXX, COV_TXY, COV_TXZ, COV_TYY, COV_TYZ, COV_TZZ)
+  // clang-format on
+
+  // To add a new ColumnId:
+  //   1. Add the enumerator above.
+  //   2. Specialize ColumnTraits<NewId> at the bottom of this file if its
+  //      cell type is not double (the default).
+  //   3. Add a COLMAP_COLUMN_PARSER_ENTRY for the new column in
+  //      GetCellParsers() in the .cc file.
+  //   4. Update AnalyzeColumnGroups() in the .cc file if the new column
+  //      belongs to a group.
+  //   5. Update the I/O logic, documentation, and tests.
+
+  template <ColumnId Id>
+  struct ColumnTraits {
+    using value_type = double;
+  };
+
+  // Ordered list of column types describing the layout of each data row.
+  struct Schema {
+    std::vector<ColumnId> columns;
+
+    bool IsValid(const Metadata& metadata) const;
+  };
+
+  Metadata metadata;
+  Schema schema;
+  std::vector<row_t> data;
+
+  size_t NumColumns() const;
+  size_t NumRows() const;
+
+  bool IsValid() const;
+
+  using data_id_resolver_t =
+      std::function<std::optional<data_t>(const std::string&)>;
+
+  // Update an existing vector of PosePrior objects with data from the archive.
+  //
+  // For each row in the archive, the data_id_from_name callback is called to
+  // resolve the image name to a data_t. If the data_id already exists in
+  // pose_priors, the matching entry is updated in-place — only fields whose
+  // column types appear in this archive's schema are overwritten, all other
+  // fields on the existing PosePrior are preserved. If the data_id does not
+  // exist and allow_new_priors is true, a new PosePrior is appended.
+  void UpdatePosePriors(const data_id_resolver_t& data_id_from_name,
+                        bool allow_new_priors,
+                        std::vector<PosePrior>& pose_priors) const;
+
+  // Convert the archive data to a vector of PosePrior objects. Rows whose
+  // name cannot be resolved are skipped with a warning.
+  std::vector<PosePrior> ToPosePriors(
+      const data_id_resolver_t& data_id_from_name) const;
+};
+
+// Read a pose prior archive from a file.
+//
+// JSON format:
+//   {
+//     "coordinate_system": "WGS84",
+//     "sensor_type": "CAMERA",
+//     "translation_convention": "WORLD_FROM_CAM",
+//     "cartesian_frame": "ENU",
+//     "ellipsoid": "WGS84",
+//     "enu_origin": [47.0, 8.0, 500.0],
+//     "schema": ["NAME", "LAT", "LON", "ALT"],
+//     "data": [
+//       ["img001.jpg", 47.3769, 8.5417, 500.0],
+//       ["img002.jpg", 47.3770, 8.5418, 501.0]
+//     ]
+//   }
+PosePriorArchive ReadPosePriorArchive(const std::filesystem::path& path);
+
+// TODO: Implement WritePosePriorArchive
+
+template <>
+struct PosePriorArchive::ColumnTraits<PosePriorArchive::ColumnId::UNKNOWN> {
+  using value_type = std::monostate;
+};
+
+template <>
+struct PosePriorArchive::ColumnTraits<PosePriorArchive::ColumnId::NAME> {
+  using value_type = std::string;
+};
+
+}  // namespace colmap

--- a/src/colmap/geometry/pose_prior_io_test.cc
+++ b/src/colmap/geometry/pose_prior_io_test.cc
@@ -1,0 +1,488 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/geometry/pose_prior_io.h"
+
+#include "colmap/util/testing.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+std::filesystem::path WriteTestJSON(const std::string& content) {
+  const auto path = CreateTestDir() / "test.json";
+  std::ofstream file(path);
+  file << content;
+  file.close();
+  return path;
+}
+
+TEST(PosePriorArchive, EmptySchema) {
+  PosePriorArchive archive;
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+  EXPECT_FALSE(archive.IsValid());
+}
+
+TEST(PosePriorArchive, NumColumnsAndRows) {
+  PosePriorArchive archive;
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::LAT,
+                            PosePriorArchive::ColumnId::LON,
+                            PosePriorArchive::ColumnId::ALT};
+  archive.data = {
+      {std::string("img001.jpg"), 47.0, 8.0, 500.0},
+      {std::string("img002.jpg"), 48.0, 9.0, 600.0},
+  };
+  EXPECT_EQ(archive.NumColumns(), 4);
+  EXPECT_EQ(archive.NumRows(), 2);
+}
+
+TEST(PosePriorArchive, MetadataIsValid) {
+  PosePriorArchive::Metadata metadata;
+  EXPECT_FALSE(metadata.IsValid());
+
+  metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+  EXPECT_TRUE(metadata.IsValid());
+
+  metadata.cartesian_frame = PosePriorArchive::CartesianFrame::ENU;
+  EXPECT_FALSE(metadata.IsValid());
+
+  metadata = {};
+  metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  EXPECT_TRUE(metadata.IsValid());
+
+  metadata.cartesian_frame = PosePriorArchive::CartesianFrame::ENU;
+  EXPECT_FALSE(metadata.IsValid());
+
+  metadata.enu_origin = Eigen::Vector3d::Zero();
+  EXPECT_TRUE(metadata.IsValid());
+
+  metadata.sensor_type = SensorType::INVALID;
+  EXPECT_FALSE(metadata.IsValid());
+}
+
+TEST(PosePriorArchive, SchemaIsValid) {
+  PosePriorArchive::Metadata metadata;
+  metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+
+  EXPECT_FALSE(PosePriorArchive::Schema{}.IsValid(metadata));
+
+  PosePriorArchive::Schema schema;
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::LAT,
+                    PosePriorArchive::ColumnId::LON,
+                    PosePriorArchive::ColumnId::ALT};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::LAT,
+                    PosePriorArchive::ColumnId::LON};
+  EXPECT_FALSE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::LAT,
+                    PosePriorArchive::ColumnId::LON,
+                    PosePriorArchive::ColumnId::ALT,
+                    PosePriorArchive::ColumnId::TX};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY};
+  EXPECT_FALSE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::LAT};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::STD_TX,
+                    PosePriorArchive::ColumnId::STD_TY};
+  EXPECT_FALSE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::COV_TXX,
+                    PosePriorArchive::ColumnId::COV_TXY};
+  EXPECT_FALSE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::STD_TX,
+                    PosePriorArchive::ColumnId::STD_TY,
+                    PosePriorArchive::ColumnId::STD_TZ,
+                    PosePriorArchive::ColumnId::COV_TXX,
+                    PosePriorArchive::ColumnId::COV_TXY,
+                    PosePriorArchive::ColumnId::COV_TXZ,
+                    PosePriorArchive::ColumnId::COV_TYY,
+                    PosePriorArchive::ColumnId::COV_TYZ,
+                    PosePriorArchive::ColumnId::COV_TZZ};
+  EXPECT_FALSE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::STD_TX,
+                    PosePriorArchive::ColumnId::STD_TY,
+                    PosePriorArchive::ColumnId::STD_TZ};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::TX,
+                    PosePriorArchive::ColumnId::TY,
+                    PosePriorArchive::ColumnId::TZ,
+                    PosePriorArchive::ColumnId::COV_TXX,
+                    PosePriorArchive::ColumnId::COV_TXY,
+                    PosePriorArchive::ColumnId::COV_TXZ,
+                    PosePriorArchive::ColumnId::COV_TYY,
+                    PosePriorArchive::ColumnId::COV_TYZ,
+                    PosePriorArchive::ColumnId::COV_TZZ};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+  schema.columns = {PosePriorArchive::ColumnId::NAME};
+  EXPECT_TRUE(schema.IsValid(metadata));
+
+  metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  schema.columns = {PosePriorArchive::ColumnId::NAME,
+                    PosePriorArchive::ColumnId::STD_TX,
+                    PosePriorArchive::ColumnId::STD_TY,
+                    PosePriorArchive::ColumnId::STD_TZ};
+  EXPECT_TRUE(schema.IsValid(metadata));
+}
+
+TEST(PosePriorArchive, IsValid) {
+  PosePriorArchive archive;
+  EXPECT_FALSE(archive.IsValid());
+
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::WGS84;
+  EXPECT_FALSE(archive.IsValid());
+
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::LAT,
+                            PosePriorArchive::ColumnId::LON,
+                            PosePriorArchive::ColumnId::ALT};
+  EXPECT_TRUE(archive.IsValid());
+
+  archive.metadata.sensor_type = SensorType::INVALID;
+  EXPECT_FALSE(archive.IsValid());
+
+  archive.metadata.sensor_type = SensorType::CAMERA;
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::NAME};
+  EXPECT_FALSE(archive.IsValid());
+}
+
+TEST(PosePriorArchive, ReadPosePriorArchive_WGS84) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "WGS84",
+    "translation_convention": "WORLD_FROM_CAM",
+    "schema": ["NAME", "LAT", "LON", "ALT"],
+    "data": [
+      ["img001.jpg", 47.3769, 8.5417, 500.0],
+      ["img002.jpg", 47.3770, 8.5418, 501.0]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+
+  EXPECT_EQ(archive.metadata.coordinate_system,
+            PosePrior::CoordinateSystem::WGS84);
+  EXPECT_EQ(archive.metadata.translation_convention,
+            PosePriorArchive::PoseConvention::WORLD_FROM_CAM);
+  ASSERT_EQ(archive.schema.columns.size(), 4);
+  ASSERT_EQ(archive.data.size(), 2);
+  EXPECT_EQ(std::get<std::string>(archive.data[0][0]), "img001.jpg");
+  EXPECT_DOUBLE_EQ(std::get<double>(archive.data[0][1]), 47.3769);
+}
+
+TEST(PosePriorArchive, ReadPosePriorArchive_WithENUMetadata) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "CARTESIAN",
+    "cartesian_frame": "ENU",
+    "ellipsoid": "WGS84",
+    "enu_origin": [47.0, 8.0, 500.0],
+    "schema": ["NAME", "TX", "TY", "TZ"],
+    "data": [
+      ["img001.jpg", 1.0, 2.0, 3.0]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+
+  EXPECT_EQ(archive.metadata.coordinate_system,
+            PosePrior::CoordinateSystem::CARTESIAN);
+  ASSERT_TRUE(archive.metadata.cartesian_frame.has_value());
+  EXPECT_EQ(*archive.metadata.cartesian_frame,
+            PosePriorArchive::CartesianFrame::ENU);
+  ASSERT_TRUE(archive.metadata.ellipsoid.has_value());
+  EXPECT_EQ(*archive.metadata.ellipsoid, GPSTransform::Ellipsoid::WGS84);
+  EXPECT_DOUBLE_EQ(archive.metadata.enu_origin->x(), 47.0);
+}
+
+TEST(PosePriorArchive, ToPosePriors_WGS84) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "WGS84",
+    "schema": ["NAME", "LAT", "LON", "ALT"],
+    "data": [
+      ["img001.jpg", 47.3769, 8.5417, 500.0],
+      ["img002.jpg", 47.3770, 8.5418, 501.0]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+
+  int next_id = 1;
+  const auto resolve = [&](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), next_id++);
+    }
+    if (name == "img002.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), next_id++);
+    }
+    return std::nullopt;
+  };
+
+  const auto priors = archive.ToPosePriors(resolve);
+  ASSERT_EQ(priors.size(), 2);
+  EXPECT_DOUBLE_EQ(priors[0].position.x(), 47.3769);
+  EXPECT_DOUBLE_EQ(priors[0].position.y(), 8.5417);
+  EXPECT_DOUBLE_EQ(priors[0].position.z(), 500.0);
+  EXPECT_FALSE(priors[0].HasPositionCov());
+}
+
+TEST(PosePriorArchive, ToPosePriors_CartesianWithSTD) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "CARTESIAN",
+    "schema": ["NAME", "TX", "TY", "TZ", "STD_TX", "STD_TY", "STD_TZ"],
+    "data": [
+      ["img001.jpg", 1.0, 2.0, 3.0, 0.1, 0.2, 0.3]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+
+  const auto resolve = [](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), 1);
+    }
+    return std::nullopt;
+  };
+
+  const auto priors = archive.ToPosePriors(resolve);
+  ASSERT_EQ(priors.size(), 1);
+  EXPECT_TRUE(priors[0].HasPosition());
+  EXPECT_TRUE(priors[0].HasPositionCov());
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(0, 0), 0.01);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(1, 1), 0.04);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(2, 2), 0.09);
+}
+
+TEST(PosePriorArchive, ToPosePriors_UnresolvedName) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "CARTESIAN",
+    "schema": ["NAME", "TX", "TY", "TZ"],
+    "data": [
+      ["unknown.jpg", 1.0, 2.0, 3.0]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+  const auto resolve = [](const std::string&) -> std::optional<data_t> {
+    return std::nullopt;
+  };
+  const auto priors = archive.ToPosePriors(resolve);
+  EXPECT_TRUE(priors.empty());
+}
+
+TEST(PosePriorArchive, ToPosePriors_CartesianWithSTDOnly) {
+  const auto path = WriteTestJSON(R"({
+    "coordinate_system": "CARTESIAN",
+    "schema": ["NAME", "STD_TX", "STD_TY", "STD_TZ"],
+    "data": [
+      ["img001.jpg", 0.1, 0.2, 0.3]
+    ]
+  })");
+  const auto archive = ReadPosePriorArchive(path);
+
+  const auto resolve = [](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), 1);
+    }
+    return std::nullopt;
+  };
+
+  const auto priors = archive.ToPosePriors(resolve);
+  ASSERT_EQ(priors.size(), 1);
+  EXPECT_FALSE(priors[0].HasPosition());
+  EXPECT_TRUE(priors[0].HasPositionCov());
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(0, 0), 0.01);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(1, 1), 0.04);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(2, 2), 0.09);
+}
+
+TEST(PosePriorArchive, UpdatePosePriors_Existing) {
+  PosePriorArchive archive;
+  archive.metadata.sensor_type = SensorType::CAMERA;
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  archive.metadata.translation_convention =
+      PosePriorArchive::PoseConvention::WORLD_FROM_CAM;
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::TX,
+                            PosePriorArchive::ColumnId::TY,
+                            PosePriorArchive::ColumnId::TZ};
+  archive.data = {
+      {std::string("img001.jpg"), 10.0, 20.0, 30.0},
+  };
+  ASSERT_TRUE(archive.IsValid());
+
+  const auto resolve = [](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), 1);
+    }
+    return std::nullopt;
+  };
+
+  PosePrior old_prior;
+  old_prior.pose_prior_id = 42;
+  old_prior.corr_data_id = data_t(sensor_t(SensorType::CAMERA, 1), 1);
+  old_prior.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+  old_prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+
+  std::vector<PosePrior> priors = {old_prior};
+  archive.UpdatePosePriors(resolve, /*allow_new_priors=*/false, priors);
+
+  ASSERT_EQ(priors.size(), 1);
+  EXPECT_EQ(priors[0].pose_prior_id, 42);
+  EXPECT_DOUBLE_EQ(priors[0].position.x(), 10.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.y(), 20.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.z(), 30.0);
+}
+
+TEST(PosePriorArchive, UpdatePosePriors_PartialSTD) {
+  PosePriorArchive archive;
+  archive.metadata.sensor_type = SensorType::CAMERA;
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  archive.metadata.translation_convention =
+      PosePriorArchive::PoseConvention::WORLD_FROM_CAM;
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::STD_TX,
+                            PosePriorArchive::ColumnId::STD_TY,
+                            PosePriorArchive::ColumnId::STD_TZ};
+  archive.data = {
+      {std::string("img001.jpg"), 0.1, 0.2, 0.3},
+  };
+  ASSERT_TRUE(archive.IsValid());
+
+  const auto resolve = [](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), 1);
+    }
+    return std::nullopt;
+  };
+
+  PosePrior old_prior;
+  old_prior.pose_prior_id = 42;
+  old_prior.corr_data_id = data_t(sensor_t(SensorType::CAMERA, 1), 1);
+  old_prior.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+  old_prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+
+  std::vector<PosePrior> priors = {old_prior};
+  archive.UpdatePosePriors(resolve, /*allow_new_priors=*/false, priors);
+
+  ASSERT_EQ(priors.size(), 1);
+  EXPECT_EQ(priors[0].pose_prior_id, 42);
+  EXPECT_TRUE(priors[0].HasPosition());
+  EXPECT_DOUBLE_EQ(priors[0].position.x(), 1.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.y(), 2.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.z(), 3.0);
+  EXPECT_TRUE(priors[0].HasPositionCov());
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(0, 0), 0.01);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(1, 1), 0.04);
+  EXPECT_DOUBLE_EQ(priors[0].position_covariance(2, 2), 0.09);
+}
+
+TEST(PosePriorArchive, UpdatePosePriors_AllowNewPriors) {
+  PosePriorArchive archive;
+  archive.metadata.sensor_type = SensorType::CAMERA;
+  archive.metadata.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  archive.metadata.translation_convention =
+      PosePriorArchive::PoseConvention::WORLD_FROM_CAM;
+  archive.schema.columns = {PosePriorArchive::ColumnId::NAME,
+                            PosePriorArchive::ColumnId::TX,
+                            PosePriorArchive::ColumnId::TY,
+                            PosePriorArchive::ColumnId::TZ};
+  archive.data = {
+      {std::string("img001.jpg"), 10.0, 20.0, 30.0},
+  };
+  ASSERT_TRUE(archive.IsValid());
+
+  const auto resolve = [](const std::string& name) -> std::optional<data_t> {
+    if (name == "img001.jpg") {
+      return data_t(sensor_t(SensorType::CAMERA, 1), 1);
+    }
+    return std::nullopt;
+  };
+
+  std::vector<PosePrior> priors;
+  archive.UpdatePosePriors(resolve, /*allow_new_priors=*/true, priors);
+
+  ASSERT_EQ(priors.size(), 1);
+  EXPECT_TRUE(priors[0].HasPosition());
+  EXPECT_DOUBLE_EQ(priors[0].position.x(), 10.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.y(), 20.0);
+  EXPECT_DOUBLE_EQ(priors[0].position.z(), 30.0);
+}
+
+}  // namespace
+}  // namespace colmap


### PR DESCRIPTION
Introduces `PosePriorArchive`, a format-independent intermediate representation for loading external pose priors.

The archive decouples global metadata (coordinate system, reference frame, ellipsoid, sensor type, and translation convention) from a flexible column-based schema with arbitrary column ordering and typed data rows.

Key features:
- JSON parser with schema validation and global metadata support
- `pose_prior_importer` CLI supporting full replacement (`--overwrite`) and selective update (`--update`) modes
- Unit tests covering validation, parsing, conversion, and update paths

Future work:
- CSV input support
- GUI import support
- Additional column types (e.g., rotation, gravity)

---

Validated on South-Building (128 images):
- Added a 1000-unit X-offset to the reconstructed camera poses and converted them into JSON pose priors.
- Imported the modified pose priors and computed matches using the `spatial_matcher`.
- Reconstructed the model using `pose_prior_mapper`.
- Compared the reconstructed model against the original model to verify that the applied offset was correctly recovered.

The attached script, [images_txt_to_pose_prior.py](https://github.com/user-attachments/files/29998652/images_txt_to_pose_prior.py), converts camera poses from the COLMAP reconstruction `images.txt` into the JSON pose prior format:

```
python images_txt_to_pose_prior.py south-building/images.txt
--std 0.05 --offset-x 1000 -o output/priors.json

colmap feature_extractor --database_path output/database.db
--image_path south-building/images --ImageReader.single_camera 1

colmap pose_prior_importer --database_path output/database.db
--pose_prior_path output/priors.json

colmap spatial_matcher --database_path output/database.db
--SpatialMatching.max_distance 0 --SpatialMatching.min_num_neighbors 10

colmap mapper --image_path south-building/images
--database_path output/database.db --output_path output/mapper

colmap pose_prior_mapper --image_path south-building/images
--database_path output/database.db --output_path output/pose_prior_mapper

colmap model_comparer --input_path1 output/mapper/0
--input_path2 output/pose_prior_mapper/0 --output_path output
```
The `model_comparer` result:
```
I20260714 15:27:33.410850 34624 model.cc:593] === Comparing reconstructed image poses ===
I20260714 15:27:33.410980 34624 model.cc:596] Common images: 128
I20260714 15:27:33.675782 34624 model.cc:622] Computed alignment transform:
    1.00575 -0.00072506 -0.00587314     1000.03
0.000787093     1.00571   0.0106278    0.008911
 0.00586515  -0.0106322     1.00569   0.0271838
I20260714 15:27:33.676150 34624 model.cc:627] --- Image alignment error summary ---

Rotation errors (degrees)
Min:    0.0023788
Max:    0.00717671
Mean:   0.00549476
Median: 0.00547288
P90:    0.00595599
P99:    0.00650775

Projection center errors
Min:    1.48562e-05
Max:    0.000568069
Mean:   0.000264483
Median: 0.000235601
P90:    0.000524238
P99:    0.000563086
```
The applied X-axis offset is correctly recovered after alignment, with rotation and projection center errors consistent with the original reconstruction, demonstrating that the pose priors are correctly applied.