### PR TITLE
Fix feature matching slowdown from process-global omp critical in RANSAC

### DIFF
--- a/src/colmap/optim/loransac.h
+++ b/src/colmap/optim/loransac.h
@@ -37,6 +37,7 @@
 
 #include <atomic>
 #include <cfloat>
+#include <mutex>
 #include <optional>
 #include <type_traits>
 #include <vector>
@@ -164,6 +165,15 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
   std::atomic<size_t> dyn_max_num_trials(max_num_trials);
   std::atomic<bool> abort_flag(false);
 
+  // Guards updates to the shared best model/support in the parallel case. We
+  // deliberately avoid `#pragma omp critical`, which maps to a single
+  // process-global lock and would serialize concurrent single-threaded RANSAC
+  // calls (e.g. during multi-threaded geometric verification, where many
+  // matches are estimated in parallel with num_threads == 1). A per-call mutex
+  // is only contended among this call's own threads and is not even locked in
+  // the serial case.
+  std::mutex best_mutex;
+
 // This creates a parallel region that runs with num_threads threads (or
 // serially when num_threads == 1 via the if-clause). Without OpenMP, the
 // pragma is absent and the block runs once serially.
@@ -228,10 +238,11 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
         // case, multiple threads may pass this check concurrently — the
         // authoritative update below re-checks under the same lock.
         bool is_better = false;
-#ifdef _OPENMP
-#pragma omp critical
-#endif
         {
+          std::unique_lock<std::mutex> lock(best_mutex, std::defer_lock);
+          if (num_threads > 1) {
+            lock.lock();
+          }
           is_better =
               thread_support_measurer.IsLeftBetter(support, best_support);
         }
@@ -308,10 +319,11 @@ LORANSAC<Estimator, LocalEstimator, SupportMeasurer, Sampler>::Estimate(
           }
 
           // Commit local optimization result to global best under lock.
-#ifdef _OPENMP
-#pragma omp critical
-#endif
           {
+            std::unique_lock<std::mutex> lock(best_mutex, std::defer_lock);
+            if (num_threads > 1) {
+              lock.lock();
+            }
             if (thread_support_measurer.IsLeftBetter(local_best_support,
                                                      best_support)) {
               best_support = local_best_support;

--- a/src/colmap/optim/ransac.h
+++ b/src/colmap/optim/ransac.h
@@ -37,6 +37,7 @@
 
 #include <atomic>
 #include <cfloat>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -246,6 +247,15 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
   std::atomic<size_t> dyn_max_num_trials(max_num_trials);
   std::atomic<bool> abort_flag(false);
 
+  // Guards updates to the shared best model/support in the parallel case. We
+  // deliberately avoid `#pragma omp critical`, which maps to a single
+  // process-global lock and would serialize concurrent single-threaded RANSAC
+  // calls (e.g. during multi-threaded geometric verification, where many
+  // matches are estimated in parallel with num_threads == 1). A per-call mutex
+  // is only contended among this call's own threads and is not even locked in
+  // the serial case.
+  std::mutex best_mutex;
+
 // This creates a parallel region that runs with num_threads threads (or
 // serially when num_threads == 1 via the if-clause). Without OpenMP, the
 // pragma is absent and the block runs once serially.
@@ -300,10 +310,11 @@ RANSAC<Estimator, SupportMeasurer, Sampler>::Estimate(
             thread_support_measurer.Evaluate(residuals, max_residual);
 
         // Save as best subset if better than all previous subsets.
-#ifdef _OPENMP
-#pragma omp critical
-#endif
         {
+          std::unique_lock<std::mutex> lock(best_mutex, std::defer_lock);
+          if (num_threads > 1) {
+            lock.lock();
+          }
           if (thread_support_measurer.IsLeftBetter(support, best_support)) {
             best_support = support;
             best_model = sample_model;


### PR DESCRIPTION
## Problem

Feature matching became ~4-6x slower after the OpenMP parallelization of `RANSAC`/`LORANSAC` introduced in #4169, as reported in #4482.

## Root cause

The parallelization used an **unnamed** `#pragma omp critical` to guard updates to the shared best model/support. An unnamed `omp critical` maps to a *single process-global lock* shared by every unnamed critical region, and it is acquired **even when not inside a parallel region**.

Geometric verification (`two_view_geometry.cc`) runs many `RANSAC`/`LORANSAC` calls concurrently across the matcher's `std::thread` pool, each with the default `num_threads == 1` (i.e. serial — the `#pragma omp parallel ... if (num_threads > 1)` region is never entered). Despite running serially, every model evaluation still acquired the one global critical lock, so all concurrent verification threads serialized on it in the hottest loop.

## Fix

Replace the `#pragma omp critical` with a per-call `std::mutex`, locked via `std::unique_lock(..., std::defer_lock)` only when `num_threads > 1`:

- **Serial path** (matching's default): no lock is taken at all → no cross-thread contention.
- **Parallel path** (`num_threads > 1`): a call-local mutex, contended only among that call's own team threads → correctness preserved.

## Verification

- `ransac_test` (6/6) and `loransac_test` (3/3) pass, including the `Parallel*` tests.
- A standalone reproduction of the pattern confirmed the unnamed `omp critical` is ~100-150x slower than the per-call mutex under concurrent serial callers.
- Audited the entire repository: these two were the only unnamed `omp critical` sites in first-party COLMAP code; all other `omp parallel` regions are either `num_threads(1)` or one-shot MVS worksharing loops and are unaffected.

Fixes #4482