### PR TITLE
ui: Color camera frustums by reprojection error in the model viewer

### DIFF
--- a/src/colmap/ui/colormaps.cc
+++ b/src/colmap/ui/colormaps.cc
@@ -32,6 +32,11 @@
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/hash_containers.h"
 
+#include <algorithm>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 namespace colmap {
 
 PointColormapBase::PointColormapBase()
@@ -253,6 +258,51 @@ void ImageColormapNameFilter::ComputeColor(const Image& image,
 
   *plane_color = kDefaultPlaneColor;
   *frame_color = kDefaultFrameColor;
+}
+
+void ImageColormapReprojectionError::Prepare(
+    NodeHashMap<camera_t, Camera>& cameras,
+    NodeHashMap<image_t, Image>& images,
+    NodeHashMap<point3D_t, Point3D>& points3D,
+    std::vector<image_t>& reg_image_ids) {
+  // Accumulate the sum and count of per-observation reprojection errors for
+  // every image from the 3D point tracks, then store the per-image mean.
+  std::unordered_map<image_t, std::pair<double, int>> error_sums;
+  for (const auto& point3D : points3D) {
+    const double error = point3D.second.error;
+    for (const auto& track_el : point3D.second.track.Elements()) {
+      auto& sum = error_sums[track_el.image_id];
+      sum.first += error;
+      sum.second += 1;
+    }
+  }
+
+  image_errors_.clear();
+  image_errors_.reserve(error_sums.size());
+  for (const auto& [image_id, sum] : error_sums) {
+    const float mean_error =
+        sum.second > 0 ? static_cast<float>(sum.first / sum.second) : 0.0f;
+    image_errors_.emplace(image_id, mean_error);
+  }
+}
+
+void ImageColormapReprojectionError::ComputeColor(
+    const Image& image,
+    Eigen::Vector4f* plane_color,
+    Eigen::Vector4f* frame_color) {
+  float gray = 0.0f;
+  const auto it = image_errors_.find(image.ImageId());
+  if (it != image_errors_.end() && max_error > 0.0f) {
+    // Absolute scale: 0 px -> 0 (blue), max_error px -> 1 (red).
+    gray = std::min(std::max(it->second / max_error, 0.0f), 1.0f);
+  }
+  const float red = JetColormap::Red(gray);
+  const float green = JetColormap::Green(gray);
+  const float blue = JetColormap::Blue(gray);
+  // Keep the frame opaque and the plane translucent, matching the default
+  // image colors' alpha values.
+  *plane_color = Eigen::Vector4f(red, green, blue, kDefaultPlaneColor.w());
+  *frame_color = Eigen::Vector4f(red, green, blue, kDefaultFrameColor.w());
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/colormaps.h
+++ b/src/colmap/ui/colormaps.h
@@ -174,4 +174,29 @@ class ImageColormapNameFilter : public ImageColormapBase {
       image_name_colors_;
 };
 
+// Color images according to their mean reprojection error, on an *absolute*
+// jet scale (0 px = blue, `max_error` px = red). Unlike a relative min/max
+// normalization, this keeps the colors comparable across models: a
+// well-registered model stays blue/cyan, and only genuinely high-error cameras
+// turn red, instead of stretching a tiny error spread over the whole spectrum.
+class ImageColormapReprojectionError : public ImageColormapBase {
+ public:
+  void Prepare(NodeHashMap<camera_t, Camera>& cameras,
+               NodeHashMap<image_t, Image>& images,
+               NodeHashMap<point3D_t, Point3D>& points3D,
+               std::vector<image_t>& reg_image_ids) override;
+
+  void ComputeColor(const Image& image,
+                    Eigen::Vector4f* plane_color,
+                    Eigen::Vector4f* frame_color) override;
+
+  // Errors at or above this value (in pixels) map to the top of the scale
+  // (red). User-adjustable so the sensitivity can be dialed per scene.
+  float max_error = 2.0f;
+
+ private:
+  // Mean reprojection error per image, accumulated from the 3D point tracks.
+  FlatHashMap<image_t, float> image_errors_;
+};
+
 }  // namespace colmap

--- a/src/colmap/ui/render_options_widget.cc
+++ b/src/colmap/ui/render_options_widget.cc
@@ -31,6 +31,13 @@
 
 #include "colmap/ui/colormaps.h"
 #include "colmap/ui/render_options.h"
+#include "colmap/util/logging.h"
+#include "colmap/util/string.h"
+
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <utility>
 
 namespace colmap {
 
@@ -47,7 +54,8 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
       point3D_colormap_min_q_(0.02),
       point3D_colormap_max_q_(0.98),
       image_plane_color_(ImageColormapUniform::kDefaultPlaneColor),
-      image_frame_color_(ImageColormapUniform::kDefaultFrameColor) {
+      image_frame_color_(ImageColormapUniform::kDefaultFrameColor),
+      image_colormap_max_error_(2.0) {
   setWindowFlags(Qt::Dialog);
   setWindowModality(Qt::ApplicationModal);
   setWindowTitle("Render options");
@@ -134,7 +142,23 @@ RenderOptionsWidget::RenderOptionsWidget(QWidget* parent,
   image_colormap_cb_ = new QComboBox(this);
   image_colormap_cb_->addItem("Uniform color");
   image_colormap_cb_->addItem("Images with words in name");
+  image_colormap_cb_->addItem("Reprojection error");
   AddWidgetRow("Image colormap", image_colormap_cb_);
+
+  // Upper bound of the absolute reprojection-error color scale (0 px = blue,
+  // this value = red). Shown only for the reprojection-error colormap.
+  QDoubleSpinBox* image_colormap_max_error_sb = AddOptionDouble(
+      &image_colormap_max_error_, "Reproj. error for red [px]", 0.1, 1e4, 0.1, 2);
+  image_colormap_max_error_sb->setToolTip(
+      "Absolute color scale for the reprojection-error colormap.\n"
+      "A camera frustum whose mean reprojection error is 0 px is blue; one at\n"
+      "this value (or higher) is red; values in between fade blue->green->red.\n"
+      "\n"
+      "Lower it to spread the colors across low-error cameras (see fine\n"
+      "differences); raise it so only genuinely high-error cameras stand out.\n"
+      "Your model's actual per-image error range is printed to the Log when you\n"
+      "click Apply.");
+  HideOption(&image_colormap_max_error_);
 
   select_image_plane_color_ = new QPushButton(tr("Select color"), this);
   connect(select_image_plane_color_, &QPushButton::released, this, [&]() {
@@ -270,12 +294,58 @@ void RenderOptionsWidget::ApplyImageColormap() {
       image_color_map = std::make_unique<ImageColormapNameFilter>(
           image_colormap_name_filter_);
       break;
+    case 2: {
+      auto reproj_error = std::make_unique<ImageColormapReprojectionError>();
+      reproj_error->max_error = static_cast<float>(image_colormap_max_error_);
+      image_color_map = std::move(reproj_error);
+      // Print the model's actual per-image error range so the abstract color
+      // scale maps to concrete numbers the user can reason about.
+      LogReprojectionErrorScale();
+      break;
+    }
     default:
       image_color_map = std::make_unique<ImageColormapUniform>();
       break;
   }
 
   model_viewer_widget_->SetImageColormap(std::move(image_color_map));
+}
+
+void RenderOptionsWidget::LogReprojectionErrorScale() {
+  const std::shared_ptr<Reconstruction>& reconstruction =
+      model_viewer_widget_->reconstruction;
+  if (reconstruction == nullptr) {
+    return;
+  }
+  // Mean reprojection error per image, accumulated from the 3D point tracks.
+  std::unordered_map<image_t, std::pair<double, int>> error_sums;
+  for (const auto& point3D : reconstruction->Points3D()) {
+    for (const auto& track_el : point3D.second.track.Elements()) {
+      auto& sum = error_sums[track_el.image_id];
+      sum.first += point3D.second.error;
+      sum.second += 1;
+    }
+  }
+  if (error_sums.empty()) {
+    return;
+  }
+  double min_error = std::numeric_limits<double>::max();
+  double max_error = 0.0;
+  double sum_error = 0.0;
+  for (const auto& [image_id, sum] : error_sums) {
+    const double mean_error = sum.second > 0 ? sum.first / sum.second : 0.0;
+    min_error = std::min(min_error, mean_error);
+    max_error = std::max(max_error, mean_error);
+    sum_error += mean_error;
+  }
+  LOG(INFO) << StringPrintf(
+      "Reprojection-error colormap: %zu images, per-image error %.2f-%.2f px "
+      "(mean %.2f px). Color scale: 0 px = blue, %.2f px = red.",
+      error_sums.size(),
+      min_error,
+      max_error,
+      sum_error / error_sums.size(),
+      image_colormap_max_error_);
 }
 
 void RenderOptionsWidget::ApplyBackgroundColor() {
@@ -314,10 +384,18 @@ void RenderOptionsWidget::SelectImageColormap(const int idx) {
     ShowWidget(select_image_plane_color_);
     ShowWidget(select_image_frame_color_);
     HideLayout(image_colormap_name_filter_layout_);
-  } else {
+    HideOption(&image_colormap_max_error_);
+  } else if (idx == 1) {
     HideWidget(select_image_plane_color_);
     HideWidget(select_image_frame_color_);
     ShowLayout(image_colormap_name_filter_layout_);
+    HideOption(&image_colormap_max_error_);
+  } else {
+    // Reprojection-error colormap: only the absolute error scale is adjustable.
+    HideWidget(select_image_plane_color_);
+    HideWidget(select_image_frame_color_);
+    HideLayout(image_colormap_name_filter_layout_);
+    ShowOption(&image_colormap_max_error_);
   }
 }
 

--- a/src/colmap/ui/render_options_widget.h
+++ b/src/colmap/ui/render_options_widget.h
@@ -62,6 +62,10 @@ class RenderOptionsWidget : public OptionsWidget {
   void SelectPointColormap(int idx);
   void SelectImageColormap(int idx);
 
+  // Log the model's per-image reprojection-error range and the current color
+  // scale, so the reprojection-error colormap maps to concrete numbers.
+  void LogReprojectionErrorScale();
+
   void IncreasePointSize();
   void DecreasePointSize();
   void IncreaseCameraSize();
@@ -90,6 +94,9 @@ class RenderOptionsWidget : public OptionsWidget {
   Eigen::Vector4f image_plane_color_;
   Eigen::Vector4f image_frame_color_;
   ImageColormapNameFilter image_colormap_name_filter_;
+  // Upper bound (px) of the absolute scale for the reprojection-error image
+  // colormap: errors at/above this map to red.
+  double image_colormap_max_error_;
 };
 
 }  // namespace colmap

--- a/src/colmap/ui/render_options_widget.h
+++ b/src/colmap/ui/render_options_widget.h
@@ -61,6 +61,10 @@ class RenderOptionsWidget : public OptionsWidget {
   void SelectPointColormap(int idx);
   void SelectImageColormap(int idx);
 
+  // Log the model's per-image reprojection-error range and the current color
+  // scale, so the reprojection-error colormap maps to concrete numbers.
+  void LogReprojectionErrorScale();
+
   void IncreasePointSize();
   void DecreasePointSize();
   void IncreaseCameraSize();
@@ -89,6 +93,9 @@ class RenderOptionsWidget : public OptionsWidget {
   Eigen::Vector4f image_plane_color_;
   Eigen::Vector4f image_frame_color_;
   ImageColormapNameFilter image_colormap_name_filter_;
+  // Upper bound (px) of the absolute scale for the reprojection-error image
+  // colormap: errors at/above this map to red.
+  double image_colormap_max_error_;
 };
 
 }  // namespace colmap


### PR DESCRIPTION
## Summary

Adds a **"Reprojection error"** option to the *Image colormap* dropdown in the
model viewer, coloring each camera frustum by its mean reprojection error. This
mirrors the existing point-cloud **"Error"** colormap (`PointColormapError`) —
extending the same idea from 3D points to the cameras that observe them — so you
can spot which cameras the solver struggled with directly in the 3D view.

The default colormap is unchanged ("Uniform color"); this is an opt-in choice.
No new dependencies; ~160 lines across `colormaps.{h,cc}` and
`render_options_widget.{h,cc}`.

## How it works

There are really just **three steps**: get a number per camera, squash that
number to 0–1, then look up a color.

### Step 1 — Each camera gets one number: its mean reprojection error (in pixels)

- **Reprojection error** = for a single 3D point seen in a photo, project that 3D
  point back into the image and measure how far (in pixels) it lands from the
  actual detected feature. Small = the 3D model agrees with the photo; large =
  it doesn't.
- A camera sees hundreds of 3D points, each with its own error. **The camera's
  number = the average of those errors.** So each frustum has one value like
  "0.64 px."

For the `south-building` sample model, those per-camera numbers range
**0.47 → 0.79 px** (reported in the log when the colormap is applied).

### Step 2 — Turn that number into a fraction from 0 to 1

This is the *only* place the **max** (red threshold) matters:

```
t = camera_error / max        (then clamp to the 0–1 range)
```

- `t = 0`  → the bottom of the scale
- `t = 1`  → the top of the scale (error is at or above `max`)

### Step 3 — Look up a color for `t` on the "jet" scale

`t` is fed into the existing `JetColormap`:

```
t:     0.0      0.25      0.5       0.75      1.0
color: blue  →  cyan  →  green  →  yellow  →  red
```

That's the whole algorithm. **The error doesn't pick the color directly — it's
error ÷ max that does.** That is why the same camera changes color when you move
the slider.

### Worked example

**At max = 2.0 px** (default):

| camera | t = err ÷ 2.0 | color |
|--------|---------------|-------|
| 0.47 (best)  | 0.24 | blue |
| 0.64 (mean)  | 0.32 | cyan |
| 0.79 (worst) | 0.40 | cyan-green |

→ everything lands in the blue–cyan zone (all `t` are small because 2 px is far
bigger than any real error). That's the "all blue = all good" view.

**At max = 0.8 px:**

| camera | t = err ÷ 0.8 | color |
|--------|---------------|-------|
| 0.47 (best)  | 0.59 | green |
| 0.64 (mean)  | 0.80 | orange |
| 0.79 (worst) | 0.99 | red |

→ now the same 0.47–0.79 range is stretched across green→red, so you see the
differences.

**So:** the colors aren't tied to absolute "good/bad" — they're tied to *where
each camera falls between 0 and the `max` you chose*. Setting `max` near your
worst camera (~0.8) spreads the rainbow across your data; setting it high (2 px)
squashes everyone to blue unless something is genuinely bad.

### Design choice: absolute vs. relative scale

An earlier version normalized colors to each model's own min/max error. That was
misleading: on a well-registered model where every camera is ~0.5 px, it still
painted a full blue→red rainbow, implying some cameras were bad when none were.
The **absolute** scale above keeps colors comparable across models and reserves
red for genuinely high error. The `max` is user-adjustable (with a tooltip), and
applying the colormap logs the model's actual per-image error range so the scale
maps to concrete numbers.

## Screenshots

The same `south-building` model with **"Reproj. error for red [px]"** swept from
a small value to the 2 px default. The *identical* per-camera errors sweep across
the whole colormap — showing that the color reflects `error ÷ max`, not an
absolute good/bad verdict:

**Small max → the whole scale is used up almost immediately, so every camera is red:**

![max well below the data — all red](https://raw.githubusercontent.com/behnamasadi/colmap/assets-frustum-reproj-colormap/docs/pr-assets/frustum-error-1.png)

![raising max — red/orange/yellow](https://raw.githubusercontent.com/behnamasadi/colmap/assets-frustum-reproj-colormap/docs/pr-assets/frustum-error-2.png)

![max near the data range — green/yellow/orange spread](https://raw.githubusercontent.com/behnamasadi/colmap/assets-frustum-reproj-colormap/docs/pr-assets/frustum-error-3.png)

![larger max — cyan/green](https://raw.githubusercontent.com/behnamasadi/colmap/assets-frustum-reproj-colormap/docs/pr-assets/frustum-error-4.png)

**Default max = 2 px → all cameras well under tolerance, so all blue/cyan ("all good"):**

![default max = 2 px — all blue/cyan](https://raw.githubusercontent.com/behnamasadi/colmap/assets-frustum-reproj-colormap/docs/pr-assets/frustum-error-5.png)

## Notes

- Jet is used for consistency with the existing point "Error" colormap; a
  colorblind-safe coolwarm ramp is an easy swap if preferred.
- Built with `-DGUI_ENABLED=ON` and verified visually. GUI code is not covered by
  the headless unit tests.
