### PR TITLE
Optimize image warping for small resizes

### DIFF
--- a/src/colmap/image/undistortion.cc
+++ b/src/colmap/image/undistortion.cc
@@ -291,7 +291,8 @@ void UndistortImage(const UndistortCameraOptions& options,
 
   *undistorted_camera = UndistortCamera(options, distorted_camera);
 
-  WarpImageBetweenCameras(distorted_camera,
+  WarpImageBetweenCameras(options.warp_options,
+                          distorted_camera,
                           *undistorted_camera,
                           distorted_bitmap,
                           undistorted_bitmap);
@@ -474,12 +475,14 @@ void RectifyAndUndistortStereoImages(const UndistortCameraOptions& options,
   RectifyStereoCameras(
       *undistorted_camera, *undistorted_camera, cam2_from_cam1, &H1, &H2, Q);
 
-  WarpImageWithHomographyBetweenCameras(H1.inverse(),
+  WarpImageWithHomographyBetweenCameras(options.warp_options,
+                                        H1.inverse(),
                                         distorted_camera1,
                                         *undistorted_camera,
                                         distorted_image1,
                                         undistorted_image1);
-  WarpImageWithHomographyBetweenCameras(H2.inverse(),
+  WarpImageWithHomographyBetweenCameras(options.warp_options,
+                                        H2.inverse(),
                                         distorted_camera2,
                                         *undistorted_camera,
                                         distorted_image2,

--- a/src/colmap/image/undistortion.h
+++ b/src/colmap/image/undistortion.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/geometry/rigid3.h"
+#include "colmap/image/warp.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/sensor/bitmap.h"
 
@@ -64,6 +65,9 @@ struct UndistortCameraOptions {
   // output dimensions. Points with norm exceeding this threshold are skipped.
   // Set to -1 to disable the check (default).
   double max_cam_point_norm = -1;
+
+  // Options controlling image warping during undistortion.
+  WarpImageOptions warp_options;
 };
 
 // Undistort camera by resizing the image and shifting the principal point.

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -34,6 +34,10 @@
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/eigen_matchers.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -231,12 +235,18 @@ TEST(UndistortImage, WarpOptions) {
   distorted_camera.params[3] = 0.5;
 
   Bitmap distorted_image(100, 100, true);
-  for (size_t i = 0; i < distorted_image.RowMajorData().size(); ++i) {
-    distorted_image.RowMajorData()[i] = static_cast<uint8_t>(i % 251);
+  for (int y = 0; y < distorted_image.Height(); ++y) {
+    for (int x = 0; x < distorted_image.Width(); ++x) {
+      distorted_image.SetPixel(
+          x,
+          y,
+          BitmapColor<uint8_t>(static_cast<uint8_t>(x),
+                               static_cast<uint8_t>(y),
+                               static_cast<uint8_t>((x + y) / 2)));
+    }
   }
 
   UndistortCameraOptions options;
-  options.warp_options.direct_warp_min_scale = 0.0;
   Bitmap direct_image;
   Camera direct_camera;
   UndistortImage(options,
@@ -244,6 +254,12 @@ TEST(UndistortImage, WarpOptions) {
                  distorted_camera,
                  &direct_image,
                  &direct_camera);
+  const double direct_scale =
+      std::min(static_cast<double>(direct_camera.width) /
+                   static_cast<double>(distorted_camera.width),
+               static_cast<double>(direct_camera.height) /
+                   static_cast<double>(distorted_camera.height));
+  ASSERT_GE(direct_scale, options.warp_options.direct_warp_min_scale);
 
   options.warp_options.direct_warp_min_scale = 1.0;
   Bitmap resized_image;
@@ -258,6 +274,24 @@ TEST(UndistortImage, WarpOptions) {
   EXPECT_EQ(direct_image.Width(), resized_image.Width());
   EXPECT_EQ(direct_image.Height(), resized_image.Height());
   EXPECT_NE(direct_image.RowMajorData(), resized_image.RowMajorData());
+
+  uint64_t total_absolute_difference = 0;
+  int max_absolute_difference = 0;
+  for (size_t i = 0; i < direct_image.RowMajorData().size(); ++i) {
+    const int absolute_difference =
+        std::abs(static_cast<int>(direct_image.RowMajorData()[i]) -
+                 static_cast<int>(resized_image.RowMajorData()[i]));
+    total_absolute_difference += absolute_difference;
+    max_absolute_difference =
+        std::max(max_absolute_difference, absolute_difference);
+  }
+  const double mean_absolute_difference =
+      static_cast<double>(total_absolute_difference) /
+      direct_image.RowMajorData().size();
+  // The extra resize changes rounding, but not by a perceptible amount for
+  // smooth image content.
+  EXPECT_LT(mean_absolute_difference, 0.5);
+  EXPECT_LE(max_absolute_difference, 1);
 }
 
 TEST(UndistortReconstruction, Nominal) {

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -33,15 +33,48 @@
 #include "colmap/scene/synthetic.h"
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/eigen_matchers.h"
+#include "colmap/util/logging.h"
 
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 namespace colmap {
 namespace {
+
+uint64_t TotalAbsoluteDifference(const Bitmap& bitmap1, const Bitmap& bitmap2) {
+  const std::vector<uint8_t>& data1 = bitmap1.RowMajorData();
+  const std::vector<uint8_t>& data2 = bitmap2.RowMajorData();
+  THROW_CHECK_EQ(data1.size(), data2.size());
+  uint64_t total_absolute_difference = 0;
+  for (size_t i = 0; i < data1.size(); ++i) {
+    total_absolute_difference +=
+        std::abs(static_cast<int>(data1[i]) - static_cast<int>(data2[i]));
+  }
+  return total_absolute_difference;
+}
+
+double MeanAbsoluteDifference(const Bitmap& bitmap1, const Bitmap& bitmap2) {
+  THROW_CHECK_GT(bitmap1.RowMajorData().size(), 0);
+  return static_cast<double>(TotalAbsoluteDifference(bitmap1, bitmap2)) /
+         bitmap1.RowMajorData().size();
+}
+
+int MaxAbsoluteDifference(const Bitmap& bitmap1, const Bitmap& bitmap2) {
+  const std::vector<uint8_t>& data1 = bitmap1.RowMajorData();
+  const std::vector<uint8_t>& data2 = bitmap2.RowMajorData();
+  THROW_CHECK_EQ(data1.size(), data2.size());
+  int max_absolute_difference = 0;
+  for (size_t i = 0; i < data1.size(); ++i) {
+    max_absolute_difference = std::max(
+        max_absolute_difference,
+        std::abs(static_cast<int>(data1[i]) - static_cast<int>(data2[i])));
+  }
+  return max_absolute_difference;
+}
 
 TEST(UndistortCamera, Nominal) {
   UndistortCameraOptions options;
@@ -275,23 +308,10 @@ TEST(UndistortImage, WarpOptions) {
   EXPECT_EQ(direct_image.Height(), resized_image.Height());
   EXPECT_NE(direct_image.RowMajorData(), resized_image.RowMajorData());
 
-  uint64_t total_absolute_difference = 0;
-  int max_absolute_difference = 0;
-  for (size_t i = 0; i < direct_image.RowMajorData().size(); ++i) {
-    const int absolute_difference =
-        std::abs(static_cast<int>(direct_image.RowMajorData()[i]) -
-                 static_cast<int>(resized_image.RowMajorData()[i]));
-    total_absolute_difference += absolute_difference;
-    max_absolute_difference =
-        std::max(max_absolute_difference, absolute_difference);
-  }
-  const double mean_absolute_difference =
-      static_cast<double>(total_absolute_difference) /
-      direct_image.RowMajorData().size();
   // The extra resize changes rounding, but not by a perceptible amount for
   // smooth image content.
-  EXPECT_LT(mean_absolute_difference, 0.5);
-  EXPECT_LE(max_absolute_difference, 1);
+  EXPECT_LT(MeanAbsoluteDifference(direct_image, resized_image), 0.5);
+  EXPECT_LE(MaxAbsoluteDifference(direct_image, resized_image), 1);
 }
 
 TEST(UndistortReconstruction, Nominal) {

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -225,6 +225,41 @@ TEST(UndistortCamera, NoBlankPixels) {
   }
 }
 
+TEST(UndistortImage, WarpOptions) {
+  Camera distorted_camera =
+      Camera::CreateFromModelId(1, CameraModelId::kSimpleRadial, 100, 100, 100);
+  distorted_camera.params[3] = 0.5;
+
+  Bitmap distorted_image(100, 100, true);
+  for (size_t i = 0; i < distorted_image.RowMajorData().size(); ++i) {
+    distorted_image.RowMajorData()[i] = static_cast<uint8_t>(i % 251);
+  }
+
+  UndistortCameraOptions options;
+  options.warp_options.direct_warp_min_scale = 0.0;
+  Bitmap direct_image;
+  Camera direct_camera;
+  UndistortImage(options,
+                 distorted_image,
+                 distorted_camera,
+                 &direct_image,
+                 &direct_camera);
+
+  options.warp_options.direct_warp_min_scale = 1.0;
+  Bitmap resized_image;
+  Camera resized_camera;
+  UndistortImage(options,
+                 distorted_image,
+                 distorted_camera,
+                 &resized_image,
+                 &resized_camera);
+
+  EXPECT_EQ(direct_camera, resized_camera);
+  EXPECT_EQ(direct_image.Width(), resized_image.Width());
+  EXPECT_EQ(direct_image.Height(), resized_image.Height());
+  EXPECT_NE(direct_image.RowMajorData(), resized_image.RowMajorData());
+}
+
 TEST(UndistortReconstruction, Nominal) {
   const size_t kNumImages = 10;
   const size_t kNumPoints2D = 10;

--- a/src/colmap/image/warp.cc
+++ b/src/colmap/image/warp.cc
@@ -34,6 +34,8 @@
 
 #include "thirdparty/VLFeat/imopv.h"
 
+#include <algorithm>
+
 #include <Eigen/Geometry>
 
 namespace colmap {
@@ -51,9 +53,29 @@ float GetPixelConstantBorder(const float* data,
   }
 }
 
+bool ShouldWarpDirectly(const Camera& source_camera,
+                        const Camera& target_camera,
+                        const WarpImageOptions& options) {
+  THROW_CHECK_GE(options.direct_warp_min_scale, 0);
+  THROW_CHECK_GT(source_camera.width, 0);
+  THROW_CHECK_GT(source_camera.height, 0);
+  THROW_CHECK_GT(target_camera.width, 0);
+  THROW_CHECK_GT(target_camera.height, 0);
+  if (target_camera.width == source_camera.width &&
+      target_camera.height == source_camera.height) {
+    return true;
+  }
+  const double scale_x = static_cast<double>(target_camera.width) /
+                         static_cast<double>(source_camera.width);
+  const double scale_y = static_cast<double>(target_camera.height) /
+                         static_cast<double>(source_camera.height);
+  return std::min(scale_x, scale_y) >= options.direct_warp_min_scale;
+}
+
 }  // namespace
 
-void WarpImageBetweenCameras(const Camera& source_camera,
+void WarpImageBetweenCameras(const WarpImageOptions& options,
+                             const Camera& source_camera,
                              const Camera& target_camera,
                              const Bitmap& source_image,
                              Bitmap* target_image) {
@@ -61,17 +83,17 @@ void WarpImageBetweenCameras(const Camera& source_camera,
   THROW_CHECK_EQ(source_camera.height, source_image.Height());
   THROW_CHECK_NOTNULL(target_image);
 
-  *target_image = Bitmap(static_cast<int>(source_camera.width),
-                         static_cast<int>(source_camera.height),
-                         source_image.IsRGB());
-
-  // To avoid aliasing, perform the warping in the source resolution and
-  // then rescale the image at the end.
-  Camera scaled_target_camera = target_camera;
-  if (target_camera.width != source_camera.width ||
-      target_camera.height != source_camera.height) {
-    scaled_target_camera.Rescale(source_camera.width, source_camera.height);
+  const bool warp_directly =
+      ShouldWarpDirectly(source_camera, target_camera, options);
+  Camera warp_target_camera = target_camera;
+  if (!warp_directly) {
+    warp_target_camera.Rescale(source_camera.width, source_camera.height);
   }
+  *target_image = Bitmap(static_cast<int>(warp_directly ? target_camera.width
+                                                        : source_camera.width),
+                         static_cast<int>(warp_directly ? target_camera.height
+                                                        : source_camera.height),
+                         source_image.IsRGB());
 
   Eigen::Vector2d image_point;
   for (int y = 0; y < target_image->Height(); ++y) {
@@ -81,7 +103,7 @@ void WarpImageBetweenCameras(const Camera& source_camera,
 
       // Camera models assume that the upper left pixel center is (0.5, 0.5).
       const std::optional<Eigen::Vector2d> cam_point =
-          scaled_target_camera.CamFromImg(image_point);
+          warp_target_camera.CamFromImg(image_point);
       if (!cam_point) {
         target_image->SetPixel(x, y, BitmapColor<uint8_t>(0));
         continue;
@@ -102,8 +124,7 @@ void WarpImageBetweenCameras(const Camera& source_camera,
     }
   }
 
-  if (target_camera.width != source_camera.width ||
-      target_camera.height != source_camera.height) {
+  if (!warp_directly) {
     target_image->Rescale(target_camera.width, target_camera.height);
   }
 }
@@ -134,7 +155,8 @@ void WarpImageWithHomography(const Eigen::Matrix3d& H,
   }
 }
 
-void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
+void WarpImageWithHomographyBetweenCameras(const WarpImageOptions& options,
+                                           const Eigen::Matrix3d& H,
                                            const Camera& source_camera,
                                            const Camera& target_camera,
                                            const Bitmap& source_image,
@@ -143,17 +165,13 @@ void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
   THROW_CHECK_EQ(source_camera.height, source_image.Height());
   THROW_CHECK_NOTNULL(target_image);
 
-  *target_image = Bitmap(static_cast<int>(source_camera.width),
-                         static_cast<int>(source_camera.height),
+  const bool warp_directly =
+      ShouldWarpDirectly(source_camera, target_camera, options);
+  *target_image = Bitmap(static_cast<int>(warp_directly ? target_camera.width
+                                                        : source_camera.width),
+                         static_cast<int>(warp_directly ? target_camera.height
+                                                        : source_camera.height),
                          source_image.IsRGB());
-
-  // To avoid aliasing, perform the warping in the source resolution and
-  // then rescale the image at the end.
-  Camera scaled_target_camera = target_camera;
-  if (target_camera.width != source_camera.width ||
-      target_camera.height != source_camera.height) {
-    scaled_target_camera.Rescale(source_camera.width, source_camera.height);
-  }
 
   Eigen::Vector3d image_point(0, 0, 1);
   for (int y = 0; y < target_image->Height(); ++y) {
@@ -189,8 +207,7 @@ void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
     }
   }
 
-  if (target_camera.width != source_camera.width ||
-      target_camera.height != source_camera.height) {
+  if (!warp_directly) {
     target_image->Rescale(target_camera.width, target_camera.height);
   }
 }

--- a/src/colmap/image/warp.h
+++ b/src/colmap/image/warp.h
@@ -34,10 +34,22 @@
 
 namespace colmap {
 
+struct WarpImageOptions {
+  // Minimum target-to-source dimension ratio for warping directly at target
+  // resolution. Smaller ratios warp at source resolution and resize the result
+  // to avoid aliasing.
+  double direct_warp_min_scale = 0.9;
+};
+
 // Warp source image to target image by projecting the pixels of the target
 // image up to infinity and projecting it down into the source image
-// (i.e. an inverse mapping). The function allocates the target image.
-void WarpImageBetweenCameras(const Camera& source_camera,
+// (i.e. an inverse mapping). The function allocates the target image. If the
+// minimum target-to-source dimension ratio is at least
+// `options.direct_warp_min_scale`, the image is warped directly at target
+// resolution. Otherwise, it is warped at source resolution and resized to
+// avoid aliasing.
+void WarpImageBetweenCameras(const WarpImageOptions& options,
+                             const Camera& source_camera,
                              const Camera& target_camera,
                              const Bitmap& source_image,
                              Bitmap* target_image);
@@ -52,8 +64,10 @@ void WarpImageWithHomography(const Eigen::Matrix3d& H,
 // First, warp source image to target image by projecting the pixels of the
 // target image up to infinity and projecting it down into the source image
 // (i.e. an inverse mapping). Second, warp the coordinates from the first
-// warping with the given homography. The function allocates the target image.
-void WarpImageWithHomographyBetweenCameras(const Eigen::Matrix3d& H,
+// warping with the given homography. The function allocates the target image
+// and uses the same direct-warp threshold as `WarpImageBetweenCameras`.
+void WarpImageWithHomographyBetweenCameras(const WarpImageOptions& options,
+                                           const Eigen::Matrix3d& H,
                                            const Camera& source_camera,
                                            const Camera& target_camera,
                                            const Bitmap& source_image,

--- a/src/colmap/image/warp.h
+++ b/src/colmap/image/warp.h
@@ -38,7 +38,7 @@ struct WarpImageOptions {
   // Minimum target-to-source dimension ratio for warping directly at target
   // resolution. Smaller ratios warp at source resolution and resize the result
   // to avoid aliasing.
-  double direct_warp_min_scale = 0.9;
+  double direct_warp_min_scale = 0.5;
 };
 
 // Warp source image to target image by projecting the pixels of the target

--- a/src/colmap/image/warp_test.cc
+++ b/src/colmap/image/warp_test.cc
@@ -53,6 +53,19 @@ const Bitmap GenerateRandomBitmap(const int width,
   return bitmap;
 }
 
+void CheckBitmapsExactlyEqual(const Bitmap& bitmap1, const Bitmap& bitmap2) {
+  EXPECT_EQ(bitmap1.Width(), bitmap2.Width());
+  EXPECT_EQ(bitmap1.Height(), bitmap2.Height());
+  EXPECT_EQ(bitmap1.IsRGB(), bitmap2.IsRGB());
+  EXPECT_EQ(bitmap1.RowMajorData(), bitmap2.RowMajorData());
+}
+
+WarpImageOptions DirectWarpMinScaleOptions(const double min_scale) {
+  WarpImageOptions options;
+  options.direct_warp_min_scale = min_scale;
+  return options;
+}
+
 // Check that the two bitmaps are equal, ignoring a 1px boundary.
 void CheckBitmapsEqual(const Bitmap& bitmap1, const Bitmap& bitmap2) {
   ASSERT_EQ(bitmap1.IsGrey(), bitmap2.IsGrey());
@@ -94,13 +107,80 @@ TEST(Warp, IdenticalCameras) {
       Camera::CreateFromModelId(1, CameraModelId::kPinhole, 1, 100, 100);
   const Bitmap source_image_gray = GenerateRandomBitmap(100, 100, false);
   Bitmap target_image_gray;
-  WarpImageBetweenCameras(
-      camera, camera, source_image_gray, &target_image_gray);
+  WarpImageBetweenCameras(WarpImageOptions(),
+                          camera,
+                          camera,
+                          source_image_gray,
+                          &target_image_gray);
   CheckBitmapsEqual(source_image_gray, target_image_gray);
   const Bitmap source_image_rgb = GenerateRandomBitmap(100, 100, true);
   Bitmap target_image_rgb;
-  WarpImageBetweenCameras(camera, camera, source_image_rgb, &target_image_rgb);
+  WarpImageBetweenCameras(
+      WarpImageOptions(), camera, camera, source_image_rgb, &target_image_rgb);
   CheckBitmapsEqual(source_image_rgb, target_image_rgb);
+}
+
+TEST(Warp, DirectWarpMinScale) {
+  const Camera source_camera =
+      Camera::CreateFromModelId(1, CameraModelId::kPinhole, 100, 100, 100);
+  const Bitmap source_image = GenerateRandomBitmap(100, 100, true);
+
+  Camera target_camera = source_camera;
+  target_camera.Rescale(90, 90);
+  Bitmap default_image;
+  WarpImageBetweenCameras(WarpImageOptions(),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &default_image);
+  Bitmap direct_image;
+  WarpImageBetweenCameras(DirectWarpMinScaleOptions(0.0),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &direct_image);
+  Bitmap resized_image;
+  WarpImageBetweenCameras(DirectWarpMinScaleOptions(1.0),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &resized_image);
+  CheckBitmapsExactlyEqual(default_image, direct_image);
+  EXPECT_NE(default_image.RowMajorData(), resized_image.RowMajorData());
+
+  target_camera = source_camera;
+  target_camera.Rescale(89, 89);
+  WarpImageBetweenCameras(WarpImageOptions(),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &default_image);
+  WarpImageBetweenCameras(DirectWarpMinScaleOptions(1.0),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &resized_image);
+  CheckBitmapsExactlyEqual(default_image, resized_image);
+
+  target_camera = source_camera;
+  target_camera.Rescale(95, 89);
+  WarpImageBetweenCameras(WarpImageOptions(),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &default_image);
+  WarpImageBetweenCameras(DirectWarpMinScaleOptions(1.0),
+                          source_camera,
+                          target_camera,
+                          source_image,
+                          &resized_image);
+  CheckBitmapsExactlyEqual(default_image, resized_image);
+
+  EXPECT_ANY_THROW(WarpImageBetweenCameras(DirectWarpMinScaleOptions(-0.1),
+                                           source_camera,
+                                           target_camera,
+                                           source_image,
+                                           &default_image));
 }
 
 TEST(Warp, ShiftedCameras) {
@@ -110,8 +190,11 @@ TEST(Warp, ShiftedCameras) {
   target_camera.SetPrincipalPointX(0.0);
   const Bitmap source_image_gray = GenerateRandomBitmap(100, 100, true);
   Bitmap target_image_gray;
-  WarpImageBetweenCameras(
-      source_camera, target_camera, source_image_gray, &target_image_gray);
+  WarpImageBetweenCameras(WarpImageOptions(),
+                          source_camera,
+                          target_camera,
+                          source_image_gray,
+                          &target_image_gray);
   for (int x = 0; x < target_image_gray.Width(); ++x) {
     for (int y = 0; y < target_image_gray.Height(); ++y) {
       const auto color = target_image_gray.GetPixel(x, y);
@@ -162,7 +245,8 @@ TEST(Warp, WarpImageWithHomographyBetweenCamerasIdentity) {
       Camera::CreateFromModelId(1, CameraModelId::kPinhole, 1, 100, 100);
   const Bitmap source_image_gray = GenerateRandomBitmap(100, 100, false);
   Bitmap target_image_gray;
-  WarpImageWithHomographyBetweenCameras(Eigen::Matrix3d::Identity(),
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        Eigen::Matrix3d::Identity(),
                                         camera,
                                         camera,
                                         source_image_gray,
@@ -171,12 +255,69 @@ TEST(Warp, WarpImageWithHomographyBetweenCamerasIdentity) {
 
   const Bitmap source_image_rgb = GenerateRandomBitmap(100, 100, true);
   Bitmap target_image_rgb;
-  WarpImageWithHomographyBetweenCameras(Eigen::Matrix3d::Identity(),
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        Eigen::Matrix3d::Identity(),
                                         camera,
                                         camera,
                                         source_image_rgb,
                                         &target_image_rgb);
   CheckBitmapsEqual(source_image_rgb, target_image_rgb);
+}
+
+TEST(Warp, HomographyDirectWarpMinScale) {
+  const Camera source_camera =
+      Camera::CreateFromModelId(1, CameraModelId::kPinhole, 100, 100, 100);
+  const Bitmap source_image = GenerateRandomBitmap(100, 100, false);
+
+  Camera target_camera = source_camera;
+  target_camera.Rescale(90, 90);
+  Bitmap default_image;
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        Eigen::Matrix3d::Identity(),
+                                        source_camera,
+                                        target_camera,
+                                        source_image,
+                                        &default_image);
+  Bitmap direct_image;
+  WarpImageWithHomographyBetweenCameras(DirectWarpMinScaleOptions(0.0),
+                                        Eigen::Matrix3d::Identity(),
+                                        source_camera,
+                                        target_camera,
+                                        source_image,
+                                        &direct_image);
+  Bitmap resized_image;
+  WarpImageWithHomographyBetweenCameras(DirectWarpMinScaleOptions(1.0),
+                                        Eigen::Matrix3d::Identity(),
+                                        source_camera,
+                                        target_camera,
+                                        source_image,
+                                        &resized_image);
+  CheckBitmapsExactlyEqual(default_image, direct_image);
+  EXPECT_NE(default_image.RowMajorData(), resized_image.RowMajorData());
+
+  target_camera = source_camera;
+  target_camera.Rescale(89, 89);
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        Eigen::Matrix3d::Identity(),
+                                        source_camera,
+                                        target_camera,
+                                        source_image,
+                                        &default_image);
+  WarpImageWithHomographyBetweenCameras(DirectWarpMinScaleOptions(1.0),
+                                        Eigen::Matrix3d::Identity(),
+                                        source_camera,
+                                        target_camera,
+                                        source_image,
+                                        &resized_image);
+  CheckBitmapsExactlyEqual(default_image, resized_image);
+
+  EXPECT_ANY_THROW(
+      WarpImageWithHomographyBetweenCameras(DirectWarpMinScaleOptions(-0.1),
+                                            Eigen::Matrix3d::Identity(),
+                                            source_camera,
+                                            target_camera,
+                                            source_image,
+                                            &default_image));
 }
 
 TEST(Warp, WarpImageWithHomographyBetweenCamerasTransposed) {
@@ -188,14 +329,22 @@ TEST(Warp, WarpImageWithHomographyBetweenCamerasTransposed) {
 
   const Bitmap source_image_gray = GenerateRandomBitmap(100, 100, false);
   Bitmap target_image_gray;
-  WarpImageWithHomographyBetweenCameras(
-      H, camera, camera, source_image_gray, &target_image_gray);
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        H,
+                                        camera,
+                                        camera,
+                                        source_image_gray,
+                                        &target_image_gray);
   CheckBitmapsTransposed(source_image_gray, target_image_gray);
 
   const Bitmap source_image_rgb = GenerateRandomBitmap(100, 100, true);
   Bitmap target_image_rgb;
-  WarpImageWithHomographyBetweenCameras(
-      H, camera, camera, source_image_rgb, &target_image_rgb);
+  WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
+                                        H,
+                                        camera,
+                                        camera,
+                                        source_image_rgb,
+                                        &target_image_rgb);
   CheckBitmapsTransposed(source_image_rgb, target_image_rgb);
 }
 

--- a/src/colmap/image/warp_test.cc
+++ b/src/colmap/image/warp_test.cc
@@ -126,7 +126,7 @@ TEST(Warp, DirectWarpMinScale) {
   const Bitmap source_image = GenerateRandomBitmap(100, 100, true);
 
   Camera target_camera = source_camera;
-  target_camera.Rescale(90, 90);
+  target_camera.Rescale(50, 50);
   Bitmap default_image;
   WarpImageBetweenCameras(WarpImageOptions(),
                           source_camera,
@@ -149,7 +149,7 @@ TEST(Warp, DirectWarpMinScale) {
   EXPECT_NE(default_image.RowMajorData(), resized_image.RowMajorData());
 
   target_camera = source_camera;
-  target_camera.Rescale(89, 89);
+  target_camera.Rescale(49, 49);
   WarpImageBetweenCameras(WarpImageOptions(),
                           source_camera,
                           target_camera,
@@ -163,7 +163,7 @@ TEST(Warp, DirectWarpMinScale) {
   CheckBitmapsExactlyEqual(default_image, resized_image);
 
   target_camera = source_camera;
-  target_camera.Rescale(95, 89);
+  target_camera.Rescale(95, 49);
   WarpImageBetweenCameras(WarpImageOptions(),
                           source_camera,
                           target_camera,
@@ -270,7 +270,7 @@ TEST(Warp, HomographyDirectWarpMinScale) {
   const Bitmap source_image = GenerateRandomBitmap(100, 100, false);
 
   Camera target_camera = source_camera;
-  target_camera.Rescale(90, 90);
+  target_camera.Rescale(50, 50);
   Bitmap default_image;
   WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
                                         Eigen::Matrix3d::Identity(),
@@ -296,7 +296,7 @@ TEST(Warp, HomographyDirectWarpMinScale) {
   EXPECT_NE(default_image.RowMajorData(), resized_image.RowMajorData());
 
   target_camera = source_camera;
-  target_camera.Rescale(89, 89);
+  target_camera.Rescale(49, 49);
   WarpImageWithHomographyBetweenCameras(WarpImageOptions(),
                                         Eigen::Matrix3d::Identity(),
                                         source_camera,

--- a/src/pycolmap/image/undistortion.cc
+++ b/src/pycolmap/image/undistortion.cc
@@ -11,6 +11,13 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindUndistortion(py::module& m) {
+  auto PyWarpImageOptions =
+      py::classh<WarpImageOptions>(m, "WarpImageOptions")
+          .def(py::init<>())
+          .def_readwrite("direct_warp_min_scale",
+                         &WarpImageOptions::direct_warp_min_scale);
+  MakeDataclass(PyWarpImageOptions);
+
   auto PyUndistortCameraOptions =
       py::classh<UndistortCameraOptions>(m, "UndistortCameraOptions")
           .def(py::init<>())
@@ -24,7 +31,8 @@ void BindUndistortion(py::module& m) {
           .def_readwrite("roi_max_x", &UndistortCameraOptions::roi_max_x)
           .def_readwrite("roi_max_y", &UndistortCameraOptions::roi_max_y)
           .def_readwrite("max_cam_point_norm",
-                         &UndistortCameraOptions::max_cam_point_norm);
+                         &UndistortCameraOptions::max_cam_point_norm)
+          .def_readwrite("warp_options", &UndistortCameraOptions::warp_options);
   MakeDataclass(PyUndistortCameraOptions);
 
   m.def("undistort_camera",

--- a/src/pycolmap/image/undistortion_test.py
+++ b/src/pycolmap/image/undistortion_test.py
@@ -10,9 +10,9 @@ def test_undistort_camera_options_default_init():
 
 def test_warp_image_options_direct_warp_min_scale_readwrite():
     options = pycolmap.WarpImageOptions()
-    assert options.direct_warp_min_scale == 0.9
-    options.direct_warp_min_scale = 0.5
     assert options.direct_warp_min_scale == 0.5
+    options.direct_warp_min_scale = 0.4
+    assert options.direct_warp_min_scale == 0.4
 
 
 def test_undistort_camera_options_warp_options_readwrite():

--- a/src/pycolmap/image/undistortion_test.py
+++ b/src/pycolmap/image/undistortion_test.py
@@ -8,6 +8,20 @@ def test_undistort_camera_options_default_init():
     assert options is not None
 
 
+def test_warp_image_options_direct_warp_min_scale_readwrite():
+    options = pycolmap.WarpImageOptions()
+    assert options.direct_warp_min_scale == 0.9
+    options.direct_warp_min_scale = 0.5
+    assert options.direct_warp_min_scale == 0.5
+
+
+def test_undistort_camera_options_warp_options_readwrite():
+    options = pycolmap.UndistortCameraOptions()
+    assert isinstance(options.warp_options, pycolmap.WarpImageOptions)
+    options.warp_options.direct_warp_min_scale = 0.5
+    assert options.warp_options.direct_warp_min_scale == 0.5
+
+
 def test_undistort_camera_options_blank_pixels_readwrite():
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.blank_pixels, float)


### PR DESCRIPTION
## Summary

- add `WarpImageOptions::direct_warp_min_scale`, defaulting to `0.5`, to warp directly at the target resolution for equal-size outputs and reductions of up to 2x per dimension
- retain the source-resolution warp plus OpenImageIO resize when either target/source dimension ratio is below the threshold
- propagate the options through camera undistortion and stereo rectification
- expose `WarpImageOptions` and `UndistortCameraOptions.warp_options` in pycolmap

## Performance

Release benchmarks at 1920x1080 on the development host:

| Camera model | Legacy | Direct warp (default) | Speedup |
|---|---:|---:|---:|
| OPENCV | 230.6 ms | 34.0 ms | 6.8x |
| OPENCV_FISHEYE | 296.2 ms | 71.3 ms | 4.2x |

The improvement comes from avoiding both the higher source-resolution pixel loop and the final generic OpenImageIO resize. These benchmark outputs qualify for direct warping with the new `0.5` default.

## Accuracy tradeoff

For a pure, aligned 2x reduction, COLMAP's pixel-center convention makes bilinear interpolation average the corresponding 2x2 source pixels. This makes `0.5` a practical cutoff for ordinary imagery rather than limiting direct warping to very small reductions.

This is not an unconditional antialiasing guarantee: undistortion and homography mappings can produce rotated, stretched, or spatially varying source footprints, and a 2x2 box average is not an ideal low-pass filter. Reductions larger than 2x retain the legacy source-resolution warp and OpenImageIO resize. Callers can set the threshold to `1.0` to retain that path for every downscale, or lower it to favor performance.

## Tests

- `ctest --output-on-failure -R '(image/(warp|undistortion)|controllers/undistorters)_test'`
- pycolmap undistortion and image pipeline tests (21 passed)
- `git diff --check`