### PR TITLE
Fix typos in user-facing help string and FAQ

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -39,7 +39,7 @@ COLMAP supports two feature extraction algorithms: SIFT (default) and ALIKED
 
 - **SIFT** is the most widely tested and robust choice. It works well for
   scenarios with moderate to high view overlap, sufficient scene texture,
-  and captured under similar illumination conditiions. It supports both GPU
+  and captured under similar illumination conditions. It supports both GPU
   and CPU extraction.
 
 - **ALIKED** is a learned feature extractor that can produce more repeatable

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -482,7 +482,7 @@ int RunPosePriorMapper(int argc, char** argv) {
       "overwrite_priors_covariance",
       &overwrite_priors_covariance,
       "Priors covariance read from database. If true, overwrite the priors "
-      "covariance using the follwoing prior_position_std_... options");
+      "covariance using the following prior_position_std_... options");
   options.AddDefaultOption("prior_position_std_x", &prior_position_std_x);
   options.AddDefaultOption("prior_position_std_y", &prior_position_std_y);
   options.AddDefaultOption("prior_position_std_z", &prior_position_std_z);


### PR DESCRIPTION
## Summary

- `exe/sfm.cc`: "follwoing" → "following" in the `pose_prior_mapper` `--overwrite_priors_covariance` help text.
- `doc/faq.rst`: "conditiions" → "conditions".
