### PR TITLE
Run pycolmap tests on Windows

### DIFF
--- a/python/ci/test-colmap-windows.ps1
+++ b/python/ci/test-colmap-windows.ps1
@@ -1,4 +1,10 @@
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
 & "$PSScriptRoot/../../scripts/shell/enter_vs_dev_shell.ps1"
 & "${env:VCPKG_ROOT}/vcpkg.exe" integrate install
 
 & python -c "import pycolmap; print(pycolmap.__version__)"
+
+Set-Location "$PSScriptRoot/../.."
+& python -m pytest

--- a/src/pycolmap/sfm/global_mapper_test.py
+++ b/src/pycolmap/sfm/global_mapper_test.py
@@ -11,7 +11,7 @@ def test_global_mapper_options_init():
 def test_global_mapper_options_image_path():
     options = pycolmap.GlobalMapperOptions()
     options.image_path = "/tmp/images"
-    assert str(options.image_path) == "/tmp/images"
+    assert options.image_path == Path("/tmp/images")
 
 
 def test_global_mapper_options_ba_gpu_index():


### PR DESCRIPTION
## Summary

- run the full configured pytest suite for Windows pycolmap wheels
- execute pytest from the repository root so it uses the shared `pyproject.toml` configuration
- preserve the Windows-specific Visual Studio and vcpkg environment setup
- make native command failures terminate the PowerShell test script

This closes the coverage gap identified while reviewing #4648: Windows previously only imported `pycolmap`, so Python regression tests did not run on the platform affected by #3798.

## Validation

- `PYENV_VERSION=colmap python -m pytest` (948 passed)
- `git diff --check`