### PR TITLE
Fix missing gflags::gflags alias for downstream CMake consumers

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -91,6 +91,14 @@ find_package(Git)
 
 find_package(CHOLMOD REQUIRED)
 
+# Ceres and glog expose gflags::gflags in their interface dependencies, but gflags
+# only defines the namespaced target when GFLAGS_USE_TARGET_NAMESPACE is ON. Bridge
+# the gap so consumers can resolve the expected target when only the plain target exists.
+find_package(gflags CONFIG QUIET)
+if(NOT TARGET gflags::gflags AND TARGET gflags)
+    add_library(gflags::gflags ALIAS gflags)
+endif()
+
 # Ceres is found before Glog on purpose. Some distributions (e.g. Fedora) ship a
 # Ceres whose bundled FindGlog.cmake unconditionally calls add_library(glog::glog)
 # in module mode. If we created the glog::glog target first, that call collides

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,38 +32,6 @@ endif()
 
 find_package(colmap REQUIRED)
 
-# On Windows with MSVC, the linker receives bare "gflags.lib" (no path) because
-# CMake's multi-config generators fail to propagate IMPORTED_IMPLIB_<CONFIG>
-# from the gflags imported target to the linker. Both glog::glog and Ceres::ceres
-# reference gflags in their INTERFACE_LINK_LIBRARIES, so replace those references
-# with the absolute path to gflags.lib to bypass CMake target resolution.
-if(MSVC)
-    if(TARGET gflags::gflags_shared)
-        set(_gflags_target gflags::gflags_shared)
-    elseif(TARGET gflags_shared)
-        set(_gflags_target gflags_shared)
-    endif()
-    if(_gflags_target)
-        get_target_property(_gflags_implib ${_gflags_target} IMPORTED_IMPLIB_RELEASE)
-        if(_gflags_implib)
-            if(TARGET glog::glog)
-                get_target_property(_glog_iface glog::glog INTERFACE_LINK_LIBRARIES)
-                string(REPLACE "gflags::gflags" "${_gflags_implib}" _glog_iface_fixed "${_glog_iface}")
-                set_target_properties(glog::glog PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${_glog_iface_fixed}")
-            endif()
-            if(TARGET Ceres::ceres)
-                get_target_property(_ceres_iface Ceres::ceres INTERFACE_LINK_LIBRARIES)
-                string(REPLACE ";gflags;" ";${_gflags_implib};" _ceres_iface_fixed "${_ceres_iface}")
-                set_target_properties(Ceres::ceres PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${_ceres_iface_fixed}")
-            endif()
-        endif()
-    endif()
-    unset(_gflags_target)
-    unset(_gflags_implib)
-endif()
-
 if(CCACHE_ENABLED)
     find_program(CCACHE ccache)
     if(CCACHE)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,6 +32,38 @@ endif()
 
 find_package(colmap REQUIRED)
 
+# On Windows with MSVC, the linker receives bare "gflags.lib" (no path) because
+# CMake's multi-config generators fail to propagate IMPORTED_IMPLIB_<CONFIG>
+# from the gflags imported target to the linker. Both glog::glog and Ceres::ceres
+# reference gflags in their INTERFACE_LINK_LIBRARIES, so replace those references
+# with the absolute path to gflags.lib to bypass CMake target resolution.
+if(MSVC)
+    if(TARGET gflags::gflags_shared)
+        set(_gflags_target gflags::gflags_shared)
+    elseif(TARGET gflags_shared)
+        set(_gflags_target gflags_shared)
+    endif()
+    if(_gflags_target)
+        get_target_property(_gflags_implib ${_gflags_target} IMPORTED_IMPLIB_RELEASE)
+        if(_gflags_implib)
+            if(TARGET glog::glog)
+                get_target_property(_glog_iface glog::glog INTERFACE_LINK_LIBRARIES)
+                string(REPLACE "gflags::gflags" "${_gflags_implib}" _glog_iface_fixed "${_glog_iface}")
+                set_target_properties(glog::glog PROPERTIES
+                    INTERFACE_LINK_LIBRARIES "${_glog_iface_fixed}")
+            endif()
+            if(TARGET Ceres::ceres)
+                get_target_property(_ceres_iface Ceres::ceres INTERFACE_LINK_LIBRARIES)
+                string(REPLACE ";gflags;" ";${_gflags_implib};" _ceres_iface_fixed "${_ceres_iface}")
+                set_target_properties(Ceres::ceres PROPERTIES
+                    INTERFACE_LINK_LIBRARIES "${_ceres_iface_fixed}")
+            endif()
+        endif()
+    endif()
+    unset(_gflags_target)
+    unset(_gflags_implib)
+endif()
+
 if(CCACHE_ENABLED)
     find_program(CCACHE ccache)
     if(CCACHE)


### PR DESCRIPTION
## Description

When consuming COLMAP as a CMake package with:

```cmake
find_package(colmap CONFIG REQUIRED)
target_link_libraries(app PRIVATE colmap::colmap)
```

the downstream project may fail during linking/configuration if the transitive gflags target namespace does not match the one expected by the exported dependencies.

```
LINK : fatal error LNK1181: cannot open input file 'gflags.lib'
```

## Root cause

The exported glog::glog target references gflags::gflags as an interface dependency. However, gflags only defines this namespaced target when `GFLAGS_USE_TARGET_NAMESPACE=ON`; otherwise, it only provides the plain gflags target.

COLMAP relies on the Ceres → glog → gflags dependency chain, so this target namespace mismatch can propagate to downstream consumers linking against `colmap::colmap`.

The current pycolmap CI does not reproduce this issue because it builds with the vcpkg `CMAKE_TOOLCHAIN_FILE`, which keeps the dependency configuration consistent. However, other consumers using the same installed packages without that toolchain file (or using a different packaging setup) may encounter this issue.