### PR TITLE
doc: Add FAQ entry on re-running feature matching with different options

### DIFF
--- a/doc/features.rst
+++ b/doc/features.rst
@@ -78,6 +78,19 @@ In the GUI, open ``Processing > Feature matching``, select any matching tab
 (Exhaustive, Sequential, etc.), and choose the matcher type from the "Type"
 dropdown in the shared options section.
 
+When re-running matching on an existing database, image pairs that already have
+a two-view geometry are skipped, so changing ``--FeatureMatching.type`` on such
+a database leaves previously matched pairs untouched. To force re-matching, first
+clear the existing results with ``database_cleaner``::
+
+    $ colmap database_cleaner \
+        --database_path $DATASET_PATH/database.db \
+        --type two_view_geometries
+
+Use ``--type matches`` to also clear the raw feature matches, or ``--type
+features`` to additionally clear the extracted keypoints and descriptors (needed
+when re-extracting with a different ``--FeatureExtraction.type``).
+
 
 Compatible Extractor and Matcher Types
 --------------------------------------

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -78,19 +78,6 @@ In the GUI, open ``Processing > Feature matching``, select any matching tab
 (Exhaustive, Sequential, etc.), and choose the matcher type from the "Type"
 dropdown in the shared options section.
 
-When re-running matching on an existing database, image pairs that already have
-a two-view geometry are skipped, so changing ``--FeatureMatching.type`` on such
-a database leaves previously matched pairs untouched. To force re-matching, first
-clear the existing results with ``database_cleaner``::
-
-    $ colmap database_cleaner \
-        --database_path $DATASET_PATH/database.db \
-        --type two_view_geometries
-
-Use ``--type matches`` to also clear the raw feature matches, or ``--type
-features`` to additionally clear the extracted keypoints and descriptors (needed
-when re-extracting with a different ``--FeatureExtraction.type``).
-
 
 Compatible Extractor and Matcher Types
 --------------------------------------
@@ -117,3 +104,20 @@ different trade-offs between speed and accuracy:
 Specify the model path using ``--AlikedExtraction.*_model_path``. If the path is
 a URL, COLMAP will automatically download and cache the model. You can download
 different ALIKED models from the release page at https://github.com/colmap/colmap/releases/
+
+
+Iterative Runs
+---------------------
+
+When re-running matching on an existing database, image pairs that already have
+a two-view geometry are skipped, so changing ``--FeatureMatching.type`` on such
+a database leaves previously matched pairs untouched. To force re-matching, first
+clear the existing results with ``database_cleaner``::
+
+    $ colmap database_cleaner \
+        --database_path $DATASET_PATH/database.db \
+        --type two_view_geometries \
+        --type matches
+
+When re-extracting with a different ``--FeatureExtraction.type``, use
+``--type features`` to additionally clear the extracted keypoints and descriptors.


### PR DESCRIPTION
## Summary

Adds a FAQ entry documenting a behavior that repeatedly confuses users (most recently in #4367):

- When re-running feature matching on an existing database, image pairs with existing two-view geometries are skipped and not updated (`feature_matching_utils.cc`), so changed matching/verification options (e.g. `--TwoViewGeometry.min_num_inliers`) only affect previously unprocessed pairs.
- How to re-run matching from scratch using `colmap database_cleaner` with `--type two_view_geometries` / `matches` / `features`.
- Clarifies that `min_num_inliers` applies per image pair unless `--FeatureMatching.rig_verification` is enabled (per-frame-pair verification), as explained by @ahojnnes in #4367.

Docs build cleanly with Sphinx and the section renders correctly.

Related to #4367