### PR TITLE
Fix point triangulator image list handling

### DIFF
--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -77,6 +77,12 @@ COLMAP_ADD_LIBRARY(
         colmap_sfm
 )
 
+COLMAP_ADD_TEST(
+    NAME sfm_test
+    SRCS sfm_test.cc
+    LINK_LIBS colmap_exe
+)
+
 set(COLMAP_MAIN_SRCS
     colmap.cc
     database.cc

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -644,6 +644,7 @@ void RunPointTriangulatorImpl(
   custom_options->ba_refine_extra_params = refine_intrinsics;
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
+  reconstruction_manager->Get(reconstruction_manager->Add()) = reconstruction;
   IncrementalPipeline mapper(
       custom_options, Database::Open(database_path), reconstruction_manager);
   mapper.TriangulateReconstruction(reconstruction);

--- a/src/colmap/exe/sfm_test.cc
+++ b/src/colmap/exe/sfm_test.cc
@@ -1,0 +1,76 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/exe/sfm.h"
+
+#include "colmap/scene/database.h"
+#include "colmap/scene/synthetic.h"
+#include "colmap/util/file.h"
+#include "colmap/util/testing.h"
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+TEST(PointTriangulator, IncludesRegisteredImagesOutsideImageList) {
+  const auto test_path = CreateTestDir();
+  const auto database_path = test_path / "database.db";
+  auto database = Database::Open(database_path);
+
+  auto reconstruction = std::make_shared<Reconstruction>();
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 1;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 3;
+  synthetic_options.num_points3D = 10;
+  SynthesizeDataset(synthetic_options, reconstruction.get(), database.get());
+
+  ASSERT_EQ(reconstruction->NumRegImages(), 3);
+  IncrementalPipelineOptions options;
+  options.image_names = {reconstruction->Image(1).Name(),
+                         reconstruction->Image(2).Name()};
+  options.ba_global_max_refinements = 0;
+  options.num_threads = 1;
+
+  database.reset();
+  const auto output_path = test_path / "output";
+  CreateDirIfNotExists(output_path);
+  EXPECT_NO_THROW(RunPointTriangulatorImpl(reconstruction,
+                                           database_path,
+                                           test_path,
+                                           output_path,
+                                           options,
+                                           /*clear_points=*/false,
+                                           /*refine_intrinsics=*/false));
+  EXPECT_EQ(reconstruction->NumRegImages(), 3);
+}
+
+}  // namespace
+}  // namespace colmap


### PR DESCRIPTION
## Summary
- register the input reconstruction with the incremental pipeline before loading the database cache
- include all registered reconstruction images when `Mapper.image_list_path` filters the candidate images
- add an executable-level regression test for a reconstruction containing images outside the list

## Testing
- `ctest --test-dir build -R '^exe/sfm_test$' --output-on-failure`
- `ctest --test-dir build -R '^controllers/incremental_pipeline_test$' --output-on-failure`
- `cmake --build build --target colmap_main -j2`

Fixes #4580