### PR TITLE
Use optional cameras if available when decomposing relative poses.

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -1460,11 +1460,20 @@ void MaybeDecomposeRelativePoses(DatabaseCache* database_cache) {
 
     decompose_count++;
 
+    // Calibrate rays with the intrinsics the solver estimated where available
+    // (its focal, not the camera's stale default), else the given cameras.
+    const Camera& effective_camera1 = two_view_geometry.camera1.has_value()
+                                          ? *two_view_geometry.camera1
+                                          : camera1;
+    const Camera& effective_camera2 = two_view_geometry.camera2.has_value()
+                                          ? *two_view_geometry.camera2
+                                          : camera2;
+
     std::vector<Eigen::Vector3d> inlier_cam_rays1;
     std::vector<Eigen::Vector3d> inlier_cam_rays2;
-    ExtractInlierCamRays(camera1,
+    ExtractInlierCamRays(effective_camera1,
                          points1,
-                         camera2,
+                         effective_camera2,
                          points2,
                          two_view_geometry.inlier_matches,
                          &inlier_cam_rays1,

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -1207,6 +1207,104 @@ TEST(MaybeDecomposeRelativePoses, Nominal) {
             geometry_second.cam2_from_cam1->translation());
 }
 
+// A pair whose focal a two-view solver recovered is UNCALIBRATED but carries
+// the estimated intrinsics in camera1/camera2. MaybeDecomposeRelativePoses
+// must calibrate the rays with those, not the camera's stale default focal.
+// The pose survives a wrong focal (it comes from E alone); tri_angle, measured
+// between the rays, does not.
+TEST(MaybeDecomposeRelativePoses, SharedFocalUsesEstimatedIntrinsics) {
+  SetPRNGSeed(42);
+
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 2;
+  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.camera_has_prior_focal_length = false;
+  // A focal well away from the no-prior default of 1.2 * max(width, height),
+  // so that using the wrong one is actually observable.
+  synthetic_dataset_options.camera_params = {1000, 512, 384, 0.05};
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction, database.get());
+
+  const Image& image1 = reconstruction.Image(1);
+  const Image& image2 = reconstruction.Image(2);
+  ASSERT_EQ(image1.CameraId(), image2.CameraId());
+  const Rigid3d gt_cam2_from_cam1 =
+      image2.CamFromWorld() * Inverse(image1.CamFromWorld());
+
+  // Emulate the shared-focal solver output: the true focal is surfaced via
+  // camera1/camera2, while the camera stored in the database still carries an
+  // arbitrary default focal that must not be used to calibrate the rays.
+  const Camera true_camera = *image1.CameraPtr();
+
+  TwoViewGeometry geometry = database->ReadTwoViewGeometry(1, 2);
+  ASSERT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::UNCALIBRATED);
+  ASSERT_TRUE(geometry.E.has_value());
+  geometry.camera1 = true_camera;
+  geometry.camera2 = true_camera;
+  database->UpdateTwoViewGeometry(1, 2, geometry);
+
+  // Reference run: the database camera happens to carry the correct focal, so
+  // the estimated intrinsics and the database camera agree.
+  DatabaseCache::Options cache_options;
+  auto reference_cache = DatabaseCache::Create(*database, cache_options);
+  MaybeDecomposeRelativePoses(reference_cache.get());
+  const TwoViewGeometry reference_geometry =
+      reference_cache->CorrespondenceGraph()->ExtractTwoViewGeometry(
+          1, 2, /*extract_inlier_matches=*/false);
+  ASSERT_TRUE(reference_geometry.cam2_from_cam1.has_value());
+  ASSERT_GT(reference_geometry.tri_angle, 0);
+
+  // Now give the database camera the focal it would actually carry without a
+  // prior, i.e. ImageReaderOptions::default_focal_length_factor times the
+  // larger image dimension -- which is exactly the case the shared-focal
+  // solver runs in. The result must be unchanged: the decomposition has to key
+  // off the estimated intrinsics, not the database camera.
+  Camera default_camera = true_camera;
+  default_camera.SetFocalLength(
+      1.2 * std::max(true_camera.width, true_camera.height));
+  default_camera.has_prior_focal_length = false;
+  ASSERT_GT(
+      std::abs(default_camera.FocalLength() / true_camera.FocalLength() - 1.0),
+      0.1);
+  database->UpdateCamera(default_camera);
+
+  auto cache = DatabaseCache::Create(*database, cache_options);
+  const TwoViewGeometry geometry_before =
+      cache->CorrespondenceGraph()->ExtractTwoViewGeometry(
+          1, 2, /*extract_inlier_matches=*/false);
+  ASSERT_FALSE(geometry_before.cam2_from_cam1.has_value());
+  ASSERT_TRUE(geometry_before.camera1.has_value());
+
+  MaybeDecomposeRelativePoses(cache.get());
+
+  const TwoViewGeometry geometry_after =
+      cache->CorrespondenceGraph()->ExtractTwoViewGeometry(
+          1, 2, /*extract_inlier_matches=*/false);
+  ASSERT_TRUE(geometry_after.cam2_from_cam1.has_value());
+
+  // The pose is recovered from E alone, so it is insensitive to the focal used
+  // to calibrate the rays; the triangulation angle is measured between those
+  // rays and is not.
+  EXPECT_THAT(*geometry_after.cam2_from_cam1,
+              Rigid3dNear(*reference_geometry.cam2_from_cam1,
+                          /*rtol=*/1e-6,
+                          /*ttol=*/1e-6));
+  EXPECT_NEAR(geometry_after.tri_angle, reference_geometry.tri_angle, 1e-6);
+
+  // Sanity check that the reference itself is meaningful.
+  EXPECT_THAT(
+      Rigid3d(reference_geometry.cam2_from_cam1->rotation(),
+              reference_geometry.cam2_from_cam1->translation().normalized()),
+      Rigid3dNear(Rigid3d(gt_cam2_from_cam1.rotation(),
+                          gt_cam2_from_cam1.translation().normalized()),
+                  /*rtol=*/1e-3,
+                  /*ttol=*/1e-2));
+}
+
 // Regression test for https://github.com/colmap/colmap/issues/4387: older
 // COLMAP databases stored the two-view geometry config without persisting
 // the E/F/H matrices. MaybeDecomposeRelativePoses must refit the missing

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -1212,7 +1212,7 @@ TEST(MaybeDecomposeRelativePoses, Nominal) {
 // must calibrate the rays with those, not the camera's stale default focal.
 // The pose survives a wrong focal (it comes from E alone); tri_angle, measured
 // between the rays, does not.
-TEST(MaybeDecomposeRelativePoses, SharedFocalUsesEstimatedIntrinsics) {
+TEST(MaybeDecomposeRelativePoses, UsesSolverEstimatedIntrinsics) {
   SetPRNGSeed(42);
 
   auto database = Database::Open(kInMemorySqliteDatabasePath);
@@ -1235,9 +1235,9 @@ TEST(MaybeDecomposeRelativePoses, SharedFocalUsesEstimatedIntrinsics) {
   const Rigid3d gt_cam2_from_cam1 =
       image2.CamFromWorld() * Inverse(image1.CamFromWorld());
 
-  // Emulate the shared-focal solver output: the true focal is surfaced via
-  // camera1/camera2, while the camera stored in the database still carries an
-  // arbitrary default focal that must not be used to calibrate the rays.
+  // Emulate an intrinsics-estimating solver: the true focal is surfaced via
+  // camera1/camera2, while the camera stored in the database still carries the
+  // default focal that must not be used to calibrate the rays.
   const Camera true_camera = *image1.CameraPtr();
 
   TwoViewGeometry geometry = database->ReadTwoViewGeometry(1, 2);
@@ -1260,9 +1260,8 @@ TEST(MaybeDecomposeRelativePoses, SharedFocalUsesEstimatedIntrinsics) {
 
   // Now give the database camera the focal it would actually carry without a
   // prior, i.e. ImageReaderOptions::default_focal_length_factor times the
-  // larger image dimension -- which is exactly the case the shared-focal
-  // solver runs in. The result must be unchanged: the decomposition has to key
-  // off the estimated intrinsics, not the database camera.
+  // larger image dimension. The result must be unchanged: the decomposition
+  // has to key off the estimated intrinsics, not the database camera.
   Camera default_camera = true_camera;
   default_camera.SetFocalLength(
       1.2 * std::max(true_camera.width, true_camera.height));

--- a/src/colmap/estimators/view_graph_calibration.cc
+++ b/src/colmap/estimators/view_graph_calibration.cc
@@ -120,8 +120,9 @@ void CrossValidatePriorFocalLengths(
                                              tvg.F.value(),
                                              camera1.CalibrationMatrix());
       tvg.config = TwoViewGeometry::CALIBRATED;
-      // E now lives in the calibrated frame; solver-estimated intrinsics are
-      // superseded.
+      // E is now built from the K of the cross-validated focal priors, and
+      // consumers calibrate the rays with camera1/camera2 whenever set. Clear
+      // them so the rays use the same K as E, not the solver's own focal.
       tvg.camera1.reset();
       tvg.camera2.reset();
       ++num_upgraded_pairs;
@@ -469,8 +470,9 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
                                              tvg.F.value(),
                                              camera1.CalibrationMatrix());
       tvg.config = TwoViewGeometry::CALIBRATED;
-      // E now lives in the calibrated frame; solver-estimated intrinsics are
-      // superseded.
+      // E is now built from the K of the calibrated focals, and consumers
+      // calibrate the rays with camera1/camera2 whenever set. Clear them so
+      // the rays use the same K as E, not the solver's own focal.
       tvg.camera1.reset();
       tvg.camera2.reset();
       valid_pair_indices.push_back(i);

--- a/src/colmap/estimators/view_graph_calibration.cc
+++ b/src/colmap/estimators/view_graph_calibration.cc
@@ -120,6 +120,10 @@ void CrossValidatePriorFocalLengths(
                                              tvg.F.value(),
                                              camera1.CalibrationMatrix());
       tvg.config = TwoViewGeometry::CALIBRATED;
+      // E now lives in the calibrated frame; solver-estimated intrinsics are
+      // superseded.
+      tvg.camera1.reset();
+      tvg.camera2.reset();
       ++num_upgraded_pairs;
     }
   }
@@ -363,7 +367,7 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
   // Read UNCALIBRATED and CALIBRATED two-view geometries. A pair whose
   // intrinsics a two-view solver estimated is UNCALIBRATED too: its focal is
   // re-estimated from F rather than trusted, so any estimated intrinsics in
-  // camera1/camera2 are ignored here.
+  // camera1/camera2 are ignored here and cleared on upgrade to CALIBRATED.
   // TODO: study whether seeding from the estimated camera1/camera2 intrinsics,
   // instead of ignoring them, improves the calibration initialization.
   std::vector<std::pair<image_pair_t, TwoViewGeometry>> pairs;
@@ -465,6 +469,10 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
                                              tvg.F.value(),
                                              camera1.CalibrationMatrix());
       tvg.config = TwoViewGeometry::CALIBRATED;
+      // E now lives in the calibrated frame; solver-estimated intrinsics are
+      // superseded.
+      tvg.camera1.reset();
+      tvg.camera2.reset();
       valid_pair_indices.push_back(i);
     }
   }


### PR DESCRIPTION
A follow-up fix of https://github.com/colmap/colmap/pull/4521. Scanned the repo and confirmed that this was the only site that we missed to handle. 