### PR TITLE
Fix row stride when uploading source images to the layered texture (regression)

### DIFF
--- a/src/colmap/mvs/patch_match_cuda.cu
+++ b/src/colmap/mvs/patch_match_cuda.cu
@@ -1617,8 +1617,19 @@ void PatchMatchCuda::InitSourceImages() {
     for (size_t i = 0; i < problem_.src_image_idxs.size(); ++i) {
       const Image& image = problem_.images->at(problem_.src_image_idxs[i]);
       const Bitmap& bitmap = image.GetBitmap();
+      // The texture reads each layer with a row stride of max_width, while
+      // the bitmap rows are packed with the image's own width. Images
+      // narrower than max_width must therefore be copied row by row - a
+      // single contiguous copy would displace row r by r * (max_width -
+      // width) pixels. Example for a 2x2 image in a 3-wide layer:
+      //   bitmap [a b; c d] -> contiguous copy [a b c; d 0 0] (wrong)
+      //                        row-wise copy   [a b 0; c d 0] (correct)
+      const uint8_t* src = bitmap.RowMajorData().data();
       uint8_t* dest = src_images_host_data.data() + max_width * max_height * i;
-      memcpy(dest, bitmap.RowMajorData().data(), bitmap.NumBytes());
+      for (size_t r = 0; r < image.GetHeight(); ++r) {
+        memcpy(dest, src + r * image.GetWidth(), image.GetWidth());
+        dest += max_width;
+      }
     }
 
     // Create source images texture.


### PR DESCRIPTION
Restore the row-by-row copy used up to commit 7d2058ba (the parent of 8e014c5b).

Correct copy before the regression:
https://github.com/colmap/colmap/blob/7d2058baaae1406160b5e0c7ae9b47582ade1b32/src/colmap/mvs/patch_match_cuda.cu#L1578-L1582 Regressed copy introduced by 8e014c5b:
https://github.com/colmap/colmap/blob/8e014c5bc70c7e01506f1d5ef7daaf25dc3190ae/src/colmap/mvs/patch_match_cuda.cu#L1577

Since commit 8e014c5b (#3459) the bitmaps were copied with a single contiguous memcpy, displacing row r of every image narrower than max_width by r * (max_width - width) pixels. Example for a 2x2 image in a 3-wide layer:

```
  bitmap [a b; c d] -> contiguous copy [a b c; d 0 0] (wrong)
                       row-wise copy   [a b 0; c d 0] (correct)
```

Workspaces where all source images share the same dimensions are unaffected (the two copies coincide there), which is why the standard single-camera case never showed the problem. Workspaces with mixed image sizes get silently corrupted photometric costs for every source image narrower than the widest one.