### PR TITLE
Fix pose-prior BA gating to count frames, not images (#4368)

### DIFF
--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -1172,9 +1172,14 @@ bool IncrementalMapper::AdjustGlobalBundle(
     }
   }
 
-  // Only use prior pose if at least 3 images have been registered.
+  // Only use prior pose if at least 3 frames (not images) have been
+// registered. Count frames, not images: a multi-camera rig registers
+// several images per frame/position, so NumImages() overstates the
+// number of distinct positions, which could enable pose-prior BA with
+// fewer than 3 usable positions and make AlignReconstructionToPosePriors()
+// fail (see #4368).
   const bool use_prior_position =
-      options.use_prior_position && ba_config.NumImages() > 2;
+      options.use_prior_position && reconstruction_->NumRegFrames() > 2;
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster;
   if (!use_prior_position) {


### PR DESCRIPTION
Fixes #4368.

AdjustGlobalBundle() decided whether to enable pose-prior bundle adjustment using `ba_config.NumImages() > 2`. This counts every image across every sensor, but a multi-camera rig registers several images per frame/position. E.g. a 2-camera rig with only 2 registered frames already has 4 images, so the ">2" check passed with just 2 distinct positions. AlignReconstructionToPosePriors() requires >= 3 correspondences to fit a similarity transform, so it then failed, leaving the reconstruction unaligned with the pose priors (see #4368, diagnosed by @hayamdk).

This changes the check to use `reconstruction_->NumRegFrames()`, which counts distinct registered frames/positions instead of raw images.

Testing: this is a targeted, minimal condition change (swap `ba_config.NumImages()` for `reconstruction_->NumRegFrames()`, both already used elsewhere in this file/function) reviewed by reading `incremental_mapper.cc`, `alignment.cc`, and `bundle_adjustment.h`. I was not able to build the full COLMAP/Ceres toolchain in my environment to run `incremental_mapper_test`, so I'd appreciate a maintainer double-checking against CI and, ideally, against the rig database @MarwinSc attached to #4368.