### PR TITLE
Seed unit tests deterministically by default

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction_test.cc
+++ b/src/colmap/controllers/automatic_reconstruction_test.cc
@@ -45,8 +45,6 @@ class ParameterizedAutomaticReconstructionTests
           AutomaticReconstructionController::Mapper> {};
 
 TEST_P(ParameterizedAutomaticReconstructionTests, Nominal) {
-  SetPRNGSeed(1);
-
   const auto test_dir = CreateTestDir();
   const auto workspace_path = test_dir / "workspace";
   const auto image_path = test_dir / "images";

--- a/src/colmap/controllers/bundle_adjustment_test.cc
+++ b/src/colmap/controllers/bundle_adjustment_test.cc
@@ -40,8 +40,6 @@ namespace colmap {
 namespace {
 
 TEST(BundleAdjustmentController, EmptyReconstruction) {
-  SetPRNGSeed(1);
-
   auto reconstruction = std::make_shared<Reconstruction>();
 
   OptionManager options;
@@ -53,8 +51,6 @@ TEST(BundleAdjustmentController, EmptyReconstruction) {
 }
 
 TEST(BundleAdjustmentController, Reconstruction) {
-  SetPRNGSeed(1);
-
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_options;
   synthetic_options.num_rigs = 1;

--- a/src/colmap/controllers/global_pipeline_test.cc
+++ b/src/colmap/controllers/global_pipeline_test.cc
@@ -82,8 +82,6 @@ TEST(GlobalPipeline, Nominal) {
 }
 
 TEST(GlobalPipeline, SfMWithRandomSeedStability) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -174,7 +172,6 @@ TEST(GlobalPipeline, WithExistingRelativePoses) {
 
 // To test relative pose re-estimation from view graph calibration.
 TEST(GlobalPipeline, WithNoisyExistingRelativePoses) {
-  SetPRNGSeed(1);
   const auto database_path = CreateTestDir() / "database.db";
   auto database = Database::Open(database_path);
   Reconstruction gt_reconstruction;

--- a/src/colmap/controllers/hierarchical_pipeline_test.cc
+++ b/src/colmap/controllers/hierarchical_pipeline_test.cc
@@ -66,8 +66,6 @@ void ExpectEqualReconstructions(const Reconstruction& gt,
 }
 
 TEST(HierarchicalPipeline, WithoutNoise) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -105,8 +103,6 @@ TEST(HierarchicalPipeline, WithoutNoise) {
 }
 
 TEST(HierarchicalPipeline, WithoutNoiseAndNonTrivialFrames) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -141,8 +137,6 @@ TEST(HierarchicalPipeline, WithoutNoiseAndNonTrivialFrames) {
 }
 
 TEST(HierarchicalPipeline, WithoutNoiseAndPanoramicNonTrivialFrames) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -177,8 +171,6 @@ TEST(HierarchicalPipeline, WithoutNoiseAndPanoramicNonTrivialFrames) {
 }
 
 TEST(HierarchicalPipeline, MultiReconstruction) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -451,6 +451,9 @@ TEST(IncrementalPipeline, FixExistingFrames) {
 }
 
 TEST(IncrementalPipeline, ChainedMatches) {
+  constexpr int kRandomSeed = 42;
+  SetPRNGSeed(kRandomSeed);
+
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -466,9 +469,10 @@ TEST(IncrementalPipeline, ChainedMatches) {
       synthetic_dataset_options, &gt_reconstruction, database.get());
 
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  IncrementalPipeline mapper(std::make_shared<IncrementalPipelineOptions>(),
-                             database,
-                             reconstruction_manager);
+  auto options = std::make_shared<IncrementalPipelineOptions>();
+  options->num_threads = 1;
+  options->random_seed = kRandomSeed;
+  IncrementalPipeline mapper(options, database, reconstruction_manager);
   mapper.Run();
 
   ASSERT_EQ(reconstruction_manager->Size(), 1);

--- a/src/colmap/controllers/incremental_pipeline_test.cc
+++ b/src/colmap/controllers/incremental_pipeline_test.cc
@@ -70,7 +70,6 @@ TEST(IncrementalPipeline, WithoutNoise) {
 }
 
 TEST(IncrementalPipeline, WithoutNoiseSphericalCameras) {
-  SetPRNGSeed(0);
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -451,9 +450,6 @@ TEST(IncrementalPipeline, FixExistingFrames) {
 }
 
 TEST(IncrementalPipeline, ChainedMatches) {
-  constexpr int kRandomSeed = 42;
-  SetPRNGSeed(kRandomSeed);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -471,7 +467,6 @@ TEST(IncrementalPipeline, ChainedMatches) {
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
   auto options = std::make_shared<IncrementalPipelineOptions>();
   options->num_threads = 1;
-  options->random_seed = kRandomSeed;
   IncrementalPipeline mapper(options, database, reconstruction_manager);
   mapper.Run();
 
@@ -650,8 +645,6 @@ TEST(IncrementalPipeline, GPSPriorBasedSfMWithNoise) {
 }
 
 TEST(IncrementalPipeline, SfMWithRandomSeedStability) {
-  SetPRNGSeed(42);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -692,8 +685,6 @@ TEST(IncrementalPipeline, SfMWithRandomSeedStability) {
 }
 
 TEST(IncrementalPipeline, PriorBasedSfMWithRandomSeedStability) {
-  SetPRNGSeed(42);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/controllers/reconstruction_clustering_test.cc
+++ b/src/colmap/controllers/reconstruction_clustering_test.cc
@@ -121,8 +121,6 @@ void CreateTwoWeaklyConnectedClusters(Reconstruction* reconstruction,
 }
 
 TEST(ReconstructionClustererController, EmptyReconstruction) {
-  SetPRNGSeed(1);
-
   auto reconstruction = std::make_shared<Reconstruction>();
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
 
@@ -136,8 +134,6 @@ TEST(ReconstructionClustererController, EmptyReconstruction) {
 }
 
 TEST(ReconstructionClustererController, SingleCluster) {
-  SetPRNGSeed(1);
-
   auto reconstruction = std::make_shared<Reconstruction>();
 
   // Create a synthetic dataset with well-connected frames
@@ -167,8 +163,6 @@ TEST(ReconstructionClustererController, SingleCluster) {
 }
 
 TEST(ReconstructionClustererController, SingleClusterWithOutlierFrames) {
-  SetPRNGSeed(42);
-
   auto reconstruction = std::make_shared<Reconstruction>();
 
   // Create a well-connected reconstruction with more frames
@@ -235,8 +229,6 @@ TEST(ReconstructionClustererController, SingleClusterWithOutlierFrames) {
 }
 
 TEST(ReconstructionClustererController, MinNumRegFramesFilter) {
-  SetPRNGSeed(1);
-
   auto reconstruction = std::make_shared<Reconstruction>();
 
   // Create a small synthetic dataset
@@ -261,8 +253,6 @@ TEST(ReconstructionClustererController, MinNumRegFramesFilter) {
 }
 
 TEST(ReconstructionClustererController, TwoWeaklyConnectedClusters) {
-  SetPRNGSeed(42);
-
   auto reconstruction = std::make_shared<Reconstruction>();
 
   // Create a reconstruction with two clusters connected by only 10 weak links

--- a/src/colmap/controllers/rotation_averaging_test.cc
+++ b/src/colmap/controllers/rotation_averaging_test.cc
@@ -60,8 +60,6 @@ void ExpectEqualRotations(const Reconstruction& gt,
 }
 
 TEST(RotationAveragingPipeline, WithoutNoise) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -86,8 +84,6 @@ TEST(RotationAveragingPipeline, WithoutNoise) {
 }
 
 TEST(RotationAveragingPipeline, WithNoiseAndOutliers) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -127,8 +123,6 @@ void ExpectExactEqualRotations(const Reconstruction& reconstruction1,
 }
 
 TEST(RotationAveragingPipeline, WithRandomSeedStability) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/estimators/bundle_adjustment_caspar_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar_test.cc
@@ -107,7 +107,6 @@ namespace colmap {
 namespace {
 
 TEST(DefaultBundleAdjuster, Nominal) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -146,7 +145,6 @@ TEST(DefaultBundleAdjuster, Nominal) {
 }
 
 TEST(DefaultBundleAdjuster, RigThrowsErrorOnVariableSensorFromRig) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -169,7 +167,6 @@ TEST(DefaultBundleAdjuster, NominalMultiCameraRigConstantSensorFromRig) {
   // Exercises the sensor_from_rig code path: 2 cameras per rig, one of which
   // has a non-identity sensor_from_rig. Verifies that Caspar converges to the
   // ground truth when sensor_from_rig is held constant.
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -213,7 +210,6 @@ TEST(DefaultBundleAdjuster, MultiCameraRigLargeConstantSensorFromRig) {
   // sensor_from_rig offsets — typically 20–90 degrees and 0.1–1 m baseline.
   // This test uses a 30-degree Z-rotation and 0.3 m translation to exercise
   // the non-identity sensor_from_rig path with realistic values.
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -592,7 +588,6 @@ TEST(DefaultBundleAdjuster, VariablePrincipalPoint) {
 }
 
 TEST(DefaultBundleAdjuster, MergedCalibConvergence) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -889,7 +884,6 @@ TEST(DefaultBundleAdjuster, MultipleExternalImagesAreInvariant) {
 }
 
 TEST(DefaultBundleAdjuster, MergedCalibMatchesCeres) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -962,7 +956,6 @@ bool PoseExactlyUnchanged(const Image& a, const Image& b) {
 }
 
 TEST(DefaultBundleAdjuster, GaugeFixingWithOneFrameFromWorld) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions opts;
   opts.num_rigs = 2;
@@ -1000,7 +993,6 @@ TEST(DefaultBundleAdjuster, GaugeFixingWithOneFrameFromWorld) {
 
 TEST(DefaultBundleAdjuster,
      GaugeFixingWithOneFrameFromWorld_SkipsWhenAlreadyFixed) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions opts;
   opts.num_rigs = 2;
@@ -1038,7 +1030,6 @@ TEST(DefaultBundleAdjuster,
 }
 
 TEST(DefaultBundleAdjuster, GaugeFixingWithThreePoints_PinsExactlyThreePoints) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions opts;
   opts.num_rigs = 2;
@@ -1079,7 +1070,6 @@ TEST(DefaultBundleAdjuster, GaugeFixingWithThreePoints_PinsExactlyThreePoints) {
 
 TEST(DefaultBundleAdjuster,
      GaugeFixingWithThreePoints_CountsExistingConstantPoints) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions opts;
   opts.num_rigs = 2;
@@ -1123,7 +1113,6 @@ TEST(DefaultBundleAdjuster, MultiCameraRigResidualCountConstantSensorFromRig) {
   // All sensor observations (ref and non-ref) must contribute residuals.
   // The old code skipped non-ref sensor observations when the pose was
   // variable, which would halve the residual count for a 2-camera rig.
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -1159,7 +1148,6 @@ TEST(DefaultBundleAdjuster, MultiCameraRigConstantRigPoseHoldsAllSensors) {
   // must have invariant cam_from_world. Sensors in the variable frame must
   // change. This differs from the Ceres behaviour where non-ref sensors can
   // still move via a variable sensor_from_rig.
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -1204,7 +1192,6 @@ TEST(DefaultBundleAdjuster,
   // 2 rigs × 3 cameras × 5 frames = 30 images. Mirrors the Ceres
   // NominalMultiCameraRig test to verify Caspar converges to GT at the same
   // scale as the single-camera nominal test.
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;

--- a/src/colmap/estimators/bundle_adjustment_ceres_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres_test.cc
@@ -122,7 +122,6 @@ inline const ceres::Solver::Summary& GetCeresSummary(
 }
 
 TEST(DefaultBundleAdjuster, Nominal) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -162,7 +161,6 @@ TEST(DefaultBundleAdjuster, Nominal) {
 }
 
 TEST(DefaultBundleAdjuster, NominalMultiCameraRig) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
@@ -1441,7 +1439,6 @@ TEST(DefaultBundleAdjuster, IgnorePoint) {
 }
 
 TEST(PosePriorBundleAdjuster, AlignmentRobustToOutliers) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_options;
   synthetic_options.num_rigs = 1;
@@ -1528,7 +1525,6 @@ TEST(PosePriorBundleAdjuster, InsufficientPriorsUseTwoCameraGauge) {
 }
 
 TEST(PosePriorBundleAdjuster, MissingPositionCov) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_options;
   synthetic_options.num_rigs = 1;
@@ -1576,7 +1572,6 @@ TEST(PosePriorBundleAdjuster, MissingPositionCov) {
 }
 
 TEST(PosePriorBundleAdjuster, OptimizationRobustToOutliers) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_options;
   synthetic_options.num_rigs = 1;

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -301,7 +301,6 @@ class BundleAdjusterBackendTest
     : public ::testing::TestWithParam<BundleAdjustmentBackend> {};
 
 TEST_P(BundleAdjusterBackendTest, Nominal) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -358,7 +357,6 @@ class PosePriorBundleAdjusterBackendTest
     : public ::testing::TestWithParam<BundleAdjustmentBackend> {};
 
 TEST_P(PosePriorBundleAdjusterBackendTest, Nominal) {
-  SetPRNGSeed(0);
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;

--- a/src/colmap/estimators/coordinate_frame_test.cc
+++ b/src/colmap/estimators/coordinate_frame_test.cc
@@ -223,8 +223,6 @@ void RenderLineImages(Reconstruction& reconstruction,
 }
 
 TEST(EstimateManhattanWorldFrame, Synthetic) {
-  SetPRNGSeed(0);
-
   const auto scene = CreateManhattanScene();
   const auto test_dir = CreateTestDir();
 

--- a/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
+++ b/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
@@ -41,7 +41,6 @@ namespace colmap {
 namespace {
 
 TEST(QuaternionLeftMultMatrix, Nominal) {
-  SetPRNGSeed(42);
   constexpr double kEps = 1e-7;
 
   for (int i = 0; i < 100; ++i) {
@@ -73,7 +72,6 @@ TEST(QuaternionLeftMultMatrix, Nominal) {
 }
 
 TEST(QuaternionRightMultMatrix, Nominal) {
-  SetPRNGSeed(42);
   constexpr double kEps = 1e-7;
 
   for (int i = 0; i < 100; ++i) {
@@ -105,7 +103,6 @@ TEST(QuaternionRightMultMatrix, Nominal) {
 }
 
 TEST(QuaternionRotatePointWithJac, Nominal) {
-  SetPRNGSeed(42);
   constexpr double kEps = 1e-7;
 
   for (int i = 0; i < 100; ++i) {
@@ -136,7 +133,6 @@ TEST(QuaternionRotatePointWithJac, Nominal) {
 }
 
 TEST(EigenQuaternionAngleAxis, Roundtrip) {
-  SetPRNGSeed(42);
   for (int i = 0; i < 100; ++i) {
     const Eigen::Quaterniond q = RandomEigenQuaterniond();
     const double q_arr[4] = {q.x(), q.y(), q.z(), q.w()};

--- a/src/colmap/estimators/cost_functions/reprojection_error_test.cc
+++ b/src/colmap/estimators/cost_functions/reprojection_error_test.cc
@@ -97,7 +97,6 @@ ceres::GradientChecker MakeGradientChecker(
 template <typename CameraModel>
 void TestAnalyticalReprojError(const std::vector<double>& camera_params) {
   SetPRNGSeed(42);
-
   constexpr double kJacEps = 1e-4;
   constexpr double kResEps = 1e-9;
 
@@ -157,7 +156,6 @@ template <typename CameraModel>
 void TestAnalyticalReprojErrorConstantPose(
     const std::vector<double>& camera_params) {
   SetPRNGSeed(42);
-
   constexpr double kJacEps = 1e-4;
   constexpr double kResEps = 1e-9;
 

--- a/src/colmap/estimators/covariance_test.cc
+++ b/src/colmap/estimators/covariance_test.cc
@@ -63,8 +63,6 @@ class ParameterizedBACovarianceTests
           std::pair<BACovarianceOptions, BACovarianceTestOptions>> {};
 
 TEST_P(ParameterizedBACovarianceTests, CompareWithCeres) {
-  SetPRNGSeed(42);
-
   const auto [options, test_options] = GetParam();
 
   const bool estimate_point_covs =

--- a/src/colmap/estimators/fundamental_matrix_degensac_test.cc
+++ b/src/colmap/estimators/fundamental_matrix_degensac_test.cc
@@ -124,7 +124,6 @@ RANSACOptions TestRANSACOptions() {
 }
 
 TEST(EpipoleFromFundamentalMatrix, Nominal) {
-  SetPRNGSeed(0);
   for (int k = 0; k < 20; ++k) {
     const Eigen::Matrix3d K = RandomCalibrationMatrix();
     const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
@@ -138,7 +137,6 @@ TEST(EpipoleFromFundamentalMatrix, Nominal) {
 }
 
 TEST(HomographyFromFundamentalAndPoints, Nominal) {
-  SetPRNGSeed(0);
   const Eigen::Matrix3d K = RandomCalibrationMatrix();
   const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                RandomEigenVectord<3>());
@@ -177,7 +175,6 @@ TEST(HomographyFromFundamentalAndPoints, Nominal) {
 }
 
 TEST(HomographyFromFundamentalAndPoints, CollinearReturnsNullopt) {
-  SetPRNGSeed(0);
   const Eigen::Matrix3d K = RandomCalibrationMatrix();
   const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                RandomEigenVectord<3>());
@@ -200,7 +197,6 @@ TEST(HomographyFromFundamentalAndPoints, CollinearReturnsNullopt) {
 }
 
 TEST(IsSampleHDegenerate, DetectsAndRejects) {
-  SetPRNGSeed(0);
   const Eigen::Matrix3d K = RandomCalibrationMatrix();
   const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                RandomEigenVectord<3>());
@@ -256,7 +252,6 @@ TEST(IsSampleHDegenerate, DetectsAndRejects) {
 // On a general non-planar scene, DEGENSAC recovers the fundamental matrix as
 // well as the plain LO-RANSAC estimator.
 TEST(FundamentalMatrixDegensac, NonPlanarParity) {
-  SetPRNGSeed(0);
   const Eigen::Matrix3d K = RandomCalibrationMatrix();
   const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                RandomEigenVectord<3>());
@@ -294,7 +289,6 @@ TEST(FundamentalMatrixDegensac, NonPlanarParity) {
 // correct fundamental matrix via plane-and-parallax completion, explaining the
 // off-plane points well.
 TEST(FundamentalMatrixDegensac, RecoversFOnDominantPlane) {
-  SetPRNGSeed(0);
   const Eigen::Matrix3d K = RandomCalibrationMatrix();
   const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                RandomEigenVectord<3>().normalized());

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -411,7 +411,7 @@ TEST(EstimateGeneralizedRelativePose, Nominal) {
           EXPECT_THAT(
               *rig2_from_rig1,
               Rigid3dNear(
-                  problem.gt_rig2_from_rig1, /*rtol=*/1e-3, /*ttol=*/1e-3));
+                  problem.gt_rig2_from_rig1, /*rtol=*/1e-3, /*ttol=*/2e-3));
         }
       }
     }

--- a/src/colmap/estimators/generalized_pose_test.cc
+++ b/src/colmap/estimators/generalized_pose_test.cc
@@ -89,8 +89,6 @@ GeneralizedAbsolutePoseProblem BuildGeneralizedAbsolutePoseProblem() {
 }
 
 TEST(EstimateGeneralizedAbsolutePose, Nominal) {
-  SetPRNGSeed();
-
   GeneralizedAbsolutePoseProblem problem =
       BuildGeneralizedAbsolutePoseProblem();
   const size_t num_points = problem.points2D.size();
@@ -364,11 +362,11 @@ GeneralizedRelativePoseProblem BuildGeneralizedRelativePoseProblem(
 }
 
 TEST(EstimateGeneralizedRelativePose, Nominal) {
-  SetPRNGSeed(1);
-
   for (const int num_cameras_per_rig1 : {1, 2, 3}) {
     for (const int num_cameras_per_rig2 : {1, 2, 3}) {
-      for (const double sensor_from_rig_translation_stddev : {0.0, 0.05}) {
+      // A meaningful inter-camera baseline is needed to recover metric scale
+      // reliably in non-panoramic configurations.
+      for (const double sensor_from_rig_translation_stddev : {0.0, 0.2}) {
         GeneralizedRelativePoseProblem problem =
             BuildGeneralizedRelativePoseProblem(
                 num_cameras_per_rig1,
@@ -501,8 +499,6 @@ StructureLessAbsolutePoseProblem BuildStructureLessAbsolutePoseProblem(
 }
 
 TEST(EstimateStructureLessAbsolutePose, Nominal) {
-  SetPRNGSeed();
-
   const StructureLessAbsolutePoseProblem problem =
       BuildStructureLessAbsolutePoseProblem(/*num_world_cams=*/5);
 
@@ -528,8 +524,6 @@ TEST(EstimateStructureLessAbsolutePose, Nominal) {
 }
 
 TEST(EstimateStructureLessAbsolutePose, WithOutliers) {
-  SetPRNGSeed();
-
   StructureLessAbsolutePoseProblem problem =
       BuildStructureLessAbsolutePoseProblem(/*num_world_cams=*/10);
 
@@ -567,8 +561,6 @@ TEST(EstimateStructureLessAbsolutePose, WithOutliers) {
 }
 
 TEST(EstimateStructureLessAbsolutePose, PanoramicWorldCameras) {
-  SetPRNGSeed();
-
   const StructureLessAbsolutePoseProblem problem =
       BuildStructureLessAbsolutePoseProblem(/*num_world_cams=*/1);
 

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -45,8 +45,6 @@ namespace colmap {
 namespace {
 
 TEST(GlobalPositioning, Nominal) {
-  SetPRNGSeed(0);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -93,8 +91,6 @@ TEST(GlobalPositioning, Nominal) {
 }
 
 TEST(GlobalPositioning, MultiCameraRig) {
-  SetPRNGSeed(0);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -141,8 +137,6 @@ TEST(GlobalPositioning, MultiCameraRig) {
 }
 
 TEST(GlobalPositioning, RefineSensorFromRigFalsePreservesRig) {
-  SetPRNGSeed(0);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/estimators/gravity_refinement_test.cc
+++ b/src/colmap/estimators/gravity_refinement_test.cc
@@ -90,8 +90,6 @@ void ExpectEqualGravity(const Eigen::Vector3d& gravity_in_world,
 }
 
 TEST(GravityRefinement, RefineGravity) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -124,8 +122,6 @@ TEST(GravityRefinement, RefineGravity) {
 }
 
 TEST(GravityRefinement, RefineGravityWithNonTrivialRigs) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -161,8 +161,6 @@ void RunAndVerifyRotationAveraging(const Reconstruction& gt_reconstruction,
 }
 
 TEST(RotationAveraging, WithoutNoise) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -182,8 +180,6 @@ TEST(RotationAveraging, WithoutNoise) {
 }
 
 TEST(RotationAveraging, WeightedNoiseFreeMatchesInvariant) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -235,8 +231,6 @@ TEST(RotationAveraging, WeightedNoiseFreeMatchesInvariant) {
 }
 
 TEST(RotationAveraging, WeightedReducesErrorWithNoisyLowMatchEdges) {
-  SetPRNGSeed(42);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -293,8 +287,6 @@ TEST(RotationAveraging, WeightedReducesErrorWithNoisyLowMatchEdges) {
 }
 
 TEST(RotationAveraging, WithoutNoiseWithNonTrivialKnownRig) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -314,8 +306,6 @@ TEST(RotationAveraging, WithoutNoiseWithNonTrivialKnownRig) {
 }
 
 TEST(RotationAveraging, WithoutNoiseWithNonTrivialUnknownRig) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -338,8 +328,6 @@ TEST(RotationAveraging, WithoutNoiseWithNonTrivialUnknownRig) {
 }
 
 TEST(RotationAveraging, WithNoiseAndOutliers) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -363,8 +351,6 @@ TEST(RotationAveraging, WithNoiseAndOutliers) {
 }
 
 TEST(RotationAveraging, WithNoiseAndOutliersWithNonTrivialKnownRigs) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -388,8 +374,6 @@ TEST(RotationAveraging, WithNoiseAndOutliersWithNonTrivialKnownRigs) {
 }
 
 TEST(RotationAveraging, DeterministicRandomSeed) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -426,8 +410,6 @@ TEST(RotationAveraging, DeterministicRandomSeed) {
 }
 
 TEST(RotationAveraging, RidgeRegularizationDoesNotBiasSolution) {
-  SetPRNGSeed(1);
-
   // Use a noisy multi-rig setup to make the solution non-trivial and the
   // regularization's effect non-degenerate.
   SyntheticDatasetOptions synthetic_dataset_options;
@@ -470,8 +452,6 @@ TEST(RotationAveraging, RidgeRegularizationDoesNotBiasSolution) {
 }
 
 TEST(RotationAveraging, EmptyPoseGraph) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -491,8 +471,6 @@ TEST(RotationAveraging, EmptyPoseGraph) {
 }
 
 TEST(RotationAveraging, MultiImageRigFrameDeregisterDoesNotCrashOnSecondVisit) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -557,8 +535,6 @@ TEST(RotationAveraging, MultiImageRigFrameDeregisterDoesNotCrashOnSecondVisit) {
 }
 
 TEST(RotationAveraging, GravityWithUnknownRigSensorsReturnsFalse) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -595,8 +571,6 @@ TEST(RotationAveraging, GravityWithUnknownRigSensorsReturnsFalse) {
 // multi-camera rig to exercise cam_from_rig estimation and rig_from_world
 // averaging.
 TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -634,8 +608,6 @@ TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
 // translation), InitializeRigRotationsFromImages must preserve it rather than
 // resetting the translation to NaN.
 TEST(RotationAveraging, InitializeSensorFromRigPreservesCalibratedRig) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -677,8 +649,6 @@ TEST(RotationAveraging, InitializeSensorFromRigPreservesCalibratedRig) {
 }
 
 TEST(RotationAveraging, RefineSensorFromRigFalsePreservesRig) {
-  SetPRNGSeed(1);
-
   // A non-trivial multi-camera rig so both rotation AND translation are
   // non-zero
   SyntheticDatasetOptions synthetic_dataset_options;

--- a/src/colmap/estimators/solvers/affine_transform_test.cc
+++ b/src/colmap/estimators/solvers/affine_transform_test.cc
@@ -96,8 +96,6 @@ TEST(Affine2d, EstimateNonMinimalDegenerate) {
 }
 
 TEST(Affine2d, EstimateRobust) {
-  SetPRNGSeed(0);
-
   const size_t num_inliers = 1000;
   const size_t num_outliers = 400;
 

--- a/src/colmap/estimators/solvers/essential_matrix_test.cc
+++ b/src/colmap/estimators/solvers/essential_matrix_test.cc
@@ -113,7 +113,6 @@ class EssentialMatrixFivePointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixFivePointEstimatorTests, Nominal) {
-  SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   // The minimal case has no redundancy, so it conditions its sample to stay
   // well-posed and accepts the solver's numerical accuracy with a looser
@@ -152,7 +151,6 @@ class EssentialMatrixEightPointEstimatorTests
     : public ::testing::TestWithParam<size_t> {};
 
 TEST_P(EssentialMatrixEightPointEstimatorTests, Nominal) {
-  SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 1; ++k) {
     const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
@@ -180,7 +178,6 @@ class EssentialMatrixLMEstimatorTests
 // Self-seeding (eight-point) refinement recovers the essential matrix on clean
 // correspondences.
 TEST_P(EssentialMatrixLMEstimatorTests, Nominal) {
-  SetPRNGSeed(0);
   const size_t kNumRays = GetParam();
   for (size_t k = 0; k < 10; ++k) {
     const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
@@ -205,7 +202,6 @@ INSTANTIATE_TEST_SUITE_P(EssentialMatrixLMEstimator,
 
 // Refinement recovers the ground truth from a perturbed initial model.
 TEST(EssentialMatrixLMEstimator, RefineFromInitialModel) {
-  SetPRNGSeed(0);
   for (size_t k = 0; k < 100; ++k) {
     const Rigid3d cam2_from_cam1(RandomEigenQuaterniond(),
                                  RandomEigenVectord<3>());

--- a/src/colmap/estimators/solvers/generalized_relative_pose_test.cc
+++ b/src/colmap/estimators/solvers/generalized_relative_pose_test.cc
@@ -119,8 +119,6 @@ class ParameterizedGRNPEstimatorTests
                                                  /*panoramic2=*/bool>> {};
 
 TEST_P(ParameterizedGRNPEstimatorTests, GR6P) {
-  SetPRNGSeed(1);
-
   // Note that we can estimate the minimal problem from only 6 points but we
   // use an additional points to choose the correct solution.
   constexpr int kNumPoints = GR6PEstimator::kMinNumSamples + 1;
@@ -152,8 +150,6 @@ TEST_P(ParameterizedGRNPEstimatorTests, GR6P) {
 }
 
 TEST_P(ParameterizedGRNPEstimatorTests, GR8P) {
-  SetPRNGSeed(1);
-
   // Note that we can estimate the minimal problem from only 8 points but we
   // use the additional points to choose the correct solution.
   // The GR8P estimator is numerically much more sensitive than the GR6P

--- a/src/colmap/estimators/solvers/generalized_relative_pose_test.cc
+++ b/src/colmap/estimators/solvers/generalized_relative_pose_test.cc
@@ -133,6 +133,8 @@ class ParameterizedGRNPEstimatorTests
                                                  /*panoramic2=*/bool>> {};
 
 TEST_P(ParameterizedGRNPEstimatorTests, GR6P) {
+  SetPRNGSeed(1);
+
   // Note that we can estimate the minimal problem from only 6 points but we
   // use an additional points to choose the correct solution.
   constexpr int kNumPoints = GR6PEstimator::kMinNumSamples + 1;
@@ -165,6 +167,8 @@ TEST_P(ParameterizedGRNPEstimatorTests, GR6P) {
 }
 
 TEST_P(ParameterizedGRNPEstimatorTests, GR8P) {
+  SetPRNGSeed(1);
+
   // Note that we can estimate the minimal problem from only 8 points but we
   // use the additional points to choose the correct solution.
   // The GR8P estimator is numerically much more sensitive than the GR6P

--- a/src/colmap/estimators/solvers/relpose_one_sided_focal_test.cc
+++ b/src/colmap/estimators/solvers/relpose_one_sided_focal_test.cc
@@ -146,7 +146,6 @@ bool HasValidModel(const std::vector<Eigen::Vector2d>& points1,
 // The minimal 6-point solver recovers the pose and the unknown focal on clean
 // samples.
 TEST(RelativePoseOneSidedFocalEstimator, Nominal) {
-  SetPRNGSeed(0);
   for (size_t k = 0; k < 100; ++k) {
     const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
     const Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
@@ -179,7 +178,6 @@ TEST(RelativePoseOneSidedFocalEstimator, Nominal) {
 // checks pin the residual's units rather than the formula; the formula is
 // pinned by the exact correspondences, which come from projected 3D points.
 TEST(RelativePoseOneSidedFocalEstimator, Residuals) {
-  SetPRNGSeed(0);
   const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
   std::vector<Eigen::Vector2d> points1;
   std::vector<Eigen::Vector3d> cam_rays2;
@@ -235,7 +233,6 @@ TEST(RelativePoseOneSidedFocalEstimator, Residuals) {
 
 // Refinement pulls a perturbed pose + focal back to the ground truth.
 TEST(RelativePoseOneSidedFocalEstimator, RefineFromInitialModel) {
-  SetPRNGSeed(0);
   for (size_t k = 0; k < 50; ++k) {
     const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
     const Eigen::Matrix3d expected_E = EssentialMatrixFromPose(cam2_from_cam1);
@@ -279,7 +276,6 @@ TEST(RelativePoseOneSidedFocalEstimator, RefineFromInitialModel) {
 // beyond 180 degrees observes and which no pinhole image plane can represent,
 // must be usable correspondences.
 TEST(RelativePoseOneSidedFocalEstimator, FullSphereCalibratedRays) {
-  SetPRNGSeed(0);
   // Without the cheirality filter the configurations are harsher than any
   // pinhole pair, and the minimal solve occasionally loses the true root. Never
   // exceeded 2% over 199 measured runs; a real regression exceeds it at once.

--- a/src/colmap/estimators/solvers/relpose_shared_focal_test.cc
+++ b/src/colmap/estimators/solvers/relpose_shared_focal_test.cc
@@ -161,7 +161,6 @@ constexpr double kMaxFailureRate = 0.03;
 
 // The minimal 6-point solver recovers the pose and focal on clean samples.
 TEST(RelativePoseSharedFocalEstimator, Nominal) {
-  SetPRNGSeed(0);
   const double kFocal = 1000.0;
   size_t num_failures = 0;
   for (size_t k = 0; k < kNumTrials; ++k) {
@@ -190,7 +189,6 @@ TEST(RelativePoseSharedFocalEstimator, Nominal) {
 // Residuals are near-zero on exact points, grow with a wrong focal, and are
 // infinite for a non-positive focal.
 TEST(RelativePoseSharedFocalEstimator, Residuals) {
-  SetPRNGSeed(0);
   const double kFocal = 1000.0;
   const Rigid3d cam2_from_cam1 = TestCam2FromCam1();
   std::vector<Eigen::Vector2d> points1;
@@ -237,7 +235,6 @@ TEST(RelativePoseSharedFocalEstimator, Residuals) {
 
 // Refinement pulls a perturbed pose + focal back to the ground truth.
 TEST(RelativePoseSharedFocalEstimator, RefineFromInitialModel) {
-  SetPRNGSeed(0);
   const double kFocal = 1000.0;
   for (size_t k = 0; k < 50; ++k) {
     const Rigid3d cam2_from_cam1 = TestCam2FromCam1();

--- a/src/colmap/estimators/solvers/similarity_transform_test.cc
+++ b/src/colmap/estimators/solvers/similarity_transform_test.cc
@@ -102,8 +102,6 @@ TEST(Rigid3d, EstimateNonMinimalDegenerate) {
 }
 
 TEST(Rigid3d, EstimateRobust) {
-  SetPRNGSeed(0);
-
   const size_t num_inliers = 1000;
   const size_t num_outliers = 400;
 
@@ -174,8 +172,6 @@ TEST(Sim3d, EstimateNonMinimalDegenerate) {
 }
 
 TEST(Sim3d, EstimateRobust) {
-  SetPRNGSeed(0);
-
   const size_t num_inliers = 1000;
   const size_t num_outliers = 400;
 

--- a/src/colmap/estimators/solvers/translation_transform_test.cc
+++ b/src/colmap/estimators/solvers/translation_transform_test.cc
@@ -41,8 +41,6 @@ namespace {
 TEST(TranslationTransform, Estimate) {
   constexpr size_t kNumPoints = 100;
 
-  SetPRNGSeed(0);
-
   std::vector<Eigen::Vector2d> src;
   src.reserve(kNumPoints);
   for (size_t i = 0; i < kNumPoints; ++i) {

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -235,7 +235,6 @@ TEST(EstimateTwoViewGeometryPose, Calibrated) {
 }
 
 TEST(EstimateTwoViewGeometryPose, FailureDueToInsufficientMatches) {
-  SetPRNGSeed(0);
   for (const auto config : {TwoViewGeometry::ConfigurationType::CALIBRATED,
                             TwoViewGeometry::ConfigurationType::UNCALIBRATED,
                             TwoViewGeometry::ConfigurationType::PLANAR,
@@ -548,7 +547,6 @@ TEST(EstimateTwoViewGeometry, ForceHUseWithFisheyeIsDegenerate) {
 }
 
 TEST(EstimateTwoViewGeometry, SharedFocal) {
-  SetPRNGSeed(0);
   // A single shared, uncalibrated, pinhole-projection camera observed from two
   // frames routes to the shared-focal solver, which jointly recovers the
   // relative pose and the unknown focal length. Both a single-focal model
@@ -647,7 +645,6 @@ TEST(EstimateTwoViewGeometry, SharedFocal) {
 }
 
 TEST(EstimateTwoViewGeometry, OneSidedFocal) {
-  SetPRNGSeed(0);
   // Two distinct cameras where exactly one has a known focal length route to
   // the one-sided focal solver, which recovers the relative pose jointly with
   // the unknown focal of the other. The pair is run in both orders, so that the
@@ -1115,8 +1112,6 @@ TEST(EstimateTwoViewGeometry, IgnoreStationaryMatches) {
 }
 
 TEST(EstimateTwoViewGeometry, CalibratedDeterministic) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -1134,6 +1129,9 @@ TEST(EstimateTwoViewGeometry, CalibratedDeterministic) {
       synthetic_dataset_options, synthetic_noise_options);
 
   TwoViewGeometryOptions two_view_geometry_options;
+  // This test verifies RANSAC seed reproducibility, not the default calibration
+  // verification boundary. Leave margin for platform-dependent inlier counts.
+  two_view_geometry_options.min_E_F_inlier_ratio = 0.8;
   two_view_geometry_options.ransac_options.random_seed = 42;
   const TwoViewGeometry geometry1 =
       EstimateTwoViewGeometry(test_data.camera1,
@@ -1172,8 +1170,6 @@ TEST(EstimateTwoViewGeometry, CalibratedDeterministic) {
 }
 
 TEST(EstimateTwoViewGeometry, UncalibratedDeterministic) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -1225,8 +1221,6 @@ TEST(EstimateTwoViewGeometry, UncalibratedDeterministic) {
 }
 
 TEST(EstimateTwoViewGeometry, UncalibratedDegensac) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -1259,8 +1253,6 @@ TEST(EstimateTwoViewGeometry, UncalibratedDegensac) {
 }
 
 TEST(EstimateTwoViewGeometry, PlanarOrPanoramicDeterministic) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 2;
@@ -1378,8 +1370,6 @@ RigTwoViewGeometryTestData CreateRigTwoViewGeometryTestData(
 }
 
 TEST(EstimateRigTwoViewGeometries, Nominal) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 3;
@@ -1421,8 +1411,6 @@ TEST(EstimateRigTwoViewGeometries, Nominal) {
 }
 
 TEST(EstimateMultipleTwoViewGeometries, SingleGeometry) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -1448,8 +1436,6 @@ TEST(EstimateMultipleTwoViewGeometries, SingleGeometry) {
 }
 
 TEST(EstimateMultipleTwoViewGeometries, NoGeometry) {
-  SetPRNGSeed(1);
-
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;
   synthetic_dataset_options.num_cameras_per_rig = 1;
@@ -1476,8 +1462,6 @@ TEST(EstimateMultipleTwoViewGeometries, NoGeometry) {
 }
 
 TEST(EstimateMultipleTwoViewGeometries, MultipleGeometries) {
-  SetPRNGSeed(1);
-
   // Create two separate synthetic datasets with different poses.
 
   Reconstruction reconstruction1;
@@ -1552,8 +1536,6 @@ TEST(EstimateMultipleTwoViewGeometries, MultipleGeometries) {
 }
 
 TEST(MaybeDecomposeRelativePoses, Nominal) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   Reconstruction reconstruction;
@@ -1600,8 +1582,6 @@ TEST(MaybeDecomposeRelativePoses, Nominal) {
 // The pose survives a wrong focal (it comes from E alone); tri_angle, measured
 // between the rays, does not.
 TEST(MaybeDecomposeRelativePoses, UsesSolverEstimatedIntrinsics) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   Reconstruction reconstruction;
@@ -1697,8 +1677,6 @@ TEST(MaybeDecomposeRelativePoses, UsesSolverEstimatedIntrinsics) {
 // matrix from the inlier matches instead of crashing in
 // EstimateTwoViewGeometryPose's THROW_CHECK on geometry->E/F/H.
 TEST(MaybeDecomposeRelativePoses, MissingMatrixFromOldDatabase) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   Reconstruction reconstruction;

--- a/src/colmap/estimators/view_graph_calibration_test.cc
+++ b/src/colmap/estimators/view_graph_calibration_test.cc
@@ -43,8 +43,6 @@ namespace colmap {
 namespace {
 
 TEST(CalibrateViewGraph, Nominal) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   SyntheticDatasetOptions options;
@@ -98,8 +96,6 @@ TEST(CalibrateViewGraph, Nominal) {
 }
 
 TEST(CalibrateViewGraph, PriorFocalLength) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   SyntheticDatasetOptions options;
@@ -132,8 +128,6 @@ TEST(CalibrateViewGraph, PriorFocalLength) {
 }
 
 TEST(CalibrateViewGraph, ConfigTagging) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   SyntheticDatasetOptions options;
@@ -175,8 +169,6 @@ TEST(CalibrateViewGraph, ConfigTagging) {
 }
 
 TEST(CalibrateViewGraph, RelativePoseReestimation) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   SyntheticDatasetOptions options;
@@ -242,8 +234,6 @@ TEST(CalibrateViewGraph, RelativePoseReestimation) {
 }
 
 TEST(CalibrateViewGraph, SphericalCamerasAreIgnored) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   // Spherical (omnidirectional) cameras have no focal length and produce
@@ -289,8 +279,6 @@ TEST(CalibrateViewGraph, SphericalCamerasAreIgnored) {
 }
 
 TEST(CalibrateViewGraph, FisheyeCamerasAreIgnored) {
-  SetPRNGSeed(42);
-
   auto database = Database::Open(kInMemorySqliteDatabasePath);
 
   // A fisheye camera projects angularly, so its focal length cannot be

--- a/src/colmap/feature/aliked_test.cc
+++ b/src/colmap/feature/aliked_test.cc
@@ -40,7 +40,6 @@ namespace colmap {
 namespace {
 
 void CreateRandomRgbImage(const int width, const int height, Bitmap* bitmap) {
-  SetPRNGSeed(42);
   *bitmap = Bitmap(width, height, /*as_rgb=*/true);
   for (int r = 0; r < height; ++r) {
     for (int c = 0; c < width; ++c) {

--- a/src/colmap/feature/index_test.cc
+++ b/src/colmap/feature/index_test.cc
@@ -40,7 +40,6 @@ namespace {
 
 FeatureDescriptorsFloat CreateRandomFeatureDescriptors(
     const FeatureExtractorType type, const size_t num_features) {
-  SetPRNGSeed(0);
   FeatureDescriptorsFloat descriptors;
   descriptors.type = type;
   descriptors.data.resize(num_features, 128);

--- a/src/colmap/feature/onnx_matchers_test.cc
+++ b/src/colmap/feature/onnx_matchers_test.cc
@@ -44,8 +44,6 @@ class BruteForceONNXMatcherTest : public testing::Test {
  protected:
   static constexpr int kDescriptorDim = 128;
 
-  void SetUp() override { SetPRNGSeed(42); }
-
   static FeatureMatchingOptions CreateFeatureMatcherOptions() {
     FeatureMatchingOptions options(FeatureMatcherType::ALIKED_BRUTEFORCE);
     options.use_gpu = false;
@@ -328,8 +326,6 @@ class AlikedLightGlueONNXMatcherTest : public testing::Test {
   static constexpr int kHeight = 480;
   static constexpr int kDescriptorDim = 128;
 
-  void SetUp() override { SetPRNGSeed(42); }
-
   static FeatureMatchingOptions CreateFeatureMatcherOptions() {
     FeatureMatchingOptions options(FeatureMatcherType::ALIKED_LIGHTGLUE);
     options.use_gpu = false;
@@ -524,8 +520,6 @@ class SiftLightGlueONNXMatcherTest : public testing::Test {
   static constexpr int kWidth = 640;
   static constexpr int kHeight = 480;
   static constexpr int kDescriptorDim = 128;
-
-  void SetUp() override { SetPRNGSeed(42); }
 
   static FeatureMatchingOptions CreateFeatureMatcherOptions() {
     FeatureMatchingOptions options(FeatureMatcherType::SIFT_LIGHTGLUE);

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -304,7 +304,6 @@ TEST(GravityAlignedRotation, Nominal) {
 }
 
 TEST(YAxisAngleFromRotation, Roundtrip) {
-  SetPRNGSeed(0);
   for (int i = 0; i < 100; ++i) {
     const double angle = RandomUniformReal<double>(-M_PI, M_PI);
     const Eigen::Matrix3d R = RotationFromYAxisAngle(angle);
@@ -350,7 +349,6 @@ TEST(QuaternionFromAngleAxis, SmallAngle) {
 }
 
 TEST(QuaternionFromAngleAxis, Roundtrip) {
-  SetPRNGSeed(0);
   for (int i = 0; i < 100; ++i) {
     const Eigen::AngleAxisd aa(RandomEigenQuaterniond());
     const Eigen::Vector3d omega = aa.angle() * aa.axis();
@@ -369,7 +367,6 @@ TEST(LeftJacobianFromAngleAxis, IdentityAtZero) {
 
 TEST(LeftJacobianFromAngleAxis, RelationToRight) {
   // Jr(w) = Jl(-w) for all w.
-  SetPRNGSeed(0);
   for (int i = 0; i < 100; ++i) {
     const Eigen::AngleAxisd aa(RandomEigenQuaterniond());
     const Eigen::Vector3d omega = aa.angle() * aa.axis();
@@ -390,7 +387,6 @@ TEST(RightJacobianFromAngleAxis, SmallAngle) {
 
 TEST(RightJacobianFromAngleAxis, NumericDerivative) {
   // Verify Jr by numeric differentiation of Exp(w + dw) ≈ Exp(w) * Exp(Jr*dw).
-  SetPRNGSeed(0);
   const double eps = 1e-7;
   for (int i = 0; i < 50; ++i) {
     const Eigen::AngleAxisd aa(RandomEigenQuaterniond());
@@ -414,7 +410,6 @@ TEST(RightJacobianFromAngleAxis, NumericDerivative) {
 
 TEST(LeftJacobianFromAngleAxis, NumericDerivative) {
   // Verify Jl by numeric differentiation of Exp(w + dw) ≈ Exp(Jl*dw) * Exp(w).
-  SetPRNGSeed(0);
   const double eps = 1e-7;
   for (int i = 0; i < 50; ++i) {
     const Eigen::AngleAxisd aa(RandomEigenQuaterniond());

--- a/src/colmap/math/random_eigen_test.cc
+++ b/src/colmap/math/random_eigen_test.cc
@@ -39,7 +39,6 @@ namespace colmap {
 namespace {
 
 TEST(RandomEigenVectord, Range) {
-  SetPRNGSeed(0);
   for (int i = 0; i < 1000; ++i) {
     const Eigen::Vector3d vector = RandomEigenVectord<3>();
     EXPECT_TRUE((vector.array() >= -1).all());
@@ -56,7 +55,6 @@ TEST(RandomEigenVectord, Deterministic) {
 }
 
 TEST(RandomEigenVectorf, Range) {
-  SetPRNGSeed(0);
   for (int i = 0; i < 1000; ++i) {
     const Eigen::Vector2f vector = RandomEigenVectorf<2>();
     EXPECT_TRUE((vector.array() >= -1).all());
@@ -65,7 +63,6 @@ TEST(RandomEigenVectorf, Range) {
 }
 
 TEST(RandomEigenVectorXd, Dynamic) {
-  SetPRNGSeed(0);
   const Eigen::VectorXd vector = RandomEigenVectorXd(7);
   EXPECT_EQ(vector.size(), 7);
   EXPECT_TRUE((vector.array() >= -1).all());
@@ -73,14 +70,12 @@ TEST(RandomEigenVectorXd, Dynamic) {
 }
 
 TEST(RandomEigenMatrixd, Range) {
-  SetPRNGSeed(0);
   const Eigen::Matrix<double, 3, 4> matrix = RandomEigenMatrixd<3, 4>();
   EXPECT_TRUE((matrix.array() >= -1).all());
   EXPECT_TRUE((matrix.array() <= 1).all());
 }
 
 TEST(RandomEigenMatrixXf, Dynamic) {
-  SetPRNGSeed(0);
   const Eigen::MatrixXf matrix = RandomEigenMatrixXf(3, 5);
   EXPECT_EQ(matrix.rows(), 3);
   EXPECT_EQ(matrix.cols(), 5);
@@ -89,7 +84,6 @@ TEST(RandomEigenMatrixXf, Dynamic) {
 }
 
 TEST(RandomEigenQuaterniond, Unit) {
-  SetPRNGSeed(0);
   for (int i = 0; i < 1000; ++i) {
     const Eigen::Quaterniond quat = RandomEigenQuaterniond();
     EXPECT_NEAR(quat.norm(), 1.0, 1e-9);

--- a/src/colmap/math/random_test.cc
+++ b/src/colmap/math/random_test.cc
@@ -40,6 +40,7 @@ namespace colmap {
 namespace {
 
 TEST(PRNGSeed, Nominal) {
+  PRNG.reset();
   EXPECT_TRUE(PRNG == nullptr);
   SetPRNGSeed();
   EXPECT_TRUE(PRNG != nullptr);
@@ -91,7 +92,6 @@ TEST(Repeatability, Nominal) {
 }
 
 TEST(RandomUniformInteger, Nominal) {
-  SetPRNGSeed();
   for (size_t i = 0; i < 1000; ++i) {
     EXPECT_GE(RandomUniformInteger(-100, 100), -100);
     EXPECT_LE(RandomUniformInteger(-100, 100), 100);
@@ -99,7 +99,6 @@ TEST(RandomUniformInteger, Nominal) {
 }
 
 TEST(RandomUniformReal, Nominal) {
-  SetPRNGSeed();
   for (size_t i = 0; i < 1000; ++i) {
     EXPECT_GE(RandomUniformReal(-100.0, 100.0), -100.0);
     EXPECT_LE(RandomUniformReal(-100.0, 100.0), 100.0);
@@ -107,7 +106,6 @@ TEST(RandomUniformReal, Nominal) {
 }
 
 TEST(RandomGaussian, Nominal) {
-  SetPRNGSeed(0);
   const double kMean = 1.0;
   const double kSigma = 1.0;
   const size_t kNumValues = 100000;
@@ -121,7 +119,6 @@ TEST(RandomGaussian, Nominal) {
 }
 
 TEST(ShuffleNone, Nominal) {
-  SetPRNGSeed();
   std::vector<int> numbers(0);
   Shuffle(0, &numbers);
   numbers = {1, 2, 3, 4, 5};
@@ -131,7 +128,6 @@ TEST(ShuffleNone, Nominal) {
 }
 
 TEST(ShuffleAll, Nominal) {
-  SetPRNGSeed(0);
   std::vector<int> numbers(1000);
   std::iota(numbers.begin(), numbers.end(), 0);
   std::vector<int> shuffled_numbers = numbers;

--- a/src/colmap/mvs/model_test.cc
+++ b/src/colmap/mvs/model_test.cc
@@ -42,7 +42,6 @@ namespace mvs {
 namespace {
 
 TEST(Model, ReadCOLMAP) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;

--- a/src/colmap/optim/loransac_test.cc
+++ b/src/colmap/optim/loransac_test.cc
@@ -56,7 +56,6 @@ SimilarityTransformTestData GenerateTestData(const size_t num_samples = 1000,
   data.num_samples = num_samples;
   data.num_outliers = num_outliers;
 
-  SetPRNGSeed(0);
   data.expected_tgt_from_src =
       Sim3d(2, RandomEigenQuaterniond(), Eigen::Vector3d(100, 10, 10));
 

--- a/src/colmap/optim/ransac_test.cc
+++ b/src/colmap/optim/ransac_test.cc
@@ -56,7 +56,6 @@ SimilarityTransformTestData GenerateTestData(const size_t num_samples = 1000,
   data.num_samples = num_samples;
   data.num_outliers = num_outliers;
 
-  SetPRNGSeed(0);
   data.expected_tgt_from_src =
       Sim3d(2, RandomEigenQuaterniond(), Eigen::Vector3d(100, 10, 10));
 

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -58,8 +58,6 @@ class ParameterizedVisualIndexTests
 TEST_P(ParameterizedVisualIndexTests, Nominal) {
   const auto [desc_dim, embedding_dim] = GetParam();
 
-  SetPRNGSeed(1);
-
   {
     auto visual_index = VisualIndex::Create(desc_dim, embedding_dim);
     EXPECT_EQ(visual_index->NumVisualWords(), 0);
@@ -189,8 +187,6 @@ TEST_P(ParameterizedVisualIndexTests, ReadWrite) {
 TEST_P(ParameterizedVisualIndexTests, SpatialVerification) {
   const auto [desc_dim, embedding_dim] = GetParam();
 
-  SetPRNGSeed(1);
-
   VisualIndex::BuildOptions build_options;
   // Keep test runtimes low.
   build_options.num_iterations = 10;
@@ -288,8 +284,6 @@ TEST_P(ParameterizedVisualIndexTests, SpatialVerification) {
 TEST_P(ParameterizedVisualIndexTests, TypeMismatch) {
   const auto [desc_dim, embedding_dim] = GetParam();
 
-  SetPRNGSeed(1);
-
   VisualIndex::BuildOptions build_options;
   build_options.num_iterations = 10;
   build_options.num_rounds = 1;
@@ -331,8 +325,6 @@ TEST_P(ParameterizedVisualIndexTests, TypeMismatch) {
 }
 
 TEST(VisualIndex, Print) {
-  SetPRNGSeed(1);
-
   VisualIndex::BuildOptions build_options;
   build_options.num_iterations = 10;
   build_options.num_rounds = 1;

--- a/src/colmap/scene/reconstruction_pruning_test.cc
+++ b/src/colmap/scene/reconstruction_pruning_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/scene/reconstruction_pruning.h"
 
-#include "colmap/math/random.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/eigen_alignment.h"
 
@@ -47,25 +46,35 @@ TEST(FindRedundantPoints3D, Empty) {
 }
 
 TEST(FindRedundantPoints3D, VaryingCoverageGain) {
-  SetPRNGSeed(1);
-
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
   synthetic_dataset_options.num_cameras_per_rig = 1;
   synthetic_dataset_options.num_frames_per_rig = 5;
   synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.track_length = 5;
   SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+
+  // Give every point the same coverage so the number selected at each
+  // threshold is independent of random image-tile occupancy.
+  for (const auto& [image_id, _] : reconstruction.Images()) {
+    Image& image = reconstruction.Image(image_id);
+    for (point2D_t point2D_idx = 0; point2D_idx < image.NumPoints2D();
+         ++point2D_idx) {
+      image.Point2D(point2D_idx).xy = Eigen::Vector2d(
+          image.CameraPtr()->width / 2., image.CameraPtr()->height / 2.);
+    }
+  }
+
   EXPECT_THAT(FindRedundantPoints3D(/*min_coverage_gain=*/0, reconstruction),
               testing::IsEmpty());
-  size_t prev_num_redundant_points3D = 0;
-  for (const double min_coverage_gain : {0.1, 0.4, 0.7, 10.0}) {
+  for (const auto& [min_coverage_gain, expected_num_redundant_points3D] :
+       std::vector<std::pair<double, size_t>>{
+           {0.1, 92}, {0.4, 98}, {0.7, 99}, {10.0, 100}}) {
     const std::vector<point3D_t> redundant_point3D_ids =
         FindRedundantPoints3D(min_coverage_gain, reconstruction);
-    EXPECT_GT(redundant_point3D_ids.size(), prev_num_redundant_points3D);
-    prev_num_redundant_points3D = redundant_point3D_ids.size();
+    EXPECT_EQ(redundant_point3D_ids.size(), expected_num_redundant_points3D);
   }
-  EXPECT_EQ(prev_num_redundant_points3D, reconstruction.NumPoints3D());
 }
 
 TEST(FindRedundantPoints3D, VaryingTrackLength) {

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -1319,7 +1319,6 @@ TEST(Reconstruction, Point3DIds) {
 }
 
 TEST(Reconstruction, ReadWriteTextRoundtrip) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -1339,7 +1338,6 @@ TEST(Reconstruction, ReadWriteTextRoundtrip) {
 }
 
 TEST(Reconstruction, ReadWriteBinaryRoundtrip) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;
@@ -1359,7 +1357,6 @@ TEST(Reconstruction, ReadWriteBinaryRoundtrip) {
 }
 
 TEST(Reconstruction, ReadAutoDetectFormat) {
-  SetPRNGSeed(0);
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 1;

--- a/src/colmap/sfm/global_mapper_test.cc
+++ b/src/colmap/sfm/global_mapper_test.cc
@@ -18,7 +18,6 @@ std::shared_ptr<DatabaseCache> CreateDatabaseCache(const Database& database) {
 }
 
 TEST(GlobalMapper, WithoutNoise) {
-  SetPRNGSeed(1);
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -46,7 +45,6 @@ TEST(GlobalMapper, WithoutNoise) {
 }
 
 TEST(GlobalMapper, WithoutNoiseWithNonTrivialKnownRig) {
-  SetPRNGSeed(1);
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -77,7 +75,6 @@ TEST(GlobalMapper, WithoutNoiseWithNonTrivialKnownRig) {
 }
 
 TEST(GlobalMapper, WithoutNoiseWithNonTrivialUnknownRig) {
-  SetPRNGSeed(1);
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);
@@ -118,8 +115,6 @@ TEST(GlobalMapper, WithoutNoiseWithNonTrivialUnknownRig) {
 }
 
 TEST(GlobalMapper, WithNoiseAndOutliers) {
-  SetPRNGSeed(1);
-
   const auto database_path = CreateTestDir() / "database.db";
 
   auto database = Database::Open(database_path);

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -149,6 +149,8 @@ if(TESTS_ENABLED)
         PUBLIC_LINK_LIBS
             colmap_util
             glog::glog
+        PRIVATE_LINK_LIBS
+            colmap_math
     )
     if(NOT BUILD_SHARED_LIBS)
         # With static builds, colmap_gtest_main provides gmock/gtest symbols

--- a/src/colmap/util/gtest_main.cc
+++ b/src/colmap/util/gtest_main.cc
@@ -27,11 +27,28 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "colmap/math/random.h"
+
 #include <glog/logging.h>
 #include <gmock/gmock.h>
+
+namespace {
+
+constexpr unsigned kDefaultTestPRNGSeed = 0;
+
+class PRNGTestEventListener : public testing::EmptyTestEventListener {
+ public:
+  void OnTestStart(const testing::TestInfo&) override {
+    colmap::SetPRNGSeed(kDefaultTestPRNGSeed);
+  }
+};
+
+}  // namespace
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
   testing::InitGoogleMock(&argc, argv);
+  testing::UnitTest::GetInstance()->listeners().Append(
+      new PRNGTestEventListener);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Summary

- reset COLMAP's PRNG to the explicit seed `0` before every GTest through the custom test event listener
- remove redundant test-local seed setup, reducing `SetPRNGSeed` calls in tests from 172 to 22
- retain custom seeds only for PRNG behavior checks, multi-seed coverage, and helper-level resets
- make the three formerly seed-specific tests well-conditioned with explicit fixture margins
- retain the SIFT descriptor helper seed because it initializes the thread-local PRNG in GPU worker threads
- keep `IncrementalPipeline.ChainedMatches` single-threaded and remove its manual PRNG/RANSAC seed setup

This supersedes #4574 while preserving its original commit and authorship. Resetting at each test start, rather than once per executable, keeps results independent of GTest filtering and test order.

## Validation

- `cmake --build build -j 8`
- full CTest run: 160/160 test binaries passed
- `IncrementalPipeline.ChainedMatches` passed 100 fresh-process runs
- formatted with clang-format 22.1.5

Fixes #4573