### PR TITLE
Publish macOS app artifact in CI

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -99,6 +99,16 @@ jobs:
           set +e
           ctest --output-on-failure
 
+      - name: Export package
+        run: |
+          ./scripts/shell/build_mac_app.sh build/src/colmap/exe/colmap
+
+      - name: Upload package
+        uses: actions/upload-artifact@v7
+        with:
+          name: colmap-arm64-macos
+          path: build/src/colmap/exe/COLMAP-mac.zip
+
       - name: Cleanup compiler cache
         run: |
           set -x

--- a/doc/_static/install_selector.js
+++ b/doc/_static/install_selector.js
@@ -65,8 +65,16 @@
     },
     macos: {
       label: "macOS",
-      methods: ["pip", "conda", "brew", "docker", "source"],
+      methods: ["binary", "pip", "conda", "brew", "docker", "source"],
       cells: {
+        binary: {
+          cuda: null,
+          cpu: link(
+            "Download from GitHub Releases",
+            "https://github.com/colmap/colmap/releases",
+            "Use the colmap-arm64-macos package."
+          ),
+        },
         pip: { cuda: null, cpu: cmd("pip install pycolmap") },
         conda: { cuda: null, cpu: cmd("conda install -c conda-forge colmap") },
         brew: { cuda: null, cpu: cmd("brew install colmap") },

--- a/scripts/shell/build_mac_app.sh
+++ b/scripts/shell/build_mac_app.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright (c), ETH Zurich and UNC Chapel Hill.
 # All rights reserved.
 #
@@ -28,18 +30,32 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-# This script creates a deployable package of COLMAP for Mac OS X.
+# This script creates a deployable package of COLMAP for macOS.
 
-BASE_PATH=$(dirname $1)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 /path/to/colmap" >&2
+    exit 1
+fi
+
+BINARY_PATH=$1
+BASE_PATH=$(dirname "$BINARY_PATH")
+APP_PATH="$BASE_PATH/COLMAP.app"
+APP_BINARY="$APP_PATH/Contents/MacOS/colmap"
+APP_LAUNCHER="$APP_PATH/Contents/MacOS/colmap_gui.sh"
+ARCHIVE_PATH="$BASE_PATH/COLMAP-mac.zip"
+
+rm -rf "$APP_PATH" "$ARCHIVE_PATH"
 
 echo "Creating bundle directory"
-mkdir -p "$BASE_PATH/COLMAP.app/Contents/MacOS"
+mkdir -p "$APP_PATH/Contents/MacOS"
 
 echo "Copying binary"
-cp "$BASE_PATH/colmap" "$BASE_PATH/COLMAP.app/Contents/MacOS/colmap"
+cp "$BINARY_PATH" "$APP_BINARY"
 
 echo "Writing Info.plist"
-cat <<EOM >"$BASE_PATH/COLMAP.app/Contents/Info.plist"
+cat <<EOM >"$APP_PATH/Contents/Info.plist"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -62,25 +78,42 @@ cat <<EOM >"$BASE_PATH/COLMAP.app/Contents/Info.plist"
 </plist>
 EOM
 
-install_name_tool -change @rpath/libtbb.dylib /usr/local/lib/libtbb.dylib $BASE_PATH/COLMAP.app/Contents/MacOS/COLMAP
-install_name_tool -change @rpath/libtbbmalloc.dylib /usr/local/lib/libtbbmalloc.dylib $BASE_PATH/COLMAP.app/Contents/MacOS/COLMAP
-
 echo "Linking dynamic libraries"
-if [ -d "$(brew --prefix)/opt/qt6" ]; then
-    $(brew --prefix)/opt/qt6/bin/macdeployqt "$BASE_PATH/COLMAP.app"
-else
-    $(brew --prefix)/opt/qt5/bin/macdeployqt "$BASE_PATH/COLMAP.app"
-fi
+"$(brew --prefix qt)/bin/macdeployqt" "$APP_PATH" -no-codesign
 
 echo "Wrapping binary"
-cat <<EOM >"$BASE_PATH/COLMAP.app/Contents/MacOS/colmap_gui.sh"
+cat <<'EOM' >"$APP_LAUNCHER"
 #!/bin/bash
-script_path="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
-\$script_path/colmap gui
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$script_path/colmap" gui
 EOM
-chmod +x $BASE_PATH/COLMAP.app/Contents/MacOS/colmap_gui.sh
-sed -i '' 's#<string>colmap</string>#<string>colmap_gui.sh</string>#g' $BASE_PATH/COLMAP.app/Contents/Info.plist
+chmod +x "$APP_LAUNCHER"
+sed -i '' 's#<string>colmap</string>#<string>colmap_gui.sh</string>#g' "$APP_PATH/Contents/Info.plist"
+
+echo "Signing application binaries"
+BREW_PREFIX=$(brew --prefix)
+remove_homebrew_rpaths() {
+    local binary_path=$1
+    while IFS= read -r rpath; do
+        if [[ $rpath == "$BREW_PREFIX/"* ]]; then
+            install_name_tool -delete_rpath "$rpath" "$binary_path"
+        fi
+    done < <(otool -l "$binary_path" | awk '/LC_RPATH/{getline; getline; print $2}')
+}
+
+while IFS= read -r file_path; do
+    if file "$file_path" | grep -q "Mach-O"; then
+        remove_homebrew_rpaths "$file_path"
+        codesign --force --sign - "$file_path" >/dev/null 2>&1
+    fi
+done < <(find "$APP_PATH/Contents/Frameworks" "$APP_PATH/Contents/PlugIns" -type f)
+remove_homebrew_rpaths "$APP_BINARY"
+codesign --force --sign - "$APP_BINARY" >/dev/null 2>&1
+codesign --force --sign - "$APP_PATH" >/dev/null 2>&1
+
+echo "Checking packaged binary"
+"$APP_BINARY" help >/dev/null
+codesign --verify --deep --strict "$APP_PATH"
 
 echo "Compressing application"
-cd "$BASE_PATH"
-zip -r "COLMAP-mac.zip" "COLMAP.app"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ARCHIVE_PATH"


### PR DESCRIPTION
## Summary

- package the arm64 macOS build as a self-contained `COLMAP.app` archive
- upload the archive as the `colmap-arm64-macos` CI artifact
- remove Homebrew rpaths, ad-hoc sign deployed binaries, and preserve bundle metadata and symlinks
- smoke-test the packaged CLI and verify the completed bundle signature before upload
- link the macOS binary package from the documentation landing-page install selector

## Testing

- built `COLMAP-mac.zip` locally with `scripts/shell/build_mac_app.sh`
- extracted the archive and ran `colmap help` successfully
- launched the packaged GUI entry point and confirmed it remained running
- verified no Homebrew libraries were loaded from the extracted package
- verified the bundle signature and ZIP integrity
- built the documentation with `PYENV_VERSION=colmap make html`