### PR TITLE
Avoid cross-sensor sequential rig pairs

### DIFF
--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -492,8 +492,7 @@ void SequentialPairGenerator::MaybeExpandRigImages(image_t image_id1,
 
 bool SequentialPairGenerator::IsValidSequentialNeighbor(
     image_t image_id1, image_t image_id2) const {
-  if (!options_.expand_rig_images ||
-      !image_to_frame_id_.contains(image_id1) ||
+  if (!options_.expand_rig_images || !image_to_frame_id_.contains(image_id1) ||
       !image_to_frame_id_.contains(image_id2)) {
     return true;
   }

--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -473,6 +473,47 @@ bool SequentialPairGenerator::HasFinished() const {
                                      : true);
 }
 
+void SequentialPairGenerator::MaybeExpandRigImages(image_t image_id1,
+                                                   image_t image_id2) {
+  if (!options_.expand_rig_images) {
+    return;
+  }
+  const auto frame_id2_it = image_to_frame_ids_.find(image_id2);
+  if (frame_id2_it != image_to_frame_ids_.end()) {
+    // Pair with all images in second frame.
+    for (const image_t frame_image_id2 :
+         frame_to_image_ids_.at(frame_id2_it->second)) {
+      if (image_id1 != frame_image_id2 && image_id2 != frame_image_id2) {
+        image_pairs_.emplace_back(image_id1, frame_image_id2);
+      }
+    }
+  }
+}
+
+bool SequentialPairGenerator::IsValidSequentialNeighbor(
+    image_t image_id1, image_t image_id2) const {
+  if (!options_.expand_rig_images ||
+      !image_to_frame_ids_.contains(image_id1) ||
+      !image_to_frame_ids_.contains(image_id2)) {
+    return true;
+  }
+
+  const frame_t frame_id1 = image_to_frame_ids_.at(image_id1);
+  const frame_t frame_id2 = image_to_frame_ids_.at(image_id2);
+  if (frame_to_image_ids_.at(frame_id1).size() == 1 &&
+      frame_to_image_ids_.at(frame_id2).size() == 1) {
+    return true;
+  }
+
+  // Rig images are sorted by their sensor-prefixed names. Crossing from the
+  // end of one sensor's sequence to the beginning of the next would create
+  // a false temporal neighbor. Same-frame sensor pairs are added in Next(),
+  // and temporal pairs are expanded to the other sensors by
+  // MaybeExpandRigImages().
+  return cache_->GetImage(image_id1).CameraId() ==
+         cache_->GetImage(image_id2).CameraId();
+}
+
 std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
   image_pairs_.clear();
   if (image_idx_ >= image_ids_.size()) {
@@ -499,51 +540,12 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
     }
   }
 
-  auto MaybeExpandRigImages = [this](image_t image_id1, image_t image_id2) {
-    if (!options_.expand_rig_images) {
-      return;
-    }
-    const auto frame_id2_it = image_to_frame_ids_.find(image_id2);
-    if (frame_id2_it != image_to_frame_ids_.end()) {
-      // Pair with all images in second frame.
-      for (const image_t frame_image_id2 :
-           frame_to_image_ids_.at(frame_id2_it->second)) {
-        if (image_id1 != frame_image_id2 && image_id2 != frame_image_id2) {
-          image_pairs_.emplace_back(image_id1, frame_image_id2);
-        }
-      }
-    }
-  };
-
-  auto IsValidSequentialNeighbor = [this, image_id1](image_t image_id2) {
-    if (!options_.expand_rig_images ||
-        !image_to_frame_ids_.contains(image_id1) ||
-        !image_to_frame_ids_.contains(image_id2)) {
-      return true;
-    }
-
-    const frame_t frame_id1 = image_to_frame_ids_.at(image_id1);
-    const frame_t frame_id2 = image_to_frame_ids_.at(image_id2);
-    if (frame_to_image_ids_.at(frame_id1).size() == 1 &&
-        frame_to_image_ids_.at(frame_id2).size() == 1) {
-      return true;
-    }
-
-    // Rig images are sorted by their sensor-prefixed names. Crossing from the
-    // end of one sensor's sequence to the beginning of the next would create
-    // a false temporal neighbor. Same-frame sensor pairs are added above, and
-    // temporal pairs are expanded to the other sensors by
-    // MaybeExpandRigImages.
-    return cache_->GetImage(image_id1).CameraId() ==
-           cache_->GetImage(image_id2).CameraId();
-  };
-
   for (int i = 0; i < options_.overlap; ++i) {
     if (options_.quadratic_overlap) {
       const size_t image_idx_2_quadratic = image_idx_ + (1ull << i);
       if (image_idx_2_quadratic < image_ids_.size()) {
         const image_t image_id2 = image_ids_.at(image_idx_2_quadratic);
-        if (!IsValidSequentialNeighbor(image_id2)) {
+        if (!IsValidSequentialNeighbor(image_id1, image_id2)) {
           continue;
         }
         image_pairs_.emplace_back(image_id1, image_id2);
@@ -555,7 +557,7 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
       const size_t image_idx_2 = image_idx_ + i + 1;
       if (image_idx_2 < image_ids_.size()) {
         const image_t image_id2 = image_ids_.at(image_idx_2);
-        if (!IsValidSequentialNeighbor(image_id2)) {
+        if (!IsValidSequentialNeighbor(image_id1, image_id2)) {
           continue;
         }
         image_pairs_.emplace_back(image_id1, image_id2);

--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -515,11 +515,37 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
     }
   };
 
+  auto IsValidSequentialNeighbor = [this, image_id1](image_t image_id2) {
+    if (!options_.expand_rig_images ||
+        !image_to_frame_ids_.contains(image_id1) ||
+        !image_to_frame_ids_.contains(image_id2)) {
+      return true;
+    }
+
+    const frame_t frame_id1 = image_to_frame_ids_.at(image_id1);
+    const frame_t frame_id2 = image_to_frame_ids_.at(image_id2);
+    if (frame_to_image_ids_.at(frame_id1).size() == 1 &&
+        frame_to_image_ids_.at(frame_id2).size() == 1) {
+      return true;
+    }
+
+    // Rig images are sorted by their sensor-prefixed names. Crossing from the
+    // end of one sensor's sequence to the beginning of the next would create
+    // a false temporal neighbor. Same-frame sensor pairs are added above, and
+    // temporal pairs are expanded to the other sensors by
+    // MaybeExpandRigImages.
+    return cache_->GetImage(image_id1).CameraId() ==
+           cache_->GetImage(image_id2).CameraId();
+  };
+
   for (int i = 0; i < options_.overlap; ++i) {
     if (options_.quadratic_overlap) {
       const size_t image_idx_2_quadratic = image_idx_ + (1ull << i);
       if (image_idx_2_quadratic < image_ids_.size()) {
         const image_t image_id2 = image_ids_.at(image_idx_2_quadratic);
+        if (!IsValidSequentialNeighbor(image_id2)) {
+          continue;
+        }
         image_pairs_.emplace_back(image_id1, image_id2);
         MaybeExpandRigImages(image_id1, image_id2);
       } else {
@@ -529,6 +555,9 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
       const size_t image_idx_2 = image_idx_ + i + 1;
       if (image_idx_2 < image_ids_.size()) {
         const image_t image_id2 = image_ids_.at(image_idx_2);
+        if (!IsValidSequentialNeighbor(image_id2)) {
+          continue;
+        }
         image_pairs_.emplace_back(image_id1, image_id2);
         MaybeExpandRigImages(image_id1, image_id2);
       } else {

--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -440,13 +440,13 @@ SequentialPairGenerator::SequentialPairGenerator(
   if (options_.expand_rig_images) {
     const std::vector<frame_t> frame_ids = cache_->GetFrameIds();
     frame_to_image_ids_.reserve(frame_ids.size());
-    image_to_frame_ids_.reserve(image_ids_.size());
+    image_to_frame_id_.reserve(image_ids_.size());
     for (const frame_t frame_id : frame_ids) {
       const Frame& frame = cache_->GetFrame(frame_id);
       auto& frame_image_ids = frame_to_image_ids_[frame_id];
       for (const data_t& data_id : frame.ImageIds()) {
         frame_image_ids.push_back(data_id.id);
-        image_to_frame_ids_[data_id.id] = frame_id;
+        image_to_frame_id_[data_id.id] = frame_id;
       }
     }
   }
@@ -478,8 +478,8 @@ void SequentialPairGenerator::MaybeExpandRigImages(image_t image_id1,
   if (!options_.expand_rig_images) {
     return;
   }
-  const auto frame_id2_it = image_to_frame_ids_.find(image_id2);
-  if (frame_id2_it != image_to_frame_ids_.end()) {
+  const auto frame_id2_it = image_to_frame_id_.find(image_id2);
+  if (frame_id2_it != image_to_frame_id_.end()) {
     // Pair with all images in second frame.
     for (const image_t frame_image_id2 :
          frame_to_image_ids_.at(frame_id2_it->second)) {
@@ -493,13 +493,13 @@ void SequentialPairGenerator::MaybeExpandRigImages(image_t image_id1,
 bool SequentialPairGenerator::IsValidSequentialNeighbor(
     image_t image_id1, image_t image_id2) const {
   if (!options_.expand_rig_images ||
-      !image_to_frame_ids_.contains(image_id1) ||
-      !image_to_frame_ids_.contains(image_id2)) {
+      !image_to_frame_id_.contains(image_id1) ||
+      !image_to_frame_id_.contains(image_id2)) {
     return true;
   }
 
-  const frame_t frame_id1 = image_to_frame_ids_.at(image_id1);
-  const frame_t frame_id2 = image_to_frame_ids_.at(image_id2);
+  const frame_t frame_id1 = image_to_frame_id_.at(image_id1);
+  const frame_t frame_id2 = image_to_frame_id_.at(image_id2);
   if (frame_to_image_ids_.at(frame_id1).size() == 1 &&
       frame_to_image_ids_.at(frame_id2).size() == 1) {
     return true;
@@ -529,8 +529,8 @@ std::vector<std::pair<image_t, image_t>> SequentialPairGenerator::Next() {
 
   // If image is part of a rig, then pair the other images in the same frame.
   if (options_.expand_rig_images) {
-    if (const auto frame_id1_it = image_to_frame_ids_.find(image_id1);
-        frame_id1_it != image_to_frame_ids_.end()) {
+    if (const auto frame_id1_it = image_to_frame_id_.find(image_id1);
+        frame_id1_it != image_to_frame_id_.end()) {
       for (const image_t frame_image_id2 :
            frame_to_image_ids_.at(frame_id1_it->second)) {
         if (image_id1 != frame_image_id2) {

--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -492,13 +492,19 @@ void SequentialPairGenerator::MaybeExpandRigImages(image_t image_id1,
 
 bool SequentialPairGenerator::IsValidSequentialNeighbor(
     image_t image_id1, image_t image_id2) const {
-  if (!options_.expand_rig_images || !image_to_frame_id_.contains(image_id1) ||
-      !image_to_frame_id_.contains(image_id2)) {
+  if (!options_.expand_rig_images) {
     return true;
   }
 
-  const frame_t frame_id1 = image_to_frame_id_.at(image_id1);
-  const frame_t frame_id2 = image_to_frame_id_.at(image_id2);
+  const auto frame_id1_it = image_to_frame_id_.find(image_id1);
+  const auto frame_id2_it = image_to_frame_id_.find(image_id2);
+  if (frame_id1_it == image_to_frame_id_.end() ||
+      frame_id2_it == image_to_frame_id_.end()) {
+    return true;
+  }
+
+  const frame_t frame_id1 = frame_id1_it->second;
+  const frame_t frame_id2 = frame_id2_it->second;
   if (frame_to_image_ids_.at(frame_id1).size() == 1 &&
       frame_to_image_ids_.at(frame_id2).size() == 1) {
     return true;

--- a/src/colmap/controllers/pairing.h
+++ b/src/colmap/controllers/pairing.h
@@ -326,6 +326,10 @@ class SequentialPairGenerator : public PairGenerator {
   std::vector<std::pair<image_t, image_t>> Next() override;
 
  private:
+  void MaybeExpandRigImages(image_t image_id1, image_t image_id2);
+
+  bool IsValidSequentialNeighbor(image_t image_id1, image_t image_id2) const;
+
   std::vector<image_t> GetOrderedImageIds() const;
 
   const SequentialPairingOptions options_;

--- a/src/colmap/controllers/pairing.h
+++ b/src/colmap/controllers/pairing.h
@@ -337,7 +337,7 @@ class SequentialPairGenerator : public PairGenerator {
   std::vector<image_t> image_ids_;
   // Optional mapping from frames to images and vice versa.
   NodeHashMap<frame_t, std::vector<image_t>> frame_to_image_ids_;
-  NodeHashMap<image_t, frame_t> image_to_frame_ids_;
+  NodeHashMap<image_t, frame_t> image_to_frame_id_;
   std::unique_ptr<VocabTreePairGenerator> vocab_tree_pair_generator_;
   std::vector<std::pair<image_t, image_t>> image_pairs_;
   size_t image_idx_ = 0;

--- a/src/colmap/controllers/pairing_test.cc
+++ b/src/colmap/controllers/pairing_test.cc
@@ -224,14 +224,61 @@ TEST(SequentialPairGenerator, LinearRig) {
                   std::make_pair(images[2].ImageId(), images[5].ImageId())));
   EXPECT_THAT(generator.Next(),
               testing::ElementsAre(
-                  std::make_pair(images[4].ImageId(), images[5].ImageId()),
-                  std::make_pair(images[4].ImageId(), images[1].ImageId()),
-                  std::make_pair(images[4].ImageId(), images[0].ImageId())));
+                  std::make_pair(images[4].ImageId(), images[5].ImageId())));
   EXPECT_THAT(generator.Next(),
               testing::ElementsAre(
                   std::make_pair(images[1].ImageId(), images[0].ImageId()),
                   std::make_pair(images[1].ImageId(), images[3].ImageId()),
                   std::make_pair(images[1].ImageId(), images[2].ImageId())));
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[3].ImageId(), images[2].ImageId()),
+                  std::make_pair(images[3].ImageId(), images[5].ImageId()),
+                  std::make_pair(images[3].ImageId(), images[4].ImageId())));
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[5].ImageId(), images[4].ImageId())));
+  EXPECT_TRUE(generator.Next().empty());
+  EXPECT_TRUE(generator.HasFinished());
+}
+
+TEST(SequentialPairGenerator, QuadraticRig) {
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+  Reconstruction unused_reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 3;
+  SynthesizeDataset(
+      synthetic_dataset_options, &unused_reconstruction, database.get());
+  const std::vector<Image> images = database->ReadAllImages();
+
+  SequentialPairingOptions options;
+  options.overlap = 3;
+  options.quadratic_overlap = true;
+  SequentialPairGenerator generator(options, database);
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[0].ImageId(), images[1].ImageId()),
+                  std::make_pair(images[0].ImageId(), images[2].ImageId()),
+                  std::make_pair(images[0].ImageId(), images[3].ImageId()),
+                  std::make_pair(images[0].ImageId(), images[4].ImageId()),
+                  std::make_pair(images[0].ImageId(), images[5].ImageId())));
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[2].ImageId(), images[3].ImageId()),
+                  std::make_pair(images[2].ImageId(), images[4].ImageId()),
+                  std::make_pair(images[2].ImageId(), images[5].ImageId())));
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[4].ImageId(), images[5].ImageId())));
+  EXPECT_THAT(generator.Next(),
+              testing::ElementsAre(
+                  std::make_pair(images[1].ImageId(), images[0].ImageId()),
+                  std::make_pair(images[1].ImageId(), images[3].ImageId()),
+                  std::make_pair(images[1].ImageId(), images[2].ImageId()),
+                  std::make_pair(images[1].ImageId(), images[5].ImageId()),
+                  std::make_pair(images[1].ImageId(), images[4].ImageId())));
   EXPECT_THAT(generator.Next(),
               testing::ElementsAre(
                   std::make_pair(images[3].ImageId(), images[2].ImageId()),


### PR DESCRIPTION
## Summary

- require sequential seed pairs to use the same camera when rig expansion is enabled
- retain same-frame rig pairs and expand valid temporal pairs across all rig sensors
- add linear and quadratic rig pairing regression coverage

## Motivation

Folder-major image ordering can place the last image of one rig sensor next to the first image of another sensor. Sequential pairing interpreted those boundaries as temporal neighbors and expanded them into complete frame-pair graphs. On the TartanAir panorama rig this added geometrically unrelated frame pairs.

## Benchmark

Using 11 TartanAir scenes from #4590 with fixed seed 0, CPU SIFT, and one thread per scene:

- attempted image pairs per scene: 59,724 -> 34,128 (-42.9%)
- summed matching time: 4,322.5s -> 2,435.5s (-43.7%)
- pooled relative-pose AUC at 0.5/1/5/10 degrees: 44.28/46.82/48.89/49.20 -> 51.38/54.89/58.72/59.81
- mapping time: 394.7s -> 313.7s

Rendered images and descriptors were held fixed; only pairing, verification, and mapping were rerun.

## Tests

- `ctest -R controllers/pairing_test --output-on-failure`