### PR TITLE
Restrict projective geometry paths to pinhole based camera models

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -458,6 +458,20 @@ TwoViewGeometry EstimateTwoViewGeometry(
     return EstimateMultipleTwoViewGeometries(
         camera1, points1, camera2, points2, matches, multiple_model_options);
   } else if (options.force_H_use) {
+    // In image coordinates, a homography relates two views of a plane only
+    // under a pinhole projection. Fisheye and spherical models map the plane
+    // non-linearly, so the estimated homography would be meaningless.
+    // TODO: support non-pinhole models here, e.g. by estimating the homography
+    // on bearing vectors rather than image points.
+    if (!camera1.IsPerspectivePinhole() || !camera2.IsPerspectivePinhole()) {
+      LOG_FIRST_N(WARNING, 1)
+          << "Ignoring force_H_use for non-pinhole cameras, as a homography "
+             "does not relate their images of a plane. Such pairs are marked "
+             "as degenerate.";
+      TwoViewGeometry geometry;
+      geometry.config = TwoViewGeometry::ConfigurationType::DEGENERATE;
+      return geometry;
+    }
     return EstimateCalibratedHomography(
         camera1, points1, camera2, points2, matches, options);
   } else {
@@ -470,7 +484,7 @@ TwoViewGeometry EstimateTwoViewGeometry(
     // a barrier here (as in the fundamental-matrix path, it is absorbed by the
     // epipolar fit and later refined). Otherwise, use the calibrated path if
     // both cameras have a known focal length, and the uncalibrated path
-    // otherwise.
+    // otherwise, the latter being restricted to pinhole models.
     if (camera1.IsSpherical() || camera2.IsSpherical()) {
       return EstimateSphericalTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
@@ -483,6 +497,22 @@ TwoViewGeometry EstimateTwoViewGeometry(
                camera2.has_prior_focal_length) {
       return EstimateCalibratedTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
+    } else if (!camera1.IsPerspectivePinhole() ||
+               !camera2.IsPerspectivePinhole()) {
+      // Without a focal-length prior, the only remaining option is the
+      // fundamental-matrix path below, which assumes a pinhole projection that
+      // a fisheye camera does not have. The calibrated path above does handle
+      // fisheye, as it works on bearing vectors.
+      // TODO: support uncalibrated fisheye pairs, e.g. by estimating F in a
+      // virtual pinhole frame.
+      LOG_FIRST_N(WARNING, 1)
+          << "Marking fisheye pairs without a focal length prior as "
+             "degenerate, as their focal length cannot be recovered from a "
+             "fundamental matrix. Provide a focal length prior to register "
+             "these pairs.";
+      TwoViewGeometry geometry;
+      geometry.config = TwoViewGeometry::ConfigurationType::DEGENERATE;
+      return geometry;
     } else {
       return EstimateUncalibratedTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -463,20 +463,20 @@ TwoViewGeometry EstimateTwoViewGeometry(
   } else {
     // A spherical (omnidirectional) camera has no pinhole image plane, so only
     // the bearing-based essential matrix is meaningful. Otherwise, if both
-    // images share the same pinhole-projection camera (perspective and
-    // non-fisheye) without a focal-length prior, recover a single shared focal
-    // length jointly with the relative pose; multi-focal models (e.g. PINHOLE)
-    // are seeded isotropically (fx = fy = f) and refined later by bundle
-    // adjustment. Distortion is not a barrier here (as in the
-    // fundamental-matrix path, it is absorbed by the epipolar fit and later
-    // refined). Otherwise, use the calibrated path if both cameras have a known
-    // focal length, and the uncalibrated path otherwise.
+    // images share the same pinhole-projection camera without a focal-length
+    // prior, recover a single shared focal length jointly with the relative
+    // pose; multi-focal models (e.g. PINHOLE) are seeded isotropically
+    // (fx = fy = f) and refined later by bundle adjustment. Distortion is not
+    // a barrier here (as in the fundamental-matrix path, it is absorbed by the
+    // epipolar fit and later refined). Otherwise, use the calibrated path if
+    // both cameras have a known focal length, and the uncalibrated path
+    // otherwise.
     if (camera1.IsSpherical() || camera2.IsSpherical()) {
       return EstimateSphericalTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
     } else if (camera1.camera_id == camera2.camera_id &&
-               !camera1.has_prior_focal_length && camera1.IsPerspective() &&
-               !camera1.IsFisheye()) {
+               !camera1.has_prior_focal_length &&
+               camera1.HasPinholeProjection()) {
       return EstimateSharedFocalTwoViewGeometry(
           camera1, points1, points2, matches, options);
     } else if (camera1.has_prior_focal_length &&

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -476,7 +476,7 @@ TwoViewGeometry EstimateTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
     } else if (camera1.camera_id == camera2.camera_id &&
                !camera1.has_prior_focal_length &&
-               camera1.HasPinholeProjection()) {
+               camera1.IsPerspectivePinhole()) {
       return EstimateSharedFocalTwoViewGeometry(
           camera1, points1, points2, matches, options);
     } else if (camera1.has_prior_focal_length &&

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -454,6 +454,98 @@ TEST(EstimateTwoViewGeometry, Spherical) {
   EXPECT_FALSE(calibrated_geometry.H.has_value());
 }
 
+TEST(EstimateTwoViewGeometry, UncalibratedFisheyeIsDegenerate) {
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 200;
+  synthetic_dataset_options.camera_model_id =
+      OpenCVFisheyeCameraModel::model_id;
+  synthetic_dataset_options.camera_params = {1280, 1280, 512, 384, 0, 0, 0, 0};
+  synthetic_dataset_options.camera_has_prior_focal_length = false;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsPerspectiveFisheye());
+  ASSERT_FALSE(test_data.camera1.has_prior_focal_length);
+
+  // Without a focal length prior the only remaining model is the fundamental
+  // matrix, which assumes a pinhole projection that a fisheye camera does not
+  // have. The pair is therefore rejected rather than fit with a meaningless
+  // fundamental matrix.
+  TwoViewGeometryOptions two_view_geometry_options;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::DEGENERATE);
+  EXPECT_FALSE(geometry.F.has_value());
+  EXPECT_FALSE(geometry.H.has_value());
+}
+
+TEST(EstimateTwoViewGeometry, CalibratedFisheyeIsEstimated) {
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 200;
+  synthetic_dataset_options.camera_model_id =
+      OpenCVFisheyeCameraModel::model_id;
+  synthetic_dataset_options.camera_params = {1280, 1280, 512, 384, 0, 0, 0, 0};
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsPerspectiveFisheye());
+  ASSERT_TRUE(test_data.camera1.has_prior_focal_length);
+
+  // With a known focal length the calibrated path applies, which works on
+  // bearing vectors and is therefore valid for fisheye cameras.
+  TwoViewGeometryOptions two_view_geometry_options;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::CALIBRATED);
+  EXPECT_TRUE(geometry.E.has_value());
+  EXPECT_GE(geometry.inlier_matches.size(), test_data.matches.size() / 2);
+}
+
+TEST(EstimateTwoViewGeometry, ForceHUseWithFisheyeIsDegenerate) {
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 200;
+  synthetic_dataset_options.camera_model_id =
+      OpenCVFisheyeCameraModel::model_id;
+  synthetic_dataset_options.camera_params = {1280, 1280, 512, 384, 0, 0, 0, 0};
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsPerspectiveFisheye());
+
+  // A homography only relates two images of a plane under a pinhole
+  // projection, so it is not estimated for fisheye cameras even when the
+  // caller explicitly asks for it.
+  TwoViewGeometryOptions two_view_geometry_options;
+  two_view_geometry_options.force_H_use = true;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::DEGENERATE);
+  EXPECT_FALSE(geometry.H.has_value());
+}
+
 TEST(EstimateTwoViewGeometry, SharedFocal) {
   SetPRNGSeed(0);
   // A single shared, uncalibrated, pinhole-projection camera observed from two

--- a/src/colmap/estimators/view_graph_calibration.cc
+++ b/src/colmap/estimators/view_graph_calibration.cc
@@ -112,7 +112,9 @@ void CrossValidatePriorFocalLengths(
     const Camera& camera1 = *image_id_to_camera.at(image_id1);
     const Camera& camera2 = *image_id_to_camera.at(image_id2);
 
-    if (camera_validity[camera1.camera_id] &&
+    // Computing E from F assumes a pinhole projection for both cameras.
+    if (camera1.HasPinholeProjection() && camera2.HasPinholeProjection() &&
+        camera_validity[camera1.camera_id] &&
         camera_validity[camera2.camera_id]) {
       THROW_CHECK(tvg.F.has_value())
           << "UNCALIBRATED two-view geometry must have F matrix";
@@ -227,8 +229,8 @@ FocalLengthCalibResult CalibrateFocalLengths(
   auto loss_function = options.CreateLossFunction();
 
   for (const auto& input : inputs) {
-    if (!cameras.at(input.camera_id1).IsPerspective() ||
-        !cameras.at(input.camera_id2).IsPerspective()) {
+    if (!cameras.at(input.camera_id1).HasPinholeProjection() ||
+        !cameras.at(input.camera_id2).HasPinholeProjection()) {
       continue;
     }
     if (input.camera_id1 == input.camera_id2) {
@@ -252,7 +254,7 @@ FocalLengthCalibResult CalibrateFocalLengths(
   // Parameterize cameras (fix those with prior, set lower bound).
   size_t num_cameras = 0;
   for (const auto& [camera_id, camera] : cameras) {
-    if (!camera.IsPerspective()) continue;
+    if (!camera.HasPinholeProjection()) continue;
     double* focal_ptr = &focal_lengths[camera_id].optimized;
     if (!problem.HasParameterBlock(focal_ptr)) continue;
 
@@ -411,7 +413,7 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const Camera& camera1 = *image_id_to_camera.at(image_id1);
     const Camera& camera2 = *image_id_to_camera.at(image_id2);
-    if (!camera1.IsPerspective() || !camera2.IsPerspective()) {
+    if (!camera1.HasPinholeProjection() || !camera2.HasPinholeProjection()) {
       continue;
     }
     THROW_CHECK(tvg.F.has_value())

--- a/src/colmap/estimators/view_graph_calibration.cc
+++ b/src/colmap/estimators/view_graph_calibration.cc
@@ -112,8 +112,9 @@ void CrossValidatePriorFocalLengths(
     const Camera& camera1 = *image_id_to_camera.at(image_id1);
     const Camera& camera2 = *image_id_to_camera.at(image_id2);
 
-    // Computing E from F assumes a pinhole projection for both cameras.
-    if (camera1.HasPinholeProjection() && camera2.HasPinholeProjection() &&
+    // Computing E from F assumes a pinhole projection for both cameras. See
+    // CalibrateFocalLengths for why fisheye models are excluded.
+    if (camera1.IsPerspectivePinhole() && camera2.IsPerspectivePinhole() &&
         camera_validity[camera1.camera_id] &&
         camera_validity[camera2.camera_id]) {
       THROW_CHECK(tvg.F.has_value())
@@ -229,8 +230,14 @@ FocalLengthCalibResult CalibrateFocalLengths(
   auto loss_function = options.CreateLossFunction();
 
   for (const auto& input : inputs) {
-    if (!cameras.at(input.camera_id1).HasPinholeProjection() ||
-        !cameras.at(input.camera_id2).HasPinholeProjection()) {
+    // The focal length is recovered from F in closed form, which requires the
+    // calibration to act projectively on the rays. This holds for pinhole
+    // models: their distortion is zero-initialized at this stage and mild
+    // distortion is absorbed by the epipolar fit. It does not hold for fisheye
+    // models, whose angular projection is part of the model itself, so they
+    // would need a different formulation and are skipped here.
+    if (!cameras.at(input.camera_id1).IsPerspectivePinhole() ||
+        !cameras.at(input.camera_id2).IsPerspectivePinhole()) {
       continue;
     }
     if (input.camera_id1 == input.camera_id2) {
@@ -254,7 +261,7 @@ FocalLengthCalibResult CalibrateFocalLengths(
   // Parameterize cameras (fix those with prior, set lower bound).
   size_t num_cameras = 0;
   for (const auto& [camera_id, camera] : cameras) {
-    if (!camera.HasPinholeProjection()) continue;
+    if (!camera.IsPerspectivePinhole()) continue;
     double* focal_ptr = &focal_lengths[camera_id].optimized;
     if (!problem.HasParameterBlock(focal_ptr)) continue;
 
@@ -413,7 +420,7 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const Camera& camera1 = *image_id_to_camera.at(image_id1);
     const Camera& camera2 = *image_id_to_camera.at(image_id2);
-    if (!camera1.HasPinholeProjection() || !camera2.HasPinholeProjection()) {
+    if (!camera1.IsPerspectivePinhole() || !camera2.IsPerspectivePinhole()) {
       continue;
     }
     THROW_CHECK(tvg.F.has_value())

--- a/src/colmap/estimators/view_graph_calibration.cc
+++ b/src/colmap/estimators/view_graph_calibration.cc
@@ -209,7 +209,9 @@ FocalLengthCalibResult CalibrateFocalLengths(
     return result;
   }
 
-  // Initialize focal lengths from all perspective cameras.
+  // Initialize focal lengths from all perspective pinhole cameras. Only these
+  // are calibrated below, and every camera seeded here is reported back to the
+  // caller, which marks it as having a prior focal length.
   struct FocalLengthState {
     double optimized = 0.0;
     double initial = 0.0;
@@ -217,7 +219,7 @@ FocalLengthCalibResult CalibrateFocalLengths(
   NodeHashMap<camera_t, FocalLengthState> focal_lengths;
   focal_lengths.reserve(cameras.size());
   for (const auto& [camera_id, camera] : cameras) {
-    if (camera.IsPerspective()) {
+    if (camera.IsPerspectivePinhole()) {
       const double focal = camera.MeanFocalLength();
       focal_lengths[camera_id] = {focal, focal};
     }
@@ -307,7 +309,7 @@ FocalLengthCalibResult CalibrateFocalLengths(
   // Validate focal lengths and revert degenerate ones.
   size_t rejected_cameras = 0;
   for (const auto& [camera_id, camera] : cameras) {
-    if (!camera.IsPerspective()) continue;
+    if (!camera.IsPerspectivePinhole()) continue;
     auto& focal = focal_lengths[camera_id];
     if (!problem.HasParameterBlock(&focal.optimized)) continue;
 
@@ -395,7 +397,9 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
         options.min_calibrated_pair_ratio, image_id_to_camera, pairs);
   }
 
-  // Recompute F from E for CALIBRATED pairs using current calibration.
+  // Recompute F from E for CALIBRATED pairs using current calibration. This
+  // goes through the calibration matrices, so it is restricted to pinhole
+  // models for the same reason as CalibrateFocalLengths below.
   for (auto& [pair_id, tvg] : pairs) {
     if (tvg.config != TwoViewGeometry::CALIBRATED ||
         !tvg.cam2_from_cam1.has_value()) {
@@ -404,7 +408,7 @@ bool CalibrateViewGraph(const ViewGraphCalibrationOptions& options,
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const Camera& camera1 = *image_id_to_camera.at(image_id1);
     const Camera& camera2 = *image_id_to_camera.at(image_id2);
-    if (!camera1.IsPerspective() || !camera2.IsPerspective()) {
+    if (!camera1.IsPerspectivePinhole() || !camera2.IsPerspectivePinhole()) {
       continue;
     }
     tvg.F = FundamentalFromEssentialMatrix(

--- a/src/colmap/estimators/view_graph_calibration_test.cc
+++ b/src/colmap/estimators/view_graph_calibration_test.cc
@@ -288,5 +288,46 @@ TEST(CalibrateViewGraph, SphericalCamerasAreIgnored) {
   }
 }
 
+TEST(CalibrateViewGraph, FisheyeCamerasAreIgnored) {
+  SetPRNGSeed(42);
+
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+
+  // A fisheye camera projects angularly, so its focal length cannot be
+  // recovered from a fundamental matrix. View graph calibration must skip it
+  // entirely, leaving both its parameters and its focal length prior flag
+  // untouched, rather than reporting a focal length it never optimized.
+  SyntheticDatasetOptions options;
+  options.num_rigs = 10;
+  options.num_cameras_per_rig = 1;
+  options.num_frames_per_rig = 1;
+  options.num_points3D = 200;
+  options.camera_model_id = OpenCVFisheyeCameraModel::model_id;
+  options.camera_params = {1280, 1280, 512, 384, 0, 0, 0, 0};
+  options.camera_has_prior_focal_length = false;
+
+  Reconstruction reconstruction;
+  SynthesizeDataset(options, &reconstruction, database.get());
+
+  // Store original camera parameters to verify they remain untouched.
+  NodeHashMap<camera_t, std::vector<double>> original_params;
+  for (const auto& [camera_id, camera] : reconstruction.Cameras()) {
+    original_params[camera_id] = camera.params;
+  }
+
+  ViewGraphCalibrationOptions calib_options;
+  calib_options.reestimate_relative_pose = false;
+  EXPECT_TRUE(CalibrateViewGraph(calib_options, database.get()));
+
+  for (const auto& [camera_id, params] : original_params) {
+    const Camera camera = database->ReadCamera(camera_id);
+    ASSERT_TRUE(camera.IsPerspectiveFisheye());
+    EXPECT_EQ(camera.params, params);
+    // Never calibrated, so it must not be marked as having a prior focal
+    // length, which would make downstream stages trust an unestimated value.
+    EXPECT_FALSE(camera.has_prior_focal_length);
+  }
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -132,15 +132,11 @@ struct Camera {
   // panorama), i.e. the EQUIRECTANGULAR model.
   inline bool IsSpherical() const;
 
-  // Whether the camera model is a fisheye model.
-  inline bool IsFisheye() const;
+  // Whether the camera model is perspective and fisheye.
+  inline bool IsPerspectiveFisheye() const;
 
-  // Whether the camera model is built on a pinhole projection
-  // (r = f * tan(theta)), possibly with distortion layered on top. Fisheye
-  // models (r ~ f * theta) and spherical models are not. Required by
-  // estimators whose model is linear in pixel coordinates (F, E, H) or that
-  // recover a focal length from one.
-  inline bool HasPinholeProjection() const;
+  // Whether the camera model is perspective and not fisheye.
+  inline bool IsPerspectivePinhole() const;
 
   // Check whether camera has bogus parameters.
   inline bool HasBogusParams(double min_focal_length_ratio,
@@ -279,10 +275,12 @@ bool Camera::IsPerspective() const {
 
 bool Camera::IsSpherical() const { return CameraModelIsSpherical(model_id); }
 
-bool Camera::IsFisheye() const { return CameraModelIsFisheye(model_id); }
+bool Camera::IsPerspectiveFisheye() const {
+  return CameraModelIsPerspectiveFisheye(model_id);
+}
 
-bool Camera::HasPinholeProjection() const {
-  return IsPerspective() && !IsFisheye();
+bool Camera::IsPerspectivePinhole() const {
+  return CameraModelIsPerspectivePinhole(model_id);
 }
 
 bool Camera::VerifyParams() const {

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -105,6 +105,11 @@ struct Camera {
 
   // Get intrinsic calibration matrix composed from focal length and principal
   // point parameters, excluding distortion parameters.
+  //
+  // This is the affine part of the projection, which is a projective camera
+  // matrix only for pinhole models. For fisheye models the normalized
+  // coordinates are angular, so callers relying on x ~ K * [R | t] * X must
+  // restrict themselves to IsPerspectivePinhole() cameras.
   Eigen::Matrix3d CalibrationMatrix() const;
 
   // Get human-readable information about the parameter vector ordering.

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -135,6 +135,13 @@ struct Camera {
   // Whether the camera model is a fisheye model.
   inline bool IsFisheye() const;
 
+  // Whether the camera model is built on a pinhole projection
+  // (r = f * tan(theta)), possibly with distortion layered on top. Fisheye
+  // models (r ~ f * theta) and spherical models are not. Required by
+  // estimators whose model is linear in pixel coordinates (F, E, H) or that
+  // recover a focal length from one.
+  inline bool HasPinholeProjection() const;
+
   // Check whether camera has bogus parameters.
   inline bool HasBogusParams(double min_focal_length_ratio,
                              double max_focal_length_ratio,
@@ -273,6 +280,10 @@ bool Camera::IsPerspective() const {
 bool Camera::IsSpherical() const { return CameraModelIsSpherical(model_id); }
 
 bool Camera::IsFisheye() const { return CameraModelIsFisheye(model_id); }
+
+bool Camera::HasPinholeProjection() const {
+  return IsPerspective() && !IsFisheye();
+}
 
 bool Camera::VerifyParams() const {
   return CameraModelVerifyParams(model_id, params);

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -399,5 +399,30 @@ TEST(Camera, Spherical) {
   EXPECT_FALSE(pinhole.IsSpherical());
 }
 
+TEST(Camera, HasPinholeProjection) {
+  const Camera pinhole =
+      Camera::CreateFromModelId(1, PinholeCameraModel::model_id, 1.0, 1, 1);
+  EXPECT_TRUE(pinhole.HasPinholeProjection());
+
+  // Distortion is layered on top of a pinhole projection.
+  const Camera radial = Camera::CreateFromModelId(
+      2, SimpleRadialCameraModel::model_id, 1.0, 1, 1);
+  EXPECT_TRUE(radial.HasPinholeProjection());
+
+  // Fisheye models are perspective but map angles as r ~ f * theta, so they
+  // have no pinhole projection.
+  const Camera fisheye = Camera::CreateFromModelId(
+      3, OpenCVFisheyeCameraModel::model_id, 1.0, 1, 1);
+  EXPECT_TRUE(fisheye.IsPerspective());
+  EXPECT_TRUE(fisheye.IsFisheye());
+  EXPECT_FALSE(fisheye.HasPinholeProjection());
+
+  // Spherical models have no focal length at all.
+  const Camera spherical = Camera::CreateFromModelId(
+      4, EquirectangularCameraModel::model_id, 0.0, 1000, 500);
+  EXPECT_FALSE(spherical.IsFisheye());
+  EXPECT_FALSE(spherical.HasPinholeProjection());
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/scene/camera_test.cc
+++ b/src/colmap/scene/camera_test.cc
@@ -399,29 +399,25 @@ TEST(Camera, Spherical) {
   EXPECT_FALSE(pinhole.IsSpherical());
 }
 
-TEST(Camera, HasPinholeProjection) {
+TEST(Camera, IsPerspectivePinhole) {
   const Camera pinhole =
       Camera::CreateFromModelId(1, PinholeCameraModel::model_id, 1.0, 1, 1);
-  EXPECT_TRUE(pinhole.HasPinholeProjection());
+  EXPECT_TRUE(pinhole.IsPerspectivePinhole());
 
-  // Distortion is layered on top of a pinhole projection.
   const Camera radial = Camera::CreateFromModelId(
       2, SimpleRadialCameraModel::model_id, 1.0, 1, 1);
-  EXPECT_TRUE(radial.HasPinholeProjection());
+  EXPECT_TRUE(radial.IsPerspectivePinhole());
 
-  // Fisheye models are perspective but map angles as r ~ f * theta, so they
-  // have no pinhole projection.
   const Camera fisheye = Camera::CreateFromModelId(
       3, OpenCVFisheyeCameraModel::model_id, 1.0, 1, 1);
   EXPECT_TRUE(fisheye.IsPerspective());
-  EXPECT_TRUE(fisheye.IsFisheye());
-  EXPECT_FALSE(fisheye.HasPinholeProjection());
+  EXPECT_TRUE(fisheye.IsPerspectiveFisheye());
+  EXPECT_FALSE(fisheye.IsPerspectivePinhole());
 
-  // Spherical models have no focal length at all.
   const Camera spherical = Camera::CreateFromModelId(
       4, EquirectangularCameraModel::model_id, 0.0, 1000, 500);
-  EXPECT_FALSE(spherical.IsFisheye());
-  EXPECT_FALSE(spherical.HasPinholeProjection());
+  EXPECT_FALSE(spherical.IsPerspectiveFisheye());
+  EXPECT_FALSE(spherical.IsPerspectivePinhole());
 }
 
 }  // namespace

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -271,15 +271,18 @@ MAKE_ENUM_CLASS_OVERLOAD_STREAM(CameraModelId,
 // models. The hierarchy is:
 //
 //   BaseCameraModel                            (shared by all camera models)
-//     - BasePerspectiveCameraModel             (finite pinhole image plane)
-//         - Perspective models
+//     - BasePerspectiveCameraModel             (focal length, image plane)
+//         - BasePerspectivePinholeCameraModel  (pinhole projection)
+//             - Pinhole models
 //         - BasePerspectiveFisheyeCameraModel  (fisheye projection)
 //             - Fisheye models
 //     - BaseSphericalCameraModel               (spherical/omnidirectional)
 //        - EquirectangularCameraModel
 //
-// Whether a model is perspective is derived from its position in this hierarchy
-// (see CameraModelIsPerspective), rather than from a separate flag.
+// Whether a model is perspective, and whether its projection is pinhole or
+// fisheye, is derived from its position in this hierarchy (see
+// CameraModelIsPerspective, CameraModelIsPerspectivePinhole and
+// CameraModelIsPerspectiveFisheye), rather than from a separate flag.
 template <typename CameraModel>
 struct BaseCameraModel {
  private:
@@ -387,6 +390,19 @@ struct BaseSphericalCameraModel : public BaseCameraModel<CameraModel> {
   friend CameraModel;
 };
 
+// Base model for perspective pinhole camera models, i.e. models that project
+// onto the normalized plane as x = X / Z and then apply a deformation of that
+// plane. Their calibration therefore acts projectively on the rays, so a
+// calibration matrix K describes the projection exactly in the zero-distortion
+// limit and remains the exact linearization at the optical axis otherwise.
+template <typename CameraModel>
+struct BasePerspectivePinholeCameraModel
+    : public BasePerspectiveCameraModel<CameraModel> {
+ private:
+  BasePerspectivePinholeCameraModel() = default;
+  friend CameraModel;
+};
+
 // Base model for perspective fisheye camera models.
 template <typename CameraModel>
 struct BasePerspectiveFisheyeCameraModel
@@ -431,7 +447,7 @@ struct BasePerspectiveFisheyeCameraModel
 //
 // See https://en.wikipedia.org/wiki/Pinhole_camera_model
 struct SimplePinholeCameraModel
-    : public BasePerspectiveCameraModel<SimplePinholeCameraModel> {
+    : public BasePerspectivePinholeCameraModel<SimplePinholeCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kSimplePinhole, "SIMPLE_PINHOLE", 1, 2, 0, true)
 };
@@ -446,7 +462,7 @@ struct SimplePinholeCameraModel
 //
 // See https://en.wikipedia.org/wiki/Pinhole_camera_model
 struct PinholeCameraModel
-    : public BasePerspectiveCameraModel<PinholeCameraModel> {
+    : public BasePerspectivePinholeCameraModel<PinholeCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kPinhole, "PINHOLE", 2, 2, 0, true)
 };
@@ -463,7 +479,7 @@ struct PinholeCameraModel
 //    f, cx, cy, k
 //
 struct SimpleRadialCameraModel
-    : public BasePerspectiveCameraModel<SimpleRadialCameraModel> {
+    : public BasePerspectivePinholeCameraModel<SimpleRadialCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kSimpleRadial, "SIMPLE_RADIAL", 1, 2, 1, true)
 };
@@ -479,7 +495,7 @@ struct SimpleRadialCameraModel
 //    f, cx, cy, k1, k2
 //
 struct RadialCameraModel
-    : public BasePerspectiveCameraModel<RadialCameraModel> {
+    : public BasePerspectivePinholeCameraModel<RadialCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kRadial, "RADIAL", 1, 2, 2, true)
 };
@@ -497,7 +513,7 @@ struct RadialCameraModel
 // See
 // http://docs.opencv.org/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
 struct OpenCVCameraModel
-    : public BasePerspectiveCameraModel<OpenCVCameraModel> {
+    : public BasePerspectivePinholeCameraModel<OpenCVCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kOpenCV, "OPENCV", 2, 2, 4, true)
 };
@@ -533,7 +549,7 @@ struct OpenCVFisheyeCameraModel
 // See
 // http://docs.opencv.org/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
 struct FullOpenCVCameraModel
-    : public BasePerspectiveCameraModel<FullOpenCVCameraModel> {
+    : public BasePerspectivePinholeCameraModel<FullOpenCVCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kFullOpenCV, "FULL_OPENCV", 2, 2, 8, true)
 };
@@ -552,7 +568,8 @@ struct FullOpenCVCameraModel
 // Frederic Devernay, Olivier Faugeras. Straight lines have to be straight:
 // Automatic calibration and removal of distortion from scenes of structured
 // environments. Machine vision and applications, 2001.
-struct FOVCameraModel : public BasePerspectiveCameraModel<FOVCameraModel> {
+struct FOVCameraModel
+    : public BasePerspectivePinholeCameraModel<FOVCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kFOV, "FOV", 2, 2, 1, true)
 
@@ -653,7 +670,7 @@ struct RadTanThinPrismFisheyeModel
 //    f, cx, cy, k
 //
 struct SimpleDivisionCameraModel
-    : public BasePerspectiveCameraModel<SimpleDivisionCameraModel> {
+    : public BasePerspectivePinholeCameraModel<SimpleDivisionCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kSimpleDivision, "SIMPLE_DIVISION", 1, 2, 1, true)
 };
@@ -671,7 +688,7 @@ struct SimpleDivisionCameraModel
 //    fx, fy, cx, cy, k
 //
 struct DivisionCameraModel
-    : public BasePerspectiveCameraModel<DivisionCameraModel> {
+    : public BasePerspectivePinholeCameraModel<DivisionCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kDivision, "DIVISION", 2, 2, 1, true)
 };
@@ -721,7 +738,8 @@ struct FisheyeCameraModel
 //
 //      fx, fy, cx, cy, alpha, beta
 //
-struct EUCMCameraModel : public BasePerspectiveCameraModel<EUCMCameraModel> {
+struct EUCMCameraModel
+    : public BasePerspectivePinholeCameraModel<EUCMCameraModel> {
   PERSPECTIVE_CAMERA_MODEL_DEFINITIONS(
       CameraModelId::kEUCM, "EUCM", 2, 2, 2, true)
 
@@ -958,8 +976,10 @@ inline bool CameraModelIsPerspectiveFisheye(CameraModelId model_id);
 // @return              Whether it is a perspective camera model.
 inline bool CameraModelIsPerspective(CameraModelId model_id);
 
-// Test if a camera model is perspective and not fisheye, i.e. derives from
-// BasePerspectiveCameraModel but not BasePerspectiveFisheyeCameraModel.
+// Test if a camera model is a perspective pinhole camera model, i.e. derives
+// from BasePerspectivePinholeCameraModel. Such models project as x = X / Z and
+// then deform the normalized plane, so their calibration acts projectively on
+// the rays and a calibration matrix K is meaningful for them.
 //
 // @param model_id      Unique identifier of camera model.
 //
@@ -2847,8 +2867,18 @@ bool CameraModelIsPerspective(const CameraModelId model_id) {
 }
 
 bool CameraModelIsPerspectivePinhole(const CameraModelId model_id) {
-  return CameraModelIsPerspective(model_id) &&
-         !CameraModelIsPerspectiveFisheye(model_id);
+  switch (model_id) {
+#define CAMERA_MODEL_CASE(CameraModel)                                       \
+  case CameraModel::model_id:                                                \
+    return std::is_base_of_v<BasePerspectivePinholeCameraModel<CameraModel>, \
+                             CameraModel>;
+
+    CAMERA_MODEL_SWITCH_CASES
+
+#undef CAMERA_MODEL_CASE
+  }
+
+  return false;
 }
 
 bool CameraModelIsSpherical(const CameraModelId model_id) {

--- a/src/colmap/sensor/models.h
+++ b/src/colmap/sensor/models.h
@@ -942,12 +942,13 @@ inline double CameraModelCamFromImgThreshold(CameraModelId model_id,
                                              const std::vector<double>& params,
                                              double threshold);
 
-// Test if a camera model represents a fisheye camera.
+// Test if a camera model is a perspective fisheye camera model, i.e. derives
+// from BasePerspectiveFisheyeCameraModel.
 //
 // @param model_id      Unique identifier of camera model.
 //
-// @return              Whether it is a fisheye camera model.
-inline bool CameraModelIsFisheye(CameraModelId model_id);
+// @return              Whether it is a perspective fisheye camera model.
+inline bool CameraModelIsPerspectiveFisheye(CameraModelId model_id);
 
 // Test if a camera model is perspective, i.e. has a focal length and a finite
 // pinhole image plane. Omnidirectional models such as EQUIRECTANGULAR are not.
@@ -956,6 +957,14 @@ inline bool CameraModelIsFisheye(CameraModelId model_id);
 //
 // @return              Whether it is a perspective camera model.
 inline bool CameraModelIsPerspective(CameraModelId model_id);
+
+// Test if a camera model is perspective and not fisheye, i.e. derives from
+// BasePerspectiveCameraModel but not BasePerspectiveFisheyeCameraModel.
+//
+// @param model_id      Unique identifier of camera model.
+//
+// @return              Whether it is a perspective pinhole camera model.
+inline bool CameraModelIsPerspectivePinhole(CameraModelId model_id);
 
 // Test if a camera model represents a spherical (equirectangular
 // omnidirectional panorama) camera.
@@ -2807,7 +2816,7 @@ double CameraModelCamFromImgThreshold(const CameraModelId model_id,
   return -1;
 }
 
-bool CameraModelIsFisheye(const CameraModelId model_id) {
+bool CameraModelIsPerspectiveFisheye(const CameraModelId model_id) {
   switch (model_id) {
 #define CAMERA_MODEL_CASE(CameraModel) case CameraModel::model_id:
 
@@ -2835,6 +2844,11 @@ bool CameraModelIsPerspective(const CameraModelId model_id) {
   }
 
   return false;
+}
+
+bool CameraModelIsPerspectivePinhole(const CameraModelId model_id) {
+  return CameraModelIsPerspective(model_id) &&
+         !CameraModelIsPerspectiveFisheye(model_id);
 }
 
 bool CameraModelIsSpherical(const CameraModelId model_id) {

--- a/src/colmap/sensor/models_test.cc
+++ b/src/colmap/sensor/models_test.cc
@@ -195,7 +195,7 @@ void TestModel(const std::vector<double>& params) {
 
   for (int x = 0; x <= 800; x += 50) {
     for (int y = 0; y <= 800; y += 50) {
-      if (CameraModelIsFisheye(CameraModel::model_id) &&
+      if (CameraModelIsPerspectiveFisheye(CameraModel::model_id) &&
           !FisheyeCameraModelIsValidPixel(
               CameraModel::model_id, params, Eigen::Vector2d(x, y))) {
         continue;

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -136,6 +136,16 @@ void BindCamera(py::module& m) {
            &Camera::IsSpherical,
            "Whether the camera model is spherical (equirectangular "
            "omnidirectional panorama).")
+      .def("is_fisheye",
+           &Camera::IsFisheye,
+           "Whether the camera model is a fisheye model.")
+      .def("has_pinhole_projection",
+           &Camera::HasPinholeProjection,
+           "Whether the camera model is built on a pinhole projection "
+           "(r = f * tan(theta)), possibly with distortion layered on top. "
+           "Fisheye models (r ~ f * theta) and spherical models are not. "
+           "Required by estimators whose model is linear in pixel coordinates "
+           "(F, E, H) or that recover a focal length from one.")
       .def("cam_from_img",
            &Camera::CamFromImg,
            "image_point"_a,

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -136,16 +136,12 @@ void BindCamera(py::module& m) {
            &Camera::IsSpherical,
            "Whether the camera model is spherical (equirectangular "
            "omnidirectional panorama).")
-      .def("is_fisheye",
-           &Camera::IsFisheye,
-           "Whether the camera model is a fisheye model.")
-      .def("has_pinhole_projection",
-           &Camera::HasPinholeProjection,
-           "Whether the camera model is built on a pinhole projection "
-           "(r = f * tan(theta)), possibly with distortion layered on top. "
-           "Fisheye models (r ~ f * theta) and spherical models are not. "
-           "Required by estimators whose model is linear in pixel coordinates "
-           "(F, E, H) or that recover a focal length from one.")
+      .def("is_perspective_fisheye",
+           &Camera::IsPerspectiveFisheye,
+           "Whether the camera model is perspective and fisheye.")
+      .def("is_perspective_pinhole",
+           &Camera::IsPerspectivePinhole,
+           "Whether the camera model is perspective and not fisheye.")
       .def("cam_from_img",
            &Camera::CamFromImg,
            "image_point"_a,

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -226,18 +226,18 @@ def test_camera_is_spherical(simple_camera):
     assert spherical_camera.is_spherical() is True
 
 
-def test_camera_has_pinhole_projection(simple_camera):
-    assert simple_camera.has_pinhole_projection() is True
+def test_camera_is_perspective_pinhole(simple_camera):
+    assert simple_camera.is_perspective_pinhole() is True
     fisheye_camera = pycolmap.Camera.create_from_model_name(
         3, "OPENCV_FISHEYE", 1.0, 1024, 512
     )
     assert fisheye_camera.is_perspective() is True
-    assert fisheye_camera.is_fisheye() is True
-    assert fisheye_camera.has_pinhole_projection() is False
+    assert fisheye_camera.is_perspective_fisheye() is True
+    assert fisheye_camera.is_perspective_pinhole() is False
     spherical_camera = pycolmap.Camera.create_from_model_name(
         4, "EQUIRECTANGULAR", 0.0, 1024, 512
     )
-    assert spherical_camera.has_pinhole_projection() is False
+    assert spherical_camera.is_perspective_pinhole() is False
 
 
 def test_camera_has_bogus_params(simple_camera):

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -226,6 +226,20 @@ def test_camera_is_spherical(simple_camera):
     assert spherical_camera.is_spherical() is True
 
 
+def test_camera_has_pinhole_projection(simple_camera):
+    assert simple_camera.has_pinhole_projection() is True
+    fisheye_camera = pycolmap.Camera.create_from_model_name(
+        3, "OPENCV_FISHEYE", 1.0, 1024, 512
+    )
+    assert fisheye_camera.is_perspective() is True
+    assert fisheye_camera.is_fisheye() is True
+    assert fisheye_camera.has_pinhole_projection() is False
+    spherical_camera = pycolmap.Camera.create_from_model_name(
+        4, "EQUIRECTANGULAR", 0.0, 1024, 512
+    )
+    assert spherical_camera.has_pinhole_projection() is False
+
+
 def test_camera_has_bogus_params(simple_camera):
     result = simple_camera.has_bogus_params(0.1, 100.0, 1.0)
     assert isinstance(result, bool)


### PR DESCRIPTION
Fundamental matrix does not natively make sense for perspective Fisheye cameras without focal length prior. 