### PR TITLE
Budget the homography ransac with minimum inlier ratio

### DIFF
--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -158,8 +158,13 @@ TwoViewGeometry EstimateCalibratedHomography(
 
   // Estimate planar or panoramic model.
 
+  auto ransac_options = options.ransac_options;
+  if (options.min_inlier_ratio > 0) {
+    ransac_options.min_inlier_ratio = options.min_inlier_ratio;
+  }
+
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      options.ransac_options);
+      ransac_options);
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -224,8 +229,15 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
+  // Budget the search for the ratio the homography must beat to be selected
+  // below, since a weaker one is discarded anyway.
+  auto H_ransac_options = options.ransac_options;
+  H_ransac_options.min_inlier_ratio =
+      std::max(options.ransac_options.min_inlier_ratio,
+               options.max_H_inlier_ratio * F_report.support.num_inliers /
+                   matches.size());
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      options.ransac_options);
+      H_ransac_options);
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -916,8 +928,16 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
+  // As above. The competing model depends on the branch taken below, so the
+  // smaller inlier count is the lowest bar the homography might have to clear.
+  auto H_ransac_options = ransac_options;
+  H_ransac_options.min_inlier_ratio = std::max(
+      ransac_options.min_inlier_ratio,
+      options.max_H_inlier_ratio *
+          std::min(E_report.support.num_inliers, F_report.support.num_inliers) /
+          matches.size());
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      ransac_options);
+      H_ransac_options);
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -1075,8 +1095,14 @@ TwoViewGeometry EstimateSharedFocalTwoViewGeometry(
   // Estimate a homography to detect planar/panoramic degeneracies, where
   // two-view focal recovery is ill-posed and the 6-point solver returns a
   // meaningless focal length.
+  // As in EstimateUncalibratedTwoViewGeometry.
+  auto H_ransac_options = ransac_options;
+  H_ransac_options.min_inlier_ratio =
+      std::max(ransac_options.min_inlier_ratio,
+               options.max_H_inlier_ratio * SF_report.support.num_inliers /
+                   matches.size());
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      ransac_options);
+      H_ransac_options);
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -1266,8 +1292,14 @@ TwoViewGeometry EstimateOneSidedFocalTwoViewGeometry(
   // spherical one it is skipped, as in the spherical path. A default report has
   // no inliers, so the checks below then behave as a failed estimate.
   const bool has_image_plane = !camera2.IsSpherical();
+  // As in EstimateUncalibratedTwoViewGeometry.
+  auto H_ransac_options = ransac_options;
+  H_ransac_options.min_inlier_ratio =
+      std::max(ransac_options.min_inlier_ratio,
+               options.max_H_inlier_ratio * focal_report.support.num_inliers /
+                   matches.size());
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator> H_ransac(
-      ransac_options);
+      H_ransac_options);
   LORANSAC<HomographyMatrixEstimator, HomographyMatrixEstimator>::Report
       H_report;
   if (has_image_plane) {

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -928,7 +928,7 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
-  // Budget the estimation as above. The competing model depends on the branch 
+  // Budget the estimation as above. The competing model depends on the branch
   // taken below so the homography must reach the smallest count of the two.
   auto H_ransac_options = ransac_options;
   H_ransac_options.min_inlier_ratio = std::max(

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -928,8 +928,8 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
-  // As above. The competing model depends on the branch taken below, so the
-  // smaller inlier count is the lowest bar the homography might have to clear.
+  // Budget the estimation as above. The competing model depends on the branch 
+  // taken below so the homography must reach the smallest count of the two.
   auto H_ransac_options = ransac_options;
   H_ransac_options.min_inlier_ratio = std::max(
       ransac_options.min_inlier_ratio,

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -1292,7 +1292,7 @@ TwoViewGeometry EstimateOneSidedFocalTwoViewGeometry(
   // spherical one it is skipped, as in the spherical path. A default report has
   // no inliers, so the checks below then behave as a failed estimate.
   const bool has_image_plane = !camera2.IsSpherical();
-  // As in EstimateUncalibratedTwoViewGeometry.
+  // Budget the estimation as in EstimateUncalibratedTwoViewGeometry.
   auto H_ransac_options = ransac_options;
   H_ransac_options.min_inlier_ratio =
       std::max(ransac_options.min_inlier_ratio,

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -229,8 +229,8 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
 
   // Estimate planar or panoramic model.
 
-  // Budget the search for the ratio the homography must beat to be selected
-  // below, since a weaker one is discarded anyway.
+  // Budget the search for the inlier ratio that the homography must reach
+  // to be selected below, since a weaker one is discarded anyway.
   auto H_ransac_options = options.ransac_options;
   H_ransac_options.min_inlier_ratio =
       std::max(options.ransac_options.min_inlier_ratio,


### PR DESCRIPTION
Splitted from https://github.com/colmap/colmap/pull/4617 and also cover shared focal and one sided focal. 

| ETH3D undistorted PINHOLE, 2068 pairs | AUC@1/5/10 | ms | 
  |---|---|---|
  | baseline | 89.5 97.6 98.7 | 14.20 |
  | + budget | 89.6 97.6 98.7 | 9.47 |

  | ETH3D thinprism, 992 pairs | AUC@1/5/10 | ms |
  |---|---|---|
  | baseline | 88.4 97.2 98.5 | 14.70 |
  | + budget | 88.5 97.3 98.6 | 9.92 |