### PR TITLE
Fix Caspar BA option handling and GlobalMapper fallback

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_caspar.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar.cc
@@ -21,14 +21,25 @@ class CasparBundleAdjuster : public BundleAdjuster {
                        BundleAdjustmentConfig config,
                        Reconstruction& reconstruction)
       : BundleAdjuster(options, config), reconstruction_(reconstruction) {
-    VLOG(1) << "Using Caspar bundle adjuster";
+    VLOG(2) << "Creating Caspar bundle adjuster";
 
+    LogUnsupportedOptions();
     BuildObservationCounts();
     FixGauge();
     BuildFactors();
   }
 
  private:
+  void LogUnsupportedOptions() const {
+    if (options_.refine_rig_from_world &&
+        options_.constant_rig_from_world_rotation) {
+      LOG(ERROR)
+          << "Caspar does not support constant_rig_from_world_rotation=true. "
+             "The option will be ignored and eligible rig rotations will be "
+             "refined.";
+    }
+  }
+
   ICasparModelAdapter* GetAdapter(const CameraModelId model_id) {
     auto it = adapters_.find(model_id);
     if (it != adapters_.end()) {
@@ -59,7 +70,8 @@ class CasparBundleAdjuster : public BundleAdjuster {
       }
       for (const Point2D& point2D : image.Points2D()) {
         if (!point2D.HasPoint3D() ||
-            config_.IsIgnoredPoint(point2D.point3D_id)) {
+            config_.IsIgnoredPoint(point2D.point3D_id) ||
+            !HasSufficientTrackLength(point2D.point3D_id)) {
           continue;
         }
         point3D_num_observations_[point2D.point3D_id]++;
@@ -74,6 +86,9 @@ class CasparBundleAdjuster : public BundleAdjuster {
   }
 
   void CountExternalObservations(const point3D_t point3D_id) {
+    if (!HasSufficientTrackLength(point3D_id)) {
+      return;
+    }
     const Point3D& point3D = reconstruction_.Point3D(point3D_id);
     for (const auto& track_el : point3D.track.Elements()) {
       if (!config_.HasImage(track_el.image_id)) {
@@ -225,6 +240,9 @@ class CasparBundleAdjuster : public BundleAdjuster {
 
   void AddFactorsForExternalObservations(const point3D_t point3D_id) {
     THROW_CHECK(!config_.IsIgnoredPoint(point3D_id));
+    if (!HasSufficientTrackLength(point3D_id)) {
+      return;
+    }
     Point3D& point3D = reconstruction_.Point3D(point3D_id);
     GetOrCreatePoint(point3D_id, point3D);
 
@@ -461,13 +479,20 @@ class CasparBundleAdjuster : public BundleAdjuster {
   }
 
   bool IsPointVariable(const point3D_t point3D_id) const {
-    if (config_.HasConstantPoint(point3D_id) ||
+    if (!options_.refine_points3D || config_.HasConstantPoint(point3D_id) ||
         gauge_fixed_points_.count(point3D_id)) {
       return false;
     }
     const auto it = point3D_num_observations_.find(point3D_id);
     return it != point3D_num_observations_.end() &&
            reconstruction_.Point3D(point3D_id).track.Length() <= it->second;
+  }
+
+  bool HasSufficientTrackLength(const point3D_t point3D_id) const {
+    return options_.min_track_length <= 0 ||
+           static_cast<int>(
+               reconstruction_.Point3D(point3D_id).track.Length()) >=
+               options_.min_track_length;
   }
 
   void FixGauge() {

--- a/src/colmap/estimators/bundle_adjustment_caspar_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar_test.cc
@@ -377,6 +377,45 @@ TEST(DefaultBundleAdjuster, PartiallyContainedTracks) {
   }
 }
 
+TEST(DefaultBundleAdjuster, MinimumTrackLengthWithExternalObservations) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 3;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.num_points2D_without_point3D = 0;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  SynthesizeNoise(synthetic_noise_options, &reconstruction);
+
+  // Shorten one track from three to two observations. The remaining
+  // observations are split between a configured image and an external image.
+  reconstruction.DeleteObservation(2, 0);
+
+  BundleAdjustmentConfig config;
+  config.AddImage(1);
+  config.AddImage(2);
+  for (const auto& [point3D_id, _] : reconstruction.Points3D()) {
+    config.AddVariablePoint(point3D_id);
+  }
+  config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+
+  BundleAdjustmentOptions options;
+  options.min_track_length = 3;
+  const auto summary =
+      CreateDefaultCasparBundleAdjuster(options, config, reconstruction)
+          ->Solve();
+  ASSERT_NE(summary->termination_type,
+            BundleAdjustmentTerminationType::FAILURE);
+
+  // 99 points x 3 observations x 2 residuals per observation. The point with
+  // a two-observation track is excluded from both configured and external
+  // images.
+  EXPECT_EQ(summary->num_residuals, 594);
+}
+
 TEST(DefaultBundleAdjuster, ConstantPoints) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;

--- a/src/colmap/estimators/bundle_adjustment_caspar_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar_test.cc
@@ -463,6 +463,39 @@ TEST(DefaultBundleAdjuster, ConstantPoints) {
   }
 }
 
+TEST(DefaultBundleAdjuster, ConstantAllPoints) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 100;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  SynthesizeNoise(synthetic_noise_options, &reconstruction);
+  const Reconstruction orig_reconstruction = reconstruction;
+
+  BundleAdjustmentConfig config;
+  config.AddImage(1);
+  config.AddImage(2);
+  config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+
+  BundleAdjustmentOptions options;
+  options.refine_points3D = false;
+  const auto summary =
+      CreateDefaultCasparBundleAdjuster(options, config, reconstruction)
+          ->Solve();
+  ASSERT_NE(summary->termination_type,
+            BundleAdjustmentTerminationType::FAILURE);
+
+  // 100 points, 2 images, 2 residuals per point per image.
+  EXPECT_EQ(summary->num_residuals, 400);
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    CheckConstantPoint(point3D, orig_reconstruction.Point3D(point3D_id));
+  }
+}
+
 TEST(DefaultBundleAdjuster, VariableImage) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions synthetic_dataset_options;

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -600,6 +600,8 @@ class DefaultBundleAdjuster : public CeresBundleAdjuster {
                         Reconstruction& reconstruction)
       : CeresBundleAdjuster(options, config),
         loss_function_(options_.ceres->CreateLossFunction()) {
+    VLOG(2) << "Creating Ceres bundle adjuster";
+
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
     problem_ = std::make_shared<ceres::Problem>(problem_options);
@@ -898,6 +900,8 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
         prior_options_(prior_options),
         pose_priors_(std::move(pose_priors)),
         reconstruction_(reconstruction) {
+    VLOG(2) << "Creating Ceres pose prior bundle adjuster";
+
     THROW_CHECK(prior_options_.Check());
 
     // Filter irrelevant pose priors.

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -347,9 +347,80 @@ TEST_P(BundleAdjusterBackendTest, Nominal) {
                                  /*num_obs_tolerance=*/0.0));
 }
 
+TEST_P(BundleAdjusterBackendTest, MinimumTrackLength) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 3;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.num_points2D_without_point3D = 0;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  SynthesizeNoise(synthetic_noise_options, &reconstruction);
+
+  reconstruction.DeleteObservation(3, 0);
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+  }
+  config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+
+  BundleAdjustmentOptions options;
+  options.backend = GetParam();
+  options.min_track_length = 3;
+  const auto summary =
+      CreateDefaultBundleAdjuster(options, config, reconstruction)->Solve();
+  ASSERT_TRUE(summary->IsSolutionUsable());
+
+  // 99 points x 3 observations x 2 residuals per observation. The point with
+  // a two-observation track is excluded.
+  EXPECT_EQ(summary->num_residuals, 594);
+}
+
+TEST_P(BundleAdjusterBackendTest, ConstantPoints3D) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 20;
+  SynthesizeDataset(synthetic_dataset_options, &reconstruction);
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  SynthesizeNoise(synthetic_noise_options, &reconstruction);
+  const Reconstruction original_reconstruction = reconstruction;
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+  }
+
+  BundleAdjustmentOptions options;
+  options.backend = GetParam();
+  options.refine_points3D = false;
+  const auto summary =
+      CreateDefaultBundleAdjuster(options, config, reconstruction)->Solve();
+  ASSERT_TRUE(summary->IsSolutionUsable());
+  EXPECT_EQ(summary->num_residuals, 80);
+
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    EXPECT_EQ(point3D.xyz, original_reconstruction.Point3D(point3D_id).xyz);
+  }
+}
+
+#ifdef CASPAR_ENABLED
+INSTANTIATE_TEST_SUITE_P(BundleAdjusterBackends,
+                         BundleAdjusterBackendTest,
+                         ::testing::Values(BundleAdjustmentBackend::CERES,
+                                           BundleAdjustmentBackend::CASPAR));
+#else
 INSTANTIATE_TEST_SUITE_P(BundleAdjusterBackends,
                          BundleAdjusterBackendTest,
                          ::testing::Values(BundleAdjustmentBackend::CERES));
+#endif
 
 // Parameterized test for generic PosePriorBundleAdjuster interface across
 // backends.

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -411,16 +411,9 @@ TEST_P(BundleAdjusterBackendTest, ConstantPoints3D) {
   }
 }
 
-#ifdef CASPAR_ENABLED
-INSTANTIATE_TEST_SUITE_P(BundleAdjusterBackends,
-                         BundleAdjusterBackendTest,
-                         ::testing::Values(BundleAdjustmentBackend::CERES,
-                                           BundleAdjustmentBackend::CASPAR));
-#else
 INSTANTIATE_TEST_SUITE_P(BundleAdjusterBackends,
                          BundleAdjusterBackendTest,
                          ::testing::Values(BundleAdjustmentBackend::CERES));
-#endif
 
 // Parameterized test for generic PosePriorBundleAdjuster interface across
 // backends.

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -355,16 +355,7 @@ bool GlobalMapper::IterativeBundleAdjustment(
       // Caspar's pose node is a single retracted Pose3 (rotation+
       // translation together) with no mechanism to hold rotation
       // constant while translation is free -- constant_rig_from_world_
-      // rotation is silently ignored when backend == CASPAR (confirmed:
-      // zero references to it anywhere in bundle_adjustment_caspar.cc),
-      // so this stage would otherwise silently degrade into a second full
-      // joint optimization pass instead of a stabilizing partial one.
-      // Live 3-scene accuracy sweep confirmed this causes real
-      // scale-regime-split regressions on non-trivial scenes (floor2:
-      // 0->2, trolley_femto: 0->5; only the smallest/simplest scene
-      // stayed clean). Force Ceres for just this sub-stage -- it's the
-      // cheap half of the loop anyway; the joint-optimization stage below
-      // keeps the requested backend (Caspar's actual speed win).
+      // rotation is silently ignored when backend == CASPAR.
       if (opts_position_only.backend == BundleAdjustmentBackend::CASPAR) {
         opts_position_only.backend = BundleAdjustmentBackend::CERES;
       }

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -352,6 +352,22 @@ bool GlobalMapper::IterativeBundleAdjustment(
     if (!skip_fixed_rotation_stage) {
       BundleAdjustmentOptions opts_position_only = options;
       opts_position_only.constant_rig_from_world_rotation = true;
+      // Caspar's pose node is a single retracted Pose3 (rotation+
+      // translation together) with no mechanism to hold rotation
+      // constant while translation is free -- constant_rig_from_world_
+      // rotation is silently ignored when backend == CASPAR (confirmed:
+      // zero references to it anywhere in bundle_adjustment_caspar.cc),
+      // so this stage would otherwise silently degrade into a second full
+      // joint optimization pass instead of a stabilizing partial one.
+      // Live 3-scene accuracy sweep confirmed this causes real
+      // scale-regime-split regressions on non-trivial scenes (floor2:
+      // 0->2, trolley_femto: 0->5; only the smallest/simplest scene
+      // stayed clean). Force Ceres for just this sub-stage -- it's the
+      // cheap half of the loop anyway; the joint-optimization stage below
+      // keeps the requested backend (Caspar's actual speed win).
+      if (opts_position_only.backend == BundleAdjustmentBackend::CASPAR) {
+        opts_position_only.backend = BundleAdjustmentBackend::CERES;
+      }
       if (!RunBundleAdjustment(opts_position_only, *reconstruction_)) {
         return false;
       }


### PR DESCRIPTION
## Summary

- Use Ceres for the fixed-rotation stage of GlobalMapper iterative bundle adjustment when Caspar is selected.
- Make the Caspar backend honor `min_track_length` and `refine_points3D`.
- Report that `constant_rig_from_world_rotation` is unsupported by Caspar instead of silently ignoring it.
- Add backend diagnostics and shared Ceres/Caspar tests for the supported options, including external observations.

## Motivation

GlobalMapper performs iterative bundle adjustment in two stages: it first holds rig rotations constant to stabilize positions, then runs full joint optimization. Caspar represents each pose as one retracted `Pose3`, so it cannot keep rotation fixed while refining translation. The fixed-rotation option was therefore ignored and the first stage became another full joint-optimization pass.

A downstream three-scene accuracy sweep found internally inconsistent scale regimes in two non-trivial reconstructions when `GlobalMapper.ba_backend=CASPAR` was used. The standalone Caspar bundle adjuster also did not consistently apply the generic minimum-track-length and fixed-point options.

## Fix

GlobalMapper now uses Ceres only for its fixed-rotation sub-stage and retains Caspar for the more expensive full joint-optimization stage. Caspar now filters short tracks, keeps points fixed when point refinement is disabled, and emits an explicit diagnostic for its remaining constant-rotation limitation.

## Verification

- All 17 tests in the local Ceres-enabled `bundle_adjustment_test` binary pass.
- Shared Ceres tests cover `min_track_length` and `refine_points3D`.
- Dedicated Caspar tests cover `min_track_length`, including external observations, and `refine_points3D`.
- Both previously regressed real scenes reconstruct without inconsistent scale regimes after the GlobalMapper fallback (previously 2 and 5 regimes). The internal BA loop retains a substantial speedup over CPU/Ceres (approximately 299 s versus 884 s on a 1,599-frame scene).

Related: #4484, #4611.
