### PR TITLE
Disable DEGENSAC by default and expose it as a CLI option

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -365,6 +365,8 @@ void OptionManager::AddTwoViewGeometryOptions() {
                    &two_view_geometry->filter_stationary_matches);
   AddDefaultOption("TwoViewGeometry.stationary_matches_max_error",
                    &two_view_geometry->stationary_matches_max_error);
+  AddDefaultOption("TwoViewGeometry.use_degensac",
+                   &two_view_geometry->use_degensac);
   AddDefaultOption("TwoViewGeometry.max_error",
                    &two_view_geometry->ransac_options.max_error);
   AddDefaultOption("TwoViewGeometry.confidence",

--- a/src/colmap/estimators/two_view_geometry.h
+++ b/src/colmap/estimators/two_view_geometry.h
@@ -99,9 +99,8 @@ struct TwoViewGeometryOptions {
   bool force_H_use = false;
 
   // Use DEGENSAC (Chum et al., CVPR 2005) for the fundamental matrix instead of
-  // plain LO-RANSAC, making estimation robust to a dominant scene plane. On by
-  // default.
-  bool use_degensac = true;
+  // plain LO-RANSAC, making estimation robust to a dominant scene plane.
+  bool use_degensac = false;
 
   // Whether to compute the relative pose between the two views.
   bool compute_relative_pose = false;


### PR DESCRIPTION
Regression reported on IMC2023 that we are not yet able to resolve. Disabled for now and awaiting for more in-depth analysis. cc: @vlarsson 

Below shows the results after view graph calibration. 

## Focal AUC@5% (IMC2023, mean of 3 seeds, [min, max])

  | scene | 4.0.4 | main | main-nodeg | delta |
  |---|---|---|---|---|
  | st_pauls_cathedral | 31.64 [25.7, 35.0] | **9.90** [8.2, 12.2] | 32.17 [27.8, 34.3] | **−21.75** |
  | sagrada_familia | 33.04 [30.4, 38.3] | **16.57** [10.6, 22.9] | 33.11 [30.9, 36.1] | **−16.47** |
  | piazza_san_marco | 9.04 [5.3, 12.2] | 6.94 [4.1, 8.8] | 8.74 [4.5, 12.0] | −2.11 |

  ## Focal AUC@20% (IMC2023, mean of 3 seeds, [min, max])

  | scene | 4.0.4 | main | main-nodeg | delta |
  |---|---|---|---|---|
  | st_pauls_cathedral | 60.53 [53.1, 65.3] | **35.23** [32.5, 38.0] | 61.38 [56.3, 66.4] | **−25.29** |
  | sagrada_familia | 59.64 [57.3, 62.8] | **45.66** [41.6, 52.5] | 59.61 [58.2, 60.8] | **−13.98** |
  | piazza_san_marco | 31.21 [28.3, 36.9] | 29.59 [25.1, 32.6] | 31.11 [26.8, 36.3] | −1.62 |

  main = 7e7b86ec (DEGENSAC on by default, #4543).
  main-nodeg = same commit with use_degensac = false.
  Metric: relative focal error |f_est - f_gt| / f_gt per image after
  view_graph_calibrator, macro-averaged AUC. One camera per image, no EXIF
  priors, exhaustive matching, no mapper.