### PR TITLE
Fix constant rig poses with pose prior BA

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -990,7 +990,7 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
     Image& image = reconstruction.Image(image_id);
 
     const bool constant_sensor_from_rig =
-        !options_.refine_sensor_from_rig ||
+        image.IsRefInFrame() || !options_.refine_sensor_from_rig ||
         config_.HasConstantSensorFromRigPose(image.CameraPtr()->SensorId());
     const bool constant_rig_from_world =
         !options_.refine_rig_from_world ||
@@ -1035,6 +1035,14 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
           prior_loss_function_.get(),
           cam_from_rig.params.data(),
           rig_from_world.params.data());
+      // Reprojection residuals may omit constant poses, so the prior can add
+      // their parameter blocks after the default parameterization pass.
+      if (constant_sensor_from_rig) {
+        problem.SetParameterBlockConstant(cam_from_rig.params.data());
+      }
+    }
+    if (constant_rig_from_world) {
+      problem.SetParameterBlockConstant(rig_from_world.params.data());
     }
   }
 

--- a/src/colmap/estimators/bundle_adjustment_ceres_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres_test.cc
@@ -1591,6 +1591,48 @@ TEST(PosePriorBundleAdjuster, MissingPositionCov) {
                                  /*num_obs_tolerance=*/0.02));
 }
 
+TEST(PosePriorBundleAdjuster, ConstantSensorFromRigWithMissingPositionCov) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 1;
+  synthetic_options.num_cameras_per_rig = 2;
+  synthetic_options.num_frames_per_rig = 3;
+  synthetic_options.num_points3D = 50;
+  synthetic_options.prior_position = true;
+  const auto database_path = CreateTestDir() / "database.db";
+  auto database = Database::Open(database_path);
+  SynthesizeDataset(synthetic_options, &reconstruction, database.get());
+
+  std::vector<PosePrior> pose_priors = database->ReadAllPosePriors();
+  for (const PosePrior& pose_prior : pose_priors) {
+    EXPECT_FALSE(pose_prior.HasPositionCov());
+  }
+
+  BundleAdjustmentOptions ba_options;
+  ba_options.refine_sensor_from_rig = false;
+  BundleAdjustmentConfig ba_config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    ba_config.AddImage(image_id);
+  }
+
+  auto adjuster =
+      CreatePosePriorBundleAdjuster(ba_options,
+                                    PosePriorBundleAdjustmentOptions(),
+                                    ba_config,
+                                    std::move(pose_priors),
+                                    reconstruction);
+  ceres::Problem& problem = GetCeresProblem(*adjuster);
+
+  for (auto& [_, rig] : reconstruction.Rigs()) {
+    for (auto& [_, sensor_from_rig] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig.has_value());
+      ASSERT_TRUE(problem.HasParameterBlock(sensor_from_rig->params.data()));
+      EXPECT_TRUE(
+          problem.IsParameterBlockConstant(sensor_from_rig->params.data()));
+    }
+  }
+}
+
 TEST(PosePriorBundleAdjuster, OptimizationRobustToOutliers) {
   Reconstruction gt_reconstruction;
   SyntheticDatasetOptions synthetic_options;


### PR DESCRIPTION
Fixes #4649.

Pose-prior residuals could reintroduce fixed rig transforms as variable Ceres parameter blocks. Preserve their constant parameterization and add regression coverage.

Test: bundle_adjustment_ceres_test