### PR TITLE
Reset viewer status when clearing reconstruction

### DIFF
--- a/src/colmap/ui/main_window.cc
+++ b/src/colmap/ui/main_window.cc
@@ -1462,9 +1462,6 @@ void MainWindow::ReconstructionReset() {
   reconstruction_manager_->Clear();
   reconstruction_manager_widget_->Update();
 
-  timer_.Reset();
-  UpdateTimer();
-
   EnableBlockingActions();
   action_reconstruction_start_->setText(tr("Start reconstruction"));
   action_reconstruction_pause_->setEnabled(false);
@@ -1571,6 +1568,8 @@ void MainWindow::RenderClear() {
   reconstruction_manager_widget_->SelectReconstruction(
       ReconstructionManagerWidget::kNewestReconstructionIdx);
   model_viewer_widget_->ClearReconstruction();
+  timer_.Reset();
+  UpdateTimer();
 }
 
 void MainWindow::RenderOptions() {

--- a/src/colmap/ui/model_viewer_widget.cc
+++ b/src/colmap/ui/model_viewer_widget.cc
@@ -561,6 +561,7 @@ void ModelViewerWidget::ClearReconstruction() {
   surface_texture_height = 0;
   selected_image_id_ = kInvalidImageId;
   selected_point3D_id_ = kInvalidPoint3DId;
+  statusbar_status_label->setText("0 Frames - 0 Images - 0 Points");
   Upload();
 }
 


### PR DESCRIPTION
## Summary

- reset the viewer status bar reconstruction counts when clearing the reconstruction
- reset the elapsed reconstruction timer whenever the viewer is cleared
- keep the displayed frame, image, point, and time values consistent with the empty viewer

## Testing

- `PYENV_VERSION=colmap scripts/format/c++.sh`
- `ninja -C build colmap_ui`