### PR TITLE
Fix mypy error on Python 3.10 and cover 3.10 in PR builds

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -35,10 +35,11 @@ jobs:
       FETCHCONTENT_CACHE_VERSION: 1
       FETCHCONTENT_CACHE_DIR: ${{ github.workspace }}/fetchcontent-cache
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.config.deploymentTarget }}
-      # For faster builds in PRs, build only a single Python version. We use
-      # cp312 (the oldest Python supported by the pinned Sphinx used in the docs
-      # job, which reuses this wheel); main builds all versions.
-      PULL_REQUEST_CIBW_BUILD: cp312-{macosx,manylinux,win}*
+      # For faster builds in PRs, build only two Python versions instead of all:
+      # the oldest supported one, so that version-specific breakage does not
+      # reach main, and cp312, the oldest version supported by the pinned Sphinx
+      # used in the docs job, which reuses this wheel.
+      PULL_REQUEST_CIBW_BUILD: cp3{10,12}-{macosx,manylinux,win}*
     steps:
       - name: Free disk space
         if: runner.os == 'Linux' && matrix.config.cudaEnabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ test-command = "pwsh -File {project}/python/ci/test-colmap-windows.ps1"
 # Skip mypy on source files for Python 3.10. There's a bug in numpy's type
 # annotations that was fixed in version 2.3.0, but numpy stopped shipping
 # wheels for Python 3.10 in 2.3.0. This causes mypy to fail.
+# TODO: remove once support for Python 3.10 is dropped after its EOL in
+# October 2026.
 [[tool.cibuildwheel.overrides]]
 select = "cp310-{macosx,manylinux}*"
 test-command = """\

--- a/python/pycolmap/panorama.py
+++ b/python/pycolmap/panorama.py
@@ -24,6 +24,8 @@ if sys.version_info >= (3, 11):
 else:
     # Backport of enum.StrEnum, added in Python 3.11. Members compare equal to
     # their string value and auto() yields the lower-cased member name.
+    # TODO: remove once support for Python 3.10 is dropped after its EOL in
+    # October 2026.
     class StrEnum(str, enum.Enum):
         @staticmethod
         def _generate_next_value_(
@@ -414,6 +416,8 @@ class PanoProcessor:
                     continue
                 # The cast is needed because numpy<2.3, the latest version
                 # supporting Python 3.10, does not infer the array shape.
+                # TODO: remove once support for Python 3.10 is dropped after
+                # its EOL in October 2026.
                 xy = cast(
                     NDArrayNx2,
                     np.array([point2D.xy for point2D in image.points2D]),

--- a/python/pycolmap/panorama.py
+++ b/python/pycolmap/panorama.py
@@ -3,6 +3,7 @@
 import collections
 import enum
 import os
+import sys
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -18,19 +19,35 @@ from . import _core as pycolmap
 logging = pycolmap.logging
 
 
-class Matcher(enum.StrEnum):
+if sys.version_info >= (3, 11):
+    StrEnum = enum.StrEnum
+else:
+    # Backport of enum.StrEnum, added in Python 3.11. Members compare equal to
+    # their string value and auto() yields the lower-cased member name.
+    class StrEnum(str, enum.Enum):
+        @staticmethod
+        def _generate_next_value_(
+            name: str, start: int, count: int, last_values: list
+        ) -> str:
+            return name.lower()
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+
+class Matcher(StrEnum):
     SEQUENTIAL = enum.auto()
     EXHAUSTIVE = enum.auto()
     VOCABTREE = enum.auto()
     SPATIAL = enum.auto()
 
 
-class Mapper(enum.StrEnum):
+class Mapper(StrEnum):
     INCREMENTAL = enum.auto()
     GLOBAL = enum.auto()
 
 
-class PanoRenderType(enum.StrEnum):
+class PanoRenderType(StrEnum):
     PERSPECTIVE_OVERLAPPING = enum.auto()
     PERSPECTIVE_NON_OVERLAPPING = enum.auto()
     # Reconstruct directly on the panoramas with the native EQUIRECTANGULAR
@@ -395,7 +412,12 @@ class PanoProcessor:
                 if num_points2D == 0:
                     old_to_new_point2D[image.image_id] = {}
                     continue
-                xy = np.array([point2D.xy for point2D in image.points2D])
+                # The cast is needed because numpy<2.3, the latest version
+                # supporting Python 3.10, does not infer the array shape.
+                xy = cast(
+                    NDArrayNx2,
+                    np.array([point2D.xy for point2D in image.points2D]),
+                )
                 rays_in_cam: npt.NDArray[np.floating] = np.asarray(
                     self._camera.cam_ray_from_img(image_points=xy)
                 )


### PR DESCRIPTION
Fixes the CI failure in the main branch: https://github.com/colmap/colmap/actions/runs/30466183035/job/91398492572

The EOL of Python 3.10 is still three months to go so we have to live with it for now. 