### PR TITLE
Fix calculation of local origin during spatial matching

### DIFF
--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -747,11 +747,25 @@ Eigen::RowMajorMatrixXf SpatialPairGenerator::ReadPositionPriorData(
     }
   }
 
+  // Trim unused rows for images without a valid position before calculating
+  // the mean coordinate below.
+  const size_t num_populated_rows = position_idxs_.size();
+  position_matrix.conservativeResize(num_populated_rows, Eigen::NoChange);
+
   // Subtract the mean coordinate before casting to float for better numerical
-  // precision when dealing with large coordinates (e.g. GPS). For even better
-  // precision, we could also rescale the coordinates.
-  position_matrix.rowwise() -= position_matrix.colwise().mean();
-  return position_matrix.topRows(position_idxs_.size()).cast<float>();
+  // precision when dealing with large coordinates (e.g. GPS). This is
+  // particularly important for projected Cartesian coordinate systems, which
+  // can contain very large values in metres. For even better precision, we
+  // could also rescale the coordinates.
+  const Eigen::RowVector3d mean_position = position_matrix.colwise().mean();
+
+  Eigen::IOFormat vec_fmt(Eigen::FullPrecision, Eigen::DontAlignCols, ", ");
+  VLOG(1) << "Internally offsetting image pose priors by mean coordinate "
+          << mean_position.format(vec_fmt) << " prior to spatial matching.";
+
+  position_matrix.rowwise() -= mean_position;
+
+  return position_matrix.cast<float>();
 }
 
 TransitivePairGenerator::TransitivePairGenerator(

--- a/src/colmap/controllers/pairing_test.cc
+++ b/src/colmap/controllers/pairing_test.cc
@@ -33,6 +33,7 @@
 #include "colmap/retrieval/visual_index.h"
 #include "colmap/scene/database_sqlite.h"
 #include "colmap/scene/synthetic.h"
+#include "colmap/util/eigen_matchers.h"
 #include "colmap/util/testing.h"
 
 #include <fstream>
@@ -460,6 +461,57 @@ TEST(SpatialPairGenerator, LargeCoordinates) {
                   std::make_pair(images[2].ImageId(), images[1].ImageId())));
   EXPECT_TRUE(generator.Next().empty());
   EXPECT_TRUE(generator.HasFinished());
+}
+
+TEST(SpatialPairGenerator, CentersLargeCoordinatesWithMissingPosePrior) {
+  // Verifies that images with missing pose priors do not bias the internal
+  // offset applied to position priors during spatial matching, i.e. by
+  // including rows of zeros in the average position calculation.
+
+  constexpr int kNumImages = 4;
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+  CreateSyntheticDatabase(kNumImages, *database);
+  const std::vector<Image> images = database->ReadAllImages();
+  CHECK_EQ(images.size(), kNumImages);
+
+  // Add pose priors for 3 of the 4 images, with large coordinate values.
+  database->ClearPosePriors();
+
+  const Eigen::Vector3d offset(1'600'000, 5'400'000, 100);
+
+  PosePrior pose_prior1;
+  pose_prior1.corr_data_id = images[0].DataId();
+  pose_prior1.position = offset + Eigen::Vector3d(-1, -2, -3);
+  pose_prior1.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  database->WritePosePrior(pose_prior1);
+
+  PosePrior pose_prior2;
+  pose_prior2.corr_data_id = images[1].DataId();
+  pose_prior2.position = offset + Eigen::Vector3d(0, 0, 0);
+  pose_prior2.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  database->WritePosePrior(pose_prior2);
+
+  PosePrior pose_prior4;
+  pose_prior4.corr_data_id = images[3].DataId();
+  pose_prior4.position = offset + Eigen::Vector3d(1, 2, 3);
+  pose_prior4.coordinate_system = PosePrior::CoordinateSystem::CARTESIAN;
+  database->WritePosePrior(pose_prior4);
+
+  // Read the position prior data, with the expectation that positions will be
+  // centered automatically around a local origin.
+  SpatialPairingOptions options;
+  options.ignore_z = false;
+
+  auto cache = std::make_shared<FeatureMatcherCache>(
+      options.CacheSize(), THROW_CHECK_NOTNULL(database));
+  SpatialPairGenerator generator(options, cache);
+  const Eigen::RowMajorMatrixXf position_matrix =
+      generator.ReadPositionPriorData(*cache);
+
+  // Verify that the missing pose prior did not bias the calculated offset.
+  Eigen::RowMajorMatrixXf expected_position_matrix(3, 3);
+  expected_position_matrix << -1, -2, -3, 0, 0, 0, 1, 2, 3;
+  EXPECT_THAT(position_matrix, EigenMatrixNear(expected_position_matrix));
 }
 
 TEST(SpatialPairGenerator, MinNumNeighborsControlsMatchingDistance) {


### PR DESCRIPTION
Bugfix for #4630 

**Summary**

`SpatialPairGenerator::ReadPositionPriorData` calculates the mean coordinate of the image position priors and subtracts this from the positions matrix to improve numerical precision. In the case where some images do not have a pose prior, their corresponding zero-valued rows were still included in calculation of the mean position, and this could significantly bias the calculated mean position. 

For pose priors using projected Cartesian coordinates in particular, where coordinate values might be on the order of 1e6, this could result in large numerical errors and cause subsequent spatial matching to fail.

**Changes**

- `SpatialPairGenerator::ReadPositionPriorData` has been updated to trim unpopulated position rows prior to calculation of mean coordinate
- Debug logging has been added that prints the calculated offset at log level 1
- A test `CentersLargeCoordinatesWithMissingPosePrior` has been added to test for regressions

Hopefully this PR is welcome and follows general expectations; let me know if there are issues.