### PR TITLE
Fallback to CPU for Ceres BA without CUDA GPU

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -140,11 +140,19 @@ ceres::Solver::Options CeresBundleAdjustmentOptions::CreateSolverOptions(
 
 #ifdef COLMAP_CUDA_ENABLED
   bool cuda_solver_enabled = false;
+  const bool cuda_solver_requested =
+      use_gpu && num_images >= min_num_images_gpu_solver;
+  const bool use_cuda_solver = cuda_solver_requested && GetNumCudaDevices() > 0;
+  if (cuda_solver_requested && !use_cuda_solver) {
+    LOG_FIRST_N(WARNING, 1)
+        << "Requested to use GPU for bundle adjustment, but no CUDA GPU is "
+           "available. Falling back to CPU-based solvers.";
+  }
 
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2)) && \
     !defined(CERES_NO_CUDA)
-  if (use_gpu && num_images >= min_num_images_gpu_solver) {
+  if (use_cuda_solver) {
     cuda_solver_enabled = true;
     custom_solver_options.dense_linear_algebra_library_type = ceres::CUDA;
     max_num_images_direct_dense_solver = max_num_images_direct_dense_gpu_solver;
@@ -161,7 +169,7 @@ ceres::Solver::Options CeresBundleAdjustmentOptions::CreateSolverOptions(
 #if (CERES_VERSION_MAJOR >= 3 ||                                \
      (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 3)) && \
     !defined(CERES_NO_CUDSS)
-  if (use_gpu && num_images >= min_num_images_gpu_solver) {
+  if (use_cuda_solver) {
     cuda_solver_enabled = true;
     custom_solver_options.sparse_linear_algebra_library_type =
         ceres::CUDA_SPARSE;

--- a/src/colmap/estimators/bundle_adjustment_ceres_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres_test.cc
@@ -33,6 +33,7 @@
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/cuda.h"
 #include "colmap/util/testing.h"
 
 #include <gtest/gtest.h>
@@ -120,6 +121,25 @@ inline const ceres::Solver::Summary& GetCeresSummary(
   CHECK_NOTNULL(ceres_summary);
   return ceres_summary->ceres_summary;
 }
+
+#ifdef COLMAP_CUDA_ENABLED
+TEST(CeresBundleAdjustmentOptions, FallsBackToCpuWithoutCudaDevice) {
+  if (GetNumCudaDevices() > 0) {
+    GTEST_SKIP() << "CUDA GPU is available";
+  }
+
+  CeresBundleAdjustmentOptions options;
+  options.use_gpu = true;
+  options.min_num_images_gpu_solver = 0;
+
+  const ceres::Solver::Options solver_options =
+      options.CreateSolverOptions(BundleAdjustmentConfig(), ceres::Problem());
+  EXPECT_EQ(solver_options.dense_linear_algebra_library_type,
+            options.solver_options.dense_linear_algebra_library_type);
+  EXPECT_EQ(solver_options.sparse_linear_algebra_library_type,
+            options.solver_options.sparse_linear_algebra_library_type);
+}
+#endif  // COLMAP_CUDA_ENABLED
 
 TEST(DefaultBundleAdjuster, Nominal) {
   Reconstruction gt_reconstruction;

--- a/src/colmap/util/cuda.cc
+++ b/src/colmap/util/cuda.cc
@@ -51,8 +51,14 @@ bool CompareCudaDevice(const cudaDeviceProp& d1, const cudaDeviceProp& d2) {
 }  // namespace
 
 int GetNumCudaDevices() {
-  int num_cuda_devices;
-  CUDA_SAFE_CALL(cudaGetDeviceCount(&num_cuda_devices));
+  int num_cuda_devices = 0;
+  const cudaError_t error = cudaGetDeviceCount(&num_cuda_devices);
+#ifdef COLMAP_CUDA_ENABLED
+  if (error == cudaErrorNoDevice || error == cudaErrorInsufficientDriver) {
+    return 0;
+  }
+#endif
+  CUDA_SAFE_CALL(error);
   return num_cuda_devices;
 }
 


### PR DESCRIPTION
## Summary

- detect when GPU bundle adjustment is requested but no CUDA device is available
- retain the CPU dense and sparse solver backends instead of failing during device selection
- add a CUDA-build regression test for hosts without a CUDA GPU

## Verification

- PYENV_VERSION=colmap scripts/format/c++.sh
- ctest --test-dir build -R ^estimators/bundle_adjustment_ceres_test$ --output-on-failure
- ctest --test-dir build -R ^estimators/bundle_adjustment_test$ --output-on-failure