### PR TITLE
pycolmap: Document that Database must be opened via Database.open()

### DIFF
--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -453,11 +453,12 @@ void BindDatabase(py::module& m) {
       "the database on exit automatically:\n\n"
       "    with pycolmap.Database.open(path) as db:\n"
       "        ...");
-  PyDatabase.def_static("open",
-                        &Database::Open,
-                        "path"_a,
-                        "Open (creating it if necessary) the database file at "
-                        "the given path and return it.")
+  PyDatabase
+      .def_static("open",
+                  &Database::Open,
+                  "path"_a,
+                  "Open (creating it if necessary) the database file at "
+                  "the given path and return it.")
       .def("close", &Database::Close)
       .def("__enter__", [](Database& self) { return &self; })
       .def("__exit__", [](Database& self, const py::args&) { self.Close(); })

--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -442,8 +442,22 @@ class PyDatabaseImpl : public Database, py::trampoline_self_life_support {
 }  // namespace
 
 void BindDatabase(py::module& m) {
-  py::classh<Database, PyDatabaseImpl> PyDatabase(m, "Database");
-  PyDatabase.def_static("open", &Database::Open, "path"_a)
+  py::classh<Database, PyDatabaseImpl> PyDatabase(
+      m,
+      "Database",
+      "Database storing all extracted and matched information (cameras, "
+      "images, keypoints, descriptors, matches, rigs, and pose priors).\n\n"
+      "A Database cannot be constructed directly; open an existing or new "
+      "database file with ``Database.open(path)`` and release it with "
+      "``close()``. It can also be used as a context manager, which closes "
+      "the database on exit:\n\n"
+      "    with pycolmap.Database.open(path) as db:\n"
+      "        ...");
+  PyDatabase.def_static("open",
+                        &Database::Open,
+                        "path"_a,
+                        "Open (creating it if necessary) the database file at "
+                        "the given path and return it.")
       .def("close", &Database::Close)
       .def("__enter__", [](Database& self) { return &self; })
       .def("__exit__", [](Database& self, const py::args&) { self.Close(); })

--- a/src/pycolmap/scene/database.cc
+++ b/src/pycolmap/scene/database.cc
@@ -447,10 +447,10 @@ void BindDatabase(py::module& m) {
       "Database",
       "Database storing all extracted and matched information (cameras, "
       "images, keypoints, descriptors, matches, rigs, and pose priors).\n\n"
-      "A Database cannot be constructed directly; open an existing or new "
-      "database file with ``Database.open(path)`` and release it with "
-      "``close()``. It can also be used as a context manager, which closes "
-      "the database on exit:\n\n"
+      "A Database cannot be constructed directly; instead open an existing "
+      "or new database file with ``Database.open(path)`` and release it with "
+      "``close()``. It can also be used with a context manager, which closes "
+      "the database on exit automatically:\n\n"
       "    with pycolmap.Database.open(path) as db:\n"
       "        ...");
   PyDatabase.def_static("open",


### PR DESCRIPTION
## Summary

`pycolmap.Database` exposes `Database.open(path)` as the only entry point but has
no constructor and no docstring, so `pycolmap.Database(path)` fails with the
cryptic `TypeError: pycolmap._core.Database: No constructor defined!` (#4485,
#4422 — a maintainer noted the `.open()` workflow was never documented).

This adds:
- a **class docstring** explaining that a `Database` must be opened with
  `Database.open(path)` and can be used as a context manager;
- a **docstring for the `open` static method**.

Docstrings only — no behavior change. Verified `Database::Open` uses
`SQLITE_OPEN_CREATE` (opens the file, creating it if necessary).
