### PR TITLE
Fix warnings in tiny_manifold_test.cc

### DIFF
--- a/src/colmap/estimators/cost_functions/tiny_manifold_test.cc
+++ b/src/colmap/estimators/cost_functions/tiny_manifold_test.cc
@@ -153,7 +153,7 @@ TEST(ProductManifold, SizesAndBlockStructure) {
   const Eigen::Vector3d t = Eigen::Vector3d(1.0, -2.0, 0.5).normalized();
   double x[7] = {q.x(), q.y(), q.z(), q.w(), t.x(), t.y(), t.z()};
 
-  const RelativePoseManifold manifold;
+  const RelativePoseManifold manifold{};
 
   // Plus at zero recovers the point.
   const double zero[5] = {0, 0, 0, 0, 0};
@@ -203,7 +203,7 @@ TEST(ProductManifold, ThreeWaySizesAndBlockStructure) {
                         q1.z(),
                         q1.w()};
 
-  const ThreeWayManifold manifold;
+  const ThreeWayManifold manifold{};
 
   // Plus at zero recovers the point.
   const double zero[kTangent] = {0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
in the `windows-2025 Release` CI:
```
..\src\colmap\estimators\cost_functions\tiny_manifold_test.cc(156): warning C4269: 'manifold': 'const' automatic data initialized with compiler generated default constructor produces unreliable results
..\src\colmap\estimators\cost_functions\tiny_manifold_test.cc(206): warning C4269: 'manifold': 'const' automatic data initialized with compiler generated default constructor produces unreliable results
```