### PR TITLE
Reject reconstruction merges with inconsistent image id<->name mappings

### DIFF
--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -484,32 +484,26 @@ bool MergeReconstructions(const double max_reproj_error,
 
   // Find common and missing images in the two reconstructions. Images are
   // matched by image id, which assumes that both reconstructions share a
-  // consistent image id<->name mapping (i.e. were derived from the same
+  // consistent image_id<->name mapping (i.e. were derived from the same
   // database). If this assumption is violated -- e.g. the reconstructions were
   // built from independent databases that both number their images 1..N -- then
-  // distinct physical images end up with colliding ids. Merging by id would
-  // then silently treat these distinct images as already-present, dropping
-  // images and corrupting tracks (see issues #3405, #3218, #3175). Detect the
-  // inconsistency via the image name and fail loudly instead. Note that the
-  // preceding alignment step already matches images by name (via
-  // Reconstruction::FindCommonRegImageIds), so a merge that reaches this point
-  // with inconsistent id<->name mappings would otherwise produce a corrupt
-  // result.
-  FlatHashSet<image_t> common_image_ids;
-  common_image_ids.reserve(src_reconstruction.NumRegImages());
-  FlatHashSet<image_t> missing_image_ids;
-  missing_image_ids.reserve(src_reconstruction.NumRegImages());
-  for (const image_t image_id : src_reconstruction.RegImageIds()) {
-    if (tgt_reconstruction.ExistsImage(image_id)) {
+  // distinct physical images end up with colliding ids. Detect the
+  // inconsistency via the image name and fail loudly instead.
+FlatHashSet<image_t> common_image_ids;
+common_image_ids.reserve(src_reconstruction.NumRegImages());
+FlatHashSet<image_t> missing_image_ids;
+missing_image_ids.reserve(src_reconstruction.NumRegImages());
+for (const image_t image_id : src_reconstruction.RegImageIds()) {
+if (tgt_reconstruction.ExistsImage(image_id)) {
       const std::string& src_name = src_reconstruction.Image(image_id).Name();
       const std::string& tgt_name = tgt_reconstruction.Image(image_id).Name();
       if (src_name != tgt_name) {
         LOG(ERROR)
-            << "Cannot merge reconstructions: image id " << image_id
-            << " refers to \"" << src_name << "\" in one reconstruction but \""
-            << tgt_name << "\" in the other. MergeReconstructions requires both "
-            << "reconstructions to share a consistent image id<->name mapping "
-            << "(i.e. be derived from the same database).";
+            << "Cannot merge reconstructions: image_id=" << image_id
+            << " refers to \"" << src_name << "\" in the source reconstruction but \""
+            << tgt_name << "\" in the target. MergeReconstructions requires both "
+            << "reconstructions to share a consistent image_id<->name mapping "
+            << "(i.e., be derived from the same database).";
         return false;
       }
       common_image_ids.insert(image_id);

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -500,8 +500,9 @@ bool MergeReconstructions(const double max_reproj_error,
       if (src_name != tgt_name) {
         LOG(ERROR)
             << "Cannot merge reconstructions: image_id=" << image_id
-            << " refers to \"" << src_name << "\" in the source reconstruction but \""
-            << tgt_name << "\" in the target. MergeReconstructions requires both "
+            << " refers to \"" << src_name
+            << "\" in the source reconstruction but \"" << tgt_name
+            << "\" in the target. MergeReconstructions requires both "
             << "reconstructions to share a consistent image_id<->name mapping "
             << "(i.e., be derived from the same database).";
         return false;

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -482,13 +482,36 @@ bool MergeReconstructions(const double max_reproj_error,
     return false;
   }
 
-  // Find common and missing images in the two reconstructions.
+  // Find common and missing images in the two reconstructions. Images are
+  // matched by image id, which assumes that both reconstructions share a
+  // consistent image id<->name mapping (i.e. were derived from the same
+  // database). If this assumption is violated -- e.g. the reconstructions were
+  // built from independent databases that both number their images 1..N -- then
+  // distinct physical images end up with colliding ids. Merging by id would
+  // then silently treat these distinct images as already-present, dropping
+  // images and corrupting tracks (see issues #3405, #3218, #3175). Detect the
+  // inconsistency via the image name and fail loudly instead. Note that the
+  // preceding alignment step already matches images by name (via
+  // Reconstruction::FindCommonRegImageIds), so a merge that reaches this point
+  // with inconsistent id<->name mappings would otherwise produce a corrupt
+  // result.
   FlatHashSet<image_t> common_image_ids;
   common_image_ids.reserve(src_reconstruction.NumRegImages());
   FlatHashSet<image_t> missing_image_ids;
   missing_image_ids.reserve(src_reconstruction.NumRegImages());
   for (const image_t image_id : src_reconstruction.RegImageIds()) {
     if (tgt_reconstruction.ExistsImage(image_id)) {
+      const std::string& src_name = src_reconstruction.Image(image_id).Name();
+      const std::string& tgt_name = tgt_reconstruction.Image(image_id).Name();
+      if (src_name != tgt_name) {
+        LOG(ERROR)
+            << "Cannot merge reconstructions: image id " << image_id
+            << " refers to \"" << src_name << "\" in one reconstruction but \""
+            << tgt_name << "\" in the other. MergeReconstructions requires both "
+            << "reconstructions to share a consistent image id<->name mapping "
+            << "(i.e. be derived from the same database).";
+        return false;
+      }
       common_image_ids.insert(image_id);
     } else {
       missing_image_ids.insert(image_id);

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -489,12 +489,12 @@ bool MergeReconstructions(const double max_reproj_error,
   // built from independent databases that both number their images 1..N -- then
   // distinct physical images end up with colliding ids. Detect the
   // inconsistency via the image name and fail loudly instead.
-FlatHashSet<image_t> common_image_ids;
-common_image_ids.reserve(src_reconstruction.NumRegImages());
-FlatHashSet<image_t> missing_image_ids;
-missing_image_ids.reserve(src_reconstruction.NumRegImages());
-for (const image_t image_id : src_reconstruction.RegImageIds()) {
-if (tgt_reconstruction.ExistsImage(image_id)) {
+  FlatHashSet<image_t> common_image_ids;
+  common_image_ids.reserve(src_reconstruction.NumRegImages());
+  FlatHashSet<image_t> missing_image_ids;
+  missing_image_ids.reserve(src_reconstruction.NumRegImages());
+  for (const image_t image_id : src_reconstruction.RegImageIds()) {
+    if (tgt_reconstruction.ExistsImage(image_id)) {
       const std::string& src_name = src_reconstruction.Image(image_id).Name();
       const std::string& tgt_name = tgt_reconstruction.Image(image_id).Name();
       if (src_name != tgt_name) {

--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -227,6 +227,55 @@ TEST(Alignment, MergeReconstructions) {
             orig_reconstruction.ComputeNumObservations());
 }
 
+TEST(Alignment, MergeReconstructionsInconsistentImageNames) {
+  // Reconstructions built from independent databases can assign the same image
+  // id to distinct physical images. Merging by id would then silently drop
+  // images and corrupt tracks, so such an inconsistent id<->name mapping must
+  // be detected and rejected rather than merged (see issue #3405).
+  Reconstruction src_reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 3;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 10;
+  synthetic_dataset_options.num_points3D = 50;
+  SynthesizeDataset(synthetic_dataset_options, &src_reconstruction);
+  Reconstruction tgt_reconstruction = src_reconstruction;
+
+  auto remove_rig_frames = [](Reconstruction& reconstruction, rig_t rig_id) {
+    const std::vector<frame_t> frame_ids = reconstruction.RegFrameIds();
+    for (const auto& frame_id : frame_ids) {
+      if (reconstruction.Frame(frame_id).RigId() == rig_id) {
+        reconstruction.DeRegisterFrame(frame_id);
+      }
+    }
+  };
+  remove_rig_frames(src_reconstruction, 1);
+  remove_rig_frames(tgt_reconstruction, 2);
+  src_reconstruction.TearDown();
+  tgt_reconstruction.TearDown();
+
+  // Find an image id registered in both reconstructions and give it a different
+  // name in the target, simulating an id collision between two distinct images.
+  // Enough images still share a consistent name for the alignment step (which
+  // matches by name) to succeed, so the merge reaches -- and must fail at --
+  // the id/name consistency check.
+  bool found_shared_id = false;
+  for (const image_t image_id : src_reconstruction.RegImageIds()) {
+    if (tgt_reconstruction.ExistsImage(image_id)) {
+      tgt_reconstruction.Image(image_id).SetName("colliding_name.jpg");
+      found_shared_id = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found_shared_id);
+
+  const size_t num_tgt_images_before_merge = tgt_reconstruction.NumImages();
+  EXPECT_FALSE(MergeReconstructions(
+      /*max_reproj_error=*/1e-4, src_reconstruction, tgt_reconstruction));
+  // The merge must abort before mutating the target reconstruction.
+  EXPECT_EQ(tgt_reconstruction.NumImages(), num_tgt_images_before_merge);
+}
+
 TEST(Alignment, AlignReconstructionToOrigRigScales) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;


### PR DESCRIPTION
## Summary

`MergeReconstructions` classifies each registered source image as "common" or
"missing" purely by image id: if the target already contains that id, the image
is assumed to be the same physical image and is not copied. This is only valid
when both reconstructions share a consistent image id<->name mapping (i.e. were
derived from the same database).

When the two reconstructions come from independent databases that both number
their images `1..N`, distinct physical images collide on id. They are
misclassified as common, never copied, and their tracks are treated as
conflicting — silently dropping images and 3D points from the merged model
(e.g. 90 instead of 160 images). Reported in #3405, #3218, #3175.

The preceding alignment step already matches images by name
(`Reconstruction::FindCommonRegImageIds`), so any merge that reaches the
id-based classification with an inconsistent id<->name mapping produces a
corrupt result. This PR detects that case by comparing the source and target
image names for each colliding id and fails loudly with a clear error message,
instead of silently corrupting the merge.

Full cross-database merging (remapping colliding ids by name) is left as a
follow-up.

## Test

Adds a unit test covering the id-collision case, asserting the merge is rejected
and the target reconstruction is left unmodified.
