### PR TITLE
doc: Add FAQ explaining why reconstruction scale/orientation is arbitrary

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -400,6 +400,31 @@ recommended to run another global bundle adjustment after the merge::
         --output_path /path/to/refined-merged-model
 
 
+Why is the reconstruction scale/orientation arbitrary?
+------------------------------------------------------
+
+Structure-from-Motion from images alone can only recover the scene up to an
+arbitrary similarity transformation: the global scale, orientation, and position
+of a reconstruction are not determined by 2D image measurements. The same images
+could show a small object up close or a large object from far away and produce
+identical projections, so the absolute scale is unobservable. The particular
+scale and orientation you obtain also depend on which image pair was used to
+initialize the reconstruction.
+
+To obtain a metric and/or geo-referenced reconstruction, you must supply
+external information:
+
+- **Known distance:** if you know one real-world distance in the scene (between
+  two 3D points, two camera centers, or a camera and a point), measure the same
+  distance in the model; the ratio of the two gives the scale factor.
+- **GPS / control points:** align the model to known camera-center coordinates
+  with ``model_aligner``, which estimates a full 3D similarity transform (scale,
+  rotation, and translation); see the `Geo-registration`_ section below.
+- **Pose priors during mapping:** reconstruct with the ``pose_prior_mapper`` so
+  that GPS (or other) position priors constrain the solution during mapping; see
+  the `Reconstruction with pose priors (GPS)`_ section.
+
+
 Geo-registration
 ----------------
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -407,6 +407,31 @@ recommended to run another global bundle adjustment after the merge::
         --output_path /path/to/refined-merged-model
 
 
+Why is the reconstruction scale/orientation arbitrary?
+------------------------------------------------------
+
+Structure-from-Motion from images alone can only recover the scene up to an
+arbitrary similarity transformation: the global scale, orientation, and position
+of a reconstruction are not determined by 2D image measurements. The same images
+could show a small object up close or a large object from far away and produce
+identical projections, so the absolute scale is unobservable. The particular
+scale and orientation you obtain also depend on which image pair was used to
+initialize the reconstruction.
+
+To obtain a metric and/or geo-referenced reconstruction, you must supply
+external information:
+
+- **Known distance:** if you know one real-world distance in the scene (between
+  two 3D points, two camera centers, or a camera and a point), measure the same
+  distance in the model; the ratio of the two gives the scale factor.
+- **GPS / control points:** align the model to known camera-center coordinates
+  with ``model_aligner``, which estimates a full 3D similarity transform (scale,
+  rotation, and translation); see the `Geo-registration`_ section below.
+- **Pose priors during mapping:** reconstruct with the ``pose_prior_mapper`` so
+  that GPS (or other) position priors constrain the solution during mapping; see
+  the `Reconstruction with pose priors (GPS)`_ section.
+
+
 Geo-registration
 ----------------
 


### PR DESCRIPTION
## Summary

Adds a FAQ entry addressing a recurring question (#1471): why the scale (and
orientation/position) of a COLMAP reconstruction appears arbitrary.

The entry explains that image-only Structure-from-Motion can recover the scene
only up to a similarity transformation — global scale, orientation, and position
are not observable from 2D measurements, and the specific values obtained also
depend on the initialization image pair. It then lists the three ways to obtain a
metric and/or geo-referenced reconstruction:

- a **known real-world distance** (ratio to the same distance measured in the model);
- **GPS / control points** via `model_aligner` (full 3D similarity transform);
- **pose priors during mapping** via the `pose_prior_mapper`.

Cross-links the existing `Geo-registration` and `Reconstruction with pose priors
(GPS)` sections. Docs build cleanly with Sphinx.

Fixes #1471
