### PR TITLE
Add RigMap repr and iteration regression coverage

### DIFF
--- a/src/pycolmap/sensor/rig_test.py
+++ b/src/pycolmap/sensor/rig_test.py
@@ -145,3 +145,22 @@ def test_rig_map_insert_and_access():
     rig_map[1] = rig
     assert len(rig_map) == 1
     assert rig_map[1].rig_id == 1
+    assert "RigMap{1: Rig(rig_id=1" in repr(rig_map)
+
+
+def test_reconstruction_rig_map_views_and_iteration():
+    reconstruction = pycolmap.Reconstruction()
+    camera = pycolmap.Camera.create_from_model_id(
+        camera_id=1,
+        model=pycolmap.CameraModelId.SIMPLE_PINHOLE,
+        focal_length=1.0,
+        width=1,
+        height=1,
+    )
+    reconstruction.add_camera_with_trivial_rig(camera)
+
+    assert isinstance(repr(reconstruction.rigs.values()), str)
+    assert [rig.rig_id for rig in reconstruction.rigs.values()] == [1]
+    assert [
+        (rig_id, rig.rig_id) for rig_id, rig in reconstruction.rigs.items()
+    ] == [(1, 1)]


### PR DESCRIPTION
## Summary

Add regression coverage for the non-empty `RigMap` access paths reported in #3798:

- representing a directly constructed `RigMap`;
- representing `Reconstruction.rigs.values()`;
- iterating over `Reconstruction.rigs.values()`;
- iterating over `Reconstruction.rigs.items()`.

## Investigation

Issue #3798 reports a Windows crash when accessing or printing a non-empty `pycolmap.RigMap`, including the `Reconstruction.rigs.values()` path.

On the current `main` branch, the original reproducer no longer crashes in a Windows/vcpkg-style Boost container configuration after the recent hash-container backend changes. I therefore did not add a speculative production-code change or claim a root-cause fix that could not be reproduced against the current implementation.

The existing tests only checked `RigMap` length and indexed access. They did not exercise the representation and view-iteration paths from the report, leaving those paths unprotected against regression.

## Implementation

The existing direct `RigMap` test now verifies that representing a non-empty map includes the stored rig.

A second test constructs a `Reconstruction`, adds a camera with a trivial rig, and exercises:

- the values-view representation;
- values iteration;
- items iteration.

The assertions validate the retained rig identifiers instead of depending on container ordering beyond this single-entry fixture.

## Validation

- `python -m pytest -q src/pycolmap/sensor` — 46 passed
- full pycolmap test suite — 814 passed, 33 skipped
- `ruff check src/pycolmap/sensor/rig_test.py`
- `ruff format --check src/pycolmap/sensor/rig_test.py`
- `git diff --check`

The skipped full-suite tests require MVS or CUDA support that is not enabled in the local build.

Related: #3798
