### PR TITLE
Add GPU bundle adjustment option to global pipeline

### DIFF
--- a/src/colmap/controllers/automatic_reconstruction.cc
+++ b/src/colmap/controllers/automatic_reconstruction.cc
@@ -342,6 +342,7 @@ void AutomaticReconstructionController::RunSparseMapper() {
       global_options.image_path = *option_manager_.image_path;
       global_options.num_threads = options_.num_threads;
       global_options.random_seed = options_.random_seed;
+      global_options.ba_use_gpu = options_.use_gpu;
       mapper = std::make_unique<GlobalPipeline>(std::move(global_options),
                                                 std::move(database),
                                                 reconstruction_manager_);

--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -107,6 +107,9 @@ void GlobalPipeline::Run() {
   mapper_options.image_path = options_.image_path;
   mapper_options.num_threads = options_.num_threads;
   mapper_options.random_seed = options_.random_seed;
+  if (mapper_options.bundle_adjustment.ceres) {
+    mapper_options.bundle_adjustment.ceres->use_gpu = options_.ba_use_gpu;
+  }
 
   GlobalMapper global_mapper(database_cache_);
   global_mapper.BeginReconstruction(reconstruction);

--- a/src/colmap/controllers/global_pipeline.h
+++ b/src/colmap/controllers/global_pipeline.h
@@ -55,6 +55,9 @@ struct GlobalPipelineOptions {
   // Number of threads for parallel processing.
   int num_threads = -1;
 
+  // Whether to use GPU-based bundle adjustment, if supported by the backend.
+  bool ba_use_gpu = false;
+
   // Random seed for reproducibility.
   int random_seed = -1;
 

--- a/src/colmap/controllers/incremental_pipeline.h
+++ b/src/colmap/controllers/incremental_pipeline.h
@@ -137,9 +137,10 @@ struct IncrementalPipelineOptions {
   int ba_global_max_refinements = 5;
   double ba_global_max_refinement_change = 0.0005;
 
-  // Whether to use Ceres' CUDA sparse linear algebra library, if available.
+  // Whether to use GPU-based bundle adjustment, if supported by the backend.
   bool ba_use_gpu = false;
-  // GPU device index for bundle adjustment (-1 = auto-select).
+  // GPU device index for bundle adjustment, shared by all backends
+  // (-1 = auto-select).
   std::string ba_gpu_index = "-1";
 
   // Bundle adjustment solver backend for local bundle adjustment.

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -818,11 +818,10 @@ void OptionManager::AddGlobalMapperOptions() {
                        &global_mapper->mapper.bundle_adjustment.backend,
                        BundleAdjustmentBackendToString,
                        BundleAdjustmentBackendFromString);
+  AddDefaultOption("GlobalMapper.ba_use_gpu", &global_mapper->ba_use_gpu);
   AddDefaultOption("GlobalMapper.ba_gpu_index",
                    &global_mapper->mapper.ba_gpu_index);
   // Bundle adjustment options (Ceres-specific).
-  AddDefaultOption("GlobalMapper.ba_ceres_use_gpu",
-                   &global_mapper->mapper.bundle_adjustment.ceres->use_gpu);
   AddDefaultOption(
       "GlobalMapper.ba_ceres_loss_function_scale",
       &global_mapper->mapper.bundle_adjustment.ceres->loss_function_scale);

--- a/src/colmap/controllers/option_manager_test.cc
+++ b/src/colmap/controllers/option_manager_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/controllers/option_manager.h"
 
+#include "colmap/controllers/global_pipeline.h"
 #include "colmap/controllers/image_reader.h"
 #include "colmap/controllers/incremental_pipeline.h"
 #include "colmap/feature/sift.h"
@@ -135,6 +136,7 @@ TEST(OptionManager, WriteAndRead) {
   options_write.feature_extraction->max_image_size = 2048;
   options_write.feature_extraction->sift->max_num_features = 4096;
   options_write.mapper->min_num_matches = 20;
+  options_write.global_mapper->ba_use_gpu = true;
 
   // Write to file
   options_write.Write(config_path);
@@ -159,6 +161,8 @@ TEST(OptionManager, WriteAndRead) {
             options_write.feature_extraction->sift->max_num_features);
   EXPECT_EQ(options_read.mapper->min_num_matches,
             options_write.mapper->min_num_matches);
+  EXPECT_EQ(options_read.global_mapper->ba_use_gpu,
+            options_write.global_mapper->ba_use_gpu);
 }
 
 TEST(OptionManager, ReRead) {

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -41,7 +41,6 @@ struct GlobalMapperOptions {
     if (options.ceres) {
       options.ceres->loss_function_type =
           CeresBundleAdjustmentOptions::LossFunctionType::HUBER;
-      options.ceres->use_gpu = true;
       // TODO: Investigate whether disabling auto solver selection and using
       // explicit SPARSE_SCHUR is necessary for global SfM, or if we can just
       // rely on COLMAP's auto selection.
@@ -77,8 +76,8 @@ struct GlobalMapperOptions {
   double max_normalized_reproj_error = 1e-2;  // for bundle adjustment
   double min_tri_angle_deg = 1.;              // for triangulation
 
-  // GPU device index for bundle adjustment, shared by the Ceres and Caspar
-  // backends (-1 = auto-select).
+  // GPU device index for bundle adjustment, shared by all backends
+  // (-1 = auto-select).
   std::string ba_gpu_index = "-1";
 
   // Control the number of iterations for bundle adjustment.

--- a/src/pycolmap/sfm/global_mapper.cc
+++ b/src/pycolmap/sfm/global_mapper.cc
@@ -93,6 +93,7 @@ void BindGlobalMapper(py::module& m) {
             "The image path at which to find the images to extract point "
             "colors.")
         .def_readwrite("num_threads", &Opts::num_threads)
+        .def_readwrite("ba_use_gpu", &Opts::ba_use_gpu)
         .def_readwrite("random_seed", &Opts::random_seed)
         .def_readwrite("decompose_relative_pose",
                        &Opts::decompose_relative_pose)

--- a/src/pycolmap/sfm/global_mapper_test.py
+++ b/src/pycolmap/sfm/global_mapper_test.py
@@ -20,6 +20,13 @@ def test_global_mapper_options_ba_gpu_index():
     assert options.ba_gpu_index == "0"
 
 
+def test_global_pipeline_options_ba_use_gpu():
+    options = pycolmap.GlobalPipelineOptions()
+    assert not options.ba_use_gpu
+    options.ba_use_gpu = True
+    assert options.ba_use_gpu
+
+
 def test_global_mapper_options_get_rotation_averaging():
     options = pycolmap.GlobalMapperOptions()
     assert options.get_rotation_averaging() is not None


### PR DESCRIPTION
## Summary

- add a backend-neutral ba_use_gpu flag to GlobalPipelineOptions, defaulting to CPU like the incremental pipeline
- replace GlobalMapper.ba_ceres_use_gpu with GlobalMapper.ba_use_gpu and forward it to Ceres during pipeline setup
- propagate the setting through automatic reconstruction and expose it in pycolmap

## Tests

- PYENV_VERSION=colmap scripts/format/c++.sh
- PYENV_VERSION=colmap scripts/format/python.sh
- ctest --test-dir build --output-on-failure -R ^(controllers/(global_pipeline|option_manager)_test|sfm/global_mapper_test)$
- PYENV_VERSION=colmap pytest -q src/pycolmap/sfm/global_mapper_test.py