### PR TITLE
Fix bitmap rescaling performance

### DIFF
--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -530,6 +530,7 @@ void Bitmap::Rescale(const int new_width,
       new_data.data());
   switch (filter) {
     case RescaleFilter::kBilinear:
+      // Unlike resample(), resize() applies antialiasing when downsampling.
 #if OIIO_VERSION >= OIIO_MAKE_VERSION(3, 0, 0)
       THROW_CHECK(OIIO::ImageBufAlgo::resize(
           new_buf, buf, {{"filtername", "triangle"}}));

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -530,8 +530,13 @@ void Bitmap::Rescale(const int new_width,
       new_data.data());
   switch (filter) {
     case RescaleFilter::kBilinear:
-      THROW_CHECK(
-          OIIO::ImageBufAlgo::resample(new_buf, buf, /*interpolate=*/true));
+#if OIIO_VERSION >= OIIO_MAKE_VERSION(3, 0, 0)
+      THROW_CHECK(OIIO::ImageBufAlgo::resize(
+          new_buf, buf, {{"filtername", "triangle"}}));
+#else
+      THROW_CHECK(OIIO::ImageBufAlgo::resize(
+          new_buf, buf, /*filtername=*/"triangle", /*filterwidth=*/0.0f));
+#endif
       break;
     case RescaleFilter::kBox:
 #if OIIO_VERSION >= OIIO_MAKE_VERSION(3, 0, 0)

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -528,7 +528,21 @@ void Bitmap::Rescale(const int new_width,
   OIIO::ImageBuf new_buf(
       OIIO::ImageSpec(new_width, new_height, channels_, OIIO::TypeDesc::UINT8),
       new_data.data());
-  THROW_CHECK(OIIO::ImageBufAlgo::resize(new_buf, buf));
+  switch (filter) {
+    case RescaleFilter::kBilinear:
+      THROW_CHECK(
+          OIIO::ImageBufAlgo::resample(new_buf, buf, /*interpolate=*/true));
+      break;
+    case RescaleFilter::kBox:
+#if OIIO_VERSION >= OIIO_MAKE_VERSION(3, 0, 0)
+      THROW_CHECK(
+          OIIO::ImageBufAlgo::resize(new_buf, buf, {{"filtername", "box"}}));
+#else
+      THROW_CHECK(OIIO::ImageBufAlgo::resize(
+          new_buf, buf, /*filtername=*/"box", /*filterwidth=*/0.0f));
+#endif
+      break;
+  }
 
   width_ = new_width;
   height_ = new_height;

--- a/src/colmap/sensor/bitmap_test.cc
+++ b/src/colmap/sensor/bitmap_test.cc
@@ -404,6 +404,19 @@ TEST(Bitmap, RescaleGrey) {
   EXPECT_EQ(bitmap2.Channels(), 1);
 }
 
+TEST(Bitmap, RescaleFilters) {
+  Bitmap bitmap(4, 4, /*as_rgb=*/false);
+  bitmap.Fill(BitmapColor<uint8_t>(0));
+  bitmap.SetPixel(0, 0, BitmapColor<uint8_t>(255));
+
+  Bitmap bilinear = bitmap.Clone();
+  bilinear.Rescale(1, 1, Bitmap::RescaleFilter::kBilinear);
+  Bitmap box = bitmap.Clone();
+  box.Rescale(1, 1, Bitmap::RescaleFilter::kBox);
+
+  EXPECT_NE(bilinear.GetPixel(0, 0)->r, box.GetPixel(0, 0)->r);
+}
+
 TEST(Bitmap, Thumbnail) {
   Bitmap bitmap(100, 80, /*as_rgb=*/true);
 


### PR DESCRIPTION
## Summary

- honor the requested Bitmap::Rescale filter
- use an explicit antialiased triangle filter for bilinear resizing instead of OpenImageIO's expensive default Lanczos filter
- explicitly retain box filtering where requested
- add a regression test verifying that the two filter modes differ

This addresses the severe slowdown when feature extraction downsizes images reported in #4638. It does not claim to resolve the separate no-resize CUDA slowdown discussed there.

## Performance

Using 30 copies of the 1920x1345 image from #4638, resized to 960px with CPU SIFT configured to detect no features:

- before: 8.08 s
- after: 3.11 s
- COLMAP 3.13.0: 2.13 s

A focused resize microbenchmark measured OpenImageIO's default downsampling at about 234 ms per image and explicit triangle-filtered downsampling at about 52 ms per image. The triangle filter preserves low-pass filtering for downsampling, unlike ImageBufAlgo::resample.

## Testing

- PYENV_VERSION=colmap scripts/format/c++.sh
- ctest --test-dir build --output-on-failure -R sensor/bitmap_test\|controllers/feature_extraction_test