### PR TITLE
Show image/point viewer metadata when images are missing on disk

### DIFF
--- a/src/colmap/ui/image_viewer_widget.cc
+++ b/src/colmap/ui/image_viewer_widget.cc
@@ -175,7 +175,11 @@ void FeatureImageViewerWidget::ReadAndShowWithKeypoints(
     const std::vector<char>& tri_mask) {
   Bitmap bitmap;
   if (!bitmap.Read(path, /*as_rgb=*/true)) {
-    LOG(ERROR) << "Cannot read image at path " << path;
+    LOG(WARNING) << "Cannot read image at path " << path
+                 << ", showing metadata only";
+    image1_ = QPixmap();
+    image2_ = image1_;
+    ShowPixmap(image1_);
     return;
   }
 
@@ -378,10 +382,10 @@ void DatabaseImageViewerWidget::ShowImageWithId(const image_t image_id) {
 }
 
 void DatabaseImageViewerWidget::ResizeTable() {
-  // Set fixed table dimensions.
+  // Set fixed table dimensions. The horizontal header is hidden, so its height
+  // must not be included or it leaves an empty strip below the last row.
   table_widget_->resizeColumnsToContents();
-  int height = table_widget_->horizontalHeader()->height() +
-               2 * table_widget_->frameWidth();
+  int height = 2 * table_widget_->frameWidth();
   for (int i = 0; i < table_widget_->rowCount(); i++) {
     height += table_widget_->rowHeight(i);
   }

--- a/src/colmap/ui/point_viewer_widget.cc
+++ b/src/colmap/ui/point_viewer_widget.cc
@@ -193,7 +193,7 @@ void PointViewerWidget::Show(const point3D_t point3D_id) {
     Bitmap bitmap;
     const std::filesystem::path path = *options_->image_path / image.Name();
     if (!bitmap.Read(path, /*as_rgb=*/true, /*linearize=*/false)) {
-      LOG(ERROR) << "Cannot read image at path " << path;
+      LOG(WARNING) << "Cannot read image at path " << path;
       continue;
     }
 


### PR DESCRIPTION
## Motivation

When double-clicking an image in the 3D model viewer whose file cannot be found on disk, the image viewer window never appeared at all — the user only got a console error, even though the metadata was available. This makes the GUI more forgiving when working with reconstructions whose source images are no longer present.

## Changes

- **Image viewer (double-click an image):** show the viewer with an empty image pane when the file cannot be read, so the metadata table (image/frame/rig id, camera, pose, point counts, name) remains visible. Previously `ShowPixmap` — which shows and raises the widget — was only called after a successful read, so a failed read returned early and the window never opened. The log is downgraded from error to warning.

- **Image viewer table:** fix `ResizeTable` including the height of the *hidden* horizontal header, which left an empty strip below the last row that looked like an extra empty row.

- **Point viewer (select a 3D point):** downgrade the missing-image log from error to warning. The loop already skips images that cannot be read, so a missing source image is expected rather than an error.