### PR TITLE
Use optional cameras if available at guided matching

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -1065,9 +1065,10 @@ TwoViewGeometry EstimateSharedFocalTwoViewGeometry(
     estimated_camera.SetFocalLength(SF_report.model.focal);
     geometry.camera1 = estimated_camera;
     geometry.camera2 = estimated_camera;
-    // Also expose F = K^-T E K^-1 (K = diag(f, f, 1) at the principal point) so
-    // epipolar consumers unaware of the shared focal, e.g. guided matching, can
-    // use this config directly.
+    // Also expose F = K^-T E K^-1 (K = diag(f, f, 1) at the principal point),
+    // which view graph calibration requires from every UNCALIBRATED pair to
+    // calibrate focal lengths. It is also the only epipolar model persisted to
+    // the database, which has no columns for the estimated intrinsics.
     Eigen::Matrix3d K = Eigen::Matrix3d::Identity();
     K(0, 0) = K(1, 1) = SF_report.model.focal;
     K(0, 2) = principal_point.x();

--- a/src/colmap/feature/sift.cc
+++ b/src/colmap/feature/sift.cc
@@ -56,6 +56,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 
 #include <Eigen/Geometry>
@@ -1032,6 +1033,28 @@ double ComputeNormalizedGuidedMatchingMaxResidual(const Camera& camera1,
                 normalized_max_error2 * normalized_max_error2);
 }
 
+// Selects the epipolar model used to guide matching. The essential matrix is
+// preferred whenever the intrinsics are known, which properly handles
+// non-pinhole camera models where the fundamental matrix relationship does not
+// hold. The intrinsics are known either from priors (calibrated configs) or
+// because the two-view solver recovered them: such pairs are labeled
+// UNCALIBRATED but carry the estimated intrinsics in `camera1`/`camera2`.
+// Either side alone suffices, to support solvers that estimate only one side
+// against an already calibrated view.
+bool UseEssentialMatrixForGuidedMatching(const TwoViewGeometry& geometry) {
+  if (!geometry.E.has_value()) {
+    return false;
+  }
+  if (geometry.config == TwoViewGeometry::CALIBRATED ||
+      geometry.config == TwoViewGeometry::CALIBRATED_RIG) {
+    return true;
+  }
+  if (geometry.config == TwoViewGeometry::UNCALIBRATED) {
+    return geometry.camera1.has_value() || geometry.camera2.has_value();
+  }
+  return false;
+}
+
 class SiftCPUFeatureMatcher : public FeatureMatcher {
  public:
   explicit SiftCPUFeatureMatcher(const FeatureMatchingOptions& options)
@@ -1138,14 +1161,10 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
       prev_image_id2_ = image2.image_id;
     }
 
-    // For calibrated cases, use the essential matrix with normalized
-    // coordinates. This properly handles non-pinhole camera models (with
-    // distortion) where the fundamental matrix relationship doesn't hold.
     const bool use_essential_matrix =
-        (two_view_geometry->config == TwoViewGeometry::CALIBRATED ||
-         two_view_geometry->config == TwoViewGeometry::CALIBRATED_RIG) &&
-        two_view_geometry->E.has_value();
+        UseEssentialMatrixForGuidedMatching(*two_view_geometry);
     const bool use_fundamental_matrix =
+        !use_essential_matrix &&
         two_view_geometry->config == TwoViewGeometry::UNCALIBRATED &&
         two_view_geometry->F.has_value();
     const bool use_homography =
@@ -1153,13 +1172,21 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
          two_view_geometry->config == TwoViewGeometry::PANORAMIC ||
          two_view_geometry->config == TwoViewGeometry::PLANAR_OR_PANORAMIC) &&
         two_view_geometry->H.has_value();
+    // Normalize with the intrinsics the solver estimated where available (its
+    // focal, not the camera's stale default), else the given cameras.
+    const Camera& effective_camera1 = two_view_geometry->camera1.has_value()
+                                          ? *two_view_geometry->camera1
+                                          : *image1.camera;
+    const Camera& effective_camera2 = two_view_geometry->camera2.has_value()
+                                          ? *two_view_geometry->camera2
+                                          : *image2.camera;
     const FeatureKeypoints normalized_keypoints1 =
         use_essential_matrix
-            ? NormalizeFeatureKeypoints(*image1.camera, *image1.keypoints)
+            ? NormalizeFeatureKeypoints(effective_camera1, *image1.keypoints)
             : FeatureKeypoints();
     const FeatureKeypoints normalized_keypoints2 =
         use_essential_matrix
-            ? NormalizeFeatureKeypoints(*image2.camera, *image2.keypoints)
+            ? NormalizeFeatureKeypoints(effective_camera2, *image2.keypoints)
             : FeatureKeypoints();
 
     const Eigen::Matrix3f E_or_F =
@@ -1175,7 +1202,7 @@ class SiftCPUFeatureMatcher : public FeatureMatcher {
     const float max_residual =
         use_essential_matrix
             ? static_cast<float>(ComputeNormalizedGuidedMatchingMaxResidual(
-                  *image1.camera, *image2.camera, max_error))
+                  effective_camera1, effective_camera2, max_error))
             : static_cast<float>(max_error * max_error);
 
     std::function<bool(float, float, float, float)> guided_filter;
@@ -1407,16 +1434,31 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
 
     constexpr size_t kFeatureShapeNumElems = 4;
 
-    // For calibrated cases, use the essential matrix with normalized
-    // coordinates. This properly handles non-pinhole camera models (with
-    // distortion) where the fundamental matrix relationship doesn't hold.
     const bool use_essential_matrix =
-        two_view_geometry->config == TwoViewGeometry::CALIBRATED ||
-        two_view_geometry->config == TwoViewGeometry::CALIBRATED_RIG;
+        UseEssentialMatrixForGuidedMatching(*two_view_geometry);
+    const bool use_fundamental_matrix =
+        !use_essential_matrix &&
+        two_view_geometry->config == TwoViewGeometry::UNCALIBRATED &&
+        two_view_geometry->F.has_value();
+    // Normalize with the intrinsics the solver estimated where available (its
+    // focal, not the camera's stale default), else the given cameras.
+    const Camera& effective_camera1 = two_view_geometry->camera1.has_value()
+                                          ? *two_view_geometry->camera1
+                                          : *image1.camera;
+    const Camera& effective_camera2 = two_view_geometry->camera2.has_value()
+                                          ? *two_view_geometry->camera2
+                                          : *image2.camera;
 
+    // The uploaded feature locations depend on the normalizing camera, which is
+    // not a function of the image alone: a shared-focal pair carries a focal
+    // length estimated per pair, so the same image matched against different
+    // partners normalizes differently. The camera is therefore part of the
+    // cache key, alongside the image id and the coordinate space.
     if (prev_image_id1_ == kInvalidImageId || !prev_is_guided_ ||
         prev_image_id1_ != image1.image_id ||
-        use_essential_matrix != prev_use_essential_matrix_) {
+        use_essential_matrix != prev_use_essential_matrix_ ||
+        (use_essential_matrix &&
+         !SameNormalizationCamera(prev_norm_camera1_, effective_camera1))) {
       WarnIfMaxNumMatchesReachedGPU(image1.descriptors->data);
       constexpr size_t kIndex = 0;
       sift_match_gpu_.SetDescriptors(kIndex,
@@ -1424,23 +1466,27 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
                                      image1.descriptors->data.data());
       if (use_essential_matrix) {
         const FeatureKeypoints normalized_keypoints1 =
-            NormalizeFeatureKeypoints(*image1.camera, *image1.keypoints);
+            NormalizeFeatureKeypoints(effective_camera1, *image1.keypoints);
         sift_match_gpu_.SetFeatureLocation(
             kIndex,
             reinterpret_cast<const float*>(normalized_keypoints1.data()),
             kFeatureShapeNumElems);
+        prev_norm_camera1_ = effective_camera1;
       } else {
         sift_match_gpu_.SetFeatureLocation(
             kIndex,
             reinterpret_cast<const float*>(image1.keypoints->data()),
             kFeatureShapeNumElems);
+        prev_norm_camera1_.reset();
       }
       prev_image_id1_ = image1.image_id;
     }
 
     if (prev_image_id2_ == kInvalidImageId || !prev_is_guided_ ||
         prev_image_id2_ != image2.image_id ||
-        use_essential_matrix != prev_use_essential_matrix_) {
+        use_essential_matrix != prev_use_essential_matrix_ ||
+        (use_essential_matrix &&
+         !SameNormalizationCamera(prev_norm_camera2_, effective_camera2))) {
       WarnIfMaxNumMatchesReachedGPU(image2.descriptors->data);
       constexpr size_t kIndex = 1;
       sift_match_gpu_.SetDescriptors(kIndex,
@@ -1448,16 +1494,18 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
                                      image2.descriptors->data.data());
       if (use_essential_matrix) {
         const FeatureKeypoints normalized_keypoints2 =
-            NormalizeFeatureKeypoints(*image2.camera, *image2.keypoints);
+            NormalizeFeatureKeypoints(effective_camera2, *image2.keypoints);
         sift_match_gpu_.SetFeatureLocation(
             kIndex,
             reinterpret_cast<const float*>(normalized_keypoints2.data()),
             kFeatureShapeNumElems);
+        prev_norm_camera2_ = effective_camera2;
       } else {
         sift_match_gpu_.SetFeatureLocation(
             kIndex,
             reinterpret_cast<const float*>(image2.keypoints->data()),
             kFeatureShapeNumElems);
+        prev_norm_camera2_.reset();
       }
       prev_image_id2_ = image2.image_id;
     }
@@ -1469,22 +1517,22 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
     Eigen::Matrix<float, 3, 3, Eigen::RowMajor> H;
     float* E_or_F_ptr = nullptr;
     float* H_ptr = nullptr;
-    if (two_view_geometry->config == TwoViewGeometry::CALIBRATED ||
-        two_view_geometry->config == TwoViewGeometry::CALIBRATED_RIG ||
-        two_view_geometry->config == TwoViewGeometry::UNCALIBRATED) {
-      if (use_essential_matrix) {
-        // Use essential matrix with normalized coordinates.
-        E_or_F = two_view_geometry->E.value().cast<float>();
-      } else {
-        // Use fundamental matrix with pixel coordinates.
-        E_or_F = two_view_geometry->F.value().cast<float>();
-      }
+    if (use_essential_matrix) {
+      // Use essential matrix with normalized coordinates.
+      E_or_F = two_view_geometry->E->cast<float>();
+      E_or_F_ptr = E_or_F.data();
+    } else if (use_fundamental_matrix) {
+      // Use fundamental matrix with pixel coordinates.
+      E_or_F = two_view_geometry->F->cast<float>();
       E_or_F_ptr = E_or_F.data();
     } else if (two_view_geometry->config == TwoViewGeometry::PLANAR ||
                two_view_geometry->config == TwoViewGeometry::PANORAMIC ||
                two_view_geometry->config ==
                    TwoViewGeometry::PLANAR_OR_PANORAMIC) {
-      H = two_view_geometry->H.value().cast<float>();
+      if (!two_view_geometry->H.has_value()) {
+        return;
+      }
+      H = two_view_geometry->H->cast<float>();
       H_ptr = H.data();
     } else {
       return;
@@ -1498,7 +1546,7 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
     const float max_residual =
         use_essential_matrix
             ? static_cast<float>(ComputeNormalizedGuidedMatchingMaxResidual(
-                  *image1.camera, *image2.camera, max_error))
+                  effective_camera1, effective_camera2, max_error))
             : static_cast<float>(max_error * max_error);
 
     const int num_matches = sift_match_gpu_.GetGuidedSiftMatch(
@@ -1525,6 +1573,14 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
   }
 
  private:
+  // Whether keypoints normalized with `prev` can be reused for `camera`. Only
+  // the projection matters, so the image dimensions are not compared.
+  static bool SameNormalizationCamera(const std::optional<Camera>& prev,
+                                      const Camera& camera) {
+    return prev.has_value() && prev->model_id == camera.model_id &&
+           prev->params == camera.params;
+  }
+
   void WarnIfMaxNumMatchesReachedGPU(
       const FeatureDescriptorsData& descriptors) {
     if (sift_match_gpu_.GetMaxSift() < descriptors.rows()) {
@@ -1543,6 +1599,10 @@ class SiftGPUFeatureMatcher : public FeatureMatcher {
   bool prev_use_essential_matrix_ = false;
   image_t prev_image_id1_ = kInvalidImageId;
   image_t prev_image_id2_ = kInvalidImageId;
+  // Cameras the currently uploaded feature locations were normalized with, or
+  // nullopt if raw pixel coordinates were uploaded.
+  std::optional<Camera> prev_norm_camera1_;
+  std::optional<Camera> prev_norm_camera2_;
 };
 #endif  // COLMAP_GPU_ENABLED
 

--- a/src/colmap/feature/sift_test.cc
+++ b/src/colmap/feature/sift_test.cc
@@ -647,13 +647,16 @@ void TestGuidedMatchingWithCameraDistortion(
         const std::vector<FeatureMatcher::Image>&)>& matcher_factory) {
   // Test guided matching with essential matrix using calibrated cameras.
   // This exercises the code path that uses normalized coordinates.
-  // Use kRadial model with strong radial and tangential distortion.
+  // Use the OPENCV model with strong radial and tangential distortion. Its
+  // params are fx, fy, cx, cy, k1, k2, p1, p2. The distortion is strong enough
+  // that the pixel-coordinate fundamental matrix finds no matches, but must
+  // stay invertible over the keypoints used below, which is what bounds how
+  // large these coefficients can be; p2 is left at zero for that reason.
   Camera camera =
       Camera::CreateFromModelId(1, CameraModelId::kOpenCV, 100.0, 100, 200);
-  camera.params[3] = 0.5;   // k1
-  camera.params[4] = -0.5;  // k2
-  camera.params[5] = 0.5;   // p1
-  camera.params[6] = -0.5;  // p2
+  camera.params[4] = -0.5;  // k1
+  camera.params[5] = 0.5;   // k2
+  camera.params[6] = -0.5;  // p1
 
   // Two points on the epipolar line (v=0 in normalized coordinates).
   const Eigen::Vector2f img_point11 =
@@ -733,14 +736,30 @@ TEST(MatchGuidedSiftFeaturesCPU, EssentialMatrix) {
 void TestGuidedMatchingSharedFocal(
     const std::function<std::unique_ptr<FeatureMatcher>(
         const std::vector<FeatureMatcher::Image>&)>& matcher_factory) {
-  // Regression guard: an UNCALIBRATED pair that carries solver-estimated
-  // intrinsics (camera1/camera2) and an essential matrix must still be
-  // guided-matched via its fundamental matrix, like any UNCALIBRATED pair,
-  // rather than diverted to the E path or dropped. A pinhole camera keeps the
-  // pixel-coordinate F exact so matches are actually found.
-  constexpr double kFocal = 100.0;
-  const Camera camera = Camera::CreateFromModelId(
-      1, CameraModelId::kSimplePinhole, kFocal, 100, 200);
+  // An UNCALIBRATED pair carrying solver-estimated intrinsics (camera1/camera2)
+  // is guided-matched via the essential matrix in normalized coordinates, using
+  // those estimated intrinsics rather than the images' cameras, whose focal
+  // length is only a placeholder. Distortion is strong enough that the
+  // pixel-coordinate F path finds nothing, and the placeholder focal is wrong
+  // enough that normalizing with it finds nothing either, so the test passes
+  // only if the estimated camera is the one used.
+  //
+  // As elsewhere on the E path, E is taken to relate undistorted rays.
+  constexpr double kEstimatedFocal = 100.0;
+  constexpr double kPlaceholderFocal = 500.0;
+  // OPENCV params are fx, fy, cx, cy, k1, k2, p1, p2. Same distortion as in
+  // TestGuidedMatchingWithCameraDistortion: strong, but invertible over the
+  // keypoints used below.
+  Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kOpenCV, kEstimatedFocal, 100, 200);
+  camera.params[4] = -0.5;  // k1
+  camera.params[5] = 0.5;   // k2
+  camera.params[6] = -0.5;  // p1
+
+  // The camera as stored in the database: same model and distortion, but the
+  // focal length has not been recovered yet.
+  Camera placeholder_camera = camera;
+  placeholder_camera.SetFocalLength(kPlaceholderFocal);
 
   // Two points on the epipolar line (v=0 in normalized coordinates).
   const Eigen::Vector2f img_point11 =
@@ -752,28 +771,23 @@ void TestGuidedMatchingSharedFocal(
   const Eigen::Vector2f img_point22 =
       camera.ImgFromCam({-0.4, 0.1, 1.0}).value().cast<float>();
 
-  const FeatureMatcher::Image image0 = {
-      /*image_id=*/0,
-      /*camera=*/&camera,
-      std::make_shared<FeatureKeypoints>(0),
-      std::make_shared<FeatureDescriptors>(CreateEmptyDescriptors())};
   const FeatureMatcher::Image image1 = {
       /*image_id=*/1,
-      /*camera=*/&camera,
+      /*camera=*/&placeholder_camera,
       std::make_shared<FeatureKeypoints>(
           std::vector<FeatureKeypoint>{{img_point11.x(), img_point11.y()},
                                        {img_point12.x(), img_point12.y()}}),
       std::make_shared<FeatureDescriptors>(CreateRandomFeatureDescriptors(2))};
   const FeatureMatcher::Image image2 = {
       /*image_id=*/2,
-      /*camera=*/&camera,
+      /*camera=*/&placeholder_camera,
       std::make_shared<FeatureKeypoints>(
           std::vector<FeatureKeypoint>{{img_point21.x(), img_point21.y()},
                                        {img_point22.x(), img_point22.y()}}),
       std::make_shared<FeatureDescriptors>(
           CreateReversedDescriptors(*image1.descriptors))};
 
-  auto matcher = matcher_factory({image0, image1, image2});
+  auto matcher = matcher_factory({image1, image2});
 
   TwoViewGeometry two_view_geometry;
   two_view_geometry.config = TwoViewGeometry::UNCALIBRATED;
@@ -789,19 +803,109 @@ void TestGuidedMatchingSharedFocal(
 
   constexpr double kMaxError = 1.0;
 
-  // Shared-focal pairs are guided-matched (not dropped) via the F path.
+  // Matches are found only by normalizing with the estimated intrinsics. The
+  // complementary case, an UNCALIBRATED pair without them falling back to the
+  // F path, is covered by TestGuidedMatchingWithCameraDistortion.
+  matcher->MatchGuided(kMaxError, image1, image2, &two_view_geometry);
+  ExpectReversedInlierMatches(two_view_geometry);
+}
+
+// The normalizing camera is not a function of the image alone: a shared-focal
+// pair carries a focal length estimated per pair, so the same image matched
+// against different partners must be renormalized. Guards the GPU matcher's
+// feature-location cache, which keys on the image id.
+void TestGuidedMatchingSharedFocalPerPairFocal(
+    const std::function<std::unique_ptr<FeatureMatcher>(
+        const std::vector<FeatureMatcher::Image>&)>& matcher_factory) {
+  constexpr double kFocalA = 100.0;
+  constexpr double kFocalB = 200.0;
+  const Camera camera_a = Camera::CreateFromModelId(
+      1, CameraModelId::kSimplePinhole, kFocalA, 100, 200);
+  const Camera camera_b = Camera::CreateFromModelId(
+      2, CameraModelId::kSimplePinhole, kFocalB, 100, 200);
+
+  // image1's pixels normalize to y = +-0.1 under camera_a, and to half that,
+  // y = +-0.05, under camera_b. The relative pose is a pure x-translation, so a
+  // match requires the partner's normalized y to agree.
+  const Eigen::Vector2f img_point11 =
+      camera_a.ImgFromCam({-0.5, 0.1, 1.0}).value().cast<float>();
+  const Eigen::Vector2f img_point12 =
+      camera_a.ImgFromCam({0.4, -0.1, 1.0}).value().cast<float>();
+  // Partner for the camera_a pair.
+  const Eigen::Vector2f img_point21 =
+      camera_a.ImgFromCam({0.3, -0.1, 1.0}).value().cast<float>();
+  const Eigen::Vector2f img_point22 =
+      camera_a.ImgFromCam({-0.4, 0.1, 1.0}).value().cast<float>();
+  // Partner for the camera_b pair.
+  const Eigen::Vector2f img_point31 =
+      camera_b.ImgFromCam({0.3, -0.05, 1.0}).value().cast<float>();
+  const Eigen::Vector2f img_point32 =
+      camera_b.ImgFromCam({-0.4, 0.05, 1.0}).value().cast<float>();
+
+  const FeatureMatcher::Image image1 = {
+      /*image_id=*/1,
+      /*camera=*/&camera_a,
+      std::make_shared<FeatureKeypoints>(
+          std::vector<FeatureKeypoint>{{img_point11.x(), img_point11.y()},
+                                       {img_point12.x(), img_point12.y()}}),
+      std::make_shared<FeatureDescriptors>(CreateRandomFeatureDescriptors(2))};
+  const FeatureMatcher::Image image2 = {
+      /*image_id=*/2,
+      /*camera=*/&camera_a,
+      std::make_shared<FeatureKeypoints>(
+          std::vector<FeatureKeypoint>{{img_point21.x(), img_point21.y()},
+                                       {img_point22.x(), img_point22.y()}}),
+      std::make_shared<FeatureDescriptors>(
+          CreateReversedDescriptors(*image1.descriptors))};
+  const FeatureMatcher::Image image3 = {
+      /*image_id=*/3,
+      /*camera=*/&camera_a,
+      std::make_shared<FeatureKeypoints>(
+          std::vector<FeatureKeypoint>{{img_point31.x(), img_point31.y()},
+                                       {img_point32.x(), img_point32.y()}}),
+      std::make_shared<FeatureDescriptors>(
+          CreateReversedDescriptors(*image1.descriptors))};
+
+  auto matcher = matcher_factory({image1, image2, image3});
+
+  TwoViewGeometry two_view_geometry;
+  two_view_geometry.config = TwoViewGeometry::UNCALIBRATED;
+  two_view_geometry.E = EssentialMatrixFromPose(
+      Rigid3d(Eigen::Quaterniond::Identity(), Eigen::Vector3d(1, 0, 0)));
+
+  constexpr double kMaxError = 1.0;
+
+  two_view_geometry.camera1 = camera_a;
+  two_view_geometry.camera2 = camera_a;
   matcher->MatchGuided(kMaxError, image1, image2, &two_view_geometry);
   ExpectReversedInlierMatches(two_view_geometry);
 
-  // Non-corresponding images still find nothing.
-  two_view_geometry.config = TwoViewGeometry::UNCALIBRATED;
-  matcher->MatchGuided(kMaxError, image0, image2, &two_view_geometry);
-  EXPECT_EQ(two_view_geometry.inlier_matches.size(), 0);
+  // Same image1, different estimated focal: stale normalized keypoints from the
+  // previous call would put image1 at y = +-0.1 instead of +-0.05, far outside
+  // the ~1/f normalized threshold.
+  two_view_geometry.camera1 = camera_b;
+  two_view_geometry.camera2 = camera_b;
+  matcher->MatchGuided(kMaxError, image1, image3, &two_view_geometry);
+  ExpectReversedInlierMatches(two_view_geometry);
 }
 
 TEST(MatchGuidedSiftFeaturesCPU, SharedFocal) {
   std::unique_ptr<FeatureDescriptorIndexCacheHelper> index_cache_helper;
   TestGuidedMatchingSharedFocal(
+      [&index_cache_helper](const std::vector<FeatureMatcher::Image>& images) {
+        index_cache_helper =
+            std::make_unique<FeatureDescriptorIndexCacheHelper>(images);
+        FeatureMatchingOptions options(FeatureMatcherType::SIFT_BRUTEFORCE);
+        options.use_gpu = false;
+        options.sift->cpu_descriptor_index_cache =
+            &index_cache_helper->index_cache;
+        return CreateSiftFeatureMatcher(options);
+      });
+}
+
+TEST(MatchGuidedSiftFeaturesCPU, SharedFocalPerPairFocal) {
+  std::unique_ptr<FeatureDescriptorIndexCacheHelper> index_cache_helper;
+  TestGuidedMatchingSharedFocalPerPairFocal(
       [&index_cache_helper](const std::vector<FeatureMatcher::Image>& images) {
         index_cache_helper =
             std::make_unique<FeatureDescriptorIndexCacheHelper>(images);
@@ -1066,6 +1170,18 @@ TEST(MatchGuidedSiftFeaturesGPU, EssentialMatrix) {
 TEST(MatchGuidedSiftFeaturesGPU, SharedFocal) {
   RunGpuTest([] {
     TestGuidedMatchingSharedFocal(
+        [](const std::vector<FeatureMatcher::Image>& images) {
+          FeatureMatchingOptions options(FeatureMatcherType::SIFT_BRUTEFORCE);
+          options.use_gpu = true;
+          options.max_num_matches = 1000;
+          return THROW_CHECK_NOTNULL(CreateSiftFeatureMatcher(options));
+        });
+  });
+}
+
+TEST(MatchGuidedSiftFeaturesGPU, SharedFocalPerPairFocal) {
+  RunGpuTest([] {
+    TestGuidedMatchingSharedFocalPerPairFocal(
         [](const std::vector<FeatureMatcher::Image>& images) {
           FeatureMatchingOptions options(FeatureMatcherType::SIFT_BRUTEFORCE);
           options.use_gpu = true;


### PR DESCRIPTION
This does not affect a lot the behavior for shared focal solver, but would be crucial for the one-side focal case where the calibrated camera can be with any camera model. Without this PR (as in the pre-existing code), the guided matching would wrongly assume pinhole cameras for the already calibrated camera in the one-side focal case.

In preparation for https://github.com/colmap/colmap/pull/4561