### PR TITLE
Estimate homography on rays for distorted cameras and spherical cases

### DIFF
--- a/src/colmap/estimators/solvers/homography_matrix.cc
+++ b/src/colmap/estimators/solvers/homography_matrix.cc
@@ -32,6 +32,9 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
+#include <limits>
+#include <optional>
+
 #include <Eigen/Geometry>
 #include <Eigen/LU>
 #include <Eigen/SVD>
@@ -127,6 +130,111 @@ void HomographyMatrixEstimator::Residuals(const std::vector<X_t>& points1,
     const double dd_1 = d_1 - pd_1 * inv_pd_2;
 
     (*residuals)[i] = dd_0 * dd_0 + dd_1 * dd_1;
+  }
+}
+
+void HomographyMatrixRayEstimator::Estimate(const std::vector<X_t>& cam_rays1,
+                                            const std::vector<Y_t>& cam_rays2,
+                                            std::vector<M_t>* models) const {
+  THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
+  THROW_CHECK_GE(cam_rays1.size(), 4);
+  THROW_CHECK(models != nullptr);
+
+  models->clear();
+
+  const size_t num_rays = cam_rays1.size();
+
+  // Setup constraint matrix from x2 x (H x1) = 0. Of the three equations, the
+  // rows of [x2]_x, only two are independent, and the weakest is always the one
+  // omitting the largest component of x2. For a perspective camera z dominates
+  // and this reduces to the pixel estimator's rows.
+  Eigen::Matrix<double, Eigen::Dynamic, 9> A(2 * num_rays, 9);
+  for (size_t i = 0; i < num_rays; ++i) {
+    const Eigen::Vector3d& ray1 = cam_rays1[i];
+    const Eigen::Vector3d& ray2 = cam_rays2[i].ray;
+
+    Eigen::Matrix<double, 3, 9> equations = Eigen::Matrix<double, 3, 9>::Zero();
+    equations.block<1, 3>(0, 3) = -ray2.z() * ray1.transpose();
+    equations.block<1, 3>(0, 6) = ray2.y() * ray1.transpose();
+    equations.block<1, 3>(1, 0) = ray2.z() * ray1.transpose();
+    equations.block<1, 3>(1, 6) = -ray2.x() * ray1.transpose();
+    equations.block<1, 3>(2, 0) = -ray2.y() * ray1.transpose();
+    equations.block<1, 3>(2, 3) = ray2.x() * ray1.transpose();
+
+    // Equation j omits component j of x2, so the one to drop is the argmax.
+    int dropped_equation_idx = 0;
+    ray2.cwiseAbs().maxCoeff(&dropped_equation_idx);
+    int num_kept = 0;
+    for (int j = 0; j < 3; ++j) {
+      if (j != dropped_equation_idx) {
+        A.row(2 * i + num_kept++) = equations.row(j);
+      }
+    }
+  }
+
+  Eigen::Matrix3d H;
+  if (num_rays == 4) {
+    const Eigen::Matrix<double, 9, 1> h = A.block<8, 8>(0, 0)
+                                              .partialPivLu()
+                                              .solve(-A.block<8, 1>(0, 8))
+                                              .homogeneous();
+    if (h.hasNaN()) {
+      return;
+    }
+    H = Eigen::Map<const Eigen::Matrix3d>(h.data()).transpose();
+  } else {
+    // Solve for the nullspace of the constraint matrix.
+    Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, 9>> svd(
+        A, Eigen::ComputeFullV);
+    if (svd.rank() < 8) {
+      return;
+    }
+    const Eigen::VectorXd nullspace = svd.matrixV().col(8);
+    H = Eigen::Map<const Eigen::Matrix3d>(nullspace.data()).transpose();
+  }
+
+  if (std::abs(H.determinant()) < 1e-8) {
+    return;
+  }
+
+  // H is defined up to scale, but the residual projects H x1 back into an image
+  // that does not contain both a direction and its opposite, so the sign
+  // matters. It is global, not per correspondence: a visible plane point has
+  // positive depth, so x2 ~ lambda H x1 holds with lambda > 0 throughout and
+  // the only freedom is that the solver may return -H. Resolving it per point
+  // instead would score each against its nearer antipode, letting a 180 degree
+  // error pass as a perfect inlier.
+  int sign_votes = 0;
+  for (size_t i = 0; i < num_rays; ++i) {
+    sign_votes += (H * cam_rays1[i]).dot(cam_rays2[i].ray) > 0 ? 1 : -1;
+  }
+  if (sign_votes < 0) {
+    H = -H;
+  }
+
+  models->resize(1);
+  (*models)[0] = H;
+}
+
+void HomographyMatrixRayEstimator::Residuals(
+    const std::vector<X_t>& cam_rays1,
+    const std::vector<Y_t>& cam_rays2,
+    const M_t& H,
+    std::vector<double>* residuals) const {
+  THROW_CHECK_EQ(cam_rays1.size(), cam_rays2.size());
+  THROW_CHECK_NOTNULL(camera2_);
+
+  residuals->resize(cam_rays1.size());
+
+  for (size_t i = 0; i < cam_rays1.size(); ++i) {
+    const std::optional<Eigen::Vector2d> img_point =
+        camera2_->ImgFromCam(H * cam_rays1[i]);
+    if (img_point.has_value()) {
+      (*residuals)[i] = (*img_point - cam_rays2[i].img_point).squaredNorm();
+    } else {
+      // Transferred out of the camera's field, so there is nothing to score.
+      (*residuals)[i] = std::numeric_limits<double>::max();
+    }
   }
 }
 

--- a/src/colmap/estimators/solvers/homography_matrix.cc
+++ b/src/colmap/estimators/solvers/homography_matrix.cc
@@ -32,6 +32,7 @@
 #include "colmap/util/eigen_alignment.h"
 #include "colmap/util/logging.h"
 
+#include <cmath>
 #include <limits>
 #include <optional>
 
@@ -226,15 +227,26 @@ void HomographyMatrixRayEstimator::Residuals(
 
   residuals->resize(cam_rays1.size());
 
+  // Azimuthal models wrap at the +-pi seam, where a raw pixel difference jumps
+  // by about the image width. Wrap it into [-width/2, width/2), as
+  // WrapEquirectangularHorizontalSeam does for the reprojection error, which
+  // spells the same rounding as a floor since it must stay autodiff-safe.
+  const bool is_periodic = camera2_->IsSpherical();
+  const double width = static_cast<double>(camera2_->width);
+
   for (size_t i = 0; i < cam_rays1.size(); ++i) {
     const std::optional<Eigen::Vector2d> img_point =
         camera2_->ImgFromCam(H * cam_rays1[i]);
-    if (img_point.has_value()) {
-      (*residuals)[i] = (*img_point - cam_rays2[i].img_point).squaredNorm();
-    } else {
+    if (!img_point.has_value()) {
       // Transferred out of the camera's field, so there is nothing to score.
       (*residuals)[i] = std::numeric_limits<double>::max();
+      continue;
     }
+    Eigen::Vector2d error = *img_point - cam_rays2[i].img_point;
+    if (is_periodic) {
+      error.x() -= width * std::round(error.x() / width);
+    }
+    (*residuals)[i] = error.squaredNorm();
   }
 }
 

--- a/src/colmap/estimators/solvers/homography_matrix.h
+++ b/src/colmap/estimators/solvers/homography_matrix.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/scene/camera.h"
 #include "colmap/util/eigen_alignment.h"
 
 #include <vector>
@@ -74,6 +75,69 @@ class HomographyMatrixEstimator {
                         const std::vector<Y_t>& points2,
                         const M_t& H,
                         std::vector<double>* residuals);
+};
+
+// A ray together with the image point it was unprojected from. The ray drives
+// the estimation, the image point is what the residual is measured against.
+struct CamRayWithImgPoint {
+  Eigen::Vector3d ray;
+  Eigen::Vector2d img_point;
+};
+
+// Direct linear transformation algorithm to compute the homography between
+// bearing rays. A world plane induces x2 ~ H x1 on the rays of any central
+// camera, whereas image points are related by a 3x3 matrix only under a pinhole
+// projection, which every model but SIMPLE_PINHOLE and PINHOLE breaks.
+//
+// The rays must come from cameras with known intrinsics. The estimated H maps
+// rays to rays; conjugate it as K2 H K1^-1 for the pixel-space homography,
+// which spherical cameras have no calibration matrix for.
+class HomographyMatrixRayEstimator {
+ public:
+  using X_t = Eigen::Vector3d;
+  using Y_t = CamRayWithImgPoint;
+  using M_t = Eigen::Matrix3d;
+
+  // The minimum number of samples needed to estimate a model.
+  static const int kMinNumSamples = 4;
+
+  // RANSAC copies the estimator per thread, so this must stay cheap to copy.
+  // The camera must outlive the estimator.
+  explicit HomographyMatrixRayEstimator(const Camera* camera2 = nullptr)
+      : camera2_(camera2) {}
+
+  // Estimate the projective transformation (homography) between bearing rays.
+  //
+  // The number of corresponding rays must be at least 4.
+  //
+  // @param cam_rays1  First set of corresponding rays.
+  // @param cam_rays2  Second set of corresponding rays and image points.
+  //
+  // @return         3x3 homogeneous transformation matrix.
+  void Estimate(const std::vector<X_t>& cam_rays1,
+                const std::vector<Y_t>& cam_rays2,
+                std::vector<M_t>* models) const;
+
+  // Calculate the transformation error for each corresponding ray pair.
+  //
+  // Residuals are defined as the squared transformation error in the second
+  // camera's pixels: the first ray is transferred through H and projected back
+  // into the image. Unlike the essential matrix, a homography transfers a point
+  // to a point rather than to a line, so this is the exact geometric error and
+  // needs no linearization. Rays with no image point, i.e. transferred behind a
+  // perspective camera, are scored at the maximum residual.
+  //
+  // @param cam_rays1  First set of corresponding rays.
+  // @param cam_rays2  Second set of corresponding rays and image points.
+  // @param H          3x3 projective matrix mapping rays to rays.
+  // @param residuals  Output vector of residuals.
+  void Residuals(const std::vector<X_t>& cam_rays1,
+                 const std::vector<Y_t>& cam_rays2,
+                 const M_t& H,
+                 std::vector<double>* residuals) const;
+
+ private:
+  const Camera* camera2_;
 };
 
 }  // namespace colmap

--- a/src/colmap/estimators/solvers/homography_matrix_test.cc
+++ b/src/colmap/estimators/solvers/homography_matrix_test.cc
@@ -29,8 +29,12 @@
 
 #include "colmap/estimators/solvers/homography_matrix.h"
 
+#include "colmap/math/math.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/eigen_alignment.h"
+
+#include <algorithm>
+#include <limits>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -163,6 +167,228 @@ TEST_P(HomographyMatrixTests, Degenerate) {
 
 INSTANTIATE_TEST_SUITE_P(HomographyMatrix,
                          HomographyMatrixTests,
+                         ::testing::Values(4, 8, 64, 1024));
+
+class HomographyMatrixRayTests : public ::testing::TestWithParam<size_t> {};
+
+// Correspondences for a plane whose pixel-space homography is `H_pix`, with
+// `dst` displaced by `offset` pixels so that residuals are non-trivial.
+void SyntheticRayCorrespondences(const Camera& camera1,
+                                 const Camera& camera2,
+                                 const Eigen::Matrix3d& H_pix,
+                                 size_t num_points,
+                                 double offset,
+                                 std::vector<Eigen::Vector2d>* src,
+                                 std::vector<Eigen::Vector2d>* dst,
+                                 std::vector<Eigen::Vector3d>* cam_rays1,
+                                 std::vector<CamRayWithImgPoint>* cam_rays2) {
+  for (size_t i = 0; i < num_points; ++i) {
+    const Eigen::Vector2d image_size(static_cast<double>(camera1.width),
+                                     static_cast<double>(camera1.height));
+    const Eigen::Vector2d point1 = image_size.cwiseProduct(
+        0.5 * (RandomEigenVectord<2>() + Eigen::Vector2d::Ones()));
+    const Eigen::Vector2d point2 =
+        (H_pix * point1.homogeneous()).hnormalized() +
+        offset * RandomEigenVectord<2>();
+    src->push_back(point1);
+    dst->push_back(point2);
+    cam_rays1->push_back(camera1.CamRayFromImg(point1).value());
+    cam_rays2->push_back({camera2.CamRayFromImg(point2).value(), point2});
+  }
+}
+
+TEST_P(HomographyMatrixRayTests, Nominal) {
+  const size_t kNumPoints = GetParam();
+  const Camera camera1 = Camera::CreateFromModelId(
+      1, CameraModelId::kSimplePinhole, 1000, 1920, 1080);
+  const Camera camera2 = Camera::CreateFromModelId(
+      2, CameraModelId::kSimplePinhole, 1200, 1920, 1080);
+
+  for (int x = 1; x < 10; ++x) {
+    Eigen::Matrix3d H_pix;
+    H_pix << 1 + 0.1 * x, 0.02, 30, 0.03, 1.1, 20, 1e-5, 2e-5, 1;
+
+    std::vector<Eigen::Vector2d> src;
+    std::vector<Eigen::Vector2d> dst;
+    std::vector<Eigen::Vector3d> cam_rays1;
+    std::vector<CamRayWithImgPoint> cam_rays2;
+    SyntheticRayCorrespondences(camera1,
+                                camera2,
+                                H_pix,
+                                kNumPoints,
+                                /*offset=*/0,
+                                &src,
+                                &dst,
+                                &cam_rays1,
+                                &cam_rays2);
+
+    const HomographyMatrixRayEstimator estimator(&camera2);
+    std::vector<Eigen::Matrix3d> models;
+    estimator.Estimate(cam_rays1, cam_rays2, &models);
+
+    ASSERT_EQ(models.size(), 1);
+
+    // Also guards the global sign: a negated H transfers every ray behind the
+    // camera and scores every residual at the maximum.
+    std::vector<double> residuals;
+    estimator.Residuals(cam_rays1, cam_rays2, models[0], &residuals);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      EXPECT_LT(residuals[i], 1e-6);
+    }
+
+    // The estimate maps rays to rays, so it must agree with the pixel-space
+    // homography only after conjugation by the calibration matrices.
+    const Eigen::Matrix3d H_from_rays = camera2.CalibrationMatrix() *
+                                        models[0] *
+                                        camera1.CalibrationMatrix().inverse();
+    EXPECT_TRUE(H_from_rays.normalized().isApprox(H_pix.normalized(), 1e-6) ||
+                H_from_rays.normalized().isApprox(-H_pix.normalized(), 1e-6));
+  }
+}
+
+// For undistorted pinhole cameras the two residuals are algebraically
+// identical, since projecting K2^-1 H K1 x1 back through K2 dehomogenizes to
+// exactly H p1. Large offsets are included because a first-order relationship
+// would also pass near zero.
+TEST_P(HomographyMatrixRayTests, PixelEquivalence) {
+  const size_t kNumPoints = GetParam();
+  const Camera camera1 = Camera::CreateFromModelId(
+      1, CameraModelId::kSimplePinhole, 1000, 1920, 1080);
+  const Camera camera2 =
+      Camera::CreateFromModelId(2, CameraModelId::kPinhole, 1200, 1920, 1080);
+
+  for (const double offset : {0.0, 1.0, 20.0, 200.0}) {
+    Eigen::Matrix3d H_pix;
+    H_pix << 1.2, 0.02, 30, 0.03, 1.1, 20, 1e-5, 2e-5, 1;
+
+    std::vector<Eigen::Vector2d> src;
+    std::vector<Eigen::Vector2d> dst;
+    std::vector<Eigen::Vector3d> cam_rays1;
+    std::vector<CamRayWithImgPoint> cam_rays2;
+    SyntheticRayCorrespondences(camera1,
+                                camera2,
+                                H_pix,
+                                kNumPoints,
+                                offset,
+                                &src,
+                                &dst,
+                                &cam_rays1,
+                                &cam_rays2);
+
+    const Eigen::Matrix3d H_ray = camera2.CalibrationMatrix().inverse() *
+                                  H_pix * camera1.CalibrationMatrix();
+
+    std::vector<double> pixel_residuals;
+    HomographyMatrixEstimator().Residuals(src, dst, H_pix, &pixel_residuals);
+
+    std::vector<double> ray_residuals;
+    HomographyMatrixRayEstimator(&camera2).Residuals(
+        cam_rays1, cam_rays2, H_ray, &ray_residuals);
+
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      EXPECT_NEAR(ray_residuals[i],
+                  pixel_residuals[i],
+                  1e-9 * std::max(1.0, pixel_residuals[i]));
+    }
+  }
+}
+
+// A hypothesis that transfers a ray out of a perspective camera's field has no
+// image point to score against. Cannot happen for a true inlier, whose measured
+// ray faces forward, so this only guards wrong hypotheses.
+TEST(HomographyMatrixRay, BehindCamera) {
+  const Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kSimplePinhole, 1000, 1920, 1080);
+  const std::vector<Eigen::Vector3d> cam_rays1 = {Eigen::Vector3d::UnitZ()};
+  const std::vector<CamRayWithImgPoint> cam_rays2 = {
+      {Eigen::Vector3d::UnitZ(), Eigen::Vector2d(960, 540)}};
+
+  std::vector<double> residuals;
+  HomographyMatrixRayEstimator(&camera).Residuals(
+      cam_rays1,
+      cam_rays2,
+      Eigen::AngleAxisd(DegToRad(100.0), Eigen::Vector3d::UnitY())
+          .toRotationMatrix(),
+      &residuals);
+
+  EXPECT_EQ(residuals[0], std::numeric_limits<double>::max());
+}
+
+// A spherical camera images every direction, so the estimator must work over
+// the whole sphere and reject nothing on cheirality grounds.
+TEST_P(HomographyMatrixRayTests, Spherical) {
+  const size_t kNumPoints = GetParam();
+  const Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kEquirectangular, /*focal_length=*/0, 2048, 1024);
+  ASSERT_TRUE(camera.IsSpherical());
+
+  for (int x = 1; x < 10; ++x) {
+    const Eigen::Matrix3d expected_H =
+        Eigen::AngleAxisd(0.2 * x, Eigen::Vector3d(0.2, 1, 0.3).normalized())
+            .toRotationMatrix();
+
+    std::vector<Eigen::Vector3d> cam_rays1;
+    std::vector<CamRayWithImgPoint> cam_rays2;
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      const Eigen::Vector3d ray1 = RandomEigenVectord<3>().normalized();
+      const Eigen::Vector3d ray2 = (expected_H * ray1).normalized();
+      cam_rays1.push_back(ray1);
+      cam_rays2.push_back({ray2, camera.ImgFromCam(ray2).value()});
+    }
+
+    const HomographyMatrixRayEstimator estimator(&camera);
+    std::vector<Eigen::Matrix3d> models;
+    estimator.Estimate(cam_rays1, cam_rays2, &models);
+
+    ASSERT_EQ(models.size(), 1);
+    EXPECT_TRUE(models[0].normalized().isApprox(expected_H.normalized(), 1e-6));
+
+    std::vector<double> residuals;
+    estimator.Residuals(cam_rays1, cam_rays2, models[0], &residuals);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      EXPECT_LT(residuals[i], 1e-6);
+    }
+  }
+}
+
+// Why Estimate must resolve the sign of H. A spherical camera projects -H x1 as
+// happily as H x1, only to the antipode, so a negated model is not rejected but
+// silently scored against the wrong half of the sphere.
+TEST(HomographyMatrixRay, SphericalSign) {
+  const Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kEquirectangular, /*focal_length=*/0, 2048, 1024);
+  const Eigen::Matrix3d H =
+      Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.2, 1, 0.3).normalized())
+          .toRotationMatrix();
+
+  std::vector<Eigen::Vector3d> cam_rays1;
+  std::vector<CamRayWithImgPoint> cam_rays2;
+  for (int i = 0; i < 64; ++i) {
+    const Eigen::Vector3d ray1 = RandomEigenVectord<3>().normalized();
+    const Eigen::Vector3d ray2 = (H * ray1).normalized();
+    cam_rays1.push_back(ray1);
+    cam_rays2.push_back({ray2, camera.ImgFromCam(ray2).value()});
+  }
+
+  const HomographyMatrixRayEstimator estimator(&camera);
+
+  std::vector<double> residuals;
+  estimator.Residuals(cam_rays1, cam_rays2, H, &residuals);
+  for (const double residual : residuals) {
+    EXPECT_LT(residual, 1e-6);
+  }
+
+  std::vector<double> negated_residuals;
+  estimator.Residuals(cam_rays1, cam_rays2, -H, &negated_residuals);
+  for (const double residual : negated_residuals) {
+    // Finite, so nothing rejects it, but half the image away in azimuth.
+    EXPECT_LT(residual, std::numeric_limits<double>::max());
+    EXPECT_GT(residual, 1e4);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(HomographyMatrixRay,
+                         HomographyMatrixRayTests,
                          ::testing::Values(4, 8, 64, 1024));
 
 }  // namespace

--- a/src/colmap/estimators/solvers/homography_matrix_test.cc
+++ b/src/colmap/estimators/solvers/homography_matrix_test.cc
@@ -34,6 +34,7 @@
 #include "colmap/util/eigen_alignment.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include <Eigen/Core>
@@ -299,19 +300,27 @@ TEST_P(HomographyMatrixRayTests, PixelEquivalence) {
 TEST(HomographyMatrixRay, BehindCamera) {
   const Camera camera = Camera::CreateFromModelId(
       1, CameraModelId::kSimplePinhole, 1000, 1920, 1080);
-  const std::vector<Eigen::Vector3d> cam_rays1 = {Eigen::Vector3d::UnitZ()};
+  const Eigen::Matrix3d H =
+      Eigen::AngleAxisd(DegToRad(100.0), Eigen::Vector3d::UnitY())
+          .toRotationMatrix();
+  // The second ray stays in front after the rotation, so the rejection must be
+  // selective rather than blanket.
+  const Eigen::Vector3d forward =
+      Eigen::AngleAxisd(DegToRad(-70.0), Eigen::Vector3d::UnitY()) *
+      Eigen::Vector3d::UnitZ();
+  const std::vector<Eigen::Vector3d> cam_rays1 = {Eigen::Vector3d::UnitZ(),
+                                                  forward};
   const std::vector<CamRayWithImgPoint> cam_rays2 = {
-      {Eigen::Vector3d::UnitZ(), Eigen::Vector2d(960, 540)}};
+      {Eigen::Vector3d::UnitZ(), Eigen::Vector2d(960, 540)},
+      {(H * forward).normalized(),
+       camera.ImgFromCam((H * forward).normalized()).value()}};
 
   std::vector<double> residuals;
   HomographyMatrixRayEstimator(&camera).Residuals(
-      cam_rays1,
-      cam_rays2,
-      Eigen::AngleAxisd(DegToRad(100.0), Eigen::Vector3d::UnitY())
-          .toRotationMatrix(),
-      &residuals);
+      cam_rays1, cam_rays2, H, &residuals);
 
   EXPECT_EQ(residuals[0], std::numeric_limits<double>::max());
+  EXPECT_LT(residuals[1], 1e-6);
 }
 
 // A spherical camera images every direction, so the estimator must work over
@@ -349,6 +358,29 @@ TEST_P(HomographyMatrixRayTests, Spherical) {
       EXPECT_LT(residuals[i], 1e-6);
     }
   }
+}
+
+// The azimuth wraps, so two nearly identical directions can sit a full image
+// width apart in pixels. Scoring that raw difference would reject every
+// correspondence near the seam.
+TEST(HomographyMatrixRay, SphericalSeam) {
+  const Camera camera = Camera::CreateFromModelId(
+      1, CameraModelId::kEquirectangular, /*focal_length=*/0, 2048, 1024);
+  constexpr double kDelta = 0.01;
+  const Eigen::Vector3d ray1(
+      std::sin(M_PI - kDelta), 0, std::cos(M_PI - kDelta));
+  const Eigen::Vector3d ray2(
+      std::sin(-M_PI + kDelta), 0, std::cos(-M_PI + kDelta));
+  const Eigen::Vector2d point1 = camera.ImgFromCam(ray1).value();
+  const Eigen::Vector2d point2 = camera.ImgFromCam(ray2).value();
+  ASSERT_GT((point1 - point2).norm(), 2000);
+
+  std::vector<double> residuals;
+  HomographyMatrixRayEstimator(&camera).Residuals(
+      {ray1}, {{ray2, point2}}, Eigen::Matrix3d::Identity(), &residuals);
+
+  const double expected = 2 * kDelta * camera.width / (2 * M_PI);
+  EXPECT_NEAR(residuals[0], expected * expected, 1e-6);
 }
 
 // Why Estimate must resolve the sign of H. A spherical camera projects -H x1 as

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -99,33 +99,26 @@ FundamentalMatrixReport EstimateFundamentalMatrix(
 using HomographyMatrixReport =
     LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>::Report;
 
-// Robustly estimate the homography relating two calibrated views. A world plane
-// relates image points projectively only under a pinhole projection, so
-// distorted cameras are estimated on bearing rays and mapped back to pixels.
-// Undistorted pinhole cameras keep the pixel estimator, where the two are
-// algebraically equivalent, so that path stays bit-identical.
-HomographyMatrixReport EstimateHomographyMatrix(
+// Robustly estimate the pixel-space homography of a distorted camera pair. A
+// world plane relates image points projectively only under a pinhole
+// projection, so the estimate is made on bearing rays, where it holds for any
+// central camera, and conjugated back by the calibration matrices.
+HomographyMatrixReport EstimateHomographyMatrixFromRays(
     const RANSACOptions& ransac_options,
     const Camera& camera1,
     const std::vector<Eigen::Vector2d>& points1,
     const Camera& camera2,
-    const std::vector<Eigen::Vector2d>& points2,
-    const std::vector<CamRayWithJac>& cam_rays1_with_jac,
-    const std::vector<CamRayWithJac>& cam_rays2_with_jac) {
-  if (camera1.IsUndistorted() && camera2.IsUndistorted()) {
-    return LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>(
-               ransac_options)
-        .Estimate(points1, points2);
-  }
+    const std::vector<Eigen::Vector2d>& points2) {
+  THROW_CHECK_EQ(points1.size(), points2.size());
 
-  // The estimator handles any central camera, but publishing the result in
-  // pixel space needs a calibration matrix, which spherical cameras lack. Such
-  // pairs are routed to EstimateSphericalTwoViewGeometry before reaching here.
-  std::vector<Eigen::Vector3d> cam_rays1(cam_rays1_with_jac.size());
-  std::vector<CamRayWithImgPoint> cam_rays2(cam_rays2_with_jac.size());
-  for (size_t i = 0; i < cam_rays1_with_jac.size(); ++i) {
-    cam_rays1[i] = cam_rays1_with_jac[i].ray;
-    cam_rays2[i] = {cam_rays2_with_jac[i].ray, points2[i]};
+  std::vector<Eigen::Vector3d> cam_rays1(points1.size());
+  std::vector<CamRayWithImgPoint> cam_rays2(points2.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    cam_rays1[i] =
+        camera1.CamRayFromImg(points1[i]).value_or(Eigen::Vector3d::Zero());
+    cam_rays2[i] = {
+        camera2.CamRayFromImg(points2[i]).value_or(Eigen::Vector3d::Zero()),
+        points2[i]};
   }
 
   const HomographyMatrixRayEstimator estimator(&camera2);
@@ -453,10 +446,18 @@ TwoViewGeometry EstimateSphericalTwoViewGeometry(
     matched_cam_rays2[i] = {matched_cam_rays2_with_jac[i].ray,
                             matched_img_points2[i]};
   }
+  // Budget the search for the ratio the homography must beat to be selected
+  // below, rather than the default. See EstimateCalibratedTwoViewGeometry.
+  auto H_ransac_options = ransac_options;
+  H_ransac_options.min_inlier_ratio = std::max(
+      ransac_options.min_inlier_ratio,
+      options.max_H_inlier_ratio *
+          static_cast<double>(E_report.support.num_inliers) / matches.size());
+
   const HomographyMatrixRayEstimator H_estimator(&camera2);
   const auto H_report =
       LORANSAC<HomographyMatrixRayEstimator, HomographyMatrixRayEstimator>(
-          ransac_options, H_estimator, H_estimator)
+          H_ransac_options, H_estimator, H_estimator)
           .Estimate(matched_cam_rays1, matched_cam_rays2);
   if (H_report.success) {
     geometry.H = H_report.model;
@@ -1012,13 +1013,31 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
-  const auto H_report = EstimateHomographyMatrix(ransac_options,
-                                                 camera1,
-                                                 matched_img_points1,
-                                                 camera2,
-                                                 matched_img_points2,
-                                                 matched_cam_rays1_with_jac,
-                                                 matched_cam_rays2_with_jac);
+  // A homography is only selected below if it beats max_H_inlier_ratio times
+  // the epipolar model's inlier count, so budget the search for that ratio
+  // rather than the default. Lower ratios are found less reliably, but such a
+  // homography would be discarded anyway. The smaller of the two epipolar
+  // counts is the lowest bar it might have to clear.
+  auto H_ransac_options = ransac_options;
+  H_ransac_options.min_inlier_ratio =
+      std::max(ransac_options.min_inlier_ratio,
+               options.max_H_inlier_ratio *
+                   static_cast<double>(std::min(E_report.support.num_inliers,
+                                                F_report.support.num_inliers)) /
+                   matches.size());
+
+  // Undistorted pinhole cameras keep the pixel estimator, where the two are
+  // algebraically equivalent, so that path stays bit-identical.
+  const auto H_report =
+      (camera1.IsUndistorted() && camera2.IsUndistorted())
+          ? LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>(
+                H_ransac_options)
+                .Estimate(matched_img_points1, matched_img_points2)
+          : EstimateHomographyMatrixFromRays(H_ransac_options,
+                                             camera1,
+                                             matched_img_points1,
+                                             camera2,
+                                             matched_img_points2);
   geometry.H = H_report.model;
 
   if ((!E_report.success && !F_report.success && !H_report.success) ||

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -96,6 +96,57 @@ FundamentalMatrixReport EstimateFundamentalMatrix(
       .Estimate(points1, points2);
 }
 
+using HomographyMatrixReport =
+    LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>::Report;
+
+// Robustly estimate the homography relating two calibrated views. A world plane
+// relates image points projectively only under a pinhole projection, so
+// distorted cameras are estimated on bearing rays and mapped back to pixels.
+// Undistorted pinhole cameras keep the pixel estimator, where the two are
+// algebraically equivalent, so that path stays bit-identical.
+HomographyMatrixReport EstimateHomographyMatrix(
+    const RANSACOptions& ransac_options,
+    const Camera& camera1,
+    const std::vector<Eigen::Vector2d>& points1,
+    const Camera& camera2,
+    const std::vector<Eigen::Vector2d>& points2,
+    const std::vector<CamRayWithJac>& cam_rays1_with_jac,
+    const std::vector<CamRayWithJac>& cam_rays2_with_jac) {
+  if (camera1.IsUndistorted() && camera2.IsUndistorted()) {
+    return LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>(
+               ransac_options)
+        .Estimate(points1, points2);
+  }
+
+  // The estimator handles any central camera, but publishing the result in
+  // pixel space needs a calibration matrix, which spherical cameras lack. Such
+  // pairs are routed to EstimateSphericalTwoViewGeometry before reaching here.
+  std::vector<Eigen::Vector3d> cam_rays1(cam_rays1_with_jac.size());
+  std::vector<CamRayWithImgPoint> cam_rays2(cam_rays2_with_jac.size());
+  for (size_t i = 0; i < cam_rays1_with_jac.size(); ++i) {
+    cam_rays1[i] = cam_rays1_with_jac[i].ray;
+    cam_rays2[i] = {cam_rays2_with_jac[i].ray, points2[i]};
+  }
+
+  const HomographyMatrixRayEstimator estimator(&camera2);
+  const auto ray_report =
+      LORANSAC<HomographyMatrixRayEstimator, HomographyMatrixRayEstimator>(
+          ransac_options, estimator, estimator)
+          .Estimate(cam_rays1, cam_rays2);
+
+  HomographyMatrixReport report;
+  report.success = ray_report.success;
+  report.num_trials = ray_report.num_trials;
+  report.support = ray_report.support;
+  report.inlier_mask = ray_report.inlier_mask;
+  // The estimator maps rays to rays, so publish K2 H K1^-1 to keep the stored
+  // homography in pixel space. K carries no distortion, so for a distorted
+  // camera that is the homography in its virtual pinhole frame.
+  report.model = camera2.CalibrationMatrix() * ray_report.model *
+                 camera1.CalibrationMatrix().inverse();
+  return report;
+}
+
 FeatureMatches ExtractInlierMatches(const FeatureMatches& matches,
                                     const size_t num_inliers,
                                     const std::vector<char>& inlier_mask) {
@@ -156,7 +207,9 @@ TwoViewGeometry EstimateCalibratedHomography(
     matched_img_points2[i] = points2[matches[i].point2D_idx2];
   }
 
-  // Estimate planar or panoramic model.
+  // Estimate planar or panoramic model. Estimated on image points rather than
+  // rays: the caller only guarantees a pinhole projection here, not a focal
+  // length prior, so no rays can be built.
 
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
       options.ransac_options);
@@ -222,7 +275,10 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
                                                   matched_img_points2);
   geometry.F = F_report.model;
 
-  // Estimate planar or panoramic model.
+  // Estimate planar or panoramic model. Estimated on image points rather than
+  // rays, as the intrinsics are unknown here and no rays can be built without
+  // them. The fundamental matrix above shares that frame, so the comparison
+  // below stays self-consistent.
 
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
       options.ransac_options);
@@ -916,10 +972,13 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
-  LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      ransac_options);
-  const auto H_report =
-      H_ransac.Estimate(matched_img_points1, matched_img_points2);
+  const auto H_report = EstimateHomographyMatrix(ransac_options,
+                                                 camera1,
+                                                 matched_img_points1,
+                                                 camera2,
+                                                 matched_img_points2,
+                                                 matched_cam_rays1_with_jac,
+                                                 matched_cam_rays2_with_jac);
   geometry.H = H_report.model;
 
   if ((!E_report.success && !F_report.success && !H_report.success) ||
@@ -1074,7 +1133,10 @@ TwoViewGeometry EstimateSharedFocalTwoViewGeometry(
 
   // Estimate a homography to detect planar/panoramic degeneracies, where
   // two-view focal recovery is ill-posed and the 6-point solver returns a
-  // meaningless focal length.
+  // meaningless focal length. Estimated on image points rather than rays, as
+  // the focal length is the unknown here and no rays can be built without it.
+  // The shared-focal solver above also works in image points, so the inlier
+  // comparison below stays self-consistent.
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
       ransac_options);
   const auto H_report =

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -378,12 +378,12 @@ TwoViewGeometry EstimateMultipleTwoViewGeometries(
 
 // Estimate two-view geometry for an image pair where at least one camera is
 // omnidirectional (no pinhole image plane, e.g. EQUIRECTANGULAR) and both sides
-// have known intrinsics. The fundamental matrix and homography are not
-// geometrically meaningful for such cameras, so only the bearing-based
-// essential matrix is estimated and the result is committed to the CALIBRATED
-// configuration (or DEGENERATE). A spherical camera paired with one of unknown
-// focal length is routed to EstimateOneSidedFocalTwoViewGeometry instead, which
-// recovers that focal rather than relying on the camera's placeholder.
+// have known intrinsics. The fundamental matrix is not geometrically meaningful
+// for such cameras, so the pair is classified from the bearing-based essential
+// matrix and a ray-space homography. A spherical camera paired with one of
+// unknown focal length is routed to EstimateOneSidedFocalTwoViewGeometry
+// instead, which recovers that focal rather than relying on the camera's
+// placeholder.
 TwoViewGeometry EstimateSphericalTwoViewGeometry(
     const Camera& camera1,
     const std::vector<Eigen::Vector2d>& points1,
@@ -443,33 +443,67 @@ TwoViewGeometry EstimateSphericalTwoViewGeometry(
       E_ransac.Estimate(matched_cam_rays1_with_jac, matched_cam_rays2_with_jac);
   geometry.E = E_report.model;
 
-  if (!E_report.success || E_report.support.num_inliers < min_num_inliers) {
+  // Detect the planar/panoramic degeneracy: under pure rotation E vanishes and
+  // its pose decomposition is meaningless, which is the usual capture mode for
+  // a 360 degree camera. Kept in ray space, as spherical cameras have no K.
+  std::vector<Eigen::Vector3d> matched_cam_rays1(matches.size());
+  std::vector<CamRayWithImgPoint> matched_cam_rays2(matches.size());
+  for (size_t i = 0; i < matches.size(); ++i) {
+    matched_cam_rays1[i] = matched_cam_rays1_with_jac[i].ray;
+    matched_cam_rays2[i] = {matched_cam_rays2_with_jac[i].ray,
+                            matched_img_points2[i]};
+  }
+  const HomographyMatrixRayEstimator H_estimator(&camera2);
+  const auto H_report =
+      LORANSAC<HomographyMatrixRayEstimator, HomographyMatrixRayEstimator>(
+          ransac_options, H_estimator, H_estimator)
+          .Estimate(matched_cam_rays1, matched_cam_rays2);
+  if (H_report.success) {
+    geometry.H = H_report.model;
+  }
+
+  if ((!E_report.success || E_report.support.num_inliers < min_num_inliers) &&
+      (!H_report.success || H_report.support.num_inliers < min_num_inliers)) {
     geometry.config = TwoViewGeometry::ConfigurationType::DEGENERATE;
     return geometry;
   }
 
-  geometry.config = TwoViewGeometry::ConfigurationType::CALIBRATED;
-  geometry.inlier_matches = ExtractInlierMatches(
-      matches, E_report.support.num_inliers, E_report.inlier_mask);
+  const std::vector<char>* best_inlier_mask = &E_report.inlier_mask;
+  size_t num_inliers = E_report.support.num_inliers;
+  const double H_E_inlier_ratio =
+      static_cast<double>(H_report.support.num_inliers) /
+      E_report.support.num_inliers;
+  if (E_report.success && E_report.support.num_inliers >= min_num_inliers &&
+      H_E_inlier_ratio <= options.max_H_inlier_ratio) {
+    geometry.config = TwoViewGeometry::ConfigurationType::CALIBRATED;
+  } else {
+    geometry.config = TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC;
+    if (H_report.support.num_inliers > num_inliers) {
+      num_inliers = H_report.support.num_inliers;
+      best_inlier_mask = &H_report.inlier_mask;
+    }
+  }
+
+  geometry.inlier_matches =
+      ExtractInlierMatches(matches, num_inliers, *best_inlier_mask);
 
   // Check inlier ratio threshold.
   if (options.min_inlier_ratio > 0) {
     const double inlier_ratio =
-        static_cast<double>(E_report.support.num_inliers) / matches.size();
+        static_cast<double>(num_inliers) / matches.size();
     if (inlier_ratio < options.min_inlier_ratio) {
       geometry.config = TwoViewGeometry::ConfigurationType::DEGENERATE;
       return geometry;
     }
   }
 
-  if (options.detect_watermark &&
-      DetectWatermarkMatches(camera1,
-                             matched_img_points1,
-                             camera2,
-                             matched_img_points2,
-                             E_report.support.num_inliers,
-                             E_report.inlier_mask,
-                             options)) {
+  if (options.detect_watermark && DetectWatermarkMatches(camera1,
+                                                         matched_img_points1,
+                                                         camera2,
+                                                         matched_img_points2,
+                                                         num_inliers,
+                                                         *best_inlier_mask,
+                                                         options)) {
     geometry.config = TwoViewGeometry::ConfigurationType::WATERMARK;
   }
 
@@ -550,8 +584,8 @@ TwoViewGeometry EstimateTwoViewGeometry(
       return EstimateOneSidedFocalTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
     } else if (camera1.IsSpherical() || camera2.IsSpherical()) {
-      // No pinhole image plane, so only the bearing-based essential matrix is
-      // meaningful. Mixed spherical/uncalibrated pairs are caught above.
+      // No pinhole image plane, so the fundamental matrix is not meaningful.
+      // Mixed spherical/uncalibrated pairs are caught above.
       return EstimateSphericalTwoViewGeometry(
           camera1, points1, camera2, points2, matches, options);
     } else if (camera1.camera_id == camera2.camera_id &&
@@ -772,11 +806,9 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
   std::vector<Eigen::Vector3d> points3D;
 
   // Omnidirectional cameras (no focal length, e.g. EQUIRECTANGULAR) have no
-  // calibration matrix, so only the bearing-based essential-matrix path is
-  // valid for them. EstimateTwoViewGeometry already commits such pairs to the
-  // CALIBRATED configuration (or DEGENERATE), so they carry an E and are
-  // handled by the essential-matrix branch below, never reaching the
-  // CalibrationMatrix() calls.
+  // calibration matrix, so they never reach the fundamental-matrix branch
+  // below. The homography branch handles them by decomposing through the
+  // identity, their homography already being in ray space.
   Rigid3d cam2_from_cam1;
   std::vector<int> valid_indices;
   // Decompose the model the solver selected. A calibrated pair, or one whose
@@ -811,10 +843,18 @@ bool EstimateTwoViewGeometryPoseFromCamRays(
              geometry->config ==
                  TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC) {
     THROW_CHECK(geometry->H.has_value());
+    // The decomposition removes the calibration first. The spherical path
+    // stores its homography in ray space, having no calibration matrix, so such
+    // a pair passes the identity on both sides.
+    const bool is_ray_space = camera1.IsSpherical() || camera2.IsSpherical();
+    const Eigen::Matrix3d K1 = is_ray_space ? Eigen::Matrix3d::Identity()
+                                            : camera1.CalibrationMatrix();
+    const Eigen::Matrix3d K2 = is_ray_space ? Eigen::Matrix3d::Identity()
+                                            : camera2.CalibrationMatrix();
     Eigen::Vector3d normal;
     PoseFromHomographyMatrix(*geometry->H,
-                             camera1.CalibrationMatrix(),
-                             camera2.CalibrationMatrix(),
+                             K1,
+                             K2,
                              inlier_cam_rays1,
                              inlier_cam_rays2,
                              &cam2_from_cam1,

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -410,9 +410,9 @@ TEST(EstimateTwoViewGeometry, Spherical) {
   TwoViewGeometryOptions two_view_geometry_options;
   two_view_geometry_options.compute_relative_pose = true;
 
-  // Spherical cameras have no pinhole image plane, so the fundamental matrix
-  // and homography are not estimated; only the bearing-based essential matrix
-  // is, committing to the CALIBRATED configuration.
+  // Spherical cameras have no pinhole image plane, so the fundamental matrix is
+  // not estimated; the pair is classified from the bearing-based essential
+  // matrix and a ray-space homography.
   const TwoViewGeometry geometry =
       EstimateTwoViewGeometry(test_data.camera1,
                               test_data.points1,
@@ -423,7 +423,7 @@ TEST(EstimateTwoViewGeometry, Spherical) {
   EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::CALIBRATED);
   EXPECT_TRUE(geometry.E.has_value());
   EXPECT_FALSE(geometry.F.has_value());
-  EXPECT_FALSE(geometry.H.has_value());
+  EXPECT_TRUE(geometry.H.has_value());
   EXPECT_GE(geometry.inlier_matches.size(), test_data.matches.size() / 2);
 
   // The recovered relative pose should match the ground truth: rotation
@@ -439,7 +439,7 @@ TEST(EstimateTwoViewGeometry, Spherical) {
                   /*ttol=*/1e-2));
 
   // EstimateCalibratedTwoViewGeometry delegates to the spherical path rather
-  // than estimating a meaningless fundamental matrix / homography.
+  // than estimating a meaningless fundamental matrix.
   const TwoViewGeometry calibrated_geometry =
       EstimateCalibratedTwoViewGeometry(test_data.camera1,
                                         test_data.points1,
@@ -451,7 +451,7 @@ TEST(EstimateTwoViewGeometry, Spherical) {
             TwoViewGeometry::ConfigurationType::CALIBRATED);
   EXPECT_TRUE(calibrated_geometry.E.has_value());
   EXPECT_FALSE(calibrated_geometry.F.has_value());
-  EXPECT_FALSE(calibrated_geometry.H.has_value());
+  EXPECT_TRUE(calibrated_geometry.H.has_value());
 }
 
 TEST(EstimateTwoViewGeometry, UncalibratedFisheyeIsDegenerate) {
@@ -551,6 +551,39 @@ TEST(EstimateTwoViewGeometry, ForceHUseWithFisheyeIsDegenerate) {
 // pixel-space homography cannot fit the correspondences at all, so it loses the
 // inliers that drive the classification. Estimating it on bearing rays restores
 // the fit and with it the PLANAR_OR_PANORAMIC label.
+// A rotating 360 degree camera is the usual capture mode, and the essential
+// matrix degenerates there, so the spherical path must catch it.
+TEST(EstimateTwoViewGeometry, PanoramicWithSphericalCameraIsDetected) {
+  SetPRNGSeed(42);
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.camera_model_id =
+      EquirectangularCameraModel::model_id;
+  synthetic_dataset_options.camera_width = 1000;
+  synthetic_dataset_options.camera_height = 500;
+  synthetic_dataset_options.camera_params = {1000, 500};
+  synthetic_dataset_options.sensor_from_rig_translation_stddev = 0;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsSpherical());
+
+  TwoViewGeometryOptions two_view_geometry_options;
+  two_view_geometry_options.ransac_options.random_seed = 42;
+  two_view_geometry_options.compute_relative_pose = true;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::PANORAMIC);
+  EXPECT_TRUE(geometry.H.has_value());
+}
+
 TEST(EstimateTwoViewGeometry, PanoramicWithDistortedCameraIsDetected) {
   SetPRNGSeed(42);
   SyntheticDatasetOptions synthetic_dataset_options;
@@ -933,7 +966,7 @@ TEST(EstimateTwoViewGeometry, SphericalAndCalibratedPerspective) {
   EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::CALIBRATED);
   EXPECT_TRUE(geometry.E.has_value());
   EXPECT_FALSE(geometry.F.has_value());
-  EXPECT_FALSE(geometry.H.has_value());
+  EXPECT_TRUE(geometry.H.has_value());
   EXPECT_GE(geometry.inlier_matches.size(), matches.size() / 2);
 }
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -546,6 +546,73 @@ TEST(EstimateTwoViewGeometry, ForceHUseWithFisheyeIsDegenerate) {
   EXPECT_FALSE(geometry.H.has_value());
 }
 
+// A pure-rotation pair is the configuration a homography must catch, since the
+// essential matrix degenerates there. With a strongly distorted camera the
+// pixel-space homography cannot fit the correspondences at all, so it loses the
+// inliers that drive the classification. Estimating it on bearing rays restores
+// the fit and with it the PLANAR_OR_PANORAMIC label.
+TEST(EstimateTwoViewGeometry, PanoramicWithDistortedCameraIsDetected) {
+  SetPRNGSeed(42);
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.camera_model_id = OpenCVCameraModel::model_id;
+  synthetic_dataset_options.camera_params = {
+      1280, 1280, 512, 384, 0.15, -0.03, 0.001, 0.001};
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
+  synthetic_dataset_options.sensor_from_rig_translation_stddev = 0;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsPerspectivePinhole());
+  ASSERT_FALSE(test_data.camera1.IsUndistorted());
+
+  TwoViewGeometryOptions two_view_geometry_options;
+  two_view_geometry_options.ransac_options.random_seed = 42;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config,
+            TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC);
+}
+
+// As above for a fisheye camera, which reaches the calibrated path today
+// because it short-circuits only spherical models. No gate change is involved.
+TEST(EstimateTwoViewGeometry, PanoramicWithFisheyeCameraIsDetected) {
+  SetPRNGSeed(42);
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 1;
+  synthetic_dataset_options.num_points3D = 500;
+  synthetic_dataset_options.camera_model_id =
+      OpenCVFisheyeCameraModel::model_id;
+  synthetic_dataset_options.camera_params = {
+      1280, 1280, 512, 384, 0.05, -0.01, 0, 0};
+  synthetic_dataset_options.camera_has_prior_focal_length = true;
+  synthetic_dataset_options.sensor_from_rig_translation_stddev = 0;
+  const TwoViewGeometryTestData test_data =
+      CreateTwoViewGeometryTestData(synthetic_dataset_options);
+  ASSERT_TRUE(test_data.camera1.IsPerspectiveFisheye());
+
+  TwoViewGeometryOptions two_view_geometry_options;
+  two_view_geometry_options.ransac_options.random_seed = 42;
+  const TwoViewGeometry geometry =
+      EstimateTwoViewGeometry(test_data.camera1,
+                              test_data.points1,
+                              test_data.camera2,
+                              test_data.points2,
+                              test_data.matches,
+                              two_view_geometry_options);
+  EXPECT_EQ(geometry.config,
+            TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC);
+}
+
 TEST(EstimateTwoViewGeometry, SharedFocal) {
   // A single shared, uncalibrated, pinhole-projection camera observed from two
   // frames routes to the shared-focal solver, which jointly recovers the

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -581,7 +581,10 @@ TEST(EstimateTwoViewGeometry, PanoramicWithSphericalCameraIsDetected) {
                               test_data.matches,
                               two_view_geometry_options);
   EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::PANORAMIC);
+  EXPECT_TRUE(geometry.E.has_value());
   EXPECT_TRUE(geometry.H.has_value());
+  EXPECT_FALSE(geometry.F.has_value());
+  EXPECT_GE(geometry.inlier_matches.size(), test_data.matches.size() / 2);
 }
 
 TEST(EstimateTwoViewGeometry, PanoramicWithDistortedCameraIsDetected) {
@@ -603,6 +606,7 @@ TEST(EstimateTwoViewGeometry, PanoramicWithDistortedCameraIsDetected) {
 
   TwoViewGeometryOptions two_view_geometry_options;
   two_view_geometry_options.ransac_options.random_seed = 42;
+  two_view_geometry_options.compute_relative_pose = true;
   const TwoViewGeometry geometry =
       EstimateTwoViewGeometry(test_data.camera1,
                               test_data.points1,
@@ -610,8 +614,9 @@ TEST(EstimateTwoViewGeometry, PanoramicWithDistortedCameraIsDetected) {
                               test_data.points2,
                               test_data.matches,
                               two_view_geometry_options);
-  EXPECT_EQ(geometry.config,
-            TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::PANORAMIC);
+  EXPECT_TRUE(geometry.H.has_value());
+  EXPECT_GE(geometry.inlier_matches.size(), test_data.matches.size() / 2);
 }
 
 // As above for a fisheye camera, which reaches the calibrated path today
@@ -635,6 +640,7 @@ TEST(EstimateTwoViewGeometry, PanoramicWithFisheyeCameraIsDetected) {
 
   TwoViewGeometryOptions two_view_geometry_options;
   two_view_geometry_options.ransac_options.random_seed = 42;
+  two_view_geometry_options.compute_relative_pose = true;
   const TwoViewGeometry geometry =
       EstimateTwoViewGeometry(test_data.camera1,
                               test_data.points1,
@@ -642,8 +648,9 @@ TEST(EstimateTwoViewGeometry, PanoramicWithFisheyeCameraIsDetected) {
                               test_data.points2,
                               test_data.matches,
                               two_view_geometry_options);
-  EXPECT_EQ(geometry.config,
-            TwoViewGeometry::ConfigurationType::PLANAR_OR_PANORAMIC);
+  EXPECT_EQ(geometry.config, TwoViewGeometry::ConfigurationType::PANORAMIC);
+  EXPECT_TRUE(geometry.H.has_value());
+  EXPECT_GE(geometry.inlier_matches.size(), test_data.matches.size() / 2);
 }
 
 TEST(EstimateTwoViewGeometry, SharedFocal) {


### PR DESCRIPTION
The existing homography estimation is not geometrically correct for distorted cameras. 

This PR includes the following improvements:

* Homography estimation on rays rather than pixels when one or both of the cameras have distortions. The homography estimation in practice is gated in practice, and remain the same for two non-distorted cameras (as the ray homography is 1.5 - 6x slower compared to the pixel homography). Scoring is kept the same on the pixel space. 
* Therefore able to add homography path for spherical cameras, and thereby support detection of planar/panoramic mode. 


Plane-dominated two-view scenes, 500 points, 1 px noise, 300 problems per cell, 4.0 px threshold.

AUC@1/5/10 deg on max(rot, trans) error, and mean ms per problem.

| camera             | outl | pixel          | pixel normalized     | ray            | ms px/pxnorm/ray    |
|--------------------|------|----------------|----------------|----------------|-------------------|
| PINHOLE            |   0% | 49.0 74.3 81.1 | 79.8 90.6 92.1 | 79.4 90.5 92.1 |  0.21  0.31  0.29 |
| PINHOLE            |  40% | 46.4 73.9 81.3 | 75.5 88.4 90.2 | 74.6 88.0 89.8 |  0.29  0.37  0.75 |
| OPENCV k1=0.05     |   0% |  0.3  4.8 14.4 |  0.2  4.7 13.9 | 81.1 92.5 94.1 |  0.43  0.58  0.31 |
| OPENCV k1=0.05     |  40% |  0.3  4.5 13.6 |  0.3  4.7 13.6 | 75.1 88.8 90.7 |  1.38  1.32  0.84 |
| OPENCV k1=0.30     |   0% |  0.0  0.7  1.7 |  0.0  0.7  1.5 | 69.3 85.8 88.7 |  5.83  5.43  0.29 |
| OPENCV k1=0.30     |  40% |  0.0  0.4  1.0 |  0.0  0.3  1.1 | 67.4 85.2 88.2 | 34.80 33.79  0.89 |
| OPENCV_FISHEYE     |   0% |  0.0  0.2  1.3 |  0.0  0.2  1.2 | 71.0 80.6 82.0 | 11.06 10.50  0.34 |
| OPENCV_FISHEYE     |  40% |  0.0  0.0  1.1 |  0.0  0.0  1.0 | 68.5 80.9 82.6 | 56.09 56.07  1.42 |
| THIN_PRISM_FISHEYE |   0% |  0.0  0.2  1.1 |  0.0  0.2  1.2 | 71.4 81.2 82.6 | 10.91 10.28  0.35 |
| THIN_PRISM_FISHEYE |  40% |  0.0  0.0  1.2 |  0.0  0.2  1.4 | 68.8 81.2 82.9 | 64.11 59.70  1.59 |

ETH3D DSLR, THIN_PRISM_FISHEYE, correspondences from GT tracks, 4.0 px threshold, 100 pairs per scene max.

Relative pose AUC@1/5/10 deg from the homography decomposition, against ground truth.

| scene          | pair | pixel          | pixel normalized     | ray            |
|----------------|------|----------------|----------------|----------------|
| courtyard      |  100 |  0.6 11.2 28.4 |  0.5 12.0 29.6 | 38.3 67.1 75.0 |
| delivery_area  |  100 |  0.6 10.3 20.5 |  0.8  9.8 19.8 | 13.9 40.4 56.1 |
| electro        |  100 |  1.0  8.5 19.7 |  1.4  9.3 20.8 | 12.4 41.3 56.6 |
| facade         |  100 |  0.0 12.1 24.8 |  0.0 12.5 25.8 | 41.6 72.2 81.5 |
| kicker         |  100 |  1.2 13.1 30.6 |  1.0 14.4 31.9 |  8.6 34.3 50.9 |
| office         |   64 |  1.0  8.1 15.8 |  1.0  8.1 15.1 | 24.9 51.9 61.8 |
| pipes          |   28 |  0.0 15.0 32.1 |  1.9 18.2 32.9 | 10.3 45.5 62.7 |
| playground     |  100 |  2.2 12.5 21.0 |  1.3 10.7 19.6 | 14.4 35.6 48.3 |
| relief         |  100 |  2.4 29.7 45.3 |  4.3 33.1 49.0 | 36.8 69.1 77.7 |
| relief_2       |  100 |  4.5 35.6 54.3 |  3.6 38.3 57.6 | 48.7 75.8 84.2 |
| terrains       |  100 |  8.2 25.0 48.1 |  8.3 26.7 48.3 | 29.5 59.7 75.1 |
| ALL            |      |  2.0 16.5 30.9 |  2.2 17.6 31.8 | 25.4 53.9 66.3 |
