### PR TITLE
Expose ordered reconstruction composition hooks

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -39,6 +39,7 @@
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
 
+#include <cmath>
 #include <iomanip>
 
 namespace colmap {
@@ -116,7 +117,13 @@ CeresBundleAdjustmentOptions::CeresBundleAdjustmentOptions() {
 
 std::unique_ptr<ceres::LossFunction>
 CeresBundleAdjustmentOptions::CreateLossFunction() const {
-  return colmap::CreateLossFunction(loss_function_type, loss_function_scale);
+  std::unique_ptr<ceres::LossFunction> loss_function =
+      colmap::CreateLossFunction(loss_function_type, loss_function_scale);
+  if (loss_function_weight == 1.0) {
+    return loss_function;
+  }
+  return std::make_unique<ceres::ScaledLoss>(
+      loss_function.release(), loss_function_weight, ceres::TAKE_OWNERSHIP);
 }
 
 ceres::Solver::Options CeresBundleAdjustmentOptions::CreateSolverOptions(
@@ -233,6 +240,8 @@ ceres::Solver::Options CeresBundleAdjustmentOptions::CreateSolverOptions(
 
 bool CeresBundleAdjustmentOptions::Check() const {
   CHECK_OPTION_GE(loss_function_scale, 0);
+  CHECK_OPTION(std::isfinite(loss_function_weight));
+  CHECK_OPTION_GE(loss_function_weight, 0);
   CHECK_OPTION_LT(max_num_images_direct_dense_cpu_solver,
                   max_num_images_direct_sparse_cpu_solver);
   CHECK_OPTION_LT(max_num_images_direct_dense_gpu_solver,

--- a/src/colmap/estimators/bundle_adjustment_ceres.h
+++ b/src/colmap/estimators/bundle_adjustment_ceres.h
@@ -45,6 +45,10 @@ struct CeresBundleAdjustmentOptions {
   // Scaling factor determines residual at which robustification takes place.
   double loss_function_scale = 1.0;
 
+  // Outer weight applied to the complete robust loss. A value of one keeps
+  // the historical objective unchanged.
+  double loss_function_weight = 1.0;
+
   // Whether to use Ceres' CUDA linear algebra library, if available.
   bool use_gpu = false;
   std::string gpu_index = "-1";

--- a/src/colmap/estimators/bundle_adjustment_ceres_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres_test.cc
@@ -36,6 +36,8 @@
 #include "colmap/util/cuda.h"
 #include "colmap/util/testing.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 // Due to pose normalization operations, constant variables may not be perfectly
@@ -120,6 +122,34 @@ inline const ceres::Solver::Summary& GetCeresSummary(
       dynamic_cast<const CeresBundleAdjustmentSummary*>(summary);
   CHECK_NOTNULL(ceres_summary);
   return ceres_summary->ceres_summary;
+}
+
+TEST(CeresBundleAdjustmentOptions, LossFunctionWeightIsOuterAndDefaultOne) {
+  CeresBundleAdjustmentOptions options;
+  options.loss_function_type =
+      CeresBundleAdjustmentOptions::LossFunctionType::CAUCHY;
+  options.loss_function_scale = 3.0;
+  std::unique_ptr<ceres::LossFunction> unweighted =
+      options.CreateLossFunction();
+  double expected[3];
+  unweighted->Evaluate(4.0, expected);
+
+  options.loss_function_weight = 2.5;
+  std::unique_ptr<ceres::LossFunction> weighted = options.CreateLossFunction();
+  double actual[3];
+  weighted->Evaluate(4.0, actual);
+
+  EXPECT_DOUBLE_EQ(actual[0], 2.5 * expected[0]);
+  EXPECT_DOUBLE_EQ(actual[1], 2.5 * expected[1]);
+  EXPECT_DOUBLE_EQ(actual[2], 2.5 * expected[2]);
+}
+
+TEST(CeresBundleAdjustmentOptions, RejectsInvalidLossFunctionWeight) {
+  CeresBundleAdjustmentOptions options;
+  options.loss_function_weight = -1.0;
+  EXPECT_FALSE(options.Check());
+  options.loss_function_weight = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(options.Check());
 }
 
 #ifdef COLMAP_CUDA_ENABLED

--- a/src/colmap/scene/correspondence_graph.cc
+++ b/src/colmap/scene/correspondence_graph.cc
@@ -290,6 +290,36 @@ void CorrespondenceGraph::ExtractTransitiveCorrespondences(
   corrs->pop_back();
 }
 
+std::vector<std::vector<CorrespondenceGraph::Correspondence>>
+CorrespondenceGraph::ExtractTransitiveCorrespondenceComponents(
+    const std::vector<Correspondence>& ordered_seeds,
+    const size_t transitivity) const {
+  std::vector<std::vector<Correspondence>> components;
+  FlatHashSet<std::pair<image_t, point2D_t>, PairHash> visited;
+  std::vector<Correspondence> transitive_correspondences;
+  for (const Correspondence& seed : ordered_seeds) {
+    const std::pair<image_t, point2D_t> seed_key(seed.image_id,
+                                                 seed.point2D_idx);
+    if (visited.count(seed_key) != 0) {
+      continue;
+    }
+
+    ExtractTransitiveCorrespondences(seed.image_id,
+                                     seed.point2D_idx,
+                                     transitivity,
+                                     &transitive_correspondences);
+    std::vector<Correspondence>& component = components.emplace_back();
+    component.reserve(transitive_correspondences.size() + 1);
+    component.push_back(seed);
+    visited.insert(seed_key);
+    for (const Correspondence& correspondence : transitive_correspondences) {
+      component.push_back(correspondence);
+      visited.insert({correspondence.image_id, correspondence.point2D_idx});
+    }
+  }
+  return components;
+}
+
 void CorrespondenceGraph::ExtractMatchesBetweenImages(
     const image_t image_id1,
     const image_t image_id2,

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -133,6 +133,14 @@ class CorrespondenceGraph {
       size_t transitivity,
       std::vector<Correspondence>* corrs) const;
 
+  // Extract each connected correspondence component exactly once, following
+  // the supplied seed order. Each component starts with its seed and retains
+  // the discovery order of ExtractTransitiveCorrespondences.
+  std::vector<std::vector<Correspondence>>
+  ExtractTransitiveCorrespondenceComponents(
+      const std::vector<Correspondence>& ordered_seeds,
+      size_t transitivity) const;
+
   // Find all matches between two images.
   void ExtractMatchesBetweenImages(image_t image_id1,
                                    image_t image_id2,

--- a/src/colmap/scene/correspondence_graph_test.cc
+++ b/src/colmap/scene/correspondence_graph_test.cc
@@ -32,6 +32,8 @@
 #include "colmap/geometry/rigid3_matchers.h"
 #include "colmap/math/random_eigen.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -295,6 +297,25 @@ TEST_P(CorrespondenceGraphFinalizeTest, ThreeView) {
             2);
   EXPECT_EQ(CountNumTransitiveCorrespondences(correspondence_graph, 2, 0, 3),
             2);
+
+  const std::vector<CorrespondenceGraph::Correspondence> seeds = {
+      {0, 0}, {1, 0}, {2, 0}, {1, 5}, {2, 5}};
+  const auto components =
+      correspondence_graph.ExtractTransitiveCorrespondenceComponents(
+          seeds, std::numeric_limits<size_t>::max());
+  ASSERT_EQ(components.size(), 2);
+  ASSERT_EQ(components[0].size(), 3);
+  EXPECT_EQ(components[0][0].image_id, 0);
+  EXPECT_EQ(components[0][0].point2D_idx, 0);
+  EXPECT_EQ(components[0][1].image_id, 2);
+  EXPECT_EQ(components[0][1].point2D_idx, 0);
+  EXPECT_EQ(components[0][2].image_id, 1);
+  EXPECT_EQ(components[0][2].point2D_idx, 0);
+  ASSERT_EQ(components[1].size(), 2);
+  EXPECT_EQ(components[1][0].image_id, 1);
+  EXPECT_EQ(components[1][0].point2D_idx, 5);
+  EXPECT_EQ(components[1][1].image_id, 2);
+  EXPECT_EQ(components[1][1].point2D_idx, 5);
 }
 
 INSTANTIATE_TEST_SUITE_P(CorrespondenceGraph,

--- a/src/colmap/scene/pose_graph.cc
+++ b/src/colmap/scene/pose_graph.cc
@@ -55,6 +55,40 @@ FlatHashSet<frame_t> PoseGraph::ComputeLargestConnectedFrameComponent(
                               largest_component_vec.end());
 }
 
+FlatHashSet<frame_t>
+PoseGraph::ComputeLargestConnectedFrameComponentInPairOrder(
+    const Reconstruction& reconstruction,
+    const std::vector<image_pair_t>& pair_order,
+    const bool filter_unregistered) const {
+  FlatHashSet<frame_t> nodes;
+  std::vector<std::pair<frame_t, frame_t>> graph_edges;
+  graph_edges.reserve(pair_order.size());
+
+  for (const image_pair_t pair_id : pair_order) {
+    const auto edge_it = edges_.find(pair_id);
+    THROW_CHECK(edge_it != edges_.end());
+    THROW_CHECK(edge_it->second.valid);
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+    const frame_t frame_id1 = reconstruction.Image(image_id1).FrameId();
+    const frame_t frame_id2 = reconstruction.Image(image_id2).FrameId();
+    if (filter_unregistered && (!reconstruction.Frame(frame_id1).HasPose() ||
+                                !reconstruction.Frame(frame_id2).HasPose())) {
+      continue;
+    }
+    nodes.insert(frame_id1);
+    nodes.insert(frame_id2);
+    graph_edges.emplace_back(frame_id1, frame_id2);
+  }
+
+  if (nodes.empty()) {
+    return {};
+  }
+  const std::vector<frame_t> largest_component =
+      FindLargestConnectedComponent(nodes, graph_edges);
+  return FlatHashSet<frame_t>(largest_component.begin(),
+                              largest_component.end());
+}
+
 void PoseGraph::InvalidatePairsOutsideActiveImageIds(
     const FlatHashSet<image_t>& active_image_ids) {
   for (const auto& [pair_id, edge] : edges_) {

--- a/src/colmap/scene/pose_graph.h
+++ b/src/colmap/scene/pose_graph.h
@@ -6,6 +6,8 @@
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/types.h"
 
+#include <vector>
+
 namespace colmap {
 
 class PoseGraph {
@@ -74,6 +76,14 @@ class PoseGraph {
   // Returns the set of frame_ids in the largest connected component.
   FlatHashSet<frame_t> ComputeLargestConnectedFrameComponent(
       const Reconstruction& reconstruction,
+      bool filter_unregistered = true) const;
+
+  // Compute the largest connected frame component while consuming edges in
+  // the caller-provided pair order. This makes equal-size component selection
+  // reproducible for callers that already own a stable edge order.
+  FlatHashSet<frame_t> ComputeLargestConnectedFrameComponentInPairOrder(
+      const Reconstruction& reconstruction,
+      const std::vector<image_pair_t>& pair_order,
       bool filter_unregistered = true) const;
 
   // Mark image pairs as invalid if either image is not in the active set.

--- a/src/colmap/scene/pose_graph_test.cc
+++ b/src/colmap/scene/pose_graph_test.cc
@@ -353,6 +353,44 @@ TEST(PoseGraph, ComputeLargestConnectedFrameComponentEmpty) {
   EXPECT_TRUE(result.empty());
 }
 
+TEST(PoseGraph, ComputeLargestConnectedFrameComponentInPairOrder) {
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 5;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 1;
+  synthetic_options.num_points3D = 10;
+  Reconstruction reconstruction;
+  SynthesizeDataset(synthetic_options, &reconstruction);
+  const std::vector<image_t> image_ids = reconstruction.RegImageIds();
+  ASSERT_EQ(image_ids.size(), 5);
+
+  PoseGraph pose_graph;
+  const image_pair_t pair01 = ImagePairToPairId(image_ids[0], image_ids[1]);
+  const image_pair_t pair12 = ImagePairToPairId(image_ids[1], image_ids[2]);
+  const image_pair_t pair34 = ImagePairToPairId(image_ids[3], image_ids[4]);
+  pose_graph.AddEdge(image_ids[0], image_ids[1], SynthesizeEdge());
+  pose_graph.AddEdge(image_ids[1], image_ids[2], SynthesizeEdge());
+  pose_graph.AddEdge(image_ids[3], image_ids[4], SynthesizeEdge());
+
+  const auto component =
+      pose_graph.ComputeLargestConnectedFrameComponentInPairOrder(
+          reconstruction,
+          {pair01, pair12, pair34},
+          /*filter_unregistered=*/false);
+  EXPECT_THAT(component,
+              testing::UnorderedElementsAre(
+                  reconstruction.Image(image_ids[0]).FrameId(),
+                  reconstruction.Image(image_ids[1]).FrameId(),
+                  reconstruction.Image(image_ids[2]).FrameId()));
+
+  pose_graph.SetInvalidEdge(pair01);
+  EXPECT_THROW(pose_graph.ComputeLargestConnectedFrameComponentInPairOrder(
+                   reconstruction,
+                   {pair01, pair12, pair34},
+                   /*filter_unregistered=*/false),
+               std::invalid_argument);
+}
+
 TEST(PoseGraph, InvalidatePairsOutsideActiveImageIds) {
   PoseGraph pose_graph;
   pose_graph.AddEdge(1, 2, SynthesizeEdge());

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -432,16 +432,17 @@ size_t ObservationManager::FilterObservationsWithNegativeDepth() {
   return num_filtered;
 }
 
-size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
-    const double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids) {
-  // Number of filtered observations.
-  size_t num_filtered_observations = 0;
-
+std::vector<point3D_t>
+ObservationManager::FindPoints3DWithSmallTriangulationAngle(
+    const double min_tri_angle,
+    const FlatHashSet<point3D_t>& point3D_ids) const {
   // Minimum triangulation angle in radians.
   const double min_tri_angle_rad = DegToRad(min_tri_angle);
 
   // Cache for image projection centers.
   FlatHashMap<image_t, Eigen::Vector3d> proj_centers;
+  std::vector<point3D_t> point3D_ids_to_filter;
+  point3D_ids_to_filter.reserve(point3D_ids.size());
 
   for (const auto point3D_id : point3D_ids) {
     if (!reconstruction_.ExistsPoint3D(point3D_id)) {
@@ -460,6 +461,10 @@ size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
       Eigen::Vector3d proj_center1;
       if (proj_centers.count(image_id1) == 0) {
         const Image& image1 = reconstruction_.Image(image_id1);
+        if (!image1.HasPose()) {
+          throw std::invalid_argument(
+              "triangulation filtering requires posed images");
+        }
         proj_center1 = image1.ProjectionCenter();
         proj_centers.emplace(image_id1, proj_center1);
       } else {
@@ -468,7 +473,17 @@ size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
 
       for (size_t i2 = 0; i2 < i1; ++i2) {
         const image_t image_id2 = point3D.track.Element(i2).image_id;
-        const Eigen::Vector3d& proj_center2 = proj_centers.at(image_id2);
+        auto proj_center2_it = proj_centers.find(image_id2);
+        if (proj_center2_it == proj_centers.end()) {
+          const Image& image2 = reconstruction_.Image(image_id2);
+          if (!image2.HasPose()) {
+            throw std::invalid_argument(
+                "triangulation filtering requires posed images");
+          }
+          proj_center2_it =
+              proj_centers.emplace(image_id2, image2.ProjectionCenter()).first;
+        }
+        const Eigen::Vector3d& proj_center2 = proj_center2_it->second;
 
         const double tri_angle = CalculateTriangulationAngle(
             proj_center1, proj_center2, point3D.xyz);
@@ -485,9 +500,21 @@ size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
     }
 
     if (!keep_point) {
-      num_filtered_observations += point3D.track.Length();
-      DeletePoint3D(point3D_id);
+      point3D_ids_to_filter.push_back(point3D_id);
     }
+  }
+
+  return point3D_ids_to_filter;
+}
+
+size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
+    const double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids) {
+  size_t num_filtered_observations = 0;
+  for (const point3D_t point3D_id :
+       FindPoints3DWithSmallTriangulationAngle(min_tri_angle, point3D_ids)) {
+    num_filtered_observations +=
+        reconstruction_.Point3D(point3D_id).track.Length();
+    DeletePoint3D(point3D_id);
   }
 
   return num_filtered_observations;

--- a/src/colmap/sfm/observation_manager.h
+++ b/src/colmap/sfm/observation_manager.h
@@ -122,6 +122,12 @@ class ObservationManager {
   // @return    The number of filtered observations.
   size_t FilterObservationsWithNegativeDepth();
 
+  // Find points with insufficient triangulation angle without modifying the
+  // reconstruction. The returned order matches the input set traversal used
+  // by FilterPoints3DWithSmallTriangulationAngle.
+  std::vector<point3D_t> FindPoints3DWithSmallTriangulationAngle(
+      double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids) const;
+
   size_t FilterPoints3DWithSmallTriangulationAngle(
       double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids);
 

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -134,6 +134,36 @@ TEST(ObservationManager, FilterPoints3D) {
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
 }
 
+TEST(ObservationManager, FindPoints3DWithSmallTriangulationAngle) {
+  Reconstruction reconstruction;
+  GenerateReconstruction(2, reconstruction);
+  reconstruction.Frame(2).SetRigFromWorld(
+      Rigid3d(Eigen::Quaterniond::Identity(), Eigen::Vector3d(-1, 0, 0)));
+  const point3D_t wide_point =
+      reconstruction.AddPoint3D(Eigen::Vector3d(0, 0, 5), Track());
+  reconstruction.AddObservation(wide_point, TrackElement(1, 0));
+  reconstruction.AddObservation(wide_point, TrackElement(2, 0));
+  const point3D_t one_view_point =
+      reconstruction.AddPoint3D(Eigen::Vector3d(0, 0, 5), Track());
+  reconstruction.AddObservation(one_view_point, TrackElement(1, 1));
+  const FlatHashSet<point3D_t> point_ids{wide_point, one_view_point};
+
+  ObservationManager obs_manager(reconstruction);
+  const std::vector<point3D_t> small_points =
+      obs_manager.FindPoints3DWithSmallTriangulationAngle(5.0, point_ids);
+  EXPECT_EQ(small_points.size(), 1);
+  EXPECT_EQ(small_points.front(), one_view_point);
+  EXPECT_TRUE(reconstruction.ExistsPoint3D(wide_point));
+  EXPECT_TRUE(reconstruction.ExistsPoint3D(one_view_point));
+  EXPECT_TRUE(reconstruction.Image(1).Point2D(0).HasPoint3D());
+  EXPECT_TRUE(reconstruction.Image(1).Point2D(1).HasPoint3D());
+
+  EXPECT_EQ(
+      obs_manager.FilterPoints3DWithSmallTriangulationAngle(5.0, point_ids), 1);
+  EXPECT_TRUE(reconstruction.ExistsPoint3D(wide_point));
+  EXPECT_FALSE(reconstruction.ExistsPoint3D(one_view_point));
+}
+
 TEST(ObservationManager, FilterPoints3DWithLargeReprojectionErrorTypes) {
   Reconstruction reconstruction;
   const camera_t kCameraId = 1;

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -204,6 +204,9 @@ void BindBundleAdjuster(py::module& m) {
                          &CeresBAOpts::loss_function_scale,
                          "Scaling factor determines residual at which "
                          "robustification takes place.")
+          .def_readwrite("loss_function_weight",
+                         &CeresBAOpts::loss_function_weight,
+                         "Outer weight applied to the complete robust loss.")
           .def_readwrite("use_gpu",
                          &CeresBAOpts::use_gpu,
                          "Whether to use Ceres' CUDA linear algebra library, "

--- a/src/pycolmap/estimators/bundle_adjustment_test.py
+++ b/src/pycolmap/estimators/bundle_adjustment_test.py
@@ -107,6 +107,9 @@ def test_bundle_adjustment_config_images_property():
 def test_ceres_ba_options_default_init():
     options = pycolmap.CeresBundleAdjustmentOptions()
     assert options is not None
+    assert options.loss_function_weight == 1.0
+    options.loss_function_weight = 2.5
+    assert options.loss_function_weight == 2.5
 
 
 def test_ceres_ba_options_check():

--- a/src/pycolmap/sfm/observation_manager.cc
+++ b/src/pycolmap/sfm/observation_manager.cc
@@ -99,6 +99,12 @@ void BindObservationManager(py::module& m) {
            &ObservationManager::FilterObservationsWithNegativeDepth,
            "Filter observations that have negative depth. Return the number of "
            "filtered observations.")
+      .def("find_points3D_with_small_triangulation_angle",
+           &ObservationManager::FindPoints3DWithSmallTriangulationAngle,
+           "min_tri_angle"_a,
+           "point3D_ids"_a,
+           "Find 3D points with insufficient triangulation angle in degrees "
+           "without modifying the reconstruction.")
       .def("filter_points3D_with_large_reprojection_error",
            &ObservationManager::FilterPoints3DWithLargeReprojectionError,
            "max_error"_a,

--- a/src/pycolmap/sfm/observation_manager_test.py
+++ b/src/pycolmap/sfm/observation_manager_test.py
@@ -62,3 +62,16 @@ def test_observation_manager_num_correspondences(synthetic_reconstruction):
     image_ids = list(synthetic_reconstruction.images.keys())
     count = manager.num_correspondences(image_ids[0])
     assert isinstance(count, int)
+
+
+def test_find_small_triangulation_angle_points_is_non_mutating(
+    synthetic_reconstruction,
+):
+    manager = _make_observation_manager(synthetic_reconstruction)
+    point_ids = set(synthetic_reconstruction.points3D.keys())
+    before = synthetic_reconstruction.num_points3D()
+    selected = manager.find_points3D_with_small_triangulation_angle(
+        180.0, point_ids
+    )
+    assert set(selected) == point_ids
+    assert synthetic_reconstruction.num_points3D() == before


### PR DESCRIPTION
## Summary
- add non-mutating small-triangulation-angle selection to ObservationManager
- add caller-ordered correspondence and PoseGraph component operations
- add a default-one outer weight for Ceres bundle-adjustment losses
- expose the two user-facing option/query surfaces in PyCOLMAP

## Validation
- focused C++ tests: 69 passed
- focused PyCOLMAP tests: 46 passed
- formatting and diff checks pass

All defaults preserve existing behavior. The ordered APIs make caller ordering explicit; the BA weight is applied only when it differs from one.