### PR TITLE
Restore pycolmap relative pose ray overloads

### DIFF
--- a/src/pycolmap/estimators/pose.cc
+++ b/src/pycolmap/estimators/pose.cc
@@ -115,6 +115,41 @@ py::typing::Optional<py::dict> PyEstimateAndRefineAbsolutePose(
   return result;
 }
 
+std::vector<CamRayWithJac> CamRaysWithIdentityJacobians(
+    const std::vector<Eigen::Vector3d>& cam_rays) {
+  // The identity embedding selects the first two ray coordinates in the
+  // tangent Sampson denominator, matching the legacy Sampson error on rays.
+  std::vector<CamRayWithJac> cam_rays_with_jac(cam_rays.size());
+  for (size_t i = 0; i < cam_rays.size(); ++i) {
+    cam_rays_with_jac[i] = {cam_rays[i], Eigen::Matrix3x2d::Identity()};
+  }
+  return cam_rays_with_jac;
+}
+
+py::typing::Optional<py::dict> PyEstimateRelativePoseFromRays(
+    const std::vector<Eigen::Vector3d>& cam_rays1,
+    const std::vector<Eigen::Vector3d>& cam_rays2,
+    const RANSACOptions& estimation_options) {
+  py::gil_scoped_release release;
+  Rigid3d cam2_from_cam1;
+  size_t num_inliers;
+  std::vector<char> inlier_mask;
+  if (!EstimateRelativePose(estimation_options,
+                            CamRaysWithIdentityJacobians(cam_rays1),
+                            CamRaysWithIdentityJacobians(cam_rays2),
+                            &cam2_from_cam1,
+                            &num_inliers,
+                            &inlier_mask)) {
+    py::gil_scoped_acquire acquire;
+    return py::none();
+  }
+
+  py::gil_scoped_acquire acquire;
+  return py::dict("cam2_from_cam1"_a = cam2_from_cam1,
+                  "num_inliers"_a = num_inliers,
+                  "inlier_mask"_a = ToPythonMask(inlier_mask));
+}
+
 py::typing::Optional<py::dict> PyEstimateRelativePose(
     const Camera& camera1,
     const std::vector<Eigen::Vector2d>& points2D1,
@@ -191,6 +226,29 @@ py::typing::Optional<py::dict> PyRefineRelativePose(
   py::gil_scoped_acquire acquire;
   py::dict result("cam2_from_cam1"_a = refined_cam2_from_cam1);
   return result;
+}
+
+py::typing::Optional<py::dict> PyRefineRelativePoseFromRays(
+    const Rigid3d& init_cam2_from_cam1,
+    const std::vector<Eigen::Vector3d>& cam_rays1,
+    const std::vector<Eigen::Vector3d>& cam_rays2,
+    const PyInlierMask& inlier_mask,
+    const ceres::Solver::Options& refinement_options) {
+  py::gil_scoped_release release;
+  Rigid3d refined_cam2_from_cam1 = init_cam2_from_cam1;
+  std::vector<char> inlier_mask_char(inlier_mask.size());
+  Eigen::Map<Eigen::Matrix<char, Eigen::Dynamic, 1>>(
+      inlier_mask_char.data(), inlier_mask.size()) = inlier_mask.cast<char>();
+  if (!RefineRelativePose(refinement_options,
+                          inlier_mask_char,
+                          CamRaysWithIdentityJacobians(cam_rays1),
+                          CamRaysWithIdentityJacobians(cam_rays2),
+                          &refined_cam2_from_cam1)) {
+    py::gil_scoped_acquire acquire;
+    return py::none();
+  }
+  py::gil_scoped_acquire acquire;
+  return py::dict("cam2_from_cam1"_a = refined_cam2_from_cam1);
 }
 
 void BindAbsolutePoseEstimator(py::module& m) {
@@ -278,6 +336,13 @@ void BindAbsolutePoseEstimator(py::module& m) {
       "Local optimization non-linearly refines that error over the current "
       "inlier set, but the returned pose receives no final refinement over its "
       "own inliers; use refine_relative_pose for that.");
+  m.def("estimate_relative_pose",
+        &PyEstimateRelativePoseFromRays,
+        "cam_rays1"_a,
+        "cam_rays2"_a,
+        py::arg_v("options", RANSACOptions(), "RANSACOptions()"),
+        "Robustly estimate relative pose from camera rays using LO-RANSAC. "
+        "This overload is retained for backwards compatibility.");
   m.def("refine_relative_pose",
         &PyRefineRelativePose,
         "cam2_from_cam1"_a,
@@ -289,4 +354,13 @@ void BindAbsolutePoseEstimator(py::module& m) {
         py::arg_v("options", ceres::Solver::Options()),
         "Non-linear refinement of relative pose from 2D-2D correspondences "
         "(camera + image points) with the tangent Sampson error.");
+  m.def("refine_relative_pose",
+        &PyRefineRelativePoseFromRays,
+        "cam2_from_cam1"_a,
+        "cam_rays1"_a,
+        "cam_rays2"_a,
+        "inlier_mask"_a,
+        py::arg_v("options", ceres::Solver::Options()),
+        "Non-linear refinement of relative pose from camera rays. This "
+        "overload is retained for backwards compatibility.");
 }

--- a/src/pycolmap/estimators/pose_test.py
+++ b/src/pycolmap/estimators/pose_test.py
@@ -103,3 +103,32 @@ def test_absolute_pose_refinement_options_position_prior_covariance_readwrite():
 )
 def test_public_api_callable(name):
     assert callable(getattr(pycolmap, name))
+
+
+def test_relative_pose_ray_overloads():
+    rng = np.random.default_rng(0)
+    points3D = rng.uniform(-1.0, 1.0, size=(20, 3))
+    points3D[:, 2] += 4.0
+    translation = np.array([0.5, 0.1, 0.0])
+    cam_rays1 = points3D / np.linalg.norm(points3D, axis=1, keepdims=True)
+    points3D_in_cam2 = points3D + translation
+    cam_rays2 = points3D_in_cam2 / np.linalg.norm(
+        points3D_in_cam2, axis=1, keepdims=True
+    )
+
+    options = pycolmap.RANSACOptions()
+    options.max_error = 1e-3
+    options.random_seed = 0
+    estimation = pycolmap.estimate_relative_pose(
+        cam_rays1=cam_rays1, cam_rays2=cam_rays2, options=options
+    )
+    assert estimation is not None
+    assert estimation["num_inliers"] == len(points3D)
+
+    refinement = pycolmap.refine_relative_pose(
+        cam2_from_cam1=estimation["cam2_from_cam1"],
+        cam_rays1=cam_rays1,
+        cam_rays2=cam_rays2,
+        inlier_mask=estimation["inlier_mask"],
+    )
+    assert refinement is not None

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "baseline": "a0b1c8d3a477c1cb4813d8e127a56961707ca42b"
+    "baseline": "127402f1c75bb3d5ff6bce04b285faa4930a5aca"
   }
 }


### PR DESCRIPTION
Follow-up to review feedback in #4641.

## Summary
- restore the camera-ray overloads of pycolmap.estimate_relative_pose and pycolmap.refine_relative_pose
- attach identity Jacobians to preserve the legacy Sampson-error normalization
- add regression coverage for both compatibility overloads

## Testing
- PYENV_VERSION=colmap scripts/format/c++.sh
- PYENV_VERSION=colmap scripts/format/python.sh
- PYENV_VERSION=colmap python -m pytest -q src/pycolmap/estimators/pose_test.py