### PR TITLE
Add pycolmap bindings for the hierarchical mapper

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -422,6 +422,28 @@ int RunGlobalMapper(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
+bool RunHierarchicalMapperImpl(
+    const std::filesystem::path& database_path,
+    const std::filesystem::path& image_path,
+    const std::filesystem::path& output_path,
+    const std::shared_ptr<HierarchicalPipelineOptions>& mapper_options,
+    std::shared_ptr<ReconstructionManager>& reconstruction_manager) {
+  HierarchicalPipelineOptions options = *mapper_options;
+  options.image_path = image_path;
+
+  HierarchicalPipeline hierarchical_mapper(
+      options, Database::Open(database_path), reconstruction_manager);
+  hierarchical_mapper.Run();
+
+  if (reconstruction_manager->Size() == 0) {
+    LOG(ERROR) << "Failed to create sparse model";
+    return false;
+  }
+
+  reconstruction_manager->Write(output_path);
+  return true;
+}
+
 int RunHierarchicalMapper(int argc, char** argv) {
   std::filesystem::path output_path;
 
@@ -443,18 +465,14 @@ int RunHierarchicalMapper(int argc, char** argv) {
 
   options.hierarchical_mapper->incremental_options = *options.mapper;
   auto reconstruction_manager = std::make_shared<ReconstructionManager>();
-  HierarchicalPipeline hierarchical_mapper(
-      *options.hierarchical_mapper,
-      Database::Open(*options.database_path),
-      reconstruction_manager);
-  hierarchical_mapper.Run();
-
-  if (reconstruction_manager->Size() == 0) {
-    LOG(ERROR) << "failed to create sparse model";
+  if (!RunHierarchicalMapperImpl(*options.database_path,
+                                 options.hierarchical_mapper->image_path,
+                                 output_path,
+                                 options.hierarchical_mapper,
+                                 reconstruction_manager)) {
     return EXIT_FAILURE;
   }
 
-  reconstruction_manager->Write(output_path);
   options.Write(output_path / "project.ini");
 
   return EXIT_SUCCESS;

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/controllers/global_pipeline.h"
+#include "colmap/controllers/hierarchical_pipeline.h"
 #include "colmap/controllers/incremental_pipeline.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/scene/reconstruction_manager.h"
@@ -61,6 +62,13 @@ bool RunGlobalMapperImpl(
     const std::filesystem::path& image_path,
     const std::filesystem::path& output_path,
     const std::shared_ptr<GlobalPipelineOptions>& mapper_options,
+    std::shared_ptr<ReconstructionManager>& reconstruction_manager);
+
+bool RunHierarchicalMapperImpl(
+    const std::filesystem::path& database_path,
+    const std::filesystem::path& image_path,
+    const std::filesystem::path& output_path,
+    const std::shared_ptr<HierarchicalPipelineOptions>& mapper_options,
     std::shared_ptr<ReconstructionManager>& reconstruction_manager);
 
 int RunAutomaticReconstructor(int argc, char** argv);

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -1,6 +1,7 @@
 #include "colmap/exe/sfm.h"
 
 #include "colmap/controllers/bundle_adjustment.h"
+#include "colmap/controllers/hierarchical_pipeline.h"
 #include "colmap/controllers/incremental_pipeline.h"
 #include "colmap/estimators/view_graph_calibration.h"
 #include "colmap/scene/database.h"
@@ -125,6 +126,30 @@ std::map<size_t, std::shared_ptr<Reconstruction>> GlobalMapping(
   return ReconstructionManagerToMap(reconstruction_manager);
 }
 
+std::map<size_t, std::shared_ptr<Reconstruction>> HierarchicalMapping(
+    const std::filesystem::path& database_path,
+    const std::filesystem::path& image_path,
+    const std::filesystem::path& output_path,
+    HierarchicalPipelineOptions options) {
+  THROW_CHECK_FILE_EXISTS(database_path);
+  THROW_CHECK_DIR_EXISTS(image_path);
+  CreateDirIfNotExists(output_path);
+
+  py::gil_scoped_release release;
+  auto reconstruction_manager = std::make_shared<ReconstructionManager>();
+  auto options_ =
+      std::make_shared<HierarchicalPipelineOptions>(std::move(options));
+  if (!RunHierarchicalMapperImpl(database_path,
+                                 image_path,
+                                 output_path,
+                                 options_,
+                                 reconstruction_manager)) {
+    return {};
+  }
+
+  return ReconstructionManagerToMap(reconstruction_manager);
+}
+
 void BundleAdjustment(const std::shared_ptr<Reconstruction>& reconstruction,
                       const BundleAdjustmentOptions& options) {
   py::gil_scoped_release release;
@@ -172,70 +197,6 @@ void BindSfM(py::module& m) {
     MakeDataclass(PyOpts);
   }
 
-  // GlobalMapperOptions
-  {
-    using Opts = GlobalMapperOptions;
-    auto PyOpts =
-        py::classh<Opts>(m, "GlobalMapperOptions")
-            .def(py::init<>())
-            .def_readwrite("num_threads", &Opts::num_threads)
-            .def_readwrite("random_seed", &Opts::random_seed)
-            .def_readwrite("refine_sensor_from_rig",
-                           &Opts::refine_sensor_from_rig,
-                           "When False, treat each non-ref sensor's "
-                           "cam_from_rig as a pre-calibrated constant across "
-                           "rotation averaging, global positioning and "
-                           "bundle adjustment.")
-            .def_readwrite("rotation_averaging", &Opts::rotation_averaging)
-            .def_readwrite("global_positioning", &Opts::global_positioning)
-            .def_readwrite("bundle_adjustment", &Opts::bundle_adjustment)
-            .def_readwrite("retriangulation", &Opts::retriangulation)
-            .def_readwrite("track_intra_image_consistency_threshold",
-                           &Opts::track_intra_image_consistency_threshold)
-            .def_readwrite("track_required_tracks_per_view",
-                           &Opts::track_required_tracks_per_view)
-            .def_readwrite("track_min_num_views_per_track",
-                           &Opts::track_min_num_views_per_track)
-            .def_readwrite("keep_max_num_tracks", &Opts::keep_max_num_tracks)
-            .def_readwrite("max_angular_reproj_error_deg",
-                           &Opts::max_angular_reproj_error_deg)
-            .def_readwrite("max_normalized_reproj_error",
-                           &Opts::max_normalized_reproj_error)
-            .def_readwrite("min_tri_angle_deg", &Opts::min_tri_angle_deg)
-            .def_readwrite("ba_num_iterations", &Opts::ba_num_iterations)
-            .def_readwrite("ba_skip_fixed_rotation_stage",
-                           &Opts::ba_skip_fixed_rotation_stage)
-            .def_readwrite("ba_skip_joint_optimization_stage",
-                           &Opts::ba_skip_joint_optimization_stage)
-            .def_readwrite("skip_rotation_averaging",
-                           &Opts::skip_rotation_averaging)
-            .def_readwrite("skip_track_establishment",
-                           &Opts::skip_track_establishment)
-            .def_readwrite("skip_global_positioning",
-                           &Opts::skip_global_positioning)
-            .def_readwrite("skip_bundle_adjustment",
-                           &Opts::skip_bundle_adjustment)
-            .def_readwrite("skip_retriangulation", &Opts::skip_retriangulation);
-    MakeDataclass(PyOpts);
-  }
-
-  // GlobalPipelineOptions
-  {
-    using Opts = GlobalPipelineOptions;
-    auto PyOpts =
-        py::classh<Opts>(m, "GlobalPipelineOptions")
-            .def(py::init<>())
-            .def_readwrite("min_num_matches", &Opts::min_num_matches)
-            .def_readwrite("ignore_watermarks", &Opts::ignore_watermarks)
-            .def_readwrite("image_names", &Opts::image_names)
-            .def_readwrite("num_threads", &Opts::num_threads)
-            .def_readwrite("random_seed", &Opts::random_seed)
-            .def_readwrite("decompose_relative_pose",
-                           &Opts::decompose_relative_pose)
-            .def_readwrite("mapper", &Opts::mapper);
-    MakeDataclass(PyOpts);
-  }
-
   m.def("triangulate_points",
         &TriangulatePoints,
         "reconstruction"_a,
@@ -270,6 +231,19 @@ void BindSfM(py::module& m) {
       "output_path"_a,
       py::arg_v("options", GlobalPipelineOptions(), "GlobalPipelineOptions()"),
       "Recover 3D points and camera poses using global SfM (GLOMAP)");
+
+  m.def("hierarchical_mapping",
+        &HierarchicalMapping,
+        "database_path"_a,
+        "image_path"_a,
+        "output_path"_a,
+        py::arg_v("options",
+                  HierarchicalPipelineOptions(),
+                  "HierarchicalPipelineOptions()"),
+        "Recover 3D points and unknown camera poses by partitioning the scene "
+        "into overlapping clusters, reconstructing them separately using "
+        "incremental mapping, and merging them into a globally consistent "
+        "reconstruction");
 
   m.def("calibrate_view_graph",
         &ViewGraphCalibration,

--- a/src/pycolmap/pipeline/sfm_test.py
+++ b/src/pycolmap/pipeline/sfm_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import pycolmap
@@ -29,6 +31,7 @@ def test_global_pipeline_options_min_num_matches():
     [
         "incremental_mapping",
         "global_mapping",
+        "hierarchical_mapping",
         "triangulate_points",
         "calibrate_view_graph",
         "bundle_adjustment",
@@ -36,3 +39,119 @@ def test_global_pipeline_options_min_num_matches():
 )
 def test_public_api_callable(name):
     assert callable(getattr(pycolmap, name))
+
+
+def test_hierarchical_pipeline_options_init():
+    options = pycolmap.HierarchicalPipelineOptions()
+    assert options is not None
+
+
+def test_incremental_mapping(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    image_path = tmp_path / "images"
+    image_path.mkdir()
+    output_path = tmp_path / "sparse"
+    output_path.mkdir()
+
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 7
+        synthetic_dataset_options.num_points3D = 50
+        synthetic_dataset_options.camera_has_prior_focal_length = False
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+    reconstructions = pycolmap.incremental_mapping(
+        database_path, image_path, output_path
+    )
+
+    assert len(reconstructions) == 1
+    assert (
+        reconstructions[0].num_reg_images()
+        == gt_reconstruction.num_reg_images()
+    )
+    assert (output_path / "0").exists()
+
+
+def test_global_mapping(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    image_path = tmp_path / "images"
+    image_path.mkdir()
+    output_path = tmp_path / "sparse"
+    output_path.mkdir()
+
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 7
+        synthetic_dataset_options.num_points3D = 50
+        synthetic_dataset_options.camera_has_prior_focal_length = False
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+    # Global mapping requires calibrated two-view geometries.
+    assert pycolmap.calibrate_view_graph(database_path)
+
+    reconstructions = pycolmap.global_mapping(
+        database_path, image_path, output_path
+    )
+
+    assert len(reconstructions) == 1
+    assert (
+        reconstructions[0].num_reg_images()
+        == gt_reconstruction.num_reg_images()
+    )
+    assert (output_path / "0").exists()
+    result = pycolmap.compare_reconstructions(
+        reconstructions[0],
+        gt_reconstruction,
+        alignment_error="proj_center",
+        max_proj_center_error=1e-4,
+    )
+    assert result is not None
+    for error in result["errors"]:
+        assert error.rotation_error_deg < 1e-2
+        assert error.proj_center_error < 1e-4
+
+
+def test_hierarchical_mapping(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    image_path = tmp_path / "images"
+    image_path.mkdir()
+    output_path = tmp_path / "sparse"
+    output_path.mkdir()
+
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 10
+        synthetic_dataset_options.num_points3D = 100
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+    options = pycolmap.HierarchicalPipelineOptions()
+    options.clustering_options.leaf_max_num_images = 5
+    options.clustering_options.image_overlap = 3
+    reconstructions = pycolmap.hierarchical_mapping(
+        database_path, image_path, output_path, options
+    )
+
+    assert len(reconstructions) == 1
+    assert (
+        reconstructions[0].num_reg_images()
+        == gt_reconstruction.num_reg_images()
+    )
+    assert (output_path / "0").exists()

--- a/src/pycolmap/sfm/bindings.cc
+++ b/src/pycolmap/sfm/bindings.cc
@@ -5,9 +5,15 @@ namespace py = pybind11;
 void BindObservationManager(py::module& m);
 void BindIncrementalTriangulator(py::module& m);
 void BindIncrementalMapper(py::module& m);
+void BindHierarchicalMapper(py::module& m);
+void BindGlobalMapper(py::module& m);
 
 void BindSfm(py::module& m) {
   BindObservationManager(m);
   BindIncrementalTriangulator(m);
   BindIncrementalMapper(m);
+  BindHierarchicalMapper(m);
+  // Must be bound after BindIncrementalTriangulator, because
+  // GlobalMapperOptions has an IncrementalTriangulatorOptions member.
+  BindGlobalMapper(m);
 }

--- a/src/pycolmap/sfm/global_mapper.cc
+++ b/src/pycolmap/sfm/global_mapper.cc
@@ -1,0 +1,136 @@
+#include "colmap/sfm/global_mapper.h"
+
+#include "colmap/controllers/global_pipeline.h"
+#include "colmap/scene/database.h"
+#include "colmap/scene/reconstruction_manager.h"
+
+#include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
+
+#include <memory>
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+void BindGlobalMapper(py::module& m) {
+  {
+    using Opts = GlobalMapperOptions;
+    auto PyOpts = py::classh<Opts>(m, "GlobalMapperOptions");
+    PyOpts.def(py::init<>())
+        .def_readwrite("num_threads", &Opts::num_threads)
+        .def_readwrite("random_seed", &Opts::random_seed)
+        .def_readwrite(
+            "image_path",
+            &Opts::image_path,
+            "The image path at which to find the images to extract point "
+            "colors.")
+        .def_readwrite("refine_sensor_from_rig",
+                       &Opts::refine_sensor_from_rig,
+                       "When False, treat each non-ref sensor's "
+                       "cam_from_rig as a pre-calibrated constant across "
+                       "rotation averaging, global positioning and "
+                       "bundle adjustment.")
+        .def_readwrite("rotation_averaging", &Opts::rotation_averaging)
+        .def_readwrite("global_positioning", &Opts::global_positioning)
+        .def_readwrite("bundle_adjustment", &Opts::bundle_adjustment)
+        .def_readwrite("retriangulation", &Opts::retriangulation)
+        .def_readwrite("track_intra_image_consistency_threshold",
+                       &Opts::track_intra_image_consistency_threshold)
+        .def_readwrite("track_required_tracks_per_view",
+                       &Opts::track_required_tracks_per_view)
+        .def_readwrite("track_min_num_views_per_track",
+                       &Opts::track_min_num_views_per_track)
+        .def_readwrite("keep_max_num_tracks", &Opts::keep_max_num_tracks)
+        .def_readwrite("max_angular_reproj_error_deg",
+                       &Opts::max_angular_reproj_error_deg)
+        .def_readwrite("max_normalized_reproj_error",
+                       &Opts::max_normalized_reproj_error)
+        .def_readwrite("min_tri_angle_deg", &Opts::min_tri_angle_deg)
+        .def_readwrite("ba_gpu_index", &Opts::ba_gpu_index)
+        .def_readwrite("ba_num_iterations", &Opts::ba_num_iterations)
+        .def_readwrite("ba_skip_fixed_rotation_stage",
+                       &Opts::ba_skip_fixed_rotation_stage)
+        .def_readwrite("ba_skip_joint_optimization_stage",
+                       &Opts::ba_skip_joint_optimization_stage)
+        .def_readwrite("skip_rotation_averaging",
+                       &Opts::skip_rotation_averaging)
+        .def_readwrite("skip_track_establishment",
+                       &Opts::skip_track_establishment)
+        .def_readwrite("skip_global_positioning",
+                       &Opts::skip_global_positioning)
+        .def_readwrite("skip_bundle_adjustment", &Opts::skip_bundle_adjustment)
+        .def_readwrite("skip_retriangulation", &Opts::skip_retriangulation)
+        .def("get_rotation_averaging",
+             &Opts::RotationAveraging,
+             "Get rotation averaging options with shared settings applied.")
+        .def("get_global_positioning",
+             &Opts::GlobalPositioning,
+             "Get global positioning options with shared settings applied.")
+        .def("get_bundle_adjustment",
+             &Opts::BundleAdjustment,
+             "Get bundle adjustment options with shared settings applied.")
+        .def("get_retriangulation",
+             &Opts::Retriangulation,
+             "Get retriangulation options with shared settings applied.");
+    MakeDataclass(PyOpts);
+  }
+
+  {
+    using Opts = GlobalPipelineOptions;
+    auto PyOpts = py::classh<Opts>(m, "GlobalPipelineOptions");
+    PyOpts.def(py::init<>())
+        .def_readwrite("min_num_matches", &Opts::min_num_matches)
+        .def_readwrite("ignore_watermarks", &Opts::ignore_watermarks)
+        .def_readwrite("image_names", &Opts::image_names)
+        .def_readwrite(
+            "image_path",
+            &Opts::image_path,
+            "The image path at which to find the images to extract point "
+            "colors.")
+        .def_readwrite("num_threads", &Opts::num_threads)
+        .def_readwrite("random_seed", &Opts::random_seed)
+        .def_readwrite("decompose_relative_pose",
+                       &Opts::decompose_relative_pose)
+        .def_readwrite("mapper", &Opts::mapper);
+    MakeDataclass(PyOpts);
+  }
+
+  using CallbackType = GlobalPipeline::CallbackType;
+  auto PyCallbackType =
+      py::enum_<CallbackType>(m, "GlobalPipelineCallback")
+          .value("MODEL_UPDATE_CALLBACK", CallbackType::MODEL_UPDATE_CALLBACK);
+  AddStringToEnumConstructor(PyCallbackType);
+
+  py::classh<GlobalPipeline>(
+      m,
+      "GlobalPipeline",
+      "Class that controls the global mapping procedure (GLOMAP) by jointly "
+      "estimating all camera poses from the view graph using rotation "
+      "averaging and global positioning, followed by bundle adjustment and "
+      "retriangulation.")
+      .def(py::init<GlobalPipelineOptions,
+                    std::shared_ptr<Database>,
+                    std::shared_ptr<ReconstructionManager>>(),
+           "options"_a,
+           "database"_a,
+           "reconstruction_manager"_a,
+           py::call_guard<py::gil_scoped_release>())
+      .def("add_callback",
+           &GlobalPipeline::AddCallback,
+           "id"_a,
+           "func"_a,
+           "Add a callback function for the given callback type.")
+      .def("callback",
+           &GlobalPipeline::Callback,
+           "id"_a,
+           "Invoke the callback for the given callback type.")
+      .def("run",
+           &GlobalPipeline::Run,
+           py::call_guard<py::gil_scoped_release>(),
+           "Run the full global mapping pipeline.");
+}

--- a/src/pycolmap/sfm/global_mapper_test.py
+++ b/src/pycolmap/sfm/global_mapper_test.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+import pycolmap
+
+
+def test_global_mapper_options_init():
+    options = pycolmap.GlobalMapperOptions()
+    assert options is not None
+
+
+def test_global_mapper_options_image_path():
+    options = pycolmap.GlobalMapperOptions()
+    options.image_path = "/tmp/images"
+    assert str(options.image_path) == "/tmp/images"
+
+
+def test_global_mapper_options_ba_gpu_index():
+    options = pycolmap.GlobalMapperOptions()
+    options.ba_gpu_index = "0"
+    assert options.ba_gpu_index == "0"
+
+
+def test_global_mapper_options_get_rotation_averaging():
+    options = pycolmap.GlobalMapperOptions()
+    assert options.get_rotation_averaging() is not None
+
+
+def test_global_mapper_options_get_global_positioning():
+    options = pycolmap.GlobalMapperOptions()
+    assert options.get_global_positioning() is not None
+
+
+def test_global_mapper_options_get_bundle_adjustment():
+    options = pycolmap.GlobalMapperOptions()
+    assert options.get_bundle_adjustment() is not None
+
+
+def test_global_mapper_options_get_retriangulation():
+    options = pycolmap.GlobalMapperOptions()
+    assert options.get_retriangulation() is not None
+
+
+def test_global_pipeline_options_init():
+    options = pycolmap.GlobalPipelineOptions()
+    assert options is not None
+
+
+def test_global_pipeline_options_nested_options():
+    options = pycolmap.GlobalPipelineOptions()
+    options.mapper.min_tri_angle_deg = 2.0
+    assert options.mapper.min_tri_angle_deg == 2.0
+
+
+def test_global_pipeline_options_from_dict():
+    options = pycolmap.GlobalPipelineOptions(
+        min_num_matches=20, mapper={"ba_num_iterations": 5}
+    )
+    assert options.min_num_matches == 20
+    assert options.mapper.ba_num_iterations == 5
+
+
+def test_global_pipeline_callback_model_update():
+    assert pycolmap.GlobalPipelineCallback.MODEL_UPDATE_CALLBACK is not None
+
+
+def test_global_pipeline_run(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 7
+        synthetic_dataset_options.num_points3D = 50
+        synthetic_dataset_options.camera_has_prior_focal_length = False
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+    # Global mapping requires calibrated two-view geometries.
+    assert pycolmap.calibrate_view_graph(database_path)
+
+    with pycolmap.Database.open(database_path) as database:
+        num_model_updates = 0
+
+        def on_model_update():
+            nonlocal num_model_updates
+            num_model_updates += 1
+
+        reconstruction_manager = pycolmap.ReconstructionManager()
+        pipeline = pycolmap.GlobalPipeline(
+            pycolmap.GlobalPipelineOptions(),
+            database,
+            reconstruction_manager,
+        )
+        pipeline.add_callback(
+            pycolmap.GlobalPipelineCallback.MODEL_UPDATE_CALLBACK,
+            on_model_update,
+        )
+        pipeline.run()
+
+    assert num_model_updates > 0
+    assert reconstruction_manager.size() == 1
+    reconstruction = reconstruction_manager.get(0)
+    assert reconstruction.num_reg_images() == gt_reconstruction.num_reg_images()
+    result = pycolmap.compare_reconstructions(
+        reconstruction,
+        gt_reconstruction,
+        alignment_error="proj_center",
+        max_proj_center_error=1e-4,
+    )
+    assert result is not None
+    for error in result["errors"]:
+        assert error.rotation_error_deg < 1e-2
+        assert error.proj_center_error < 1e-4

--- a/src/pycolmap/sfm/hierarchical_mapper.cc
+++ b/src/pycolmap/sfm/hierarchical_mapper.cc
@@ -1,0 +1,102 @@
+#include "colmap/controllers/hierarchical_pipeline.h"
+#include "colmap/scene/database.h"
+#include "colmap/scene/reconstruction_manager.h"
+#include "colmap/scene/scene_clustering.h"
+
+#include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
+
+#include <memory>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+void BindHierarchicalMapper(py::module& m) {
+  {
+    using Opts = SceneClustering::Options;
+    auto PyOpts = py::classh<Opts>(m, "SceneClusteringOptions");
+    PyOpts.def(py::init<>())
+        .def_readwrite("is_hierarchical",
+                       &Opts::is_hierarchical,
+                       "Flag for hierarchical vs. flat clustering.")
+        .def_readwrite("branching",
+                       &Opts::branching,
+                       "The branching factor of the hierarchical clustering.")
+        .def_readwrite(
+            "image_overlap",
+            &Opts::image_overlap,
+            "The number of overlapping images between child clusters.")
+        .def_readwrite(
+            "num_image_matches",
+            &Opts::num_image_matches,
+            "The max related images matches to look for in a flat cluster.")
+        .def_readwrite(
+            "leaf_max_num_images",
+            &Opts::leaf_max_num_images,
+            "The maximum number of images in a leaf node cluster, otherwise "
+            "the cluster is further partitioned using the given branching "
+            "factor. Note that a cluster leaf node will have at most "
+            "`leaf_max_num_images + image_overlap` images to satisfy the "
+            "overlap constraint.")
+        .def("check", &Opts::Check);
+    MakeDataclass(PyOpts);
+  }
+
+  {
+    using Opts = HierarchicalPipelineOptions;
+    auto PyOpts = py::classh<Opts>(m, "HierarchicalPipelineOptions");
+    PyOpts.def(py::init<>())
+        .def_readwrite(
+            "image_path",
+            &Opts::image_path,
+            "The image path at which to find the images to extract point "
+            "colors. If not specified, all point colors will be black.")
+        .def_readwrite("init_num_trials",
+                       &Opts::init_num_trials,
+                       "The maximum number of trials to initialize a cluster.")
+        .def_readwrite(
+            "num_threads",
+            &Opts::num_threads,
+            "The total number of threads for the hierarchical pipeline. This "
+            "budget is divided across workers to avoid thread "
+            "oversubscription. Note that incremental_options.num_threads is "
+            "ignored in favor of this option.")
+        .def_readwrite(
+            "num_workers",
+            &Opts::num_workers,
+            "The number of workers used to reconstruct clusters in parallel.")
+        .def_readwrite("clustering_options",
+                       &Opts::clustering_options,
+                       "Options for clustering the scene graph.")
+        .def_readwrite("incremental_options",
+                       &Opts::incremental_options,
+                       "Options used to reconstruct each cluster individually.")
+        .def("check", &Opts::Check);
+    MakeDataclass(PyOpts);
+  }
+
+  py::classh<HierarchicalPipeline>(
+      m,
+      "HierarchicalPipeline",
+      "Class that controls the hierarchical mapping procedure by first "
+      "partitioning the scene into multiple overlapping clusters, then "
+      "reconstructing them separately using incremental mapping, and finally "
+      "merging them all into a globally consistent reconstruction. This is "
+      "especially useful for larger-scale scenes, since incremental mapping "
+      "becomes slow with an increasing number of images.")
+      .def(py::init<const HierarchicalPipelineOptions&,
+                    std::shared_ptr<Database>,
+                    std::shared_ptr<ReconstructionManager>>(),
+           "options"_a,
+           "database"_a,
+           "reconstruction_manager"_a,
+           py::call_guard<py::gil_scoped_release>())
+      .def("run",
+           &HierarchicalPipeline::Run,
+           py::call_guard<py::gil_scoped_release>(),
+           "Run the full hierarchical mapping pipeline.");
+}

--- a/src/pycolmap/sfm/hierarchical_mapper_test.py
+++ b/src/pycolmap/sfm/hierarchical_mapper_test.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pycolmap
+
+
+def test_scene_clustering_options_init():
+    options = pycolmap.SceneClusteringOptions()
+    assert options is not None
+
+
+def test_scene_clustering_options_check():
+    options = pycolmap.SceneClusteringOptions()
+    assert options.check()
+
+
+def test_scene_clustering_options_leaf_max_num_images():
+    options = pycolmap.SceneClusteringOptions()
+    options.leaf_max_num_images = 100
+    assert options.leaf_max_num_images == 100
+
+
+def test_hierarchical_pipeline_options_init():
+    options = pycolmap.HierarchicalPipelineOptions()
+    assert options is not None
+
+
+def test_hierarchical_pipeline_options_check():
+    options = pycolmap.HierarchicalPipelineOptions()
+    assert options.check()
+
+
+def test_hierarchical_pipeline_options_num_workers():
+    options = pycolmap.HierarchicalPipelineOptions()
+    options.num_workers = 2
+    assert options.num_workers == 2
+
+
+def test_hierarchical_pipeline_options_nested_options():
+    options = pycolmap.HierarchicalPipelineOptions()
+    options.clustering_options.image_overlap = 10
+    assert options.clustering_options.image_overlap == 10
+    options.incremental_options.min_num_matches = 20
+    assert options.incremental_options.min_num_matches == 20
+
+
+def test_hierarchical_pipeline_options_from_dict():
+    options = pycolmap.HierarchicalPipelineOptions(
+        num_workers=3, clustering_options={"leaf_max_num_images": 50}
+    )
+    assert options.num_workers == 3
+    assert options.clustering_options.leaf_max_num_images == 50
+
+
+def test_hierarchical_pipeline_run(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 10
+        synthetic_dataset_options.num_points3D = 100
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+        options = pycolmap.HierarchicalPipelineOptions()
+        options.clustering_options.leaf_max_num_images = 5
+        options.clustering_options.image_overlap = 3
+        reconstruction_manager = pycolmap.ReconstructionManager()
+        pipeline = pycolmap.HierarchicalPipeline(
+            options, database, reconstruction_manager
+        )
+        pipeline.run()
+
+    assert reconstruction_manager.size() == 1
+    reconstruction = reconstruction_manager.get(0)
+    assert reconstruction.num_reg_images() == gt_reconstruction.num_reg_images()
+    assert (
+        reconstruction.compute_num_observations()
+        >= gt_reconstruction.compute_num_observations()
+    )
+    result = pycolmap.compare_reconstructions(
+        reconstruction,
+        gt_reconstruction,
+        alignment_error="proj_center",
+        max_proj_center_error=1e-4,
+    )
+    assert result is not None

--- a/src/pycolmap/sfm/incremental_mapper_test.py
+++ b/src/pycolmap/sfm/incremental_mapper_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pycolmap
 
 
@@ -155,3 +157,41 @@ def test_incremental_pipeline_options_ba_global_backend_readwrite():
     assert options.ba_global_backend == pycolmap.BundleAdjustmentBackend.CERES
     options.ba_global_backend = pycolmap.BundleAdjustmentBackend.CASPAR
     assert options.ba_global_backend == pycolmap.BundleAdjustmentBackend.CASPAR
+
+
+def test_incremental_pipeline_run(tmp_path: Path):
+    pycolmap.set_random_seed(0)
+
+    database_path = tmp_path / "database.db"
+    with pycolmap.Database.open(database_path) as database:
+        synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
+        synthetic_dataset_options.num_rigs = 2
+        synthetic_dataset_options.num_cameras_per_rig = 1
+        synthetic_dataset_options.num_frames_per_rig = 7
+        synthetic_dataset_options.num_points3D = 50
+        synthetic_dataset_options.camera_has_prior_focal_length = False
+        gt_reconstruction = pycolmap.synthesize_dataset(
+            synthetic_dataset_options, database
+        )
+
+        reconstruction_manager = pycolmap.ReconstructionManager()
+        pipeline = pycolmap.IncrementalPipeline(
+            pycolmap.IncrementalPipelineOptions(),
+            database,
+            reconstruction_manager,
+        )
+        pipeline.run()
+
+    assert reconstruction_manager.size() == 1
+    reconstruction = reconstruction_manager.get(0)
+    assert reconstruction.num_reg_images() == gt_reconstruction.num_reg_images()
+    result = pycolmap.compare_reconstructions(
+        reconstruction,
+        gt_reconstruction,
+        alignment_error="proj_center",
+        max_proj_center_error=1e-4,
+    )
+    assert result is not None
+    for error in result["errors"]:
+        assert error.rotation_error_deg < 1e-2
+        assert error.proj_center_error < 1e-4


### PR DESCRIPTION
Exposes the hierarchical mapping pipeline to Python, and brings the global mapper bindings up to the same level of completeness.

## Hierarchical mapper (new)

- `pycolmap.SceneClusteringOptions` and `pycolmap.HierarchicalPipelineOptions` dataclasses
- `pycolmap.HierarchicalPipeline` class with `run()`
- `pycolmap.hierarchical_mapping(database_path, image_path, output_path, options)`, mirroring `incremental_mapping()` and `global_mapping()`

```python
options = pycolmap.HierarchicalPipelineOptions()
options.clustering_options.leaf_max_num_images = 500
reconstructions = pycolmap.hierarchical_mapping(
    database_path, image_path, output_path, options
)
```

To share one code path between the CLI and Python, `RunHierarchicalMapperImpl()` is factored out of `RunHierarchicalMapper()`, mirroring the existing `RunGlobalMapperImpl()`.

`add_callback`/`callback` are deliberately not bound on `HierarchicalPipeline` — unlike the other two controllers it registers no callbacks, so they would be dead API.

## Global mapper

While adding the above it became apparent that the global mapper bindings were the least complete of the three:

- `GlobalPipeline` was not bound as a class at all, only the free `global_mapping()` function. It is now bound along with its `MODEL_UPDATE_CALLBACK` (new `pycolmap.GlobalPipelineCallback` enum), so the in-progress reconstruction can be rendered from Python.
- `GlobalPipelineOptions.image_path`, `GlobalMapperOptions.image_path` and `GlobalMapperOptions.ba_gpu_index` were never bound. Not broken in practice, since `global_mapping()` sets `image_path` from its argument, but unreachable when driving the options directly.
- The `RotationAveraging()`, `GlobalPositioning()`, `BundleAdjustment()` and `Retriangulation()` accessors — the analogues of `IncrementalPipelineOptions.get_mapper()` — were not bound. They are now exposed as `get_*`.

`GlobalMapperOptions`/`GlobalPipelineOptions` are moved from `pipeline/sfm.cc` into the new `sfm/global_mapper.cc`, so all three mappers follow the same layout: controller and options in `pycolmap/sfm/<name>_mapper.cc`, free pipeline function in `pycolmap/pipeline/sfm.cc`. This requires binding the global mapper after the incremental triangulator (`GlobalMapperOptions.retriangulation` is an `IncrementalTriangulatorOptions`), which is noted in `sfm/bindings.cc`. Happy to drop this move if it is more churn than wanted here.

## Tests

Previously no pycolmap test ran a mapping pipeline to completion — `sfm_test.py` only asserted the functions were `callable`, and the only end-to-end coverage lived in `python/examples/custom_incremental_pipeline_test.py`, which drives a Python reimplementation of the loop rather than `IncrementalPipeline.run()`.

Added end-to-end tests on synthetic datasets, mirroring the corresponding C++ controller tests and checking recovered poses against ground truth via `compare_reconstructions`:

- `IncrementalPipeline.run()`, `GlobalPipeline.run()`, `HierarchicalPipeline.run()`
- `incremental_mapping()`, `global_mapping()`, `hierarchical_mapping()`

The global pipeline test also asserts that `MODEL_UPDATE_CALLBACK` actually fires, and gives `calibrate_view_graph()` its first real coverage. Each new test runs in well under a second.