### PR TITLE
Inline bitmap interpolation methods

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -231,68 +231,6 @@ void Bitmap::Fill(const BitmapColor<uint8_t>& color) {
   }
 }
 
-std::optional<BitmapColor<uint8_t>> Bitmap::InterpolateNearestNeighbor(
-    const double x, const double y) const {
-  const int xx = static_cast<int>(std::round(x));
-  const int yy = static_cast<int>(std::round(y));
-  return GetPixel(xx, yy);
-}
-
-std::optional<BitmapColor<float>> Bitmap::InterpolateBilinear(
-    const double x, const double y) const {
-  const int x0 = static_cast<int>(std::floor(x));
-  const int x1 = x0 + 1;
-  const int y0 = static_cast<int>(std::floor(y));
-  const int y1 = y0 + 1;
-
-  if (x0 < 0 || x1 >= width_ || y0 < 0 || y1 >= height_) {
-    return std::nullopt;
-  }
-
-  const double dx = x - x0;
-  const double dy = y - y0;
-  const double dx_1 = 1 - dx;
-  const double dy_1 = 1 - dy;
-
-  const int pitch = width_ * channels_;
-  const uint8_t* line0 = &data_[y0 * pitch];
-  const uint8_t* line1 = &data_[y1 * pitch];
-
-  if (IsGrey()) {
-    // Top row, column-wise linear interpolation.
-    const double v0 = dx_1 * line0[x0] + dx * line0[x1];
-
-    // Bottom row, column-wise linear interpolation.
-    const double v1 = dx_1 * line1[x0] + dx * line1[x1];
-
-    // Row-wise linear interpolation.
-    const float r = dy_1 * v0 + dy * v1;
-    return BitmapColor<float>(r, r, r);
-  } else if (IsRGB()) {
-    const uint8_t* p00 = &line0[3 * x0];
-    const uint8_t* p01 = &line0[3 * x1];
-    const uint8_t* p10 = &line1[3 * x0];
-    const uint8_t* p11 = &line1[3 * x1];
-
-    // Top row, column-wise linear interpolation.
-    const double v0_r = dx_1 * p00[0] + dx * p01[0];
-    const double v0_g = dx_1 * p00[1] + dx * p01[1];
-    const double v0_b = dx_1 * p00[2] + dx * p01[2];
-
-    // Bottom row, column-wise linear interpolation.
-    const double v1_r = dx_1 * p10[0] + dx * p11[0];
-    const double v1_g = dx_1 * p10[1] + dx * p11[1];
-    const double v1_b = dx_1 * p10[2] + dx * p11[2];
-
-    // Row-wise linear interpolation.
-    return BitmapColor<float>(dy_1 * v0_r + dy * v1_r,
-                              dy_1 * v0_g + dy * v1_g,
-                              dy_1 * v0_b + dy * v1_b);
-  }
-
-  return std::nullopt;
-}
-
 std::optional<int> Bitmap::ExifOrientation() const {
   int orientation = 0;
   if (GetMetaData("Orientation", "int", &orientation)) {

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -113,10 +113,10 @@ class Bitmap {
   void Fill(const BitmapColor<uint8_t>& color);
 
   // Interpolate color at given floating point position.
-  std::optional<BitmapColor<uint8_t>> InterpolateNearestNeighbor(
+  inline std::optional<BitmapColor<uint8_t>> InterpolateNearestNeighbor(
       double x, double y) const;
-  std::optional<BitmapColor<float>> InterpolateBilinear(double x,
-                                                        double y) const;
+  inline std::optional<BitmapColor<float>> InterpolateBilinear(double x,
+                                                               double y) const;
 
   // Extract EXIF information from bitmap. Returns std::nullopt if no EXIF
   // information is embedded in the bitmap.
@@ -324,6 +324,68 @@ bool Bitmap::SetPixel(const int x,
   }
 
   return false;
+}
+
+std::optional<BitmapColor<uint8_t>> Bitmap::InterpolateNearestNeighbor(
+    const double x, const double y) const {
+  const int xx = static_cast<int>(std::round(x));
+  const int yy = static_cast<int>(std::round(y));
+  return GetPixel(xx, yy);
+}
+
+std::optional<BitmapColor<float>> Bitmap::InterpolateBilinear(
+    const double x, const double y) const {
+  const int x0 = static_cast<int>(std::floor(x));
+  const int x1 = x0 + 1;
+  const int y0 = static_cast<int>(std::floor(y));
+  const int y1 = y0 + 1;
+
+  if (x0 < 0 || x1 >= width_ || y0 < 0 || y1 >= height_) {
+    return std::nullopt;
+  }
+
+  const double dx = x - x0;
+  const double dy = y - y0;
+  const double dx_1 = 1 - dx;
+  const double dy_1 = 1 - dy;
+
+  const int pitch = width_ * channels_;
+  const uint8_t* line0 = &data_[y0 * pitch];
+  const uint8_t* line1 = &data_[y1 * pitch];
+
+  if (IsGrey()) {
+    // Top row, column-wise linear interpolation.
+    const double v0 = dx_1 * line0[x0] + dx * line0[x1];
+
+    // Bottom row, column-wise linear interpolation.
+    const double v1 = dx_1 * line1[x0] + dx * line1[x1];
+
+    // Row-wise linear interpolation.
+    const float r = dy_1 * v0 + dy * v1;
+    return BitmapColor<float>(r, r, r);
+  } else if (IsRGB()) {
+    const uint8_t* p00 = &line0[3 * x0];
+    const uint8_t* p01 = &line0[3 * x1];
+    const uint8_t* p10 = &line1[3 * x0];
+    const uint8_t* p11 = &line1[3 * x1];
+
+    // Top row, column-wise linear interpolation.
+    const double v0_r = dx_1 * p00[0] + dx * p01[0];
+    const double v0_g = dx_1 * p00[1] + dx * p01[1];
+    const double v0_b = dx_1 * p00[2] + dx * p01[2];
+
+    // Bottom row, column-wise linear interpolation.
+    const double v1_r = dx_1 * p10[0] + dx * p11[0];
+    const double v1_g = dx_1 * p10[1] + dx * p11[1];
+    const double v1_b = dx_1 * p10[2] + dx * p11[2];
+
+    // Row-wise linear interpolation.
+    return BitmapColor<float>(dy_1 * v0_r + dy * v1_r,
+                              dy_1 * v0_g + dy * v1_g,
+                              dy_1 * v0_b + dy * v1_b);
+  }
+
+  return std::nullopt;
 }
 
 }  // namespace colmap


### PR DESCRIPTION
## Summary

- Move `Bitmap::InterpolateNearestNeighbor` and `Bitmap::InterpolateBilinear` into `bitmap.h` so callers can inline them.
- Preserve the existing interpolation algorithms, API, and numerical results.
- Enable the optimization for all call sites, including image warping, MVS fusion and texture mapping, and reconstruction color extraction.

## Performance

Measured with a 1920x1080 RGB camera warp in a Release build with IPO on an Apple M3 Pro. Results are median CPU time over 30 randomized repetitions:

| Interpolation | Out of line | Inlined | Improvement |
| --- | ---: | ---: | ---: |
| Bilinear | 34.3 ms | 31.1 ms | 9.3% |
| Nearest neighbor | 22.9 ms | 22.7 ms | 0.9% |

Bilinear benefits more because inlining lets the compiler optimize interpolation together with the subsequent `BitmapColor<float>` to `BitmapColor<uint8_t>` conversion and eliminate the intermediate `std::optional` boundary.

I also evaluated changing bilinear arithmetic to `float`. Float accumulation was only 0.4% faster in the complete warp and full-float coordinates were 0.4% slower, both within noise, so this PR retains double-precision behavior.

## Testing

- `ctest --output-on-failure -R "^(sensor/bitmap_test|image/warp_test)$"`