### PR TITLE
doc: Fix install selector whitespace on mobile

### DIFF
--- a/doc/_static/landing.css
+++ b/doc/_static/landing.css
@@ -285,6 +285,10 @@ section.hero-title > h1 > a.headerlink {
     flex-direction: column;
     gap: 0.4rem;
   }
+  .cis__label {
+    flex: none;
+    padding-top: 0;
+  }
   .hero__title {
     font-size: 2.25rem;
   }


### PR DESCRIPTION
## Problem

On the documentation landing page, the install selector grid (OS / Package / Compute) renders with excessive whitespace on mobile: each section header sits at the top of a tall box with its option buttons pushed far below.

## Cause

`.cis__label` uses `flex: 0 0 92px` to give the header a fixed **92px column width** in the desktop side-by-side (row) layout. On mobile the row switches to `flex-direction: column`, so `flex-basis: 92px` now applies to the **main axis = height**, forcing every header into a 92px-tall box.

## Fix

Reset the label to `flex: none` (basis auto) inside the existing `@media (max-width: 500px)` block so it sizes to its content height. Also drop the header's `padding-top`, which was only there to align it with the buttons in the horizontal layout and is unneeded once stacked.

Verified on a mobile-width viewport: the gap now collapses to the intended `0.4rem`.