### PR TITLE
Mitigate vcpkg app-local Windows CI race

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -166,6 +166,7 @@ jobs:
             -DCUDAToolkit_ROOT="${{ steps.cuda-toolkit.outputs.CUDA_PATH }}" `
             -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows-release `
+            -DVCPKG_USE_LEGACY_APPLOCAL=ON `
             -DCMAKE_INSTALL_PREFIX=install `
             -DFETCHCONTENT_FULLY_DISCONNECTED=${{ steps.cache-fetchcontent.outputs.cache-hit == 'true' && 'ON' || 'OFF' }}
           ninja


### PR DESCRIPTION
## Summary

- restore vcpkg's legacy `applocal.ps1` deployment in Windows CI
- avoid intermittent native `z-applocal` sharing violations during parallel linking

vcpkg switched CMake integration to native `z-applocal` by default in [microsoft/vcpkg#52315](https://github.com/microsoft/vcpkg/pull/52315). Its dependency-resolution reads can hard-fail on transient Windows sharing violations, as tracked in [microsoft/vcpkg-tool#2076](https://github.com/microsoft/vcpkg-tool/issues/2076).

COLMAP has hit this in unrelated PR and `main` builds, for example:

- [`essential_matrix_test.exe`](https://github.com/colmap/colmap/actions/runs/29814081707/job/88581314782)
- [`pairing_test.exe`](https://github.com/colmap/colmap/actions/runs/29565671832/job/87837704346)
- [`utils_test.exe` on `main`](https://github.com/colmap/colmap/actions/runs/29765466800/job/88430528943)

`VCPKG_USE_LEGACY_APPLOCAL=ON` is the upstream-provided escape hatch and can be removed once the native implementation handles transient sharing violations safely.

## Test plan

- `git diff --check`
- Windows CI