### PR TITLE
Stabilize chained matches pipeline test

### DIFF
--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -451,6 +451,9 @@ TEST(IncrementalPipeline, FixExistingFrames) {
 }
 
 TEST(IncrementalPipeline, ChainedMatches) {
+  constexpr int kRandomSeed = 42;
+  SetPRNGSeed(kRandomSeed);
+
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -466,9 +469,10 @@ TEST(IncrementalPipeline, ChainedMatches) {
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  IncrementalPipeline mapper(std::make_shared<IncrementalPipelineOptions>(),
-                             database,
-                             reconstruction_manager);
+  auto options = std::make_shared<IncrementalPipelineOptions>();
+  options->num_threads = 1;
+  options->random_seed = kRandomSeed;
+  IncrementalPipeline mapper(options, database, reconstruction_manager);
   mapper.Run();
 
   ASSERT_EQ(reconstruction_manager->Size(), 1);


### PR DESCRIPTION
## Problem

`IncrementalPipeline.ChainedMatches` exercises incremental SfM on a sparse four-image chain: only adjacent image pairs match. The test expects exactly one reconstruction and checks that it aligns with the synthesized ground truth.

The scene geometry is synthesized randomly, while the pipeline is constructed with the default stochastic RANSAC configuration (`random_seed = -1`) and automatic thread selection (`num_threads = -1`). This makes initial-pair selection dependent on both sampled geometry and execution order. The [recorded upstream CUDA CI failure](https://github.com/colmap/colmap/actions/runs/29721410910/job/88285023077#logs) failed to find a valid initial image pair and therefore produced zero reconstructions instead of one.

## Root Cause and Approach

- Seed the test PRNG before synthesizing the chained-match scene, so the generated camera poses and 3D points are stable.
- Propagate the same seed through `IncrementalPipelineOptions` to the mapper and triangulator RANSAC paths.
- Run this small deterministic regression test with one pipeline thread, avoiding schedule-dependent RANSAC outcomes.

The test still verifies the same contract: one reconstruction must be produced and must align with the original synthetic ground truth.

## Scope and Risk

This is intentionally test-only. It does not change the incremental mapper, triangulator, RANSAC implementation, CLI/API defaults, reconstruction thresholds, or production parallel behavior. The serial setting only makes this particular synthetic correctness test reproducible; parallel behavior remains unchanged and is not being redefined by this PR.

## Validation

- Built `colmap_controllers_incremental_pipeline_test` locally with CUDA, GUI, MVS, and ONNX disabled.
- `ctest --test-dir build-localdeps-test --output-on-failure -R "^controllers/incremental_pipeline_test$"` passed: 22/22 tests.
- Ran `IncrementalPipeline.ChainedMatches` 100 times in fresh processes; all runs passed. Fresh processes are used so each run gets the fixture cleanup performed by `CreateTestDir()`.

Fixes #4573