### PR TITLE
Fix pose-prior alignment for camera rigs

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -134,6 +134,31 @@ bool HasUnknownSensorFromRig(const Reconstruction& reconstruction) {
   return false;
 }
 
+void AlignReconstructionToPriorsOrRigScale(
+    const IncrementalPipelineOptions& options,
+    const DatabaseCache& database_cache,
+    Reconstruction* reconstruction) {
+  if (options.use_prior_position) {
+    PosePriorBundleAdjustmentOptions prior_options;
+    prior_options.alignment_ransac_options.random_seed = options.random_seed;
+
+    Sim3d metric_from_reconstruction;
+    if (AlignReconstructionToPosePriors(
+            *reconstruction,
+            database_cache.PosePriors(),
+            prior_options.alignment_ransac_options,
+            prior_options.prior_position_fallback_stddev,
+            &metric_from_reconstruction)) {
+      reconstruction->Transform(metric_from_reconstruction);
+      return;
+    }
+    LOG(WARNING) << "Final alignment w.r.t. prior positions failed; restoring "
+                    "the original rig scale instead";
+  }
+
+  AlignReconstructionToOrigRigScales(database_cache.Rigs(), reconstruction);
+}
+
 }  // namespace
 
 IncrementalMapper::Options IncrementalPipelineOptions::Mapper() const {
@@ -709,8 +734,8 @@ IncrementalPipeline::Status IncrementalPipeline::Reconstruct(
         reconstruction->UpdatePoint3DErrors();
         LOG(INFO) << "Keeping reconstruction due to interrupt";
         mapper.EndReconstruction(/*discard=*/false);
-        AlignReconstructionToOrigRigScales(database_cache_->Rigs(),
-                                           reconstruction.get());
+        AlignReconstructionToPriorsOrRigScale(
+            *options_, *database_cache_, reconstruction.get());
         return Status::STOP;
       }
 
@@ -767,8 +792,8 @@ IncrementalPipeline::Status IncrementalPipeline::Reconstruct(
           reconstruction->UpdatePoint3DErrors();
           LOG(INFO) << "Keeping successful reconstruction";
           mapper.EndReconstruction(/*discard=*/false);
-          AlignReconstructionToOrigRigScales(database_cache_->Rigs(),
-                                             reconstruction.get());
+          AlignReconstructionToPriorsOrRigScale(
+              *options_, *database_cache_, reconstruction.get());
         }
 
         Callback(LAST_IMAGE_REG_CALLBACK);

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -533,6 +533,21 @@ TEST(IncrementalPipeline, PriorBasedSfMWithoutNoiseAndWithNonTrivialFrames) {
   SynthesizeDataset(
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
+  // Match the common rig setup where only the reference sensor has absolute
+  // positions. Registering two frames then yields many images but only two
+  // usable pose priors.
+  FlatHashSet<sensor_t> ref_sensor_ids;
+  for (const auto& [_, rig] : gt_reconstruction.Rigs()) {
+    ref_sensor_ids.insert(rig.RefSensorId());
+  }
+  const std::vector<PosePrior> pose_priors = database->ReadAllPosePriors();
+  database->ClearPosePriors();
+  for (const PosePrior& pose_prior : pose_priors) {
+    if (ref_sensor_ids.count(pose_prior.corr_data_id.sensor_id)) {
+      database->WritePosePrior(pose_prior);
+    }
+  }
+
   std::shared_ptr<IncrementalPipelineOptions> mapper_options =
       std::make_shared<IncrementalPipelineOptions>();
 
@@ -549,7 +564,8 @@ TEST(IncrementalPipeline, PriorBasedSfMWithoutNoiseAndWithNonTrivialFrames) {
                                  /*max_rotation_error_deg=*/1e-1,
                                  /*max_proj_center_error=*/1e-1,
                                  /*max_scale_error=*/std::nullopt,
-                                 /*num_obs_tolerance=*/0.02));
+                                 /*num_obs_tolerance=*/0.02,
+                                 /*align=*/false));
 }
 
 TEST(IncrementalPipeline, PriorBasedSfMWithNoise) {

--- a/src/colmap/estimators/alignment.cc
+++ b/src/colmap/estimators/alignment.cc
@@ -240,12 +240,17 @@ bool AlignReconstructionToLocations(
 bool AlignReconstructionToPosePriors(
     const Reconstruction& src_reconstruction,
     const std::vector<PosePrior>& tgt_pose_priors,
-    const RANSACOptions& ransac_options,
+    RANSACOptions ransac_options,
+    const double prior_position_fallback_stddev,
     Sim3d* tgt_from_src) {
+  THROW_CHECK_GT(prior_position_fallback_stddev, 0.0);
+
   std::vector<Eigen::Vector3d> src;
   std::vector<Eigen::Vector3d> tgt;
+  std::vector<double> rms_vars;
   src.reserve(tgt_pose_priors.size());
   tgt.reserve(tgt_pose_priors.size());
+  rms_vars.reserve(tgt_pose_priors.size());
 
   NodeHashMap<image_t, PosePrior> tgt_image_to_pose_prior;
   for (const auto& pose_prior : tgt_pose_priors) {
@@ -264,6 +269,10 @@ bool AlignReconstructionToPosePriors(
       const auto& image = src_reconstruction.Image(image_id);
       src.push_back(image.ProjectionCenter());
       tgt.push_back(pose_prior_it->second.position);
+      const double trace = pose_prior_it->second.position_covariance.trace();
+      if (trace > 0.0) {
+        rms_vars.push_back(trace / 3.0);
+      }
     }
   }
 
@@ -272,10 +281,21 @@ bool AlignReconstructionToPosePriors(
     return false;
   }
 
-  if (ransac_options.max_error > 0) {
-    return EstimateSim3dRobust(src, tgt, ransac_options, *tgt_from_src).success;
+  if (ransac_options.max_error <= 0) {
+    if (rms_vars.empty()) {
+      LOG(WARNING) << "No pose priors with valid covariance found.";
+      rms_vars.push_back(prior_position_fallback_stddev *
+                         prior_position_fallback_stddev);
+    }
+
+    // Scale the median RMS variance by the 95% chi-square quantile for 3 DOF.
+    ransac_options.max_error =
+        std::sqrt(kChiSquare95ThreeDof * Median(rms_vars));
   }
-  return EstimateSim3d(src, tgt, *tgt_from_src);
+
+  VLOG(2) << "Robustly aligning reconstruction with max_error="
+          << ransac_options.max_error;
+  return EstimateSim3dRobust(src, tgt, ransac_options, *tgt_from_src).success;
 }
 
 bool AlignReconstructionsViaReprojections(

--- a/src/colmap/estimators/alignment.h
+++ b/src/colmap/estimators/alignment.h
@@ -47,11 +47,13 @@ bool AlignReconstructionToLocations(
     const RANSACOptions& ransac_options,
     Sim3d* tgt_from_src);
 
-// Robustly align reconstruction to given pose priors.
+// Robustly align reconstruction to given pose priors. If max_error is not set
+// in the RANSAC options, derive it from the median position covariance.
 bool AlignReconstructionToPosePriors(
     const Reconstruction& src_reconstruction,
     const std::vector<PosePrior>& tgt_pose_priors,
-    const RANSACOptions& ransac_options,
+    RANSACOptions ransac_options,
+    double prior_position_fallback_stddev,
     Sim3d* tgt_from_src);
 
 // Robustly compute alignment between reconstructions by finding images that

--- a/src/colmap/estimators/alignment_test.cc
+++ b/src/colmap/estimators/alignment_test.cc
@@ -122,8 +122,41 @@ TEST(Alignment, AlignReconstructionToPosePriors) {
   ransac_options.max_error = 1e-2;
 
   Sim3d tgt_from_src;
-  ASSERT_TRUE(AlignReconstructionToPosePriors(
-      src_reconstruction, tgt_pose_priors, ransac_options, &tgt_from_src));
+  ASSERT_TRUE(
+      AlignReconstructionToPosePriors(src_reconstruction,
+                                      tgt_pose_priors,
+                                      ransac_options,
+                                      /*prior_position_fallback_stddev=*/1.0,
+                                      &tgt_from_src));
+  ExpectEqualSim3d(gt_tgt_from_src, tgt_from_src);
+}
+
+TEST(Alignment, AlignReconstructionToPosePriorsWithAutomaticMaxError) {
+  Reconstruction src_reconstruction = GenerateReconstructionForAlignment();
+  Reconstruction tgt_reconstruction = src_reconstruction;
+
+  const Sim3d gt_tgt_from_src = TestSim3d();
+  tgt_reconstruction.Transform(gt_tgt_from_src);
+
+  std::vector<PosePrior> tgt_pose_priors;
+  for (const auto& [image_id, image] : tgt_reconstruction.Images()) {
+    PosePrior& pose_prior = tgt_pose_priors.emplace_back();
+    pose_prior.pose_prior_id = tgt_pose_priors.size();
+    pose_prior.corr_data_id = image.DataId();
+    pose_prior.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+    pose_prior.position = image.ProjectionCenter();
+    pose_prior.position_covariance = 1e-4 * Eigen::Matrix3d::Identity();
+  }
+
+  RANSACOptions ransac_options;
+  ransac_options.max_error = 0.0;
+  Sim3d tgt_from_src;
+  ASSERT_TRUE(
+      AlignReconstructionToPosePriors(src_reconstruction,
+                                      tgt_pose_priors,
+                                      ransac_options,
+                                      /*prior_position_fallback_stddev=*/1.0,
+                                      &tgt_from_src));
   ExpectEqualSim3d(gt_tgt_from_src, tgt_from_src);
 }
 

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -912,16 +912,17 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
                        }),
         pose_priors_.end());
 
-    const bool use_prior_position = AlignReconstruction();
+    const bool use_prior_position =
+        pose_priors_.size() >= 3 && AlignReconstruction();
 
-    // Fix 7-DOFs of BA problem if not enough valid pose priors.
+    // Fix 7-DOFs of the BA problem if the pose priors cannot constrain them.
     if (use_prior_position) {
       // Normalize the reconstruction to avoid any numerical instability but
       // do not transform priors as they will be transformed when added to
       // ceres::Problem.
       normalized_from_metric_ = reconstruction_.Normalize(/*fixed_scale=*/true);
     } else {
-      config_.FixGauge(BundleAdjustmentGauge::THREE_POINTS);
+      config_.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
     }
 
     // WARNING: Do not move this above the reconstruction normalization.
@@ -1026,37 +1027,13 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
   }
 
   bool AlignReconstruction() {
-    RANSACOptions ransac_options = prior_options_.alignment_ransac_options;
-    if (ransac_options.max_error <= 0) {
-      std::vector<double> rms_vars;
-      rms_vars.reserve(pose_priors_.size());
-      for (const auto& pose_prior : pose_priors_) {
-        const double trace = pose_prior.position_covariance.trace();
-        if (trace <= 0.0) {
-          continue;
-        }
-        rms_vars.push_back(trace / 3.0);
-      }
-
-      if (rms_vars.empty()) {
-        LOG(WARNING) << "No pose priors with valid covariance found.";
-        rms_vars.push_back(prior_options_.prior_position_fallback_stddev *
-                           prior_options_.prior_position_fallback_stddev);
-      }
-
-      // Set max error using the median RMS variance of valid pose priors.
-      // Scaled by sqrt(chi-square 95% quantile, 3 DOF) to approximate a 95%
-      // confidence radius.
-      ransac_options.max_error =
-          std::sqrt(kChiSquare95ThreeDof * Median(rms_vars));
-    }
-
-    VLOG(2) << "Robustly aligning reconstruction with max_error="
-            << ransac_options.max_error;
-
     Sim3d metric_from_orig;
     if (!AlignReconstructionToPosePriors(
-            reconstruction_, pose_priors_, ransac_options, &metric_from_orig)) {
+            reconstruction_,
+            pose_priors_,
+            prior_options_.alignment_ransac_options,
+            prior_options_.prior_position_fallback_stddev,
+            &metric_from_orig)) {
       LOG(WARNING) << "Alignment w.r.t. prior positions failed";
       return false;
     }

--- a/src/colmap/estimators/bundle_adjustment_ceres_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres_test.cc
@@ -1496,6 +1496,37 @@ TEST(PosePriorBundleAdjuster, AlignmentRobustToOutliers) {
                                  /*num_obs_tolerance=*/0.02));
 }
 
+TEST(PosePriorBundleAdjuster, InsufficientPriorsUseTwoCameraGauge) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 1;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 3;
+  synthetic_options.num_points3D = 50;
+  synthetic_options.prior_position = true;
+  const auto database_path = CreateTestDir() / "database.db";
+  auto database = Database::Open(database_path);
+  SynthesizeDataset(synthetic_options, &reconstruction, database.get());
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+  }
+
+  std::vector<PosePrior> pose_priors = database->ReadAllPosePriors();
+  pose_priors.resize(2);
+  auto adjuster =
+      CreatePosePriorBundleAdjuster(BundleAdjustmentOptions(),
+                                    PosePriorBundleAdjustmentOptions(),
+                                    config,
+                                    std::move(pose_priors),
+                                    reconstruction);
+
+  EXPECT_EQ(adjuster->Config().FixedGauge(),
+            BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+  EXPECT_TRUE(adjuster->Solve()->IsSolutionUsable());
+}
+
 TEST(PosePriorBundleAdjuster, MissingPositionCov) {
   SetPRNGSeed(0);
   Reconstruction gt_reconstruction;

--- a/src/colmap/sfm/incremental_mapper.cc
+++ b/src/colmap/sfm/incremental_mapper.cc
@@ -59,6 +59,19 @@ void SeedEstimatedInitialCameras(Reconstruction& reconstruction,
   }
 }
 
+size_t NumRegisteredPosePriors(const std::vector<PosePrior>& pose_priors,
+                               const BundleAdjustmentConfig& ba_config) {
+  size_t num_registered_pose_priors = 0;
+  for (const PosePrior& pose_prior : pose_priors) {
+    if (pose_prior.HasPosition() &&
+        pose_prior.corr_data_id.sensor_id.type == SensorType::CAMERA &&
+        ba_config.HasImage(pose_prior.corr_data_id.id)) {
+      ++num_registered_pose_priors;
+    }
+  }
+  return num_registered_pose_priors;
+}
+
 }  // namespace
 
 bool IncrementalMapper::Options::Check() const {
@@ -1172,9 +1185,9 @@ bool IncrementalMapper::AdjustGlobalBundle(
     }
   }
 
-  // Only use prior pose if at least 3 images have been registered.
   const bool use_prior_position =
-      options.use_prior_position && ba_config.NumImages() > 2;
+      options.use_prior_position &&
+      NumRegisteredPosePriors(database_cache_->PosePriors(), ba_config) >= 3;
 
   std::unique_ptr<BundleAdjuster> bundle_adjuster;
   if (!use_prior_position) {


### PR DESCRIPTION
## Summary

- select pose-prior bundle adjustment using the number of registered, usable pose priors rather than the number of images or frames
- derive the alignment RANSAC threshold from registered prior covariances and use the stable two-camera gauge when priors cannot constrain a Sim3
- preserve a verified pose-prior alignment during final pipeline output, falling back to the original rig scale only when prior alignment is unavailable

## Problem

In #4368, a five-camera rig has one pose prior on the reference camera for each frame. The initial two frames therefore register ten images but provide only two usable priors. The image-count gate incorrectly enters pose-prior BA.

More importantly, after later pose-prior BA successfully aligns the reconstruction, `AlignReconstructionToOrigRigScales()` applies a global scale about the world origin. For the supplied reconstruction roughly 2 km from the origin, this moves the final model by more than 100 m.

PR #4593 avoids the initial two-frame BA path, but frame count is still a proxy for usable priors and the final rig-scale correction remains unchanged.

## Reproduction

Using the database attached to #4368:

| Result | Pose-prior RMSE |
| --- | ---: |
| Attached reconstruction | 142.278 m |
| PR #4593 | 127.383 m |
| This change | 0.0073 m |

The reconstruction registers all 30 images and completes without the initial insufficient-prior warnings.

## Tests

- `controllers/incremental_pipeline_test`
- `estimators/alignment_test`
- `estimators/bundle_adjustment_test`
- `estimators/bundle_adjustment_ceres_test`
- `sfm/incremental_mapper_test`
- end-to-end reproduction with the database attached to #4368

Fixes #4368.