### PR TITLE
Fix mypy error on Python 3.11 for benchmark scripts

### DIFF
--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -39,7 +39,7 @@ jobs:
       # the oldest supported one, so that version-specific breakage does not
       # reach main, and cp312, the oldest version supported by the pinned Sphinx
       # used in the docs job, which reuses this wheel.
-      PULL_REQUEST_CIBW_BUILD: cp3{10,12}-{macosx,manylinux,win}*
+      PULL_REQUEST_CIBW_BUILD: cp3{10,11,12}-{macosx,manylinux,win}*
     steps:
       - name: Free disk space
         if: runner.os == 'Linux' && matrix.config.cudaEnabled

--- a/.github/workflows/build-pycolmap.yml
+++ b/.github/workflows/build-pycolmap.yml
@@ -39,7 +39,7 @@ jobs:
       # the oldest supported one, so that version-specific breakage does not
       # reach main, and cp312, the oldest version supported by the pinned Sphinx
       # used in the docs job, which reuses this wheel.
-      PULL_REQUEST_CIBW_BUILD: cp3{10,11,12}-{macosx,manylinux,win}*
+      PULL_REQUEST_CIBW_BUILD: cp3{10,12}-{macosx,manylinux,win}*
     steps:
       - name: Free disk space
         if: runner.os == 'Linux' && matrix.config.cudaEnabled

--- a/benchmark/reconstruction/evaluation/tartanair/__init__.py
+++ b/benchmark/reconstruction/evaluation/tartanair/__init__.py
@@ -22,8 +22,10 @@ def tartanair_world_from_camera(
     world_from_ned = pycolmap.Rigid3d(
         pycolmap.Rotation3d(quaternion_xyzw), translation[:, np.newaxis]
     )
+    # The translation defaults to zero. Passing np.zeros((3, 1)) explicitly
+    # fails mypy with numpy 2.4, the latest version available on Python 3.11.
     ned_from_colmap = pycolmap.Rigid3d(
-        pycolmap.Rotation3d(NED_FROM_COLMAP), np.zeros((3, 1))
+        rotation=pycolmap.Rotation3d(NED_FROM_COLMAP)
     )
     return world_from_ned * ned_from_colmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ wheel.packages = ["python/pycolmap"]
 [tool.cibuildwheel]
 build = "cp3{10,11,12,13,14}-{macosx,manylinux,win}*"
 archs = ["auto64"]
-test-requires = "pytest>=8.0 mypy==2.1.0 enlighten==1.14.1"
+# pillow and requests are imported by the TartanAir packaging script, whose
+# tests are otherwise silently skipped.
+test-requires = "pytest>=8.0 mypy==2.1.0 enlighten==1.14.1 pillow requests"
 test-command = """\
     python -c "import pycolmap; print(pycolmap.__version__)" && \
     cd {project} && \


### PR DESCRIPTION
There are missing mypy issues for py311 on benchmarking scripts as well, on which py310 was skipped: https://github.com/colmap/colmap/actions/runs/30723480336/job/91430968247

My suggestion is that we treat this as a one-time fix without covering py311 in PR builds, as the time overhead is unnecessary. We anyway will switch from py310 to py311 in three months. 