### PR TITLE
Remove unused includes

### DIFF
--- a/src/colmap/controllers/bundle_adjustment_test.cc
+++ b/src/colmap/controllers/bundle_adjustment_test.cc
@@ -30,7 +30,6 @@
 #include "colmap/controllers/bundle_adjustment.h"
 
 #include "colmap/controllers/option_manager.h"
-#include "colmap/math/random.h"
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
 

--- a/src/colmap/controllers/feature_matching.h
+++ b/src/colmap/controllers/feature_matching.h
@@ -35,7 +35,6 @@
 #include "colmap/util/threading.h"
 
 #include <memory>
-#include <string>
 
 namespace colmap {
 

--- a/src/colmap/controllers/global_pipeline.cc
+++ b/src/colmap/controllers/global_pipeline.cc
@@ -33,7 +33,6 @@
 #include "colmap/estimators/two_view_geometry.h"
 #include "colmap/scene/database_cache.h"
 #include "colmap/sfm/global_mapper.h"
-#include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 namespace colmap {

--- a/src/colmap/controllers/global_pipeline_test.cc
+++ b/src/colmap/controllers/global_pipeline_test.cc
@@ -30,7 +30,6 @@
 #include "colmap/controllers/global_pipeline.h"
 
 #include "colmap/estimators/view_graph_calibration.h"
-#include "colmap/math/random.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/scene/database.h"
 #include "colmap/scene/reconstruction_matchers.h"

--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -35,7 +35,6 @@
 #include "colmap/util/file.h"
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
-#include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 #include <fstream>

--- a/src/colmap/controllers/reconstruction_clustering.cc
+++ b/src/colmap/controllers/reconstruction_clustering.cc
@@ -30,7 +30,6 @@
 #include "colmap/controllers/reconstruction_clustering.h"
 
 #include "colmap/scene/reconstruction_clustering.h"
-#include "colmap/util/file.h"
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/misc.h"

--- a/src/colmap/controllers/rotation_averaging_test.cc
+++ b/src/colmap/controllers/rotation_averaging_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/controllers/rotation_averaging.h"
 
-#include "colmap/math/random.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 

--- a/src/colmap/estimators/bundle_adjustment_caspar_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar_test.cc
@@ -34,7 +34,6 @@
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/sensor/models.h"
-#include "colmap/util/testing.h"
 
 #include <gtest/gtest.h>
 

--- a/src/colmap/estimators/bundle_adjustment_ceres.h
+++ b/src/colmap/estimators/bundle_adjustment_ceres.h
@@ -31,7 +31,6 @@
 
 #include "colmap/estimators/bundle_adjustment.h"
 #include "colmap/math/math.h"
-#include "colmap/optim/ransac.h"
 
 #include <ceres/ceres.h>
 

--- a/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
+++ b/src/colmap/estimators/cost_functions/quaternion_utils_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/estimators/cost_functions/quaternion_utils.h"
 
-#include "colmap/math/random.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/eigen_matchers.h"
 

--- a/src/colmap/estimators/covariance_test.cc
+++ b/src/colmap/estimators/covariance_test.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/estimators/bundle_adjustment_ceres.h"
 #include "colmap/estimators/cost_functions/manifold.h"
-#include "colmap/math/random.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/scene/synthetic.h"
 

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/estimators/global_positioning.h"
 
-#include "colmap/math/random.h"
 #include "colmap/scene/database_cache.h"
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction_matchers.h"

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/math/math.h"
 #include "colmap/math/random.h"
-#include "colmap/math/random_eigen.h"
 #include "colmap/scene/database_cache.h"
 #include "colmap/scene/database_sqlite.h"
 #include "colmap/scene/pose_graph.h"

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/estimators/two_view_geometry.h"
 
-#include "colmap/estimators/solvers/relpose_one_sided_focal.h"
 #include "colmap/estimators/solvers/relpose_shared_focal.h"
 #include "colmap/geometry/essential_matrix.h"
 #include "colmap/geometry/homography_matrix.h"

--- a/src/colmap/estimators/view_graph_calibration_test.cc
+++ b/src/colmap/estimators/view_graph_calibration_test.cc
@@ -34,7 +34,6 @@
 #include "colmap/scene/database_sqlite.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/sensor/models.h"
-#include "colmap/util/eigen_matchers.h"
 #include "colmap/util/hash_containers.h"
 
 #include <gtest/gtest.h>

--- a/src/colmap/exe/feature.cc
+++ b/src/colmap/exe/feature.cc
@@ -33,7 +33,6 @@
 #include "colmap/controllers/feature_matching.h"
 #include "colmap/controllers/image_reader.h"
 #include "colmap/controllers/option_manager.h"
-#include "colmap/exe/gui.h"
 #include "colmap/feature/sift.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/file.h"

--- a/src/colmap/exe/feature.cc
+++ b/src/colmap/exe/feature.cc
@@ -33,6 +33,7 @@
 #include "colmap/controllers/feature_matching.h"
 #include "colmap/controllers/image_reader.h"
 #include "colmap/controllers/option_manager.h"
+#include "colmap/exe/gui.h"
 #include "colmap/feature/sift.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/file.h"

--- a/src/colmap/exe/gui.cc
+++ b/src/colmap/exe/gui.cc
@@ -33,7 +33,6 @@
 #include "colmap/ui/main_window.h"
 #endif
 #include "colmap/controllers/option_manager.h"
-#include "colmap/util/opengl_utils.h"
 
 namespace colmap {
 

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -38,6 +38,7 @@
 #include "colmap/estimators/bundle_adjustment.h"
 #include "colmap/estimators/solvers/similarity_transform.h"
 #include "colmap/estimators/view_graph_calibration.h"
+#include "colmap/exe/gui.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/sfm/observation_manager.h"
 #include "colmap/util/file.h"

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -38,7 +38,6 @@
 #include "colmap/estimators/bundle_adjustment.h"
 #include "colmap/estimators/solvers/similarity_transform.h"
 #include "colmap/estimators/view_graph_calibration.h"
-#include "colmap/exe/gui.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/sfm/observation_manager.h"
 #include "colmap/util/file.h"

--- a/src/colmap/exe/vocab_tree.cc
+++ b/src/colmap/exe/vocab_tree.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/controllers/option_manager.h"
 #include "colmap/feature/utils.h"
-#include "colmap/retrieval/resources.h"
 #include "colmap/retrieval/visual_index.h"
 #include "colmap/scene/database.h"
 #include "colmap/util/file.h"

--- a/src/colmap/feature/extractor.h
+++ b/src/colmap/feature/extractor.h
@@ -31,7 +31,6 @@
 
 #include "colmap/feature/types.h"
 #include "colmap/sensor/bitmap.h"
-#include "colmap/util/enum_utils.h"
 
 #include <memory>
 

--- a/src/colmap/feature/extractor_test.cc
+++ b/src/colmap/feature/extractor_test.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/feature/aliked.h"
 #include "colmap/feature/sift.h"
-#include "colmap/util/testing.h"
 
 #include <gtest/gtest.h>
 

--- a/src/colmap/feature/matcher.cc
+++ b/src/colmap/feature/matcher.cc
@@ -30,7 +30,6 @@
 #include "colmap/feature/matcher.h"
 
 #include "colmap/feature/aliked.h"
-#include "colmap/feature/onnx_matchers.h"
 #include "colmap/feature/sift.h"
 #include "colmap/util/misc.h"
 

--- a/src/colmap/feature/matcher_test.cc
+++ b/src/colmap/feature/matcher_test.cc
@@ -33,7 +33,6 @@
 #include "colmap/feature/extractor.h"
 #include "colmap/feature/onnx_matchers.h"
 #include "colmap/feature/sift.h"
-#include "colmap/util/testing.h"
 
 #include <gtest/gtest.h>
 

--- a/src/colmap/feature/onnx_utils.h
+++ b/src/colmap/feature/onnx_utils.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#include "colmap/util/logging.h"
-
 #include <memory>
 #include <string>
 #include <string_view>

--- a/src/colmap/feature/types_test.cc
+++ b/src/colmap/feature/types_test.cc
@@ -29,8 +29,6 @@
 
 #include "colmap/feature/types.h"
 
-#include "colmap/math/math.h"
-
 #include <gtest/gtest.h>
 
 namespace colmap {

--- a/src/colmap/feature/types_test.cc
+++ b/src/colmap/feature/types_test.cc
@@ -29,6 +29,8 @@
 
 #include "colmap/feature/types.h"
 
+#include "colmap/math/math.h"
+
 #include <gtest/gtest.h>
 
 namespace colmap {

--- a/src/colmap/geometry/pose.h
+++ b/src/colmap/geometry/pose.h
@@ -32,7 +32,6 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/geometry/sim3.h"
 #include "colmap/util/eigen_alignment.h"
-#include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 
 #include <vector>

--- a/src/colmap/geometry/pose_prior.cc
+++ b/src/colmap/geometry/pose_prior.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/geometry/pose_prior.h"
 
+#include "colmap/math/math.h"
 #include "colmap/util/logging.h"
 
 namespace colmap {

--- a/src/colmap/geometry/pose_prior.cc
+++ b/src/colmap/geometry/pose_prior.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/geometry/pose_prior.h"
 
-#include "colmap/math/math.h"
 #include "colmap/util/logging.h"
 
 namespace colmap {

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/geometry/pose.h"
 
+#include "colmap/math/math.h"
 #include "colmap/math/random.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/eigen_alignment.h"

--- a/src/colmap/geometry/pose_test.cc
+++ b/src/colmap/geometry/pose_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/geometry/pose.h"
 
-#include "colmap/math/math.h"
 #include "colmap/math/random.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/eigen_alignment.h"

--- a/src/colmap/geometry/rigid3_test.cc
+++ b/src/colmap/geometry/rigid3_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/geometry/rigid3.h"
 
-#include "colmap/geometry/rigid3_matchers.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/eigen_matchers.h"
 

--- a/src/colmap/image/undistortion_test.cc
+++ b/src/colmap/image/undistortion_test.cc
@@ -30,7 +30,6 @@
 #include "colmap/image/undistortion.h"
 
 #include "colmap/geometry/pose.h"
-#include "colmap/scene/synthetic.h"
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/eigen_matchers.h"
 #include "colmap/util/logging.h"

--- a/src/colmap/math/random.h
+++ b/src/colmap/math/random.h
@@ -31,10 +31,8 @@
 
 #include "colmap/util/logging.h"
 
-#include <chrono>
 #include <memory>
 #include <random>
-#include <thread>
 
 namespace colmap {
 

--- a/src/colmap/mvs/delaunay_meshing.cc
+++ b/src/colmap/mvs/delaunay_meshing.cc
@@ -34,7 +34,6 @@
 #include "colmap/math/random.h"
 #include "colmap/mvs/fusion.h"
 #include "colmap/scene/reconstruction.h"
-#include "colmap/util/endian.h"
 #include "colmap/util/file.h"
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"

--- a/src/colmap/mvs/model_test.cc
+++ b/src/colmap/mvs/model_test.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/mvs/model.h"
 
-#include "colmap/math/random.h"
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 

--- a/src/colmap/mvs/workspace.h
+++ b/src/colmap/mvs/workspace.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include "colmap/mvs/consistency_graph.h"
 #include "colmap/mvs/depth_map.h"
 #include "colmap/mvs/model.h"
 #include "colmap/mvs/normal_map.h"

--- a/src/colmap/retrieval/visual_index_test.cc
+++ b/src/colmap/retrieval/visual_index_test.cc
@@ -30,7 +30,6 @@
 #include "colmap/retrieval/visual_index.h"
 
 #include "colmap/feature/types.h"
-#include "colmap/math/random.h"
 #include "colmap/math/random_eigen.h"
 #include "colmap/util/file.h"
 #include "colmap/util/testing.h"

--- a/src/colmap/scene/camera.h
+++ b/src/colmap/scene/camera.h
@@ -35,7 +35,6 @@
 #include "colmap/util/logging.h"
 #include "colmap/util/types.h"
 
-#include <utility>
 #include <vector>
 
 #include <Eigen/Geometry>

--- a/src/colmap/scene/database_sqlite.h
+++ b/src/colmap/scene/database_sqlite.h
@@ -33,7 +33,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <string>
 
 namespace colmap {
 

--- a/src/colmap/scene/reconstruction_clustering.cc
+++ b/src/colmap/scene/reconstruction_clustering.cc
@@ -29,7 +29,6 @@
 
 #include "colmap/scene/reconstruction_clustering.h"
 
-#include "colmap/math/connected_components.h"
 #include "colmap/math/math.h"
 #include "colmap/math/union_find.h"
 #include "colmap/util/hash_containers.h"

--- a/src/colmap/scene/reconstruction_io.h
+++ b/src/colmap/scene/reconstruction_io.h
@@ -34,7 +34,6 @@
 #include "colmap/scene/reconstruction_io_text.h"
 
 #include <filesystem>
-#include <iostream>
 
 #include <Eigen/Core>
 

--- a/src/colmap/scene/scene_clustering_test.cc
+++ b/src/colmap/scene/scene_clustering_test.cc
@@ -29,8 +29,6 @@
 
 #include "colmap/scene/scene_clustering.h"
 
-#include "colmap/scene/database.h"
-
 #include <set>
 
 #include <gtest/gtest.h>

--- a/src/colmap/sfm/incremental_mapper.h
+++ b/src/colmap/sfm/incremental_mapper.h
@@ -36,8 +36,6 @@
 #include "colmap/sfm/observation_manager.h"
 #include "colmap/util/hash_containers.h"
 
-#include <optional>
-
 namespace colmap {
 
 // Class that provides all functionality for the incremental reconstruction

--- a/src/colmap/ui/database_management_widget.cc
+++ b/src/colmap/ui/database_management_widget.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/scene/database.h"
 #include "colmap/sensor/models.h"
-#include "colmap/util/file.h"
 #include "colmap/util/misc.h"
 
 namespace colmap {

--- a/src/colmap/ui/dense_reconstruction_widget.cc
+++ b/src/colmap/ui/dense_reconstruction_widget.cc
@@ -38,7 +38,6 @@
 #include "colmap/mvs/poisson_meshing.h"
 #endif
 #include "colmap/ui/main_window.h"
-#include "colmap/ui/render_options.h"
 #include "colmap/util/controller_thread.h"
 
 namespace colmap {

--- a/src/colmap/ui/feature_matching_widget.h
+++ b/src/colmap/ui/feature_matching_widget.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
-#include "colmap/util/misc.h"
 
 #include <QtCore>
 #include <QtWidgets>

--- a/src/colmap/ui/image_viewer_widget.cc
+++ b/src/colmap/ui/image_viewer_widget.cc
@@ -30,7 +30,6 @@
 #include "colmap/ui/image_viewer_widget.h"
 
 #include "colmap/ui/model_viewer_widget.h"
-#include "colmap/util/file.h"
 
 namespace colmap {
 

--- a/src/colmap/ui/image_viewer_widget.h
+++ b/src/colmap/ui/image_viewer_widget.h
@@ -30,8 +30,6 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
-#include "colmap/scene/database.h"
-#include "colmap/scene/projection.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/ui/qt_utils.h"
 

--- a/src/colmap/ui/log_widget.h
+++ b/src/colmap/ui/log_widget.h
@@ -33,8 +33,6 @@
 
 #include <QtGui>
 #include <QtWidgets>
-#include <fstream>
-#include <iostream>
 
 namespace colmap {
 

--- a/src/colmap/ui/point_viewer_widget.cc
+++ b/src/colmap/ui/point_viewer_widget.cc
@@ -30,7 +30,6 @@
 #include "colmap/ui/point_viewer_widget.h"
 
 #include "colmap/ui/model_viewer_widget.h"
-#include "colmap/util/file.h"
 
 namespace colmap {
 

--- a/src/colmap/ui/point_viewer_widget.h
+++ b/src/colmap/ui/point_viewer_widget.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
-#include "colmap/scene/reconstruction.h"
 
 #include <QtCore>
 #include <QtWidgets>

--- a/src/colmap/ui/project_widget.h
+++ b/src/colmap/ui/project_widget.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
-#include "colmap/util/misc.h"
 
 #include <QtCore>
 #include <QtWidgets>

--- a/src/colmap/ui/qt_utils.cc
+++ b/src/colmap/ui/qt_utils.cc
@@ -29,9 +29,6 @@
 
 #include "colmap/ui/qt_utils.h"
 
-#include "colmap/sensor/models.h"
-#include "colmap/util/misc.h"
-
 #include <QApplication>
 #include <QPainter>
 #include <QPalette>

--- a/src/colmap/ui/qt_utils.h
+++ b/src/colmap/ui/qt_utils.h
@@ -32,7 +32,6 @@
 #include "colmap/feature/types.h"
 #include "colmap/sensor/bitmap.h"
 #include "colmap/util/eigen_alignment.h"
-#include "colmap/util/types.h"
 
 #include <QtCore>
 #include <QtGui>

--- a/src/colmap/ui/render_options.h
+++ b/src/colmap/ui/render_options.h
@@ -31,8 +31,6 @@
 
 #include "colmap/util/logging.h"
 
-#include <iostream>
-
 namespace colmap {
 
 struct RenderOptions {

--- a/src/colmap/ui/render_options_widget.h
+++ b/src/colmap/ui/render_options_widget.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include "colmap/sfm/incremental_mapper.h"
 #include "colmap/ui/model_viewer_widget.h"
 #include "colmap/ui/options_widget.h"
 

--- a/src/colmap/util/cuda.cc
+++ b/src/colmap/util/cuda.cc
@@ -31,7 +31,6 @@
 
 #include "colmap/util/cudacc.h"
 #include "colmap/util/logging.h"
-#include "colmap/util/string.h"
 
 #include <algorithm>
 #include <iostream>

--- a/src/colmap/util/enum_utils_test.cc
+++ b/src/colmap/util/enum_utils_test.cc
@@ -29,8 +29,6 @@
 
 #include "colmap/util/enum_utils.h"
 
-#include <string>
-
 #include <gtest/gtest.h>
 
 namespace colmap {

--- a/src/colmap/util/testing.h
+++ b/src/colmap/util/testing.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include <filesystem>
-#include <string>
 
 namespace colmap {
 


### PR DESCRIPTION
Summary:
- remove 56 unused includes identified with clangd and the compilation database
- retain includes needed by conditional builds, platform-specific code, macro expansion, and compatibility paths

Testing:
- PYENV_VERSION=colmap scripts/format/c++.sh
- cmake --build build --parallel 8
- ctest --test-dir build --output-on-failure --parallel 8 (160 tests passed)