### PR TITLE
Add Caspar support for THIN_PRISM_FISHEYE cameras

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_caspar.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar.cc
@@ -643,14 +643,10 @@ class CasparBundleAdjuster : public BundleAdjuster {
           const size_t cal_size = adapter_ptr->CalibSize();
           std::vector<StorageType> calib_data(n_calib * cal_size);
           for (size_t i = 0; i < n_calib; ++i) {
-            for (size_t j = 0; j < fae_size; ++j) {
-              calib_data[i * cal_size + j] =
-                  md.focal_and_extra_data[i * fae_size + j];
-            }
-            for (size_t j = 0; j < pp_size; ++j) {
-              calib_data[i * cal_size + fae_size + j] =
-                  md.principal_point_data[i * pp_size + j];
-            }
+            adapter_ptr->MergeCalibData(
+                md.focal_and_extra_data.data() + i * fae_size,
+                md.principal_point_data.data() + i * pp_size,
+                calib_data.data() + i * cal_size);
           }
           if (n_calib > 0) {
             VLOG(2) << "  SetCalibNodes [cam 0, model "
@@ -719,14 +715,10 @@ class CasparBundleAdjuster : public BundleAdjuster {
                     << calib_data[3] << "]";
           }
           for (size_t i = 0; i < n_calib; ++i) {
-            for (size_t j = 0; j < fae_size; ++j) {
-              md.focal_and_extra_data[i * fae_size + j] =
-                  calib_data[i * cal_size + j];
-            }
-            for (size_t j = 0; j < pp_size; ++j) {
-              md.principal_point_data[i * pp_size + j] =
-                  calib_data[i * cal_size + fae_size + j];
-            }
+            adapter_ptr->SplitCalibData(
+                calib_data.data() + i * cal_size,
+                md.focal_and_extra_data.data() + i * fae_size,
+                md.principal_point_data.data() + i * pp_size);
           }
           if (n_calib > 0) {
             VLOG(2) << "  After split-back [cam 0]: fae=["
@@ -881,6 +873,10 @@ class CasparBundleAdjuster : public BundleAdjuster {
         it != num_poses_per_model_.end()) {
       sz.num_pinhole_poses = it->second;
     }
+    if (auto it = num_poses_per_model_.find(CameraModelId::kThinPrismFisheye);
+        it != num_poses_per_model_.end()) {
+      sz.num_thin_prism_fisheye_poses = it->second;
+    }
     auto get_md = [&](CameraModelId id) -> const ModelData* {
       auto it = model_data_per_model_.find(id);
       return it != model_data_per_model_.end() ? &it->second : nullptr;
@@ -899,6 +895,12 @@ class CasparBundleAdjuster : public BundleAdjuster {
       sz.num_pinhole_calibs = get_n(CameraModelId::kPinhole);
       adapters_.at(CameraModelId::kPinhole)
           ->FillSizing(sz, *md, sz.num_pinhole_calibs);
+    }
+    if (const ModelData* md = get_md(CameraModelId::kThinPrismFisheye)) {
+      sz.num_thin_prism_fisheye_calibs =
+          get_n(CameraModelId::kThinPrismFisheye);
+      adapters_.at(CameraModelId::kThinPrismFisheye)
+          ->FillSizing(sz, *md, sz.num_thin_prism_fisheye_calibs);
     }
     return sz;
   }

--- a/src/colmap/estimators/bundle_adjustment_caspar_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_caspar_test.cc
@@ -489,6 +489,165 @@ bool PoseExactlyUnchanged(const Image& a, const Image& b) {
          a.CamFromWorld().translation() == b.CamFromWorld().translation();
 }
 
+SyntheticDatasetOptions ThinPrismFisheyeRigOptions() {
+  SyntheticDatasetOptions opts;
+  opts.num_rigs = 1;
+  opts.num_cameras_per_rig = 2;
+  opts.num_frames_per_rig = 3;
+  opts.num_points3D = 80;
+  opts.num_points2D_without_point3D = 0;
+  opts.camera_width = 1024;
+  opts.camera_height = 1024;
+  opts.camera_model_id = ThinPrismFisheyeCameraModel::model_id;
+  opts.camera_params = {700.0,
+                        710.0,
+                        512.0,
+                        500.0,
+                        2.0e-2,
+                        -3.0e-3,
+                        1.0e-3,
+                        -7.0e-4,
+                        2.0e-4,
+                        -1.0e-5,
+                        3.0e-4,
+                        -4.0e-4};
+  opts.sensor_from_rig_rotation_stddev = 20.0;
+  opts.sensor_from_rig_translation_stddev = 0.2;
+  return opts;
+}
+
+double MaxPointDelta(const Reconstruction& reconstruction,
+                     const Reconstruction& orig_reconstruction) {
+  double max_delta = 0.0;
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    max_delta = std::max(
+        max_delta,
+        (point3D.xyz - orig_reconstruction.Point3D(point3D_id).xyz).norm());
+  }
+  return max_delta;
+}
+
+TEST(DefaultBundleAdjuster, ThinPrismFisheyeRigPointsOnlyFixedCalibration) {
+  SetPRNGSeed(0);
+  Reconstruction reconstruction;
+  SynthesizeDataset(ThinPrismFisheyeRigOptions(), &reconstruction);
+
+  SyntheticNoiseOptions noise_opts;
+  noise_opts.point2D_stddev = 0.5;
+  noise_opts.point3D_stddev = 0.05;
+  SynthesizeNoise(noise_opts, &reconstruction);
+  const Reconstruction orig_reconstruction = reconstruction;
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+    config.SetConstantRigFromWorldPose(reconstruction.Image(image_id).FrameId());
+  }
+  for (const auto& [camera_id, _] : reconstruction.Cameras()) {
+    config.SetConstantCamIntrinsics(camera_id);
+  }
+
+  BundleAdjustmentOptions options;
+  options.refine_focal_length = false;
+  options.refine_principal_point = false;
+  options.refine_extra_params = false;
+  options.refine_sensor_from_rig = false;
+  options.refine_rig_from_world = false;
+  options.refine_points3D = true;
+  options.caspar->solver_iter_max = 10;
+
+  std::unique_ptr<BundleAdjuster> bundle_adjuster =
+      CreateDefaultCasparBundleAdjuster(options, config, reconstruction);
+  const auto summary = bundle_adjuster->Solve();
+  ASSERT_NE(summary->termination_type,
+            BundleAdjustmentTerminationType::FAILURE);
+  EXPECT_EQ(config.NumResiduals(reconstruction), summary->num_residuals);
+  EXPECT_GT(summary->num_residuals, 0);
+
+  for (const auto& [camera_id, camera] : reconstruction.Cameras()) {
+    EXPECT_EQ(camera.model_id, ThinPrismFisheyeCameraModel::model_id);
+    EXPECT_EQ(camera.params, orig_reconstruction.Camera(camera_id).params);
+  }
+
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    CheckConstantCamFromWorld(reconstruction.Image(image_id),
+                              orig_reconstruction.Image(image_id));
+  }
+
+  for (const auto& [rig_id, rig] : reconstruction.Rigs()) {
+    const Rig& orig_rig = orig_reconstruction.Rig(rig_id);
+    EXPECT_EQ(rig.RefSensorId(), orig_rig.RefSensorId());
+    EXPECT_EQ(rig.NonRefSensors().size(), orig_rig.NonRefSensors().size());
+    for (const auto& [sensor_id, sensor_from_rig] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig.has_value());
+      ASSERT_TRUE(orig_rig.NonRefSensors().at(sensor_id).has_value());
+      EXPECT_THAT(*sensor_from_rig,
+                  Rigid3dEq(*orig_rig.NonRefSensors().at(sensor_id)));
+    }
+  }
+
+  EXPECT_GT(MaxPointDelta(reconstruction, orig_reconstruction), 0.0);
+}
+
+TEST(DefaultBundleAdjuster, ThinPrismFisheyeMatchesCeresPointsOnly) {
+  SetPRNGSeed(0);
+  Reconstruction reconstruction;
+  SynthesizeDataset(ThinPrismFisheyeRigOptions(), &reconstruction);
+
+  SyntheticNoiseOptions noise_opts;
+  noise_opts.point2D_stddev = 0.5;
+  noise_opts.point3D_stddev = 0.05;
+  SynthesizeNoise(noise_opts, &reconstruction);
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+    config.SetConstantRigFromWorldPose(reconstruction.Image(image_id).FrameId());
+  }
+  for (const auto& [camera_id, _] : reconstruction.Cameras()) {
+    config.SetConstantCamIntrinsics(camera_id);
+  }
+
+  BundleAdjustmentOptions options;
+  options.refine_focal_length = false;
+  options.refine_principal_point = false;
+  options.refine_extra_params = false;
+  options.refine_sensor_from_rig = false;
+  options.refine_rig_from_world = false;
+  options.refine_points3D = true;
+  options.caspar->solver_iter_max = 20;
+  options.ceres->solver_options.max_num_iterations = 20;
+
+  Reconstruction reconstruction_ceres = reconstruction;
+  Reconstruction reconstruction_caspar = reconstruction;
+
+  std::unique_ptr<BundleAdjuster> ceres_adjuster =
+      CreateDefaultCeresBundleAdjuster(options, config, reconstruction_ceres);
+  const auto ceres_summary = ceres_adjuster->Solve();
+  ASSERT_NE(ceres_summary->termination_type,
+            BundleAdjustmentTerminationType::FAILURE);
+
+  std::unique_ptr<BundleAdjuster> caspar_adjuster =
+      CreateDefaultCasparBundleAdjuster(options, config, reconstruction_caspar);
+  const auto caspar_summary = caspar_adjuster->Solve();
+  ASSERT_NE(caspar_summary->termination_type,
+            BundleAdjustmentTerminationType::FAILURE);
+  EXPECT_EQ(ceres_summary->num_residuals, caspar_summary->num_residuals);
+
+#ifdef CASPAR_USE_DOUBLE
+  constexpr double kPointTol = 1e-3;
+#else
+  constexpr double kPointTol = 2e-2;
+#endif
+  for (const auto& [point3D_id, point3D_ceres] :
+       reconstruction_ceres.Points3D()) {
+    const Point3D& point3D_caspar = reconstruction_caspar.Point3D(point3D_id);
+    EXPECT_NEAR((point3D_ceres.xyz - point3D_caspar.xyz).norm(),
+                0.0,
+                kPointTol);
+  }
+}
+
 TEST(DefaultBundleAdjuster, GaugeFixingWithOneFrameFromWorld) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions opts;

--- a/src/colmap/estimators/caspar/caspar_model_adapter.h
+++ b/src/colmap/estimators/caspar/caspar_model_adapter.h
@@ -19,6 +19,7 @@ struct CasparSolverSizing {
   // Pose pools are per-model to prevent cross-model factor batching.
   size_t num_simple_radial_poses = 0;
   size_t num_pinhole_poses = 0;
+  size_t num_thin_prism_fisheye_poses = 0;
   size_t num_points = 0;
 
   // SimpleRadial: num_calibs is shared by the merged Calib pool and the split
@@ -66,6 +67,34 @@ struct CasparSolverSizing {
   size_t num_pinhole_split_fixed_pose_fixed_focal_fixed_point = 0;
   size_t num_pinhole_split_fixed_pose_fixed_principal_point_fixed_point = 0;
   size_t num_pinhole_split_fixed_focal_fixed_principal_point_fixed_point = 0;
+
+  // ThinPrismFisheye: same 4 merged + 11 split variant layout.
+  size_t num_thin_prism_fisheye_calibs = 0;
+  size_t num_thin_prism_fisheye = 0;
+  size_t num_thin_prism_fisheye_fixed_pose = 0;
+  size_t num_thin_prism_fisheye_fixed_point = 0;
+  size_t num_thin_prism_fisheye_fixed_pose_fixed_point = 0;
+  size_t num_thin_prism_fisheye_split_fixed_focal_and_extra = 0;
+  size_t num_thin_prism_fisheye_split_fixed_principal_point = 0;
+  size_t num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra = 0;
+  size_t num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point = 0;
+  size_t
+      num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point =
+          0;
+  size_t num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point = 0;
+  size_t num_thin_prism_fisheye_split_fixed_principal_point_fixed_point = 0;
+  size_t
+      num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point =
+          0;
+  size_t
+      num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point =
+          0;
+  size_t
+      num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point =
+          0;
+  size_t
+      num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point =
+          0;
 };
 
 // One implementation per camera model.
@@ -83,6 +112,32 @@ class ICasparModelAdapter {
   // Number of floats in the merged Calib node per camera
   // (= FocalAndExtraSize() + PrincipalPointSize()).
   virtual size_t CalibSize() const = 0;
+
+  virtual void MergeCalibData(const StorageType* focal_and_extra,
+                              const StorageType* principal_point,
+                              StorageType* calib) const {
+    const size_t fae_size = FocalAndExtraSize();
+    const size_t pp_size = PrincipalPointSize();
+    for (size_t i = 0; i < fae_size; ++i) {
+      calib[i] = focal_and_extra[i];
+    }
+    for (size_t i = 0; i < pp_size; ++i) {
+      calib[fae_size + i] = principal_point[i];
+    }
+  }
+
+  virtual void SplitCalibData(const StorageType* calib,
+                              StorageType* focal_and_extra,
+                              StorageType* principal_point) const {
+    const size_t fae_size = FocalAndExtraSize();
+    const size_t pp_size = PrincipalPointSize();
+    for (size_t i = 0; i < fae_size; ++i) {
+      focal_and_extra[i] = calib[i];
+    }
+    for (size_t i = 0; i < pp_size; ++i) {
+      principal_point[i] = calib[fae_size + i];
+    }
+  }
 
   virtual void SetCalibNodes(caspar::GraphSolver& solver,
                              StorageType* data,
@@ -525,6 +580,457 @@ class SimpleRadialAdapter : public ICasparModelAdapter {
   }
 };
 
+// ThinPrismFisheye implementation
+
+class ThinPrismFisheyeAdapter : public ICasparModelAdapter {
+ public:
+  CameraModelId ModelId() const override {
+    return CameraModelId::kThinPrismFisheye;
+  }
+  // ThinPrismFisheye: params =
+  // [fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1]
+  // focal_and_extra = [fx, fy, k1, k2, p1, p2, k3, k4, sx1, sy1]
+  // principal_point = [cx, cy]
+  // merged calib    = COLMAP order above
+  size_t FocalAndExtraSize() const override { return 10; }
+  size_t PrincipalPointSize() const override { return 2; }
+  size_t CalibSize() const override {
+    return FocalAndExtraSize() + PrincipalPointSize();
+  }
+
+  void FillSizing(CasparSolverSizing& sz,
+                  const ModelData& md,
+                  size_t num_calibs) const override {
+    sz.num_thin_prism_fisheye_calibs = num_calibs;
+    for (int v = 0; v < CASPAR_NUM_VARIANTS; ++v) {
+      const size_t n = md.variants[v].num_factors;
+      switch (static_cast<FactorVariant>(v)) {
+        // Merged variants: both focal_and_extra and principal_point are
+        // tunable.
+        case FactorVariant::BASE:
+          sz.num_thin_prism_fisheye = n;
+          break;
+        case FactorVariant::FIXED_POSE:
+          sz.num_thin_prism_fisheye_fixed_pose = n;
+          break;
+        case FactorVariant::FIXED_POINT:
+          sz.num_thin_prism_fisheye_fixed_point = n;
+          break;
+        case FactorVariant::FIXED_POSE_FIXED_POINT:
+          sz.num_thin_prism_fisheye_fixed_pose_fixed_point = n;
+          break;
+        // Split variants: at least one intrinsic group is fixed.
+        case FactorVariant::FIXED_FOCAL_AND_EXTRA:
+          sz.num_thin_prism_fisheye_split_fixed_focal_and_extra = n;
+          break;
+        case FactorVariant::FIXED_PRINCIPAL_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_principal_point = n;
+          break;
+        case FactorVariant::FIXED_POSE_FIXED_FOCAL_AND_EXTRA:
+          sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra = n;
+          break;
+        case FactorVariant::FIXED_POSE_FIXED_PRINCIPAL_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point = n;
+          break;
+        case FactorVariant::FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point =
+              n;
+          break;
+        case FactorVariant::FIXED_FOCAL_AND_EXTRA_FIXED_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point = n;
+          break;
+        case FactorVariant::FIXED_PRINCIPAL_POINT_FIXED_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_principal_point_fixed_point = n;
+          break;
+        case FactorVariant::
+            FIXED_POSE_FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point =
+              n;
+          break;
+        case FactorVariant::FIXED_POSE_FIXED_FOCAL_AND_EXTRA_FIXED_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point =
+              n;
+          break;
+        case FactorVariant::FIXED_POSE_FIXED_PRINCIPAL_POINT_FIXED_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point =
+              n;
+          break;
+        case FactorVariant::
+            FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT_FIXED_POINT:
+          sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point =
+              n;
+          break;
+      }
+    }
+  }
+
+  void ExtractFocalAndExtra(const Camera& camera,
+                            std::vector<StorageType>& out) const override {
+    out.push_back(static_cast<StorageType>(camera.params[0]));   // fx
+    out.push_back(static_cast<StorageType>(camera.params[1]));   // fy
+    out.push_back(static_cast<StorageType>(camera.params[4]));   // k1
+    out.push_back(static_cast<StorageType>(camera.params[5]));   // k2
+    out.push_back(static_cast<StorageType>(camera.params[6]));   // p1
+    out.push_back(static_cast<StorageType>(camera.params[7]));   // p2
+    out.push_back(static_cast<StorageType>(camera.params[8]));   // k3
+    out.push_back(static_cast<StorageType>(camera.params[9]));   // k4
+    out.push_back(static_cast<StorageType>(camera.params[10]));  // sx1
+    out.push_back(static_cast<StorageType>(camera.params[11]));  // sy1
+  }
+
+  void ExtractPrincipalPoint(const Camera& camera,
+                             std::vector<StorageType>& out) const override {
+    out.push_back(static_cast<StorageType>(camera.params[2]));  // cx
+    out.push_back(static_cast<StorageType>(camera.params[3]));  // cy
+  }
+
+  void WriteFocalAndExtra(Camera& camera,
+                          const StorageType* data,
+                          size_t idx) const override {
+    camera.params[0] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 0]);  // fx
+    camera.params[1] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 1]);  // fy
+    camera.params[4] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 2]);  // k1
+    camera.params[5] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 3]);  // k2
+    camera.params[6] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 4]);  // p1
+    camera.params[7] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 5]);  // p2
+    camera.params[8] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 6]);  // k3
+    camera.params[9] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 7]);  // k4
+    camera.params[10] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 8]);  // sx1
+    camera.params[11] =
+        static_cast<double>(data[idx * FocalAndExtraSize() + 9]);  // sy1
+  }
+
+  void WritePrincipalPoint(Camera& camera,
+                           const StorageType* data,
+                           size_t idx) const override {
+    camera.params[2] =
+        static_cast<double>(data[idx * PrincipalPointSize() + 0]);  // cx
+    camera.params[3] =
+        static_cast<double>(data[idx * PrincipalPointSize() + 1]);  // cy
+  }
+
+  void MergeCalibData(const StorageType* focal_and_extra,
+                      const StorageType* principal_point,
+                      StorageType* calib) const override {
+    calib[0] = focal_and_extra[0];   // fx
+    calib[1] = focal_and_extra[1];   // fy
+    calib[2] = principal_point[0];   // cx
+    calib[3] = principal_point[1];   // cy
+    calib[4] = focal_and_extra[2];   // k1
+    calib[5] = focal_and_extra[3];   // k2
+    calib[6] = focal_and_extra[4];   // p1
+    calib[7] = focal_and_extra[5];   // p2
+    calib[8] = focal_and_extra[6];   // k3
+    calib[9] = focal_and_extra[7];   // k4
+    calib[10] = focal_and_extra[8];  // sx1
+    calib[11] = focal_and_extra[9];  // sy1
+  }
+
+  void SplitCalibData(const StorageType* calib,
+                      StorageType* focal_and_extra,
+                      StorageType* principal_point) const override {
+    focal_and_extra[0] = calib[0];  // fx
+    focal_and_extra[1] = calib[1];  // fy
+    principal_point[0] = calib[2];  // cx
+    principal_point[1] = calib[3];  // cy
+    focal_and_extra[2] = calib[4];  // k1
+    focal_and_extra[3] = calib[5];  // k2
+    focal_and_extra[4] = calib[6];  // p1
+    focal_and_extra[5] = calib[7];  // p2
+    focal_and_extra[6] = calib[8];  // k3
+    focal_and_extra[7] = calib[9];  // k4
+    focal_and_extra[8] = calib[10];  // sx1
+    focal_and_extra[9] = calib[11];  // sy1
+  }
+
+  void SetPoseNodes(caspar::GraphSolver& s,
+                    StorageType* data,
+                    size_t n) const override {
+    s.SetThinPrismFisheyePoseNodesFromStackedHost(data, 0, n);
+  }
+
+  void GetPoseNodes(caspar::GraphSolver& s,
+                    StorageType* data,
+                    size_t n) const override {
+    s.GetThinPrismFisheyePoseNodesToStackedHost(data, 0, n);
+  }
+
+  void SetFocalAndExtraNodes(caspar::GraphSolver& s,
+                             StorageType* data,
+                             size_t n) const override {
+    s.SetThinPrismFisheyeFocalAndExtraNodesFromStackedHost(data, 0, n);
+  }
+
+  void GetFocalAndExtraNodes(caspar::GraphSolver& s,
+                             StorageType* data,
+                             size_t n) const override {
+    s.GetThinPrismFisheyeFocalAndExtraNodesToStackedHost(data, 0, n);
+  }
+
+  void SetPrincipalPointNodes(caspar::GraphSolver& s,
+                              StorageType* data,
+                              size_t n) const override {
+    s.SetThinPrismFisheyePrincipalPointNodesFromStackedHost(data, 0, n);
+  }
+
+  void GetPrincipalPointNodes(caspar::GraphSolver& s,
+                              StorageType* data,
+                              size_t n) const override {
+    s.GetThinPrismFisheyePrincipalPointNodesToStackedHost(data, 0, n);
+  }
+
+  void SetCalibNodes(caspar::GraphSolver& s,
+                     StorageType* data,
+                     size_t n) const override {
+    s.SetThinPrismFisheyeCalibNodesFromStackedHost(data, 0, n);
+  }
+
+  void GetCalibNodes(caspar::GraphSolver& s,
+                     StorageType* data,
+                     size_t n) const override {
+    s.GetThinPrismFisheyeCalibNodesToStackedHost(data, 0, n);
+  }
+
+  void SetVariantFactors(caspar::GraphSolver& s,
+                         FactorVariant variant,
+                         const VariantData& d) const override {
+    const size_t n = d.num_factors;
+    switch (variant) {
+      // Merged variants: the calib index is the same as
+      // focal_and_extra_index, so no VariantData changes are needed for
+      // these cases.
+      case FactorVariant::BASE:
+        s.SetThinPrismFisheyeNum(n);
+        s.SetThinPrismFisheyePoseIndicesFromHost(d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeCalibIndicesFromHost(d.focal_and_extra_indices.data(),
+                                              n);
+        s.SetThinPrismFisheyePointIndicesFromHost(d.point_indices.data(), n);
+        s.SetThinPrismFisheyePixelDataFromStackedHost(d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE:
+        s.SetThinPrismFisheyeFixedPoseNum(n);
+        s.SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPoseCalibIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeFixedPosePointIndicesFromHost(d.point_indices.data(),
+                                                       n);
+        s.SetThinPrismFisheyeFixedPosePoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPosePixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_FOCAL_AND_EXTRA:
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraNum(n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromHost(
+            d.principal_point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_PRINCIPAL_POINT:
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POINT:
+        s.SetThinPrismFisheyeFixedPointNum(n);
+        s.SetThinPrismFisheyeFixedPointPoseIndicesFromHost(d.pose_indices.data(),
+                                                       n);
+        s.SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPointCalibIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE_FIXED_FOCAL_AND_EXTRA:
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraNum(n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromHost(
+            d.principal_point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE_FIXED_PRINCIPAL_POINT:
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE_FIXED_POINT:
+        s.SetThinPrismFisheyeFixedPoseFixedPointNum(n);
+        s.SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT:
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_FOCAL_AND_EXTRA_FIXED_POINT:
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+            d.principal_point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_PRINCIPAL_POINT_FIXED_POINT:
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::
+          FIXED_POSE_FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT:
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointNum(
+            n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+            d.point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE_FIXED_FOCAL_AND_EXTRA_FIXED_POINT:
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+            d.principal_point_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::FIXED_POSE_FIXED_PRINCIPAL_POINT_FIXED_POINT:
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointNum(n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+            d.focal_and_extra_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedHost(
+            d.const_poses.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+      case FactorVariant::
+          FIXED_FOCAL_AND_EXTRA_FIXED_PRINCIPAL_POINT_FIXED_POINT:
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointNum(
+            n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromHost(
+            d.pose_indices.data(), n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+            d.sensor_from_rig_data.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedHost(
+            d.const_focal_and_extra.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+            d.const_principal_point.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedHost(
+            d.const_points.data(), 0, n);
+        s.SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+            d.pixels.data(), 0, n);
+        break;
+    }
+  }
+};
+
+
 // Pinhole implementation
 
 class PinholeAdapter : public ICasparModelAdapter {
@@ -908,6 +1414,8 @@ inline std::unique_ptr<ICasparModelAdapter> CreateCasparAdapter(
       return std::make_unique<SimpleRadialAdapter>();
     case CameraModelId::kPinhole:
       return std::make_unique<PinholeAdapter>();
+    case CameraModelId::kThinPrismFisheye:
+      return std::make_unique<ThinPrismFisheyeAdapter>();
     default:
       return nullptr;
   }
@@ -917,8 +1425,9 @@ inline std::unique_ptr<ICasparModelAdapter> CreateCasparAdapter(
 // Caspar release. Order:
 //   1. Node type counts, alphabetical by type name
 //   2. Factor counts, in registration order from caspar_generate.py:
-//        simple_radial (4) → pinhole (4) →
-//        simple_radial_split (11) → pinhole_split (11)
+//        simple_radial (4) → pinhole (4) → thin_prism_fisheye (4) →
+//        simple_radial_split (11) → pinhole_split (11) →
+//        thin_prism_fisheye_split (11)
 inline caspar::GraphSolver CreateSolver(
     const caspar::SolverParams<StorageType>& params,
     const CasparSolverSizing& sz,
@@ -929,7 +1438,9 @@ inline caspar::GraphSolver CreateSolver(
       //   PinholeCalib, PinholeFocal, PinholePose,
       //   PinholePrincipalPoint, Point,
       //   SimpleRadialCalib, SimpleRadialFocalAndExtra,
-      //   SimpleRadialPose, SimpleRadialPrincipalPoint
+      //   SimpleRadialPose, SimpleRadialPrincipalPoint,
+      //   ThinPrismFisheyeCalib, ThinPrismFisheyeFocalAndExtra,
+      //   ThinPrismFisheyePose, ThinPrismFisheyePrincipalPoint
       sz.num_pinhole_calibs,        // PinholeCalib        (merged pool)
       sz.num_pinhole_calibs,        // PinholeFocal         (split pool)
       sz.num_pinhole_poses,         // PinholePose
@@ -942,6 +1453,13 @@ inline caspar::GraphSolver CreateSolver(
       sz.num_simple_radial_poses,   // SimpleRadialPose
       sz.num_simple_radial_calibs,  // SimpleRadialPrincipalPoint      (split
                                     // pool)
+      sz.num_thin_prism_fisheye_calibs,  // ThinPrismFisheyeCalib       (merged
+                                         // pool)
+      sz.num_thin_prism_fisheye_calibs,  // ThinPrismFisheyeFocalAndExtra
+                                         // (split pool)
+      sz.num_thin_prism_fisheye_poses,   // ThinPrismFisheyePose
+      sz.num_thin_prism_fisheye_calibs,  // ThinPrismFisheyePrincipalPoint
+                                         // (split pool)
       // simple_radial factor counts (r=0..2 over {pose, point}):
       sz.num_simple_radial,                         // {}
       sz.num_simple_radial_fixed_pose,              // {pose}
@@ -952,6 +1470,11 @@ inline caspar::GraphSolver CreateSolver(
       sz.num_pinhole_fixed_pose,              // {pose}
       sz.num_pinhole_fixed_point,             // {point}
       sz.num_pinhole_fixed_pose_fixed_point,  // {pose, point}
+      // thin_prism_fisheye factor counts (same order):
+      sz.num_thin_prism_fisheye,                         // {}
+      sz.num_thin_prism_fisheye_fixed_pose,              // {pose}
+      sz.num_thin_prism_fisheye_fixed_point,             // {point}
+      sz.num_thin_prism_fisheye_fixed_pose_fixed_point,  // {pose, point}
       // simple_radial_split factor counts (11 variants, must_fix_one_of):
       sz.num_simple_radial_split_fixed_focal_and_extra,             // r=1 {fae}
       sz.num_simple_radial_split_fixed_principal_point,             // r=1 {pp}
@@ -980,6 +1503,22 @@ inline caspar::GraphSolver CreateSolver(
       sz.num_pinhole_split_fixed_pose_fixed_focal_fixed_point,            // r=3
       sz.num_pinhole_split_fixed_pose_fixed_principal_point_fixed_point,  // r=3
       sz.num_pinhole_split_fixed_focal_fixed_principal_point_fixed_point,  // r=3
+      // thin_prism_fisheye_split factor counts (same 11-variant order):
+      sz.num_thin_prism_fisheye_split_fixed_focal_and_extra,  // r=1 {fae}
+      sz.num_thin_prism_fisheye_split_fixed_principal_point,  // r=1 {pp}
+      sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra,  // r=2
+                                                                         // {pose,fae}
+      sz.num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point,  // r=2
+                                                                         // {pose,pp}
+      sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point,  // r=2 {fae,pp}
+      sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point,  // r=2
+                                                                          // {fae,pt}
+      sz.num_thin_prism_fisheye_split_fixed_principal_point_fixed_point,  // r=2
+                                                                          // {pp,pt}
+      sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point,  // r=3
+      sz.num_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point,  // r=3
+      sz.num_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point,  // r=3
+      sz.num_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point,  // r=3
       device_id);
 }
 

--- a/src/thirdparty/Symforce-Caspar/caspar_generate.py
+++ b/src/thirdparty/Symforce-Caspar/caspar_generate.py
@@ -120,6 +120,45 @@ class ConstPinholeFocal(sf.V2):
     pass
 
 
+# ThinPrismFisheye: params =
+# [fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1]
+#
+# The merged Calib node keeps COLMAP's parameter order exactly. The split
+# layout follows the existing CASPAR focal/extra + principal-point scheme:
+# focal_and_extra = [fx, fy, k1, k2, p1, p2, k3, k4, sx1, sy1]
+# principal_point = [cx, cy].
+class ThinPrismFisheyePose(sf.Pose3):
+    pass
+
+
+class ConstThinPrismFisheyePose(sf.Pose3):
+    pass
+
+
+class ThinPrismFisheyeCalib(sf.Matrix(12, 1).__class__):
+    pass
+
+
+class ConstThinPrismFisheyeCalib(sf.Matrix(12, 1).__class__):
+    pass
+
+
+class ThinPrismFisheyePrincipalPoint(sf.V2):
+    pass
+
+
+class ConstThinPrismFisheyePrincipalPoint(sf.V2):
+    pass
+
+
+class ThinPrismFisheyeFocalAndExtra(sf.Matrix(10, 1).__class__):
+    pass
+
+
+class ConstThinPrismFisheyeFocalAndExtra(sf.Matrix(10, 1).__class__):
+    pass
+
+
 # Constant sensor-from-rig calibration, stored as ConstantSequential
 # (7 floats = 28 B f32 / 56 B f64 loaded from global memory per factor).
 # ConstantShared would deduplicate to one slot per unique sensor per block,
@@ -134,6 +173,10 @@ class ConstSimpleRadialSensorFromRig(sf.Pose3):
 
 
 class ConstPinholeSensorFromRig(sf.Pose3):
+    pass
+
+
+class ConstThinPrismFisheyeSensorFromRig(sf.Pose3):
     pass
 
 
@@ -262,6 +305,55 @@ def pinhole_core(
     return sf.V2([fx * p[0] + cx, fy * p[1] + cy]) - pixel
 
 
+def thin_prism_fisheye_project(point_cam, calib) -> sf.V2:
+    """COLMAP THIN_PRISM_FISHEYE projection.
+
+    calib is in COLMAP order:
+    [fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1].
+    COLMAP maps normalized pinhole coordinates to fisheye coordinates first,
+    then applies radial/tangential/thin-prism distortion in fisheye space.
+    """
+    fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1 = calib
+    depth = point_cam[2]
+    p = sf.V2(point_cam[:2]) / (depth + sf.epsilon() * sf.sign_no_zero(depth))
+    r2_normal = p.squared_norm()
+    r_normal = sf.sqrt(r2_normal)
+    theta = sf.atan(r_normal)
+    fisheye_scale = theta / (
+        r_normal + sf.epsilon() * sf.sign_no_zero(r_normal)
+    )
+    uu = fisheye_scale * p[0]
+    vv = fisheye_scale * p[1]
+
+    uu2 = uu * uu
+    uuvv = uu * vv
+    vv2 = vv * vv
+    rr2 = uu2 + vv2
+    rr4 = rr2 * rr2
+    rr6 = rr4 * rr2
+    rr8 = rr6 * rr2
+    radial = k1 * rr2 + k2 * rr4 + k3 * rr6 + k4 * rr8
+    du = uu * radial + 2 * p1 * uuvv + p2 * (rr2 + 2 * uu2) + sx1 * rr2
+    dv = vv * radial + 2 * p2 * uuvv + p1 * (rr2 + 2 * vv2) + sy1 * rr2
+    return sf.V2([fx * (uu + du) + cx, fy * (vv + dv) + cy])
+
+
+def thin_prism_fisheye_core(
+    pose: T.Annotated[ThinPrismFisheyePose, mem.TunableShared],
+    sensor_from_rig: T.Annotated[
+        ConstThinPrismFisheyeSensorFromRig, mem.ConstantSequential
+    ],
+    calib: T.Annotated[
+        ThinPrismFisheyeCalib, mem.TunableShared
+    ],  # [fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1]
+    point: T.Annotated[Point, mem.TunableShared],
+    pixel: T.Annotated[ConstPixel, mem.ConstantSequential],
+) -> sf.V2:
+    """Reprojection residual for COLMAP's THIN_PRISM_FISHEYE model."""
+    cam_T_world = sensor_from_rig * pose
+    return thin_prism_fisheye_project(cam_T_world * point, calib) - pixel
+
+
 # Split cores delegate to merged cores to avoid duplicating projection math.
 
 
@@ -311,6 +403,46 @@ def pinhole_split_core(
     return pinhole_core(pose, sensor_from_rig, calib, point, pixel)
 
 
+def thin_prism_fisheye_split_core(
+    pose: T.Annotated[ThinPrismFisheyePose, mem.TunableShared],
+    sensor_from_rig: T.Annotated[
+        ConstThinPrismFisheyeSensorFromRig, mem.ConstantSequential
+    ],
+    focal_and_extra: T.Annotated[
+        ThinPrismFisheyeFocalAndExtra, mem.TunableShared
+    ],
+    principal_point: T.Annotated[
+        ThinPrismFisheyePrincipalPoint, mem.TunableShared
+    ],
+    point: T.Annotated[Point, mem.TunableShared],
+    pixel: T.Annotated[ConstPixel, mem.ConstantSequential],
+) -> sf.V2:
+    """Split-calib variant of thin_prism_fisheye_core.
+
+    focal_and_extra = [fx, fy, k1, k2, p1, p2, k3, k4, sx1, sy1],
+    principal_point = [cx, cy].
+    """
+    calib = sf.Matrix(
+        [
+            focal_and_extra[0],
+            focal_and_extra[1],
+            principal_point[0],
+            principal_point[1],
+            focal_and_extra[2],
+            focal_and_extra[3],
+            focal_and_extra[4],
+            focal_and_extra[5],
+            focal_and_extra[6],
+            focal_and_extra[7],
+            focal_and_extra[8],
+            focal_and_extra[9],
+        ]
+    )
+    return thin_prism_fisheye_core(
+        pose, sensor_from_rig, calib, point, pixel
+    )
+
+
 dtype = mem.DType.DOUBLE if precision == "f64" else mem.DType.FLOAT
 caslib = CasparLibrary(name="caspar_lib", dtype=dtype)
 
@@ -348,6 +480,11 @@ FIXABLE_PINHOLE = {
     "point": ConstPoint,
 }
 
+FIXABLE_THIN_PRISM_FISHEYE = {
+    "pose": ConstThinPrismFisheyePose,
+    "point": ConstPoint,
+}
+
 FIXABLE_SIMPLE_RADIAL_SPLIT = {
     "pose": ConstSimpleRadialPose,
     "focal_and_extra": ConstSimpleRadialFocalAndExtra,
@@ -362,6 +499,13 @@ FIXABLE_PINHOLE_SPLIT = {
     "point": ConstPoint,
 }
 
+FIXABLE_THIN_PRISM_FISHEYE_SPLIT = {
+    "pose": ConstThinPrismFisheyePose,
+    "focal_and_extra": ConstThinPrismFisheyeFocalAndExtra,
+    "principal_point": ConstThinPrismFisheyePrincipalPoint,
+    "point": ConstPoint,
+}
+
 # Merged: BASE, FIXED_POSE, FIXED_POINT, FIXED_POSE_FIXED_POINT (4 variants).
 register_camera_model(
     caslib,
@@ -372,6 +516,13 @@ register_camera_model(
 )
 register_camera_model(
     caslib, "pinhole", pinhole_core, FIXABLE_PINHOLE, include_all_fixed=True
+)
+register_camera_model(
+    caslib,
+    "thin_prism_fisheye",
+    thin_prism_fisheye_core,
+    FIXABLE_THIN_PRISM_FISHEYE,
+    include_all_fixed=True,
 )
 
 # Split: all variants where at least one of
@@ -389,6 +540,13 @@ register_camera_model(
     pinhole_split_core,
     FIXABLE_PINHOLE_SPLIT,
     must_fix_one_of={"focal", "principal_point"},
+)
+register_camera_model(
+    caslib,
+    "thin_prism_fisheye_split",
+    thin_prism_fisheye_split_core,
+    FIXABLE_THIN_PRISM_FISHEYE_SPLIT,
+    must_fix_one_of={"focal_and_extra", "principal_point"},
 )
 
 out_dir = Path(f"{sys.argv[1]}")

--- a/src/thirdparty/Symforce-Caspar/generated/f32/CMakeLists.txt
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/CMakeLists.txt
@@ -6,9 +6,11 @@ endif()
 
 project(caspar_library LANGUAGES CXX CUDA)
 
+set(CASPAR_MIN_ARCH 75 CACHE INTERNAL "Minimum CUDA arch required by Caspar")
+
 # SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
+  set(CMAKE_CUDA_ARCHITECTURES ${CASPAR_MIN_ARCH} 80-real 86-real 89-real)
 endif()
 
 find_package(CUDAToolkit REQUIRED)

--- a/src/thirdparty/Symforce-Caspar/generated/f32/caspar_mappings.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/caspar_mappings.cu
@@ -976,6 +976,432 @@ cudaError_t ConstSimpleRadialSensorFromRigCasparToStacked(
 }
 
 __global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 10];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 10] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+    data[3] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float2*>(out_ptr)[0] = reinterpret_cast<float2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeFocalAndExtraCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 10];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+    stacked_local_ptr[7] = data[3];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float2*>(data)[0] =
+        reinterpret_cast<const float2*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 10];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel<<<num_blocks,
+                                                             block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeFocalAndExtraCasparToStacked_kernel<<<num_blocks,
+                                                             block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePoseStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePoseCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyePoseStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePoseStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyePoseCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePoseCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePrincipalPointStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 2];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 2] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float2*>(out_ptr)[0] = reinterpret_cast<float2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePrincipalPointCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 2];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    const float* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float2*>(data)[0] =
+        reinterpret_cast<const float2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 2];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar_kernel<<<num_blocks,
+                                                              block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyePrincipalPointCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePrincipalPointCasparToStacked_kernel<<<num_blocks,
+                                                              block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeSensorFromRigStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeSensorFromRigCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar_kernel<<<num_blocks,
+                                                             block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeSensorFromRigCasparToStacked_kernel<<<num_blocks,
+                                                             block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
 __launch_bounds__(block_size, 1) void PinholeCalibStackedToCaspar_kernel(
     const float* const __restrict__ stacked_data,
     float* const __restrict__ cas_data,
@@ -1808,6 +2234,446 @@ cudaError_t SimpleRadialPrincipalPointCasparToStacked(
   const int num_blocks = (num_objects + block_size - 1) / block_size;
 
   SimpleRadialPrincipalPointCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeCalibStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 12];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 12 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 12;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 12] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 12;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+    data[3] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+    data[2] = stacked_local_ptr[10];
+    data[3] = stacked_local_ptr[11];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeCalibCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 12];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 12;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+    stacked_local_ptr[7] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+    stacked_local_ptr[10] = data[2];
+    stacked_local_ptr[11] = data[3];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 12 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 12;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 12];
+  }
+}
+
+cudaError_t ThinPrismFisheyeCalibStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeCalibStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyeCalibCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeCalibCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 10];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 10] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+    data[3] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float2*>(out_ptr)[0] = reinterpret_cast<float2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeFocalAndExtraCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 10];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+    stacked_local_ptr[7] = data[3];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<float2*>(data)[0] =
+        reinterpret_cast<const float2*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 10];
+  }
+}
+
+cudaError_t ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel<<<num_blocks,
+                                                        block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeFocalAndExtraCasparToStacked_kernel<<<num_blocks,
+                                                        block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePoseStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+    data[2] = stacked_local_ptr[2];
+    data[3] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+    data[2] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(out_ptr)[0] = reinterpret_cast<float4*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePoseCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const float* in_ptr;
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    stacked_local_ptr[2] = data[2];
+    stacked_local_ptr[3] = data[3];
+    in_ptr = cas_data + 4 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<float4*>(data)[0] =
+        reinterpret_cast<const float4*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    stacked_local_ptr[6] = data[2];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ThinPrismFisheyePoseStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePoseStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyePoseCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePoseCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePrincipalPointStackedToCaspar_kernel(
+    const float* const __restrict__ stacked_data,
+    float* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 2];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 2] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    float* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float2*>(out_ptr)[0] = reinterpret_cast<float2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePrincipalPointCasparToStacked_kernel(
+    const float* const __restrict__ cas_data,
+    float* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ float stacked_data_local[block_size * 2];
+
+  if (global_thread_idx < num_objects) {
+    float data[4] = {0, 0, 0, 0};
+    float* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    const float* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<float2*>(data)[0] =
+        reinterpret_cast<const float2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 2];
+  }
+}
+
+cudaError_t ThinPrismFisheyePrincipalPointStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePrincipalPointStackedToCaspar_kernel<<<num_blocks,
+                                                         block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyePrincipalPointCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePrincipalPointCasparToStacked_kernel<<<num_blocks,
+                                                         block_size>>>(
       cas_data, stacked_data, cas_stride, cas_offset, num_objects);
 
   return cudaGetLastError();

--- a/src/thirdparty/Symforce-Caspar/generated/f32/caspar_mappings.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/caspar_mappings.h
@@ -136,6 +136,62 @@ cudaError_t ConstSimpleRadialSensorFromRigCasparToStacked(
     const unsigned int cas_offset,
     const unsigned int num_objects);
 
+cudaError_t ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePoseStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePoseCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePrincipalPointCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
 cudaError_t PinholeCalibStackedToCaspar(const float* stacked_data,
                                         float* cas_data,
                                         const unsigned int cas_stride,
@@ -244,6 +300,60 @@ cudaError_t SimpleRadialPrincipalPointStackedToCaspar(
     const unsigned int num_objects);
 
 cudaError_t SimpleRadialPrincipalPointCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeCalibStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeCalibCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const float* cas_data,
+    float* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePoseStackedToCaspar(const float* stacked_data,
+                                                float* cas_data,
+                                                const unsigned int cas_stride,
+                                                const unsigned int cas_offset,
+                                                const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePoseCasparToStacked(const float* cas_data,
+                                                float* stacked_data,
+                                                const unsigned int cas_stride,
+                                                const unsigned int cas_offset,
+                                                const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePrincipalPointStackedToCaspar(
+    const float* stacked_data,
+    float* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePrincipalPointCasparToStacked(
     const float* cas_data,
     float* stacked_data,
     const unsigned int cas_stride,

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,118 @@
+#include "kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumeratorKernel(
+        float* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        float* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        float* const ThinPrismFisheyeCalib_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyeCalib_out_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         4 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+    r4 = fmaf(r0, r4, r1 * r5);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r5,
+        r1,
+        r8);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         0 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r16);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         8 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    r4 = fmaf(r8, r12, r4);
+    r4 = fmaf(r5, r10, r4);
+    r4 = fmaf(r2, r6, r4);
+    r4 = fmaf(r13, r17, r4);
+    r4 = fmaf(r1, r11, r4);
+    r4 = fmaf(r3, r7, r4);
+    r4 = fmaf(r0, r9, r4);
+    r4 = fmaf(r14, r18, r4);
+    r4 = fmaf(r16, r20, r4);
+    r4 = fmaf(r15, r19, r4);
+  };
+  SumStore<float>(ThinPrismFisheyeCalib_out_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r4);
+  SumFlushFinal<float>(
+      ThinPrismFisheyeCalib_out_local, ThinPrismFisheyeCalib_out, 1);
+}
+
+void ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    float* const ThinPrismFisheyeCalib_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks,
+                                                               1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      ThinPrismFisheyeCalib_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    float* const ThinPrismFisheyeCalib_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.cu
@@ -1,0 +1,172 @@
+#include "kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibAlphaNumeratorDenominatorKernel(
+        float* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        float* ThinPrismFisheyeCalib_r_k,
+        unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+        float* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        float* const ThinPrismFisheyeCalib_total_ag,
+        float* const ThinPrismFisheyeCalib_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyeCalib_total_ag_local[1];
+
+  __shared__ float ThinPrismFisheyeCalib_total_ac_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    r7 = fmaf(r3, r7, r2 * r6);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r6,
+        r8,
+        r9,
+        r10);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r11,
+        r12,
+        r13,
+        r14);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r15,
+        r16,
+        r17,
+        r18);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r19,
+        r20,
+        r21,
+        r22);
+    r7 = fmaf(r9, r13, r7);
+    r7 = fmaf(r18, r22, r7);
+    r7 = fmaf(r16, r20, r7);
+    r7 = fmaf(r10, r14, r7);
+    r7 = fmaf(r8, r12, r7);
+    r7 = fmaf(r17, r21, r7);
+    r7 = fmaf(r0, r4, r7);
+    r7 = fmaf(r15, r19, r7);
+    r7 = fmaf(r6, r11, r7);
+    r7 = fmaf(r1, r5, r7);
+  };
+  SumStore<float>(ThinPrismFisheyeCalib_total_ag_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r7);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         4 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r5,
+                                         r11,
+                                         r19);
+    r7 = fmaf(r15, r7, r16 * r5);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         0 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r5,
+                                         r16,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         8 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r12,
+                                         r14,
+                                         r20);
+    r7 = fmaf(r10, r4, r7);
+    r7 = fmaf(r8, r5, r7);
+    r7 = fmaf(r17, r11, r7);
+    r7 = fmaf(r0, r21, r7);
+    r7 = fmaf(r9, r16, r7);
+    r7 = fmaf(r18, r19, r7);
+    r7 = fmaf(r6, r15, r7);
+    r7 = fmaf(r1, r12, r7);
+    r7 = fmaf(r3, r20, r7);
+    r7 = fmaf(r2, r14, r7);
+  };
+  SumStore<float>(ThinPrismFisheyeCalib_total_ac_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r7);
+  SumFlushFinal<float>(
+      ThinPrismFisheyeCalib_total_ag_local, ThinPrismFisheyeCalib_total_ag, 1);
+  SumFlushFinal<float>(
+      ThinPrismFisheyeCalib_total_ac_local, ThinPrismFisheyeCalib_total_ac, 1);
+}
+
+void ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    float* const ThinPrismFisheyeCalib_total_ag,
+    float* const ThinPrismFisheyeCalib_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibAlphaNumeratorDenominatorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      ThinPrismFisheyeCalib_total_ag,
+      ThinPrismFisheyeCalib_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    float* const ThinPrismFisheyeCalib_total_ag,
+    float* const ThinPrismFisheyeCalib_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_normalize.cu
@@ -1,0 +1,942 @@
+#include "kernel_ThinPrismFisheyeCalib_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibNormalizeKernel(float* precond_diag,
+                                         unsigned int precond_diag_num_alloc,
+                                         float* precond_tril,
+                                         unsigned int precond_tril_num_alloc,
+                                         float* njtr,
+                                         unsigned int njtr_num_alloc,
+                                         const float* const diag,
+                                         float* out_normalized,
+                                         unsigned int out_normalized_num_alloc,
+                                         size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96;
+
+  if (global_thread_idx < problem_size) {
+    r0 = -1.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         28 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r2,
+                                         r3,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         8 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r2,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         0 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r6,
+                                         r8,
+                                         r9);
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         0 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r7,
+                                         r10,
+                                         r11);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = 1.00000000000000000e+00;
+    r13 = r12 + r13;
+    r14 = 9.99999999999999955e-07;
+    r14 = r12 * r14;
+    r8 = fmaf(r8, r13, r14);
+    r8 = 1.0 / r8;
+    r12 = r0 * r8;
+    r15 = r6 * r12;
+    r1 = fmaf(r5, r15, r1);
+    r16 = r0 * r1;
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         8 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    r19 = fmaf(r19, r13, r14);
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         4 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r21 = fmaf(r21, r13, r14);
+    r10 = fmaf(r10, r13, r14);
+    r10 = fmaf(r6, r15, r10);
+    r10 = 1.0 / r10;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         20 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r6,
+                                         r25,
+                                         r26,
+                                         r27);
+    r26 = fmaf(r9, r15, r26);
+    r25 = r26 * r26;
+    r11 = fmaf(r11, r13, r14);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         12 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r28,
+                                         r29,
+                                         r30,
+                                         r31);
+    r32 = r28 * r0;
+    r7 = fmaf(r7, r13, r14);
+    r7 = 1.0 / r7;
+    r32 = r32 * r7;
+    r11 = fmaf(r28, r32, r11);
+    r11 = 1.0 / r11;
+    r3 = fmaf(r29, r32, r3);
+    r28 = r3 * r3;
+    r28 = fmaf(r11, r28, r10 * r25);
+    r25 = r9 * r9;
+    r33 = r29 * r29;
+    r28 = fmaf(r8, r25, r28);
+    r28 = fmaf(r7, r33, r28);
+    r21 = fmaf(r0, r28, r21);
+    r21 = 1.0 / r21;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         40 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r28,
+                                         r33,
+                                         r25,
+                                         r34);
+    r35 = r9 * r5;
+    r36 = r26 * r1;
+    r36 = fmaf(r10, r36, r8 * r35);
+    r36 = fmaf(r0, r36, r34);
+    r34 = r36 * r36;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         60 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r37,
+                                         r38,
+                                         r39);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         24 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r40,
+                                         r41,
+                                         r42,
+                                         r43);
+    r43 = fmaf(r2, r15, r43);
+    r44 = r43 * r1;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         56 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r45,
+                                         r46,
+                                         r47,
+                                         r48);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         48 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r49,
+                                         r50,
+                                         r51,
+                                         r52);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         32 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r53,
+                                         r54,
+                                         r55,
+                                         r56);
+    r53 = fmaf(r31, r32, r53);
+    r57 = r53 * r11;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         16 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r58,
+                                         r59,
+                                         r60,
+                                         r61);
+    r54 = fmaf(r58, r32, r54);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         44 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r61,
+                                         r62,
+                                         r63,
+                                         r64);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         36 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r65,
+                                         r66,
+                                         r67,
+                                         r68);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         4 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r65,
+                                         r69,
+                                         r70,
+                                         r71);
+    r27 = fmaf(r65, r15, r27);
+    r72 = r26 * r27;
+    r4 = fmaf(r30, r32, r4);
+    r73 = r3 * r4;
+    r73 = fmaf(r11, r73, r10 * r72);
+    r72 = r9 * r65;
+    r73 = fmaf(r8, r72, r73);
+    r74 = r29 * r30;
+    r73 = fmaf(r7, r74, r73);
+    r73 = fmaf(r0, r73, r67);
+    r67 = r3 * r54;
+    r41 = fmaf(r70, r15, r41);
+    r74 = r26 * r41;
+    r74 = fmaf(r10, r74, r11 * r67);
+    r67 = r9 * r70;
+    r74 = fmaf(r8, r67, r74);
+    r72 = r29 * r58;
+    r74 = fmaf(r7, r72, r74);
+    r74 = fmaf(r0, r74, r28);
+    r28 = r73 * r74;
+    r72 = r4 * r54;
+    r72 = fmaf(r11, r72, r21 * r28);
+    r28 = r65 * r70;
+    r72 = fmaf(r8, r28, r72);
+    r67 = r27 * r41;
+    r72 = fmaf(r10, r67, r72);
+    r75 = r30 * r58;
+    r72 = fmaf(r7, r75, r72);
+    r72 = fmaf(r0, r72, r63);
+    r40 = fmaf(r69, r15, r40);
+    r63 = r40 * r10;
+    r75 = fmaf(r26, r63, r3 * r57);
+    r67 = r9 * r69;
+    r75 = fmaf(r8, r67, r75);
+    r28 = r29 * r31;
+    r75 = fmaf(r7, r28, r75);
+    r75 = fmaf(r0, r75, r68);
+    r68 = r75 * r21;
+    r28 = fmaf(r4, r57, r73 * r68);
+    r67 = r65 * r69;
+    r28 = fmaf(r8, r67, r28);
+    r76 = r30 * r31;
+    r28 = fmaf(r7, r76, r28);
+    r28 = fmaf(r27, r63, r28);
+    r28 = fmaf(r0, r28, r62);
+    r22 = fmaf(r22, r13, r14);
+    r62 = r27 * r27;
+    r76 = r73 * r73;
+    r76 = fmaf(r21, r76, r10 * r62);
+    r62 = r4 * r4;
+    r67 = r65 * r65;
+    r77 = r30 * r30;
+    r76 = fmaf(r11, r62, r76);
+    r76 = fmaf(r8, r67, r76);
+    r76 = fmaf(r7, r77, r76);
+    r22 = fmaf(r0, r76, r22);
+    r22 = 1.0 / r22;
+    r76 = r28 * r22;
+    r77 = fmaf(r72, r76, r54 * r57);
+    r67 = r69 * r70;
+    r77 = fmaf(r8, r67, r77);
+    r62 = r31 * r58;
+    r77 = fmaf(r7, r62, r77);
+    r77 = fmaf(r74, r68, r77);
+    r77 = fmaf(r41, r63, r77);
+    r77 = fmaf(r0, r77, r52);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         52 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r52,
+                                         r62,
+                                         r67,
+                                         r78);
+    r56 = fmaf(r60, r32, r56);
+    r79 = r4 * r56;
+    r80 = r3 * r56;
+    r81 = r26 * r43;
+    r81 = fmaf(r10, r81, r11 * r80);
+    r80 = r9 * r2;
+    r81 = fmaf(r8, r80, r81);
+    r82 = r29 * r60;
+    r81 = fmaf(r7, r82, r81);
+    r81 = fmaf(r0, r81, r25);
+    r25 = r73 * r81;
+    r25 = fmaf(r21, r25, r11 * r79);
+    r79 = r27 * r43;
+    r25 = fmaf(r10, r79, r25);
+    r82 = r65 * r2;
+    r25 = fmaf(r8, r82, r25);
+    r80 = r30 * r60;
+    r25 = fmaf(r7, r80, r25);
+    r25 = fmaf(r0, r25, r49);
+    r49 = fmaf(r56, r57, r25 * r76);
+    r80 = r69 * r2;
+    r49 = fmaf(r8, r80, r49);
+    r82 = r31 * r60;
+    r49 = fmaf(r7, r82, r49);
+    r49 = fmaf(r81, r68, r49);
+    r49 = fmaf(r43, r63, r49);
+    r49 = fmaf(r0, r49, r62);
+    r62 = r77 * r49;
+    r23 = fmaf(r23, r13, r14);
+    r28 = fmaf(r28, r76, r53 * r57);
+    r53 = r69 * r69;
+    r82 = r31 * r31;
+    r28 = fmaf(r40, r63, r28);
+    r28 = fmaf(r75, r68, r28);
+    r28 = fmaf(r8, r53, r28);
+    r28 = fmaf(r7, r82, r28);
+    r23 = fmaf(r0, r28, r23);
+    r23 = 1.0 / r23;
+    r28 = r54 * r56;
+    r28 = fmaf(r11, r28, r23 * r62);
+    r62 = r74 * r81;
+    r28 = fmaf(r21, r62, r28);
+    r82 = r70 * r2;
+    r28 = fmaf(r8, r82, r28);
+    r53 = r58 * r60;
+    r28 = fmaf(r7, r53, r28);
+    r75 = r41 * r43;
+    r28 = fmaf(r10, r75, r28);
+    r40 = r72 * r25;
+    r28 = fmaf(r22, r40, r28);
+    r28 = fmaf(r0, r28, r46);
+    r46 = r41 * r1;
+    r40 = r74 * r36;
+    r40 = fmaf(r21, r40, r10 * r46);
+    r46 = r65 * r5;
+    r75 = r73 * r36;
+    r75 = fmaf(r21, r75, r8 * r46);
+    r46 = r27 * r1;
+    r75 = fmaf(r10, r46, r75);
+    r75 = fmaf(r0, r75, r50);
+    r50 = fmaf(r75, r76, r1 * r63);
+    r46 = r69 * r5;
+    r50 = fmaf(r8, r46, r50);
+    r50 = fmaf(r36, r68, r50);
+    r50 = fmaf(r0, r50, r67);
+    r67 = r50 * r23;
+    r46 = r70 * r5;
+    r40 = fmaf(r8, r46, r40);
+    r53 = r72 * r75;
+    r40 = fmaf(r22, r53, r40);
+    r40 = fmaf(r77, r67, r40);
+    r40 = fmaf(r0, r40, r47);
+    r47 = r28 * r40;
+    r24 = fmaf(r24, r13, r14);
+    r53 = r54 * r54;
+    r46 = r72 * r72;
+    r46 = fmaf(r22, r46, r11 * r53);
+    r53 = r41 * r41;
+    r82 = r74 * r74;
+    r62 = r70 * r70;
+    r80 = r58 * r58;
+    r79 = r77 * r77;
+    r46 = fmaf(r10, r53, r46);
+    r46 = fmaf(r21, r82, r46);
+    r46 = fmaf(r8, r62, r46);
+    r46 = fmaf(r7, r80, r46);
+    r46 = fmaf(r23, r79, r46);
+    r24 = fmaf(r0, r46, r24);
+    r24 = 1.0 / r24;
+    r47 = fmaf(r24, r47, r10 * r44);
+    r42 = fmaf(r71, r15, r42);
+    r44 = r42 * r1;
+    r55 = fmaf(r59, r32, r55);
+    r46 = r3 * r55;
+    r79 = r26 * r42;
+    r79 = fmaf(r10, r79, r11 * r46);
+    r46 = r9 * r71;
+    r79 = fmaf(r8, r46, r79);
+    r80 = r29 * r59;
+    r79 = fmaf(r7, r80, r79);
+    r79 = fmaf(r0, r79, r33);
+    r33 = fmaf(r55, r57, r79 * r68);
+    r80 = r69 * r71;
+    r33 = fmaf(r8, r80, r33);
+    r46 = r79 * r73;
+    r62 = r55 * r4;
+    r62 = fmaf(r11, r62, r21 * r46);
+    r46 = r42 * r27;
+    r62 = fmaf(r10, r46, r62);
+    r82 = r65 * r71;
+    r62 = fmaf(r8, r82, r62);
+    r53 = r30 * r59;
+    r62 = fmaf(r7, r53, r62);
+    r62 = fmaf(r0, r62, r64);
+    r64 = r31 * r59;
+    r33 = fmaf(r7, r64, r33);
+    r33 = fmaf(r62, r76, r33);
+    r33 = fmaf(r42, r63, r33);
+    r33 = fmaf(r0, r33, r52);
+    r44 = fmaf(r33, r67, r10 * r44);
+    r52 = r62 * r75;
+    r44 = fmaf(r22, r52, r44);
+    r64 = r71 * r5;
+    r44 = fmaf(r8, r64, r44);
+    r80 = r79 * r36;
+    r44 = fmaf(r21, r80, r44);
+    r53 = r55 * r54;
+    r82 = r70 * r71;
+    r82 = fmaf(r8, r82, r11 * r53);
+    r53 = r79 * r74;
+    r82 = fmaf(r21, r53, r82);
+    r46 = r33 * r77;
+    r82 = fmaf(r23, r46, r82);
+    r83 = r42 * r41;
+    r82 = fmaf(r10, r83, r82);
+    r84 = r58 * r59;
+    r82 = fmaf(r7, r84, r82);
+    r85 = r62 * r72;
+    r82 = fmaf(r22, r85, r82);
+    r82 = fmaf(r0, r82, r45);
+    r45 = r82 * r24;
+    r44 = fmaf(r40, r45, r44);
+    r44 = fmaf(r0, r44, r37);
+    r37 = r62 * r25;
+    r80 = r55 * r56;
+    r80 = fmaf(r11, r80, r22 * r37);
+    r37 = r33 * r49;
+    r80 = fmaf(r23, r37, r80);
+    r64 = r71 * r2;
+    r80 = fmaf(r8, r64, r80);
+    r52 = r79 * r81;
+    r80 = fmaf(r21, r52, r80);
+    r85 = r42 * r43;
+    r80 = fmaf(r10, r85, r80);
+    r84 = r59 * r60;
+    r80 = fmaf(r7, r84, r80);
+    r80 = fmaf(r28, r45, r80);
+    r80 = fmaf(r0, r80, r35);
+    r17 = fmaf(r17, r13, r14);
+    r35 = r79 * r79;
+    r84 = r33 * r33;
+    r84 = fmaf(r23, r84, r21 * r35);
+    r35 = r55 * r55;
+    r85 = r62 * r62;
+    r52 = r42 * r42;
+    r64 = r71 * r71;
+    r37 = r59 * r59;
+    r84 = fmaf(r11, r35, r84);
+    r84 = fmaf(r22, r85, r84);
+    r84 = fmaf(r10, r52, r84);
+    r84 = fmaf(r82, r45, r84);
+    r84 = fmaf(r8, r64, r84);
+    r84 = fmaf(r7, r37, r84);
+    r17 = fmaf(r0, r84, r17);
+    r17 = 1.0 / r17;
+    r84 = r80 * r17;
+    r37 = r2 * r5;
+    r47 = fmaf(r8, r37, r47);
+    r64 = r25 * r75;
+    r47 = fmaf(r22, r64, r47);
+    r82 = r81 * r36;
+    r47 = fmaf(r21, r82, r47);
+    r47 = fmaf(r49, r67, r47);
+    r47 = fmaf(r44, r84, r47);
+    r47 = fmaf(r0, r47, r39);
+    r18 = fmaf(r18, r13, r14);
+    r39 = r56 * r56;
+    r82 = r25 * r25;
+    r82 = fmaf(r22, r82, r11 * r39);
+    r39 = r49 * r49;
+    r64 = r43 * r43;
+    r37 = r81 * r81;
+    r52 = r28 * r28;
+    r85 = r2 * r2;
+    r35 = r60 * r60;
+    r82 = fmaf(r23, r39, r82);
+    r82 = fmaf(r10, r64, r82);
+    r82 = fmaf(r21, r37, r82);
+    r82 = fmaf(r80, r84, r82);
+    r82 = fmaf(r24, r52, r82);
+    r82 = fmaf(r8, r85, r82);
+    r82 = fmaf(r7, r35, r82);
+    r18 = fmaf(r0, r82, r18);
+    r18 = 1.0 / r18;
+    r82 = r47 * r18;
+    r47 = fmaf(r47, r82, r21 * r34);
+    r34 = r40 * r40;
+    r35 = r1 * r1;
+    r85 = r75 * r75;
+    r52 = r5 * r5;
+    r80 = r44 * r44;
+    r47 = fmaf(r24, r34, r47);
+    r47 = fmaf(r10, r35, r47);
+    r47 = fmaf(r50, r67, r47);
+    r47 = fmaf(r22, r85, r47);
+    r47 = fmaf(r8, r52, r47);
+    r47 = fmaf(r17, r80, r47);
+    r19 = fmaf(r0, r47, r19);
+    r19 = 1.0 / r19;
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 8 * njtr_num_alloc, global_thread_idx, r47, r80, r52, r85);
+    r50 = r0 * r67;
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r35, r34, r37, r64);
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r39, r83, r46, r53);
+    r86 = r31 * r83;
+    r86 = r86 * r0;
+    r86 = fmaf(r7, r86, r37);
+    r46 = fmaf(r39, r15, r46);
+    r37 = r0 * r46;
+    r86 = fmaf(r63, r37, r86);
+    r87 = r69 * r39;
+    r86 = fmaf(r12, r87, r86);
+    r53 = fmaf(r83, r32, r53);
+    r88 = r0 * r53;
+    r86 = fmaf(r57, r88, r86);
+    r89 = r30 * r83;
+    r89 = r89 * r0;
+    r89 = fmaf(r7, r89, r34);
+    r34 = r0 * r27;
+    r34 = r34 * r46;
+    r89 = fmaf(r10, r34, r89);
+    r90 = r65 * r39;
+    r89 = fmaf(r12, r90, r89);
+    r91 = r0 * r4;
+    r91 = r91 * r53;
+    r89 = fmaf(r11, r91, r89);
+    r92 = r0 * r73;
+    r93 = r29 * r83;
+    r93 = r93 * r0;
+    r93 = fmaf(r7, r93, r35);
+    r35 = r9 * r39;
+    r93 = fmaf(r12, r35, r93);
+    r94 = r0 * r3;
+    r94 = r94 * r53;
+    r93 = fmaf(r11, r94, r93);
+    r95 = r0 * r26;
+    r95 = r95 * r46;
+    r93 = fmaf(r10, r95, r93);
+    r92 = r92 * r93;
+    r89 = fmaf(r21, r92, r89);
+    r92 = r0 * r89;
+    r86 = fmaf(r76, r92, r86);
+    r91 = r0 * r93;
+    r86 = fmaf(r68, r91, r86);
+    r52 = fmaf(r86, r50, r52);
+    r91 = r5 * r39;
+    r52 = fmaf(r12, r91, r52);
+    r92 = r0 * r93;
+    r92 = r92 * r36;
+    r52 = fmaf(r21, r92, r52);
+    r88 = r0 * r89;
+    r88 = r88 * r75;
+    r52 = fmaf(r22, r88, r52);
+    r87 = r0 * r79;
+    r87 = r87 * r93;
+    r87 = fmaf(r21, r87, r47);
+    r47 = r0 * r33;
+    r47 = r47 * r86;
+    r87 = fmaf(r23, r47, r87);
+    r37 = r0 * r77;
+    r37 = r37 * r86;
+    r37 = fmaf(r23, r37, r64);
+    r64 = r58 * r83;
+    r64 = r64 * r0;
+    r37 = fmaf(r7, r64, r37);
+    r90 = r0 * r54;
+    r90 = r90 * r53;
+    r37 = fmaf(r11, r90, r37);
+    r34 = r0 * r41;
+    r34 = r34 * r46;
+    r37 = fmaf(r10, r34, r37);
+    r95 = r70 * r39;
+    r37 = fmaf(r12, r95, r37);
+    r94 = r0 * r74;
+    r94 = r94 * r93;
+    r37 = fmaf(r21, r94, r37);
+    r35 = r0 * r72;
+    r35 = r35 * r89;
+    r37 = fmaf(r22, r35, r37);
+    r35 = r0 * r37;
+    r87 = fmaf(r45, r35, r87);
+    r94 = r59 * r83;
+    r94 = r94 * r0;
+    r87 = fmaf(r7, r94, r87);
+    r95 = r0 * r62;
+    r95 = r95 * r89;
+    r87 = fmaf(r22, r95, r87);
+    r34 = r0 * r42;
+    r34 = r34 * r46;
+    r87 = fmaf(r10, r34, r87);
+    r90 = r71 * r39;
+    r87 = fmaf(r12, r90, r87);
+    r64 = r0 * r55;
+    r64 = r64 * r53;
+    r87 = fmaf(r11, r64, r87);
+    r64 = r0 * r87;
+    r64 = fmaf(r84, r64, r80);
+    r80 = r0 * r43;
+    r80 = r80 * r46;
+    r64 = fmaf(r10, r80, r64);
+    r90 = r60 * r83;
+    r90 = r90 * r0;
+    r64 = fmaf(r7, r90, r64);
+    r34 = r0 * r25;
+    r34 = r34 * r89;
+    r64 = fmaf(r22, r34, r64);
+    r95 = r0 * r49;
+    r95 = r95 * r86;
+    r64 = fmaf(r23, r95, r64);
+    r94 = r0 * r28;
+    r94 = r94 * r37;
+    r64 = fmaf(r24, r94, r64);
+    r35 = r0 * r81;
+    r35 = r35 * r93;
+    r64 = fmaf(r21, r35, r64);
+    r47 = r2 * r39;
+    r64 = fmaf(r12, r47, r64);
+    r96 = r0 * r56;
+    r96 = r96 * r53;
+    r64 = fmaf(r11, r96, r64);
+    r96 = r0 * r64;
+    r52 = fmaf(r82, r96, r52);
+    r47 = r0 * r87;
+    r47 = r47 * r44;
+    r52 = fmaf(r17, r47, r52);
+    r35 = r0 * r37;
+    r35 = r35 * r40;
+    r52 = fmaf(r24, r35, r52);
+    r94 = r0 * r46;
+    r94 = r94 * r1;
+    r52 = fmaf(r10, r94, r52);
+    r66 = fmaf(r6, r32, r66);
+    r94 = r3 * r66;
+    r35 = r29 * r6;
+    r35 = fmaf(r7, r35, r11 * r94);
+    r35 = fmaf(r0, r35, r61);
+    r61 = r35 * r36;
+    r94 = r79 * r35;
+    r47 = r73 * r35;
+    r96 = r30 * r6;
+    r96 = fmaf(r7, r96, r21 * r47);
+    r47 = r4 * r66;
+    r96 = fmaf(r11, r47, r96);
+    r96 = fmaf(r0, r96, r51);
+    r51 = r31 * r6;
+    r51 = fmaf(r7, r51, r96 * r76);
+    r51 = fmaf(r35, r68, r51);
+    r51 = fmaf(r66, r57, r51);
+    r51 = fmaf(r0, r51, r78);
+    r78 = r33 * r51;
+    r78 = fmaf(r23, r78, r21 * r94);
+    r94 = r77 * r51;
+    r47 = r74 * r35;
+    r47 = fmaf(r21, r47, r23 * r94);
+    r94 = r58 * r6;
+    r47 = fmaf(r7, r94, r47);
+    r88 = r72 * r96;
+    r47 = fmaf(r22, r88, r47);
+    r92 = r54 * r66;
+    r47 = fmaf(r11, r92, r47);
+    r47 = fmaf(r0, r47, r48);
+    r48 = r62 * r96;
+    r78 = fmaf(r22, r48, r78);
+    r92 = r59 * r6;
+    r78 = fmaf(r7, r92, r78);
+    r88 = r55 * r66;
+    r78 = fmaf(r11, r88, r78);
+    r78 = fmaf(r47, r45, r78);
+    r78 = fmaf(r0, r78, r38);
+    r38 = r78 * r44;
+    r38 = fmaf(r17, r38, r21 * r61);
+    r61 = r96 * r75;
+    r38 = fmaf(r22, r61, r38);
+    r88 = r47 * r40;
+    r38 = fmaf(r24, r88, r38);
+    ReadIdx2<1024, float, float, float2>(
+        precond_tril, 64 * precond_tril_num_alloc, global_thread_idx, r92, r48);
+    r48 = r81 * r35;
+    r48 = fmaf(r21, r48, r78 * r84);
+    r94 = r28 * r47;
+    r48 = fmaf(r24, r94, r48);
+    r91 = r25 * r96;
+    r48 = fmaf(r22, r91, r48);
+    r95 = r49 * r51;
+    r48 = fmaf(r23, r95, r48);
+    r34 = r60 * r6;
+    r48 = fmaf(r7, r34, r48);
+    r90 = r56 * r66;
+    r48 = fmaf(r11, r90, r48);
+    r48 = fmaf(r0, r48, r92);
+    r38 = fmaf(r51, r67, r38);
+    r38 = fmaf(r48, r82, r38);
+    r88 = r38 * r19;
+    r13 = fmaf(r20, r13, r14);
+    r20 = r66 * r66;
+    r14 = r48 * r48;
+    r14 = fmaf(r18, r14, r11 * r20);
+    r20 = r51 * r51;
+    r67 = r96 * r96;
+    r61 = r78 * r78;
+    r92 = r35 * r35;
+    r90 = r6 * r6;
+    r34 = r47 * r47;
+    r14 = fmaf(r23, r20, r14);
+    r14 = fmaf(r22, r67, r14);
+    r14 = fmaf(r17, r61, r14);
+    r14 = fmaf(r21, r92, r14);
+    r14 = fmaf(r38, r88, r14);
+    r14 = fmaf(r7, r90, r14);
+    r14 = fmaf(r24, r34, r14);
+    r13 = fmaf(r0, r14, r13);
+    r13 = 1.0 / r13;
+    r85 = fmaf(r52, r88, r85);
+    r14 = r6 * r83;
+    r14 = r14 * r0;
+    r85 = fmaf(r7, r14, r85);
+    r34 = r0 * r93;
+    r34 = r34 * r35;
+    r85 = fmaf(r21, r34, r85);
+    r90 = r0 * r53;
+    r90 = r90 * r66;
+    r85 = fmaf(r11, r90, r85);
+    r38 = r0 * r64;
+    r38 = r38 * r48;
+    r85 = fmaf(r18, r38, r85);
+    r92 = r0 * r87;
+    r92 = r92 * r78;
+    r85 = fmaf(r17, r92, r85);
+    r61 = r0 * r86;
+    r61 = r61 * r51;
+    r85 = fmaf(r23, r61, r85);
+    r67 = r0 * r89;
+    r67 = r67 * r96;
+    r85 = fmaf(r22, r67, r85);
+    r20 = r0 * r37;
+    r20 = r20 * r47;
+    r85 = fmaf(r24, r20, r85);
+    r85 = r13 * r85;
+    r88 = fmaf(r85, r88, r52 * r19);
+    r16 = r16 * r88;
+    r19 = r0 * r41;
+    r52 = r0 * r44;
+    r52 = r52 * r88;
+    r13 = r48 * r18;
+    r20 = r0 * r85;
+    r13 = fmaf(r20, r13, r64 * r18);
+    r67 = r0 * r88;
+    r13 = fmaf(r82, r67, r13);
+    r67 = r0 * r13;
+    r67 = fmaf(r84, r67, r17 * r52);
+    r52 = r78 * r17;
+    r67 = fmaf(r20, r52, r67);
+    r67 = fmaf(r87, r17, r67);
+    r52 = r0 * r67;
+    r52 = fmaf(r45, r52, r37 * r24);
+    r45 = r0 * r40;
+    r45 = r45 * r88;
+    r52 = fmaf(r24, r45, r52);
+    r84 = r47 * r24;
+    r52 = fmaf(r20, r84, r52);
+    r82 = r0 * r28;
+    r82 = r82 * r13;
+    r52 = fmaf(r24, r82, r52);
+    r19 = r19 * r52;
+    r19 = fmaf(r10, r19, r10 * r16);
+    r16 = r0 * r77;
+    r16 = r16 * r52;
+    r16 = fmaf(r23, r16, r88 * r50);
+    r50 = r0 * r33;
+    r50 = r50 * r67;
+    r16 = fmaf(r23, r50, r16);
+    r82 = r0 * r49;
+    r82 = r82 * r13;
+    r16 = fmaf(r23, r82, r16);
+    r84 = r51 * r23;
+    r16 = fmaf(r20, r84, r16);
+    r16 = fmaf(r86, r23, r16);
+    r84 = r0 * r16;
+    r19 = fmaf(r63, r84, r19);
+    r63 = r0 * r42;
+    r63 = r63 * r67;
+    r19 = fmaf(r10, r63, r19);
+    r82 = r0 * r27;
+    r50 = r0 * r16;
+    r45 = r0 * r62;
+    r45 = r45 * r67;
+    r45 = fmaf(r22, r45, r76 * r50);
+    r50 = r0 * r25;
+    r50 = r50 * r13;
+    r45 = fmaf(r22, r50, r45);
+    r76 = r0 * r72;
+    r76 = r76 * r52;
+    r45 = fmaf(r22, r76, r45);
+    r61 = r0 * r75;
+    r61 = r61 * r88;
+    r45 = fmaf(r22, r61, r45);
+    r92 = r96 * r22;
+    r45 = fmaf(r20, r92, r45);
+    r45 = fmaf(r89, r22, r45);
+    r82 = r82 * r45;
+    r19 = fmaf(r10, r82, r19);
+    r92 = r0 * r43;
+    r92 = r92 * r13;
+    r19 = fmaf(r10, r92, r19);
+    r61 = r0 * r26;
+    r76 = r0 * r74;
+    r76 = r76 * r52;
+    r50 = r0 * r36;
+    r50 = r50 * r88;
+    r50 = fmaf(r21, r50, r21 * r76);
+    r76 = r35 * r21;
+    r50 = fmaf(r20, r76, r50);
+    r38 = r0 * r16;
+    r50 = fmaf(r68, r38, r50);
+    r68 = r0 * r81;
+    r68 = r68 * r13;
+    r50 = fmaf(r21, r68, r50);
+    r90 = r0 * r79;
+    r90 = r90 * r67;
+    r50 = fmaf(r21, r90, r50);
+    r34 = r0 * r73;
+    r34 = r34 * r45;
+    r50 = fmaf(r21, r34, r50);
+    r50 = fmaf(r93, r21, r50);
+    r61 = r61 * r50;
+    r19 = fmaf(r10, r61, r19);
+    r19 = fmaf(r46, r10, r19);
+    r61 = r2 * r13;
+    r8 = fmaf(r39, r8, r12 * r61);
+    r61 = r65 * r45;
+    r8 = fmaf(r12, r61, r8);
+    r92 = r9 * r50;
+    r8 = fmaf(r12, r92, r8);
+    r82 = r71 * r67;
+    r8 = fmaf(r12, r82, r8);
+    r63 = r5 * r88;
+    r8 = fmaf(r12, r63, r8);
+    r10 = r70 * r52;
+    r8 = fmaf(r12, r10, r8);
+    r84 = r69 * r16;
+    r8 = fmaf(r12, r84, r8);
+    r8 = fmaf(r19, r15, r8);
+    r84 = r0 * r4;
+    r84 = r84 * r45;
+    r84 = fmaf(r11, r84, r53 * r11);
+    r10 = r66 * r11;
+    r84 = fmaf(r20, r10, r84);
+    r63 = r0 * r3;
+    r63 = r63 * r50;
+    r84 = fmaf(r11, r63, r84);
+    r82 = r0 * r54;
+    r82 = r82 * r52;
+    r84 = fmaf(r11, r82, r84);
+    r92 = r0 * r16;
+    r84 = fmaf(r57, r92, r84);
+    r57 = r0 * r56;
+    r57 = r57 * r13;
+    r84 = fmaf(r11, r57, r84);
+    r15 = r0 * r55;
+    r15 = r15 * r67;
+    r84 = fmaf(r11, r15, r84);
+    r15 = r6 * r7;
+    r15 = fmaf(r20, r15, r83 * r7);
+    r20 = r59 * r0;
+    r20 = r20 * r67;
+    r15 = fmaf(r7, r20, r15);
+    r57 = r31 * r0;
+    r57 = r57 * r16;
+    r15 = fmaf(r7, r57, r15);
+    r92 = r29 * r0;
+    r92 = r92 * r50;
+    r15 = fmaf(r7, r92, r15);
+    r82 = r60 * r0;
+    r82 = r82 * r13;
+    r15 = fmaf(r7, r82, r15);
+    r63 = r58 * r0;
+    r63 = r63 * r52;
+    r15 = fmaf(r7, r63, r15);
+    r10 = r30 * r0;
+    r10 = r10 * r45;
+    r15 = fmaf(r7, r10, r15);
+    r15 = fmaf(r84, r32, r15);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          0 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r8,
+                                          r15,
+                                          r19,
+                                          r84);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          4 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r50,
+                                          r45,
+                                          r16,
+                                          r52);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          8 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r67,
+                                          r13,
+                                          r88,
+                                          r85);
+  };
+}
+
+void ThinPrismFisheyeCalibNormalize(float* precond_diag,
+                                    unsigned int precond_diag_num_alloc,
+                                    float* precond_tril,
+                                    unsigned int precond_tril_num_alloc,
+                                    float* njtr,
+                                    unsigned int njtr_num_alloc,
+                                    const float* const diag,
+                                    float* out_normalized,
+                                    unsigned int out_normalized_num_alloc,
+                                    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_normalize.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibNormalize(float* precond_diag,
+                                    unsigned int precond_diag_num_alloc,
+                                    float* precond_tril,
+                                    unsigned int precond_tril_num_alloc,
+                                    float* njtr,
+                                    unsigned int njtr_num_alloc,
+                                    const float* const diag,
+                                    float* out_normalized,
+                                    unsigned int out_normalized_num_alloc,
+                                    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.cu
@@ -1,0 +1,186 @@
+#include "kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibPredDecreaseTimesTwoKernel(
+        float* ThinPrismFisheyeCalib_step,
+        unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+        float* ThinPrismFisheyeCalib_precond_diag,
+        unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyeCalib_njtr,
+        unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+        float* const out_ThinPrismFisheyeCalib_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeCalib_pred_dec_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step,
+        8 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_njtr,
+        8 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r8,
+        r9,
+        r10,
+        r11);
+    r12 = r3 * r11;
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r13);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r12 = fmaf(r13, r12, r7);
+    r7 = r2 * r10;
+    r7 = fmaf(r13, r7, r6);
+    r7 = fmaf(r2, r7, r3 * r12);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step,
+        4 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r12,
+        r6,
+        r14,
+        r15);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_njtr,
+        4 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r16,
+        r17,
+        r18,
+        r19);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r20,
+        r21,
+        r22,
+        r23);
+    r24 = r15 * r23;
+    r24 = fmaf(r13, r24, r19);
+    r19 = r0 * r8;
+    r19 = fmaf(r13, r19, r4);
+    r4 = r1 * r9;
+    r4 = fmaf(r13, r4, r5);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step,
+        0 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r5,
+        r25,
+        r26,
+        r27);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_njtr,
+        0 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r28,
+        r29,
+        r30,
+        r31);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r32,
+        r33,
+        r34,
+        r35);
+    r36 = r27 * r35;
+    r36 = fmaf(r13, r36, r31);
+    r31 = r12 * r20;
+    r31 = fmaf(r13, r31, r16);
+    r16 = r6 * r21;
+    r16 = fmaf(r13, r16, r17);
+    r17 = r26 * r34;
+    r17 = fmaf(r13, r17, r30);
+    r30 = r25 * r33;
+    r30 = fmaf(r13, r30, r29);
+    r29 = r14 * r22;
+    r29 = fmaf(r13, r29, r18);
+    r18 = r5 * r32;
+    r18 = fmaf(r13, r18, r28);
+    r7 = fmaf(r15, r24, r7);
+    r7 = fmaf(r0, r19, r7);
+    r7 = fmaf(r1, r4, r7);
+    r7 = fmaf(r27, r36, r7);
+    r7 = fmaf(r12, r31, r7);
+    r7 = fmaf(r6, r16, r7);
+    r7 = fmaf(r26, r17, r7);
+    r7 = fmaf(r25, r30, r7);
+    r7 = fmaf(r14, r29, r7);
+    r7 = fmaf(r5, r18, r7);
+  };
+  SumStore<float>(out_ThinPrismFisheyeCalib_pred_dec_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r7);
+  SumFlushFinal<float>(out_ThinPrismFisheyeCalib_pred_dec_local,
+                       out_ThinPrismFisheyeCalib_pred_dec,
+                       1);
+}
+
+void ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+    float* ThinPrismFisheyeCalib_step,
+    unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_njtr,
+    unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_step,
+      ThinPrismFisheyeCalib_step_num_alloc,
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_njtr,
+      ThinPrismFisheyeCalib_njtr_num_alloc,
+      out_ThinPrismFisheyeCalib_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+    float* ThinPrismFisheyeCalib_step,
+    unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_njtr,
+    unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_retract.cu
@@ -1,0 +1,115 @@
+#include "kernel_ThinPrismFisheyeCalib_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibRetractKernel(
+    float* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  float r0, r1, r2, r3, r4, r5, r6, r7;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib,
+                                         0 * ThinPrismFisheyeCalib_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r4, r5, r6, r7);
+    r4 = r0 + r4;
+    r5 = r1 + r5;
+    r6 = r2 + r6;
+    r7 = r3 + r7;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_retracted,
+        0 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib,
+                                         4 * ThinPrismFisheyeCalib_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r6,
+                                         r5,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r3, r2, r1, r0);
+    r3 = r7 + r3;
+    r2 = r6 + r2;
+    r1 = r5 + r1;
+    r0 = r4 + r0;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_retracted,
+        4 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib,
+                                         8 * ThinPrismFisheyeCalib_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 8 * delta_num_alloc, global_thread_idx, r4, r5, r6, r7);
+    r4 = r0 + r4;
+    r5 = r1 + r5;
+    r6 = r2 + r6;
+    r7 = r3 + r7;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_retracted,
+        8 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+}
+
+void ThinPrismFisheyeCalibRetract(
+    float* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib,
+      ThinPrismFisheyeCalib_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyeCalib_retracted,
+      out_ThinPrismFisheyeCalib_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibRetract(
+    float* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w.cu
@@ -1,0 +1,156 @@
+#include "kernel_ThinPrismFisheyeCalib_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibStartWKernel(
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         0 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         4 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r7,
+                                         r6,
+                                         r5);
+    r3 = r3 * r8;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r0 = r0 * r4;
+    r0 = r0 * r5;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         8 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r4 = r3 * r4;
+    r4 = r4 * r8;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibStartW(
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_p,
+      ThinPrismFisheyeCalib_p_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibStartW(
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w_contribute.cu
@@ -1,0 +1,157 @@
+#include "kernel_ThinPrismFisheyeCalib_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibStartWContributeKernel(
+        float* ThinPrismFisheyeCalib_precond_diag,
+        unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyeCalib_p,
+        unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+        float* out_ThinPrismFisheyeCalib_w,
+        unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         0 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         4 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r7,
+                                         r6,
+                                         r5);
+    r3 = r3 * r8;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r0 = r0 * r4;
+    r0 = r0 * r5;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_p,
+                                         8 * ThinPrismFisheyeCalib_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r4 = r3 * r4;
+    r4 = r4 * r8;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibStartWContribute(
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_p,
+      ThinPrismFisheyeCalib_p_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibStartWContribute(
+    float* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_Mp.cu
@@ -1,0 +1,175 @@
+#include "kernel_ThinPrismFisheyeCalib_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdateMpKernel(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_Mp,
+                                         0 * ThinPrismFisheyeCalib_Mp_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        0 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_Mp,
+                                         4 * ThinPrismFisheyeCalib_Mp_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r6,
+                                         r5,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    r7 = fmaf(r7, r8, r9);
+    r6 = fmaf(r6, r8, r10);
+    r5 = fmaf(r5, r8, r11);
+    r4 = fmaf(r4, r8, r12);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        4 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_Mp,
+                                         8 * ThinPrismFisheyeCalib_Mp_num_alloc,
+                                         global_thread_idx,
+                                         r12,
+                                         r11,
+                                         r10,
+                                         r9);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r16);
+    r12 = fmaf(r12, r8, r13);
+    r11 = fmaf(r11, r8, r14);
+    r10 = fmaf(r10, r8, r15);
+    r8 = fmaf(r9, r8, r16);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        8 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r12,
+        r11,
+        r10,
+        r8);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r12,
+        r11,
+        r10,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateMp(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_Mp,
+      ThinPrismFisheyeCalib_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyeCalib_Mp_kp1,
+      out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateMp(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_p.cu
@@ -1,0 +1,144 @@
+#include "kernel_ThinPrismFisheyeCalib_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdatePKernel(
+    float* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    float* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_k,
+        0 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_z,
+                                         0 * ThinPrismFisheyeCalib_z_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        0 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_k,
+        4 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_z,
+                                         4 * ThinPrismFisheyeCalib_z_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r6,
+                                         r5,
+                                         r4);
+    r3 = fmaf(r3, r8, r7);
+    r2 = fmaf(r2, r8, r6);
+    r1 = fmaf(r1, r8, r5);
+    r0 = fmaf(r0, r8, r4);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        4 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_k,
+        8 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_z,
+                                         8 * ThinPrismFisheyeCalib_z_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r8 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        8 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateP(
+    float* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    float* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_z,
+      ThinPrismFisheyeCalib_z_num_alloc,
+      ThinPrismFisheyeCalib_p_k,
+      ThinPrismFisheyeCalib_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyeCalib_p_kp1,
+      out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateP(
+    float* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    float* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r.cu
@@ -1,0 +1,169 @@
+#include "kernel_ThinPrismFisheyeCalib_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdateRKernel(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         0 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        0 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         4 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    r9 = fmaf(r9, r8, r3);
+    r10 = fmaf(r10, r8, r2);
+    r11 = fmaf(r11, r8, r1);
+    r12 = fmaf(r12, r8, r0);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        4 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         8 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r13,
+                                         r14,
+                                         r15,
+                                         r16);
+    r13 = fmaf(r13, r8, r0);
+    r14 = fmaf(r14, r8, r1);
+    r15 = fmaf(r15, r8, r2);
+    r8 = fmaf(r16, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        8 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r8);
+    r4 = fmaf(r4, r4, r14 * r14);
+    r4 = fmaf(r11, r11, r4);
+    r4 = fmaf(r10, r10, r4);
+    r4 = fmaf(r5, r5, r4);
+    r4 = fmaf(r13, r13, r4);
+    r4 = fmaf(r12, r12, r4);
+    r4 = fmaf(r7, r7, r4);
+    r4 = fmaf(r6, r6, r4);
+    r4 = fmaf(r9, r9, r4);
+    r4 = fmaf(r15, r15, r4);
+    r4 = fmaf(r8, r8, r4);
+  };
+  SumStore<float>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r4);
+  SumFlushFinal<float>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyeCalibUpdateR(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeCalib_r_kp1,
+      out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateR(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r_first.cu
@@ -1,0 +1,196 @@
+#include "kernel_ThinPrismFisheyeCalib_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateRFirstKernel(
+        float* ThinPrismFisheyeCalib_r_k,
+        unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+        float* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyeCalib_r_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+        float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeCalib_r_0_norm2_tot_local[1];
+
+  __shared__ float out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         0 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        0 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         4 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r13,
+                                         r14,
+                                         r15,
+                                         r16);
+    r13 = fmaf(r13, r8, r9);
+    r14 = fmaf(r14, r8, r10);
+    r15 = fmaf(r15, r8, r11);
+    r16 = fmaf(r16, r8, r12);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        4 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r16);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18,
+        r19,
+        r20);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyeCalib_w,
+                                         8 * ThinPrismFisheyeCalib_w_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r21 = fmaf(r21, r8, r17);
+    r22 = fmaf(r22, r8, r18);
+    r23 = fmaf(r23, r8, r19);
+    r8 = fmaf(r24, r8, r20);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        8 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r21,
+        r22,
+        r23,
+        r8);
+    r11 = fmaf(r11, r11, r12 * r12);
+    r11 = fmaf(r3, r3, r11);
+    r11 = fmaf(r2, r2, r11);
+    r11 = fmaf(r1, r1, r11);
+    r11 = fmaf(r0, r0, r11);
+    r11 = fmaf(r18, r18, r11);
+    r11 = fmaf(r17, r17, r11);
+    r11 = fmaf(r9, r9, r11);
+    r11 = fmaf(r10, r10, r11);
+    r11 = fmaf(r20, r20, r11);
+    r11 = fmaf(r19, r19, r11);
+  };
+  SumStore<float>(out_ThinPrismFisheyeCalib_r_0_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r11);
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r4, r22 * r22);
+    r4 = fmaf(r15, r15, r4);
+    r4 = fmaf(r14, r14, r4);
+    r4 = fmaf(r5, r5, r4);
+    r4 = fmaf(r21, r21, r4);
+    r4 = fmaf(r16, r16, r4);
+    r4 = fmaf(r7, r7, r4);
+    r4 = fmaf(r6, r6, r4);
+    r4 = fmaf(r13, r13, r4);
+    r4 = fmaf(r23, r23, r4);
+    r4 = fmaf(r8, r8, r4);
+  };
+  SumStore<float>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r4);
+  SumFlushFinal<float>(out_ThinPrismFisheyeCalib_r_0_norm2_tot_local,
+                       out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+                       1);
+  SumFlushFinal<float>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyeCalibUpdateRFirst(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeCalib_r_kp1,
+      out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+      out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateRFirst(
+    float* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    float* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step.cu
@@ -1,0 +1,148 @@
+#include "kernel_ThinPrismFisheyeCalib_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateStepKernel(
+        float* ThinPrismFisheyeCalib_step_k,
+        unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+        float* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyeCalib_step_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step_k,
+        0 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        0 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step_k,
+        4 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = fmaf(r3, r8, r7);
+    r2 = fmaf(r2, r8, r6);
+    r1 = fmaf(r1, r8, r5);
+    r0 = fmaf(r0, r8, r4);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        4 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_step_k,
+        8 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r8 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        8 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateStep(
+    float* ThinPrismFisheyeCalib_step_k,
+    unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_step_k,
+      ThinPrismFisheyeCalib_step_k_num_alloc,
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeCalib_step_kp1,
+      out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateStep(
+    float* ThinPrismFisheyeCalib_step_k,
+    unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step_first.cu
@@ -1,0 +1,118 @@
+#include "kernel_ThinPrismFisheyeCalib_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateStepFirstKernel(
+        float* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyeCalib_step_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    r1 = r1 * r4;
+    r2 = r2 * r4;
+    r3 = r3 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        0 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    r2 = r2 * r4;
+    r1 = r1 * r4;
+    r0 = r0 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        4 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    r0 = r0 * r4;
+    r1 = r1 * r4;
+    r2 = r2 * r4;
+    r4 = r3 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        8 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateStepFirst(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeCalib_step_kp1,
+      out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeCalib_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateStepFirst(
+    float* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,116 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumeratorKernel(
+        float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        float* const ThinPrismFisheyeFocalAndExtra_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyeFocalAndExtra_out_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r8,
+        r9,
+        r10,
+        r11);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r12,
+        r13,
+        r14,
+        r15);
+    r15 = fmaf(r11, r15, r0 * r4);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r4);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r16);
+    r15 = fmaf(r8, r12, r15);
+    r15 = fmaf(r2, r6, r15);
+    r15 = fmaf(r3, r7, r15);
+    r15 = fmaf(r11, r0, r15);
+    r15 = fmaf(r4, r16, r15);
+    r15 = fmaf(r9, r13, r15);
+    r15 = fmaf(r1, r5, r15);
+    r15 = fmaf(r10, r14, r15);
+  };
+  SumStore<float>(ThinPrismFisheyeFocalAndExtra_out_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r15);
+  SumFlushFinal<float>(ThinPrismFisheyeFocalAndExtra_out_local,
+                       ThinPrismFisheyeFocalAndExtra_out,
+                       1);
+}
+
+void ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    float* const ThinPrismFisheyeFocalAndExtra_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks,
+                                                                       1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    float* const ThinPrismFisheyeFocalAndExtra_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.cu
@@ -1,0 +1,168 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominatorKernel(
+        float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        float* const ThinPrismFisheyeFocalAndExtra_total_ag,
+        float* const ThinPrismFisheyeFocalAndExtra_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyeFocalAndExtra_total_ag_local[1];
+
+  __shared__ float ThinPrismFisheyeFocalAndExtra_total_ac_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r8,
+        r9,
+        r10,
+        r11);
+    r8 = fmaf(r4, r8, r1 * r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r12,
+        r13,
+        r14);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r15,
+        r16,
+        r17,
+        r18);
+    r8 = fmaf(r12, r16, r8);
+    r8 = fmaf(r13, r17, r8);
+    r8 = fmaf(r7, r11, r8);
+    r8 = fmaf(r5, r9, r8);
+    r8 = fmaf(r0, r2, r8);
+    r8 = fmaf(r6, r10, r8);
+    r8 = fmaf(r14, r18, r8);
+    r8 = fmaf(r3, r15, r8);
+  };
+  SumStore<float>(ThinPrismFisheyeFocalAndExtra_total_ag_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r8);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r8,
+        r15,
+        r18,
+        r10);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r9,
+        r11,
+        r17);
+    r17 = fmaf(r7, r17, r3 * r8);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r17 = fmaf(r4, r2, r17);
+    r17 = fmaf(r13, r18, r17);
+    r17 = fmaf(r14, r10, r17);
+    r17 = fmaf(r0, r7, r17);
+    r17 = fmaf(r1, r8, r17);
+    r17 = fmaf(r5, r9, r17);
+    r17 = fmaf(r12, r15, r17);
+    r17 = fmaf(r6, r11, r17);
+  };
+  SumStore<float>(ThinPrismFisheyeFocalAndExtra_total_ac_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r17);
+  SumFlushFinal<float>(ThinPrismFisheyeFocalAndExtra_total_ag_local,
+                       ThinPrismFisheyeFocalAndExtra_total_ag,
+                       1);
+  SumFlushFinal<float>(ThinPrismFisheyeFocalAndExtra_total_ac_local,
+                       ThinPrismFisheyeFocalAndExtra_total_ac,
+                       1);
+}
+
+void ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    float* const ThinPrismFisheyeFocalAndExtra_total_ag,
+    float* const ThinPrismFisheyeFocalAndExtra_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominatorKernel<<<n_blocks,
+                                                                 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_total_ag,
+      ThinPrismFisheyeFocalAndExtra_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    float* const ThinPrismFisheyeFocalAndExtra_total_ag,
+    float* const ThinPrismFisheyeFocalAndExtra_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_normalize.cu
@@ -1,0 +1,680 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraNormalizeKernel(
+        float* precond_diag,
+        unsigned int precond_diag_num_alloc,
+        float* precond_tril,
+        unsigned int precond_tril_num_alloc,
+        float* njtr,
+        unsigned int njtr_num_alloc,
+        const float* const diag,
+        float* out_normalized,
+        unsigned int out_normalized_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75;
+
+  if (global_thread_idx < problem_size) {
+    r0 = -1.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         32 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r2,
+                                         r3,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         24 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         0 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         0 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r13,
+                                         r14,
+                                         r15);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = 1.00000000000000000e+00;
+    r17 = r16 + r17;
+    r18 = 9.99999999999999955e-07;
+    r18 = r16 * r18;
+    r9 = fmaf(r9, r17, r18);
+    r9 = 1.0 / r9;
+    r16 = r11 * r9;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         8 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r19 = r21 * r22;
+    r13 = fmaf(r13, r17, r18);
+    r13 = 1.0 / r13;
+    r19 = fmaf(r13, r19, r12 * r16);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         16 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r23,
+                                         r24,
+                                         r25,
+                                         r26);
+    r27 = r20 * r22;
+    r28 = r10 * r12;
+    r28 = fmaf(r9, r28, r13 * r27);
+    r28 = fmaf(r0, r28, r25);
+    r25 = r20 * r21;
+    r25 = fmaf(r10, r16, r13 * r25);
+    r25 = fmaf(r0, r25, r24);
+    r24 = r20 * r20;
+    r27 = r10 * r10;
+    r27 = fmaf(r9, r27, r13 * r24);
+    r27 = fmaf(r0, r27, r18);
+    r27 = fmaf(r14, r17, r27);
+    r27 = 1.0 / r27;
+    r14 = r25 * r27;
+    r19 = fmaf(r28, r14, r19);
+    r19 = fmaf(r0, r19, r5);
+    r15 = fmaf(r15, r17, r18);
+    r11 = fmaf(r11, r16, r25 * r14);
+    r25 = r21 * r21;
+    r11 = fmaf(r13, r25, r11);
+    r15 = fmaf(r0, r11, r15);
+    r15 = 1.0 / r15;
+    r11 = r19 * r15;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         28 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r25,
+                                         r5,
+                                         r24,
+                                         r29);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         20 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r30,
+                                         r31,
+                                         r32,
+                                         r33);
+    r34 = r20 * r23;
+    r35 = r0 * r13;
+    r34 = fmaf(r35, r34, r33);
+    r33 = r21 * r23;
+    r33 = fmaf(r13, r33, r34 * r14);
+    r33 = fmaf(r0, r33, r5);
+    r5 = r28 * r34;
+    r5 = fmaf(r27, r5, r33 * r11);
+    r36 = r22 * r23;
+    r5 = fmaf(r13, r36, r5);
+    r5 = fmaf(r0, r5, r3);
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         4 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r3,
+                                         r36,
+                                         r37,
+                                         r38);
+    r3 = fmaf(r3, r17, r18);
+    r39 = r28 * r28;
+    r39 = fmaf(r27, r39, r19 * r11);
+    r19 = r12 * r12;
+    r40 = r22 * r22;
+    r39 = fmaf(r9, r19, r39);
+    r39 = fmaf(r13, r40, r39);
+    r3 = fmaf(r0, r39, r3);
+    r3 = 1.0 / r3;
+    r39 = r5 * r3;
+    ReadIdx2<1024, float, float, float2>(
+        precond_diag, 8 * precond_diag_num_alloc, global_thread_idx, r40, r19);
+    r19 = fmaf(r19, r17, r18);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         4 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r41,
+                                         r42,
+                                         r43,
+                                         r44);
+    r45 = r10 * r44;
+    r45 = r45 * r0;
+    r45 = fmaf(r9, r45, r32);
+    r32 = r45 * r34;
+    r46 = fmaf(r45, r14, r44 * r16);
+    r46 = fmaf(r0, r46, r25);
+    r25 = r46 * r33;
+    r25 = fmaf(r15, r25, r27 * r32);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         40 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r32,
+                                         r47,
+                                         r48,
+                                         r49);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         36 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r50,
+                                         r51,
+                                         r52,
+                                         r53);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         12 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r54,
+                                         r55,
+                                         r56,
+                                         r57);
+    r57 = r20 * r54;
+    r58 = r10 * r41;
+    r58 = fmaf(r9, r58, r13 * r57);
+    r58 = fmaf(r0, r58, r26);
+    r26 = r58 * r28;
+    r57 = fmaf(r58, r14, r41 * r16);
+    r59 = r21 * r54;
+    r57 = fmaf(r13, r59, r57);
+    r57 = fmaf(r0, r57, r6);
+    r26 = fmaf(r57, r11, r27 * r26);
+    r6 = r12 * r41;
+    r26 = fmaf(r9, r6, r26);
+    r59 = r22 * r54;
+    r26 = fmaf(r13, r59, r26);
+    r26 = fmaf(r0, r26, r24);
+    r24 = r45 * r28;
+    r24 = fmaf(r46, r11, r27 * r24);
+    r59 = r12 * r44;
+    r24 = fmaf(r9, r59, r24);
+    r24 = fmaf(r0, r24, r2);
+    r2 = r26 * r24;
+    r59 = r45 * r58;
+    r59 = fmaf(r27, r59, r3 * r2);
+    r2 = r46 * r57;
+    r59 = fmaf(r15, r2, r59);
+    r6 = r41 * r44;
+    r59 = fmaf(r9, r6, r59);
+    r59 = fmaf(r0, r59, r51);
+    r51 = r20 * r55;
+    r6 = r10 * r42;
+    r6 = fmaf(r9, r6, r13 * r51);
+    r6 = fmaf(r0, r6, r30);
+    r30 = fmaf(r42, r16, r6 * r14);
+    r51 = r21 * r55;
+    r30 = fmaf(r13, r51, r30);
+    r30 = fmaf(r0, r30, r7);
+    r7 = r12 * r42;
+    r7 = fmaf(r9, r7, r30 * r11);
+    r51 = r22 * r55;
+    r7 = fmaf(r13, r51, r7);
+    r2 = r28 * r6;
+    r7 = fmaf(r27, r2, r7);
+    r7 = fmaf(r0, r7, r29);
+    r29 = r26 * r7;
+    r2 = r41 * r42;
+    r2 = fmaf(r9, r2, r3 * r29);
+    r29 = r57 * r30;
+    r2 = fmaf(r15, r29, r2);
+    r51 = r54 * r55;
+    r2 = fmaf(r13, r51, r2);
+    r60 = r58 * r6;
+    r2 = fmaf(r27, r60, r2);
+    r2 = fmaf(r0, r2, r4);
+    r4 = r59 * r2;
+    r36 = fmaf(r36, r17, r18);
+    r60 = r57 * r57;
+    r51 = r26 * r26;
+    r51 = fmaf(r3, r51, r15 * r60);
+    r60 = r58 * r58;
+    r29 = r41 * r41;
+    r61 = r54 * r54;
+    r51 = fmaf(r27, r60, r51);
+    r51 = fmaf(r9, r29, r51);
+    r51 = fmaf(r13, r61, r51);
+    r36 = fmaf(r0, r51, r36);
+    r36 = 1.0 / r36;
+    r51 = r45 * r6;
+    r51 = fmaf(r27, r51, r36 * r4);
+    r4 = r42 * r44;
+    r51 = fmaf(r9, r4, r51);
+    r61 = r24 * r7;
+    r51 = fmaf(r3, r61, r51);
+    r29 = r46 * r30;
+    r51 = fmaf(r15, r29, r51);
+    r51 = fmaf(r0, r51, r32);
+    r32 = r7 * r5;
+    r29 = r30 * r33;
+    r29 = fmaf(r15, r29, r3 * r32);
+    r32 = r6 * r34;
+    r29 = fmaf(r27, r32, r29);
+    r61 = r26 * r5;
+    r4 = r57 * r33;
+    r4 = fmaf(r15, r4, r3 * r61);
+    r61 = r54 * r23;
+    r4 = fmaf(r13, r61, r4);
+    r60 = r58 * r34;
+    r4 = fmaf(r27, r60, r4);
+    r4 = fmaf(r0, r4, r52);
+    r52 = r2 * r4;
+    r29 = fmaf(r36, r52, r29);
+    r60 = r55 * r23;
+    r29 = fmaf(r13, r60, r29);
+    r29 = fmaf(r0, r29, r47);
+    r47 = r51 * r29;
+    r37 = fmaf(r37, r17, r18);
+    r60 = r30 * r30;
+    r52 = r2 * r2;
+    r52 = fmaf(r36, r52, r15 * r60);
+    r60 = r42 * r42;
+    r32 = r6 * r6;
+    r61 = r55 * r55;
+    r62 = r7 * r7;
+    r52 = fmaf(r9, r60, r52);
+    r52 = fmaf(r27, r32, r52);
+    r52 = fmaf(r13, r61, r52);
+    r52 = fmaf(r3, r62, r52);
+    r37 = fmaf(r0, r52, r37);
+    r37 = 1.0 / r37;
+    r25 = fmaf(r37, r47, r25);
+    r52 = r20 * r56;
+    r62 = r10 * r43;
+    r62 = fmaf(r9, r62, r13 * r52);
+    r62 = fmaf(r0, r62, r31);
+    r31 = r45 * r62;
+    r52 = fmaf(r43, r16, r62 * r14);
+    r61 = r21 * r56;
+    r52 = fmaf(r13, r61, r52);
+    r52 = fmaf(r0, r52, r8);
+    r8 = r12 * r43;
+    r8 = fmaf(r9, r8, r52 * r11);
+    r61 = r22 * r56;
+    r8 = fmaf(r13, r61, r8);
+    r32 = r28 * r62;
+    r8 = fmaf(r27, r32, r8);
+    r8 = fmaf(r0, r8, r1);
+    r1 = r8 * r3;
+    r31 = fmaf(r24, r1, r27 * r31);
+    r32 = r30 * r52;
+    r61 = r41 * r43;
+    r61 = fmaf(r9, r61, r26 * r1);
+    r60 = r54 * r56;
+    r61 = fmaf(r13, r60, r61);
+    r63 = r57 * r52;
+    r61 = fmaf(r15, r63, r61);
+    r64 = r58 * r62;
+    r61 = fmaf(r27, r64, r61);
+    r61 = fmaf(r0, r61, r50);
+    r50 = r61 * r36;
+    r32 = fmaf(r2, r50, r15 * r32);
+    r64 = r6 * r62;
+    r32 = fmaf(r27, r64, r32);
+    r63 = r42 * r43;
+    r32 = fmaf(r9, r63, r32);
+    r60 = r55 * r56;
+    r32 = fmaf(r13, r60, r32);
+    r32 = fmaf(r7, r1, r32);
+    r32 = fmaf(r0, r32, r53);
+    r53 = r32 * r37;
+    r60 = r43 * r44;
+    r31 = fmaf(r9, r60, r31);
+    r63 = r46 * r52;
+    r31 = fmaf(r15, r63, r31);
+    r31 = fmaf(r51, r53, r31);
+    r31 = fmaf(r59, r50, r31);
+    r31 = fmaf(r0, r31, r48);
+    r48 = r52 * r33;
+    r48 = fmaf(r5, r1, r15 * r48);
+    r63 = r62 * r34;
+    r48 = fmaf(r27, r63, r48);
+    r60 = r56 * r23;
+    r48 = fmaf(r13, r60, r48);
+    r48 = fmaf(r4, r50, r48);
+    r48 = fmaf(r29, r53, r48);
+    r48 = fmaf(r0, r48, r49);
+    r38 = fmaf(r38, r17, r18);
+    r8 = fmaf(r8, r1, r32 * r53);
+    r32 = r43 * r43;
+    r49 = r52 * r52;
+    r60 = r62 * r62;
+    r63 = r56 * r56;
+    r8 = fmaf(r61, r50, r8);
+    r8 = fmaf(r9, r32, r8);
+    r8 = fmaf(r15, r49, r8);
+    r8 = fmaf(r27, r60, r8);
+    r8 = fmaf(r13, r63, r8);
+    r38 = fmaf(r0, r8, r38);
+    r38 = 1.0 / r38;
+    r8 = r48 * r38;
+    r63 = r59 * r4;
+    r25 = fmaf(r36, r63, r25);
+    r60 = r24 * r5;
+    r25 = fmaf(r3, r60, r25);
+    r25 = fmaf(r31, r8, r25);
+    r17 = fmaf(r40, r17, r18);
+    r40 = r46 * r46;
+    r18 = r59 * r59;
+    r18 = fmaf(r36, r18, r15 * r40);
+    r40 = r24 * r24;
+    r60 = r45 * r45;
+    r63 = r51 * r51;
+    r47 = r31 * r31;
+    r49 = r44 * r44;
+    r18 = fmaf(r3, r40, r18);
+    r18 = fmaf(r27, r60, r18);
+    r18 = fmaf(r37, r63, r18);
+    r18 = fmaf(r38, r47, r18);
+    r18 = fmaf(r9, r49, r18);
+    r17 = fmaf(r0, r18, r17);
+    r17 = 1.0 / r17;
+    r18 = r25 * r17;
+    r48 = fmaf(r48, r8, r25 * r18);
+    r25 = r4 * r4;
+    r49 = r29 * r29;
+    r47 = r34 * r34;
+    r63 = r33 * r33;
+    r60 = r23 * r23;
+    r40 = r5 * r5;
+    r48 = fmaf(r36, r25, r48);
+    r48 = fmaf(r37, r49, r48);
+    r48 = fmaf(r27, r47, r48);
+    r48 = fmaf(r15, r63, r48);
+    r48 = fmaf(r13, r60, r48);
+    r48 = fmaf(r3, r40, r48);
+    r19 = fmaf(r0, r48, r19);
+    r19 = 1.0 / r19;
+    ReadIdx2<1024, float, float, float2>(
+        njtr, 8 * njtr_num_alloc, global_thread_idx, r48, r40);
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r60, r63, r47, r49);
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r25, r32, r61, r64);
+    r65 = r32 * r35;
+    r49 = fmaf(r56, r65, r49);
+    r66 = r43 * r25;
+    r66 = r66 * r0;
+    r49 = fmaf(r9, r66, r49);
+    r67 = r0 * r52;
+    r64 = fmaf(r21, r65, r64);
+    r68 = r25 * r0;
+    r64 = fmaf(r16, r68, r64);
+    r69 = r10 * r25;
+    r69 = r69 * r0;
+    r69 = fmaf(r9, r69, r61);
+    r69 = fmaf(r20, r65, r69);
+    r61 = r0 * r69;
+    r64 = fmaf(r14, r61, r64);
+    r67 = r67 * r64;
+    r49 = fmaf(r15, r67, r49);
+    r53 = r0 * r53;
+    r47 = fmaf(r55, r65, r47);
+    r61 = r42 * r25;
+    r61 = r61 * r0;
+    r47 = fmaf(r9, r61, r47);
+    r68 = r0 * r2;
+    r70 = r0 * r58;
+    r70 = r70 * r69;
+    r70 = fmaf(r27, r70, r63);
+    r63 = r0 * r57;
+    r63 = r63 * r64;
+    r70 = fmaf(r15, r63, r70);
+    r71 = r41 * r25;
+    r71 = r71 * r0;
+    r70 = fmaf(r9, r71, r70);
+    r72 = r0 * r26;
+    r60 = fmaf(r22, r65, r60);
+    r73 = r0 * r28;
+    r73 = r73 * r69;
+    r60 = fmaf(r27, r73, r60);
+    r74 = r12 * r25;
+    r74 = r74 * r0;
+    r60 = fmaf(r9, r74, r60);
+    r75 = r0 * r64;
+    r60 = fmaf(r11, r75, r60);
+    r72 = r72 * r60;
+    r70 = fmaf(r3, r72, r70);
+    r70 = fmaf(r54, r65, r70);
+    r68 = r68 * r70;
+    r47 = fmaf(r36, r68, r47);
+    r72 = r0 * r6;
+    r72 = r72 * r69;
+    r47 = fmaf(r27, r72, r47);
+    r71 = r0 * r7;
+    r71 = r71 * r60;
+    r47 = fmaf(r3, r71, r47);
+    r63 = r0 * r30;
+    r63 = r63 * r64;
+    r47 = fmaf(r15, r63, r47);
+    r63 = r0 * r62;
+    r63 = r63 * r69;
+    r49 = fmaf(r27, r63, r49);
+    r71 = r0 * r60;
+    r49 = fmaf(r1, r71, r49);
+    r72 = r0 * r70;
+    r49 = fmaf(r50, r72, r49);
+    r49 = fmaf(r47, r53, r49);
+    r72 = r0 * r49;
+    r72 = fmaf(r8, r72, r40);
+    r40 = r0 * r33;
+    r40 = r40 * r64;
+    r72 = fmaf(r15, r40, r72);
+    r71 = r0 * r46;
+    r71 = r71 * r64;
+    r71 = fmaf(r15, r71, r48);
+    r48 = r0 * r45;
+    r48 = r48 * r69;
+    r71 = fmaf(r27, r48, r71);
+    r63 = r44 * r25;
+    r63 = r63 * r0;
+    r71 = fmaf(r9, r63, r71);
+    r67 = r0 * r24;
+    r67 = r67 * r60;
+    r71 = fmaf(r3, r67, r71);
+    r66 = r0 * r31;
+    r66 = r66 * r49;
+    r71 = fmaf(r38, r66, r71);
+    r68 = r0 * r59;
+    r68 = r68 * r70;
+    r71 = fmaf(r36, r68, r71);
+    r61 = r0 * r51;
+    r61 = r61 * r47;
+    r71 = fmaf(r37, r61, r71);
+    r61 = r0 * r5;
+    r61 = r61 * r60;
+    r72 = fmaf(r3, r61, r72);
+    r68 = r0 * r4;
+    r68 = r68 * r70;
+    r72 = fmaf(r36, r68, r72);
+    r66 = r0 * r29;
+    r66 = r66 * r47;
+    r72 = fmaf(r37, r66, r72);
+    r67 = r0 * r34;
+    r67 = r67 * r69;
+    r72 = fmaf(r27, r67, r72);
+    r72 = fmaf(r23, r65, r72);
+    r72 = fmaf(r71, r18, r72);
+    r72 = r19 * r72;
+    r19 = r0 * r72;
+    r67 = r0 * r24;
+    r17 = fmaf(r71, r17, r72 * r18);
+    r67 = r67 * r17;
+    r67 = fmaf(r3, r67, r19 * r39);
+    r39 = r0 * r7;
+    r8 = fmaf(r49, r38, r19 * r8);
+    r71 = r0 * r31;
+    r71 = r71 * r17;
+    r8 = fmaf(r38, r71, r8);
+    r47 = fmaf(r47, r37, r8 * r53);
+    r53 = r0 * r51;
+    r53 = r53 * r17;
+    r47 = fmaf(r37, r53, r47);
+    r71 = r29 * r37;
+    r47 = fmaf(r19, r71, r47);
+    r39 = r39 * r47;
+    r67 = fmaf(r3, r39, r67);
+    r71 = r0 * r26;
+    r53 = r0 * r2;
+    r53 = r53 * r47;
+    r38 = r0 * r59;
+    r38 = r38 * r17;
+    r38 = fmaf(r36, r38, r36 * r53);
+    r53 = r0 * r8;
+    r38 = fmaf(r50, r53, r38);
+    r50 = r4 * r36;
+    r38 = fmaf(r19, r50, r38);
+    r38 = fmaf(r70, r36, r38);
+    r71 = r71 * r38;
+    r67 = fmaf(r3, r71, r67);
+    r50 = r0 * r8;
+    r67 = fmaf(r1, r50, r67);
+    r67 = fmaf(r60, r3, r67);
+    r50 = r0 * r67;
+    r71 = r0 * r46;
+    r71 = r71 * r17;
+    r71 = fmaf(r15, r71, r11 * r50);
+    r50 = r33 * r15;
+    r71 = fmaf(r19, r50, r71);
+    r11 = r0 * r52;
+    r11 = r11 * r8;
+    r71 = fmaf(r15, r11, r71);
+    r39 = r0 * r57;
+    r39 = r39 * r38;
+    r71 = fmaf(r15, r39, r71);
+    r1 = r0 * r30;
+    r1 = r1 * r47;
+    r71 = fmaf(r15, r1, r71);
+    r71 = fmaf(r64, r15, r71);
+    r1 = r0 * r62;
+    r1 = r1 * r8;
+    r39 = r0 * r58;
+    r39 = r39 * r38;
+    r39 = fmaf(r27, r39, r27 * r1);
+    r1 = r34 * r27;
+    r39 = fmaf(r19, r1, r39);
+    r19 = r0 * r45;
+    r19 = r19 * r17;
+    r39 = fmaf(r27, r19, r39);
+    r11 = r0 * r71;
+    r39 = fmaf(r14, r11, r39);
+    r14 = r0 * r6;
+    r14 = r14 * r47;
+    r39 = fmaf(r27, r14, r39);
+    r50 = r0 * r28;
+    r50 = r50 * r67;
+    r39 = fmaf(r27, r50, r39);
+    r39 = fmaf(r69, r27, r39);
+    r50 = r44 * r0;
+    r50 = r50 * r17;
+    r50 = fmaf(r9, r50, r25 * r9);
+    r14 = r43 * r0;
+    r14 = r14 * r8;
+    r50 = fmaf(r9, r14, r50);
+    r11 = r0 * r71;
+    r50 = fmaf(r16, r11, r50);
+    r16 = r41 * r0;
+    r16 = r16 * r38;
+    r50 = fmaf(r9, r16, r50);
+    r19 = r42 * r0;
+    r19 = r19 * r47;
+    r50 = fmaf(r9, r19, r50);
+    r1 = r10 * r0;
+    r1 = r1 * r39;
+    r50 = fmaf(r9, r1, r50);
+    r53 = r12 * r0;
+    r53 = r53 * r67;
+    r50 = fmaf(r9, r53, r50);
+    r53 = r56 * r8;
+    r53 = fmaf(r35, r53, r32 * r13);
+    r13 = r55 * r47;
+    r53 = fmaf(r35, r13, r53);
+    r32 = r21 * r71;
+    r53 = fmaf(r35, r32, r53);
+    r1 = r54 * r38;
+    r53 = fmaf(r35, r1, r53);
+    r19 = r20 * r39;
+    r53 = fmaf(r35, r19, r53);
+    r16 = r22 * r67;
+    r53 = fmaf(r35, r16, r53);
+    r11 = r23 * r35;
+    r53 = fmaf(r72, r11, r53);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          0 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r50,
+                                          r53,
+                                          r39,
+                                          r71);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          4 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r67,
+                                          r38,
+                                          r47,
+                                          r8);
+    WriteIdx2<1024, float, float, float2>(out_normalized,
+                                          8 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r17,
+                                          r72);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraNormalize(
+    float* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    float* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    float* njtr,
+    unsigned int njtr_num_alloc,
+    const float* const diag,
+    float* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_normalize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraNormalize(
+    float* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    float* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    float* njtr,
+    unsigned int njtr_num_alloc,
+    const float* const diag,
+    float* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.cu
@@ -1,0 +1,173 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwoKernel(
+        float* ThinPrismFisheyeFocalAndExtra_step,
+        unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyeFocalAndExtra_njtr,
+        unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        float* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeFocalAndExtra_pred_dec_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        8 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        8 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r7, r6, r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        0 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r3,
+        r8,
+        r9,
+        r10);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        0 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r11,
+        r12,
+        r13,
+        r14);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r15,
+        r16,
+        r17,
+        r18);
+    r19 = r9 * r17;
+    r19 = fmaf(r7, r19, r13);
+    r19 = fmaf(r9, r19, r1 * r6);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        4 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r6,
+        r13,
+        r20,
+        r21);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        4 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r22,
+        r23,
+        r24,
+        r25);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r26,
+        r27,
+        r28,
+        r29);
+    r30 = r21 * r29;
+    r30 = fmaf(r7, r30, r25);
+    r25 = r3 * r15;
+    r25 = fmaf(r7, r25, r11);
+    r11 = r0 * r4;
+    r11 = fmaf(r7, r11, r2);
+    r2 = r20 * r28;
+    r2 = fmaf(r7, r2, r24);
+    r24 = r6 * r26;
+    r24 = fmaf(r7, r24, r22);
+    r22 = r13 * r27;
+    r22 = fmaf(r7, r22, r23);
+    r23 = r10 * r18;
+    r23 = fmaf(r7, r23, r14);
+    r14 = r8 * r16;
+    r14 = fmaf(r7, r14, r12);
+    r19 = fmaf(r21, r30, r19);
+    r19 = fmaf(r3, r25, r19);
+    r19 = fmaf(r0, r11, r19);
+    r19 = fmaf(r20, r2, r19);
+    r19 = fmaf(r6, r24, r19);
+    r19 = fmaf(r13, r22, r19);
+    r19 = fmaf(r10, r23, r19);
+    r19 = fmaf(r8, r14, r19);
+  };
+  SumStore<float>(out_ThinPrismFisheyeFocalAndExtra_pred_dec_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r19);
+  SumFlushFinal<float>(out_ThinPrismFisheyeFocalAndExtra_pred_dec_local,
+                       out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+                       1);
+}
+
+void ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+    float* ThinPrismFisheyeFocalAndExtra_step,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_njtr,
+    unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_step,
+      ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_njtr,
+      ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+    float* ThinPrismFisheyeFocalAndExtra_step,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_njtr,
+    unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_retract.cu
@@ -1,0 +1,113 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraRetractKernel(
+        float* ThinPrismFisheyeFocalAndExtra,
+        unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+        float* delta,
+        unsigned int delta_num_alloc,
+        float* out_ThinPrismFisheyeFocalAndExtra_retracted,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  float r0, r1, r2, r3, r4, r5, r6, r7;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra,
+        0 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r4, r5, r6, r7);
+    r4 = r0 + r4;
+    r5 = r1 + r5;
+    r6 = r2 + r6;
+    r7 = r3 + r7;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        0 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra,
+        4 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r3, r2, r1, r0);
+    r3 = r7 + r3;
+    r2 = r6 + r2;
+    r1 = r5 + r1;
+    r0 = r4 + r0;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        4 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra,
+        8 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        delta, 8 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        8 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraRetract(
+    float* ThinPrismFisheyeFocalAndExtra,
+    unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_retracted,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra,
+      ThinPrismFisheyeFocalAndExtra_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_retracted,
+      out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraRetract(
+    float* ThinPrismFisheyeFocalAndExtra,
+    unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_retracted,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w.cu
@@ -1,0 +1,150 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraStartWKernel(
+        float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyeFocalAndExtra_p,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        float* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        0 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r5,
+        r6,
+        r7,
+        r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        4 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r8,
+        r7,
+        r6,
+        r5);
+    r3 = r3 * r8;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r0 = r0 * r4;
+    r0 = r0 * r5;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r4;
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        8 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = r0 * r2;
+    r4 = r1 * r4;
+    r4 = r4 * r3;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraStartW(
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_p,
+      ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraStartW(
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.cu
@@ -1,0 +1,150 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraStartWContributeKernel(
+        float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyeFocalAndExtra_p,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        float* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        0 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r5,
+        r6,
+        r7,
+        r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        4 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r8,
+        r7,
+        r6,
+        r5);
+    r3 = r3 * r8;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r0 = r0 * r4;
+    r0 = r0 * r5;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r4;
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        8 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = r0 * r2;
+    r4 = r1 * r4;
+    r4 = r4 * r3;
+    AddIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraStartWContribute(
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_p,
+      ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraStartWContribute(
+    float* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.cu
@@ -1,0 +1,168 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateMpKernel(
+        float* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_Mp,
+        unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        const float* const beta,
+        float* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        float* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        0 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        4 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    r7 = fmaf(r7, r8, r9);
+    r6 = fmaf(r6, r8, r10);
+    r5 = fmaf(r5, r8, r11);
+    r4 = fmaf(r4, r8, r12);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        8 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r12,
+        r11);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r10,
+        r9);
+    r12 = fmaf(r12, r8, r10);
+    r8 = fmaf(r11, r8, r9);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r12,
+        r8);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r12,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateMp(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_Mp,
+    unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_Mp,
+      ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateMp(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_Mp,
+    unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_p.cu
@@ -1,0 +1,140 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdatePKernel(
+        float* ThinPrismFisheyeFocalAndExtra_z,
+        unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_p_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        const float* const beta,
+        float* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        0 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        0 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        4 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        4 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    r3 = fmaf(r3, r8, r7);
+    r2 = fmaf(r2, r8, r6);
+    r1 = fmaf(r1, r8, r5);
+    r0 = fmaf(r0, r8, r4);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        8 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        8 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fmaf(r0, r8, r2);
+    r8 = fmaf(r1, r8, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateP(
+    float* ThinPrismFisheyeFocalAndExtra_z,
+    unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_p_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_z,
+      ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_p_k,
+      ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateP(
+    float* ThinPrismFisheyeFocalAndExtra_z,
+    unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_p_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r.cu
@@ -1,0 +1,162 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateRKernel(
+        float* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    r9 = fmaf(r9, r8, r3);
+    r10 = fmaf(r10, r8, r2);
+    r11 = fmaf(r11, r8, r1);
+    r12 = fmaf(r12, r8, r0);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fmaf(r2, r8, r0);
+    r8 = fmaf(r3, r8, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r8);
+    r12 = fmaf(r12, r12, r2 * r2);
+    r12 = fmaf(r4, r4, r12);
+    r12 = fmaf(r6, r6, r12);
+    r12 = fmaf(r10, r10, r12);
+    r12 = fmaf(r7, r7, r12);
+    r12 = fmaf(r11, r11, r12);
+    r12 = fmaf(r5, r5, r12);
+    r12 = fmaf(r9, r9, r12);
+    r12 = fmaf(r8, r8, r12);
+  };
+  SumStore<float>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r12);
+  SumFlushFinal<float>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateR(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateR(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.cu
@@ -1,0 +1,187 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateRFirstKernel(
+        float* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+        float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local[1];
+
+  __shared__ float out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10,
+        r11,
+        r12);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r16);
+    r13 = fmaf(r13, r8, r9);
+    r14 = fmaf(r14, r8, r10);
+    r15 = fmaf(r15, r8, r11);
+    r16 = fmaf(r16, r8, r12);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14,
+        r15,
+        r16);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    r19 = fmaf(r19, r8, r17);
+    r8 = fmaf(r20, r8, r18);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r19,
+        r8);
+    r3 = fmaf(r3, r3, r0 * r0);
+    r3 = fmaf(r10, r10, r3);
+    r3 = fmaf(r17, r17, r3);
+    r3 = fmaf(r1, r1, r3);
+    r3 = fmaf(r9, r9, r3);
+    r3 = fmaf(r12, r12, r3);
+    r3 = fmaf(r2, r2, r3);
+    r3 = fmaf(r11, r11, r3);
+    r3 = fmaf(r18, r18, r3);
+  };
+  SumStore<float>(out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r16 = fmaf(r16, r16, r19 * r19);
+    r16 = fmaf(r4, r4, r16);
+    r16 = fmaf(r6, r6, r16);
+    r16 = fmaf(r14, r14, r16);
+    r16 = fmaf(r7, r7, r16);
+    r16 = fmaf(r15, r15, r16);
+    r16 = fmaf(r5, r5, r16);
+    r16 = fmaf(r13, r13, r16);
+    r16 = fmaf(r8, r8, r16);
+  };
+  SumStore<float>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r16);
+  SumFlushFinal<float>(out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local,
+                       out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+                       1);
+  SumFlushFinal<float>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+    float* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step.cu
@@ -1,0 +1,140 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateStepKernel(
+        float* ThinPrismFisheyeFocalAndExtra_step_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        0 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        4 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r6,
+        r5,
+        r4);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = fmaf(r3, r8, r7);
+    r2 = fmaf(r2, r8, r6);
+    r1 = fmaf(r1, r8, r5);
+    r0 = fmaf(r0, r8, r4);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        8 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fmaf(r2, r8, r0);
+    r8 = fmaf(r3, r8, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r8);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateStep(
+    float* ThinPrismFisheyeFocalAndExtra_step_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_step_k,
+      ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateStep(
+    float* ThinPrismFisheyeFocalAndExtra_step_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.cu
@@ -1,0 +1,112 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateStepFirstKernel(
+        float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    r1 = r1 * r4;
+    r2 = r2 * r4;
+    r3 = r3 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    r3 = r3 * r4;
+    r2 = r2 * r4;
+    r1 = r1 * r4;
+    r0 = r0 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2,
+        r1,
+        r0);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r4;
+    r4 = r1 * r4;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+    float* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,91 @@
+#include "kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseAlphaDenominatorOrBetaNumeratorKernel(
+        float* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        float* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        float* const ThinPrismFisheyePose_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyePose_out_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_w,
+                                         0 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+    r7 = fmaf(r3, r7, r2 * r6);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r6);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_w,
+                                         4 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r2,
+                                         r8);
+    r7 = fmaf(r1, r5, r7);
+    r7 = fmaf(r0, r4, r7);
+    r7 = fmaf(r6, r8, r7);
+    r7 = fmaf(r3, r2, r7);
+  };
+  SumStore<float>(ThinPrismFisheyePose_out_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r7);
+  SumFlushFinal<float>(
+      ThinPrismFisheyePose_out_local, ThinPrismFisheyePose_out, 1);
+}
+
+void ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    float* const ThinPrismFisheyePose_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      ThinPrismFisheyePose_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    float* const ThinPrismFisheyePose_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.cu
@@ -1,0 +1,128 @@
+#include "kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseAlphaNumeratorDenominatorKernel(
+        float* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        float* ThinPrismFisheyePose_r_k,
+        unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+        float* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        float* const ThinPrismFisheyePose_total_ag,
+        float* const ThinPrismFisheyePose_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyePose_total_ag_local[1];
+
+  __shared__ float ThinPrismFisheyePose_total_ac_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_r_k,
+                                         4 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r2,
+                                         r3);
+    r2 = fmaf(r0, r2, r1 * r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r4,
+        r5,
+        r6);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_r_k,
+                                         0 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r8,
+                                         r9,
+                                         r10);
+    r2 = fmaf(r6, r10, r2);
+    r2 = fmaf(r4, r8, r2);
+    r2 = fmaf(r5, r9, r2);
+    r2 = fmaf(r3, r7, r2);
+  };
+  SumStore<float>(ThinPrismFisheyePose_total_ag_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r2);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_w,
+                                         0 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r2,
+                                         r7,
+                                         r9,
+                                         r8);
+    r8 = fmaf(r6, r8, r5 * r9);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_w,
+                                         4 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r6,
+                                         r9);
+    r8 = fmaf(r4, r7, r8);
+    r8 = fmaf(r3, r2, r8);
+    r8 = fmaf(r1, r9, r8);
+    r8 = fmaf(r0, r6, r8);
+  };
+  SumStore<float>(ThinPrismFisheyePose_total_ac_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r8);
+  SumFlushFinal<float>(
+      ThinPrismFisheyePose_total_ag_local, ThinPrismFisheyePose_total_ag, 1);
+  SumFlushFinal<float>(
+      ThinPrismFisheyePose_total_ac_local, ThinPrismFisheyePose_total_ac, 1);
+}
+
+void ThinPrismFisheyePoseAlphaNumeratorDenominator(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    float* const ThinPrismFisheyePose_total_ag,
+    float* const ThinPrismFisheyePose_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseAlphaNumeratorDenominatorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      ThinPrismFisheyePose_total_ag,
+      ThinPrismFisheyePose_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseAlphaNumeratorDenominator(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    float* const ThinPrismFisheyePose_total_ag,
+    float* const ThinPrismFisheyePose_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_normalize.cu
@@ -1,0 +1,268 @@
+#include "kernel_ThinPrismFisheyePose_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseNormalizeKernel(float* precond_diag,
+                                        unsigned int precond_diag_num_alloc,
+                                        float* precond_tril,
+                                        unsigned int precond_tril_num_alloc,
+                                        float* njtr,
+                                        unsigned int njtr_num_alloc,
+                                        const float* const diag,
+                                        float* out_normalized,
+                                        unsigned int out_normalized_num_alloc,
+                                        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34;
+
+  if (global_thread_idx < problem_size) {
+    r0 = -1.00000000000000000e+00;
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = 9.99999999999999955e-07;
+    r2 = r1 * r2;
+    ReadIdx2<1024, float, float, float2>(
+        precond_diag, 4 * precond_diag_num_alloc, global_thread_idx, r3, r4);
+    r5 = 1.00000000000000000e+00;
+    r5 = r1 + r5;
+    r3 = fmaf(r3, r5, r2);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         4 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r6,
+                                         r7,
+                                         r8);
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         0 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx4<1024, float, float, float4>(precond_diag,
+                                         0 * precond_diag_num_alloc,
+                                         global_thread_idx,
+                                         r13,
+                                         r14,
+                                         r15,
+                                         r16);
+    r13 = fmaf(r13, r5, r2);
+    r13 = 1.0 / r13;
+    r17 = r0 * r13;
+    r18 = r9 * r17;
+    r8 = fmaf(r12, r18, r8);
+    r14 = fmaf(r14, r5, r2);
+    r14 = fmaf(r9, r18, r14);
+    r14 = 1.0 / r14;
+    r9 = r8 * r14;
+    ReadIdx4<1024, float, float, float4>(precond_tril,
+                                         8 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r6 = fmaf(r10, r18, r6);
+    r23 = r10 * r12;
+    r23 = fmaf(r13, r23, r6 * r9);
+    r23 = fmaf(r0, r23, r21);
+    r15 = fmaf(r15, r5, r2);
+    r21 = r6 * r6;
+    r24 = r10 * r10;
+    r24 = fmaf(r13, r24, r14 * r21);
+    r15 = fmaf(r0, r24, r15);
+    r15 = 1.0 / r15;
+    r24 = r23 * r15;
+    r23 = fmaf(r23, r24, r8 * r9);
+    ReadIdx3<1024, float, float, float4>(precond_tril,
+                                         12 * precond_tril_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r21,
+                                         r25);
+    r26 = r10 * r11;
+    r7 = fmaf(r11, r18, r7);
+    r27 = r6 * r7;
+    r27 = fmaf(r14, r27, r13 * r26);
+    r27 = fmaf(r0, r27, r20);
+    r20 = r11 * r12;
+    r20 = fmaf(r13, r20, r27 * r24);
+    r20 = fmaf(r7, r9, r20);
+    r20 = fmaf(r0, r20, r8);
+    r16 = fmaf(r16, r5, r2);
+    r8 = r27 * r27;
+    r26 = r7 * r7;
+    r26 = fmaf(r14, r26, r15 * r8);
+    r8 = r11 * r11;
+    r26 = fmaf(r13, r8, r26);
+    r16 = fmaf(r0, r26, r16);
+    r16 = 1.0 / r16;
+    r26 = r20 * r16;
+    r8 = r12 * r12;
+    r23 = fmaf(r20, r26, r23);
+    r23 = fmaf(r13, r8, r23);
+    r3 = fmaf(r0, r23, r3);
+    r3 = 1.0 / r3;
+    ReadIdx2<1024, float, float, float2>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r23, r8);
+    ReadIdx4<1024, float, float, float4>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r20, r28, r29, r30);
+    r31 = r0 * r6;
+    r28 = fmaf(r20, r18, r28);
+    r31 = r31 * r28;
+    r31 = fmaf(r14, r31, r29);
+    r29 = r10 * r20;
+    r31 = fmaf(r17, r29, r31);
+    r29 = r0 * r31;
+    r29 = fmaf(r24, r29, r23);
+    r23 = r0 * r7;
+    r23 = r23 * r28;
+    r23 = fmaf(r14, r23, r30);
+    r30 = r11 * r20;
+    r23 = fmaf(r17, r30, r23);
+    r32 = r0 * r27;
+    r32 = r32 * r31;
+    r23 = fmaf(r15, r32, r23);
+    r32 = r0 * r23;
+    r29 = fmaf(r26, r32, r29);
+    r30 = r12 * r20;
+    r29 = fmaf(r17, r30, r29);
+    r33 = r0 * r28;
+    r29 = fmaf(r9, r33, r29);
+    r19 = fmaf(r1, r18, r19);
+    r33 = r6 * r19;
+    r30 = r10 * r1;
+    r30 = fmaf(r13, r30, r14 * r33);
+    r30 = fmaf(r0, r30, r22);
+    r22 = fmaf(r19, r9, r30 * r24);
+    r33 = r12 * r1;
+    r22 = fmaf(r13, r33, r22);
+    r32 = r27 * r30;
+    r34 = r11 * r1;
+    r34 = fmaf(r13, r34, r15 * r32);
+    r32 = r7 * r19;
+    r34 = fmaf(r14, r32, r34);
+    r34 = fmaf(r0, r34, r21);
+    r22 = fmaf(r34, r26, r22);
+    r22 = fmaf(r0, r22, r25);
+    r25 = r22 * r3;
+    r5 = fmaf(r4, r5, r2);
+    r4 = r34 * r34;
+    r22 = fmaf(r22, r25, r16 * r4);
+    r4 = r30 * r30;
+    r2 = r19 * r19;
+    r33 = r1 * r1;
+    r22 = fmaf(r15, r4, r22);
+    r22 = fmaf(r14, r2, r22);
+    r22 = fmaf(r13, r33, r22);
+    r5 = fmaf(r0, r22, r5);
+    r5 = 1.0 / r5;
+    r22 = r0 * r29;
+    r22 = fmaf(r25, r22, r8);
+    r8 = r0 * r31;
+    r8 = r8 * r30;
+    r22 = fmaf(r15, r8, r22);
+    r33 = r0 * r23;
+    r33 = r33 * r34;
+    r22 = fmaf(r16, r33, r22);
+    r2 = r0 * r28;
+    r2 = r2 * r19;
+    r22 = fmaf(r14, r2, r22);
+    r4 = r1 * r20;
+    r22 = fmaf(r17, r4, r22);
+    r22 = r5 * r22;
+    r5 = r0 * r22;
+    r25 = fmaf(r5, r25, r29 * r3);
+    r3 = r0 * r25;
+    r3 = fmaf(r23, r16, r26 * r3);
+    r26 = r34 * r16;
+    r3 = fmaf(r5, r26, r3);
+    r26 = r0 * r27;
+    r26 = r26 * r3;
+    r26 = fmaf(r31, r15, r15 * r26);
+    r4 = r0 * r25;
+    r26 = fmaf(r24, r4, r26);
+    r24 = r30 * r15;
+    r26 = fmaf(r5, r24, r26);
+    r24 = r0 * r25;
+    r24 = fmaf(r28, r14, r9 * r24);
+    r9 = r0 * r6;
+    r9 = r9 * r26;
+    r24 = fmaf(r14, r9, r24);
+    r4 = r19 * r14;
+    r24 = fmaf(r5, r4, r24);
+    r5 = r0 * r7;
+    r5 = r5 * r3;
+    r24 = fmaf(r14, r5, r24);
+    r18 = fmaf(r24, r18, r20 * r13);
+    r13 = r11 * r3;
+    r18 = fmaf(r17, r13, r18);
+    r5 = r10 * r26;
+    r18 = fmaf(r17, r5, r18);
+    r4 = r12 * r25;
+    r18 = fmaf(r17, r4, r18);
+    r9 = r1 * r17;
+    r18 = fmaf(r22, r9, r18);
+    WriteIdx4<1024, float, float, float4>(out_normalized,
+                                          0 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r18,
+                                          r24,
+                                          r26,
+                                          r3);
+    WriteIdx2<1024, float, float, float2>(out_normalized,
+                                          4 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r25,
+                                          r22);
+  };
+}
+
+void ThinPrismFisheyePoseNormalize(float* precond_diag,
+                                   unsigned int precond_diag_num_alloc,
+                                   float* precond_tril,
+                                   unsigned int precond_tril_num_alloc,
+                                   float* njtr,
+                                   unsigned int njtr_num_alloc,
+                                   const float* const diag,
+                                   float* out_normalized,
+                                   unsigned int out_normalized_num_alloc,
+                                   size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_normalize.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseNormalize(float* precond_diag,
+                                   unsigned int precond_diag_num_alloc,
+                                   float* precond_tril,
+                                   unsigned int precond_tril_num_alloc,
+                                   float* njtr,
+                                   unsigned int njtr_num_alloc,
+                                   const float* const diag,
+                                   float* out_normalized,
+                                   unsigned int out_normalized_num_alloc,
+                                   size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_pred_decrease_times_two.cu
@@ -1,0 +1,137 @@
+#include "kernel_ThinPrismFisheyePose_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePosePredDecreaseTimesTwoKernel(
+        float* ThinPrismFisheyePose_step,
+        unsigned int ThinPrismFisheyePose_step_num_alloc,
+        float* ThinPrismFisheyePose_precond_diag,
+        unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyePose_njtr,
+        unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+        float* const out_ThinPrismFisheyePose_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePose_pred_dec_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_step,
+        0 * ThinPrismFisheyePose_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_njtr,
+        0 * ThinPrismFisheyePose_njtr_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r8,
+        r9,
+        r10,
+        r11);
+    r12 = r1 * r9;
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r13);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r12 = fmaf(r13, r12, r5);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_step,
+        4 * ThinPrismFisheyePose_step_num_alloc,
+        global_thread_idx,
+        r5,
+        r14);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_njtr,
+        4 * ThinPrismFisheyePose_njtr_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    r19 = r14 * r18;
+    r19 = fmaf(r13, r19, r16);
+    r19 = fmaf(r14, r19, r1 * r12);
+    r12 = r5 * r17;
+    r12 = fmaf(r13, r12, r15);
+    r15 = r2 * r10;
+    r15 = fmaf(r13, r15, r6);
+    r6 = r3 * r11;
+    r6 = fmaf(r13, r6, r7);
+    r7 = r0 * r8;
+    r7 = fmaf(r13, r7, r4);
+    r19 = fmaf(r5, r12, r19);
+    r19 = fmaf(r2, r15, r19);
+    r19 = fmaf(r3, r6, r19);
+    r19 = fmaf(r0, r7, r19);
+  };
+  SumStore<float>(out_ThinPrismFisheyePose_pred_dec_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r19);
+  SumFlushFinal<float>(out_ThinPrismFisheyePose_pred_dec_local,
+                       out_ThinPrismFisheyePose_pred_dec,
+                       1);
+}
+
+void ThinPrismFisheyePosePredDecreaseTimesTwo(
+    float* ThinPrismFisheyePose_step,
+    unsigned int ThinPrismFisheyePose_step_num_alloc,
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_njtr,
+    unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+    float* const out_ThinPrismFisheyePose_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePosePredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_step,
+      ThinPrismFisheyePose_step_num_alloc,
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_njtr,
+      ThinPrismFisheyePose_njtr_num_alloc,
+      out_ThinPrismFisheyePose_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePosePredDecreaseTimesTwo(
+    float* ThinPrismFisheyePose_step,
+    unsigned int ThinPrismFisheyePose_step_num_alloc,
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_njtr,
+    unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+    float* const out_ThinPrismFisheyePose_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_retract.cu
@@ -1,0 +1,123 @@
+#include "kernel_ThinPrismFisheyePose_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseRetractKernel(
+    float* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15;
+
+  if (global_thread_idx < problem_size) {
+    r0 = -1.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose,
+                                         0 * ThinPrismFisheyePose_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r2,
+                                         r3,
+                                         r4);
+    ReadIdx4<1024, float, float, float4>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r5, r6, r7, r8);
+    r9 = 5.00000000000000000e-01;
+    r10 = 9.99999999999999980e-13;
+    r10 = fmaf(r7, r7, r10);
+    r10 = fmaf(r6, r6, r10);
+    r10 = fmaf(r5, r5, r10);
+    r11 = sqrtf(r10);
+    r11 = r9 * r11;
+    r9 = sinf(r11);
+    r10 = rsqrtf(r10);
+    r10 = r9 * r10;
+    r5 = r5 * r10;
+    r9 = r2 * r6;
+    r9 = fmaf(r10, r9, r1 * r5);
+    r12 = r3 * r7;
+    r9 = fmaf(r10, r12, r9);
+    r11 = cosf(r11);
+    r9 = fmaf(r4, r11, r0 * r9);
+    r12 = fmaf(r4, r5, r1 * r11);
+    r13 = r3 * r6;
+    r13 = r13 * r0;
+    r12 = fmaf(r10, r13, r12);
+    r14 = r2 * r7;
+    r12 = fmaf(r10, r14, r12);
+    r14 = fmaf(r3, r5, r2 * r11);
+    r13 = r4 * r6;
+    r14 = fmaf(r10, r13, r14);
+    r15 = r1 * r7;
+    r15 = r15 * r0;
+    r14 = fmaf(r10, r15, r14);
+    r15 = r2 * r0;
+    r15 = fmaf(r5, r15, r3 * r11);
+    r11 = r1 * r6;
+    r15 = fmaf(r10, r11, r15);
+    r5 = r4 * r7;
+    r15 = fmaf(r10, r5, r15);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_retracted,
+        0 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r12,
+        r14,
+        r15,
+        r9);
+    ReadIdx3<1024, float, float, float4>(ThinPrismFisheyePose,
+                                         4 * ThinPrismFisheyePose_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r15,
+                                         r14);
+    r8 = r9 + r8;
+    ReadIdx2<1024, float, float, float2>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r9, r12);
+    r9 = r15 + r9;
+    r12 = r14 + r12;
+    WriteIdx3<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_retracted,
+        4 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r8,
+        r9,
+        r12);
+  };
+}
+
+void ThinPrismFisheyePoseRetract(
+    float* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose,
+      ThinPrismFisheyePose_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyePose_retracted,
+      out_ThinPrismFisheyePose_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseRetract(
+    float* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w.cu
@@ -1,0 +1,115 @@
+#include "kernel_ThinPrismFisheyePose_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseStartWKernel(
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_p,
+                                         0 * ThinPrismFisheyePose_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r3 = r3 * r4;
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_p,
+                                         4 * ThinPrismFisheyePose_p_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r0);
+    r3 = r3 * r1;
+    r4 = r2 * r4;
+    r4 = r4 * r0;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseStartW(
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_p,
+      ThinPrismFisheyePose_p_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseStartW(
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w_contribute.cu
@@ -1,0 +1,116 @@
+#include "kernel_ThinPrismFisheyePose_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseStartWContributeKernel(
+        float* ThinPrismFisheyePose_precond_diag,
+        unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyePose_p,
+        unsigned int ThinPrismFisheyePose_p_num_alloc,
+        float* out_ThinPrismFisheyePose_w,
+        unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_p,
+                                         0 * ThinPrismFisheyePose_p_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r6,
+                                         r7,
+                                         r8);
+    r0 = r0 * r5;
+    r1 = r1 * r4;
+    r1 = r1 * r6;
+    r2 = r2 * r4;
+    r2 = r2 * r7;
+    r3 = r3 * r4;
+    r3 = r3 * r8;
+    AddIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r3 = r3 * r4;
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_p,
+                                         4 * ThinPrismFisheyePose_p_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r0);
+    r3 = r3 * r1;
+    r4 = r2 * r4;
+    r4 = r4 * r0;
+    AddIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseStartWContribute(
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_p,
+      ThinPrismFisheyePose_p_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseStartWContribute(
+    float* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_Mp.cu
@@ -1,0 +1,127 @@
+#include "kernel_ThinPrismFisheyePose_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateMpKernel(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_Mp,
+                                         0 * ThinPrismFisheyePose_Mp_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_r_k,
+                                         0 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_Mp_kp1,
+        0 * out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_Mp,
+                                         4 * ThinPrismFisheyePose_Mp_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r6);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_r_k,
+                                         4 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r5,
+                                         r4);
+    r7 = fmaf(r7, r8, r5);
+    r8 = fmaf(r6, r8, r4);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_Mp_kp1,
+        4 * out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateMp(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_Mp,
+      ThinPrismFisheyePose_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyePose_Mp_kp1,
+      out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateMp(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_p.cu
@@ -1,0 +1,107 @@
+#include "kernel_ThinPrismFisheyePose_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdatePKernel(
+    float* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    float* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_p_k,
+                                         0 * ThinPrismFisheyePose_p_k_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_z,
+                                         0 * ThinPrismFisheyePose_z_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r8, r4);
+    r1 = fmaf(r1, r8, r5);
+    r2 = fmaf(r2, r8, r6);
+    r3 = fmaf(r3, r8, r7);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_p_kp1,
+        0 * out_ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_p_k,
+                                         4 * ThinPrismFisheyePose_p_k_num_alloc,
+                                         global_thread_idx,
+                                         r3,
+                                         r2);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_z,
+                                         4 * ThinPrismFisheyePose_z_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r0);
+    r3 = fmaf(r3, r8, r1);
+    r8 = fmaf(r2, r8, r0);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_p_kp1,
+        4 * out_ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r8);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateP(
+    float* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    float* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_z,
+      ThinPrismFisheyePose_z_num_alloc,
+      ThinPrismFisheyePose_p_k,
+      ThinPrismFisheyePose_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyePose_p_kp1,
+      out_ThinPrismFisheyePose_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateP(
+    float* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    float* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r.cu
@@ -1,0 +1,125 @@
+#include "kernel_ThinPrismFisheyePose_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateRKernel(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePose_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_r_k,
+                                         0 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_w,
+                                         0 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_r_kp1,
+        0 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_r_k,
+                                         4 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r3,
+                                         r2);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_w,
+                                         4 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r1,
+                                         r0);
+    r1 = fmaf(r1, r8, r3);
+    r8 = fmaf(r0, r8, r2);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        4 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r8);
+    r6 = fmaf(r6, r6, r8 * r8);
+    r6 = fmaf(r7, r7, r6);
+    r6 = fmaf(r4, r4, r6);
+    r6 = fmaf(r1, r1, r6);
+    r6 = fmaf(r5, r5, r6);
+  };
+  SumStore<float>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r6);
+  SumFlushFinal<float>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyePoseUpdateR(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePose_r_kp1,
+      out_ThinPrismFisheyePose_r_kp1_num_alloc,
+      out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateR(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r_first.cu
@@ -1,0 +1,146 @@
+#include "kernel_ThinPrismFisheyePose_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseUpdateRFirstKernel(
+        float* ThinPrismFisheyePose_r_k,
+        unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+        float* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyePose_r_kp1,
+        unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+        float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePose_r_0_norm2_tot_local[1];
+
+  __shared__ float out_ThinPrismFisheyePose_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_r_k,
+                                         0 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+    ReadIdx4<1024, float, float, float4>(ThinPrismFisheyePose_w,
+                                         0 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r4,
+                                         r5,
+                                         r6,
+                                         r7);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_r_kp1,
+        0 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_r_k,
+                                         4 * ThinPrismFisheyePose_r_k_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10);
+    ReadIdx2<1024, float, float, float2>(ThinPrismFisheyePose_w,
+                                         4 * ThinPrismFisheyePose_w_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12);
+    r11 = fmaf(r11, r8, r9);
+    r8 = fmaf(r12, r8, r10);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        4 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r8);
+    r2 = fmaf(r2, r2, r1 * r1);
+    r2 = fmaf(r0, r0, r2);
+    r2 = fmaf(r3, r3, r2);
+    r2 = fmaf(r10, r10, r2);
+    r2 = fmaf(r9, r9, r2);
+  };
+  SumStore<float>(out_ThinPrismFisheyePose_r_0_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r2);
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r6, r6, r8 * r8);
+    r6 = fmaf(r7, r7, r6);
+    r6 = fmaf(r4, r4, r6);
+    r6 = fmaf(r11, r11, r6);
+    r6 = fmaf(r5, r5, r6);
+  };
+  SumStore<float>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r6);
+  SumFlushFinal<float>(out_ThinPrismFisheyePose_r_0_norm2_tot_local,
+                       out_ThinPrismFisheyePose_r_0_norm2_tot,
+                       1);
+  SumFlushFinal<float>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyePoseUpdateRFirst(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePose_r_kp1,
+      out_ThinPrismFisheyePose_r_kp1_num_alloc,
+      out_ThinPrismFisheyePose_r_0_norm2_tot,
+      out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateRFirst(
+    float* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    float* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step.cu
@@ -1,0 +1,111 @@
+#include "kernel_ThinPrismFisheyePose_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateStepKernel(
+    float* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_step_k,
+        0 * ThinPrismFisheyePose_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fmaf(r4, r8, r0);
+    r5 = fmaf(r5, r8, r1);
+    r6 = fmaf(r6, r8, r2);
+    r7 = fmaf(r7, r8, r3);
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_step_kp1,
+        0 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5,
+        r6,
+        r7);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_step_k,
+        4 * ThinPrismFisheyePose_step_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r6);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r4);
+    r5 = fmaf(r5, r8, r7);
+    r8 = fmaf(r4, r8, r6);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        4 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r8);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateStep(
+    float* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_step_k,
+      ThinPrismFisheyePose_step_k_num_alloc,
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePose_step_kp1,
+      out_ThinPrismFisheyePose_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateStep(
+    float* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step_first.cu
@@ -1,0 +1,92 @@
+#include "kernel_ThinPrismFisheyePose_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseUpdateStepFirstKernel(
+        float* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyePose_step_kp1,
+        unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r4;
+    r1 = r1 * r4;
+    r2 = r2 * r4;
+    r3 = r3 * r4;
+    WriteIdx4<1024, float, float, float4>(
+        out_ThinPrismFisheyePose_step_kp1,
+        0 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r3 = r3 * r4;
+    r4 = r2 * r4;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        4 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateStepFirst(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePose_step_kp1,
+      out_ThinPrismFisheyePose_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePose_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateStepFirst(
+    float* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,75 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumeratorKernel(
+        float* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        float* const ThinPrismFisheyePrincipalPoint_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyePrincipalPoint_out_local[1];
+
+  float r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fmaf(r1, r3, r0 * r2);
+  };
+  SumStore<float>(ThinPrismFisheyePrincipalPoint_out_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  SumFlushFinal<float>(ThinPrismFisheyePrincipalPoint_out_local,
+                       ThinPrismFisheyePrincipalPoint_out,
+                       1);
+}
+
+void ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    float* const ThinPrismFisheyePrincipalPoint_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumeratorKernel<<<
+      n_blocks,
+      1024>>>(ThinPrismFisheyePrincipalPoint_p_kp1,
+              ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+              ThinPrismFisheyePrincipalPoint_w,
+              ThinPrismFisheyePrincipalPoint_w_num_alloc,
+              ThinPrismFisheyePrincipalPoint_out,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    float* const ThinPrismFisheyePrincipalPoint_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.cu
@@ -1,0 +1,103 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointAlphaNumeratorDenominatorKernel(
+        float* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        float* const ThinPrismFisheyePrincipalPoint_total_ag,
+        float* const ThinPrismFisheyePrincipalPoint_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[128];
+
+  __shared__ float ThinPrismFisheyePrincipalPoint_total_ag_local[1];
+
+  __shared__ float ThinPrismFisheyePrincipalPoint_total_ac_local[1];
+
+  float r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fmaf(r0, r2, r1 * r3);
+  };
+  SumStore<float>(ThinPrismFisheyePrincipalPoint_total_ag_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r2);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fmaf(r1, r3, r0 * r2);
+  };
+  SumStore<float>(ThinPrismFisheyePrincipalPoint_total_ac_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  SumFlushFinal<float>(ThinPrismFisheyePrincipalPoint_total_ag_local,
+                       ThinPrismFisheyePrincipalPoint_total_ag,
+                       1);
+  SumFlushFinal<float>(ThinPrismFisheyePrincipalPoint_total_ac_local,
+                       ThinPrismFisheyePrincipalPoint_total_ac,
+                       1);
+}
+
+void ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    float* const ThinPrismFisheyePrincipalPoint_total_ag,
+    float* const ThinPrismFisheyePrincipalPoint_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointAlphaNumeratorDenominatorKernel<<<n_blocks,
+                                                                  1024>>>(
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      ThinPrismFisheyePrincipalPoint_total_ag,
+      ThinPrismFisheyePrincipalPoint_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    float* const ThinPrismFisheyePrincipalPoint_total_ag,
+    float* const ThinPrismFisheyePrincipalPoint_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_normalize.cu
@@ -1,0 +1,89 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointNormalizeKernel(
+        float* precond_diag,
+        unsigned int precond_diag_num_alloc,
+        float* precond_tril,
+        unsigned int precond_tril_num_alloc,
+        float* njtr,
+        unsigned int njtr_num_alloc,
+        const float* const diag,
+        float* out_normalized,
+        unsigned int out_normalized_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4, r5, r6;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r0, r1);
+    ReadIdx2<1024, float, float, float2>(
+        precond_diag, 0 * precond_diag_num_alloc, global_thread_idx, r2, r3);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r5 = 1.00000000000000000e+00;
+    r5 = r4 + r5;
+    r6 = 9.99999999999999955e-07;
+    r6 = r4 * r6;
+    r2 = fmaf(r2, r5, r6);
+    r2 = 1.0 / r2;
+    r2 = r0 * r2;
+    r5 = fmaf(r3, r5, r6);
+    r5 = 1.0 / r5;
+    r5 = r1 * r5;
+    WriteIdx2<1024, float, float, float2>(out_normalized,
+                                          0 * out_normalized_num_alloc,
+                                          global_thread_idx,
+                                          r2,
+                                          r5);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointNormalize(
+    float* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    float* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    float* njtr,
+    unsigned int njtr_num_alloc,
+    const float* const diag,
+    float* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_normalize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointNormalize(
+    float* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    float* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    float* njtr,
+    unsigned int njtr_num_alloc,
+    const float* const diag,
+    float* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.cu
@@ -1,0 +1,100 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointPredDecreaseTimesTwoKernel(
+        float* ThinPrismFisheyePrincipalPoint_step,
+        unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyePrincipalPoint_njtr,
+        unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+        float* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePrincipalPoint_pred_dec_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_step,
+        0 * ThinPrismFisheyePrincipalPoint_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_njtr,
+        0 * ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r7, r6, r3);
+    r3 = r0 * r4;
+    r3 = fmaf(r7, r3, r2);
+    r3 = fmaf(r0, r3, r1 * r6);
+  };
+  SumStore<float>(out_ThinPrismFisheyePrincipalPoint_pred_dec_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  SumFlushFinal<float>(out_ThinPrismFisheyePrincipalPoint_pred_dec_local,
+                       out_ThinPrismFisheyePrincipalPoint_pred_dec,
+                       1);
+}
+
+void ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+    float* ThinPrismFisheyePrincipalPoint_step,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_njtr,
+    unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_step,
+      ThinPrismFisheyePrincipalPoint_step_num_alloc,
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_njtr,
+      ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+    float* ThinPrismFisheyePrincipalPoint_step,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_njtr,
+    unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_retract.cu
@@ -1,0 +1,69 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointRetractKernel(
+        float* ThinPrismFisheyePrincipalPoint,
+        unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+        float* delta,
+        unsigned int delta_num_alloc,
+        float* out_ThinPrismFisheyePrincipalPoint_retracted,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  float r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint,
+        0 * ThinPrismFisheyePrincipalPoint_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_retracted,
+        0 * out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointRetract(
+    float* ThinPrismFisheyePrincipalPoint,
+    unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_retracted,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint,
+      ThinPrismFisheyePrincipalPoint_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_retracted,
+      out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointRetract(
+    float* ThinPrismFisheyePrincipalPoint,
+    unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+    float* delta,
+    unsigned int delta_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_retracted,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w.cu
@@ -1,0 +1,86 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointStartWKernel(
+        float* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyePrincipalPoint_p,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        float* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p,
+        0 * ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointStartW(
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_p,
+      ThinPrismFisheyePrincipalPoint_p_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointStartW(
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.cu
@@ -1,0 +1,86 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointStartWContributeKernel(
+        float* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const float* const diag,
+        float* ThinPrismFisheyePrincipalPoint_p,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        float* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, float, float>(diag, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p,
+        0 * ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    AddIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointStartWContribute(
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_p,
+      ThinPrismFisheyePrincipalPoint_p_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointStartWContribute(
+    float* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const float* const diag,
+    float* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.cu
@@ -1,0 +1,96 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateMpKernel(
+        float* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_Mp,
+        unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+        const float* const beta,
+        float* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+        float* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_Mp,
+        0 * ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r4, r2);
+    r4 = fmaf(r1, r4, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateMp(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_Mp,
+    unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_Mp,
+      ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+      out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateMp(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_Mp,
+    unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+    float* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_p.cu
@@ -1,0 +1,84 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdatePKernel(
+        float* ThinPrismFisheyePrincipalPoint_z,
+        unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_p_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+        const float* const beta,
+        float* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p_k,
+        0 * ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_z,
+        0 * ThinPrismFisheyePrincipalPoint_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(beta, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r0, r4, r2);
+    r4 = fmaf(r1, r4, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateP(
+    float* ThinPrismFisheyePrincipalPoint_z,
+    unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_p_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_z,
+      ThinPrismFisheyePrincipalPoint_z_num_alloc,
+      ThinPrismFisheyePrincipalPoint_p_k,
+      ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyePrincipalPoint_p_kp1,
+      out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateP(
+    float* ThinPrismFisheyePrincipalPoint_z,
+    unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_p_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+    const float* const beta,
+    float* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r.cu
@@ -1,0 +1,98 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateRKernel(
+        float* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fmaf(r2, r4, r0);
+    r4 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+    r2 = fmaf(r2, r2, r4 * r4);
+  };
+  SumStore<float>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r2);
+  SumFlushFinal<float>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyePrincipalPointUpdateR(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateR(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.cu
@@ -1,0 +1,114 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateRFirstKernel(
+        float* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        const float* const negalpha,
+        float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        float* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+        float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  __shared__ float out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local[1];
+
+  __shared__ float out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local[1];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(negalpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fmaf(r2, r4, r0);
+    r4 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+    r1 = fmaf(r1, r1, r0 * r0);
+  };
+  SumStore<float>(out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r1);
+  if (global_thread_idx < problem_size) {
+    r2 = fmaf(r2, r2, r4 * r4);
+  };
+  SumStore<float>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r2);
+  SumFlushFinal<float>(out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local,
+                       out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+                       1);
+  SumFlushFinal<float>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                       out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+                       1);
+}
+
+void ThinPrismFisheyePrincipalPointUpdateRFirst(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateRFirst(
+    float* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const float* const negalpha,
+    float* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+    float* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step.cu
@@ -1,0 +1,84 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateStepKernel(
+        float* ThinPrismFisheyePrincipalPoint_step_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+        float* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_step_k,
+        0 * ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fmaf(r2, r4, r0);
+    r4 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateStep(
+    float* ThinPrismFisheyePrincipalPoint_step_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_step_k,
+      ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateStep(
+    float* ThinPrismFisheyePrincipalPoint_step_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.cu
@@ -1,0 +1,72 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateStepFirstKernel(
+        float* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        const float* const alpha,
+        float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[4096];
+
+  float r0, r1, r2;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, float, float>(alpha, 0, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<float>((float*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    r2 = r1 * r2;
+    WriteIdx2<1024, float, float, float2>(
+        out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateStepFirst(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateStepFirst(
+    float* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const float* const alpha,
+    float* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,270 @@
+#include "kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        float* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<4, float, float>(calib_njtr,
+                              0 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(calib_njtr,
+                              8 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9,
+                       r10,
+                       r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         12 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r12,
+                                         r13,
+                                         r14,
+                                         r15);
+    r11 = fmaf(r11, r15, r7);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         8 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r7,
+                                         r16,
+                                         r17,
+                                         r18);
+  };
+  LoadShared<4, float, float>(calib_njtr,
+                              4 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r19,
+                       r20,
+                       r21,
+                       r22);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         4 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r23,
+                                         r24,
+                                         r25,
+                                         r26);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         0 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r27,
+                                         r28,
+                                         r29,
+                                         r30);
+    r11 = fmaf(r8, r18, r11);
+    r11 = fmaf(r21, r26, r11);
+    r11 = fmaf(r22, r16, r11);
+    r11 = fmaf(r9, r13, r11);
+    r11 = fmaf(r20, r24, r11);
+    r11 = fmaf(r19, r30, r11);
+    r11 = fmaf(r5, r28, r11);
+    r10 = fmaf(r10, r14, r6);
+    r10 = fmaf(r9, r12, r10);
+    r10 = fmaf(r8, r17, r10);
+    r10 = fmaf(r20, r23, r10);
+    r10 = fmaf(r22, r7, r10);
+    r10 = fmaf(r21, r25, r10);
+    r10 = fmaf(r19, r29, r10);
+    r10 = fmaf(r4, r27, r10);
+    r4 = fmaf(r0, r10, r1 * r11);
+    r19 = fmaf(r2, r10, r3 * r11);
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r21, r22, r20, r8);
+    r9 = fmaf(r21, r10, r22 * r11);
+    r6 = fmaf(r20, r10, r8 * r11);
+    WriteSum4<float, float>((float*)inout_shared, r4, r19, r9, r6);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r6, r9, r19, r4);
+    r5 = fmaf(r6, r10, r9 * r11);
+    r10 = fmaf(r19, r10, r4 * r11);
+    WriteSum2<float, float>((float*)inout_shared, r5, r10);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r10,
+                       r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r10, r6, r5 * r19);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r19,
+                       r11,
+                       r31,
+                       r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r31, r21, r6);
+    r6 = fmaf(r32, r20, r6);
+    r6 = fmaf(r19, r0, r6);
+    r6 = fmaf(r11, r2, r6);
+    r27 = r27 * r6;
+    r8 = fmaf(r32, r8, r5 * r4);
+    r8 = fmaf(r31, r22, r8);
+    r8 = fmaf(r19, r1, r8);
+    r8 = fmaf(r11, r3, r8);
+    r8 = fmaf(r10, r9, r8);
+    r28 = r28 * r8;
+    WriteSum4<float, float>((float*)inout_shared, r27, r28, r6, r8);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = fmaf(r30, r8, r29 * r6);
+    r23 = fmaf(r23, r6, r24 * r8);
+    r25 = fmaf(r25, r6, r26 * r8);
+    r7 = fmaf(r7, r6, r16 * r8);
+    WriteSum4<float, float>((float*)inout_shared, r30, r23, r25, r7);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r17 = fmaf(r17, r6, r18 * r8);
+    r12 = fmaf(r12, r6, r13 * r8);
+    r6 = r14 * r6;
+    r8 = r15 * r8;
+    WriteSum4<float, float>((float*)inout_shared, r17, r12, r6, r8);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac.cu
@@ -1,0 +1,2229 @@
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r11, r12, r13);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16,
+                       r17);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r19,
+                                         r20,
+                                         r21);
+    r22 = r16 * r21;
+    r23 = r15 * r18;
+    r24 = r22 + r23;
+    r25 = r17 * r20;
+    r26 = -1.00000000000000000e+00;
+    r27 = r14 * r19;
+    r24 = r24 + r25;
+    r24 = fmaf(r26, r27, r24);
+    r28 = r24 * r24;
+    r29 = -2.00000000000000000e+00;
+    r28 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r16 * r18;
+    r31 = fmaf(r26, r31, r15 * r21);
+    r31 = fmaf(r17, r19, r31);
+    r31 = fmaf(r14, r20, r31);
+    r32 = r29 * r31;
+    r32 = fmaf(r31, r32, r30);
+    r33 = r28 + r32;
+    r33 = fmaf(r11, r33, r8);
+    r8 = 2.00000000000000000e+00;
+    r34 = fmaf(r17, r18, r14 * r21);
+    r35 = r15 * r20;
+    r34 = fmaf(r26, r35, r34);
+    r34 = fmaf(r16, r19, r34);
+    r35 = r8 * r34;
+    r35 = r35 * r31;
+    r36 = r24 * r29;
+    r37 = fmaf(r15, r19, r14 * r18);
+    r37 = fmaf(r16, r20, r37);
+    r37 = fmaf(r26, r37, r17 * r21);
+    r36 = fmaf(r37, r36, r35);
+    r38 = r8 * r24;
+    r38 = r38 * r34;
+    r39 = r8 * r31;
+    r39 = fmaf(r37, r39, r38);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r40,
+                       r41,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r18 * r20;
+    r43 = r43 * r8;
+    r44 = r19 * r21;
+    r44 = fmaf(r8, r44, r43);
+    r45 = r20 * r21;
+    r46 = r18 * r19;
+    r46 = r46 * r8;
+    r45 = fmaf(r29, r45, r46);
+    r47 = r19 * r19;
+    r47 = r47 * r29;
+    r48 = r30 + r47;
+    r49 = r20 * r20;
+    r49 = r49 * r29;
+    r48 = r48 + r49;
+    r33 = fmaf(r12, r36, r33);
+    r33 = fmaf(r13, r39, r33);
+    r33 = fmaf(r42, r44, r33);
+    r33 = fmaf(r41, r45, r33);
+    r33 = fmaf(r40, r48, r33);
+    r39 = r33 * r33;
+    r36 = 9.99999999999999955e-07;
+    r50 = r29 * r31;
+    r50 = fmaf(r37, r50, r38);
+    r50 = fmaf(r11, r50, r10);
+    r10 = r19 * r21;
+    r10 = fmaf(r29, r10, r43);
+    r43 = r18 * r18;
+    r43 = r43 * r29;
+    r38 = r30 + r43;
+    r38 = r38 + r47;
+    r47 = r19 * r20;
+    r47 = r47 * r8;
+    r51 = r18 * r21;
+    r51 = fmaf(r8, r51, r47);
+    r52 = r8 * r24;
+    r52 = r52 * r31;
+    r53 = r8 * r34;
+    r53 = fmaf(r37, r53, r52);
+    r54 = r34 * r34;
+    r54 = r54 * r29;
+    r32 = r54 + r32;
+    r50 = fmaf(r40, r10, r50);
+    r50 = fmaf(r42, r38, r50);
+    r50 = fmaf(r41, r51, r50);
+    r50 = fmaf(r12, r53, r50);
+    r50 = fmaf(r13, r32, r50);
+    r32 = copysign(1.0, r50);
+    r32 = fmaf(r36, r32, r50);
+    r50 = r32 * r32;
+    r53 = 1.0 / r50;
+    r55 = r8 * r24;
+    r55 = fmaf(r37, r55, r35);
+    r55 = fmaf(r11, r55, r9);
+    r9 = r20 * r21;
+    r9 = fmaf(r8, r9, r46);
+    r43 = r30 + r43;
+    r43 = r43 + r49;
+    r49 = r18 * r21;
+    r49 = fmaf(r29, r49, r47);
+    r47 = r34 * r29;
+    r47 = fmaf(r37, r47, r52);
+    r54 = r30 + r54;
+    r54 = r54 + r28;
+    r55 = fmaf(r40, r9, r55);
+    r55 = fmaf(r41, r43, r55);
+    r55 = fmaf(r42, r49, r55);
+    r55 = fmaf(r13, r47, r55);
+    r55 = fmaf(r12, r54, r55);
+    r54 = r55 * r55;
+    r54 = fmaf(r53, r54, r53 * r39);
+    r39 = sqrtf(r54);
+    r47 = atanf(r39);
+    r42 = r55 * r47;
+    r41 = copysign(1.0, r39);
+    r41 = fmaf(r36, r41, r39);
+    r36 = r41 * r41;
+    r39 = 1.0 / r36;
+    r40 = r53 * r39;
+    r28 = r42 * r40;
+    r52 = r55 * r28;
+    r46 = r47 * r52;
+    r35 = r33 * r47;
+    r56 = 3.00000000000000000e+00;
+    r57 = r33 * r47;
+    r35 = r35 * r56;
+    r35 = r35 * r40;
+    r35 = fmaf(r57, r35, r46);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r58,
+                       r59,
+                       r60,
+                       r61);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r62 = r33 * r47;
+    r62 = r62 * r40;
+    r62 = r62 * r57;
+    r46 = r46 + r62;
+    r63 = fmaf(r60, r46, r7 * r35);
+    r64 = r6 * r8;
+    r64 = r64 * r57;
+    r63 = fmaf(r28, r64, r63);
+    r65 = r46 * r46;
+    r66 = fmaf(r5, r65, r4 * r46);
+    r67 = r65 * r65;
+    r68 = r46 * r65;
+    r66 = fmaf(r59, r67, r66);
+    r66 = fmaf(r58, r68, r66);
+    r69 = 1.0 / r32;
+    r70 = 1.0 / r41;
+    r71 = r69 * r70;
+    r72 = r66 * r71;
+    r63 = fmaf(r57, r72, r63);
+    r63 = fmaf(r71, r57, r63);
+    r2 = fmaf(r0, r63, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r64, r73);
+    r2 = fmaf(r64, r26, r2);
+    r64 = r47 * r56;
+    r64 = fmaf(r52, r64, r62);
+    r62 = fmaf(r61, r46, r6 * r64);
+    r74 = r7 * r8;
+    r74 = r74 * r57;
+    r62 = fmaf(r28, r74, r62);
+    r62 = fmaf(r42, r71, r62);
+    r62 = fmaf(r42, r72, r62);
+    r3 = fmaf(r1, r62, r3);
+    r3 = fmaf(r73, r26, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r73 = r34 * r29;
+    r74 = r14 * r21;
+    r75 = -5.00000000000000000e-01;
+    r76 = r17 * r18;
+    r76 = fmaf(r75, r76, r75 * r74);
+    r74 = r16 * r19;
+    r76 = fmaf(r75, r74, r76);
+    r77 = r15 * r20;
+    r78 = 5.00000000000000000e-01;
+    r76 = fmaf(r78, r77, r76);
+    r77 = r17 * r21;
+    r74 = r14 * r18;
+    r74 = fmaf(r75, r74, r78 * r77);
+    r77 = r15 * r19;
+    r74 = fmaf(r75, r77, r74);
+    r79 = r16 * r20;
+    r74 = fmaf(r75, r79, r74);
+    r79 = r37 * r74;
+    r77 = r29 * r79;
+    r73 = fmaf(r76, r73, r77);
+    r80 = r8 * r31;
+    r81 = r15 * r21;
+    r82 = r16 * r18;
+    r82 = fmaf(r78, r82, r75 * r81);
+    r81 = r17 * r19;
+    r82 = fmaf(r75, r81, r82);
+    r83 = r14 * r20;
+    r82 = fmaf(r75, r83, r82);
+    r80 = r80 * r82;
+    r83 = r8 * r24;
+    r81 = fmaf(r78, r23, r78 * r22);
+    r81 = fmaf(r75, r27, r81);
+    r81 = fmaf(r78, r25, r81);
+    r83 = fmaf(r81, r83, r80);
+    r73 = r73 + r83;
+    r84 = r34 * r74;
+    r85 = -4.00000000000000000e+00;
+    r84 = r84 * r85;
+    r86 = r24 * r82;
+    r87 = r85 * r86;
+    r88 = r84 + r87;
+    r88 = fmaf(r12, r88, r13 * r73);
+    r73 = r8 * r34;
+    r73 = r73 * r81;
+    r89 = r8 * r37;
+    r89 = fmaf(r82, r89, r73);
+    r90 = r8 * r31;
+    r90 = r90 * r74;
+    r91 = r8 * r24;
+    r91 = fmaf(r76, r91, r90);
+    r89 = r89 + r91;
+    r88 = fmaf(r11, r89, r88);
+    r89 = r88 * r28;
+    r92 = r8 * r47;
+    r93 = r30 + r54;
+    r93 = 1.0 / r93;
+    r54 = rsqrtf(r54);
+    r94 = r93 * r54;
+    r95 = r94 * r52;
+    r96 = r8 * r55;
+    r96 = r96 * r88;
+    r97 = r8 * r33;
+    r98 = r8 * r37;
+    r99 = r31 * r76;
+    r98 = fmaf(r8, r99, r81 * r98);
+    r100 = r8 * r34;
+    r101 = r8 * r24;
+    r101 = r101 * r74;
+    r100 = fmaf(r82, r100, r101);
+    r98 = r98 + r100;
+    r73 = r90 + r73;
+    r90 = r24 * r29;
+    r73 = fmaf(r76, r90, r73);
+    r102 = r29 * r37;
+    r73 = fmaf(r82, r102, r73);
+    r73 = fmaf(r12, r73, r13 * r98);
+    r98 = r31 * r81;
+    r98 = r98 * r85;
+    r87 = r98 + r87;
+    r73 = fmaf(r11, r87, r73);
+    r97 = r97 * r73;
+    r97 = fmaf(r53, r97, r53 * r96);
+    r96 = r55 * r55;
+    r87 = r8 * r34;
+    r87 = r87 * r76;
+    r79 = r8 * r79;
+    r102 = r87 + r79;
+    r83 = r83 + r102;
+    r90 = r29 * r37;
+    r90 = fmaf(r29, r99, r81 * r90);
+    r90 = r90 + r100;
+    r90 = fmaf(r11, r90, r12 * r83);
+    r98 = r84 + r98;
+    r90 = fmaf(r13, r98, r90);
+    r50 = r32 * r50;
+    r98 = 1.0 / r50;
+    r84 = r29 * r98;
+    r96 = r96 * r90;
+    r97 = fmaf(r84, r96, r97);
+    r83 = r33 * r33;
+    r83 = r83 * r84;
+    r97 = fmaf(r90, r83, r97);
+    r89 = fmaf(r97, r95, r92 * r89);
+    r96 = r26 * r55;
+    r36 = r41 * r36;
+    r81 = 1.0 / r36;
+    r96 = r96 * r47;
+    r96 = r96 * r97;
+    r96 = r96 * r53;
+    r96 = r96 * r54;
+    r96 = r96 * r81;
+    r89 = fmaf(r42, r96, r89);
+    r103 = r55 * r47;
+    r103 = r103 * r90;
+    r103 = r103 * r39;
+    r103 = r103 * r42;
+    r89 = fmaf(r84, r103, r89);
+    r103 = r40 * r57;
+    r96 = r92 * r103;
+    r104 = r97 * r103;
+    r105 = r33 * r94;
+    r104 = fmaf(r105, r104, r73 * r96);
+    r106 = r47 * r83;
+    r107 = r47 * r39;
+    r107 = r107 * r84;
+    r107 = r106 * r107;
+    r108 = r26 * r33;
+    r108 = r108 * r33;
+    r108 = r108 * r47;
+    r108 = r108 * r47;
+    r108 = r108 * r97;
+    r108 = r108 * r53;
+    r108 = r108 * r54;
+    r104 = fmaf(r81, r108, r104);
+    r104 = fmaf(r90, r107, r104);
+    r108 = r89 + r104;
+    r109 = r47 * r73;
+    r110 = 6.00000000000000000e+00;
+    r109 = r109 * r110;
+    r109 = r109 * r40;
+    r111 = r56 * r97;
+    r111 = r111 * r103;
+    r111 = fmaf(r105, r111, r57 * r109);
+    r109 = r33 * r33;
+    r112 = r47 * r90;
+    r113 = -6.00000000000000000e+00;
+    r112 = r112 * r113;
+    r112 = r112 * r39;
+    r112 = r112 * r98;
+    r109 = r109 * r47;
+    r111 = fmaf(r112, r109, r111);
+    r114 = -3.00000000000000000e+00;
+    r114 = r47 * r114;
+    r114 = r114 * r53;
+    r114 = r114 * r54;
+    r114 = r114 * r81;
+    r115 = r97 * r114;
+    r111 = fmaf(r106, r115, r111);
+    r111 = r111 + r89;
+    r111 = fmaf(r7, r111, r60 * r108);
+    r89 = r78 * r72;
+    r115 = r105 * r89;
+    r109 = r6 * r88;
+    r111 = fmaf(r96, r109, r111);
+    r116 = r47 * r73;
+    r111 = fmaf(r72, r116, r111);
+    r117 = r75 * r97;
+    r117 = r117 * r39;
+    r117 = r117 * r69;
+    r117 = r117 * r54;
+    r118 = r6 * r97;
+    r119 = r8 * r28;
+    r119 = r119 * r105;
+    r111 = fmaf(r119, r118, r111);
+    r120 = r47 * r73;
+    r111 = fmaf(r71, r120, r111);
+    r121 = r26 * r33;
+    r121 = r121 * r47;
+    r121 = r121 * r90;
+    r121 = r121 * r53;
+    r111 = fmaf(r70, r121, r111);
+    r122 = r5 * r8;
+    r122 = r122 * r46;
+    r122 = fmaf(r108, r122, r4 * r108);
+    r58 = r58 * r56;
+    r58 = r58 * r65;
+    r123 = 4.00000000000000000e+00;
+    r59 = r59 * r123;
+    r59 = r59 * r68;
+    r122 = fmaf(r108, r58, r122);
+    r122 = fmaf(r108, r59, r122);
+    r124 = r122 * r71;
+    r111 = fmaf(r57, r124, r111);
+    r125 = r6 * r73;
+    r125 = r125 * r28;
+    r111 = fmaf(r92, r125, r111);
+    r126 = r85 * r39;
+    r126 = r126 * r98;
+    r126 = r126 * r42;
+    r126 = r126 * r57;
+    r127 = r6 * r126;
+    r128 = r66 * r117;
+    r129 = r26 * r33;
+    r129 = r129 * r47;
+    r129 = r129 * r66;
+    r129 = r129 * r90;
+    r129 = r129 * r53;
+    r111 = fmaf(r70, r129, r111);
+    r130 = r78 * r97;
+    r130 = r130 * r71;
+    r111 = fmaf(r105, r130, r111);
+    r131 = r6 * r29;
+    r131 = r131 * r97;
+    r131 = r131 * r53;
+    r131 = r131 * r54;
+    r131 = r131 * r81;
+    r131 = r131 * r42;
+    r111 = fmaf(r57, r131, r111);
+    r111 = fmaf(r97, r115, r111);
+    r111 = fmaf(r117, r57, r111);
+    r111 = fmaf(r90, r127, r111);
+    r111 = fmaf(r57, r128, r111);
+    r131 = r0 * r111;
+    r130 = r47 * r88;
+    r130 = r130 * r110;
+    r129 = r56 * r97;
+    r129 = fmaf(r95, r129, r28 * r130);
+    r130 = r55 * r42;
+    r130 = r130 * r114;
+    r125 = r55 * r42;
+    r129 = fmaf(r112, r125, r129);
+    r129 = fmaf(r97, r130, r129);
+    r129 = r129 + r104;
+    r129 = fmaf(r6, r129, r61 * r108);
+    r108 = r55 * r78;
+    r108 = r108 * r97;
+    r108 = r108 * r71;
+    r129 = fmaf(r94, r108, r129);
+    r104 = r7 * r96;
+    r125 = r7 * r97;
+    r129 = fmaf(r119, r125, r129);
+    r112 = r55 * r97;
+    r112 = r112 * r94;
+    r129 = fmaf(r89, r112, r129);
+    r124 = r26 * r66;
+    r124 = r124 * r90;
+    r124 = r124 * r53;
+    r124 = r124 * r70;
+    r129 = fmaf(r42, r124, r129);
+    r121 = r122 * r42;
+    r129 = fmaf(r71, r121, r129);
+    r120 = r7 * r73;
+    r120 = r120 * r28;
+    r129 = fmaf(r92, r120, r129);
+    r118 = r7 * r90;
+    r129 = fmaf(r126, r118, r129);
+    r116 = r26 * r90;
+    r116 = r116 * r53;
+    r116 = r116 * r70;
+    r129 = fmaf(r42, r116, r129);
+    r109 = r7 * r29;
+    r109 = r109 * r97;
+    r109 = r109 * r53;
+    r109 = r109 * r54;
+    r109 = r109 * r81;
+    r109 = r109 * r42;
+    r129 = fmaf(r57, r109, r129);
+    r132 = r47 * r88;
+    r129 = fmaf(r72, r132, r129);
+    r133 = r47 * r88;
+    r129 = fmaf(r71, r133, r129);
+    r129 = fmaf(r42, r128, r129);
+    r129 = fmaf(r88, r104, r129);
+    r129 = fmaf(r42, r117, r129);
+    r133 = r1 * r129;
+    r117 = r55 * r55;
+    r117 = r53 * r117;
+    r132 = r8 * r33;
+    r79 = r80 + r79;
+    r80 = r8 * r24;
+    r23 = fmaf(r75, r23, r75 * r22);
+    r23 = fmaf(r78, r27, r23);
+    r23 = fmaf(r75, r25, r23);
+    r80 = r80 * r23;
+    r25 = r8 * r34;
+    r27 = r14 * r21;
+    r22 = r17 * r18;
+    r22 = fmaf(r78, r22, r78 * r27);
+    r27 = r16 * r19;
+    r22 = fmaf(r78, r27, r22);
+    r109 = r15 * r20;
+    r22 = fmaf(r75, r109, r22);
+    r25 = fmaf(r22, r25, r80);
+    r79 = r79 + r25;
+    r109 = r31 * r74;
+    r109 = r109 * r85;
+    r27 = r24 * r85;
+    r27 = r27 * r22;
+    r116 = r109 + r27;
+    r116 = fmaf(r11, r116, r13 * r79);
+    r79 = r29 * r37;
+    r79 = fmaf(r29, r86, r22 * r79);
+    r118 = r8 * r34;
+    r118 = r118 * r74;
+    r120 = r8 * r31;
+    r120 = fmaf(r23, r120, r118);
+    r79 = r79 + r120;
+    r116 = fmaf(r12, r79, r116);
+    r132 = r132 * r116;
+    r79 = r29 * r31;
+    r79 = fmaf(r82, r79, r77);
+    r79 = r79 + r25;
+    r25 = r8 * r31;
+    r25 = r25 * r22;
+    r121 = r8 * r37;
+    r121 = fmaf(r23, r121, r25);
+    r121 = r121 + r100;
+    r121 = fmaf(r12, r121, r11 * r79);
+    r79 = r34 * r23;
+    r100 = r85 * r79;
+    r109 = r109 + r100;
+    r121 = fmaf(r13, r109, r121);
+    r132 = fmaf(r121, r83, r53 * r132);
+    r109 = r55 * r55;
+    r109 = r109 * r121;
+    r132 = fmaf(r84, r109, r132);
+    r124 = r8 * r55;
+    r25 = r101 + r25;
+    r101 = r34 * r29;
+    r25 = fmaf(r82, r101, r25);
+    r82 = r29 * r37;
+    r25 = fmaf(r23, r82, r25);
+    r82 = r8 * r37;
+    r86 = fmaf(r8, r86, r22 * r82);
+    r86 = r86 + r120;
+    r86 = fmaf(r11, r86, r13 * r25);
+    r100 = r27 + r100;
+    r86 = fmaf(r12, r100, r86);
+    r124 = r124 * r86;
+    r132 = fmaf(r53, r124, r132);
+    r117 = r117 * r39;
+    r117 = r117 * r47;
+    r117 = r117 * r93;
+    r117 = r117 * r54;
+    r117 = r117 * r132;
+    r93 = r86 * r28;
+    r93 = fmaf(r92, r93, r117);
+    r124 = r26 * r55;
+    r124 = r124 * r47;
+    r124 = r124 * r132;
+    r124 = r124 * r53;
+    r124 = r124 * r54;
+    r124 = r124 * r81;
+    r93 = fmaf(r42, r124, r93);
+    r109 = r55 * r47;
+    r109 = r109 * r121;
+    r109 = r109 * r39;
+    r109 = r109 * r42;
+    r93 = fmaf(r84, r109, r93);
+    r109 = r132 * r103;
+    r124 = r26 * r33;
+    r124 = r124 * r33;
+    r124 = r124 * r47;
+    r124 = r124 * r47;
+    r124 = r124 * r132;
+    r124 = r124 * r53;
+    r124 = r124 * r54;
+    r124 = fmaf(r81, r124, r105 * r109);
+    r124 = fmaf(r121, r107, r124);
+    r124 = fmaf(r116, r96, r124);
+    r109 = r93 + r124;
+    r100 = r56 * r132;
+    r100 = r100 * r103;
+    r27 = r132 * r114;
+    r27 = fmaf(r106, r27, r105 * r100);
+    r100 = r33 * r33;
+    r100 = r100 * r47;
+    r100 = r100 * r47;
+    r100 = r100 * r113;
+    r100 = r100 * r121;
+    r100 = r100 * r39;
+    r27 = fmaf(r98, r100, r27);
+    r25 = r47 * r110;
+    r25 = r25 * r116;
+    r25 = r25 * r40;
+    r27 = fmaf(r57, r25, r27);
+    r27 = r27 + r93;
+    r27 = fmaf(r7, r27, r60 * r109);
+    r93 = r6 * r116;
+    r93 = r93 * r28;
+    r27 = fmaf(r92, r93, r27);
+    r25 = r33 * r47;
+    r25 = r25 * r75;
+    r25 = r25 * r132;
+    r25 = r25 * r39;
+    r25 = r25 * r69;
+    r27 = fmaf(r54, r25, r27);
+    r100 = r26 * r33;
+    r100 = r100 * r47;
+    r100 = r100 * r121;
+    r100 = r100 * r53;
+    r27 = fmaf(r70, r100, r27);
+    r82 = r33 * r47;
+    r82 = r82 * r66;
+    r82 = r82 * r75;
+    r82 = r82 * r132;
+    r82 = r82 * r39;
+    r82 = r82 * r69;
+    r27 = fmaf(r54, r82, r27);
+    r22 = r47 * r116;
+    r27 = fmaf(r72, r22, r27);
+    r101 = r6 * r132;
+    r27 = fmaf(r119, r101, r27);
+    r112 = r26 * r33;
+    r112 = r112 * r47;
+    r112 = r112 * r66;
+    r112 = r112 * r121;
+    r112 = r112 * r53;
+    r27 = fmaf(r70, r112, r27);
+    r125 = r5 * r8;
+    r125 = r125 * r46;
+    r125 = fmaf(r4, r109, r109 * r125);
+    r125 = fmaf(r109, r59, r125);
+    r125 = fmaf(r109, r58, r125);
+    r108 = r125 * r71;
+    r27 = fmaf(r57, r108, r27);
+    r128 = r78 * r132;
+    r128 = r128 * r71;
+    r27 = fmaf(r105, r128, r27);
+    r134 = r6 * r29;
+    r134 = r134 * r132;
+    r134 = r134 * r53;
+    r134 = r134 * r54;
+    r134 = r134 * r81;
+    r134 = r134 * r42;
+    r27 = fmaf(r57, r134, r27);
+    r135 = r6 * r86;
+    r27 = fmaf(r96, r135, r27);
+    r136 = r47 * r116;
+    r27 = fmaf(r71, r136, r27);
+    r27 = fmaf(r121, r127, r27);
+    r27 = fmaf(r132, r115, r27);
+    r136 = r0 * r27;
+    r135 = r47 * r110;
+    r135 = r135 * r86;
+    r135 = fmaf(r132, r130, r28 * r135);
+    r134 = r55 * r47;
+    r134 = r134 * r113;
+    r134 = r134 * r121;
+    r134 = r134 * r39;
+    r134 = r134 * r98;
+    r135 = fmaf(r42, r134, r135);
+    r135 = fmaf(r56, r117, r135);
+    r135 = r135 + r124;
+    r135 = fmaf(r6, r135, r61 * r109);
+    r109 = r26 * r121;
+    r109 = r109 * r53;
+    r109 = r109 * r70;
+    r135 = fmaf(r42, r109, r135);
+    r124 = r47 * r86;
+    r135 = fmaf(r72, r124, r135);
+    r117 = r7 * r116;
+    r117 = r117 * r28;
+    r135 = fmaf(r92, r117, r135);
+    r134 = r125 * r42;
+    r135 = fmaf(r71, r134, r135);
+    r128 = r55 * r132;
+    r128 = r128 * r94;
+    r135 = fmaf(r89, r128, r135);
+    r108 = r66 * r75;
+    r108 = r108 * r132;
+    r108 = r108 * r39;
+    r108 = r108 * r69;
+    r108 = r108 * r54;
+    r135 = fmaf(r42, r108, r135);
+    r112 = r7 * r132;
+    r135 = fmaf(r119, r112, r135);
+    r101 = r26 * r66;
+    r101 = r101 * r121;
+    r101 = r101 * r53;
+    r101 = r101 * r70;
+    r135 = fmaf(r42, r101, r135);
+    r22 = r55 * r78;
+    r22 = r22 * r132;
+    r22 = r22 * r71;
+    r135 = fmaf(r94, r22, r135);
+    r82 = r75 * r132;
+    r82 = r82 * r39;
+    r82 = r82 * r69;
+    r82 = r82 * r54;
+    r135 = fmaf(r42, r82, r135);
+    r100 = r7 * r121;
+    r135 = fmaf(r126, r100, r135);
+    r25 = r7 * r29;
+    r25 = r25 * r132;
+    r25 = r25 * r53;
+    r25 = r25 * r54;
+    r25 = r25 * r81;
+    r25 = r25 * r42;
+    r135 = fmaf(r57, r25, r135);
+    r93 = r47 * r86;
+    r135 = fmaf(r71, r93, r135);
+    r135 = fmaf(r86, r104, r135);
+    r93 = r1 * r135;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r131,
+                                          r133,
+                                          r136,
+                                          r93);
+    r93 = r34 * r85;
+    r136 = r15 * r21;
+    r133 = r16 * r18;
+    r133 = fmaf(r75, r133, r78 * r136);
+    r136 = r17 * r19;
+    r133 = fmaf(r78, r136, r133);
+    r131 = r14 * r20;
+    r133 = fmaf(r78, r131, r133);
+    r93 = r93 * r133;
+    r99 = r85 * r99;
+    r131 = r93 + r99;
+    r136 = r8 * r24;
+    r136 = r136 * r133;
+    r118 = r118 + r136;
+    r25 = r29 * r31;
+    r118 = fmaf(r23, r25, r118);
+    r100 = r29 * r37;
+    r118 = fmaf(r76, r100, r118);
+    r118 = fmaf(r11, r118, r13 * r131);
+    r131 = r8 * r37;
+    r131 = fmaf(r8, r79, r133 * r131);
+    r131 = r131 + r91;
+    r118 = fmaf(r12, r131, r118);
+    r131 = r8 * r33;
+    r100 = r8 * r31;
+    r100 = r100 * r133;
+    r87 = r87 + r100;
+    r25 = r24 * r29;
+    r87 = fmaf(r23, r25, r87);
+    r87 = r87 + r77;
+    r74 = r24 * r74;
+    r74 = r74 * r85;
+    r99 = r74 + r99;
+    r99 = fmaf(r11, r99, r12 * r87);
+    r87 = r8 * r37;
+    r87 = fmaf(r76, r87, r136);
+    r87 = r87 + r120;
+    r99 = fmaf(r13, r87, r99);
+    r131 = r131 * r99;
+    r131 = fmaf(r53, r131, r118 * r83);
+    r87 = r55 * r55;
+    r87 = r87 * r118;
+    r131 = fmaf(r84, r87, r131);
+    r120 = r8 * r55;
+    r100 = r80 + r100;
+    r100 = r100 + r102;
+    r102 = r29 * r37;
+    r79 = fmaf(r29, r79, r133 * r102);
+    r79 = r79 + r91;
+    r79 = fmaf(r13, r79, r11 * r100);
+    r93 = r74 + r93;
+    r79 = fmaf(r12, r93, r79);
+    r120 = r120 * r79;
+    r131 = fmaf(r53, r120, r131);
+    r120 = r79 * r28;
+    r120 = fmaf(r92, r120, r131 * r95);
+    r87 = r55 * r47;
+    r87 = r87 * r118;
+    r87 = r87 * r39;
+    r87 = r87 * r42;
+    r120 = fmaf(r84, r87, r120);
+    r93 = r26 * r55;
+    r93 = r93 * r47;
+    r93 = r93 * r131;
+    r93 = r93 * r53;
+    r93 = r93 * r54;
+    r93 = r93 * r81;
+    r120 = fmaf(r42, r93, r120);
+    r93 = r131 * r103;
+    r93 = fmaf(r105, r93, r118 * r107);
+    r87 = r26 * r33;
+    r87 = r87 * r33;
+    r87 = r87 * r47;
+    r87 = r87 * r47;
+    r87 = r87 * r131;
+    r87 = r87 * r53;
+    r87 = r87 * r54;
+    r93 = fmaf(r81, r87, r93);
+    r93 = fmaf(r99, r96, r93);
+    r87 = r120 + r93;
+    r12 = r33 * r33;
+    r12 = r12 * r47;
+    r12 = r12 * r47;
+    r12 = r12 * r113;
+    r12 = r12 * r118;
+    r12 = r12 * r39;
+    r74 = r56 * r131;
+    r74 = r74 * r103;
+    r74 = fmaf(r105, r74, r98 * r12);
+    r12 = r131 * r114;
+    r74 = fmaf(r106, r12, r74);
+    r13 = r47 * r110;
+    r13 = r13 * r99;
+    r13 = r13 * r40;
+    r74 = fmaf(r57, r13, r74);
+    r74 = r74 + r120;
+    r74 = fmaf(r7, r74, r60 * r87);
+    r120 = r6 * r79;
+    r74 = fmaf(r96, r120, r74);
+    r13 = r47 * r99;
+    r74 = fmaf(r72, r13, r74);
+    r12 = r78 * r131;
+    r12 = r12 * r71;
+    r74 = fmaf(r105, r12, r74);
+    r100 = r5 * r8;
+    r100 = r100 * r46;
+    r100 = fmaf(r87, r100, r4 * r87);
+    r100 = fmaf(r87, r58, r100);
+    r100 = fmaf(r87, r59, r100);
+    r11 = r100 * r71;
+    r74 = fmaf(r57, r11, r74);
+    r91 = r26 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r118;
+    r91 = r91 * r53;
+    r74 = fmaf(r70, r91, r74);
+    r102 = r6 * r131;
+    r74 = fmaf(r119, r102, r74);
+    r133 = r33 * r47;
+    r133 = r133 * r66;
+    r133 = r133 * r75;
+    r133 = r133 * r131;
+    r133 = r133 * r39;
+    r133 = r133 * r69;
+    r74 = fmaf(r54, r133, r74);
+    r80 = r26 * r33;
+    r80 = r80 * r47;
+    r80 = r80 * r66;
+    r80 = r80 * r118;
+    r80 = r80 * r53;
+    r74 = fmaf(r70, r80, r74);
+    r136 = r33 * r47;
+    r136 = r136 * r75;
+    r136 = r136 * r131;
+    r136 = r136 * r39;
+    r136 = r136 * r69;
+    r74 = fmaf(r54, r136, r74);
+    r76 = r6 * r29;
+    r76 = r76 * r131;
+    r76 = r76 * r53;
+    r76 = r76 * r54;
+    r76 = r76 * r81;
+    r76 = r76 * r42;
+    r74 = fmaf(r57, r76, r74);
+    r85 = r6 * r99;
+    r85 = r85 * r28;
+    r74 = fmaf(r92, r85, r74);
+    r77 = r47 * r99;
+    r74 = fmaf(r71, r77, r74);
+    r74 = fmaf(r118, r127, r74);
+    r74 = fmaf(r131, r115, r74);
+    r77 = r0 * r74;
+    r85 = r56 * r131;
+    r76 = r47 * r110;
+    r76 = r76 * r79;
+    r76 = fmaf(r28, r76, r95 * r85);
+    r85 = r55 * r47;
+    r85 = r85 * r113;
+    r85 = r85 * r118;
+    r85 = r85 * r39;
+    r85 = r85 * r98;
+    r76 = fmaf(r42, r85, r76);
+    r76 = fmaf(r131, r130, r76);
+    r76 = r76 + r93;
+    r76 = fmaf(r6, r76, r61 * r87);
+    r87 = r100 * r42;
+    r76 = fmaf(r71, r87, r76);
+    r93 = r75 * r131;
+    r93 = r93 * r39;
+    r93 = r93 * r69;
+    r93 = r93 * r54;
+    r76 = fmaf(r42, r93, r76);
+    r85 = r55 * r78;
+    r85 = r85 * r131;
+    r85 = r85 * r71;
+    r76 = fmaf(r94, r85, r76);
+    r136 = r47 * r79;
+    r76 = fmaf(r72, r136, r76);
+    r80 = r7 * r131;
+    r76 = fmaf(r119, r80, r76);
+    r133 = r7 * r118;
+    r76 = fmaf(r126, r133, r76);
+    r102 = r26 * r66;
+    r102 = r102 * r118;
+    r102 = r102 * r53;
+    r102 = r102 * r70;
+    r76 = fmaf(r42, r102, r76);
+    r91 = r55 * r131;
+    r91 = r91 * r94;
+    r76 = fmaf(r89, r91, r76);
+    r11 = r26 * r118;
+    r11 = r11 * r53;
+    r11 = r11 * r70;
+    r76 = fmaf(r42, r11, r76);
+    r12 = r7 * r29;
+    r12 = r12 * r131;
+    r12 = r12 * r53;
+    r12 = r12 * r54;
+    r12 = r12 * r81;
+    r12 = r12 * r42;
+    r76 = fmaf(r57, r12, r76);
+    r13 = r7 * r99;
+    r13 = r13 * r28;
+    r76 = fmaf(r92, r13, r76);
+    r120 = r66 * r75;
+    r120 = r120 * r131;
+    r120 = r120 * r39;
+    r120 = r120 * r69;
+    r120 = r120 * r54;
+    r76 = fmaf(r42, r120, r76);
+    r25 = r47 * r79;
+    r76 = fmaf(r71, r25, r76);
+    r76 = fmaf(r79, r104, r76);
+    r25 = r1 * r76;
+    r120 = r10 * r33;
+    r120 = r120 * r33;
+    r120 = r120 * r47;
+    r120 = r120 * r47;
+    r120 = r120 * r113;
+    r120 = r120 * r39;
+    r13 = r48 * r47;
+    r13 = r13 * r110;
+    r13 = r13 * r40;
+    r13 = fmaf(r57, r13, r98 * r120);
+    r120 = r10 * r55;
+    r120 = r120 * r55;
+    r12 = r8 * r9;
+    r12 = r12 * r55;
+    r12 = fmaf(r53, r12, r84 * r120);
+    r120 = r8 * r48;
+    r120 = r120 * r33;
+    r12 = fmaf(r53, r120, r12);
+    r12 = fmaf(r10, r83, r12);
+    r120 = r12 * r114;
+    r13 = fmaf(r106, r120, r13);
+    r11 = r56 * r12;
+    r11 = r11 * r103;
+    r13 = fmaf(r105, r11, r13);
+    r91 = r10 * r55;
+    r91 = r91 * r47;
+    r91 = r91 * r39;
+    r91 = r91 * r42;
+    r102 = r9 * r28;
+    r102 = fmaf(r92, r102, r84 * r91);
+    r91 = r26 * r55;
+    r91 = r91 * r47;
+    r91 = r91 * r12;
+    r91 = r91 * r53;
+    r91 = r91 * r54;
+    r91 = r91 * r81;
+    r102 = fmaf(r42, r91, r102);
+    r102 = fmaf(r12, r95, r102);
+    r13 = r13 + r102;
+    r11 = fmaf(r48, r96, r10 * r107);
+    r120 = r26 * r33;
+    r120 = r120 * r33;
+    r120 = r120 * r47;
+    r120 = r120 * r47;
+    r120 = r120 * r12;
+    r120 = r120 * r53;
+    r120 = r120 * r54;
+    r11 = fmaf(r81, r120, r11);
+    r91 = r12 * r103;
+    r11 = fmaf(r105, r91, r11);
+    r102 = r102 + r11;
+    r13 = fmaf(r60, r102, r7 * r13);
+    r91 = r26 * r10;
+    r91 = r91 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r53;
+    r13 = fmaf(r70, r91, r13);
+    r120 = r33 * r47;
+    r120 = r120 * r66;
+    r120 = r120 * r75;
+    r120 = r120 * r12;
+    r120 = r120 * r39;
+    r120 = r120 * r69;
+    r13 = fmaf(r54, r120, r13);
+    r133 = r26 * r10;
+    r133 = r133 * r33;
+    r133 = r133 * r47;
+    r133 = r133 * r66;
+    r133 = r133 * r53;
+    r13 = fmaf(r70, r133, r13);
+    r80 = r48 * r47;
+    r13 = fmaf(r71, r80, r13);
+    r136 = r12 * r119;
+    r85 = r6 * r48;
+    r85 = r85 * r28;
+    r13 = fmaf(r92, r85, r13);
+    r93 = r48 * r47;
+    r13 = fmaf(r72, r93, r13);
+    r87 = r33 * r47;
+    r87 = r87 * r75;
+    r87 = r87 * r12;
+    r87 = r87 * r39;
+    r87 = r87 * r69;
+    r13 = fmaf(r54, r87, r13);
+    r23 = r78 * r12;
+    r23 = r23 * r71;
+    r13 = fmaf(r105, r23, r13);
+    r82 = r5 * r8;
+    r82 = r82 * r46;
+    r82 = fmaf(r4, r102, r102 * r82);
+    r82 = fmaf(r102, r59, r82);
+    r82 = fmaf(r102, r58, r82);
+    r22 = r82 * r71;
+    r13 = fmaf(r57, r22, r13);
+    r101 = r6 * r9;
+    r13 = fmaf(r96, r101, r13);
+    r112 = r6 * r29;
+    r112 = r112 * r12;
+    r112 = r112 * r53;
+    r112 = r112 * r54;
+    r112 = r112 * r81;
+    r112 = r112 * r42;
+    r13 = fmaf(r57, r112, r13);
+    r13 = fmaf(r12, r115, r13);
+    r13 = fmaf(r6, r136, r13);
+    r13 = fmaf(r10, r127, r13);
+    r112 = r0 * r13;
+    r101 = r10 * r55;
+    r101 = r101 * r47;
+    r101 = r101 * r113;
+    r101 = r101 * r39;
+    r101 = r101 * r98;
+    r22 = r9 * r47;
+    r22 = r22 * r110;
+    r22 = fmaf(r28, r22, r42 * r101);
+    r101 = r56 * r12;
+    r22 = fmaf(r95, r101, r22);
+    r22 = fmaf(r12, r130, r22);
+    r22 = r22 + r11;
+    r102 = fmaf(r61, r102, r6 * r22);
+    r22 = r82 * r42;
+    r102 = fmaf(r71, r22, r102);
+    r11 = r26 * r10;
+    r11 = r11 * r53;
+    r11 = r11 * r70;
+    r102 = fmaf(r42, r11, r102);
+    r101 = r55 * r12;
+    r101 = r101 * r94;
+    r102 = fmaf(r89, r101, r102);
+    r23 = r75 * r12;
+    r23 = r23 * r39;
+    r23 = r23 * r69;
+    r23 = r23 * r54;
+    r102 = fmaf(r42, r23, r102);
+    r87 = r9 * r47;
+    r102 = fmaf(r71, r87, r102);
+    r93 = r26 * r10;
+    r93 = r93 * r66;
+    r93 = r93 * r53;
+    r93 = r93 * r70;
+    r102 = fmaf(r42, r93, r102);
+    r85 = r7 * r48;
+    r85 = r85 * r28;
+    r102 = fmaf(r92, r85, r102);
+    r80 = r9 * r47;
+    r102 = fmaf(r72, r80, r102);
+    r133 = r55 * r78;
+    r133 = r133 * r12;
+    r133 = r133 * r71;
+    r102 = fmaf(r94, r133, r102);
+    r120 = r66 * r75;
+    r120 = r120 * r12;
+    r120 = r120 * r39;
+    r120 = r120 * r69;
+    r120 = r120 * r54;
+    r102 = fmaf(r42, r120, r102);
+    r91 = r7 * r10;
+    r102 = fmaf(r126, r91, r102);
+    r108 = r7 * r29;
+    r108 = r108 * r12;
+    r108 = r108 * r53;
+    r108 = r108 * r54;
+    r108 = r108 * r81;
+    r108 = r108 * r42;
+    r102 = fmaf(r57, r108, r102);
+    r102 = fmaf(r7, r136, r102);
+    r102 = fmaf(r9, r104, r102);
+    r108 = r1 * r102;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r77,
+                                          r25,
+                                          r112,
+                                          r108);
+    r108 = r51 * r55;
+    r108 = r108 * r55;
+    r112 = r8 * r43;
+    r112 = r112 * r55;
+    r112 = fmaf(r53, r112, r84 * r108);
+    r108 = r8 * r45;
+    r108 = r108 * r33;
+    r112 = fmaf(r53, r108, r112);
+    r112 = fmaf(r51, r83, r112);
+    r108 = r51 * r55;
+    r108 = r108 * r47;
+    r108 = r108 * r39;
+    r108 = r108 * r42;
+    r108 = fmaf(r84, r108, r112 * r95);
+    r25 = r43 * r28;
+    r108 = fmaf(r92, r25, r108);
+    r77 = r26 * r55;
+    r77 = r77 * r47;
+    r77 = r77 * r112;
+    r77 = r77 * r53;
+    r77 = r77 * r54;
+    r77 = r77 * r81;
+    r108 = fmaf(r42, r77, r108);
+    r77 = r112 * r103;
+    r77 = fmaf(r51, r107, r105 * r77);
+    r25 = r26 * r33;
+    r25 = r25 * r33;
+    r25 = r25 * r47;
+    r25 = r25 * r47;
+    r25 = r25 * r112;
+    r25 = r25 * r53;
+    r25 = r25 * r54;
+    r77 = fmaf(r81, r25, r77);
+    r77 = fmaf(r45, r96, r77);
+    r25 = r108 + r77;
+    r91 = r56 * r112;
+    r91 = r91 * r103;
+    r120 = r51 * r33;
+    r120 = r120 * r33;
+    r120 = r120 * r47;
+    r120 = r120 * r47;
+    r120 = r120 * r113;
+    r120 = r120 * r39;
+    r120 = fmaf(r98, r120, r105 * r91);
+    r91 = r45 * r47;
+    r91 = r91 * r110;
+    r91 = r91 * r40;
+    r120 = fmaf(r57, r91, r120);
+    r133 = r112 * r114;
+    r120 = fmaf(r106, r133, r120);
+    r120 = r120 + r108;
+    r120 = fmaf(r7, r120, r60 * r25);
+    r108 = r6 * r45;
+    r108 = r108 * r28;
+    r120 = fmaf(r92, r108, r120);
+    r133 = r45 * r47;
+    r120 = fmaf(r72, r133, r120);
+    r91 = r26 * r51;
+    r91 = r91 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r66;
+    r91 = r91 * r53;
+    r120 = fmaf(r70, r91, r120);
+    r80 = r33 * r47;
+    r80 = r80 * r75;
+    r80 = r80 * r112;
+    r80 = r80 * r39;
+    r80 = r80 * r69;
+    r120 = fmaf(r54, r80, r120);
+    r85 = r5 * r8;
+    r85 = r85 * r46;
+    r85 = fmaf(r4, r25, r25 * r85);
+    r85 = fmaf(r25, r59, r85);
+    r85 = fmaf(r25, r58, r85);
+    r93 = r85 * r71;
+    r120 = fmaf(r57, r93, r120);
+    r87 = r6 * r29;
+    r87 = r87 * r112;
+    r87 = r87 * r53;
+    r87 = r87 * r54;
+    r87 = r87 * r81;
+    r87 = r87 * r42;
+    r120 = fmaf(r57, r87, r120);
+    r136 = r45 * r47;
+    r120 = fmaf(r71, r136, r120);
+    r23 = r78 * r112;
+    r23 = r23 * r71;
+    r120 = fmaf(r105, r23, r120);
+    r101 = r6 * r43;
+    r120 = fmaf(r96, r101, r120);
+    r11 = r6 * r112;
+    r120 = fmaf(r119, r11, r120);
+    r22 = r26 * r51;
+    r22 = r22 * r33;
+    r22 = r22 * r47;
+    r22 = r22 * r53;
+    r120 = fmaf(r70, r22, r120);
+    r128 = r33 * r47;
+    r128 = r128 * r66;
+    r128 = r128 * r75;
+    r128 = r128 * r112;
+    r128 = r128 * r39;
+    r128 = r128 * r69;
+    r120 = fmaf(r54, r128, r120);
+    r120 = fmaf(r112, r115, r120);
+    r120 = fmaf(r51, r127, r120);
+    r128 = r0 * r120;
+    r22 = r56 * r112;
+    r11 = r51 * r55;
+    r11 = r11 * r47;
+    r11 = r11 * r113;
+    r11 = r11 * r39;
+    r11 = r11 * r98;
+    r11 = fmaf(r42, r11, r95 * r22);
+    r22 = r43 * r47;
+    r22 = r22 * r110;
+    r11 = fmaf(r28, r22, r11);
+    r11 = fmaf(r112, r130, r11);
+    r11 = r11 + r77;
+    r11 = fmaf(r6, r11, r61 * r25);
+    r25 = r26 * r51;
+    r25 = r25 * r53;
+    r25 = r25 * r70;
+    r11 = fmaf(r42, r25, r11);
+    r77 = r7 * r45;
+    r77 = r77 * r28;
+    r11 = fmaf(r92, r77, r11);
+    r22 = r55 * r112;
+    r22 = r22 * r94;
+    r11 = fmaf(r89, r22, r11);
+    r101 = r55 * r78;
+    r101 = r101 * r112;
+    r101 = r101 * r71;
+    r11 = fmaf(r94, r101, r11);
+    r23 = r66 * r75;
+    r23 = r23 * r112;
+    r23 = r23 * r39;
+    r23 = r23 * r69;
+    r23 = r23 * r54;
+    r11 = fmaf(r42, r23, r11);
+    r136 = r7 * r29;
+    r136 = r136 * r112;
+    r136 = r136 * r53;
+    r136 = r136 * r54;
+    r136 = r136 * r81;
+    r136 = r136 * r42;
+    r11 = fmaf(r57, r136, r11);
+    r87 = r85 * r42;
+    r11 = fmaf(r71, r87, r11);
+    r93 = r7 * r112;
+    r11 = fmaf(r119, r93, r11);
+    r80 = r43 * r47;
+    r11 = fmaf(r71, r80, r11);
+    r91 = r26 * r51;
+    r91 = r91 * r66;
+    r91 = r91 * r53;
+    r91 = r91 * r70;
+    r11 = fmaf(r42, r91, r11);
+    r133 = r43 * r47;
+    r11 = fmaf(r72, r133, r11);
+    r108 = r7 * r51;
+    r11 = fmaf(r126, r108, r11);
+    r134 = r75 * r112;
+    r134 = r134 * r39;
+    r134 = r134 * r69;
+    r134 = r134 * r54;
+    r11 = fmaf(r42, r134, r11);
+    r11 = fmaf(r43, r104, r11);
+    r134 = r1 * r11;
+    r108 = r38 * r33;
+    r108 = r108 * r33;
+    r108 = r108 * r47;
+    r108 = r108 * r47;
+    r108 = r108 * r113;
+    r108 = r108 * r39;
+    r133 = r8 * r49;
+    r133 = r133 * r55;
+    r91 = r38 * r55;
+    r91 = r91 * r55;
+    r91 = fmaf(r84, r91, r53 * r133);
+    r133 = r8 * r44;
+    r133 = r133 * r33;
+    r91 = fmaf(r53, r133, r91);
+    r91 = fmaf(r38, r83, r91);
+    r83 = r91 * r114;
+    r83 = fmaf(r106, r83, r98 * r108);
+    r108 = r44 * r47;
+    r108 = r108 * r110;
+    r108 = r108 * r40;
+    r83 = fmaf(r57, r108, r83);
+    r40 = r56 * r91;
+    r40 = r40 * r103;
+    r83 = fmaf(r105, r40, r83);
+    r106 = r49 * r28;
+    r106 = fmaf(r92, r106, r91 * r95);
+    r133 = r26 * r55;
+    r133 = r133 * r47;
+    r133 = r133 * r91;
+    r133 = r133 * r53;
+    r133 = r133 * r54;
+    r133 = r133 * r81;
+    r106 = fmaf(r42, r133, r106);
+    r80 = r38 * r55;
+    r80 = r80 * r47;
+    r80 = r80 * r39;
+    r80 = r80 * r42;
+    r106 = fmaf(r84, r80, r106);
+    r83 = r83 + r106;
+    r40 = r26 * r33;
+    r40 = r40 * r33;
+    r40 = r40 * r47;
+    r40 = r40 * r47;
+    r40 = r40 * r91;
+    r40 = r40 * r53;
+    r40 = r40 * r54;
+    r40 = fmaf(r81, r40, r38 * r107);
+    r107 = r91 * r103;
+    r40 = fmaf(r105, r107, r40);
+    r40 = fmaf(r44, r96, r40);
+    r106 = r106 + r40;
+    r60 = fmaf(r60, r106, r7 * r83);
+    r83 = r33 * r47;
+    r83 = r83 * r66;
+    r83 = r83 * r75;
+    r83 = r83 * r91;
+    r83 = r83 * r39;
+    r83 = r83 * r69;
+    r60 = fmaf(r54, r83, r60);
+    r107 = r6 * r49;
+    r60 = fmaf(r96, r107, r60);
+    r96 = r5 * r8;
+    r96 = r96 * r46;
+    r96 = fmaf(r106, r96, r4 * r106);
+    r96 = fmaf(r106, r59, r96);
+    r96 = fmaf(r106, r58, r96);
+    r58 = r96 * r71;
+    r60 = fmaf(r57, r58, r60);
+    r59 = r44 * r47;
+    r60 = fmaf(r71, r59, r60);
+    r4 = r26 * r38;
+    r4 = r4 * r33;
+    r4 = r4 * r47;
+    r4 = r4 * r53;
+    r60 = fmaf(r70, r4, r60);
+    r108 = r6 * r91;
+    r60 = fmaf(r119, r108, r60);
+    r80 = r33 * r47;
+    r80 = r80 * r75;
+    r80 = r80 * r91;
+    r80 = r80 * r39;
+    r80 = r80 * r69;
+    r60 = fmaf(r54, r80, r60);
+    r133 = r6 * r29;
+    r133 = r133 * r91;
+    r133 = r133 * r53;
+    r133 = r133 * r54;
+    r133 = r133 * r81;
+    r133 = r133 * r42;
+    r60 = fmaf(r57, r133, r60);
+    r84 = r26 * r38;
+    r84 = r84 * r33;
+    r84 = r84 * r47;
+    r84 = r84 * r66;
+    r84 = r84 * r53;
+    r60 = fmaf(r70, r84, r60);
+    r93 = r6 * r44;
+    r93 = r93 * r28;
+    r60 = fmaf(r92, r93, r60);
+    r87 = r44 * r47;
+    r60 = fmaf(r72, r87, r60);
+    r136 = r78 * r91;
+    r136 = r136 * r71;
+    r60 = fmaf(r105, r136, r60);
+    r60 = fmaf(r38, r127, r60);
+    r60 = fmaf(r91, r115, r60);
+    r136 = r0 * r60;
+    r87 = r56 * r91;
+    r93 = r49 * r47;
+    r93 = r93 * r110;
+    r93 = fmaf(r28, r93, r95 * r87);
+    r87 = r38 * r55;
+    r87 = r87 * r47;
+    r87 = r87 * r113;
+    r87 = r87 * r39;
+    r87 = r87 * r98;
+    r93 = fmaf(r42, r87, r93);
+    r93 = fmaf(r91, r130, r93);
+    r93 = r93 + r40;
+    r106 = fmaf(r61, r106, r6 * r93);
+    r61 = r55 * r78;
+    r61 = r61 * r91;
+    r61 = r61 * r71;
+    r106 = fmaf(r94, r61, r106);
+    r93 = r7 * r38;
+    r106 = fmaf(r126, r93, r106);
+    r126 = r55 * r91;
+    r126 = r126 * r94;
+    r106 = fmaf(r89, r126, r106);
+    r89 = r66 * r75;
+    r89 = r89 * r91;
+    r89 = r89 * r39;
+    r89 = r89 * r69;
+    r89 = r89 * r54;
+    r106 = fmaf(r42, r89, r106);
+    r94 = r7 * r91;
+    r106 = fmaf(r119, r94, r106);
+    r119 = r75 * r91;
+    r119 = r119 * r39;
+    r119 = r119 * r69;
+    r119 = r119 * r54;
+    r106 = fmaf(r42, r119, r106);
+    r69 = r49 * r47;
+    r106 = fmaf(r72, r69, r106);
+    r72 = r7 * r29;
+    r72 = r72 * r91;
+    r72 = r72 * r53;
+    r72 = r72 * r54;
+    r72 = r72 * r81;
+    r72 = r72 * r42;
+    r106 = fmaf(r57, r72, r106);
+    r54 = r26 * r38;
+    r54 = r54 * r66;
+    r54 = r54 * r53;
+    r54 = r54 * r70;
+    r106 = fmaf(r42, r54, r106);
+    r39 = r96 * r42;
+    r106 = fmaf(r71, r39, r106);
+    r40 = r49 * r47;
+    r106 = fmaf(r71, r40, r106);
+    r87 = r26 * r38;
+    r87 = r87 * r53;
+    r87 = r87 * r70;
+    r106 = fmaf(r42, r87, r106);
+    r70 = r7 * r44;
+    r70 = r70 * r28;
+    r106 = fmaf(r92, r70, r106);
+    r106 = fmaf(r49, r104, r106);
+    r70 = r1 * r106;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r128,
+                                          r134,
+                                          r136,
+                                          r70);
+    r70 = r0 * r26;
+    r70 = r70 * r2;
+    r136 = r26 * r3;
+    r134 = r1 * r136;
+    r70 = fmaf(r129, r134, r111 * r70);
+    r128 = r0 * r26;
+    r128 = r128 * r2;
+    r128 = fmaf(r135, r134, r27 * r128);
+    r87 = r0 * r26;
+    r87 = r87 * r2;
+    r87 = fmaf(r76, r134, r74 * r87);
+    r40 = r0 * r26;
+    r40 = r40 * r2;
+    r40 = fmaf(r102, r134, r13 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r70, r128, r87, r40);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r0 * r26;
+    r40 = r40 * r2;
+    r40 = fmaf(r11, r134, r120 * r40);
+    r87 = r0 * r26;
+    r87 = r87 * r2;
+    r87 = fmaf(r106, r134, r60 * r87);
+    WriteSum2<float, float>((float*)inout_shared, r40, r87);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r87 = r1 * r1;
+    r40 = r129 * r129;
+    r128 = r111 * r111;
+    r70 = r0 * r0;
+    r128 = fmaf(r70, r128, r87 * r40);
+    r40 = r27 * r27;
+    r39 = r135 * r135;
+    r39 = fmaf(r87, r39, r70 * r40);
+    r40 = r74 * r74;
+    r54 = r76 * r76;
+    r54 = fmaf(r87, r54, r70 * r40);
+    r40 = r102 * r102;
+    r72 = r13 * r13;
+    r72 = fmaf(r70, r72, r87 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r128, r39, r54, r72);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r11 * r11;
+    r54 = r120 * r120;
+    r54 = fmaf(r70, r54, r87 * r72);
+    r72 = r106 * r106;
+    r39 = r60 * r60;
+    r39 = fmaf(r70, r39, r87 * r72);
+    WriteSum2<float, float>((float*)inout_shared, r54, r39);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r111 * r27;
+    r54 = r129 * r135;
+    r54 = fmaf(r87, r54, r70 * r39);
+    r39 = r111 * r74;
+    r72 = r129 * r76;
+    r72 = fmaf(r87, r72, r70 * r39);
+    r39 = r129 * r102;
+    r128 = r111 * r13;
+    r128 = fmaf(r70, r128, r87 * r39);
+    r39 = r111 * r120;
+    r40 = r129 * r11;
+    r40 = fmaf(r87, r40, r70 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r54, r72, r128, r40);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r111 * r60;
+    r128 = r129 * r106;
+    r128 = fmaf(r87, r128, r70 * r40);
+    r40 = r135 * r76;
+    r72 = r27 * r74;
+    r72 = fmaf(r70, r72, r87 * r40);
+    r40 = r135 * r102;
+    r54 = r27 * r13;
+    r54 = fmaf(r70, r54, r87 * r40);
+    r40 = r135 * r11;
+    r39 = r27 * r120;
+    r39 = fmaf(r70, r39, r87 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r128, r72, r54, r39);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r135 * r106;
+    r54 = r27 * r60;
+    r54 = fmaf(r70, r54, r87 * r39);
+    r39 = r76 * r102;
+    r72 = r74 * r13;
+    r72 = fmaf(r70, r72, r87 * r39);
+    r39 = r76 * r11;
+    r128 = r74 * r120;
+    r128 = fmaf(r70, r128, r87 * r39);
+    r39 = r74 * r60;
+    r40 = r76 * r106;
+    r40 = fmaf(r87, r40, r70 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r54, r72, r128, r40);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r13 * r120;
+    r128 = r102 * r11;
+    r128 = fmaf(r87, r128, r70 * r40);
+    r40 = r13 * r60;
+    r72 = r102 * r106;
+    r72 = fmaf(r87, r72, r70 * r40);
+    r40 = r11 * r106;
+    r54 = r120 * r60;
+    r54 = fmaf(r70, r54, r87 * r40);
+    WriteSum3<float, float>((float*)inout_shared, r128, r72, r54);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r0 * r46;
+    r54 = r54 * r71;
+    r54 = r54 * r57;
+    r72 = r1 * r46;
+    r72 = r72 * r42;
+    r72 = r72 * r71;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r63,
+                                          r62,
+                                          r54,
+                                          r72);
+    r128 = r1 * r64;
+    r40 = r0 * r71;
+    r40 = r40 * r57;
+    r40 = r40 * r65;
+    r39 = r1 * r42;
+    r39 = r39 * r71;
+    r39 = r39 * r65;
+    r69 = r0 * r8;
+    r69 = r69 * r57;
+    r69 = r69 * r28;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r40,
+                                          r39,
+                                          r69,
+                                          r128);
+    r119 = r0 * r35;
+    r94 = r1 * r8;
+    r94 = r94 * r57;
+    r94 = r94 * r28;
+    r89 = r0 * r71;
+    r89 = r89 * r57;
+    r89 = r89 * r68;
+    r126 = r1 * r42;
+    r126 = r126 * r71;
+    r126 = r126 * r68;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r119,
+                                          r94,
+                                          r89,
+                                          r126);
+    r93 = r0 * r46;
+    r61 = r1 * r46;
+    r104 = r0 * r71;
+    r104 = r104 * r57;
+    r104 = r104 * r67;
+    r53 = r1 * r42;
+    r53 = r53 * r71;
+    r53 = r53 * r67;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r104,
+                                          r53,
+                                          r93,
+                                          r61);
+    r130 = r26 * r63;
+    r130 = r130 * r2;
+    r113 = r26 * r2;
+    r95 = r62 * r136;
+    WriteSum4<float, float>((float*)inout_shared, r130, r95, r113, r136);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r136 = r46 * r42;
+    r136 = r136 * r71;
+    r113 = r0 * r26;
+    r113 = r113 * r46;
+    r113 = r113 * r2;
+    r113 = r113 * r71;
+    r113 = fmaf(r57, r113, r134 * r136);
+    r136 = r42 * r71;
+    r136 = r136 * r65;
+    r95 = r0 * r26;
+    r95 = r95 * r2;
+    r95 = r95 * r71;
+    r95 = r95 * r57;
+    r95 = fmaf(r65, r95, r134 * r136);
+    r136 = r0 * r29;
+    r136 = r136 * r2;
+    r136 = r136 * r57;
+    r136 = fmaf(r28, r136, r64 * r134);
+    r130 = r0 * r26;
+    r130 = r130 * r35;
+    r84 = r1 * r29;
+    r84 = r84 * r3;
+    r84 = r84 * r57;
+    r84 = fmaf(r28, r84, r2 * r130);
+    WriteSum4<float, float>((float*)inout_shared, r113, r95, r136, r84);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r84 = r0 * r26;
+    r84 = r84 * r46;
+    r84 = r84 * r2;
+    r136 = r46 * r134;
+    r95 = r42 * r71;
+    r95 = r95 * r68;
+    r113 = r0 * r26;
+    r113 = r113 * r2;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    r113 = fmaf(r68, r113, r134 * r95);
+    r95 = r42 * r71;
+    r95 = r95 * r67;
+    r130 = r0 * r26;
+    r130 = r130 * r2;
+    r130 = r130 * r71;
+    r130 = r130 * r57;
+    r130 = fmaf(r67, r130, r134 * r95);
+    WriteSum4<float, float>((float*)inout_shared, r113, r130, r84, r136);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r136 = r63 * r63;
+    r84 = r62 * r62;
+    WriteSum4<float, float>((float*)inout_shared, r136, r84, r30, r30);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r33 * r47;
+    r30 = r30 * r65;
+    r30 = r30 * r70;
+    r84 = r47 * r65;
+    r84 = r84 * r87;
+    r84 = fmaf(r52, r84, r103 * r30);
+    r30 = r33 * r47;
+    r30 = r30 * r70;
+    r30 = r30 * r103;
+    r136 = r47 * r87;
+    r136 = r136 * r67;
+    r136 = fmaf(r52, r136, r67 * r30);
+    r30 = r64 * r64;
+    r130 = r42 * r70;
+    r113 = r33 * r55;
+    r50 = r32 * r50;
+    r50 = 1.0 / r50;
+    r36 = r41 * r36;
+    r36 = 1.0 / r36;
+    r113 = r113 * r47;
+    r113 = r113 * r47;
+    r113 = r113 * r123;
+    r113 = r113 * r50;
+    r113 = r113 * r36;
+    r113 = r113 * r57;
+    r130 = fmaf(r113, r130, r87 * r30);
+    r30 = r35 * r70;
+    r36 = r42 * r87;
+    r113 = fmaf(r36, r113, r35 * r30);
+    WriteSum4<float, float>((float*)inout_shared, r84, r136, r130, r113);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r65 * r70;
+    r130 = r65 * r87;
+    r84 = r33 * r47;
+    r50 = r68 * r68;
+    r84 = r84 * r70;
+    r84 = r84 * r103;
+    r123 = r47 * r87;
+    r123 = r123 * r52;
+    r84 = fmaf(r50, r123, r50 * r84);
+    r41 = r67 * r67;
+    r32 = r70 * r103;
+    r32 = r32 * r57;
+    r41 = fmaf(r123, r41, r41 * r32);
+    WriteSum4<float, float>((float*)inout_shared, r84, r41, r113, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = 0.00000000000000000e+00;
+    r113 = r0 * r46;
+    r113 = r113 * r63;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r130, r63, r130, r113);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r0 * r35;
+    r35 = r35 * r63;
+    r113 = r0 * r63;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    r113 = r113 * r65;
+    r41 = r0 * r8;
+    r41 = r41 * r63;
+    r41 = r41 * r57;
+    r41 = r41 * r28;
+    r95 = r0 * r63;
+    r95 = r95 * r71;
+    r95 = r95 * r57;
+    r95 = r95 * r68;
+    WriteSum4<float, float>((float*)inout_shared, r113, r41, r35, r95);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r0 * r46;
+    r95 = r95 * r63;
+    r63 = r0 * r63;
+    r63 = r63 * r71;
+    r63 = r63 * r57;
+    r63 = r63 * r67;
+    WriteSum4<float, float>((float*)inout_shared, r63, r95, r130, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r1 * r64;
+    r95 = r95 * r62;
+    r63 = r1 * r46;
+    r63 = r63 * r62;
+    r63 = r63 * r42;
+    r63 = r63 * r71;
+    r35 = r1 * r62;
+    r35 = r35 * r42;
+    r35 = r35 * r71;
+    r35 = r35 * r65;
+    WriteSum4<float, float>((float*)inout_shared, r62, r63, r35, r95);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r1 * r8;
+    r95 = r95 * r62;
+    r95 = r95 * r57;
+    r95 = r95 * r28;
+    r35 = r1 * r62;
+    r35 = r35 * r42;
+    r35 = r35 * r71;
+    r35 = r35 * r68;
+    r63 = r1 * r62;
+    r63 = r63 * r42;
+    r63 = r63 * r71;
+    r63 = r63 * r67;
+    WriteSum4<float, float>((float*)inout_shared, r95, r35, r63, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r1 * r46;
+    r63 = r63 * r62;
+    WriteSum4<float, float>((float*)inout_shared, r63, r130, r54, r40);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r69, r119, r89, r104);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r93, r130, r72, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r128, r94, r126, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r33 * r47;
+    r53 = r53 * r68;
+    r53 = r53 * r70;
+    r126 = r47 * r68;
+    r126 = r126 * r87;
+    r126 = fmaf(r52, r126, r103 * r53);
+    r53 = r33 * r46;
+    r53 = r53 * r98;
+    r53 = r53 * r81;
+    r53 = r53 * r42;
+    r53 = r53 * r57;
+    r53 = r53 * r70;
+    r94 = r71 * r36;
+    r128 = r64 * r94;
+    r53 = fmaf(r46, r128, r92 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r130, r61, r126, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r71 * r57;
+    r53 = r53 * r65;
+    r53 = r53 * r70;
+    r126 = r57 * r30;
+    r61 = r71 * r126;
+    r39 = r55 * r46;
+    r39 = r39 * r98;
+    r39 = r39 * r81;
+    r39 = r39 * r57;
+    r39 = r39 * r92;
+    r39 = fmaf(r36, r39, r46 * r61);
+    r72 = r33 * r47;
+    r93 = r46 * r67;
+    r72 = r72 * r70;
+    r72 = r72 * r103;
+    r104 = r47 * r87;
+    r104 = r104 * r52;
+    r104 = fmaf(r93, r104, r93 * r72);
+    WriteSum4<float, float>((float*)inout_shared, r39, r136, r104, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r65 * r94;
+    r136 = r33 * r98;
+    r136 = r136 * r81;
+    r136 = r136 * r42;
+    r136 = r136 * r57;
+    r136 = r136 * r65;
+    r136 = r136 * r70;
+    r136 = fmaf(r65, r128, r92 * r136);
+    r39 = r55 * r98;
+    r39 = r39 * r81;
+    r39 = r39 * r57;
+    r39 = r39 * r65;
+    r39 = r39 * r92;
+    r39 = fmaf(r36, r39, r65 * r61);
+    WriteSum4<float, float>((float*)inout_shared, r53, r136, r39, r104);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r71 * r57;
+    r104 = r104 * r68;
+    r104 = r104 * r70;
+    r39 = r68 * r94;
+    r136 = r8 * r28;
+    r53 = r8 * r64;
+    r53 = r53 * r57;
+    r53 = r53 * r28;
+    r53 = fmaf(r87, r53, r126 * r136);
+    WriteSum4<float, float>((float*)inout_shared, r84, r104, r39, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r8 * r46;
+    r53 = r53 * r57;
+    r53 = r53 * r28;
+    r53 = r53 * r70;
+    r39 = r46 * r64;
+    r39 = r39 * r87;
+    r104 = r33 * r98;
+    r104 = r104 * r81;
+    r104 = r104 * r42;
+    r104 = r104 * r57;
+    r104 = r104 * r68;
+    r104 = r104 * r70;
+    r104 = fmaf(r68, r128, r92 * r104);
+    r84 = r33 * r98;
+    r84 = r84 * r81;
+    r84 = r84 * r42;
+    r84 = r84 * r57;
+    r84 = r84 * r70;
+    r84 = r84 * r92;
+    r128 = fmaf(r67, r128, r67 * r84);
+    WriteSum4<float, float>((float*)inout_shared, r104, r128, r53, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r46 * r30;
+    r39 = r8 * r46;
+    r39 = r39 * r57;
+    r39 = r39 * r28;
+    r39 = r39 * r87;
+    r53 = r55 * r98;
+    r53 = r53 * r81;
+    r53 = r53 * r57;
+    r53 = r53 * r68;
+    r53 = r53 * r92;
+    r53 = fmaf(r36, r53, r68 * r61);
+    r128 = r55 * r98;
+    r128 = r128 * r81;
+    r128 = r128 * r57;
+    r128 = r128 * r92;
+    r128 = r128 * r67;
+    r128 = fmaf(r36, r128, r67 * r61);
+    WriteSum4<float, float>((float*)inout_shared, r53, r128, r30, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r71 * r57;
+    r39 = r39 * r70;
+    r39 = r39 * r67;
+    r67 = r67 * r94;
+    r57 = r71 * r57;
+    r57 = r57 * r70;
+    r57 = r57 * r93;
+    r50 = r46 * r50;
+    r123 = fmaf(r50, r123, r50 * r32);
+    WriteSum4<float, float>((float*)inout_shared, r123, r39, r67, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r93 * r94;
+    WriteSum2<float, float>((float*)inout_shared, r94, r130);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac_first.cu
@@ -1,0 +1,2243 @@
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r11, r12, r13);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16,
+                       r17);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r19,
+                                         r20,
+                                         r21);
+    r22 = r16 * r21;
+    r23 = r15 * r18;
+    r24 = r22 + r23;
+    r25 = r17 * r20;
+    r26 = -1.00000000000000000e+00;
+    r27 = r14 * r19;
+    r24 = r24 + r25;
+    r24 = fmaf(r26, r27, r24);
+    r28 = r24 * r24;
+    r29 = -2.00000000000000000e+00;
+    r28 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r16 * r18;
+    r31 = fmaf(r26, r31, r15 * r21);
+    r31 = fmaf(r17, r19, r31);
+    r31 = fmaf(r14, r20, r31);
+    r32 = r29 * r31;
+    r32 = fmaf(r31, r32, r30);
+    r33 = r28 + r32;
+    r33 = fmaf(r11, r33, r8);
+    r8 = 2.00000000000000000e+00;
+    r34 = fmaf(r17, r18, r14 * r21);
+    r35 = r15 * r20;
+    r34 = fmaf(r26, r35, r34);
+    r34 = fmaf(r16, r19, r34);
+    r35 = r8 * r34;
+    r35 = r35 * r31;
+    r36 = r24 * r29;
+    r37 = fmaf(r15, r19, r14 * r18);
+    r37 = fmaf(r16, r20, r37);
+    r37 = fmaf(r26, r37, r17 * r21);
+    r36 = fmaf(r37, r36, r35);
+    r38 = r8 * r24;
+    r38 = r38 * r34;
+    r39 = r8 * r31;
+    r39 = fmaf(r37, r39, r38);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r40,
+                       r41,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r18 * r20;
+    r43 = r43 * r8;
+    r44 = r19 * r21;
+    r44 = fmaf(r8, r44, r43);
+    r45 = r20 * r21;
+    r46 = r18 * r19;
+    r46 = r46 * r8;
+    r45 = fmaf(r29, r45, r46);
+    r47 = r19 * r19;
+    r47 = r47 * r29;
+    r48 = r30 + r47;
+    r49 = r20 * r20;
+    r49 = r49 * r29;
+    r48 = r48 + r49;
+    r33 = fmaf(r12, r36, r33);
+    r33 = fmaf(r13, r39, r33);
+    r33 = fmaf(r42, r44, r33);
+    r33 = fmaf(r41, r45, r33);
+    r33 = fmaf(r40, r48, r33);
+    r39 = r33 * r33;
+    r36 = 9.99999999999999955e-07;
+    r50 = r29 * r31;
+    r50 = fmaf(r37, r50, r38);
+    r50 = fmaf(r11, r50, r10);
+    r10 = r19 * r21;
+    r10 = fmaf(r29, r10, r43);
+    r43 = r18 * r18;
+    r43 = r43 * r29;
+    r38 = r30 + r43;
+    r38 = r38 + r47;
+    r47 = r19 * r20;
+    r47 = r47 * r8;
+    r51 = r18 * r21;
+    r51 = fmaf(r8, r51, r47);
+    r52 = r8 * r24;
+    r52 = r52 * r31;
+    r53 = r8 * r34;
+    r53 = fmaf(r37, r53, r52);
+    r54 = r34 * r34;
+    r54 = r54 * r29;
+    r32 = r54 + r32;
+    r50 = fmaf(r40, r10, r50);
+    r50 = fmaf(r42, r38, r50);
+    r50 = fmaf(r41, r51, r50);
+    r50 = fmaf(r12, r53, r50);
+    r50 = fmaf(r13, r32, r50);
+    r32 = copysign(1.0, r50);
+    r32 = fmaf(r36, r32, r50);
+    r50 = r32 * r32;
+    r53 = 1.0 / r50;
+    r55 = r8 * r24;
+    r55 = fmaf(r37, r55, r35);
+    r55 = fmaf(r11, r55, r9);
+    r9 = r20 * r21;
+    r9 = fmaf(r8, r9, r46);
+    r43 = r30 + r43;
+    r43 = r43 + r49;
+    r49 = r18 * r21;
+    r49 = fmaf(r29, r49, r47);
+    r47 = r34 * r29;
+    r47 = fmaf(r37, r47, r52);
+    r54 = r30 + r54;
+    r54 = r54 + r28;
+    r55 = fmaf(r40, r9, r55);
+    r55 = fmaf(r41, r43, r55);
+    r55 = fmaf(r42, r49, r55);
+    r55 = fmaf(r13, r47, r55);
+    r55 = fmaf(r12, r54, r55);
+    r54 = r55 * r55;
+    r54 = fmaf(r53, r54, r53 * r39);
+    r39 = sqrtf(r54);
+    r47 = atanf(r39);
+    r42 = r55 * r47;
+    r41 = copysign(1.0, r39);
+    r41 = fmaf(r36, r41, r39);
+    r36 = r41 * r41;
+    r39 = 1.0 / r36;
+    r40 = r53 * r39;
+    r28 = r42 * r40;
+    r52 = r55 * r28;
+    r46 = r47 * r52;
+    r35 = r33 * r47;
+    r56 = 3.00000000000000000e+00;
+    r57 = r33 * r47;
+    r35 = r35 * r56;
+    r35 = r35 * r40;
+    r35 = fmaf(r57, r35, r46);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r58,
+                       r59,
+                       r60,
+                       r61);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r62 = r33 * r47;
+    r62 = r62 * r40;
+    r62 = r62 * r57;
+    r46 = r46 + r62;
+    r63 = fmaf(r60, r46, r7 * r35);
+    r64 = r6 * r8;
+    r64 = r64 * r57;
+    r63 = fmaf(r28, r64, r63);
+    r65 = r46 * r46;
+    r66 = fmaf(r5, r65, r4 * r46);
+    r67 = r65 * r65;
+    r68 = r46 * r65;
+    r66 = fmaf(r59, r67, r66);
+    r66 = fmaf(r58, r68, r66);
+    r69 = 1.0 / r32;
+    r70 = 1.0 / r41;
+    r71 = r69 * r70;
+    r72 = r66 * r71;
+    r63 = fmaf(r57, r72, r63);
+    r63 = fmaf(r71, r57, r63);
+    r2 = fmaf(r0, r63, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r64, r73);
+    r2 = fmaf(r64, r26, r2);
+    r64 = r47 * r56;
+    r64 = fmaf(r52, r64, r62);
+    r62 = fmaf(r61, r46, r6 * r64);
+    r74 = r7 * r8;
+    r74 = r74 * r57;
+    r62 = fmaf(r28, r74, r62);
+    r62 = fmaf(r42, r71, r62);
+    r62 = fmaf(r42, r72, r62);
+    r3 = fmaf(r1, r62, r3);
+    r3 = fmaf(r73, r26, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r73 = fmaf(r3, r3, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r73);
+  if (global_thread_idx < problem_size) {
+    r73 = r34 * r29;
+    r74 = r14 * r21;
+    r75 = -5.00000000000000000e-01;
+    r76 = r17 * r18;
+    r76 = fmaf(r75, r76, r75 * r74);
+    r74 = r16 * r19;
+    r76 = fmaf(r75, r74, r76);
+    r77 = r15 * r20;
+    r78 = 5.00000000000000000e-01;
+    r76 = fmaf(r78, r77, r76);
+    r77 = r17 * r21;
+    r74 = r14 * r18;
+    r74 = fmaf(r75, r74, r78 * r77);
+    r77 = r15 * r19;
+    r74 = fmaf(r75, r77, r74);
+    r79 = r16 * r20;
+    r74 = fmaf(r75, r79, r74);
+    r79 = r37 * r74;
+    r77 = r29 * r79;
+    r73 = fmaf(r76, r73, r77);
+    r80 = r8 * r31;
+    r81 = r15 * r21;
+    r82 = r16 * r18;
+    r82 = fmaf(r78, r82, r75 * r81);
+    r81 = r17 * r19;
+    r82 = fmaf(r75, r81, r82);
+    r83 = r14 * r20;
+    r82 = fmaf(r75, r83, r82);
+    r80 = r80 * r82;
+    r83 = r8 * r24;
+    r81 = fmaf(r78, r23, r78 * r22);
+    r81 = fmaf(r75, r27, r81);
+    r81 = fmaf(r78, r25, r81);
+    r83 = fmaf(r81, r83, r80);
+    r73 = r73 + r83;
+    r84 = r34 * r74;
+    r85 = -4.00000000000000000e+00;
+    r84 = r84 * r85;
+    r86 = r24 * r82;
+    r87 = r85 * r86;
+    r88 = r84 + r87;
+    r88 = fmaf(r12, r88, r13 * r73);
+    r73 = r8 * r34;
+    r73 = r73 * r81;
+    r89 = r8 * r37;
+    r89 = fmaf(r82, r89, r73);
+    r90 = r8 * r31;
+    r90 = r90 * r74;
+    r91 = r8 * r24;
+    r91 = fmaf(r76, r91, r90);
+    r89 = r89 + r91;
+    r88 = fmaf(r11, r89, r88);
+    r89 = r88 * r28;
+    r92 = r8 * r47;
+    r93 = r30 + r54;
+    r93 = 1.0 / r93;
+    r54 = rsqrtf(r54);
+    r94 = r93 * r54;
+    r95 = r94 * r52;
+    r96 = r8 * r55;
+    r96 = r96 * r88;
+    r97 = r8 * r33;
+    r98 = r8 * r37;
+    r99 = r31 * r76;
+    r98 = fmaf(r8, r99, r81 * r98);
+    r100 = r8 * r34;
+    r101 = r8 * r24;
+    r101 = r101 * r74;
+    r100 = fmaf(r82, r100, r101);
+    r98 = r98 + r100;
+    r73 = r90 + r73;
+    r90 = r24 * r29;
+    r73 = fmaf(r76, r90, r73);
+    r102 = r29 * r37;
+    r73 = fmaf(r82, r102, r73);
+    r73 = fmaf(r12, r73, r13 * r98);
+    r98 = r31 * r81;
+    r98 = r98 * r85;
+    r87 = r98 + r87;
+    r73 = fmaf(r11, r87, r73);
+    r97 = r97 * r73;
+    r97 = fmaf(r53, r97, r53 * r96);
+    r96 = r55 * r55;
+    r87 = r8 * r34;
+    r87 = r87 * r76;
+    r79 = r8 * r79;
+    r102 = r87 + r79;
+    r83 = r83 + r102;
+    r90 = r29 * r37;
+    r90 = fmaf(r29, r99, r81 * r90);
+    r90 = r90 + r100;
+    r90 = fmaf(r11, r90, r12 * r83);
+    r98 = r84 + r98;
+    r90 = fmaf(r13, r98, r90);
+    r50 = r32 * r50;
+    r98 = 1.0 / r50;
+    r84 = r29 * r98;
+    r96 = r96 * r90;
+    r97 = fmaf(r84, r96, r97);
+    r83 = r33 * r33;
+    r83 = r83 * r84;
+    r97 = fmaf(r90, r83, r97);
+    r89 = fmaf(r97, r95, r92 * r89);
+    r96 = r26 * r55;
+    r36 = r41 * r36;
+    r81 = 1.0 / r36;
+    r96 = r96 * r47;
+    r96 = r96 * r97;
+    r96 = r96 * r53;
+    r96 = r96 * r54;
+    r96 = r96 * r81;
+    r89 = fmaf(r42, r96, r89);
+    r103 = r55 * r47;
+    r103 = r103 * r90;
+    r103 = r103 * r39;
+    r103 = r103 * r42;
+    r89 = fmaf(r84, r103, r89);
+    r103 = r40 * r57;
+    r96 = r92 * r103;
+    r104 = r97 * r103;
+    r105 = r33 * r94;
+    r104 = fmaf(r105, r104, r73 * r96);
+    r106 = r47 * r83;
+    r107 = r47 * r39;
+    r107 = r107 * r84;
+    r107 = r106 * r107;
+    r108 = r26 * r33;
+    r108 = r108 * r33;
+    r108 = r108 * r47;
+    r108 = r108 * r47;
+    r108 = r108 * r97;
+    r108 = r108 * r53;
+    r108 = r108 * r54;
+    r104 = fmaf(r81, r108, r104);
+    r104 = fmaf(r90, r107, r104);
+    r108 = r89 + r104;
+    r109 = r47 * r73;
+    r110 = 6.00000000000000000e+00;
+    r109 = r109 * r110;
+    r109 = r109 * r40;
+    r111 = r56 * r97;
+    r111 = r111 * r103;
+    r111 = fmaf(r105, r111, r57 * r109);
+    r109 = r33 * r33;
+    r112 = r47 * r90;
+    r113 = -6.00000000000000000e+00;
+    r112 = r112 * r113;
+    r112 = r112 * r39;
+    r112 = r112 * r98;
+    r109 = r109 * r47;
+    r111 = fmaf(r112, r109, r111);
+    r114 = -3.00000000000000000e+00;
+    r114 = r47 * r114;
+    r114 = r114 * r53;
+    r114 = r114 * r54;
+    r114 = r114 * r81;
+    r115 = r97 * r114;
+    r111 = fmaf(r106, r115, r111);
+    r111 = r111 + r89;
+    r111 = fmaf(r7, r111, r60 * r108);
+    r89 = r78 * r72;
+    r115 = r105 * r89;
+    r109 = r6 * r88;
+    r111 = fmaf(r96, r109, r111);
+    r116 = r47 * r73;
+    r111 = fmaf(r72, r116, r111);
+    r117 = r75 * r97;
+    r117 = r117 * r39;
+    r117 = r117 * r69;
+    r117 = r117 * r54;
+    r118 = r6 * r97;
+    r119 = r8 * r28;
+    r119 = r119 * r105;
+    r111 = fmaf(r119, r118, r111);
+    r120 = r47 * r73;
+    r111 = fmaf(r71, r120, r111);
+    r121 = r26 * r33;
+    r121 = r121 * r47;
+    r121 = r121 * r90;
+    r121 = r121 * r53;
+    r111 = fmaf(r70, r121, r111);
+    r122 = r5 * r8;
+    r122 = r122 * r46;
+    r122 = fmaf(r108, r122, r4 * r108);
+    r58 = r58 * r56;
+    r58 = r58 * r65;
+    r123 = 4.00000000000000000e+00;
+    r59 = r59 * r123;
+    r59 = r59 * r68;
+    r122 = fmaf(r108, r58, r122);
+    r122 = fmaf(r108, r59, r122);
+    r124 = r122 * r71;
+    r111 = fmaf(r57, r124, r111);
+    r125 = r6 * r73;
+    r125 = r125 * r28;
+    r111 = fmaf(r92, r125, r111);
+    r126 = r85 * r39;
+    r126 = r126 * r98;
+    r126 = r126 * r42;
+    r126 = r126 * r57;
+    r127 = r6 * r126;
+    r128 = r66 * r117;
+    r129 = r26 * r33;
+    r129 = r129 * r47;
+    r129 = r129 * r66;
+    r129 = r129 * r90;
+    r129 = r129 * r53;
+    r111 = fmaf(r70, r129, r111);
+    r130 = r78 * r97;
+    r130 = r130 * r71;
+    r111 = fmaf(r105, r130, r111);
+    r131 = r6 * r29;
+    r131 = r131 * r97;
+    r131 = r131 * r53;
+    r131 = r131 * r54;
+    r131 = r131 * r81;
+    r131 = r131 * r42;
+    r111 = fmaf(r57, r131, r111);
+    r111 = fmaf(r97, r115, r111);
+    r111 = fmaf(r117, r57, r111);
+    r111 = fmaf(r90, r127, r111);
+    r111 = fmaf(r57, r128, r111);
+    r131 = r0 * r111;
+    r130 = r47 * r88;
+    r130 = r130 * r110;
+    r129 = r56 * r97;
+    r129 = fmaf(r95, r129, r28 * r130);
+    r130 = r55 * r42;
+    r130 = r130 * r114;
+    r125 = r55 * r42;
+    r129 = fmaf(r112, r125, r129);
+    r129 = fmaf(r97, r130, r129);
+    r129 = r129 + r104;
+    r129 = fmaf(r6, r129, r61 * r108);
+    r108 = r55 * r78;
+    r108 = r108 * r97;
+    r108 = r108 * r71;
+    r129 = fmaf(r94, r108, r129);
+    r104 = r7 * r96;
+    r125 = r7 * r97;
+    r129 = fmaf(r119, r125, r129);
+    r112 = r55 * r97;
+    r112 = r112 * r94;
+    r129 = fmaf(r89, r112, r129);
+    r124 = r26 * r66;
+    r124 = r124 * r90;
+    r124 = r124 * r53;
+    r124 = r124 * r70;
+    r129 = fmaf(r42, r124, r129);
+    r121 = r122 * r42;
+    r129 = fmaf(r71, r121, r129);
+    r120 = r7 * r73;
+    r120 = r120 * r28;
+    r129 = fmaf(r92, r120, r129);
+    r118 = r7 * r90;
+    r129 = fmaf(r126, r118, r129);
+    r116 = r26 * r90;
+    r116 = r116 * r53;
+    r116 = r116 * r70;
+    r129 = fmaf(r42, r116, r129);
+    r109 = r7 * r29;
+    r109 = r109 * r97;
+    r109 = r109 * r53;
+    r109 = r109 * r54;
+    r109 = r109 * r81;
+    r109 = r109 * r42;
+    r129 = fmaf(r57, r109, r129);
+    r132 = r47 * r88;
+    r129 = fmaf(r72, r132, r129);
+    r133 = r47 * r88;
+    r129 = fmaf(r71, r133, r129);
+    r129 = fmaf(r42, r128, r129);
+    r129 = fmaf(r88, r104, r129);
+    r129 = fmaf(r42, r117, r129);
+    r133 = r1 * r129;
+    r117 = r8 * r33;
+    r79 = r80 + r79;
+    r80 = r8 * r24;
+    r23 = fmaf(r75, r23, r75 * r22);
+    r23 = fmaf(r78, r27, r23);
+    r23 = fmaf(r75, r25, r23);
+    r80 = r80 * r23;
+    r25 = r8 * r34;
+    r27 = r14 * r21;
+    r22 = r17 * r18;
+    r22 = fmaf(r78, r22, r78 * r27);
+    r27 = r16 * r19;
+    r22 = fmaf(r78, r27, r22);
+    r132 = r15 * r20;
+    r22 = fmaf(r75, r132, r22);
+    r25 = fmaf(r22, r25, r80);
+    r79 = r79 + r25;
+    r132 = r31 * r74;
+    r132 = r132 * r85;
+    r27 = r24 * r85;
+    r27 = r27 * r22;
+    r109 = r132 + r27;
+    r109 = fmaf(r11, r109, r13 * r79);
+    r79 = r29 * r37;
+    r79 = fmaf(r29, r86, r22 * r79);
+    r116 = r8 * r34;
+    r116 = r116 * r74;
+    r118 = r8 * r31;
+    r118 = fmaf(r23, r118, r116);
+    r79 = r79 + r118;
+    r109 = fmaf(r12, r79, r109);
+    r117 = r117 * r109;
+    r79 = r29 * r31;
+    r79 = fmaf(r82, r79, r77);
+    r79 = r79 + r25;
+    r25 = r8 * r31;
+    r25 = r25 * r22;
+    r120 = r8 * r37;
+    r120 = fmaf(r23, r120, r25);
+    r120 = r120 + r100;
+    r120 = fmaf(r12, r120, r11 * r79);
+    r79 = r34 * r23;
+    r100 = r85 * r79;
+    r132 = r132 + r100;
+    r120 = fmaf(r13, r132, r120);
+    r117 = fmaf(r120, r83, r53 * r117);
+    r132 = r55 * r55;
+    r132 = r132 * r120;
+    r117 = fmaf(r84, r132, r117);
+    r121 = r8 * r55;
+    r25 = r101 + r25;
+    r101 = r34 * r29;
+    r25 = fmaf(r82, r101, r25);
+    r82 = r29 * r37;
+    r25 = fmaf(r23, r82, r25);
+    r82 = r8 * r37;
+    r86 = fmaf(r8, r86, r22 * r82);
+    r86 = r86 + r118;
+    r86 = fmaf(r11, r86, r13 * r25);
+    r100 = r27 + r100;
+    r86 = fmaf(r12, r100, r86);
+    r121 = r121 * r86;
+    r117 = fmaf(r53, r121, r117);
+    r121 = r117 * r103;
+    r132 = r26 * r33;
+    r132 = r132 * r33;
+    r132 = r132 * r47;
+    r132 = r132 * r47;
+    r132 = r132 * r117;
+    r132 = r132 * r53;
+    r132 = r132 * r54;
+    r132 = fmaf(r81, r132, r105 * r121);
+    r132 = fmaf(r120, r107, r132);
+    r132 = fmaf(r109, r96, r132);
+    r121 = r86 * r28;
+    r100 = r26 * r55;
+    r100 = r100 * r47;
+    r100 = r100 * r117;
+    r100 = r100 * r53;
+    r100 = r100 * r54;
+    r100 = r100 * r81;
+    r100 = fmaf(r42, r100, r92 * r121);
+    r121 = r55 * r47;
+    r121 = r121 * r120;
+    r121 = r121 * r39;
+    r121 = r121 * r42;
+    r100 = fmaf(r84, r121, r100);
+    r100 = fmaf(r117, r95, r100);
+    r121 = r132 + r100;
+    r27 = r56 * r117;
+    r27 = r27 * r103;
+    r25 = r117 * r114;
+    r25 = fmaf(r106, r25, r105 * r27);
+    r27 = r33 * r33;
+    r27 = r27 * r47;
+    r27 = r27 * r47;
+    r27 = r27 * r113;
+    r27 = r27 * r120;
+    r27 = r27 * r39;
+    r25 = fmaf(r98, r27, r25);
+    r82 = r47 * r110;
+    r82 = r82 * r109;
+    r82 = r82 * r40;
+    r25 = fmaf(r57, r82, r25);
+    r25 = r25 + r100;
+    r25 = fmaf(r7, r25, r60 * r121);
+    r100 = r6 * r109;
+    r100 = r100 * r28;
+    r25 = fmaf(r92, r100, r25);
+    r82 = r33 * r47;
+    r82 = r82 * r75;
+    r82 = r82 * r117;
+    r82 = r82 * r39;
+    r82 = r82 * r69;
+    r25 = fmaf(r54, r82, r25);
+    r27 = r26 * r33;
+    r27 = r27 * r47;
+    r27 = r27 * r120;
+    r27 = r27 * r53;
+    r25 = fmaf(r70, r27, r25);
+    r22 = r33 * r47;
+    r22 = r22 * r66;
+    r22 = r22 * r75;
+    r22 = r22 * r117;
+    r22 = r22 * r39;
+    r22 = r22 * r69;
+    r25 = fmaf(r54, r22, r25);
+    r101 = r47 * r109;
+    r25 = fmaf(r72, r101, r25);
+    r124 = r117 * r119;
+    r112 = r26 * r33;
+    r112 = r112 * r47;
+    r112 = r112 * r66;
+    r112 = r112 * r120;
+    r112 = r112 * r53;
+    r25 = fmaf(r70, r112, r25);
+    r125 = r5 * r8;
+    r125 = r125 * r46;
+    r125 = fmaf(r4, r121, r121 * r125);
+    r125 = fmaf(r121, r59, r125);
+    r125 = fmaf(r121, r58, r125);
+    r108 = r125 * r71;
+    r25 = fmaf(r57, r108, r25);
+    r128 = r78 * r117;
+    r128 = r128 * r71;
+    r25 = fmaf(r105, r128, r25);
+    r134 = r6 * r29;
+    r134 = r134 * r117;
+    r134 = r134 * r53;
+    r134 = r134 * r54;
+    r134 = r134 * r81;
+    r134 = r134 * r42;
+    r25 = fmaf(r57, r134, r25);
+    r135 = r6 * r86;
+    r25 = fmaf(r96, r135, r25);
+    r136 = r47 * r109;
+    r25 = fmaf(r71, r136, r25);
+    r25 = fmaf(r6, r124, r25);
+    r25 = fmaf(r120, r127, r25);
+    r25 = fmaf(r117, r115, r25);
+    r136 = r0 * r25;
+    r135 = r47 * r110;
+    r135 = r135 * r86;
+    r135 = fmaf(r117, r130, r28 * r135);
+    r134 = r55 * r47;
+    r134 = r134 * r113;
+    r134 = r134 * r120;
+    r134 = r134 * r39;
+    r134 = r134 * r98;
+    r135 = fmaf(r42, r134, r135);
+    r128 = r56 * r117;
+    r135 = fmaf(r95, r128, r135);
+    r135 = r135 + r132;
+    r135 = fmaf(r6, r135, r61 * r121);
+    r121 = r26 * r120;
+    r121 = r121 * r53;
+    r121 = r121 * r70;
+    r135 = fmaf(r42, r121, r135);
+    r132 = r47 * r86;
+    r135 = fmaf(r72, r132, r135);
+    r128 = r7 * r109;
+    r128 = r128 * r28;
+    r135 = fmaf(r92, r128, r135);
+    r134 = r125 * r42;
+    r135 = fmaf(r71, r134, r135);
+    r108 = r55 * r117;
+    r108 = r108 * r94;
+    r135 = fmaf(r89, r108, r135);
+    r112 = r66 * r75;
+    r112 = r112 * r117;
+    r112 = r112 * r39;
+    r112 = r112 * r69;
+    r112 = r112 * r54;
+    r135 = fmaf(r42, r112, r135);
+    r101 = r26 * r66;
+    r101 = r101 * r120;
+    r101 = r101 * r53;
+    r101 = r101 * r70;
+    r135 = fmaf(r42, r101, r135);
+    r22 = r55 * r78;
+    r22 = r22 * r117;
+    r22 = r22 * r71;
+    r135 = fmaf(r94, r22, r135);
+    r27 = r75 * r117;
+    r27 = r27 * r39;
+    r27 = r27 * r69;
+    r27 = r27 * r54;
+    r135 = fmaf(r42, r27, r135);
+    r82 = r7 * r120;
+    r135 = fmaf(r126, r82, r135);
+    r100 = r7 * r29;
+    r100 = r100 * r117;
+    r100 = r100 * r53;
+    r100 = r100 * r54;
+    r100 = r100 * r81;
+    r100 = r100 * r42;
+    r135 = fmaf(r57, r100, r135);
+    r137 = r47 * r86;
+    r135 = fmaf(r71, r137, r135);
+    r135 = fmaf(r7, r124, r135);
+    r135 = fmaf(r86, r104, r135);
+    r137 = r1 * r135;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r131,
+                                          r133,
+                                          r136,
+                                          r137);
+    r137 = r34 * r85;
+    r136 = r15 * r21;
+    r133 = r16 * r18;
+    r133 = fmaf(r75, r133, r78 * r136);
+    r136 = r17 * r19;
+    r133 = fmaf(r78, r136, r133);
+    r131 = r14 * r20;
+    r133 = fmaf(r78, r131, r133);
+    r137 = r137 * r133;
+    r99 = r85 * r99;
+    r131 = r137 + r99;
+    r136 = r8 * r24;
+    r136 = r136 * r133;
+    r116 = r116 + r136;
+    r100 = r29 * r31;
+    r116 = fmaf(r23, r100, r116);
+    r82 = r29 * r37;
+    r116 = fmaf(r76, r82, r116);
+    r116 = fmaf(r11, r116, r13 * r131);
+    r131 = r8 * r37;
+    r131 = fmaf(r8, r79, r133 * r131);
+    r131 = r131 + r91;
+    r116 = fmaf(r12, r131, r116);
+    r131 = r8 * r33;
+    r82 = r8 * r31;
+    r82 = r82 * r133;
+    r87 = r87 + r82;
+    r100 = r24 * r29;
+    r87 = fmaf(r23, r100, r87);
+    r87 = r87 + r77;
+    r74 = r24 * r74;
+    r74 = r74 * r85;
+    r99 = r74 + r99;
+    r99 = fmaf(r11, r99, r12 * r87);
+    r87 = r8 * r37;
+    r87 = fmaf(r76, r87, r136);
+    r87 = r87 + r118;
+    r99 = fmaf(r13, r87, r99);
+    r131 = r131 * r99;
+    r131 = fmaf(r53, r131, r116 * r83);
+    r87 = r55 * r55;
+    r87 = r87 * r116;
+    r131 = fmaf(r84, r87, r131);
+    r118 = r8 * r55;
+    r82 = r80 + r82;
+    r82 = r82 + r102;
+    r102 = r29 * r37;
+    r79 = fmaf(r29, r79, r133 * r102);
+    r79 = r79 + r91;
+    r79 = fmaf(r13, r79, r11 * r82);
+    r137 = r74 + r137;
+    r79 = fmaf(r12, r137, r79);
+    r118 = r118 * r79;
+    r131 = fmaf(r53, r118, r131);
+    r118 = r79 * r28;
+    r118 = fmaf(r92, r118, r131 * r95);
+    r87 = r55 * r47;
+    r87 = r87 * r116;
+    r87 = r87 * r39;
+    r87 = r87 * r42;
+    r118 = fmaf(r84, r87, r118);
+    r137 = r26 * r55;
+    r137 = r137 * r47;
+    r137 = r137 * r131;
+    r137 = r137 * r53;
+    r137 = r137 * r54;
+    r137 = r137 * r81;
+    r118 = fmaf(r42, r137, r118);
+    r137 = r131 * r103;
+    r137 = fmaf(r105, r137, r116 * r107);
+    r87 = r26 * r33;
+    r87 = r87 * r33;
+    r87 = r87 * r47;
+    r87 = r87 * r47;
+    r87 = r87 * r131;
+    r87 = r87 * r53;
+    r87 = r87 * r54;
+    r137 = fmaf(r81, r87, r137);
+    r137 = fmaf(r99, r96, r137);
+    r87 = r118 + r137;
+    r12 = r33 * r33;
+    r12 = r12 * r47;
+    r12 = r12 * r47;
+    r12 = r12 * r113;
+    r12 = r12 * r116;
+    r12 = r12 * r39;
+    r74 = r56 * r131;
+    r74 = r74 * r103;
+    r74 = fmaf(r105, r74, r98 * r12);
+    r12 = r131 * r114;
+    r74 = fmaf(r106, r12, r74);
+    r13 = r47 * r110;
+    r13 = r13 * r99;
+    r13 = r13 * r40;
+    r74 = fmaf(r57, r13, r74);
+    r74 = r74 + r118;
+    r74 = fmaf(r7, r74, r60 * r87);
+    r118 = r6 * r79;
+    r74 = fmaf(r96, r118, r74);
+    r13 = r47 * r99;
+    r74 = fmaf(r72, r13, r74);
+    r12 = r78 * r131;
+    r12 = r12 * r71;
+    r74 = fmaf(r105, r12, r74);
+    r82 = r5 * r8;
+    r82 = r82 * r46;
+    r82 = fmaf(r87, r82, r4 * r87);
+    r82 = fmaf(r87, r58, r82);
+    r82 = fmaf(r87, r59, r82);
+    r11 = r82 * r71;
+    r74 = fmaf(r57, r11, r74);
+    r91 = r26 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r116;
+    r91 = r91 * r53;
+    r74 = fmaf(r70, r91, r74);
+    r102 = r6 * r131;
+    r74 = fmaf(r119, r102, r74);
+    r133 = r33 * r47;
+    r133 = r133 * r66;
+    r133 = r133 * r75;
+    r133 = r133 * r131;
+    r133 = r133 * r39;
+    r133 = r133 * r69;
+    r74 = fmaf(r54, r133, r74);
+    r80 = r26 * r33;
+    r80 = r80 * r47;
+    r80 = r80 * r66;
+    r80 = r80 * r116;
+    r80 = r80 * r53;
+    r74 = fmaf(r70, r80, r74);
+    r136 = r33 * r47;
+    r136 = r136 * r75;
+    r136 = r136 * r131;
+    r136 = r136 * r39;
+    r136 = r136 * r69;
+    r74 = fmaf(r54, r136, r74);
+    r76 = r6 * r29;
+    r76 = r76 * r131;
+    r76 = r76 * r53;
+    r76 = r76 * r54;
+    r76 = r76 * r81;
+    r76 = r76 * r42;
+    r74 = fmaf(r57, r76, r74);
+    r85 = r6 * r99;
+    r85 = r85 * r28;
+    r74 = fmaf(r92, r85, r74);
+    r77 = r47 * r99;
+    r74 = fmaf(r71, r77, r74);
+    r74 = fmaf(r116, r127, r74);
+    r74 = fmaf(r131, r115, r74);
+    r77 = r0 * r74;
+    r85 = r56 * r131;
+    r76 = r47 * r110;
+    r76 = r76 * r79;
+    r76 = fmaf(r28, r76, r95 * r85);
+    r85 = r55 * r47;
+    r85 = r85 * r113;
+    r85 = r85 * r116;
+    r85 = r85 * r39;
+    r85 = r85 * r98;
+    r76 = fmaf(r42, r85, r76);
+    r76 = fmaf(r131, r130, r76);
+    r76 = r76 + r137;
+    r76 = fmaf(r6, r76, r61 * r87);
+    r87 = r82 * r42;
+    r76 = fmaf(r71, r87, r76);
+    r137 = r75 * r131;
+    r137 = r137 * r39;
+    r137 = r137 * r69;
+    r137 = r137 * r54;
+    r76 = fmaf(r42, r137, r76);
+    r85 = r55 * r78;
+    r85 = r85 * r131;
+    r85 = r85 * r71;
+    r76 = fmaf(r94, r85, r76);
+    r136 = r47 * r79;
+    r76 = fmaf(r72, r136, r76);
+    r80 = r7 * r131;
+    r76 = fmaf(r119, r80, r76);
+    r133 = r7 * r116;
+    r76 = fmaf(r126, r133, r76);
+    r102 = r26 * r66;
+    r102 = r102 * r116;
+    r102 = r102 * r53;
+    r102 = r102 * r70;
+    r76 = fmaf(r42, r102, r76);
+    r91 = r55 * r131;
+    r91 = r91 * r94;
+    r76 = fmaf(r89, r91, r76);
+    r11 = r26 * r116;
+    r11 = r11 * r53;
+    r11 = r11 * r70;
+    r76 = fmaf(r42, r11, r76);
+    r12 = r7 * r29;
+    r12 = r12 * r131;
+    r12 = r12 * r53;
+    r12 = r12 * r54;
+    r12 = r12 * r81;
+    r12 = r12 * r42;
+    r76 = fmaf(r57, r12, r76);
+    r13 = r7 * r99;
+    r13 = r13 * r28;
+    r76 = fmaf(r92, r13, r76);
+    r118 = r66 * r75;
+    r118 = r118 * r131;
+    r118 = r118 * r39;
+    r118 = r118 * r69;
+    r118 = r118 * r54;
+    r76 = fmaf(r42, r118, r76);
+    r100 = r47 * r79;
+    r76 = fmaf(r71, r100, r76);
+    r76 = fmaf(r79, r104, r76);
+    r100 = r1 * r76;
+    r118 = r10 * r33;
+    r118 = r118 * r33;
+    r118 = r118 * r47;
+    r118 = r118 * r47;
+    r118 = r118 * r113;
+    r118 = r118 * r39;
+    r13 = r48 * r47;
+    r13 = r13 * r110;
+    r13 = r13 * r40;
+    r13 = fmaf(r57, r13, r98 * r118);
+    r118 = r10 * r55;
+    r118 = r118 * r55;
+    r12 = r8 * r9;
+    r12 = r12 * r55;
+    r12 = fmaf(r53, r12, r84 * r118);
+    r118 = r8 * r48;
+    r118 = r118 * r33;
+    r12 = fmaf(r53, r118, r12);
+    r12 = fmaf(r10, r83, r12);
+    r118 = r12 * r114;
+    r13 = fmaf(r106, r118, r13);
+    r11 = r56 * r12;
+    r11 = r11 * r103;
+    r13 = fmaf(r105, r11, r13);
+    r91 = r10 * r55;
+    r91 = r91 * r47;
+    r91 = r91 * r39;
+    r91 = r91 * r42;
+    r102 = r9 * r28;
+    r102 = fmaf(r92, r102, r84 * r91);
+    r91 = r26 * r55;
+    r91 = r91 * r47;
+    r91 = r91 * r12;
+    r91 = r91 * r53;
+    r91 = r91 * r54;
+    r91 = r91 * r81;
+    r102 = fmaf(r42, r91, r102);
+    r102 = fmaf(r12, r95, r102);
+    r13 = r13 + r102;
+    r11 = fmaf(r48, r96, r10 * r107);
+    r118 = r26 * r33;
+    r118 = r118 * r33;
+    r118 = r118 * r47;
+    r118 = r118 * r47;
+    r118 = r118 * r12;
+    r118 = r118 * r53;
+    r118 = r118 * r54;
+    r11 = fmaf(r81, r118, r11);
+    r91 = r12 * r103;
+    r11 = fmaf(r105, r91, r11);
+    r102 = r102 + r11;
+    r13 = fmaf(r60, r102, r7 * r13);
+    r91 = r26 * r10;
+    r91 = r91 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r53;
+    r13 = fmaf(r70, r91, r13);
+    r118 = r33 * r47;
+    r118 = r118 * r66;
+    r118 = r118 * r75;
+    r118 = r118 * r12;
+    r118 = r118 * r39;
+    r118 = r118 * r69;
+    r13 = fmaf(r54, r118, r13);
+    r133 = r26 * r10;
+    r133 = r133 * r33;
+    r133 = r133 * r47;
+    r133 = r133 * r66;
+    r133 = r133 * r53;
+    r13 = fmaf(r70, r133, r13);
+    r80 = r48 * r47;
+    r13 = fmaf(r71, r80, r13);
+    r136 = r6 * r12;
+    r13 = fmaf(r119, r136, r13);
+    r85 = r6 * r48;
+    r85 = r85 * r28;
+    r13 = fmaf(r92, r85, r13);
+    r137 = r48 * r47;
+    r13 = fmaf(r72, r137, r13);
+    r87 = r33 * r47;
+    r87 = r87 * r75;
+    r87 = r87 * r12;
+    r87 = r87 * r39;
+    r87 = r87 * r69;
+    r13 = fmaf(r54, r87, r13);
+    r23 = r78 * r12;
+    r23 = r23 * r71;
+    r13 = fmaf(r105, r23, r13);
+    r27 = r5 * r8;
+    r27 = r27 * r46;
+    r27 = fmaf(r4, r102, r102 * r27);
+    r27 = fmaf(r102, r59, r27);
+    r27 = fmaf(r102, r58, r27);
+    r22 = r27 * r71;
+    r13 = fmaf(r57, r22, r13);
+    r101 = r6 * r9;
+    r13 = fmaf(r96, r101, r13);
+    r124 = r6 * r29;
+    r124 = r124 * r12;
+    r124 = r124 * r53;
+    r124 = r124 * r54;
+    r124 = r124 * r81;
+    r124 = r124 * r42;
+    r13 = fmaf(r57, r124, r13);
+    r13 = fmaf(r12, r115, r13);
+    r13 = fmaf(r10, r127, r13);
+    r124 = r0 * r13;
+    r101 = r10 * r55;
+    r101 = r101 * r47;
+    r101 = r101 * r113;
+    r101 = r101 * r39;
+    r101 = r101 * r98;
+    r22 = r9 * r47;
+    r22 = r22 * r110;
+    r22 = fmaf(r28, r22, r42 * r101);
+    r101 = r56 * r12;
+    r22 = fmaf(r95, r101, r22);
+    r22 = fmaf(r12, r130, r22);
+    r22 = r22 + r11;
+    r102 = fmaf(r61, r102, r6 * r22);
+    r22 = r27 * r42;
+    r102 = fmaf(r71, r22, r102);
+    r11 = r26 * r10;
+    r11 = r11 * r53;
+    r11 = r11 * r70;
+    r102 = fmaf(r42, r11, r102);
+    r101 = r55 * r12;
+    r101 = r101 * r94;
+    r102 = fmaf(r89, r101, r102);
+    r23 = r75 * r12;
+    r23 = r23 * r39;
+    r23 = r23 * r69;
+    r23 = r23 * r54;
+    r102 = fmaf(r42, r23, r102);
+    r87 = r7 * r12;
+    r102 = fmaf(r119, r87, r102);
+    r137 = r9 * r47;
+    r102 = fmaf(r71, r137, r102);
+    r85 = r26 * r10;
+    r85 = r85 * r66;
+    r85 = r85 * r53;
+    r85 = r85 * r70;
+    r102 = fmaf(r42, r85, r102);
+    r136 = r7 * r48;
+    r136 = r136 * r28;
+    r102 = fmaf(r92, r136, r102);
+    r80 = r9 * r47;
+    r102 = fmaf(r72, r80, r102);
+    r133 = r55 * r78;
+    r133 = r133 * r12;
+    r133 = r133 * r71;
+    r102 = fmaf(r94, r133, r102);
+    r118 = r66 * r75;
+    r118 = r118 * r12;
+    r118 = r118 * r39;
+    r118 = r118 * r69;
+    r118 = r118 * r54;
+    r102 = fmaf(r42, r118, r102);
+    r91 = r7 * r10;
+    r102 = fmaf(r126, r91, r102);
+    r112 = r7 * r29;
+    r112 = r112 * r12;
+    r112 = r112 * r53;
+    r112 = r112 * r54;
+    r112 = r112 * r81;
+    r112 = r112 * r42;
+    r102 = fmaf(r57, r112, r102);
+    r102 = fmaf(r9, r104, r102);
+    r112 = r1 * r102;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r77,
+                                          r100,
+                                          r124,
+                                          r112);
+    r112 = r55 * r55;
+    r112 = r53 * r112;
+    r124 = r51 * r55;
+    r124 = r124 * r55;
+    r100 = r8 * r43;
+    r100 = r100 * r55;
+    r100 = fmaf(r53, r100, r84 * r124);
+    r124 = r8 * r45;
+    r124 = r124 * r33;
+    r100 = fmaf(r53, r124, r100);
+    r100 = fmaf(r51, r83, r100);
+    r112 = r112 * r39;
+    r112 = r112 * r47;
+    r112 = r112 * r93;
+    r112 = r112 * r54;
+    r112 = r112 * r100;
+    r93 = r51 * r55;
+    r93 = r93 * r47;
+    r93 = r93 * r39;
+    r93 = r93 * r42;
+    r93 = fmaf(r84, r93, r112);
+    r124 = r43 * r28;
+    r93 = fmaf(r92, r124, r93);
+    r77 = r26 * r55;
+    r77 = r77 * r47;
+    r77 = r77 * r100;
+    r77 = r77 * r53;
+    r77 = r77 * r54;
+    r77 = r77 * r81;
+    r93 = fmaf(r42, r77, r93);
+    r77 = r100 * r103;
+    r77 = fmaf(r51, r107, r105 * r77);
+    r124 = r26 * r33;
+    r124 = r124 * r33;
+    r124 = r124 * r47;
+    r124 = r124 * r47;
+    r124 = r124 * r100;
+    r124 = r124 * r53;
+    r124 = r124 * r54;
+    r77 = fmaf(r81, r124, r77);
+    r77 = fmaf(r45, r96, r77);
+    r124 = r93 + r77;
+    r91 = r56 * r100;
+    r91 = r91 * r103;
+    r118 = r51 * r33;
+    r118 = r118 * r33;
+    r118 = r118 * r47;
+    r118 = r118 * r47;
+    r118 = r118 * r113;
+    r118 = r118 * r39;
+    r118 = fmaf(r98, r118, r105 * r91);
+    r91 = r45 * r47;
+    r91 = r91 * r110;
+    r91 = r91 * r40;
+    r118 = fmaf(r57, r91, r118);
+    r133 = r100 * r114;
+    r118 = fmaf(r106, r133, r118);
+    r118 = r118 + r93;
+    r118 = fmaf(r7, r118, r60 * r124);
+    r93 = r6 * r45;
+    r93 = r93 * r28;
+    r118 = fmaf(r92, r93, r118);
+    r133 = r45 * r47;
+    r118 = fmaf(r72, r133, r118);
+    r91 = r26 * r51;
+    r91 = r91 * r33;
+    r91 = r91 * r47;
+    r91 = r91 * r66;
+    r91 = r91 * r53;
+    r118 = fmaf(r70, r91, r118);
+    r80 = r33 * r47;
+    r80 = r80 * r75;
+    r80 = r80 * r100;
+    r80 = r80 * r39;
+    r80 = r80 * r69;
+    r118 = fmaf(r54, r80, r118);
+    r136 = r5 * r8;
+    r136 = r136 * r46;
+    r136 = fmaf(r4, r124, r124 * r136);
+    r136 = fmaf(r124, r59, r136);
+    r136 = fmaf(r124, r58, r136);
+    r85 = r136 * r71;
+    r118 = fmaf(r57, r85, r118);
+    r137 = r6 * r29;
+    r137 = r137 * r100;
+    r137 = r137 * r53;
+    r137 = r137 * r54;
+    r137 = r137 * r81;
+    r137 = r137 * r42;
+    r118 = fmaf(r57, r137, r118);
+    r87 = r45 * r47;
+    r118 = fmaf(r71, r87, r118);
+    r23 = r78 * r100;
+    r23 = r23 * r71;
+    r118 = fmaf(r105, r23, r118);
+    r101 = r6 * r43;
+    r118 = fmaf(r96, r101, r118);
+    r11 = r6 * r100;
+    r118 = fmaf(r119, r11, r118);
+    r22 = r26 * r51;
+    r22 = r22 * r33;
+    r22 = r22 * r47;
+    r22 = r22 * r53;
+    r118 = fmaf(r70, r22, r118);
+    r108 = r33 * r47;
+    r108 = r108 * r66;
+    r108 = r108 * r75;
+    r108 = r108 * r100;
+    r108 = r108 * r39;
+    r108 = r108 * r69;
+    r118 = fmaf(r54, r108, r118);
+    r118 = fmaf(r100, r115, r118);
+    r118 = fmaf(r51, r127, r118);
+    r108 = r0 * r118;
+    r22 = r51 * r55;
+    r22 = r22 * r47;
+    r22 = r22 * r113;
+    r22 = r22 * r39;
+    r22 = r22 * r98;
+    r22 = fmaf(r42, r22, r56 * r112);
+    r112 = r43 * r47;
+    r112 = r112 * r110;
+    r22 = fmaf(r28, r112, r22);
+    r22 = fmaf(r100, r130, r22);
+    r22 = r22 + r77;
+    r22 = fmaf(r6, r22, r61 * r124);
+    r124 = r26 * r51;
+    r124 = r124 * r53;
+    r124 = r124 * r70;
+    r22 = fmaf(r42, r124, r22);
+    r77 = r7 * r45;
+    r77 = r77 * r28;
+    r22 = fmaf(r92, r77, r22);
+    r112 = r55 * r100;
+    r112 = r112 * r94;
+    r22 = fmaf(r89, r112, r22);
+    r11 = r55 * r78;
+    r11 = r11 * r100;
+    r11 = r11 * r71;
+    r22 = fmaf(r94, r11, r22);
+    r101 = r66 * r75;
+    r101 = r101 * r100;
+    r101 = r101 * r39;
+    r101 = r101 * r69;
+    r101 = r101 * r54;
+    r22 = fmaf(r42, r101, r22);
+    r23 = r7 * r29;
+    r23 = r23 * r100;
+    r23 = r23 * r53;
+    r23 = r23 * r54;
+    r23 = r23 * r81;
+    r23 = r23 * r42;
+    r22 = fmaf(r57, r23, r22);
+    r87 = r136 * r42;
+    r22 = fmaf(r71, r87, r22);
+    r137 = r7 * r100;
+    r22 = fmaf(r119, r137, r22);
+    r85 = r43 * r47;
+    r22 = fmaf(r71, r85, r22);
+    r80 = r26 * r51;
+    r80 = r80 * r66;
+    r80 = r80 * r53;
+    r80 = r80 * r70;
+    r22 = fmaf(r42, r80, r22);
+    r91 = r43 * r47;
+    r22 = fmaf(r72, r91, r22);
+    r133 = r7 * r51;
+    r22 = fmaf(r126, r133, r22);
+    r93 = r75 * r100;
+    r93 = r93 * r39;
+    r93 = r93 * r69;
+    r93 = r93 * r54;
+    r22 = fmaf(r42, r93, r22);
+    r22 = fmaf(r43, r104, r22);
+    r93 = r1 * r22;
+    r133 = r38 * r33;
+    r133 = r133 * r33;
+    r133 = r133 * r47;
+    r133 = r133 * r47;
+    r133 = r133 * r113;
+    r133 = r133 * r39;
+    r91 = r8 * r49;
+    r91 = r91 * r55;
+    r80 = r38 * r55;
+    r80 = r80 * r55;
+    r80 = fmaf(r84, r80, r53 * r91);
+    r91 = r8 * r44;
+    r91 = r91 * r33;
+    r80 = fmaf(r53, r91, r80);
+    r80 = fmaf(r38, r83, r80);
+    r83 = r80 * r114;
+    r83 = fmaf(r106, r83, r98 * r133);
+    r133 = r44 * r47;
+    r133 = r133 * r110;
+    r133 = r133 * r40;
+    r83 = fmaf(r57, r133, r83);
+    r40 = r56 * r80;
+    r40 = r40 * r103;
+    r83 = fmaf(r105, r40, r83);
+    r106 = r49 * r28;
+    r106 = fmaf(r92, r106, r80 * r95);
+    r91 = r26 * r55;
+    r91 = r91 * r47;
+    r91 = r91 * r80;
+    r91 = r91 * r53;
+    r91 = r91 * r54;
+    r91 = r91 * r81;
+    r106 = fmaf(r42, r91, r106);
+    r85 = r38 * r55;
+    r85 = r85 * r47;
+    r85 = r85 * r39;
+    r85 = r85 * r42;
+    r106 = fmaf(r84, r85, r106);
+    r83 = r83 + r106;
+    r40 = r26 * r33;
+    r40 = r40 * r33;
+    r40 = r40 * r47;
+    r40 = r40 * r47;
+    r40 = r40 * r80;
+    r40 = r40 * r53;
+    r40 = r40 * r54;
+    r40 = fmaf(r81, r40, r38 * r107);
+    r107 = r80 * r103;
+    r40 = fmaf(r105, r107, r40);
+    r40 = fmaf(r44, r96, r40);
+    r106 = r106 + r40;
+    r60 = fmaf(r60, r106, r7 * r83);
+    r83 = r33 * r47;
+    r83 = r83 * r66;
+    r83 = r83 * r75;
+    r83 = r83 * r80;
+    r83 = r83 * r39;
+    r83 = r83 * r69;
+    r60 = fmaf(r54, r83, r60);
+    r107 = r6 * r49;
+    r60 = fmaf(r96, r107, r60);
+    r96 = r5 * r8;
+    r96 = r96 * r46;
+    r96 = fmaf(r106, r96, r4 * r106);
+    r96 = fmaf(r106, r59, r96);
+    r96 = fmaf(r106, r58, r96);
+    r58 = r96 * r71;
+    r60 = fmaf(r57, r58, r60);
+    r59 = r44 * r47;
+    r60 = fmaf(r71, r59, r60);
+    r4 = r26 * r38;
+    r4 = r4 * r33;
+    r4 = r4 * r47;
+    r4 = r4 * r53;
+    r60 = fmaf(r70, r4, r60);
+    r133 = r6 * r80;
+    r60 = fmaf(r119, r133, r60);
+    r85 = r33 * r47;
+    r85 = r85 * r75;
+    r85 = r85 * r80;
+    r85 = r85 * r39;
+    r85 = r85 * r69;
+    r60 = fmaf(r54, r85, r60);
+    r91 = r6 * r29;
+    r91 = r91 * r80;
+    r91 = r91 * r53;
+    r91 = r91 * r54;
+    r91 = r91 * r81;
+    r91 = r91 * r42;
+    r60 = fmaf(r57, r91, r60);
+    r84 = r26 * r38;
+    r84 = r84 * r33;
+    r84 = r84 * r47;
+    r84 = r84 * r66;
+    r84 = r84 * r53;
+    r60 = fmaf(r70, r84, r60);
+    r137 = r6 * r44;
+    r137 = r137 * r28;
+    r60 = fmaf(r92, r137, r60);
+    r87 = r44 * r47;
+    r60 = fmaf(r72, r87, r60);
+    r23 = r78 * r80;
+    r23 = r23 * r71;
+    r60 = fmaf(r105, r23, r60);
+    r60 = fmaf(r38, r127, r60);
+    r60 = fmaf(r80, r115, r60);
+    r23 = r0 * r60;
+    r87 = r56 * r80;
+    r137 = r49 * r47;
+    r137 = r137 * r110;
+    r137 = fmaf(r28, r137, r95 * r87);
+    r87 = r38 * r55;
+    r87 = r87 * r47;
+    r87 = r87 * r113;
+    r87 = r87 * r39;
+    r87 = r87 * r98;
+    r137 = fmaf(r42, r87, r137);
+    r137 = fmaf(r80, r130, r137);
+    r137 = r137 + r40;
+    r106 = fmaf(r61, r106, r6 * r137);
+    r61 = r55 * r78;
+    r61 = r61 * r80;
+    r61 = r61 * r71;
+    r106 = fmaf(r94, r61, r106);
+    r137 = r7 * r38;
+    r106 = fmaf(r126, r137, r106);
+    r126 = r55 * r80;
+    r126 = r126 * r94;
+    r106 = fmaf(r89, r126, r106);
+    r89 = r66 * r75;
+    r89 = r89 * r80;
+    r89 = r89 * r39;
+    r89 = r89 * r69;
+    r89 = r89 * r54;
+    r106 = fmaf(r42, r89, r106);
+    r94 = r7 * r80;
+    r106 = fmaf(r119, r94, r106);
+    r119 = r75 * r80;
+    r119 = r119 * r39;
+    r119 = r119 * r69;
+    r119 = r119 * r54;
+    r106 = fmaf(r42, r119, r106);
+    r69 = r49 * r47;
+    r106 = fmaf(r72, r69, r106);
+    r72 = r7 * r29;
+    r72 = r72 * r80;
+    r72 = r72 * r53;
+    r72 = r72 * r54;
+    r72 = r72 * r81;
+    r72 = r72 * r42;
+    r106 = fmaf(r57, r72, r106);
+    r54 = r26 * r38;
+    r54 = r54 * r66;
+    r54 = r54 * r53;
+    r54 = r54 * r70;
+    r106 = fmaf(r42, r54, r106);
+    r39 = r96 * r42;
+    r106 = fmaf(r71, r39, r106);
+    r40 = r49 * r47;
+    r106 = fmaf(r71, r40, r106);
+    r87 = r26 * r38;
+    r87 = r87 * r53;
+    r87 = r87 * r70;
+    r106 = fmaf(r42, r87, r106);
+    r70 = r7 * r44;
+    r70 = r70 * r28;
+    r106 = fmaf(r92, r70, r106);
+    r106 = fmaf(r49, r104, r106);
+    r70 = r1 * r106;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r108,
+                                          r93,
+                                          r23,
+                                          r70);
+    r70 = r0 * r26;
+    r70 = r70 * r2;
+    r23 = r26 * r3;
+    r93 = r1 * r23;
+    r70 = fmaf(r129, r93, r111 * r70);
+    r108 = r0 * r26;
+    r108 = r108 * r2;
+    r108 = fmaf(r135, r93, r25 * r108);
+    r87 = r0 * r26;
+    r87 = r87 * r2;
+    r87 = fmaf(r76, r93, r74 * r87);
+    r40 = r0 * r26;
+    r40 = r40 * r2;
+    r40 = fmaf(r102, r93, r13 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r70, r108, r87, r40);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r0 * r26;
+    r40 = r40 * r2;
+    r40 = fmaf(r22, r93, r118 * r40);
+    r87 = r0 * r26;
+    r87 = r87 * r2;
+    r87 = fmaf(r106, r93, r60 * r87);
+    WriteSum2<float, float>((float*)inout_shared, r40, r87);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r87 = r1 * r1;
+    r40 = r129 * r129;
+    r108 = r111 * r111;
+    r70 = r0 * r0;
+    r108 = fmaf(r70, r108, r87 * r40);
+    r40 = r25 * r25;
+    r39 = r135 * r135;
+    r39 = fmaf(r87, r39, r70 * r40);
+    r40 = r74 * r74;
+    r54 = r76 * r76;
+    r54 = fmaf(r87, r54, r70 * r40);
+    r40 = r102 * r102;
+    r72 = r13 * r13;
+    r72 = fmaf(r70, r72, r87 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r108, r39, r54, r72);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r22 * r22;
+    r54 = r118 * r118;
+    r54 = fmaf(r70, r54, r87 * r72);
+    r72 = r106 * r106;
+    r39 = r60 * r60;
+    r39 = fmaf(r70, r39, r87 * r72);
+    WriteSum2<float, float>((float*)inout_shared, r54, r39);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r111 * r25;
+    r54 = r129 * r135;
+    r54 = fmaf(r87, r54, r70 * r39);
+    r39 = r111 * r74;
+    r72 = r129 * r76;
+    r72 = fmaf(r87, r72, r70 * r39);
+    r39 = r129 * r102;
+    r108 = r111 * r13;
+    r108 = fmaf(r70, r108, r87 * r39);
+    r39 = r111 * r118;
+    r40 = r129 * r22;
+    r40 = fmaf(r87, r40, r70 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r54, r72, r108, r40);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r111 * r60;
+    r108 = r129 * r106;
+    r108 = fmaf(r87, r108, r70 * r40);
+    r40 = r135 * r76;
+    r72 = r25 * r74;
+    r72 = fmaf(r70, r72, r87 * r40);
+    r40 = r135 * r102;
+    r54 = r25 * r13;
+    r54 = fmaf(r70, r54, r87 * r40);
+    r40 = r135 * r22;
+    r39 = r25 * r118;
+    r39 = fmaf(r70, r39, r87 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r108, r72, r54, r39);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r135 * r106;
+    r54 = r25 * r60;
+    r54 = fmaf(r70, r54, r87 * r39);
+    r39 = r76 * r102;
+    r72 = r74 * r13;
+    r72 = fmaf(r70, r72, r87 * r39);
+    r39 = r76 * r22;
+    r108 = r74 * r118;
+    r108 = fmaf(r70, r108, r87 * r39);
+    r39 = r74 * r60;
+    r40 = r76 * r106;
+    r40 = fmaf(r87, r40, r70 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r54, r72, r108, r40);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r13 * r118;
+    r108 = r102 * r22;
+    r108 = fmaf(r87, r108, r70 * r40);
+    r40 = r13 * r60;
+    r72 = r102 * r106;
+    r72 = fmaf(r87, r72, r70 * r40);
+    r40 = r22 * r106;
+    r54 = r118 * r60;
+    r54 = fmaf(r70, r54, r87 * r40);
+    WriteSum3<float, float>((float*)inout_shared, r108, r72, r54);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r0 * r46;
+    r54 = r54 * r71;
+    r54 = r54 * r57;
+    r72 = r1 * r46;
+    r72 = r72 * r42;
+    r72 = r72 * r71;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r63,
+                                          r62,
+                                          r54,
+                                          r72);
+    r108 = r1 * r64;
+    r40 = r0 * r71;
+    r40 = r40 * r57;
+    r40 = r40 * r65;
+    r39 = r1 * r42;
+    r39 = r39 * r71;
+    r39 = r39 * r65;
+    r69 = r0 * r8;
+    r69 = r69 * r57;
+    r69 = r69 * r28;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r40,
+                                          r39,
+                                          r69,
+                                          r108);
+    r119 = r0 * r35;
+    r94 = r1 * r8;
+    r94 = r94 * r57;
+    r94 = r94 * r28;
+    r89 = r0 * r71;
+    r89 = r89 * r57;
+    r89 = r89 * r68;
+    r126 = r1 * r42;
+    r126 = r126 * r71;
+    r126 = r126 * r68;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r119,
+                                          r94,
+                                          r89,
+                                          r126);
+    r137 = r0 * r46;
+    r61 = r1 * r46;
+    r104 = r0 * r71;
+    r104 = r104 * r57;
+    r104 = r104 * r67;
+    r53 = r1 * r42;
+    r53 = r53 * r71;
+    r53 = r53 * r67;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r104,
+                                          r53,
+                                          r137,
+                                          r61);
+    r130 = r26 * r63;
+    r130 = r130 * r2;
+    r113 = r26 * r2;
+    r95 = r62 * r23;
+    WriteSum4<float, float>((float*)inout_shared, r130, r95, r113, r23);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r23 = r46 * r42;
+    r23 = r23 * r71;
+    r113 = r0 * r26;
+    r113 = r113 * r46;
+    r113 = r113 * r2;
+    r113 = r113 * r71;
+    r113 = fmaf(r57, r113, r93 * r23);
+    r23 = r42 * r71;
+    r23 = r23 * r65;
+    r95 = r0 * r26;
+    r95 = r95 * r2;
+    r95 = r95 * r71;
+    r95 = r95 * r57;
+    r95 = fmaf(r65, r95, r93 * r23);
+    r23 = r0 * r29;
+    r23 = r23 * r2;
+    r23 = r23 * r57;
+    r23 = fmaf(r28, r23, r64 * r93);
+    r130 = r0 * r26;
+    r130 = r130 * r35;
+    r84 = r1 * r29;
+    r84 = r84 * r3;
+    r84 = r84 * r57;
+    r84 = fmaf(r28, r84, r2 * r130);
+    WriteSum4<float, float>((float*)inout_shared, r113, r95, r23, r84);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r84 = r0 * r26;
+    r84 = r84 * r46;
+    r84 = r84 * r2;
+    r23 = r46 * r93;
+    r95 = r42 * r71;
+    r95 = r95 * r68;
+    r113 = r0 * r26;
+    r113 = r113 * r2;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    r113 = fmaf(r68, r113, r93 * r95);
+    r95 = r42 * r71;
+    r95 = r95 * r67;
+    r130 = r0 * r26;
+    r130 = r130 * r2;
+    r130 = r130 * r71;
+    r130 = r130 * r57;
+    r130 = fmaf(r67, r130, r93 * r95);
+    WriteSum4<float, float>((float*)inout_shared, r113, r130, r84, r23);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r23 = r63 * r63;
+    r84 = r62 * r62;
+    WriteSum4<float, float>((float*)inout_shared, r23, r84, r30, r30);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r33 * r47;
+    r30 = r30 * r65;
+    r30 = r30 * r70;
+    r84 = r47 * r65;
+    r84 = r84 * r87;
+    r84 = fmaf(r52, r84, r103 * r30);
+    r30 = r33 * r47;
+    r30 = r30 * r70;
+    r30 = r30 * r103;
+    r23 = r47 * r87;
+    r23 = r23 * r67;
+    r23 = fmaf(r52, r23, r67 * r30);
+    r30 = r64 * r64;
+    r130 = r42 * r70;
+    r113 = r33 * r55;
+    r50 = r32 * r50;
+    r50 = 1.0 / r50;
+    r36 = r41 * r36;
+    r36 = 1.0 / r36;
+    r113 = r113 * r47;
+    r113 = r113 * r47;
+    r113 = r113 * r123;
+    r113 = r113 * r50;
+    r113 = r113 * r36;
+    r113 = r113 * r57;
+    r130 = fmaf(r113, r130, r87 * r30);
+    r30 = r35 * r70;
+    r36 = r42 * r87;
+    r113 = fmaf(r36, r113, r35 * r30);
+    WriteSum4<float, float>((float*)inout_shared, r84, r23, r130, r113);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r65 * r70;
+    r130 = r65 * r87;
+    r84 = r33 * r47;
+    r50 = r68 * r68;
+    r84 = r84 * r70;
+    r84 = r84 * r103;
+    r123 = r47 * r87;
+    r123 = r123 * r52;
+    r84 = fmaf(r50, r123, r50 * r84);
+    r41 = r67 * r67;
+    r32 = r70 * r103;
+    r32 = r32 * r57;
+    r41 = fmaf(r123, r41, r41 * r32);
+    WriteSum4<float, float>((float*)inout_shared, r84, r41, r113, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = 0.00000000000000000e+00;
+    r113 = r0 * r46;
+    r113 = r113 * r63;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r130, r63, r130, r113);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r0 * r35;
+    r35 = r35 * r63;
+    r113 = r0 * r63;
+    r113 = r113 * r71;
+    r113 = r113 * r57;
+    r113 = r113 * r65;
+    r41 = r0 * r8;
+    r41 = r41 * r63;
+    r41 = r41 * r57;
+    r41 = r41 * r28;
+    r95 = r0 * r63;
+    r95 = r95 * r71;
+    r95 = r95 * r57;
+    r95 = r95 * r68;
+    WriteSum4<float, float>((float*)inout_shared, r113, r41, r35, r95);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r0 * r46;
+    r95 = r95 * r63;
+    r63 = r0 * r63;
+    r63 = r63 * r71;
+    r63 = r63 * r57;
+    r63 = r63 * r67;
+    WriteSum4<float, float>((float*)inout_shared, r63, r95, r130, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r1 * r64;
+    r95 = r95 * r62;
+    r63 = r1 * r46;
+    r63 = r63 * r62;
+    r63 = r63 * r42;
+    r63 = r63 * r71;
+    r35 = r1 * r62;
+    r35 = r35 * r42;
+    r35 = r35 * r71;
+    r35 = r35 * r65;
+    WriteSum4<float, float>((float*)inout_shared, r62, r63, r35, r95);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r1 * r8;
+    r95 = r95 * r62;
+    r95 = r95 * r57;
+    r95 = r95 * r28;
+    r35 = r1 * r62;
+    r35 = r35 * r42;
+    r35 = r35 * r71;
+    r35 = r35 * r68;
+    r63 = r1 * r62;
+    r63 = r63 * r42;
+    r63 = r63 * r71;
+    r63 = r63 * r67;
+    WriteSum4<float, float>((float*)inout_shared, r95, r35, r63, r130);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r1 * r46;
+    r63 = r63 * r62;
+    WriteSum4<float, float>((float*)inout_shared, r63, r130, r54, r40);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r69, r119, r89, r104);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r137, r130, r72, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r108, r94, r126, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r33 * r47;
+    r53 = r53 * r68;
+    r53 = r53 * r70;
+    r126 = r47 * r68;
+    r126 = r126 * r87;
+    r126 = fmaf(r52, r126, r103 * r53);
+    r53 = r33 * r46;
+    r53 = r53 * r98;
+    r53 = r53 * r81;
+    r53 = r53 * r42;
+    r53 = r53 * r57;
+    r53 = r53 * r70;
+    r94 = r71 * r36;
+    r108 = r64 * r94;
+    r53 = fmaf(r46, r108, r92 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r130, r61, r126, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r71 * r57;
+    r53 = r53 * r65;
+    r53 = r53 * r70;
+    r126 = r57 * r30;
+    r61 = r71 * r126;
+    r39 = r55 * r46;
+    r39 = r39 * r98;
+    r39 = r39 * r81;
+    r39 = r39 * r57;
+    r39 = r39 * r92;
+    r39 = fmaf(r36, r39, r46 * r61);
+    r72 = r33 * r47;
+    r137 = r46 * r67;
+    r72 = r72 * r70;
+    r72 = r72 * r103;
+    r104 = r47 * r87;
+    r104 = r104 * r52;
+    r104 = fmaf(r137, r104, r137 * r72);
+    WriteSum4<float, float>((float*)inout_shared, r39, r23, r104, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r65 * r94;
+    r23 = r33 * r98;
+    r23 = r23 * r81;
+    r23 = r23 * r42;
+    r23 = r23 * r57;
+    r23 = r23 * r65;
+    r23 = r23 * r70;
+    r23 = fmaf(r65, r108, r92 * r23);
+    r39 = r55 * r98;
+    r39 = r39 * r81;
+    r39 = r39 * r57;
+    r39 = r39 * r65;
+    r39 = r39 * r92;
+    r39 = fmaf(r36, r39, r65 * r61);
+    WriteSum4<float, float>((float*)inout_shared, r53, r23, r39, r104);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r71 * r57;
+    r104 = r104 * r68;
+    r104 = r104 * r70;
+    r39 = r68 * r94;
+    r23 = r8 * r28;
+    r53 = r8 * r64;
+    r53 = r53 * r57;
+    r53 = r53 * r28;
+    r53 = fmaf(r87, r53, r126 * r23);
+    WriteSum4<float, float>((float*)inout_shared, r84, r104, r39, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r8 * r46;
+    r53 = r53 * r57;
+    r53 = r53 * r28;
+    r53 = r53 * r70;
+    r39 = r46 * r64;
+    r39 = r39 * r87;
+    r104 = r33 * r98;
+    r104 = r104 * r81;
+    r104 = r104 * r42;
+    r104 = r104 * r57;
+    r104 = r104 * r68;
+    r104 = r104 * r70;
+    r104 = fmaf(r68, r108, r92 * r104);
+    r84 = r33 * r98;
+    r84 = r84 * r81;
+    r84 = r84 * r42;
+    r84 = r84 * r57;
+    r84 = r84 * r70;
+    r84 = r84 * r92;
+    r108 = fmaf(r67, r108, r67 * r84);
+    WriteSum4<float, float>((float*)inout_shared, r104, r108, r53, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r46 * r30;
+    r39 = r8 * r46;
+    r39 = r39 * r57;
+    r39 = r39 * r28;
+    r39 = r39 * r87;
+    r53 = r55 * r98;
+    r53 = r53 * r81;
+    r53 = r53 * r57;
+    r53 = r53 * r68;
+    r53 = r53 * r92;
+    r53 = fmaf(r36, r53, r68 * r61);
+    r108 = r55 * r98;
+    r108 = r108 * r81;
+    r108 = r108 * r57;
+    r108 = r108 * r92;
+    r108 = r108 * r67;
+    r108 = fmaf(r36, r108, r67 * r61);
+    WriteSum4<float, float>((float*)inout_shared, r53, r108, r30, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r71 * r57;
+    r39 = r39 * r70;
+    r39 = r39 * r67;
+    r67 = r67 * r94;
+    r57 = r71 * r57;
+    r57 = r57 * r70;
+    r57 = r57 * r137;
+    r50 = r46 * r50;
+    r123 = fmaf(r50, r123, r50 * r32);
+    WriteSum4<float, float>((float*)inout_shared, r123, r39, r67, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r137 * r94;
+    WriteSum2<float, float>((float*)inout_shared, r94, r130);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_res_jac_first.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_score.cu
@@ -1,0 +1,317 @@
+#include "kernel_thin_prism_fisheye_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r12, r13, r14);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r15,
+                       r16,
+                       r17,
+                       r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r23 = fmaf(r18, r19, r15 * r22);
+    r24 = r16 * r21;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r17, r20, r23);
+    r24 = 2.00000000000000000e+00;
+    r26 = fmaf(r16, r19, r17 * r22);
+    r27 = r15 * r20;
+    r26 = fmaf(r25, r27, r26);
+    r26 = fmaf(r18, r21, r26);
+    r27 = r24 * r26;
+    r28 = r23 * r27;
+    r29 = r17 * r19;
+    r29 = fmaf(r25, r29, r16 * r22);
+    r29 = fmaf(r18, r20, r29);
+    r29 = fmaf(r15, r21, r29);
+    r30 = -2.00000000000000000e+00;
+    r31 = fmaf(r16, r20, r15 * r19);
+    r31 = fmaf(r17, r21, r31);
+    r31 = fmaf(r25, r31, r18 * r22);
+    r18 = r30 * r31;
+    r32 = fmaf(r29, r18, r28);
+    r32 = fmaf(r12, r32, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r33,
+                       r34);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r35 = r19 * r21;
+    r35 = r35 * r24;
+    r36 = r20 * r22;
+    r37 = fmaf(r30, r36, r35);
+    r38 = r20 * r20;
+    r38 = r38 * r30;
+    r39 = 1.00000000000000000e+00;
+    r40 = r19 * r19;
+    r40 = fmaf(r30, r40, r39);
+    r41 = r38 + r40;
+    r42 = r20 * r21;
+    r42 = r42 * r24;
+    r43 = r19 * r22;
+    r43 = fmaf(r24, r43, r42);
+    r44 = r24 * r23;
+    r45 = r29 * r27;
+    r44 = fmaf(r31, r44, r45);
+    r46 = r29 * r29;
+    r46 = r30 * r46;
+    r47 = r39 + r46;
+    r48 = r23 * r23;
+    r48 = r30 * r48;
+    r47 = r47 + r48;
+    r32 = fmaf(r11, r37, r32);
+    r32 = fmaf(r34, r41, r32);
+    r32 = fmaf(r33, r43, r32);
+    r32 = fmaf(r13, r44, r32);
+    r32 = fmaf(r14, r47, r32);
+    r47 = copysign(1.0, r32);
+    r47 = fmaf(r8, r47, r32);
+    r32 = r47 * r47;
+    r32 = 1.0 / r32;
+    r46 = r39 + r46;
+    r44 = r26 * r26;
+    r44 = r44 * r30;
+    r46 = r46 + r44;
+    r46 = fmaf(r12, r46, r9);
+    r9 = r24 * r23;
+    r9 = r9 * r29;
+    r26 = fmaf(r26, r18, r9);
+    r43 = r24 * r29;
+    r43 = fmaf(r31, r43, r28);
+    r36 = fmaf(r24, r36, r35);
+    r35 = r21 * r22;
+    r28 = r19 * r20;
+    r28 = r28 * r24;
+    r35 = fmaf(r30, r35, r28);
+    r38 = r39 + r38;
+    r41 = r21 * r21;
+    r41 = r30 * r41;
+    r38 = r38 + r41;
+    r46 = fmaf(r13, r26, r46);
+    r46 = fmaf(r14, r43, r46);
+    r46 = fmaf(r34, r36, r46);
+    r46 = fmaf(r33, r35, r46);
+    r46 = fmaf(r11, r38, r46);
+    r38 = r46 * r46;
+    r27 = fmaf(r31, r27, r9);
+    r27 = fmaf(r12, r27, r10);
+    r12 = r21 * r22;
+    r12 = fmaf(r24, r12, r28);
+    r40 = r41 + r40;
+    r41 = r19 * r22;
+    r41 = fmaf(r30, r41, r42);
+    r18 = fmaf(r23, r18, r45);
+    r48 = r39 + r48;
+    r48 = r48 + r44;
+    r27 = fmaf(r11, r12, r27);
+    r27 = fmaf(r33, r40, r27);
+    r27 = fmaf(r34, r41, r27);
+    r27 = fmaf(r14, r18, r27);
+    r27 = fmaf(r13, r48, r27);
+    r48 = r27 * r27;
+    r13 = fmaf(r32, r48, r32 * r38);
+    r13 = sqrtf(r13);
+    r18 = copysign(1.0, r13);
+    r18 = fmaf(r8, r18, r13);
+    r8 = r18 * r18;
+    r8 = 1.0 / r8;
+    r8 = r32 * r8;
+    r13 = atanf(r13);
+    r32 = r13 * r13;
+    r8 = r8 * r32;
+    r32 = r8 * r48;
+    r14 = 3.00000000000000000e+00;
+    r14 = r14 * r8;
+    r41 = fmaf(r38, r14, r32);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r34,
+                       r40,
+                       r33,
+                       r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r8 * r38;
+    r32 = r32 + r38;
+    r33 = fmaf(r33, r32, r7 * r41);
+    r41 = r6 * r24;
+    r41 = r41 * r46;
+    r41 = r41 * r27;
+    r33 = fmaf(r8, r41, r33);
+    r11 = r32 * r32;
+    r5 = fmaf(r5, r11, r4 * r32);
+    r4 = r11 * r11;
+    r11 = r32 * r11;
+    r5 = fmaf(r40, r4, r5);
+    r5 = fmaf(r34, r11, r5);
+    r47 = 1.0 / r47;
+    r47 = r13 * r47;
+    r18 = 1.0 / r18;
+    r47 = r47 * r18;
+    r5 = r5 * r47;
+    r33 = fmaf(r46, r5, r33);
+    r33 = fmaf(r46, r47, r33);
+    r33 = fmaf(r0, r33, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r2);
+    r33 = fmaf(r0, r25, r33);
+    r14 = fmaf(r48, r14, r38);
+    r32 = fmaf(r12, r32, r6 * r14);
+    r12 = r7 * r24;
+    r12 = r12 * r46;
+    r12 = r12 * r27;
+    r32 = fmaf(r8, r12, r32);
+    r32 = fmaf(r27, r47, r32);
+    r32 = fmaf(r27, r5, r32);
+    r32 = fmaf(r1, r32, r3);
+    r32 = fmaf(r2, r25, r32);
+    r32 = fmaf(r32, r32, r33 * r33);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r32);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPointScore(float* pose,
+                                     unsigned int pose_num_alloc,
+                                     SharedIndex* pose_indices,
+                                     float* sensor_from_rig,
+                                     unsigned int sensor_from_rig_num_alloc,
+                                     float* calib,
+                                     unsigned int calib_num_alloc,
+                                     SharedIndex* calib_indices,
+                                     float* pixel,
+                                     unsigned int pixel_num_alloc,
+                                     float* point,
+                                     unsigned int point_num_alloc,
+                                     float* const out_rTr,
+                                     size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_point_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointScore(float* pose,
+                                     unsigned int pose_num_alloc,
+                                     SharedIndex* pose_indices,
+                                     float* sensor_from_rig,
+                                     unsigned int sensor_from_rig_num_alloc,
+                                     float* calib,
+                                     unsigned int calib_num_alloc,
+                                     SharedIndex* calib_indices,
+                                     float* pixel,
+                                     unsigned int pixel_num_alloc,
+                                     float* point,
+                                     unsigned int point_num_alloc,
+                                     float* const out_rTr,
+                                     size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,58 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirectKernel(
+        float* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        float* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirect(
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirect(
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.cu
@@ -1,0 +1,690 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r11, r12, r13);
+    r14 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r16,
+                                         r17,
+                                         r18);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r19, r20, r21, r22);
+    r23 = fmaf(r15, r22, r18 * r19);
+    r24 = r17 * r20;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r16, r21, r23);
+    r24 = r14 * r23;
+    r26 = r15 * r21;
+    r26 = fmaf(r25, r26, r18 * r20);
+    r26 = fmaf(r16, r22, r26);
+    r26 = fmaf(r17, r19, r26);
+    r24 = r24 * r26;
+    r27 = fmaf(r15, r20, r18 * r21);
+    r28 = r16 * r19;
+    r27 = fmaf(r25, r28, r27);
+    r27 = fmaf(r17, r22, r27);
+    r28 = r14 * r27;
+    r29 = fmaf(r16, r20, r15 * r19);
+    r29 = fmaf(r17, r21, r29);
+    r29 = fmaf(r25, r29, r18 * r22);
+    r28 = fmaf(r29, r28, r24);
+    r28 = fmaf(r11, r28, r9);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r9, r22, r30);
+    r31 = r15 * r16;
+    r31 = r31 * r14;
+    r32 = r17 * r18;
+    r32 = fmaf(r14, r32, r31);
+    r33 = -2.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r15 * r15;
+    r36 = fmaf(r33, r36, r35);
+    r37 = r34 + r36;
+    r38 = r16 * r17;
+    r38 = r38 * r14;
+    r39 = r15 * r18;
+    r39 = fmaf(r33, r39, r38);
+    r40 = r14 * r27;
+    r40 = r40 * r26;
+    r41 = r33 * r29;
+    r42 = fmaf(r23, r41, r40);
+    r43 = r23 * r23;
+    r43 = r33 * r43;
+    r44 = r35 + r43;
+    r45 = r27 * r27;
+    r45 = r33 * r45;
+    r44 = r44 + r45;
+    r28 = fmaf(r9, r32, r28);
+    r28 = fmaf(r22, r37, r28);
+    r28 = fmaf(r30, r39, r28);
+    r28 = fmaf(r13, r42, r28);
+    r28 = fmaf(r12, r44, r28);
+    r44 = r26 * r26;
+    r44 = r33 * r44;
+    r42 = r35 + r44;
+    r42 = r42 + r45;
+    r42 = fmaf(r11, r42, r8);
+    r24 = fmaf(r27, r41, r24);
+    r8 = r14 * r27;
+    r8 = r8 * r23;
+    r45 = r14 * r26;
+    r45 = fmaf(r29, r45, r8);
+    r39 = r15 * r17;
+    r39 = r39 * r14;
+    r37 = r16 * r18;
+    r32 = fmaf(r14, r37, r39);
+    r46 = r17 * r18;
+    r46 = fmaf(r33, r46, r31);
+    r31 = r16 * r16;
+    r31 = r31 * r33;
+    r47 = r35 + r31;
+    r47 = r47 + r34;
+    r42 = fmaf(r12, r24, r42);
+    r42 = fmaf(r13, r45, r42);
+    r42 = fmaf(r30, r32, r42);
+    r42 = fmaf(r22, r46, r42);
+    r42 = fmaf(r9, r47, r42);
+    r47 = r42 * r42;
+    r46 = 9.99999999999999955e-07;
+    r41 = fmaf(r26, r41, r8);
+    r41 = fmaf(r11, r41, r10);
+    r37 = fmaf(r33, r37, r39);
+    r36 = r31 + r36;
+    r31 = r15 * r18;
+    r31 = fmaf(r14, r31, r38);
+    r38 = r14 * r23;
+    r38 = fmaf(r29, r38, r40);
+    r44 = r35 + r44;
+    r44 = r44 + r43;
+    r41 = fmaf(r9, r37, r41);
+    r41 = fmaf(r30, r36, r41);
+    r41 = fmaf(r22, r31, r41);
+    r41 = fmaf(r12, r38, r41);
+    r41 = fmaf(r13, r44, r41);
+    r44 = copysign(1.0, r41);
+    r44 = fmaf(r46, r44, r41);
+    r41 = r44 * r44;
+    r13 = 1.0 / r41;
+    r38 = r28 * r28;
+    r38 = fmaf(r13, r38, r13 * r47);
+    r38 = sqrtf(r38);
+    r47 = atanf(r38);
+    r12 = r28 * r47;
+    r31 = r28 * r12;
+    r22 = copysign(1.0, r38);
+    r22 = fmaf(r46, r22, r38);
+    r46 = r22 * r22;
+    r38 = 1.0 / r46;
+    r38 = r13 * r38;
+    r13 = r47 * r38;
+    r31 = r31 * r13;
+    r36 = r42 * r42;
+    r30 = 3.00000000000000000e+00;
+    r36 = r36 * r47;
+    r36 = r36 * r30;
+    r36 = fmaf(r13, r36, r31);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r37,
+                       r9,
+                       r43,
+                       r40);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r42 * r42;
+    r29 = r29 * r47;
+    r29 = r29 * r13;
+    r31 = r31 + r29;
+    r43 = fmaf(r43, r31, r7 * r36);
+    r39 = r42 * r47;
+    r11 = r6 * r39;
+    r10 = r14 * r12;
+    r8 = r38 * r10;
+    r43 = fmaf(r8, r11, r43);
+    r32 = r31 * r31;
+    r5 = fmaf(r5, r32, r4 * r31);
+    r4 = r32 * r32;
+    r45 = r31 * r32;
+    r5 = fmaf(r9, r4, r5);
+    r5 = fmaf(r37, r45, r5);
+    r37 = 1.0 / r44;
+    r9 = 1.0 / r22;
+    r24 = r37 * r9;
+    r34 = r5 * r24;
+    r43 = fmaf(r39, r34, r43);
+    r43 = fmaf(r24, r39, r43);
+    r2 = fmaf(r0, r43, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r34, r11);
+    r2 = fmaf(r34, r25, r2);
+    r34 = r28 * r30;
+    r34 = r34 * r12;
+    r34 = fmaf(r13, r34, r29);
+    r40 = fmaf(r40, r31, r6 * r34);
+    r29 = r7 * r39;
+    r40 = fmaf(r8, r29, r40);
+    r48 = r5 * r12;
+    r40 = fmaf(r24, r48, r40);
+    r40 = fmaf(r12, r24, r40);
+    r3 = fmaf(r1, r40, r3);
+    r3 = fmaf(r11, r25, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r11 = r25 * r40;
+    r11 = r11 * r3;
+    r48 = r25 * r2;
+    r29 = r25 * r3;
+    r49 = r43 * r48;
+    WriteSum4<float, float>((float*)inout_shared, r49, r11, r48, r29);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r29 = r25 * r31;
+    r11 = r1 * r12;
+    r29 = r29 * r3;
+    r29 = r29 * r24;
+    r49 = r0 * r39;
+    r50 = r49 * r48;
+    r51 = r24 * r50;
+    r29 = fmaf(r31, r51, r11 * r29);
+    r52 = r25 * r3;
+    r53 = r1 * r28;
+    r53 = r53 * r47;
+    r53 = r53 * r32;
+    r53 = r53 * r37;
+    r53 = r53 * r9;
+    r9 = r32 * r24;
+    r50 = fmaf(r9, r50, r53 * r52);
+    r52 = r1 * r25;
+    r52 = r52 * r34;
+    r37 = r33 * r2;
+    r37 = r37 * r12;
+    r37 = r37 * r49;
+    r37 = fmaf(r38, r37, r3 * r52);
+    r52 = r0 * r36;
+    r54 = r33 * r3;
+    r54 = r54 * r39;
+    r54 = r54 * r11;
+    r54 = fmaf(r38, r54, r48 * r52);
+    WriteSum4<float, float>((float*)inout_shared, r29, r50, r37, r54);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r1 * r25;
+    r54 = r54 * r31;
+    r54 = r54 * r3;
+    r37 = r0 * r31;
+    r37 = r37 * r48;
+    r48 = r25 * r3;
+    r48 = r48 * r45;
+    r48 = r48 * r24;
+    r48 = fmaf(r45, r51, r11 * r48);
+    r50 = r25 * r3;
+    r50 = r50 * r24;
+    r50 = r50 * r11;
+    r51 = fmaf(r4, r51, r4 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r48, r51, r37, r54);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r43 * r43;
+    r37 = r40 * r40;
+    WriteSum4<float, float>((float*)inout_shared, r54, r37, r35, r35);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r42 * r42;
+    r37 = r0 * r0;
+    r35 = r35 * r47;
+    r35 = r35 * r32;
+    r35 = r35 * r13;
+    r54 = r1 * r11;
+    r51 = r28 * r54;
+    r48 = r13 * r51;
+    r35 = fmaf(r32, r48, r37 * r35);
+    r50 = r4 * r13;
+    r29 = r0 * r49;
+    r52 = r42 * r29;
+    r50 = fmaf(r4, r48, r52 * r50);
+    r55 = r1 * r1;
+    r56 = r34 * r34;
+    r57 = r28 * r12;
+    r58 = r47 * r47;
+    r59 = 4.00000000000000000e+00;
+    r41 = r44 * r41;
+    r44 = r44 * r41;
+    r44 = 1.0 / r44;
+    r46 = r22 * r46;
+    r22 = r22 * r46;
+    r22 = 1.0 / r22;
+    r58 = r58 * r59;
+    r58 = r58 * r44;
+    r58 = r58 * r22;
+    r57 = r57 * r52;
+    r57 = fmaf(r58, r57, r56 * r55);
+    r55 = r36 * r36;
+    r56 = r42 * r39;
+    r56 = r56 * r51;
+    r56 = fmaf(r58, r56, r55 * r37);
+    WriteSum4<float, float>((float*)inout_shared, r35, r50, r57, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r0;
+    r56 = r56 * r32;
+    r57 = r1 * r1;
+    r57 = r57 * r32;
+    r35 = r13 * r52;
+    r37 = r45 * r45;
+    r35 = fmaf(r37, r48, r37 * r35);
+    r55 = r13 * r52;
+    r58 = r4 * r4;
+    r58 = fmaf(r48, r58, r58 * r55);
+    WriteSum4<float, float>((float*)inout_shared, r35, r58, r56, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = 0.00000000000000000e+00;
+    r56 = r31 * r43;
+    r56 = r56 * r24;
+    r56 = r56 * r49;
+    WriteSum4<float, float>((float*)inout_shared, r57, r43, r57, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r36;
+    r56 = r56 * r43;
+    r58 = r43 * r49;
+    r58 = r58 * r9;
+    r55 = r43 * r49;
+    r55 = r55 * r8;
+    r22 = r43 * r45;
+    r22 = r22 * r24;
+    r22 = r22 * r49;
+    WriteSum4<float, float>((float*)inout_shared, r58, r55, r56, r22);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r0 * r31;
+    r22 = r22 * r43;
+    r43 = r43 * r24;
+    r43 = r43 * r49;
+    r43 = r43 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r43, r22, r57, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r1 * r34;
+    r22 = r22 * r40;
+    r43 = r31 * r40;
+    r43 = r43 * r24;
+    r43 = r43 * r11;
+    r56 = r40 * r53;
+    WriteSum4<float, float>((float*)inout_shared, r40, r43, r56, r22);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r14 * r40;
+    r22 = r22 * r39;
+    r22 = r22 * r11;
+    r22 = r22 * r38;
+    r56 = r40 * r45;
+    r56 = r56 * r24;
+    r56 = r56 * r11;
+    r43 = r40 * r24;
+    r43 = r43 * r11;
+    r43 = r43 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r22, r56, r43, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r1 * r31;
+    r43 = r43 * r40;
+    r40 = r31 * r24;
+    r40 = r40 * r49;
+    r56 = r49 * r9;
+    WriteSum4<float, float>((float*)inout_shared, r43, r57, r40, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r36;
+    r40 = r49 * r8;
+    r43 = r45 * r24;
+    r43 = r43 * r49;
+    r49 = r24 * r49;
+    r49 = r49 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r40, r56, r43, r49);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r0 * r31;
+    r43 = r31 * r24;
+    r43 = r43 * r11;
+    WriteSum4<float, float>((float*)inout_shared, r49, r57, r43, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r1 * r34;
+    r43 = r14 * r39;
+    r43 = r43 * r11;
+    r43 = r43 * r38;
+    r49 = r45 * r24;
+    r49 = r49 * r11;
+    r11 = r24 * r11;
+    r11 = r11 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r53, r43, r49, r11);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = r1 * r31;
+    r49 = r45 * r52;
+    r43 = fmaf(r45, r48, r13 * r49);
+    r53 = r31 * r52;
+    r41 = 1.0 / r41;
+    r41 = r47 * r41;
+    r46 = 1.0 / r46;
+    r41 = r41 * r46;
+    r53 = r53 * r10;
+    r46 = r31 * r34;
+    r46 = r46 * r24;
+    r46 = fmaf(r54, r46, r41 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r57, r11, r43, r46);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r29 * r9;
+    r43 = r36 * r31;
+    r43 = r43 * r24;
+    r11 = r14 * r39;
+    r11 = r11 * r51;
+    r11 = r11 * r41;
+    r43 = fmaf(r31, r11, r29 * r43);
+    r51 = r31 * r4;
+    r53 = r13 * r51;
+    r53 = fmaf(r51, r48, r52 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r43, r50, r53, r46);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r54 * r9;
+    r50 = r32 * r52;
+    r50 = r50 * r10;
+    r43 = r34 * r54;
+    r43 = fmaf(r9, r43, r41 * r50);
+    r50 = r36 * r29;
+    r50 = fmaf(r32, r11, r9 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r46, r43, r50, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r45 * r24;
+    r53 = r53 * r29;
+    r50 = r45 * r24;
+    r50 = r50 * r54;
+    r8 = r29 * r8;
+    r43 = r14 * r34;
+    r43 = r43 * r39;
+    r43 = r43 * r38;
+    r43 = fmaf(r54, r43, r36 * r8);
+    WriteSum4<float, float>((float*)inout_shared, r35, r53, r50, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r8 = r31 * r8;
+    r43 = r1 * r1;
+    r43 = r43 * r31;
+    r43 = r43 * r34;
+    r50 = r10 * r41;
+    r53 = r34 * r45;
+    r53 = r53 * r24;
+    r53 = fmaf(r54, r53, r49 * r50);
+    r50 = r4 * r52;
+    r50 = r50 * r10;
+    r49 = r34 * r24;
+    r49 = r49 * r4;
+    r49 = fmaf(r54, r49, r41 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r53, r49, r8, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r0;
+    r43 = r43 * r36;
+    r43 = r43 * r31;
+    r8 = r14 * r31;
+    r8 = r8 * r39;
+    r8 = r8 * r38;
+    r8 = r8 * r54;
+    r38 = r36 * r45;
+    r38 = r38 * r24;
+    r38 = fmaf(r45, r11, r29 * r38);
+    r49 = r36 * r24;
+    r49 = r49 * r4;
+    r11 = fmaf(r4, r11, r29 * r49);
+    WriteSum4<float, float>((float*)inout_shared, r38, r11, r43, r8);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r8 = r24 * r4;
+    r8 = r8 * r29;
+    r43 = r24 * r4;
+    r43 = r43 * r54;
+    r11 = r24 * r29;
+    r11 = r11 * r51;
+    r38 = r13 * r52;
+    r37 = r31 * r37;
+    r37 = fmaf(r48, r37, r37 * r38);
+    WriteSum4<float, float>((float*)inout_shared, r37, r8, r43, r11);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = r24 * r54;
+    r11 = r11 * r51;
+    WriteSum2<float, float>((float*)inout_shared, r11, r57);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointResJacKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.cu
@@ -1,0 +1,704 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r11, r12, r13);
+    r14 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r16,
+                                         r17,
+                                         r18);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r19, r20, r21, r22);
+    r23 = fmaf(r15, r22, r18 * r19);
+    r24 = r17 * r20;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r16, r21, r23);
+    r24 = r14 * r23;
+    r26 = r15 * r21;
+    r26 = fmaf(r25, r26, r18 * r20);
+    r26 = fmaf(r16, r22, r26);
+    r26 = fmaf(r17, r19, r26);
+    r24 = r24 * r26;
+    r27 = fmaf(r15, r20, r18 * r21);
+    r28 = r16 * r19;
+    r27 = fmaf(r25, r28, r27);
+    r27 = fmaf(r17, r22, r27);
+    r28 = r14 * r27;
+    r29 = fmaf(r16, r20, r15 * r19);
+    r29 = fmaf(r17, r21, r29);
+    r29 = fmaf(r25, r29, r18 * r22);
+    r28 = fmaf(r29, r28, r24);
+    r28 = fmaf(r11, r28, r9);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r9, r22, r30);
+    r31 = r15 * r16;
+    r31 = r31 * r14;
+    r32 = r17 * r18;
+    r32 = fmaf(r14, r32, r31);
+    r33 = -2.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r15 * r15;
+    r36 = fmaf(r33, r36, r35);
+    r37 = r34 + r36;
+    r38 = r16 * r17;
+    r38 = r38 * r14;
+    r39 = r15 * r18;
+    r39 = fmaf(r33, r39, r38);
+    r40 = r14 * r27;
+    r40 = r40 * r26;
+    r41 = r33 * r29;
+    r42 = fmaf(r23, r41, r40);
+    r43 = r23 * r23;
+    r43 = r33 * r43;
+    r44 = r35 + r43;
+    r45 = r27 * r27;
+    r45 = r33 * r45;
+    r44 = r44 + r45;
+    r28 = fmaf(r9, r32, r28);
+    r28 = fmaf(r22, r37, r28);
+    r28 = fmaf(r30, r39, r28);
+    r28 = fmaf(r13, r42, r28);
+    r28 = fmaf(r12, r44, r28);
+    r44 = r26 * r26;
+    r44 = r33 * r44;
+    r42 = r35 + r44;
+    r42 = r42 + r45;
+    r42 = fmaf(r11, r42, r8);
+    r24 = fmaf(r27, r41, r24);
+    r8 = r14 * r27;
+    r8 = r8 * r23;
+    r45 = r14 * r26;
+    r45 = fmaf(r29, r45, r8);
+    r39 = r15 * r17;
+    r39 = r39 * r14;
+    r37 = r16 * r18;
+    r32 = fmaf(r14, r37, r39);
+    r46 = r17 * r18;
+    r46 = fmaf(r33, r46, r31);
+    r31 = r16 * r16;
+    r31 = r31 * r33;
+    r47 = r35 + r31;
+    r47 = r47 + r34;
+    r42 = fmaf(r12, r24, r42);
+    r42 = fmaf(r13, r45, r42);
+    r42 = fmaf(r30, r32, r42);
+    r42 = fmaf(r22, r46, r42);
+    r42 = fmaf(r9, r47, r42);
+    r47 = r42 * r42;
+    r46 = 9.99999999999999955e-07;
+    r41 = fmaf(r26, r41, r8);
+    r41 = fmaf(r11, r41, r10);
+    r37 = fmaf(r33, r37, r39);
+    r36 = r31 + r36;
+    r31 = r15 * r18;
+    r31 = fmaf(r14, r31, r38);
+    r38 = r14 * r23;
+    r38 = fmaf(r29, r38, r40);
+    r44 = r35 + r44;
+    r44 = r44 + r43;
+    r41 = fmaf(r9, r37, r41);
+    r41 = fmaf(r30, r36, r41);
+    r41 = fmaf(r22, r31, r41);
+    r41 = fmaf(r12, r38, r41);
+    r41 = fmaf(r13, r44, r41);
+    r44 = copysign(1.0, r41);
+    r44 = fmaf(r46, r44, r41);
+    r41 = r44 * r44;
+    r13 = 1.0 / r41;
+    r38 = r28 * r28;
+    r38 = fmaf(r13, r38, r13 * r47);
+    r38 = sqrtf(r38);
+    r47 = atanf(r38);
+    r12 = r28 * r47;
+    r31 = r28 * r12;
+    r22 = copysign(1.0, r38);
+    r22 = fmaf(r46, r22, r38);
+    r46 = r22 * r22;
+    r38 = 1.0 / r46;
+    r38 = r13 * r38;
+    r13 = r47 * r38;
+    r31 = r31 * r13;
+    r36 = r42 * r42;
+    r30 = 3.00000000000000000e+00;
+    r36 = r36 * r47;
+    r36 = r36 * r30;
+    r36 = fmaf(r13, r36, r31);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r37,
+                       r9,
+                       r43,
+                       r40);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r42 * r42;
+    r29 = r29 * r47;
+    r29 = r29 * r13;
+    r31 = r31 + r29;
+    r43 = fmaf(r43, r31, r7 * r36);
+    r39 = r42 * r47;
+    r11 = r6 * r39;
+    r10 = r14 * r12;
+    r8 = r38 * r10;
+    r43 = fmaf(r8, r11, r43);
+    r32 = r31 * r31;
+    r5 = fmaf(r5, r32, r4 * r31);
+    r4 = r32 * r32;
+    r45 = r31 * r32;
+    r5 = fmaf(r9, r4, r5);
+    r5 = fmaf(r37, r45, r5);
+    r37 = 1.0 / r44;
+    r9 = 1.0 / r22;
+    r24 = r37 * r9;
+    r34 = r5 * r24;
+    r43 = fmaf(r39, r34, r43);
+    r43 = fmaf(r24, r39, r43);
+    r2 = fmaf(r0, r43, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r34, r11);
+    r2 = fmaf(r34, r25, r2);
+    r34 = r28 * r30;
+    r34 = r34 * r12;
+    r34 = fmaf(r13, r34, r29);
+    r40 = fmaf(r40, r31, r6 * r34);
+    r29 = r7 * r39;
+    r40 = fmaf(r8, r29, r40);
+    r48 = r5 * r12;
+    r40 = fmaf(r24, r48, r40);
+    r40 = fmaf(r12, r24, r40);
+    r3 = fmaf(r1, r40, r3);
+    r3 = fmaf(r11, r25, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r11 = fmaf(r3, r3, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r11);
+  if (global_thread_idx < problem_size) {
+    r11 = r25 * r40;
+    r11 = r11 * r3;
+    r48 = r25 * r2;
+    r29 = r25 * r3;
+    r49 = r43 * r48;
+    WriteSum4<float, float>((float*)inout_shared, r49, r11, r48, r29);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r29 = r25 * r31;
+    r11 = r1 * r12;
+    r29 = r29 * r3;
+    r29 = r29 * r24;
+    r49 = r0 * r39;
+    r50 = r49 * r48;
+    r51 = r24 * r50;
+    r29 = fmaf(r31, r51, r11 * r29);
+    r52 = r25 * r3;
+    r53 = r1 * r28;
+    r53 = r53 * r47;
+    r53 = r53 * r32;
+    r53 = r53 * r37;
+    r53 = r53 * r9;
+    r9 = r32 * r24;
+    r50 = fmaf(r9, r50, r53 * r52);
+    r52 = r1 * r25;
+    r52 = r52 * r34;
+    r37 = r33 * r2;
+    r37 = r37 * r12;
+    r37 = r37 * r49;
+    r37 = fmaf(r38, r37, r3 * r52);
+    r52 = r0 * r36;
+    r54 = r33 * r3;
+    r54 = r54 * r39;
+    r54 = r54 * r11;
+    r54 = fmaf(r38, r54, r48 * r52);
+    WriteSum4<float, float>((float*)inout_shared, r29, r50, r37, r54);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r1 * r25;
+    r54 = r54 * r31;
+    r54 = r54 * r3;
+    r37 = r0 * r31;
+    r37 = r37 * r48;
+    r48 = r25 * r3;
+    r48 = r48 * r45;
+    r48 = r48 * r24;
+    r48 = fmaf(r45, r51, r11 * r48);
+    r50 = r25 * r3;
+    r50 = r50 * r24;
+    r50 = r50 * r11;
+    r51 = fmaf(r4, r51, r4 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r48, r51, r37, r54);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r43 * r43;
+    r37 = r40 * r40;
+    WriteSum4<float, float>((float*)inout_shared, r54, r37, r35, r35);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r42 * r42;
+    r37 = r0 * r0;
+    r35 = r35 * r47;
+    r35 = r35 * r32;
+    r35 = r35 * r13;
+    r54 = r1 * r11;
+    r51 = r28 * r54;
+    r48 = r13 * r51;
+    r35 = fmaf(r32, r48, r37 * r35);
+    r50 = r4 * r13;
+    r29 = r0 * r49;
+    r52 = r42 * r29;
+    r50 = fmaf(r4, r48, r52 * r50);
+    r55 = r1 * r1;
+    r56 = r34 * r34;
+    r57 = r28 * r12;
+    r58 = r47 * r47;
+    r59 = 4.00000000000000000e+00;
+    r41 = r44 * r41;
+    r44 = r44 * r41;
+    r44 = 1.0 / r44;
+    r46 = r22 * r46;
+    r22 = r22 * r46;
+    r22 = 1.0 / r22;
+    r58 = r58 * r59;
+    r58 = r58 * r44;
+    r58 = r58 * r22;
+    r57 = r57 * r52;
+    r57 = fmaf(r58, r57, r56 * r55);
+    r55 = r36 * r36;
+    r56 = r42 * r39;
+    r56 = r56 * r51;
+    r56 = fmaf(r58, r56, r55 * r37);
+    WriteSum4<float, float>((float*)inout_shared, r35, r50, r57, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r0;
+    r56 = r56 * r32;
+    r57 = r1 * r1;
+    r57 = r57 * r32;
+    r35 = r13 * r52;
+    r37 = r45 * r45;
+    r35 = fmaf(r37, r48, r37 * r35);
+    r55 = r13 * r52;
+    r58 = r4 * r4;
+    r58 = fmaf(r48, r58, r58 * r55);
+    WriteSum4<float, float>((float*)inout_shared, r35, r58, r56, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = 0.00000000000000000e+00;
+    r56 = r31 * r43;
+    r56 = r56 * r24;
+    r56 = r56 * r49;
+    WriteSum4<float, float>((float*)inout_shared, r57, r43, r57, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r36;
+    r56 = r56 * r43;
+    r58 = r43 * r49;
+    r58 = r58 * r9;
+    r55 = r43 * r49;
+    r55 = r55 * r8;
+    r22 = r43 * r45;
+    r22 = r22 * r24;
+    r22 = r22 * r49;
+    WriteSum4<float, float>((float*)inout_shared, r58, r55, r56, r22);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r0 * r31;
+    r22 = r22 * r43;
+    r43 = r43 * r24;
+    r43 = r43 * r49;
+    r43 = r43 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r43, r22, r57, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r1 * r34;
+    r22 = r22 * r40;
+    r43 = r31 * r40;
+    r43 = r43 * r24;
+    r43 = r43 * r11;
+    r56 = r40 * r53;
+    WriteSum4<float, float>((float*)inout_shared, r40, r43, r56, r22);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r14 * r40;
+    r22 = r22 * r39;
+    r22 = r22 * r11;
+    r22 = r22 * r38;
+    r56 = r40 * r45;
+    r56 = r56 * r24;
+    r56 = r56 * r11;
+    r43 = r40 * r24;
+    r43 = r43 * r11;
+    r43 = r43 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r22, r56, r43, r57);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r1 * r31;
+    r43 = r43 * r40;
+    r40 = r31 * r24;
+    r40 = r40 * r49;
+    r56 = r49 * r9;
+    WriteSum4<float, float>((float*)inout_shared, r43, r57, r40, r56);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r0 * r36;
+    r40 = r49 * r8;
+    r43 = r45 * r24;
+    r43 = r43 * r49;
+    r49 = r24 * r49;
+    r49 = r49 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r40, r56, r43, r49);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r0 * r31;
+    r43 = r31 * r24;
+    r43 = r43 * r11;
+    WriteSum4<float, float>((float*)inout_shared, r49, r57, r43, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r1 * r34;
+    r43 = r14 * r39;
+    r43 = r43 * r11;
+    r43 = r43 * r38;
+    r49 = r45 * r24;
+    r49 = r49 * r11;
+    r11 = r24 * r11;
+    r11 = r11 * r4;
+    WriteSum4<float, float>((float*)inout_shared, r53, r43, r49, r11);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = r1 * r31;
+    r49 = r45 * r52;
+    r43 = fmaf(r45, r48, r13 * r49);
+    r53 = r31 * r52;
+    r41 = 1.0 / r41;
+    r41 = r47 * r41;
+    r46 = 1.0 / r46;
+    r41 = r41 * r46;
+    r53 = r53 * r10;
+    r46 = r31 * r34;
+    r46 = r46 * r24;
+    r46 = fmaf(r54, r46, r41 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r57, r11, r43, r46);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r29 * r9;
+    r43 = r36 * r31;
+    r43 = r43 * r24;
+    r11 = r14 * r39;
+    r11 = r11 * r51;
+    r11 = r11 * r41;
+    r43 = fmaf(r31, r11, r29 * r43);
+    r51 = r31 * r4;
+    r53 = r13 * r51;
+    r53 = fmaf(r51, r48, r52 * r53);
+    WriteSum4<float, float>((float*)inout_shared, r43, r50, r53, r46);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r54 * r9;
+    r50 = r32 * r52;
+    r50 = r50 * r10;
+    r43 = r34 * r54;
+    r43 = fmaf(r9, r43, r41 * r50);
+    r50 = r36 * r29;
+    r50 = fmaf(r32, r11, r9 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r46, r43, r50, r53);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r45 * r24;
+    r53 = r53 * r29;
+    r50 = r45 * r24;
+    r50 = r50 * r54;
+    r8 = r29 * r8;
+    r43 = r14 * r34;
+    r43 = r43 * r39;
+    r43 = r43 * r38;
+    r43 = fmaf(r54, r43, r36 * r8);
+    WriteSum4<float, float>((float*)inout_shared, r35, r53, r50, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r8 = r31 * r8;
+    r43 = r1 * r1;
+    r43 = r43 * r31;
+    r43 = r43 * r34;
+    r50 = r10 * r41;
+    r53 = r34 * r45;
+    r53 = r53 * r24;
+    r53 = fmaf(r54, r53, r49 * r50);
+    r50 = r4 * r52;
+    r50 = r50 * r10;
+    r49 = r34 * r24;
+    r49 = r49 * r4;
+    r49 = fmaf(r54, r49, r41 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r53, r49, r8, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r0;
+    r43 = r43 * r36;
+    r43 = r43 * r31;
+    r8 = r14 * r31;
+    r8 = r8 * r39;
+    r8 = r8 * r38;
+    r8 = r8 * r54;
+    r38 = r36 * r45;
+    r38 = r38 * r24;
+    r38 = fmaf(r45, r11, r29 * r38);
+    r49 = r36 * r24;
+    r49 = r49 * r4;
+    r11 = fmaf(r4, r11, r29 * r49);
+    WriteSum4<float, float>((float*)inout_shared, r38, r11, r43, r8);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r8 = r24 * r4;
+    r8 = r8 * r29;
+    r43 = r24 * r4;
+    r43 = r43 * r54;
+    r11 = r24 * r29;
+    r11 = r11 * r51;
+    r38 = r13 * r52;
+    r37 = r31 * r37;
+    r37 = fmaf(r48, r37, r37 * r38);
+    WriteSum4<float, float>((float*)inout_shared, r37, r8, r43, r11);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = r24 * r54;
+    r11 = r11 * r51;
+    WriteSum2<float, float>((float*)inout_shared, r11, r57);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.cu
@@ -1,0 +1,288 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r12, r13, r14);
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r16,
+                                         r17,
+                                         r18);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r19, r20, r21, r22);
+    r23 = fmaf(r15, r22, r18 * r19);
+    r24 = r17 * r20;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r16, r21, r23);
+    r24 = 2.00000000000000000e+00;
+    r26 = fmaf(r15, r20, r18 * r21);
+    r27 = r16 * r19;
+    r26 = fmaf(r25, r27, r26);
+    r26 = fmaf(r17, r22, r26);
+    r27 = r24 * r26;
+    r28 = r23 * r27;
+    r29 = r15 * r21;
+    r29 = fmaf(r25, r29, r18 * r20);
+    r29 = fmaf(r16, r22, r29);
+    r29 = fmaf(r17, r19, r29);
+    r30 = -2.00000000000000000e+00;
+    r31 = fmaf(r16, r20, r15 * r19);
+    r31 = fmaf(r17, r21, r31);
+    r31 = fmaf(r25, r31, r18 * r22);
+    r22 = r30 * r31;
+    r32 = fmaf(r29, r22, r28);
+    r32 = fmaf(r12, r32, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r11, r33, r34);
+    r35 = r15 * r17;
+    r35 = r35 * r24;
+    r36 = r16 * r18;
+    r37 = fmaf(r30, r36, r35);
+    r38 = r16 * r16;
+    r38 = r38 * r30;
+    r39 = 1.00000000000000000e+00;
+    r40 = r15 * r15;
+    r40 = fmaf(r30, r40, r39);
+    r41 = r38 + r40;
+    r42 = r16 * r17;
+    r42 = r42 * r24;
+    r43 = r15 * r18;
+    r43 = fmaf(r24, r43, r42);
+    r44 = r24 * r23;
+    r45 = r29 * r27;
+    r44 = fmaf(r31, r44, r45);
+    r46 = r29 * r29;
+    r46 = r30 * r46;
+    r47 = r39 + r46;
+    r48 = r23 * r23;
+    r48 = r30 * r48;
+    r47 = r47 + r48;
+    r32 = fmaf(r11, r37, r32);
+    r32 = fmaf(r34, r41, r32);
+    r32 = fmaf(r33, r43, r32);
+    r32 = fmaf(r13, r44, r32);
+    r32 = fmaf(r14, r47, r32);
+    r47 = copysign(1.0, r32);
+    r47 = fmaf(r8, r47, r32);
+    r32 = r47 * r47;
+    r32 = 1.0 / r32;
+    r46 = r39 + r46;
+    r44 = r26 * r26;
+    r44 = r44 * r30;
+    r46 = r46 + r44;
+    r46 = fmaf(r12, r46, r9);
+    r9 = r24 * r23;
+    r9 = r9 * r29;
+    r26 = fmaf(r26, r22, r9);
+    r43 = r24 * r29;
+    r43 = fmaf(r31, r43, r28);
+    r36 = fmaf(r24, r36, r35);
+    r35 = r17 * r18;
+    r28 = r15 * r16;
+    r28 = r28 * r24;
+    r35 = fmaf(r30, r35, r28);
+    r38 = r39 + r38;
+    r41 = r17 * r17;
+    r41 = r30 * r41;
+    r38 = r38 + r41;
+    r46 = fmaf(r13, r26, r46);
+    r46 = fmaf(r14, r43, r46);
+    r46 = fmaf(r34, r36, r46);
+    r46 = fmaf(r33, r35, r46);
+    r46 = fmaf(r11, r38, r46);
+    r38 = r46 * r46;
+    r27 = fmaf(r31, r27, r9);
+    r27 = fmaf(r12, r27, r10);
+    r12 = r17 * r18;
+    r12 = fmaf(r24, r12, r28);
+    r40 = r41 + r40;
+    r41 = r15 * r18;
+    r41 = fmaf(r30, r41, r42);
+    r22 = fmaf(r23, r22, r45);
+    r48 = r39 + r48;
+    r48 = r48 + r44;
+    r27 = fmaf(r11, r12, r27);
+    r27 = fmaf(r33, r40, r27);
+    r27 = fmaf(r34, r41, r27);
+    r27 = fmaf(r14, r22, r27);
+    r27 = fmaf(r13, r48, r27);
+    r48 = r27 * r27;
+    r13 = fmaf(r32, r48, r32 * r38);
+    r13 = sqrtf(r13);
+    r22 = copysign(1.0, r13);
+    r22 = fmaf(r8, r22, r13);
+    r8 = r22 * r22;
+    r8 = 1.0 / r8;
+    r8 = r32 * r8;
+    r13 = atanf(r13);
+    r32 = r13 * r13;
+    r8 = r8 * r32;
+    r32 = r8 * r48;
+    r14 = 3.00000000000000000e+00;
+    r14 = r14 * r8;
+    r41 = fmaf(r38, r14, r32);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r34,
+                       r40,
+                       r33,
+                       r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r8 * r38;
+    r32 = r32 + r38;
+    r33 = fmaf(r33, r32, r7 * r41);
+    r41 = r6 * r24;
+    r41 = r41 * r46;
+    r41 = r41 * r27;
+    r33 = fmaf(r8, r41, r33);
+    r11 = r32 * r32;
+    r5 = fmaf(r5, r11, r4 * r32);
+    r4 = r11 * r11;
+    r11 = r32 * r11;
+    r5 = fmaf(r40, r4, r5);
+    r5 = fmaf(r34, r11, r5);
+    r47 = 1.0 / r47;
+    r47 = r13 * r47;
+    r22 = 1.0 / r22;
+    r47 = r47 * r22;
+    r5 = r5 * r47;
+    r33 = fmaf(r46, r5, r33);
+    r33 = fmaf(r46, r47, r33);
+    r33 = fmaf(r0, r33, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r2);
+    r33 = fmaf(r0, r25, r33);
+    r14 = fmaf(r48, r14, r38);
+    r32 = fmaf(r12, r32, r6 * r14);
+    r12 = r7 * r24;
+    r12 = r12 * r46;
+    r12 = r12 * r27;
+    r32 = fmaf(r8, r12, r32);
+    r32 = fmaf(r27, r47, r32);
+    r32 = fmaf(r27, r5, r32);
+    r32 = fmaf(r1, r32, r3);
+    r32 = fmaf(r2, r25, r32);
+    r32 = fmaf(r32, r32, r33 * r33);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r32);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointScoreKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.cu
@@ -1,0 +1,235 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseJtjnjtrDirectKernel(
+        float* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        float* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31;
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r3, r4);
+    ReadIdx4<1024, float, float, float4>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r5, r6, r7, r8);
+    r9 = fmaf(r1, r7, r2 * r3);
+    r9 = fmaf(r0, r5, r9);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         0 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12,
+                                         r13);
+    r14 = r10 * r9;
+    r1 = fmaf(r1, r8, r2 * r4);
+    r1 = fmaf(r0, r6, r1);
+    r0 = r11 * r1;
+    WriteSum4<float, float>((float*)inout_shared, r14, r0, r9, r1);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r12, r9, r13 * r1);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         4 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r14,
+                                         r2,
+                                         r15,
+                                         r16);
+    r17 = fmaf(r2, r1, r14 * r9);
+    r18 = fmaf(r16, r1, r15 * r9);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         8 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r23 = fmaf(r20, r1, r19 * r9);
+    WriteSum4<float, float>((float*)inout_shared, r0, r17, r18, r23);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r23 = fmaf(r22, r1, r21 * r9);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         12 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r17,
+                                         r0,
+                                         r24);
+    r25 = fmaf(r17, r1, r18 * r9);
+    r9 = r0 * r9;
+    r1 = r24 * r1;
+    WriteSum4<float, float>((float*)inout_shared, r23, r25, r9, r1);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<4, float, float>(calib_njtr,
+                              0 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r1,
+                       r9,
+                       r25,
+                       r23);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(calib_njtr,
+                              8 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r26,
+                       r27,
+                       r28,
+                       r29);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r28, r0, r25);
+  };
+  LoadShared<4, float, float>(calib_njtr,
+                              4 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r28,
+                       r25,
+                       r30,
+                       r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fmaf(r27, r18, r0);
+    r0 = fmaf(r26, r21, r0);
+    r0 = fmaf(r25, r14, r0);
+    r0 = fmaf(r31, r19, r0);
+    r0 = fmaf(r30, r15, r0);
+    r0 = fmaf(r28, r12, r0);
+    r0 = fmaf(r1, r10, r0);
+    r24 = fmaf(r29, r24, r23);
+    r24 = fmaf(r26, r22, r24);
+    r24 = fmaf(r30, r16, r24);
+    r24 = fmaf(r31, r20, r24);
+    r24 = fmaf(r27, r17, r24);
+    r24 = fmaf(r25, r2, r24);
+    r24 = fmaf(r28, r13, r24);
+    r24 = fmaf(r9, r11, r24);
+    r6 = fmaf(r6, r24, r5 * r0);
+    r8 = fmaf(r8, r24, r7 * r0);
+    r24 = fmaf(r4, r24, r3 * r0);
+    WriteSum3<float, float>((float*)inout_shared, r6, r8, r24);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+    float* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    float* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac.cu
@@ -1,0 +1,1413 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r12,
+                       r13,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r15 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r16,
+                                         r17,
+                                         r18,
+                                         r19);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r20, r21, r22, r23);
+    r24 = fmaf(r16, r21, r19 * r22);
+    r25 = r17 * r20;
+    r26 = -1.00000000000000000e+00;
+    r24 = fmaf(r26, r25, r24);
+    r24 = fmaf(r18, r23, r24);
+    r25 = r15 * r24;
+    r27 = fmaf(r16, r23, r19 * r20);
+    r28 = r18 * r21;
+    r27 = fmaf(r26, r28, r27);
+    r27 = fmaf(r17, r22, r27);
+    r25 = r25 * r27;
+    r28 = -2.00000000000000000e+00;
+    r29 = r16 * r22;
+    r29 = fmaf(r26, r29, r19 * r21);
+    r29 = fmaf(r17, r23, r29);
+    r29 = fmaf(r18, r20, r29);
+    r30 = fmaf(r17, r21, r16 * r20);
+    r30 = fmaf(r18, r22, r30);
+    r30 = fmaf(r26, r30, r19 * r23);
+    r23 = r29 * r30;
+    r31 = fmaf(r28, r23, r25);
+    r11 = fmaf(r12, r31, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r32, r33, r34);
+    r35 = r16 * r18;
+    r35 = r35 * r15;
+    r36 = r17 * r19;
+    r37 = fmaf(r28, r36, r35);
+    r38 = r17 * r17;
+    r38 = r38 * r28;
+    r39 = 1.00000000000000000e+00;
+    r40 = r16 * r16;
+    r40 = fmaf(r28, r40, r39);
+    r41 = r38 + r40;
+    r42 = r17 * r18;
+    r42 = r42 * r15;
+    r43 = r16 * r19;
+    r43 = fmaf(r15, r43, r42);
+    r44 = r15 * r24;
+    r44 = r44 * r29;
+    r45 = r15 * r27;
+    r45 = fmaf(r30, r45, r44);
+    r46 = r28 * r29;
+    r46 = r46 * r29;
+    r47 = r39 + r46;
+    r48 = r27 * r27;
+    r48 = r28 * r48;
+    r47 = r47 + r48;
+    r11 = fmaf(r32, r37, r11);
+    r11 = fmaf(r34, r41, r11);
+    r11 = fmaf(r33, r43, r11);
+    r11 = fmaf(r13, r45, r11);
+    r11 = fmaf(r14, r47, r11);
+    r43 = copysign(1.0, r11);
+    r43 = fmaf(r8, r43, r11);
+    r11 = r43 * r43;
+    r41 = 1.0 / r11;
+    r37 = r15 * r27;
+    r37 = r37 * r29;
+    r29 = r15 * r24;
+    r29 = fmaf(r30, r29, r37);
+    r10 = fmaf(r12, r29, r10);
+    r49 = r16 * r17;
+    r49 = r49 * r15;
+    r50 = r18 * r19;
+    r50 = fmaf(r15, r50, r49);
+    r51 = r18 * r18;
+    r51 = r28 * r51;
+    r40 = r51 + r40;
+    r52 = r16 * r19;
+    r52 = fmaf(r28, r52, r42);
+    r42 = r27 * r28;
+    r42 = fmaf(r30, r42, r44);
+    r48 = r39 + r48;
+    r44 = r24 * r24;
+    r44 = r28 * r44;
+    r48 = r48 + r44;
+    r10 = fmaf(r32, r50, r10);
+    r10 = fmaf(r33, r40, r10);
+    r10 = fmaf(r34, r52, r10);
+    r10 = fmaf(r14, r42, r10);
+    r10 = fmaf(r13, r48, r10);
+    r52 = r10 * r10;
+    r52 = r41 * r52;
+    r46 = r39 + r46;
+    r46 = r46 + r44;
+    r12 = fmaf(r12, r46, r9);
+    r9 = r24 * r28;
+    r9 = fmaf(r30, r9, r37);
+    r23 = fmaf(r15, r23, r25);
+    r36 = fmaf(r15, r36, r35);
+    r35 = r18 * r19;
+    r35 = fmaf(r28, r35, r49);
+    r38 = r39 + r38;
+    r38 = r38 + r51;
+    r12 = fmaf(r13, r9, r12);
+    r12 = fmaf(r14, r23, r12);
+    r12 = fmaf(r34, r36, r12);
+    r12 = fmaf(r33, r35, r12);
+    r12 = fmaf(r32, r38, r12);
+    r38 = r12 * r12;
+    r32 = r10 * r10;
+    r32 = fmaf(r41, r32, r41 * r38);
+    r38 = sqrtf(r32);
+    r35 = copysign(1.0, r38);
+    r35 = fmaf(r8, r35, r38);
+    r8 = r35 * r35;
+    r33 = 1.0 / r8;
+    r38 = atanf(r38);
+    r36 = r38 * r38;
+    r52 = r52 * r33;
+    r52 = r52 * r36;
+    r36 = r12 * r38;
+    r34 = 3.00000000000000000e+00;
+    r14 = r41 * r33;
+    r13 = r12 * r38;
+    r36 = r36 * r34;
+    r36 = r36 * r14;
+    r36 = fmaf(r13, r36, r52);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r51,
+                       r49,
+                       r25,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r30 = r12 * r38;
+    r30 = r30 * r14;
+    r30 = r30 * r13;
+    r44 = r52 + r30;
+    r40 = fmaf(r25, r44, r7 * r36);
+    r50 = r6 * r15;
+    r53 = r10 * r38;
+    r54 = r53 * r14;
+    r50 = r50 * r13;
+    r40 = fmaf(r54, r50, r40);
+    r55 = r44 * r44;
+    r56 = fmaf(r5, r55, r4 * r44);
+    r57 = r55 * r55;
+    r58 = r44 * r55;
+    r56 = fmaf(r49, r57, r56);
+    r56 = fmaf(r51, r58, r56);
+    r59 = 1.0 / r43;
+    r60 = 1.0 / r35;
+    r61 = r59 * r60;
+    r62 = r56 * r61;
+    r40 = fmaf(r13, r62, r40);
+    r40 = fmaf(r61, r13, r40);
+    r2 = fmaf(r0, r40, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r50, r63);
+    r2 = fmaf(r50, r26, r2);
+    r30 = fmaf(r34, r52, r30);
+    r50 = fmaf(r37, r44, r6 * r30);
+    r64 = r7 * r15;
+    r64 = r64 * r13;
+    r50 = fmaf(r54, r64, r50);
+    r50 = fmaf(r53, r61, r50);
+    r50 = fmaf(r53, r62, r50);
+    r3 = fmaf(r1, r50, r3);
+    r3 = fmaf(r63, r26, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r63 = r44 * r61;
+    r64 = r0 * r13;
+    r63 = r63 * r64;
+    r65 = r1 * r44;
+    r65 = r65 * r53;
+    r65 = r65 * r61;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r40,
+                                          r50,
+                                          r63,
+                                          r65);
+    r66 = r1 * r30;
+    r67 = r61 * r55;
+    r67 = r67 * r64;
+    r68 = r1 * r53;
+    r68 = r68 * r61;
+    r68 = r68 * r55;
+    r69 = r15 * r54;
+    r69 = r69 * r64;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r67,
+                                          r68,
+                                          r69,
+                                          r66);
+    r70 = r0 * r36;
+    r71 = r1 * r15;
+    r71 = r71 * r13;
+    r71 = r71 * r54;
+    r72 = r61 * r58;
+    r72 = r72 * r64;
+    r73 = r1 * r53;
+    r73 = r73 * r61;
+    r73 = r73 * r58;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r70,
+                                          r71,
+                                          r72,
+                                          r73);
+    r74 = r0 * r44;
+    r75 = r1 * r44;
+    r76 = r61 * r64;
+    r76 = r76 * r57;
+    r77 = r1 * r53;
+    r77 = r77 * r61;
+    r77 = r77 * r57;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r76,
+                                          r77,
+                                          r74,
+                                          r75);
+    r78 = r26 * r50;
+    r78 = r78 * r3;
+    r79 = r26 * r2;
+    r80 = r26 * r3;
+    r81 = r40 * r79;
+    WriteSum4<float, float>((float*)inout_shared, r81, r78, r79, r80);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r1 * r26;
+    r80 = r80 * r44;
+    r80 = r80 * r3;
+    r80 = r80 * r53;
+    r78 = r44 * r61;
+    r78 = r78 * r64;
+    r78 = fmaf(r79, r78, r61 * r80);
+    r80 = r1 * r26;
+    r80 = r80 * r3;
+    r80 = r80 * r53;
+    r80 = r80 * r61;
+    r81 = r61 * r55;
+    r81 = r81 * r64;
+    r81 = fmaf(r79, r81, r55 * r80);
+    r80 = r1 * r26;
+    r80 = r80 * r30;
+    r82 = r28 * r2;
+    r82 = r82 * r54;
+    r82 = fmaf(r64, r82, r3 * r80);
+    r80 = r0 * r79;
+    r83 = r1 * r28;
+    r83 = r83 * r3;
+    r83 = r83 * r13;
+    r83 = fmaf(r54, r83, r36 * r80);
+    WriteSum4<float, float>((float*)inout_shared, r78, r81, r82, r83);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r1 * r26;
+    r83 = r83 * r44;
+    r83 = r83 * r3;
+    r82 = r44 * r80;
+    r81 = r1 * r26;
+    r81 = r81 * r3;
+    r81 = r81 * r53;
+    r81 = r81 * r61;
+    r78 = r61 * r58;
+    r78 = r78 * r64;
+    r78 = fmaf(r79, r78, r58 * r81);
+    r81 = r1 * r26;
+    r81 = r81 * r3;
+    r81 = r81 * r53;
+    r81 = r81 * r61;
+    r84 = r61 * r64;
+    r84 = r84 * r57;
+    r84 = fmaf(r79, r84, r57 * r81);
+    WriteSum4<float, float>((float*)inout_shared, r78, r84, r82, r83);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r40 * r40;
+    r82 = r50 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r83, r82, r39, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r12 * r38;
+    r83 = r0 * r64;
+    r82 = r82 * r14;
+    r82 = r82 * r55;
+    r84 = r1 * r1;
+    r52 = r84 * r52;
+    r82 = fmaf(r55, r52, r83 * r82);
+    r78 = r12 * r38;
+    r78 = r78 * r14;
+    r78 = r78 * r57;
+    r78 = fmaf(r57, r52, r83 * r78);
+    r81 = r30 * r30;
+    r79 = r53 * r83;
+    r85 = r12 * r10;
+    r86 = 4.00000000000000000e+00;
+    r11 = r43 * r11;
+    r43 = r43 * r11;
+    r43 = 1.0 / r43;
+    r8 = r35 * r8;
+    r35 = r35 * r8;
+    r35 = 1.0 / r35;
+    r85 = r85 * r38;
+    r85 = r85 * r38;
+    r85 = r85 * r86;
+    r85 = r85 * r43;
+    r85 = r85 * r35;
+    r79 = fmaf(r85, r79, r84 * r81);
+    r81 = r0 * r0;
+    r81 = r81 * r36;
+    r35 = r53 * r84;
+    r43 = r13 * r35;
+    r43 = fmaf(r85, r43, r36 * r81);
+    WriteSum4<float, float>((float*)inout_shared, r82, r78, r79, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r0;
+    r43 = r43 * r55;
+    r79 = r55 * r84;
+    r82 = r12 * r38;
+    r81 = r58 * r58;
+    r82 = r82 * r14;
+    r82 = r82 * r83;
+    r82 = fmaf(r81, r52, r81 * r82);
+    r85 = r12 * r38;
+    r87 = r57 * r57;
+    r85 = r85 * r14;
+    r85 = r85 * r83;
+    r87 = fmaf(r52, r87, r87 * r85);
+    WriteSum4<float, float>((float*)inout_shared, r82, r87, r43, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = 0.00000000000000000e+00;
+    r43 = r44 * r40;
+    r43 = r43 * r61;
+    r43 = r43 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r79, r40, r79, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r36;
+    r43 = r43 * r40;
+    r87 = r40 * r61;
+    r87 = r87 * r55;
+    r87 = r87 * r64;
+    r85 = r15 * r40;
+    r85 = r85 * r54;
+    r85 = r85 * r64;
+    r88 = r40 * r61;
+    r88 = r88 * r58;
+    r88 = r88 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r87, r85, r43, r88);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r0 * r44;
+    r88 = r88 * r40;
+    r40 = r40 * r61;
+    r40 = r40 * r64;
+    r40 = r40 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r40, r88, r79, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r1 * r30;
+    r88 = r88 * r50;
+    r40 = r1 * r44;
+    r40 = r40 * r50;
+    r40 = r40 * r53;
+    r40 = r40 * r61;
+    r43 = r1 * r50;
+    r43 = r43 * r53;
+    r43 = r43 * r61;
+    r43 = r43 * r55;
+    WriteSum4<float, float>((float*)inout_shared, r50, r40, r43, r88);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r1 * r15;
+    r88 = r88 * r50;
+    r88 = r88 * r13;
+    r88 = r88 * r54;
+    r43 = r1 * r50;
+    r43 = r43 * r53;
+    r43 = r43 * r61;
+    r43 = r43 * r58;
+    r40 = r1 * r50;
+    r40 = r40 * r53;
+    r40 = r40 * r61;
+    r40 = r40 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r88, r43, r40, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r1 * r44;
+    r40 = r40 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r40, r79, r63, r67);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r69, r70, r72, r76);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r74, r79, r65, r68);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r66, r71, r73, r77);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r77 = r12 * r38;
+    r77 = r77 * r14;
+    r77 = r77 * r58;
+    r77 = fmaf(r58, r52, r83 * r77);
+    r73 = r12 * r44;
+    r11 = 1.0 / r11;
+    r8 = 1.0 / r8;
+    r71 = r15 * r38;
+    r73 = r73 * r11;
+    r73 = r73 * r8;
+    r73 = r73 * r53;
+    r73 = r73 * r71;
+    r66 = r61 * r35;
+    r68 = r30 * r66;
+    r73 = fmaf(r44, r68, r83 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r79, r75, r77, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r61 * r55;
+    r73 = r73 * r83;
+    r77 = r36 * r83;
+    r75 = r61 * r77;
+    r65 = r10 * r44;
+    r65 = r65 * r11;
+    r65 = r65 * r8;
+    r65 = r65 * r13;
+    r65 = r65 * r71;
+    r65 = fmaf(r35, r65, r44 * r75);
+    r74 = r12 * r38;
+    r76 = r44 * r57;
+    r74 = r74 * r14;
+    r74 = r74 * r83;
+    r74 = fmaf(r76, r52, r76 * r74);
+    WriteSum4<float, float>((float*)inout_shared, r65, r78, r74, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r55 * r66;
+    r78 = r12 * r11;
+    r78 = r78 * r8;
+    r78 = r78 * r53;
+    r78 = r78 * r55;
+    r78 = r78 * r71;
+    r78 = fmaf(r55, r68, r83 * r78);
+    r65 = r10 * r11;
+    r65 = r65 * r8;
+    r65 = r65 * r13;
+    r65 = r65 * r55;
+    r65 = r65 * r71;
+    r65 = fmaf(r35, r65, r55 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r73, r78, r65, r74);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r61 * r58;
+    r74 = r74 * r83;
+    r65 = r58 * r66;
+    r78 = r15 * r54;
+    r73 = r15 * r30;
+    r73 = r73 * r13;
+    r73 = r73 * r54;
+    r73 = fmaf(r84, r73, r77 * r78);
+    WriteSum4<float, float>((float*)inout_shared, r82, r74, r65, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r15 * r44;
+    r73 = r73 * r54;
+    r73 = r73 * r83;
+    r65 = r44 * r30;
+    r65 = r65 * r84;
+    r74 = r12 * r11;
+    r74 = r74 * r8;
+    r74 = r74 * r53;
+    r74 = r74 * r58;
+    r74 = r74 * r71;
+    r74 = fmaf(r58, r68, r83 * r74);
+    r82 = r12 * r11;
+    r82 = r82 * r8;
+    r82 = r82 * r53;
+    r82 = r82 * r57;
+    r82 = r82 * r71;
+    r68 = fmaf(r57, r68, r83 * r82);
+    WriteSum4<float, float>((float*)inout_shared, r74, r68, r73, r65);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r0 * r0;
+    r65 = r65 * r36;
+    r65 = r65 * r44;
+    r36 = r15 * r44;
+    r36 = r36 * r13;
+    r36 = r36 * r54;
+    r36 = r36 * r84;
+    r73 = r10 * r11;
+    r73 = r73 * r8;
+    r73 = r73 * r13;
+    r73 = r73 * r58;
+    r73 = r73 * r71;
+    r73 = fmaf(r35, r73, r58 * r75);
+    r68 = r10 * r11;
+    r68 = r68 * r8;
+    r68 = r68 * r13;
+    r68 = r68 * r57;
+    r68 = r68 * r71;
+    r68 = fmaf(r35, r68, r57 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r73, r68, r65, r36);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r61 * r57;
+    r36 = r36 * r83;
+    r57 = r57 * r66;
+    r65 = r61 * r83;
+    r65 = r65 * r76;
+    r68 = r12 * r38;
+    r81 = r44 * r81;
+    r68 = r68 * r14;
+    r68 = r68 * r83;
+    r81 = fmaf(r52, r81, r81 * r68);
+    WriteSum4<float, float>((float*)inout_shared, r81, r36, r57, r65);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r76 * r66;
+    WriteSum2<float, float>((float*)inout_shared, r66, r79);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r26 * r10;
+    r66 = r15 * r29;
+    r66 = r66 * r10;
+    r76 = r15 * r46;
+    r76 = r76 * r12;
+    r76 = fmaf(r41, r76, r41 * r66);
+    r66 = r12 * r12;
+    r65 = r28 * r11;
+    r66 = r66 * r65;
+    r57 = r31 * r10;
+    r57 = r57 * r10;
+    r76 = fmaf(r65, r57, r76);
+    r76 = fmaf(r31, r66, r76);
+    r57 = rsqrtf(r32);
+    r79 = r79 * r38;
+    r79 = r79 * r76;
+    r79 = r79 * r41;
+    r79 = r79 * r8;
+    r79 = r79 * r57;
+    r32 = r39 + r32;
+    r32 = 1.0 / r32;
+    r32 = r57 * r32;
+    r39 = r76 * r32;
+    r36 = r10 * r54;
+    r39 = fmaf(r36, r39, r53 * r79);
+    r79 = r31 * r10;
+    r79 = r79 * r38;
+    r79 = r79 * r33;
+    r79 = r79 * r53;
+    r39 = fmaf(r65, r79, r39);
+    r81 = r29 * r54;
+    r39 = fmaf(r71, r81, r39);
+    r81 = r14 * r13;
+    r79 = r71 * r81;
+    r52 = r38 * r33;
+    r68 = r38 * r66;
+    r52 = r52 * r68;
+    r73 = fmaf(r31, r52, r46 * r79);
+    r75 = r12 * r32;
+    r74 = r76 * r75;
+    r73 = fmaf(r81, r74, r73);
+    r82 = r26 * r12;
+    r82 = r82 * r12;
+    r82 = r82 * r38;
+    r82 = r82 * r38;
+    r82 = r82 * r76;
+    r82 = r82 * r41;
+    r82 = r82 * r8;
+    r73 = fmaf(r57, r82, r73);
+    r82 = r39 + r73;
+    r74 = r46 * r38;
+    r78 = 6.00000000000000000e+00;
+    r74 = r74 * r78;
+    r74 = r74 * r14;
+    r77 = r31 * r38;
+    r72 = -6.00000000000000000e+00;
+    r77 = r77 * r72;
+    r77 = r77 * r33;
+    r77 = r77 * r11;
+    r70 = r12 * r77;
+    r70 = fmaf(r13, r70, r13 * r74);
+    r74 = r34 * r76;
+    r74 = r74 * r75;
+    r70 = fmaf(r81, r74, r70);
+    r69 = -3.00000000000000000e+00;
+    r69 = r38 * r69;
+    r69 = r69 * r41;
+    r69 = r69 * r8;
+    r69 = r69 * r57;
+    r67 = r76 * r69;
+    r70 = fmaf(r68, r67, r70);
+    r70 = r70 + r39;
+    r70 = fmaf(r7, r70, r25 * r82);
+    r39 = -5.00000000000000000e-01;
+    r67 = r39 * r76;
+    r67 = r67 * r33;
+    r67 = r67 * r59;
+    r67 = r67 * r57;
+    r74 = r56 * r67;
+    r63 = r76 * r75;
+    r40 = 5.00000000000000000e-01;
+    r50 = r40 * r62;
+    r70 = fmaf(r50, r63, r70);
+    r43 = r6 * r46;
+    r43 = r43 * r54;
+    r70 = fmaf(r71, r43, r70);
+    r88 = r26 * r31;
+    r88 = r88 * r12;
+    r88 = r88 * r38;
+    r88 = r88 * r41;
+    r70 = fmaf(r60, r88, r70);
+    r85 = r6 * r28;
+    r85 = r85 * r76;
+    r85 = r85 * r41;
+    r85 = r85 * r8;
+    r85 = r85 * r57;
+    r85 = r85 * r53;
+    r70 = fmaf(r13, r85, r70);
+    r87 = r6 * r76;
+    r89 = r15 * r54;
+    r89 = r89 * r75;
+    r70 = fmaf(r89, r87, r70);
+    r90 = r12 * r38;
+    r70 = fmaf(r67, r90, r70);
+    r91 = r46 * r38;
+    r70 = fmaf(r62, r91, r70);
+    r92 = r46 * r38;
+    r70 = fmaf(r61, r92, r70);
+    r93 = r6 * r31;
+    r94 = -4.00000000000000000e+00;
+    r94 = r94 * r33;
+    r94 = r94 * r11;
+    r94 = r94 * r53;
+    r94 = r94 * r13;
+    r70 = fmaf(r94, r93, r70);
+    r95 = r6 * r79;
+    r96 = r26 * r31;
+    r96 = r96 * r12;
+    r96 = r96 * r38;
+    r96 = r96 * r56;
+    r96 = r96 * r41;
+    r70 = fmaf(r60, r96, r70);
+    r97 = r5 * r15;
+    r97 = r97 * r44;
+    r97 = fmaf(r82, r97, r4 * r82);
+    r86 = r49 * r86;
+    r86 = r86 * r58;
+    r51 = r51 * r34;
+    r51 = r51 * r55;
+    r97 = fmaf(r82, r86, r97);
+    r97 = fmaf(r82, r51, r97);
+    r49 = r97 * r61;
+    r70 = fmaf(r13, r49, r70);
+    r98 = r40 * r76;
+    r98 = r98 * r61;
+    r70 = fmaf(r75, r98, r70);
+    r70 = fmaf(r74, r13, r70);
+    r70 = fmaf(r29, r95, r70);
+    r98 = r0 * r70;
+    r49 = r10 * r76;
+    r49 = r49 * r53;
+    r96 = r34 * r76;
+    r96 = r96 * r32;
+    r96 = fmaf(r36, r96, r69 * r49);
+    r49 = r10 * r53;
+    r93 = r29 * r38;
+    r93 = r93 * r78;
+    r96 = fmaf(r54, r93, r96);
+    r96 = fmaf(r77, r49, r96);
+    r96 = r96 + r73;
+    r96 = fmaf(r6, r96, r37 * r82);
+    r82 = r10 * r32;
+    r82 = r82 * r50;
+    r73 = r26 * r31;
+    r73 = r73 * r56;
+    r73 = r73 * r41;
+    r73 = r73 * r60;
+    r96 = fmaf(r53, r73, r96);
+    r93 = r7 * r46;
+    r93 = r93 * r54;
+    r96 = fmaf(r71, r93, r96);
+    r92 = r7 * r28;
+    r92 = r92 * r76;
+    r92 = r92 * r41;
+    r92 = r92 * r8;
+    r92 = r92 * r57;
+    r92 = r92 * r53;
+    r96 = fmaf(r13, r92, r96);
+    r91 = r7 * r76;
+    r96 = fmaf(r89, r91, r96);
+    r90 = r29 * r38;
+    r96 = fmaf(r62, r90, r96);
+    r87 = r10 * r40;
+    r87 = r87 * r76;
+    r87 = r87 * r61;
+    r96 = fmaf(r32, r87, r96);
+    r85 = r7 * r94;
+    r88 = r7 * r29;
+    r96 = fmaf(r79, r88, r96);
+    r43 = r26 * r31;
+    r43 = r43 * r41;
+    r43 = r43 * r60;
+    r96 = fmaf(r53, r43, r96);
+    r63 = r29 * r38;
+    r96 = fmaf(r61, r63, r96);
+    r99 = r97 * r53;
+    r96 = fmaf(r61, r99, r96);
+    r96 = fmaf(r76, r82, r96);
+    r96 = fmaf(r53, r67, r96);
+    r96 = fmaf(r31, r85, r96);
+    r96 = fmaf(r53, r74, r96);
+    r74 = r1 * r96;
+    r99 = r45 * r10;
+    r99 = r99 * r10;
+    r63 = r15 * r9;
+    r63 = r63 * r12;
+    r63 = fmaf(r41, r63, r65 * r99);
+    r99 = r15 * r48;
+    r99 = r99 * r10;
+    r63 = fmaf(r41, r99, r63);
+    r63 = fmaf(r45, r66, r63);
+    r99 = r34 * r63;
+    r99 = r99 * r75;
+    r43 = r45 * r12;
+    r43 = r43 * r12;
+    r43 = r43 * r38;
+    r43 = r43 * r38;
+    r43 = r43 * r72;
+    r43 = r43 * r33;
+    r43 = fmaf(r11, r43, r81 * r99);
+    r99 = r63 * r69;
+    r43 = fmaf(r68, r99, r43);
+    r88 = r9 * r38;
+    r88 = r88 * r78;
+    r88 = r88 * r14;
+    r43 = fmaf(r13, r88, r43);
+    r87 = r26 * r10;
+    r87 = r87 * r38;
+    r87 = r87 * r63;
+    r87 = r87 * r41;
+    r87 = r87 * r8;
+    r87 = r87 * r57;
+    r67 = r48 * r54;
+    r67 = fmaf(r71, r67, r53 * r87);
+    r87 = r63 * r32;
+    r67 = fmaf(r36, r87, r67);
+    r90 = r45 * r10;
+    r90 = r90 * r38;
+    r90 = r90 * r33;
+    r90 = r90 * r53;
+    r67 = fmaf(r65, r90, r67);
+    r43 = r43 + r67;
+    r88 = r63 * r75;
+    r88 = fmaf(r45, r52, r81 * r88);
+    r99 = r26 * r12;
+    r99 = r99 * r12;
+    r99 = r99 * r38;
+    r99 = r99 * r38;
+    r99 = r99 * r63;
+    r99 = r99 * r41;
+    r99 = r99 * r8;
+    r88 = fmaf(r57, r99, r88);
+    r88 = fmaf(r9, r79, r88);
+    r67 = r67 + r88;
+    r43 = fmaf(r25, r67, r7 * r43);
+    r99 = r12 * r38;
+    r99 = r99 * r39;
+    r99 = r99 * r63;
+    r99 = r99 * r33;
+    r99 = r99 * r59;
+    r43 = fmaf(r57, r99, r43);
+    r90 = r26 * r45;
+    r90 = r90 * r12;
+    r90 = r90 * r38;
+    r90 = r90 * r41;
+    r43 = fmaf(r60, r90, r43);
+    r87 = r26 * r45;
+    r87 = r87 * r12;
+    r87 = r87 * r38;
+    r87 = r87 * r56;
+    r87 = r87 * r41;
+    r43 = fmaf(r60, r87, r43);
+    r91 = r9 * r38;
+    r43 = fmaf(r62, r91, r43);
+    r92 = r6 * r28;
+    r92 = r92 * r63;
+    r92 = r92 * r41;
+    r92 = r92 * r8;
+    r92 = r92 * r57;
+    r92 = r92 * r53;
+    r43 = fmaf(r13, r92, r43);
+    r93 = r6 * r45;
+    r43 = fmaf(r94, r93, r43);
+    r73 = r40 * r63;
+    r73 = r73 * r61;
+    r43 = fmaf(r75, r73, r43);
+    r100 = r63 * r75;
+    r43 = fmaf(r50, r100, r43);
+    r101 = r9 * r38;
+    r43 = fmaf(r61, r101, r43);
+    r102 = r12 * r38;
+    r102 = r102 * r56;
+    r102 = r102 * r39;
+    r102 = r102 * r63;
+    r102 = r102 * r33;
+    r102 = r102 * r59;
+    r43 = fmaf(r57, r102, r43);
+    r103 = r5 * r15;
+    r103 = r103 * r44;
+    r103 = fmaf(r4, r67, r67 * r103);
+    r103 = fmaf(r67, r86, r103);
+    r103 = fmaf(r67, r51, r103);
+    r104 = r103 * r61;
+    r43 = fmaf(r13, r104, r43);
+    r105 = r6 * r9;
+    r105 = r105 * r54;
+    r43 = fmaf(r71, r105, r43);
+    r106 = r63 * r89;
+    r43 = fmaf(r48, r95, r43);
+    r43 = fmaf(r6, r106, r43);
+    r105 = r0 * r43;
+    r104 = r10 * r63;
+    r104 = r104 * r53;
+    r102 = r48 * r38;
+    r102 = r102 * r78;
+    r102 = fmaf(r54, r102, r69 * r104);
+    r104 = r34 * r63;
+    r104 = r104 * r32;
+    r102 = fmaf(r36, r104, r102);
+    r101 = r45 * r10;
+    r101 = r101 * r38;
+    r101 = r101 * r72;
+    r101 = r101 * r33;
+    r101 = r101 * r11;
+    r102 = fmaf(r53, r101, r102);
+    r102 = r102 + r88;
+    r67 = fmaf(r37, r67, r6 * r102);
+    r102 = r7 * r48;
+    r67 = fmaf(r79, r102, r67);
+    r88 = r39 * r63;
+    r88 = r88 * r33;
+    r88 = r88 * r59;
+    r88 = r88 * r57;
+    r67 = fmaf(r53, r88, r67);
+    r101 = r48 * r38;
+    r67 = fmaf(r62, r101, r67);
+    r104 = r48 * r38;
+    r67 = fmaf(r61, r104, r67);
+    r100 = r10 * r40;
+    r100 = r100 * r63;
+    r100 = r100 * r61;
+    r67 = fmaf(r32, r100, r67);
+    r73 = r7 * r28;
+    r73 = r73 * r63;
+    r73 = r73 * r41;
+    r73 = r73 * r8;
+    r73 = r73 * r57;
+    r73 = r73 * r53;
+    r67 = fmaf(r13, r73, r67);
+    r93 = r103 * r53;
+    r67 = fmaf(r61, r93, r67);
+    r92 = r26 * r45;
+    r92 = r92 * r56;
+    r92 = r92 * r41;
+    r92 = r92 * r60;
+    r67 = fmaf(r53, r92, r67);
+    r91 = r26 * r45;
+    r91 = r91 * r41;
+    r91 = r91 * r60;
+    r67 = fmaf(r53, r91, r67);
+    r87 = r56 * r39;
+    r87 = r87 * r63;
+    r87 = r87 * r33;
+    r87 = r87 * r59;
+    r87 = r87 * r57;
+    r67 = fmaf(r53, r87, r67);
+    r90 = r7 * r9;
+    r90 = r90 * r54;
+    r67 = fmaf(r71, r90, r67);
+    r67 = fmaf(r45, r85, r67);
+    r67 = fmaf(r63, r82, r67);
+    r67 = fmaf(r7, r106, r67);
+    r106 = r1 * r67;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r98,
+                                          r74,
+                                          r105,
+                                          r106);
+    r106 = r26 * r10;
+    r105 = r15 * r42;
+    r105 = r105 * r10;
+    r74 = r47 * r10;
+    r74 = r74 * r10;
+    r74 = fmaf(r65, r74, r41 * r105);
+    r105 = r15 * r23;
+    r105 = r105 * r12;
+    r74 = fmaf(r41, r105, r74);
+    r74 = fmaf(r47, r66, r74);
+    r106 = r106 * r38;
+    r106 = r106 * r74;
+    r106 = r106 * r41;
+    r106 = r106 * r8;
+    r106 = r106 * r57;
+    r105 = r42 * r54;
+    r105 = fmaf(r71, r105, r53 * r106);
+    r106 = r74 * r32;
+    r105 = fmaf(r36, r106, r105);
+    r66 = r47 * r10;
+    r66 = r66 * r38;
+    r66 = r66 * r33;
+    r66 = r66 * r53;
+    r105 = fmaf(r65, r66, r105);
+    r66 = r74 * r75;
+    r66 = fmaf(r81, r66, r23 * r79);
+    r106 = r26 * r12;
+    r106 = r106 * r12;
+    r106 = r106 * r38;
+    r106 = r106 * r38;
+    r106 = r106 * r74;
+    r106 = r106 * r41;
+    r106 = r106 * r8;
+    r66 = fmaf(r57, r106, r66);
+    r66 = fmaf(r47, r52, r66);
+    r106 = r105 + r66;
+    r52 = r23 * r38;
+    r52 = r52 * r78;
+    r52 = r52 * r14;
+    r14 = r34 * r74;
+    r14 = r14 * r75;
+    r14 = fmaf(r81, r14, r13 * r52);
+    r52 = r47 * r12;
+    r52 = r52 * r12;
+    r52 = r52 * r38;
+    r52 = r52 * r38;
+    r52 = r52 * r72;
+    r52 = r52 * r33;
+    r14 = fmaf(r11, r52, r14);
+    r81 = r74 * r69;
+    r14 = fmaf(r68, r81, r14);
+    r14 = r14 + r105;
+    r14 = fmaf(r7, r14, r25 * r106);
+    r25 = r6 * r47;
+    r14 = fmaf(r94, r25, r14);
+    r94 = r5 * r15;
+    r94 = r94 * r44;
+    r4 = fmaf(r4, r106, r106 * r94);
+    r4 = fmaf(r106, r86, r4);
+    r4 = fmaf(r106, r51, r4);
+    r51 = r4 * r61;
+    r14 = fmaf(r13, r51, r14);
+    r86 = r6 * r28;
+    r86 = r86 * r74;
+    r86 = r86 * r41;
+    r86 = r86 * r8;
+    r86 = r86 * r57;
+    r86 = r86 * r53;
+    r14 = fmaf(r13, r86, r14);
+    r94 = r6 * r74;
+    r14 = fmaf(r89, r94, r14);
+    r105 = r26 * r47;
+    r105 = r105 * r12;
+    r105 = r105 * r38;
+    r105 = r105 * r41;
+    r14 = fmaf(r60, r105, r14);
+    r68 = r12 * r38;
+    r68 = r68 * r39;
+    r68 = r68 * r74;
+    r68 = r68 * r33;
+    r68 = r68 * r59;
+    r14 = fmaf(r57, r68, r14);
+    r52 = r26 * r47;
+    r52 = r52 * r12;
+    r52 = r52 * r38;
+    r52 = r52 * r56;
+    r52 = r52 * r41;
+    r14 = fmaf(r60, r52, r14);
+    r65 = r23 * r38;
+    r14 = fmaf(r61, r65, r14);
+    r98 = r12 * r38;
+    r98 = r98 * r56;
+    r98 = r98 * r39;
+    r98 = r98 * r74;
+    r98 = r98 * r33;
+    r98 = r98 * r59;
+    r14 = fmaf(r57, r98, r14);
+    r90 = r23 * r38;
+    r14 = fmaf(r62, r90, r14);
+    r87 = r74 * r75;
+    r14 = fmaf(r50, r87, r14);
+    r50 = r40 * r74;
+    r50 = r50 * r61;
+    r14 = fmaf(r75, r50, r14);
+    r91 = r6 * r23;
+    r91 = r91 * r54;
+    r14 = fmaf(r71, r91, r14);
+    r14 = fmaf(r42, r95, r14);
+    r91 = r0 * r14;
+    r50 = r42 * r38;
+    r50 = r50 * r78;
+    r50 = fmaf(r54, r50, r81 * r49);
+    r49 = r34 * r74;
+    r49 = r49 * r32;
+    r50 = fmaf(r36, r49, r50);
+    r36 = r47 * r10;
+    r36 = r36 * r38;
+    r36 = r36 * r72;
+    r36 = r36 * r33;
+    r36 = r36 * r11;
+    r50 = fmaf(r53, r36, r50);
+    r50 = r50 + r66;
+    r50 = fmaf(r6, r50, r37 * r106);
+    r106 = r39 * r74;
+    r106 = r106 * r33;
+    r106 = r106 * r59;
+    r106 = r106 * r57;
+    r50 = fmaf(r53, r106, r50);
+    r37 = r26 * r47;
+    r37 = r37 * r56;
+    r37 = r37 * r41;
+    r37 = r37 * r60;
+    r50 = fmaf(r53, r37, r50);
+    r66 = r42 * r38;
+    r50 = fmaf(r61, r66, r50);
+    r36 = r7 * r28;
+    r36 = r36 * r74;
+    r36 = r36 * r41;
+    r36 = r36 * r8;
+    r36 = r36 * r57;
+    r36 = r36 * r53;
+    r50 = fmaf(r13, r36, r50);
+    r8 = r7 * r74;
+    r50 = fmaf(r89, r8, r50);
+    r89 = r4 * r53;
+    r50 = fmaf(r61, r89, r50);
+    r49 = r7 * r42;
+    r50 = fmaf(r79, r49, r50);
+    r79 = r56 * r39;
+    r79 = r79 * r74;
+    r79 = r79 * r33;
+    r79 = r79 * r59;
+    r79 = r79 * r57;
+    r50 = fmaf(r53, r79, r50);
+    r57 = r42 * r38;
+    r50 = fmaf(r62, r57, r50);
+    r62 = r7 * r23;
+    r62 = r62 * r54;
+    r50 = fmaf(r71, r62, r50);
+    r71 = r26 * r47;
+    r71 = r71 * r41;
+    r71 = r71 * r60;
+    r50 = fmaf(r53, r71, r50);
+    r60 = r10 * r40;
+    r60 = r60 * r74;
+    r60 = r60 * r61;
+    r50 = fmaf(r32, r60, r50);
+    r50 = fmaf(r74, r82, r50);
+    r50 = fmaf(r47, r85, r50);
+    r60 = r1 * r50;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r91,
+                                          r60);
+    r60 = r1 * r26;
+    r60 = r60 * r3;
+    r60 = fmaf(r70, r80, r96 * r60);
+    r91 = r1 * r26;
+    r91 = r91 * r3;
+    r91 = fmaf(r43, r80, r67 * r91);
+    r71 = r1 * r26;
+    r71 = r71 * r3;
+    r80 = fmaf(r14, r80, r50 * r71);
+    WriteSum3<float, float>((float*)inout_shared, r60, r91, r80);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r96 * r96;
+    r91 = r0 * r0;
+    r60 = r70 * r70;
+    r60 = fmaf(r60, r91, r84 * r80);
+    r80 = r43 * r43;
+    r71 = r67 * r67;
+    r71 = fmaf(r84, r71, r80 * r91);
+    r80 = r50 * r50;
+    r3 = r14 * r14;
+    r91 = fmaf(r3, r91, r84 * r80);
+    WriteSum3<float, float>((float*)inout_shared, r60, r71, r91);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r96 * r67;
+    r71 = r0 * r0;
+    r71 = r71 * r70;
+    r71 = fmaf(r43, r71, r84 * r91);
+    r91 = r96 * r50;
+    r60 = r0 * r0;
+    r60 = r60 * r70;
+    r60 = fmaf(r14, r60, r84 * r91);
+    r91 = r67 * r50;
+    r70 = r0 * r0;
+    r70 = r70 * r43;
+    r70 = fmaf(r14, r70, r84 * r91);
+    WriteSum3<float, float>((float*)inout_shared, r71, r60, r70);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseResJacKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.cu
@@ -1,0 +1,1427 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        float* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        float* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        float* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r12,
+                       r13,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r15 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r16,
+                                         r17,
+                                         r18,
+                                         r19);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r20, r21, r22, r23);
+    r24 = fmaf(r16, r21, r19 * r22);
+    r25 = r17 * r20;
+    r26 = -1.00000000000000000e+00;
+    r24 = fmaf(r26, r25, r24);
+    r24 = fmaf(r18, r23, r24);
+    r25 = r15 * r24;
+    r27 = fmaf(r16, r23, r19 * r20);
+    r28 = r18 * r21;
+    r27 = fmaf(r26, r28, r27);
+    r27 = fmaf(r17, r22, r27);
+    r25 = r25 * r27;
+    r28 = -2.00000000000000000e+00;
+    r29 = r16 * r22;
+    r29 = fmaf(r26, r29, r19 * r21);
+    r29 = fmaf(r17, r23, r29);
+    r29 = fmaf(r18, r20, r29);
+    r30 = fmaf(r17, r21, r16 * r20);
+    r30 = fmaf(r18, r22, r30);
+    r30 = fmaf(r26, r30, r19 * r23);
+    r23 = r29 * r30;
+    r31 = fmaf(r28, r23, r25);
+    r11 = fmaf(r12, r31, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r32, r33, r34);
+    r35 = r16 * r18;
+    r35 = r35 * r15;
+    r36 = r17 * r19;
+    r37 = fmaf(r28, r36, r35);
+    r38 = r17 * r17;
+    r38 = r38 * r28;
+    r39 = 1.00000000000000000e+00;
+    r40 = r16 * r16;
+    r40 = fmaf(r28, r40, r39);
+    r41 = r38 + r40;
+    r42 = r17 * r18;
+    r42 = r42 * r15;
+    r43 = r16 * r19;
+    r43 = fmaf(r15, r43, r42);
+    r44 = r15 * r24;
+    r44 = r44 * r29;
+    r45 = r15 * r27;
+    r45 = fmaf(r30, r45, r44);
+    r46 = r28 * r29;
+    r46 = r46 * r29;
+    r47 = r39 + r46;
+    r48 = r27 * r27;
+    r48 = r28 * r48;
+    r47 = r47 + r48;
+    r11 = fmaf(r32, r37, r11);
+    r11 = fmaf(r34, r41, r11);
+    r11 = fmaf(r33, r43, r11);
+    r11 = fmaf(r13, r45, r11);
+    r11 = fmaf(r14, r47, r11);
+    r43 = copysign(1.0, r11);
+    r43 = fmaf(r8, r43, r11);
+    r11 = r43 * r43;
+    r41 = 1.0 / r11;
+    r37 = r15 * r27;
+    r37 = r37 * r29;
+    r29 = r15 * r24;
+    r29 = fmaf(r30, r29, r37);
+    r10 = fmaf(r12, r29, r10);
+    r49 = r16 * r17;
+    r49 = r49 * r15;
+    r50 = r18 * r19;
+    r50 = fmaf(r15, r50, r49);
+    r51 = r18 * r18;
+    r51 = r28 * r51;
+    r40 = r51 + r40;
+    r52 = r16 * r19;
+    r52 = fmaf(r28, r52, r42);
+    r42 = r27 * r28;
+    r42 = fmaf(r30, r42, r44);
+    r48 = r39 + r48;
+    r44 = r24 * r24;
+    r44 = r28 * r44;
+    r48 = r48 + r44;
+    r10 = fmaf(r32, r50, r10);
+    r10 = fmaf(r33, r40, r10);
+    r10 = fmaf(r34, r52, r10);
+    r10 = fmaf(r14, r42, r10);
+    r10 = fmaf(r13, r48, r10);
+    r52 = r10 * r10;
+    r52 = r41 * r52;
+    r46 = r39 + r46;
+    r46 = r46 + r44;
+    r12 = fmaf(r12, r46, r9);
+    r9 = r24 * r28;
+    r9 = fmaf(r30, r9, r37);
+    r23 = fmaf(r15, r23, r25);
+    r36 = fmaf(r15, r36, r35);
+    r35 = r18 * r19;
+    r35 = fmaf(r28, r35, r49);
+    r38 = r39 + r38;
+    r38 = r38 + r51;
+    r12 = fmaf(r13, r9, r12);
+    r12 = fmaf(r14, r23, r12);
+    r12 = fmaf(r34, r36, r12);
+    r12 = fmaf(r33, r35, r12);
+    r12 = fmaf(r32, r38, r12);
+    r38 = r12 * r12;
+    r32 = r10 * r10;
+    r32 = fmaf(r41, r32, r41 * r38);
+    r38 = sqrtf(r32);
+    r35 = copysign(1.0, r38);
+    r35 = fmaf(r8, r35, r38);
+    r8 = r35 * r35;
+    r33 = 1.0 / r8;
+    r38 = atanf(r38);
+    r36 = r38 * r38;
+    r52 = r52 * r33;
+    r52 = r52 * r36;
+    r36 = r12 * r38;
+    r34 = 3.00000000000000000e+00;
+    r14 = r41 * r33;
+    r13 = r12 * r38;
+    r36 = r36 * r34;
+    r36 = r36 * r14;
+    r36 = fmaf(r13, r36, r52);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r51,
+                       r49,
+                       r25,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r30 = r12 * r38;
+    r30 = r30 * r14;
+    r30 = r30 * r13;
+    r44 = r52 + r30;
+    r40 = fmaf(r25, r44, r7 * r36);
+    r50 = r6 * r15;
+    r53 = r10 * r38;
+    r54 = r53 * r14;
+    r50 = r50 * r13;
+    r40 = fmaf(r54, r50, r40);
+    r55 = r44 * r44;
+    r56 = fmaf(r5, r55, r4 * r44);
+    r57 = r55 * r55;
+    r58 = r44 * r55;
+    r56 = fmaf(r49, r57, r56);
+    r56 = fmaf(r51, r58, r56);
+    r59 = 1.0 / r43;
+    r60 = 1.0 / r35;
+    r61 = r59 * r60;
+    r62 = r56 * r61;
+    r40 = fmaf(r13, r62, r40);
+    r40 = fmaf(r61, r13, r40);
+    r2 = fmaf(r0, r40, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r50, r63);
+    r2 = fmaf(r50, r26, r2);
+    r30 = fmaf(r34, r52, r30);
+    r50 = fmaf(r37, r44, r6 * r30);
+    r64 = r7 * r15;
+    r64 = r64 * r13;
+    r50 = fmaf(r54, r64, r50);
+    r50 = fmaf(r53, r61, r50);
+    r50 = fmaf(r53, r62, r50);
+    r3 = fmaf(r1, r50, r3);
+    r3 = fmaf(r63, r26, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r63 = fmaf(r3, r3, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r63);
+  if (global_thread_idx < problem_size) {
+    r63 = r44 * r61;
+    r64 = r0 * r13;
+    r63 = r63 * r64;
+    r65 = r1 * r44;
+    r65 = r65 * r53;
+    r65 = r65 * r61;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r40,
+                                          r50,
+                                          r63,
+                                          r65);
+    r66 = r1 * r30;
+    r67 = r61 * r55;
+    r67 = r67 * r64;
+    r68 = r1 * r53;
+    r68 = r68 * r61;
+    r68 = r68 * r55;
+    r69 = r15 * r54;
+    r69 = r69 * r64;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r67,
+                                          r68,
+                                          r69,
+                                          r66);
+    r70 = r0 * r36;
+    r71 = r1 * r15;
+    r71 = r71 * r13;
+    r71 = r71 * r54;
+    r72 = r61 * r58;
+    r72 = r72 * r64;
+    r73 = r1 * r53;
+    r73 = r73 * r61;
+    r73 = r73 * r58;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r70,
+                                          r71,
+                                          r72,
+                                          r73);
+    r74 = r0 * r44;
+    r75 = r1 * r44;
+    r76 = r61 * r64;
+    r76 = r76 * r57;
+    r77 = r1 * r53;
+    r77 = r77 * r61;
+    r77 = r77 * r57;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r76,
+                                          r77,
+                                          r74,
+                                          r75);
+    r78 = r26 * r50;
+    r78 = r78 * r3;
+    r79 = r26 * r2;
+    r80 = r26 * r3;
+    r81 = r40 * r79;
+    WriteSum4<float, float>((float*)inout_shared, r81, r78, r79, r80);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r1 * r26;
+    r80 = r80 * r44;
+    r80 = r80 * r3;
+    r80 = r80 * r53;
+    r78 = r44 * r61;
+    r78 = r78 * r64;
+    r78 = fmaf(r79, r78, r61 * r80);
+    r80 = r1 * r26;
+    r80 = r80 * r3;
+    r80 = r80 * r53;
+    r80 = r80 * r61;
+    r81 = r61 * r55;
+    r81 = r81 * r64;
+    r81 = fmaf(r79, r81, r55 * r80);
+    r80 = r1 * r26;
+    r80 = r80 * r30;
+    r82 = r28 * r2;
+    r82 = r82 * r54;
+    r82 = fmaf(r64, r82, r3 * r80);
+    r80 = r0 * r79;
+    r83 = r1 * r28;
+    r83 = r83 * r3;
+    r83 = r83 * r13;
+    r83 = fmaf(r54, r83, r36 * r80);
+    WriteSum4<float, float>((float*)inout_shared, r78, r81, r82, r83);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r1 * r26;
+    r83 = r83 * r44;
+    r83 = r83 * r3;
+    r82 = r44 * r80;
+    r81 = r1 * r26;
+    r81 = r81 * r3;
+    r81 = r81 * r53;
+    r81 = r81 * r61;
+    r78 = r61 * r58;
+    r78 = r78 * r64;
+    r78 = fmaf(r79, r78, r58 * r81);
+    r81 = r1 * r26;
+    r81 = r81 * r3;
+    r81 = r81 * r53;
+    r81 = r81 * r61;
+    r84 = r61 * r64;
+    r84 = r84 * r57;
+    r84 = fmaf(r79, r84, r57 * r81);
+    WriteSum4<float, float>((float*)inout_shared, r78, r84, r82, r83);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r40 * r40;
+    r82 = r50 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r83, r82, r39, r39);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r12 * r38;
+    r83 = r0 * r64;
+    r82 = r82 * r14;
+    r82 = r82 * r55;
+    r84 = r1 * r1;
+    r52 = r84 * r52;
+    r82 = fmaf(r55, r52, r83 * r82);
+    r78 = r12 * r38;
+    r78 = r78 * r14;
+    r78 = r78 * r57;
+    r78 = fmaf(r57, r52, r83 * r78);
+    r81 = r30 * r30;
+    r79 = r53 * r83;
+    r85 = r12 * r10;
+    r86 = 4.00000000000000000e+00;
+    r11 = r43 * r11;
+    r43 = r43 * r11;
+    r43 = 1.0 / r43;
+    r8 = r35 * r8;
+    r35 = r35 * r8;
+    r35 = 1.0 / r35;
+    r85 = r85 * r38;
+    r85 = r85 * r38;
+    r85 = r85 * r86;
+    r85 = r85 * r43;
+    r85 = r85 * r35;
+    r79 = fmaf(r85, r79, r84 * r81);
+    r81 = r0 * r0;
+    r81 = r81 * r36;
+    r35 = r53 * r84;
+    r43 = r13 * r35;
+    r43 = fmaf(r85, r43, r36 * r81);
+    WriteSum4<float, float>((float*)inout_shared, r82, r78, r79, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r0;
+    r43 = r43 * r55;
+    r79 = r55 * r84;
+    r82 = r12 * r38;
+    r81 = r58 * r58;
+    r82 = r82 * r14;
+    r82 = r82 * r83;
+    r82 = fmaf(r81, r52, r81 * r82);
+    r85 = r12 * r38;
+    r87 = r57 * r57;
+    r85 = r85 * r14;
+    r85 = r85 * r83;
+    r87 = fmaf(r52, r87, r87 * r85);
+    WriteSum4<float, float>((float*)inout_shared, r82, r87, r43, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = 0.00000000000000000e+00;
+    r43 = r44 * r40;
+    r43 = r43 * r61;
+    r43 = r43 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r79, r40, r79, r43);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r0 * r36;
+    r43 = r43 * r40;
+    r87 = r40 * r61;
+    r87 = r87 * r55;
+    r87 = r87 * r64;
+    r85 = r15 * r40;
+    r85 = r85 * r54;
+    r85 = r85 * r64;
+    r88 = r40 * r61;
+    r88 = r88 * r58;
+    r88 = r88 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r87, r85, r43, r88);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r0 * r44;
+    r88 = r88 * r40;
+    r40 = r40 * r61;
+    r40 = r40 * r64;
+    r40 = r40 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r40, r88, r79, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r1 * r30;
+    r88 = r88 * r50;
+    r40 = r1 * r44;
+    r40 = r40 * r50;
+    r40 = r40 * r53;
+    r40 = r40 * r61;
+    r43 = r1 * r50;
+    r43 = r43 * r53;
+    r43 = r43 * r61;
+    r43 = r43 * r55;
+    WriteSum4<float, float>((float*)inout_shared, r50, r40, r43, r88);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r1 * r15;
+    r88 = r88 * r50;
+    r88 = r88 * r13;
+    r88 = r88 * r54;
+    r43 = r1 * r50;
+    r43 = r43 * r53;
+    r43 = r43 * r61;
+    r43 = r43 * r58;
+    r40 = r1 * r50;
+    r40 = r40 * r53;
+    r40 = r40 * r61;
+    r40 = r40 * r57;
+    WriteSum4<float, float>((float*)inout_shared, r88, r43, r40, r79);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r40 = r1 * r44;
+    r40 = r40 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r40, r79, r63, r67);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r69, r70, r72, r76);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r74, r79, r65, r68);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r66, r71, r73, r77);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r77 = r12 * r38;
+    r77 = r77 * r14;
+    r77 = r77 * r58;
+    r77 = fmaf(r58, r52, r83 * r77);
+    r73 = r12 * r44;
+    r11 = 1.0 / r11;
+    r8 = 1.0 / r8;
+    r71 = r15 * r38;
+    r73 = r73 * r11;
+    r73 = r73 * r8;
+    r73 = r73 * r53;
+    r73 = r73 * r71;
+    r66 = r61 * r35;
+    r68 = r30 * r66;
+    r73 = fmaf(r44, r68, r83 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r79, r75, r77, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r61 * r55;
+    r73 = r73 * r83;
+    r77 = r36 * r83;
+    r75 = r61 * r77;
+    r65 = r10 * r44;
+    r65 = r65 * r11;
+    r65 = r65 * r8;
+    r65 = r65 * r13;
+    r65 = r65 * r71;
+    r65 = fmaf(r35, r65, r44 * r75);
+    r74 = r12 * r38;
+    r76 = r44 * r57;
+    r74 = r74 * r14;
+    r74 = r74 * r83;
+    r74 = fmaf(r76, r52, r76 * r74);
+    WriteSum4<float, float>((float*)inout_shared, r65, r78, r74, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r55 * r66;
+    r78 = r12 * r11;
+    r78 = r78 * r8;
+    r78 = r78 * r53;
+    r78 = r78 * r55;
+    r78 = r78 * r71;
+    r78 = fmaf(r55, r68, r83 * r78);
+    r65 = r10 * r11;
+    r65 = r65 * r8;
+    r65 = r65 * r13;
+    r65 = r65 * r55;
+    r65 = r65 * r71;
+    r65 = fmaf(r35, r65, r55 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r73, r78, r65, r74);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r61 * r58;
+    r74 = r74 * r83;
+    r65 = r58 * r66;
+    r78 = r15 * r54;
+    r73 = r15 * r30;
+    r73 = r73 * r13;
+    r73 = r73 * r54;
+    r73 = fmaf(r84, r73, r77 * r78);
+    WriteSum4<float, float>((float*)inout_shared, r82, r74, r65, r73);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r15 * r44;
+    r73 = r73 * r54;
+    r73 = r73 * r83;
+    r65 = r44 * r30;
+    r65 = r65 * r84;
+    r74 = r12 * r11;
+    r74 = r74 * r8;
+    r74 = r74 * r53;
+    r74 = r74 * r58;
+    r74 = r74 * r71;
+    r74 = fmaf(r58, r68, r83 * r74);
+    r82 = r12 * r11;
+    r82 = r82 * r8;
+    r82 = r82 * r53;
+    r82 = r82 * r57;
+    r82 = r82 * r71;
+    r68 = fmaf(r57, r68, r83 * r82);
+    WriteSum4<float, float>((float*)inout_shared, r74, r68, r73, r65);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r0 * r0;
+    r65 = r65 * r36;
+    r65 = r65 * r44;
+    r36 = r15 * r44;
+    r36 = r36 * r13;
+    r36 = r36 * r54;
+    r36 = r36 * r84;
+    r73 = r10 * r11;
+    r73 = r73 * r8;
+    r73 = r73 * r13;
+    r73 = r73 * r58;
+    r73 = r73 * r71;
+    r73 = fmaf(r35, r73, r58 * r75);
+    r68 = r10 * r11;
+    r68 = r68 * r8;
+    r68 = r68 * r13;
+    r68 = r68 * r57;
+    r68 = r68 * r71;
+    r68 = fmaf(r35, r68, r57 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r73, r68, r65, r36);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r61 * r57;
+    r36 = r36 * r83;
+    r57 = r57 * r66;
+    r65 = r61 * r83;
+    r65 = r65 * r76;
+    r68 = r12 * r38;
+    r81 = r44 * r81;
+    r68 = r68 * r14;
+    r68 = r68 * r83;
+    r81 = fmaf(r52, r81, r81 * r68);
+    WriteSum4<float, float>((float*)inout_shared, r81, r36, r57, r65);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r76 * r66;
+    WriteSum2<float, float>((float*)inout_shared, r66, r79);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r26 * r10;
+    r66 = r15 * r29;
+    r66 = r66 * r10;
+    r76 = r15 * r46;
+    r76 = r76 * r12;
+    r76 = fmaf(r41, r76, r41 * r66);
+    r66 = r12 * r12;
+    r65 = r28 * r11;
+    r66 = r66 * r65;
+    r57 = r31 * r10;
+    r57 = r57 * r10;
+    r76 = fmaf(r65, r57, r76);
+    r76 = fmaf(r31, r66, r76);
+    r57 = rsqrtf(r32);
+    r79 = r79 * r38;
+    r79 = r79 * r76;
+    r79 = r79 * r41;
+    r79 = r79 * r8;
+    r79 = r79 * r57;
+    r32 = r39 + r32;
+    r32 = 1.0 / r32;
+    r32 = r57 * r32;
+    r39 = r76 * r32;
+    r36 = r10 * r54;
+    r39 = fmaf(r36, r39, r53 * r79);
+    r79 = r31 * r10;
+    r79 = r79 * r38;
+    r79 = r79 * r33;
+    r79 = r79 * r53;
+    r39 = fmaf(r65, r79, r39);
+    r81 = r29 * r54;
+    r39 = fmaf(r71, r81, r39);
+    r81 = r14 * r13;
+    r79 = r71 * r81;
+    r52 = r38 * r33;
+    r68 = r38 * r66;
+    r52 = r52 * r68;
+    r73 = fmaf(r31, r52, r46 * r79);
+    r75 = r12 * r32;
+    r74 = r76 * r75;
+    r73 = fmaf(r81, r74, r73);
+    r82 = r26 * r12;
+    r82 = r82 * r12;
+    r82 = r82 * r38;
+    r82 = r82 * r38;
+    r82 = r82 * r76;
+    r82 = r82 * r41;
+    r82 = r82 * r8;
+    r73 = fmaf(r57, r82, r73);
+    r82 = r39 + r73;
+    r74 = r46 * r38;
+    r78 = 6.00000000000000000e+00;
+    r74 = r74 * r78;
+    r74 = r74 * r14;
+    r77 = r31 * r38;
+    r72 = -6.00000000000000000e+00;
+    r77 = r77 * r72;
+    r77 = r77 * r33;
+    r77 = r77 * r11;
+    r70 = r12 * r77;
+    r70 = fmaf(r13, r70, r13 * r74);
+    r74 = r34 * r76;
+    r74 = r74 * r75;
+    r70 = fmaf(r81, r74, r70);
+    r69 = -3.00000000000000000e+00;
+    r69 = r38 * r69;
+    r69 = r69 * r41;
+    r69 = r69 * r8;
+    r69 = r69 * r57;
+    r67 = r76 * r69;
+    r70 = fmaf(r68, r67, r70);
+    r70 = r70 + r39;
+    r70 = fmaf(r7, r70, r25 * r82);
+    r39 = -5.00000000000000000e-01;
+    r67 = r39 * r76;
+    r67 = r67 * r33;
+    r67 = r67 * r59;
+    r67 = r67 * r57;
+    r74 = r56 * r67;
+    r63 = r76 * r75;
+    r40 = 5.00000000000000000e-01;
+    r50 = r40 * r62;
+    r70 = fmaf(r50, r63, r70);
+    r43 = r6 * r46;
+    r43 = r43 * r54;
+    r70 = fmaf(r71, r43, r70);
+    r88 = r26 * r31;
+    r88 = r88 * r12;
+    r88 = r88 * r38;
+    r88 = r88 * r41;
+    r70 = fmaf(r60, r88, r70);
+    r85 = r6 * r28;
+    r85 = r85 * r76;
+    r85 = r85 * r41;
+    r85 = r85 * r8;
+    r85 = r85 * r57;
+    r85 = r85 * r53;
+    r70 = fmaf(r13, r85, r70);
+    r87 = r6 * r76;
+    r89 = r15 * r54;
+    r89 = r89 * r75;
+    r70 = fmaf(r89, r87, r70);
+    r90 = r12 * r38;
+    r70 = fmaf(r67, r90, r70);
+    r91 = r46 * r38;
+    r70 = fmaf(r62, r91, r70);
+    r92 = r46 * r38;
+    r70 = fmaf(r61, r92, r70);
+    r93 = r6 * r31;
+    r94 = -4.00000000000000000e+00;
+    r94 = r94 * r33;
+    r94 = r94 * r11;
+    r94 = r94 * r53;
+    r94 = r94 * r13;
+    r70 = fmaf(r94, r93, r70);
+    r95 = r6 * r79;
+    r96 = r26 * r31;
+    r96 = r96 * r12;
+    r96 = r96 * r38;
+    r96 = r96 * r56;
+    r96 = r96 * r41;
+    r70 = fmaf(r60, r96, r70);
+    r97 = r5 * r15;
+    r97 = r97 * r44;
+    r97 = fmaf(r82, r97, r4 * r82);
+    r86 = r49 * r86;
+    r86 = r86 * r58;
+    r51 = r51 * r34;
+    r51 = r51 * r55;
+    r97 = fmaf(r82, r86, r97);
+    r97 = fmaf(r82, r51, r97);
+    r49 = r97 * r61;
+    r70 = fmaf(r13, r49, r70);
+    r98 = r40 * r76;
+    r98 = r98 * r61;
+    r70 = fmaf(r75, r98, r70);
+    r70 = fmaf(r74, r13, r70);
+    r70 = fmaf(r29, r95, r70);
+    r98 = r0 * r70;
+    r49 = r10 * r76;
+    r49 = r49 * r53;
+    r96 = r34 * r76;
+    r96 = r96 * r32;
+    r96 = fmaf(r36, r96, r69 * r49);
+    r49 = r10 * r53;
+    r93 = r29 * r38;
+    r93 = r93 * r78;
+    r96 = fmaf(r54, r93, r96);
+    r96 = fmaf(r77, r49, r96);
+    r96 = r96 + r73;
+    r96 = fmaf(r6, r96, r37 * r82);
+    r82 = r10 * r32;
+    r82 = r82 * r50;
+    r73 = r26 * r31;
+    r73 = r73 * r56;
+    r73 = r73 * r41;
+    r73 = r73 * r60;
+    r96 = fmaf(r53, r73, r96);
+    r93 = r7 * r46;
+    r93 = r93 * r54;
+    r96 = fmaf(r71, r93, r96);
+    r92 = r7 * r28;
+    r92 = r92 * r76;
+    r92 = r92 * r41;
+    r92 = r92 * r8;
+    r92 = r92 * r57;
+    r92 = r92 * r53;
+    r96 = fmaf(r13, r92, r96);
+    r91 = r7 * r76;
+    r96 = fmaf(r89, r91, r96);
+    r90 = r29 * r38;
+    r96 = fmaf(r62, r90, r96);
+    r87 = r10 * r40;
+    r87 = r87 * r76;
+    r87 = r87 * r61;
+    r96 = fmaf(r32, r87, r96);
+    r85 = r7 * r94;
+    r88 = r7 * r29;
+    r96 = fmaf(r79, r88, r96);
+    r43 = r26 * r31;
+    r43 = r43 * r41;
+    r43 = r43 * r60;
+    r96 = fmaf(r53, r43, r96);
+    r63 = r29 * r38;
+    r96 = fmaf(r61, r63, r96);
+    r99 = r97 * r53;
+    r96 = fmaf(r61, r99, r96);
+    r96 = fmaf(r76, r82, r96);
+    r96 = fmaf(r53, r67, r96);
+    r96 = fmaf(r31, r85, r96);
+    r96 = fmaf(r53, r74, r96);
+    r74 = r1 * r96;
+    r99 = r45 * r10;
+    r99 = r99 * r10;
+    r63 = r15 * r9;
+    r63 = r63 * r12;
+    r63 = fmaf(r41, r63, r65 * r99);
+    r99 = r15 * r48;
+    r99 = r99 * r10;
+    r63 = fmaf(r41, r99, r63);
+    r63 = fmaf(r45, r66, r63);
+    r99 = r34 * r63;
+    r99 = r99 * r75;
+    r43 = r45 * r12;
+    r43 = r43 * r12;
+    r43 = r43 * r38;
+    r43 = r43 * r38;
+    r43 = r43 * r72;
+    r43 = r43 * r33;
+    r43 = fmaf(r11, r43, r81 * r99);
+    r99 = r63 * r69;
+    r43 = fmaf(r68, r99, r43);
+    r88 = r9 * r38;
+    r88 = r88 * r78;
+    r88 = r88 * r14;
+    r43 = fmaf(r13, r88, r43);
+    r87 = r26 * r10;
+    r87 = r87 * r38;
+    r87 = r87 * r63;
+    r87 = r87 * r41;
+    r87 = r87 * r8;
+    r87 = r87 * r57;
+    r67 = r48 * r54;
+    r67 = fmaf(r71, r67, r53 * r87);
+    r87 = r63 * r32;
+    r67 = fmaf(r36, r87, r67);
+    r90 = r45 * r10;
+    r90 = r90 * r38;
+    r90 = r90 * r33;
+    r90 = r90 * r53;
+    r67 = fmaf(r65, r90, r67);
+    r43 = r43 + r67;
+    r88 = r63 * r75;
+    r88 = fmaf(r45, r52, r81 * r88);
+    r99 = r26 * r12;
+    r99 = r99 * r12;
+    r99 = r99 * r38;
+    r99 = r99 * r38;
+    r99 = r99 * r63;
+    r99 = r99 * r41;
+    r99 = r99 * r8;
+    r88 = fmaf(r57, r99, r88);
+    r88 = fmaf(r9, r79, r88);
+    r67 = r67 + r88;
+    r43 = fmaf(r25, r67, r7 * r43);
+    r99 = r12 * r38;
+    r99 = r99 * r39;
+    r99 = r99 * r63;
+    r99 = r99 * r33;
+    r99 = r99 * r59;
+    r43 = fmaf(r57, r99, r43);
+    r90 = r26 * r45;
+    r90 = r90 * r12;
+    r90 = r90 * r38;
+    r90 = r90 * r41;
+    r43 = fmaf(r60, r90, r43);
+    r87 = r26 * r45;
+    r87 = r87 * r12;
+    r87 = r87 * r38;
+    r87 = r87 * r56;
+    r87 = r87 * r41;
+    r43 = fmaf(r60, r87, r43);
+    r91 = r9 * r38;
+    r43 = fmaf(r62, r91, r43);
+    r92 = r6 * r28;
+    r92 = r92 * r63;
+    r92 = r92 * r41;
+    r92 = r92 * r8;
+    r92 = r92 * r57;
+    r92 = r92 * r53;
+    r43 = fmaf(r13, r92, r43);
+    r93 = r6 * r45;
+    r43 = fmaf(r94, r93, r43);
+    r73 = r40 * r63;
+    r73 = r73 * r61;
+    r43 = fmaf(r75, r73, r43);
+    r100 = r63 * r75;
+    r43 = fmaf(r50, r100, r43);
+    r101 = r9 * r38;
+    r43 = fmaf(r61, r101, r43);
+    r102 = r12 * r38;
+    r102 = r102 * r56;
+    r102 = r102 * r39;
+    r102 = r102 * r63;
+    r102 = r102 * r33;
+    r102 = r102 * r59;
+    r43 = fmaf(r57, r102, r43);
+    r103 = r5 * r15;
+    r103 = r103 * r44;
+    r103 = fmaf(r4, r67, r67 * r103);
+    r103 = fmaf(r67, r86, r103);
+    r103 = fmaf(r67, r51, r103);
+    r104 = r103 * r61;
+    r43 = fmaf(r13, r104, r43);
+    r105 = r6 * r9;
+    r105 = r105 * r54;
+    r43 = fmaf(r71, r105, r43);
+    r106 = r63 * r89;
+    r43 = fmaf(r48, r95, r43);
+    r43 = fmaf(r6, r106, r43);
+    r105 = r0 * r43;
+    r104 = r10 * r63;
+    r104 = r104 * r53;
+    r102 = r48 * r38;
+    r102 = r102 * r78;
+    r102 = fmaf(r54, r102, r69 * r104);
+    r104 = r34 * r63;
+    r104 = r104 * r32;
+    r102 = fmaf(r36, r104, r102);
+    r101 = r45 * r10;
+    r101 = r101 * r38;
+    r101 = r101 * r72;
+    r101 = r101 * r33;
+    r101 = r101 * r11;
+    r102 = fmaf(r53, r101, r102);
+    r102 = r102 + r88;
+    r67 = fmaf(r37, r67, r6 * r102);
+    r102 = r7 * r48;
+    r67 = fmaf(r79, r102, r67);
+    r88 = r39 * r63;
+    r88 = r88 * r33;
+    r88 = r88 * r59;
+    r88 = r88 * r57;
+    r67 = fmaf(r53, r88, r67);
+    r101 = r48 * r38;
+    r67 = fmaf(r62, r101, r67);
+    r104 = r48 * r38;
+    r67 = fmaf(r61, r104, r67);
+    r100 = r10 * r40;
+    r100 = r100 * r63;
+    r100 = r100 * r61;
+    r67 = fmaf(r32, r100, r67);
+    r73 = r7 * r28;
+    r73 = r73 * r63;
+    r73 = r73 * r41;
+    r73 = r73 * r8;
+    r73 = r73 * r57;
+    r73 = r73 * r53;
+    r67 = fmaf(r13, r73, r67);
+    r93 = r103 * r53;
+    r67 = fmaf(r61, r93, r67);
+    r92 = r26 * r45;
+    r92 = r92 * r56;
+    r92 = r92 * r41;
+    r92 = r92 * r60;
+    r67 = fmaf(r53, r92, r67);
+    r91 = r26 * r45;
+    r91 = r91 * r41;
+    r91 = r91 * r60;
+    r67 = fmaf(r53, r91, r67);
+    r87 = r56 * r39;
+    r87 = r87 * r63;
+    r87 = r87 * r33;
+    r87 = r87 * r59;
+    r87 = r87 * r57;
+    r67 = fmaf(r53, r87, r67);
+    r90 = r7 * r9;
+    r90 = r90 * r54;
+    r67 = fmaf(r71, r90, r67);
+    r67 = fmaf(r45, r85, r67);
+    r67 = fmaf(r63, r82, r67);
+    r67 = fmaf(r7, r106, r67);
+    r106 = r1 * r67;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r98,
+                                          r74,
+                                          r105,
+                                          r106);
+    r106 = r26 * r10;
+    r105 = r15 * r42;
+    r105 = r105 * r10;
+    r74 = r47 * r10;
+    r74 = r74 * r10;
+    r74 = fmaf(r65, r74, r41 * r105);
+    r105 = r15 * r23;
+    r105 = r105 * r12;
+    r74 = fmaf(r41, r105, r74);
+    r74 = fmaf(r47, r66, r74);
+    r106 = r106 * r38;
+    r106 = r106 * r74;
+    r106 = r106 * r41;
+    r106 = r106 * r8;
+    r106 = r106 * r57;
+    r105 = r42 * r54;
+    r105 = fmaf(r71, r105, r53 * r106);
+    r106 = r74 * r32;
+    r105 = fmaf(r36, r106, r105);
+    r66 = r47 * r10;
+    r66 = r66 * r38;
+    r66 = r66 * r33;
+    r66 = r66 * r53;
+    r105 = fmaf(r65, r66, r105);
+    r66 = r74 * r75;
+    r66 = fmaf(r81, r66, r23 * r79);
+    r106 = r26 * r12;
+    r106 = r106 * r12;
+    r106 = r106 * r38;
+    r106 = r106 * r38;
+    r106 = r106 * r74;
+    r106 = r106 * r41;
+    r106 = r106 * r8;
+    r66 = fmaf(r57, r106, r66);
+    r66 = fmaf(r47, r52, r66);
+    r106 = r105 + r66;
+    r52 = r23 * r38;
+    r52 = r52 * r78;
+    r52 = r52 * r14;
+    r14 = r34 * r74;
+    r14 = r14 * r75;
+    r14 = fmaf(r81, r14, r13 * r52);
+    r52 = r47 * r12;
+    r52 = r52 * r12;
+    r52 = r52 * r38;
+    r52 = r52 * r38;
+    r52 = r52 * r72;
+    r52 = r52 * r33;
+    r14 = fmaf(r11, r52, r14);
+    r81 = r74 * r69;
+    r14 = fmaf(r68, r81, r14);
+    r14 = r14 + r105;
+    r14 = fmaf(r7, r14, r25 * r106);
+    r25 = r6 * r47;
+    r14 = fmaf(r94, r25, r14);
+    r94 = r5 * r15;
+    r94 = r94 * r44;
+    r4 = fmaf(r4, r106, r106 * r94);
+    r4 = fmaf(r106, r86, r4);
+    r4 = fmaf(r106, r51, r4);
+    r51 = r4 * r61;
+    r14 = fmaf(r13, r51, r14);
+    r86 = r6 * r28;
+    r86 = r86 * r74;
+    r86 = r86 * r41;
+    r86 = r86 * r8;
+    r86 = r86 * r57;
+    r86 = r86 * r53;
+    r14 = fmaf(r13, r86, r14);
+    r94 = r6 * r74;
+    r14 = fmaf(r89, r94, r14);
+    r105 = r26 * r47;
+    r105 = r105 * r12;
+    r105 = r105 * r38;
+    r105 = r105 * r41;
+    r14 = fmaf(r60, r105, r14);
+    r68 = r12 * r38;
+    r68 = r68 * r39;
+    r68 = r68 * r74;
+    r68 = r68 * r33;
+    r68 = r68 * r59;
+    r14 = fmaf(r57, r68, r14);
+    r52 = r26 * r47;
+    r52 = r52 * r12;
+    r52 = r52 * r38;
+    r52 = r52 * r56;
+    r52 = r52 * r41;
+    r14 = fmaf(r60, r52, r14);
+    r65 = r23 * r38;
+    r14 = fmaf(r61, r65, r14);
+    r98 = r12 * r38;
+    r98 = r98 * r56;
+    r98 = r98 * r39;
+    r98 = r98 * r74;
+    r98 = r98 * r33;
+    r98 = r98 * r59;
+    r14 = fmaf(r57, r98, r14);
+    r90 = r23 * r38;
+    r14 = fmaf(r62, r90, r14);
+    r87 = r74 * r75;
+    r14 = fmaf(r50, r87, r14);
+    r50 = r40 * r74;
+    r50 = r50 * r61;
+    r14 = fmaf(r75, r50, r14);
+    r91 = r6 * r23;
+    r91 = r91 * r54;
+    r14 = fmaf(r71, r91, r14);
+    r14 = fmaf(r42, r95, r14);
+    r91 = r0 * r14;
+    r50 = r42 * r38;
+    r50 = r50 * r78;
+    r50 = fmaf(r54, r50, r81 * r49);
+    r49 = r34 * r74;
+    r49 = r49 * r32;
+    r50 = fmaf(r36, r49, r50);
+    r36 = r47 * r10;
+    r36 = r36 * r38;
+    r36 = r36 * r72;
+    r36 = r36 * r33;
+    r36 = r36 * r11;
+    r50 = fmaf(r53, r36, r50);
+    r50 = r50 + r66;
+    r50 = fmaf(r6, r50, r37 * r106);
+    r106 = r39 * r74;
+    r106 = r106 * r33;
+    r106 = r106 * r59;
+    r106 = r106 * r57;
+    r50 = fmaf(r53, r106, r50);
+    r37 = r26 * r47;
+    r37 = r37 * r56;
+    r37 = r37 * r41;
+    r37 = r37 * r60;
+    r50 = fmaf(r53, r37, r50);
+    r66 = r42 * r38;
+    r50 = fmaf(r61, r66, r50);
+    r36 = r7 * r28;
+    r36 = r36 * r74;
+    r36 = r36 * r41;
+    r36 = r36 * r8;
+    r36 = r36 * r57;
+    r36 = r36 * r53;
+    r50 = fmaf(r13, r36, r50);
+    r8 = r7 * r74;
+    r50 = fmaf(r89, r8, r50);
+    r89 = r4 * r53;
+    r50 = fmaf(r61, r89, r50);
+    r49 = r7 * r42;
+    r50 = fmaf(r79, r49, r50);
+    r79 = r56 * r39;
+    r79 = r79 * r74;
+    r79 = r79 * r33;
+    r79 = r79 * r59;
+    r79 = r79 * r57;
+    r50 = fmaf(r53, r79, r50);
+    r57 = r42 * r38;
+    r50 = fmaf(r62, r57, r50);
+    r62 = r7 * r23;
+    r62 = r62 * r54;
+    r50 = fmaf(r71, r62, r50);
+    r71 = r26 * r47;
+    r71 = r71 * r41;
+    r71 = r71 * r60;
+    r50 = fmaf(r53, r71, r50);
+    r60 = r10 * r40;
+    r60 = r60 * r74;
+    r60 = r60 * r61;
+    r50 = fmaf(r32, r60, r50);
+    r50 = fmaf(r74, r82, r50);
+    r50 = fmaf(r47, r85, r50);
+    r60 = r1 * r50;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r91,
+                                          r60);
+    r60 = r1 * r26;
+    r60 = r60 * r3;
+    r60 = fmaf(r70, r80, r96 * r60);
+    r91 = r1 * r26;
+    r91 = r91 * r3;
+    r91 = fmaf(r43, r80, r67 * r91);
+    r71 = r1 * r26;
+    r71 = r71 * r3;
+    r80 = fmaf(r14, r80, r50 * r71);
+    WriteSum3<float, float>((float*)inout_shared, r60, r91, r80);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r96 * r96;
+    r91 = r0 * r0;
+    r60 = r70 * r70;
+    r60 = fmaf(r60, r91, r84 * r80);
+    r80 = r43 * r43;
+    r71 = r67 * r67;
+    r71 = fmaf(r84, r71, r80 * r91);
+    r80 = r50 * r50;
+    r3 = r14 * r14;
+    r91 = fmaf(r3, r91, r84 * r80);
+    WriteSum3<float, float>((float*)inout_shared, r60, r71, r91);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r96 * r67;
+    r71 = r0 * r0;
+    r71 = r71 * r70;
+    r71 = fmaf(r43, r71, r84 * r91);
+    r91 = r96 * r50;
+    r60 = r0 * r0;
+    r60 = r60 * r70;
+    r60 = fmaf(r14, r60, r84 * r91);
+    r91 = r67 * r50;
+    r70 = r0 * r0;
+    r70 = r70 * r43;
+    r70 = fmaf(r14, r70, r84 * r91);
+    WriteSum3<float, float>((float*)inout_shared, r71, r60, r70);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseResJacFirstKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_score.cu
@@ -1,0 +1,304 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseScoreKernel(float* sensor_from_rig,
+                                         unsigned int sensor_from_rig_num_alloc,
+                                         float* calib,
+                                         unsigned int calib_num_alloc,
+                                         SharedIndex* calib_indices,
+                                         float* point,
+                                         unsigned int point_num_alloc,
+                                         SharedIndex* point_indices,
+                                         float* pixel,
+                                         unsigned int pixel_num_alloc,
+                                         float* pose,
+                                         unsigned int pose_num_alloc,
+                                         float* const out_rTr,
+                                         size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r12,
+                       r13,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r16,
+                                         r17,
+                                         r18);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r19, r20, r21, r22);
+    r23 = fmaf(r15, r22, r18 * r19);
+    r24 = r17 * r20;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r16, r21, r23);
+    r24 = 2.00000000000000000e+00;
+    r26 = fmaf(r15, r20, r18 * r21);
+    r27 = r16 * r19;
+    r26 = fmaf(r25, r27, r26);
+    r26 = fmaf(r17, r22, r26);
+    r27 = r24 * r26;
+    r28 = r23 * r27;
+    r29 = r15 * r21;
+    r29 = fmaf(r25, r29, r18 * r20);
+    r29 = fmaf(r16, r22, r29);
+    r29 = fmaf(r17, r19, r29);
+    r30 = -2.00000000000000000e+00;
+    r31 = fmaf(r16, r20, r15 * r19);
+    r31 = fmaf(r17, r21, r31);
+    r31 = fmaf(r25, r31, r18 * r22);
+    r22 = r30 * r31;
+    r32 = fmaf(r29, r22, r28);
+    r32 = fmaf(r12, r32, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r11, r33, r34);
+    r35 = r15 * r17;
+    r35 = r35 * r24;
+    r36 = r16 * r18;
+    r37 = fmaf(r30, r36, r35);
+    r38 = r16 * r16;
+    r38 = r38 * r30;
+    r39 = 1.00000000000000000e+00;
+    r40 = r15 * r15;
+    r40 = fmaf(r30, r40, r39);
+    r41 = r38 + r40;
+    r42 = r16 * r17;
+    r42 = r42 * r24;
+    r43 = r15 * r18;
+    r43 = fmaf(r24, r43, r42);
+    r44 = r24 * r23;
+    r45 = r29 * r27;
+    r44 = fmaf(r31, r44, r45);
+    r46 = r29 * r29;
+    r46 = r30 * r46;
+    r47 = r39 + r46;
+    r48 = r23 * r23;
+    r48 = r30 * r48;
+    r47 = r47 + r48;
+    r32 = fmaf(r11, r37, r32);
+    r32 = fmaf(r34, r41, r32);
+    r32 = fmaf(r33, r43, r32);
+    r32 = fmaf(r13, r44, r32);
+    r32 = fmaf(r14, r47, r32);
+    r47 = copysign(1.0, r32);
+    r47 = fmaf(r8, r47, r32);
+    r32 = r47 * r47;
+    r32 = 1.0 / r32;
+    r46 = r39 + r46;
+    r44 = r26 * r26;
+    r44 = r44 * r30;
+    r46 = r46 + r44;
+    r46 = fmaf(r12, r46, r9);
+    r9 = r24 * r23;
+    r9 = r9 * r29;
+    r26 = fmaf(r26, r22, r9);
+    r43 = r24 * r29;
+    r43 = fmaf(r31, r43, r28);
+    r36 = fmaf(r24, r36, r35);
+    r35 = r17 * r18;
+    r28 = r15 * r16;
+    r28 = r28 * r24;
+    r35 = fmaf(r30, r35, r28);
+    r38 = r39 + r38;
+    r41 = r17 * r17;
+    r41 = r30 * r41;
+    r38 = r38 + r41;
+    r46 = fmaf(r13, r26, r46);
+    r46 = fmaf(r14, r43, r46);
+    r46 = fmaf(r34, r36, r46);
+    r46 = fmaf(r33, r35, r46);
+    r46 = fmaf(r11, r38, r46);
+    r38 = r46 * r46;
+    r27 = fmaf(r31, r27, r9);
+    r27 = fmaf(r12, r27, r10);
+    r12 = r17 * r18;
+    r12 = fmaf(r24, r12, r28);
+    r40 = r41 + r40;
+    r41 = r15 * r18;
+    r41 = fmaf(r30, r41, r42);
+    r22 = fmaf(r23, r22, r45);
+    r48 = r39 + r48;
+    r48 = r48 + r44;
+    r27 = fmaf(r11, r12, r27);
+    r27 = fmaf(r33, r40, r27);
+    r27 = fmaf(r34, r41, r27);
+    r27 = fmaf(r14, r22, r27);
+    r27 = fmaf(r13, r48, r27);
+    r48 = r27 * r27;
+    r13 = fmaf(r32, r48, r32 * r38);
+    r13 = sqrtf(r13);
+    r22 = copysign(1.0, r13);
+    r22 = fmaf(r8, r22, r13);
+    r8 = r22 * r22;
+    r8 = 1.0 / r8;
+    r8 = r32 * r8;
+    r13 = atanf(r13);
+    r32 = r13 * r13;
+    r8 = r8 * r32;
+    r32 = r8 * r48;
+    r14 = 3.00000000000000000e+00;
+    r14 = r14 * r8;
+    r41 = fmaf(r38, r14, r32);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r34,
+                       r40,
+                       r33,
+                       r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r8 * r38;
+    r32 = r32 + r38;
+    r33 = fmaf(r33, r32, r7 * r41);
+    r41 = r6 * r24;
+    r41 = r41 * r46;
+    r41 = r41 * r27;
+    r33 = fmaf(r8, r41, r33);
+    r11 = r32 * r32;
+    r5 = fmaf(r5, r11, r4 * r32);
+    r4 = r11 * r11;
+    r11 = r32 * r11;
+    r5 = fmaf(r40, r4, r5);
+    r5 = fmaf(r34, r11, r5);
+    r47 = 1.0 / r47;
+    r47 = r13 * r47;
+    r22 = 1.0 / r22;
+    r47 = r47 * r22;
+    r5 = r5 * r47;
+    r33 = fmaf(r46, r5, r33);
+    r33 = fmaf(r46, r47, r33);
+    r33 = fmaf(r0, r33, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r2);
+    r33 = fmaf(r0, r25, r33);
+    r14 = fmaf(r48, r14, r38);
+    r32 = fmaf(r12, r32, r6 * r14);
+    r12 = r7 * r24;
+    r12 = r12 * r46;
+    r12 = r12 * r27;
+    r32 = fmaf(r8, r12, r32);
+    r32 = fmaf(r27, r47, r32);
+    r32 = fmaf(r27, r5, r32);
+    r32 = fmaf(r1, r32, r3);
+    r32 = fmaf(r2, r25, r32);
+    r32 = fmaf(r32, r32, r33 * r33);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r32);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseScore(float* sensor_from_rig,
+                                    unsigned int sensor_from_rig_num_alloc,
+                                    float* calib,
+                                    unsigned int calib_num_alloc,
+                                    SharedIndex* calib_indices,
+                                    float* point,
+                                    unsigned int point_num_alloc,
+                                    SharedIndex* point_indices,
+                                    float* pixel,
+                                    unsigned int pixel_num_alloc,
+                                    float* pose,
+                                    unsigned int pose_num_alloc,
+                                    float* const out_rTr,
+                                    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseScoreKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_fixed_pose_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseScore(float* sensor_from_rig,
+                                    unsigned int sensor_from_rig_num_alloc,
+                                    float* calib,
+                                    unsigned int calib_num_alloc,
+                                    SharedIndex* calib_indices,
+                                    float* point,
+                                    unsigned int point_num_alloc,
+                                    SharedIndex* point_indices,
+                                    float* pixel,
+                                    unsigned int pixel_num_alloc,
+                                    float* pose,
+                                    unsigned int pose_num_alloc,
+                                    float* const out_rTr,
+                                    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_jtjnjtr_direct.cu
@@ -1,0 +1,338 @@
+#include "kernel_thin_prism_fisheye_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeJtjnjtrDirectKernel(float* pose_njtr,
+                                        unsigned int pose_njtr_num_alloc,
+                                        SharedIndex* pose_njtr_indices,
+                                        float* pose_jac,
+                                        unsigned int pose_jac_num_alloc,
+                                        float* calib_njtr,
+                                        unsigned int calib_njtr_num_alloc,
+                                        SharedIndex* calib_njtr_indices,
+                                        float* calib_jac,
+                                        unsigned int calib_jac_num_alloc,
+                                        float* point_njtr,
+                                        unsigned int point_njtr_num_alloc,
+                                        SharedIndex* point_njtr_indices,
+                                        float* point_jac,
+                                        unsigned int point_jac_num_alloc,
+                                        float* const out_pose_njtr,
+                                        unsigned int out_pose_njtr_num_alloc,
+                                        float* const out_calib_njtr,
+                                        unsigned int out_calib_njtr_num_alloc,
+                                        float* const out_point_njtr,
+                                        unsigned int out_point_njtr_num_alloc,
+                                        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<4, float, float>(calib_njtr,
+                              0 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(calib_njtr,
+                              8 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9,
+                       r10,
+                       r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         12 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r12,
+                                         r13,
+                                         r14,
+                                         r15);
+    r10 = fmaf(r10, r14, r6);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         8 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r6,
+                                         r16,
+                                         r17,
+                                         r18);
+  };
+  LoadShared<4, float, float>(calib_njtr,
+                              4 * calib_njtr_num_alloc,
+                              calib_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_njtr_indices_loc[threadIdx.x].target,
+                       r19,
+                       r20,
+                       r21,
+                       r22);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         4 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r23,
+                                         r24,
+                                         r25,
+                                         r26);
+    ReadIdx4<1024, float, float, float4>(calib_jac,
+                                         0 * calib_jac_num_alloc,
+                                         global_thread_idx,
+                                         r27,
+                                         r28,
+                                         r29,
+                                         r30);
+    r10 = fmaf(r9, r12, r10);
+    r10 = fmaf(r8, r17, r10);
+    r10 = fmaf(r20, r23, r10);
+    r10 = fmaf(r22, r6, r10);
+    r10 = fmaf(r21, r25, r10);
+    r10 = fmaf(r19, r29, r10);
+    r10 = fmaf(r4, r27, r10);
+  };
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r31,
+                       r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r33, r34);
+    ReadIdx4<1024, float, float, float4>(point_jac,
+                                         0 * point_jac_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r36,
+                                         r37,
+                                         r38);
+    r39 = fmaf(r31, r37, r32 * r33);
+    r39 = fmaf(r4, r35, r39);
+    r40 = r10 + r39;
+    r11 = fmaf(r11, r15, r7);
+    r11 = fmaf(r8, r18, r11);
+    r11 = fmaf(r21, r26, r11);
+    r11 = fmaf(r22, r16, r11);
+    r11 = fmaf(r9, r13, r11);
+    r11 = fmaf(r20, r24, r11);
+    r11 = fmaf(r19, r30, r11);
+    r11 = fmaf(r5, r28, r11);
+    r31 = fmaf(r31, r38, r32 * r34);
+    r31 = fmaf(r4, r36, r31);
+    r4 = r11 + r31;
+    r32 = fmaf(r1, r4, r0 * r40);
+    r5 = fmaf(r3, r4, r2 * r40);
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r19, r20, r9, r22);
+    r21 = fmaf(r20, r4, r19 * r40);
+    r8 = fmaf(r22, r4, r9 * r40);
+    WriteSum4<float, float>((float*)inout_shared, r32, r5, r21, r8);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r8, r21, r5, r32);
+    r7 = fmaf(r21, r4, r8 * r40);
+    r4 = fmaf(r32, r4, r5 * r40);
+    WriteSum2<float, float>((float*)inout_shared, r7, r4);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = fmaf(r4, r8, r7 * r5);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r5,
+                       r40,
+                       r41,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = fmaf(r41, r19, r8);
+    r8 = fmaf(r42, r9, r8);
+    r8 = fmaf(r5, r0, r8);
+    r8 = fmaf(r40, r2, r8);
+    r39 = r8 + r39;
+    r27 = r27 * r39;
+    r22 = fmaf(r42, r22, r7 * r32);
+    r22 = fmaf(r41, r20, r22);
+    r22 = fmaf(r5, r1, r22);
+    r22 = fmaf(r40, r3, r22);
+    r22 = fmaf(r4, r21, r22);
+    r31 = r22 + r31;
+    r28 = r28 * r31;
+    WriteSum4<float, float>((float*)inout_shared, r27, r28, r39, r31);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = fmaf(r30, r31, r29 * r39);
+    r23 = fmaf(r23, r39, r24 * r31);
+    r25 = fmaf(r25, r39, r26 * r31);
+    r6 = fmaf(r6, r39, r16 * r31);
+    WriteSum4<float, float>((float*)inout_shared, r30, r23, r25, r6);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r17 = fmaf(r17, r39, r18 * r31);
+    r12 = fmaf(r12, r39, r13 * r31);
+    r39 = r14 * r39;
+    r31 = r15 * r31;
+    WriteSum4<float, float>((float*)inout_shared, r17, r12, r39, r31);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r8 = r10 + r8;
+    r22 = r11 + r22;
+    r36 = fmaf(r36, r22, r35 * r8);
+    r38 = fmaf(r38, r22, r37 * r8);
+    r22 = fmaf(r34, r22, r33 * r8);
+    WriteSum3<float, float>((float*)inout_shared, r36, r38, r22);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeJtjnjtrDirect(float* pose_njtr,
+                                   unsigned int pose_njtr_num_alloc,
+                                   SharedIndex* pose_njtr_indices,
+                                   float* pose_jac,
+                                   unsigned int pose_jac_num_alloc,
+                                   float* calib_njtr,
+                                   unsigned int calib_njtr_num_alloc,
+                                   SharedIndex* calib_njtr_indices,
+                                   float* calib_jac,
+                                   unsigned int calib_jac_num_alloc,
+                                   float* point_njtr,
+                                   unsigned int point_njtr_num_alloc,
+                                   SharedIndex* point_njtr_indices,
+                                   float* point_jac,
+                                   unsigned int point_jac_num_alloc,
+                                   float* const out_pose_njtr,
+                                   unsigned int out_pose_njtr_num_alloc,
+                                   float* const out_calib_njtr,
+                                   unsigned int out_calib_njtr_num_alloc,
+                                   float* const out_point_njtr,
+                                   unsigned int out_point_njtr_num_alloc,
+                                   size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_jtjnjtr_direct.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeJtjnjtrDirect(float* pose_njtr,
+                                   unsigned int pose_njtr_num_alloc,
+                                   SharedIndex* pose_njtr_indices,
+                                   float* pose_jac,
+                                   unsigned int pose_jac_num_alloc,
+                                   float* calib_njtr,
+                                   unsigned int calib_njtr_num_alloc,
+                                   SharedIndex* calib_njtr_indices,
+                                   float* calib_jac,
+                                   unsigned int calib_jac_num_alloc,
+                                   float* point_njtr,
+                                   unsigned int point_njtr_num_alloc,
+                                   SharedIndex* point_njtr_indices,
+                                   float* point_jac,
+                                   unsigned int point_jac_num_alloc,
+                                   float* const out_pose_njtr,
+                                   unsigned int out_pose_njtr_num_alloc,
+                                   float* const out_calib_njtr,
+                                   unsigned int out_calib_njtr_num_alloc,
+                                   float* const out_point_njtr,
+                                   unsigned int out_point_njtr_num_alloc,
+                                   size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac.cu
@@ -1,0 +1,2781 @@
+#include "kernel_thin_prism_fisheye_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeResJacKernel(float* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 float* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 float* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 float* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 float* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 float* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 float* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 float* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 float* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 float* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 float* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 float* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 float* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 float* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 float* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 float* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 float* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 float* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150, r151, r152,
+      r153, r154, r155;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r11,
+                       r12,
+                       r13);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r14 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r15,
+                       r16,
+                       r17,
+                       r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r23 = fmaf(r18, r19, r15 * r22);
+    r24 = r16 * r21;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r17, r20, r23);
+    r24 = r14 * r23;
+    r26 = r17 * r19;
+    r26 = fmaf(r25, r26, r16 * r22);
+    r26 = fmaf(r18, r20, r26);
+    r26 = fmaf(r15, r21, r26);
+    r24 = r24 * r26;
+    r27 = r17 * r22;
+    r28 = r16 * r19;
+    r29 = r27 + r28;
+    r30 = r18 * r21;
+    r31 = r15 * r20;
+    r29 = r29 + r30;
+    r29 = fmaf(r25, r31, r29);
+    r32 = r14 * r29;
+    r33 = fmaf(r16, r20, r15 * r19);
+    r33 = fmaf(r17, r21, r33);
+    r33 = fmaf(r25, r33, r18 * r22);
+    r32 = fmaf(r33, r32, r24);
+    r9 = fmaf(r11, r32, r9);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r34,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r19 * r20;
+    r37 = r37 * r14;
+    r38 = r21 * r22;
+    r38 = fmaf(r14, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r19 * r19;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r20 * r21;
+    r44 = r44 * r14;
+    r45 = r19 * r22;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r14 * r29;
+    r46 = r46 * r26;
+    r47 = r23 * r40;
+    r47 = fmaf(r33, r47, r46);
+    r48 = r23 * r23;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r29 * r29;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r9 = fmaf(r34, r38, r9);
+    r9 = fmaf(r35, r43, r9);
+    r9 = fmaf(r36, r45, r9);
+    r9 = fmaf(r13, r47, r9);
+    r9 = fmaf(r12, r49, r9);
+    r51 = r9 * r9;
+    r52 = r40 * r26;
+    r52 = r52 * r26;
+    r53 = r41 + r52;
+    r53 = r53 + r50;
+    r8 = fmaf(r11, r53, r8);
+    r50 = r29 * r40;
+    r50 = fmaf(r33, r50, r24);
+    r24 = r14 * r29;
+    r24 = r24 * r23;
+    r54 = r14 * r26;
+    r54 = fmaf(r33, r54, r24);
+    r55 = r19 * r21;
+    r55 = r55 * r14;
+    r56 = r20 * r22;
+    r56 = fmaf(r14, r56, r55);
+    r57 = r21 * r22;
+    r57 = fmaf(r40, r57, r37);
+    r37 = r20 * r20;
+    r37 = r37 * r40;
+    r58 = r41 + r37;
+    r58 = r58 + r39;
+    r8 = fmaf(r12, r50, r8);
+    r8 = fmaf(r13, r54, r8);
+    r8 = fmaf(r36, r56, r8);
+    r8 = fmaf(r35, r57, r8);
+    r8 = fmaf(r34, r58, r8);
+    r39 = r8 * r8;
+    r59 = 9.99999999999999955e-07;
+    r60 = r40 * r26;
+    r60 = fmaf(r33, r60, r24);
+    r10 = fmaf(r11, r60, r10);
+    r24 = r20 * r22;
+    r24 = fmaf(r40, r24, r55);
+    r42 = r37 + r42;
+    r37 = r19 * r22;
+    r37 = fmaf(r14, r37, r44);
+    r44 = r14 * r23;
+    r44 = fmaf(r33, r44, r46);
+    r52 = r41 + r52;
+    r52 = r52 + r48;
+    r10 = fmaf(r34, r24, r10);
+    r10 = fmaf(r36, r42, r10);
+    r10 = fmaf(r35, r37, r10);
+    r10 = fmaf(r12, r44, r10);
+    r10 = fmaf(r13, r52, r10);
+    r35 = copysign(1.0, r10);
+    r35 = fmaf(r59, r35, r10);
+    r10 = r35 * r35;
+    r36 = 1.0 / r10;
+    r34 = r9 * r9;
+    r34 = fmaf(r36, r34, r36 * r39);
+    r39 = sqrtf(r34);
+    r48 = atanf(r39);
+    r46 = copysign(1.0, r39);
+    r46 = fmaf(r59, r46, r39);
+    r59 = r46 * r46;
+    r39 = 1.0 / r59;
+    r55 = r48 * r36;
+    r61 = r39 * r55;
+    r51 = r51 * r48;
+    r51 = r51 * r61;
+    r62 = 3.00000000000000000e+00;
+    r63 = r8 * r62;
+    r64 = r8 * r48;
+    r63 = r63 * r61;
+    r63 = fmaf(r64, r63, r51);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r65,
+                       r66,
+                       r67,
+                       r68);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r69 = r8 * r61;
+    r69 = r69 * r64;
+    r51 = r51 + r69;
+    r70 = fmaf(r67, r51, r7 * r63);
+    r71 = r6 * r9;
+    r72 = r14 * r61;
+    r73 = r64 * r72;
+    r70 = fmaf(r73, r71, r70);
+    r74 = r51 * r51;
+    r75 = fmaf(r5, r74, r4 * r51);
+    r76 = r74 * r74;
+    r77 = r51 * r74;
+    r75 = fmaf(r66, r76, r75);
+    r75 = fmaf(r65, r77, r75);
+    r78 = 1.0 / r35;
+    r79 = 1.0 / r46;
+    r80 = r78 * r79;
+    r81 = r75 * r80;
+    r70 = fmaf(r64, r81, r70);
+    r70 = fmaf(r80, r64, r70);
+    r71 = r0 * r70;
+    r2 = r2 + r71;
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r82, r83);
+    r2 = fmaf(r82, r25, r2);
+    r82 = r9 * r9;
+    r82 = r82 * r48;
+    r82 = r82 * r62;
+    r82 = fmaf(r61, r82, r69);
+    r69 = fmaf(r68, r51, r6 * r82);
+    r84 = r7 * r73;
+    r85 = r9 * r48;
+    r69 = fmaf(r80, r85, r69);
+    r86 = r9 * r48;
+    r69 = fmaf(r81, r86, r69);
+    r69 = fmaf(r9, r84, r69);
+    r3 = fmaf(r1, r69, r3);
+    r3 = fmaf(r83, r25, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r83 = r23 * r40;
+    r86 = r15 * r22;
+    r85 = -5.00000000000000000e-01;
+    r87 = r18 * r19;
+    r87 = fmaf(r85, r87, r85 * r86);
+    r86 = r17 * r20;
+    r87 = fmaf(r85, r86, r87);
+    r88 = r16 * r21;
+    r89 = 5.00000000000000000e-01;
+    r87 = fmaf(r89, r88, r87);
+    r88 = r18 * r22;
+    r86 = r15 * r19;
+    r86 = fmaf(r85, r86, r89 * r88);
+    r88 = r16 * r20;
+    r86 = fmaf(r85, r88, r86);
+    r90 = r17 * r21;
+    r86 = fmaf(r85, r90, r86);
+    r90 = r33 * r86;
+    r88 = r40 * r90;
+    r83 = fmaf(r87, r83, r88);
+    r91 = r14 * r26;
+    r92 = r16 * r22;
+    r93 = r17 * r19;
+    r93 = fmaf(r89, r93, r85 * r92);
+    r92 = r18 * r20;
+    r93 = fmaf(r85, r92, r93);
+    r94 = r15 * r21;
+    r93 = fmaf(r85, r94, r93);
+    r91 = r91 * r93;
+    r94 = r14 * r29;
+    r92 = fmaf(r89, r28, r89 * r27);
+    r92 = fmaf(r85, r31, r92);
+    r92 = fmaf(r89, r30, r92);
+    r94 = fmaf(r92, r94, r91);
+    r83 = r83 + r94;
+    r95 = r23 * r86;
+    r96 = -4.00000000000000000e+00;
+    r95 = r95 * r96;
+    r97 = r29 * r93;
+    r98 = r96 * r97;
+    r99 = r95 + r98;
+    r99 = fmaf(r12, r99, r13 * r83);
+    r83 = r14 * r23;
+    r83 = r83 * r92;
+    r100 = r14 * r33;
+    r100 = fmaf(r93, r100, r83);
+    r101 = r14 * r26;
+    r101 = r101 * r86;
+    r102 = r14 * r29;
+    r102 = fmaf(r87, r102, r101);
+    r100 = r100 + r102;
+    r99 = fmaf(r11, r100, r99);
+    r100 = r99 * r72;
+    r103 = r9 * r48;
+    r104 = r14 * r9;
+    r104 = r104 * r99;
+    r105 = r14 * r8;
+    r106 = r14 * r33;
+    r107 = r26 * r87;
+    r106 = fmaf(r14, r107, r92 * r106);
+    r108 = r14 * r23;
+    r109 = r14 * r29;
+    r109 = r109 * r86;
+    r108 = fmaf(r93, r108, r109);
+    r106 = r106 + r108;
+    r83 = r101 + r83;
+    r101 = r29 * r40;
+    r83 = fmaf(r87, r101, r83);
+    r110 = r40 * r33;
+    r83 = fmaf(r93, r110, r83);
+    r83 = fmaf(r12, r83, r13 * r106);
+    r106 = r26 * r92;
+    r106 = r106 * r96;
+    r98 = r106 + r98;
+    r83 = fmaf(r11, r98, r83);
+    r105 = r105 * r83;
+    r105 = fmaf(r36, r105, r36 * r104);
+    r104 = r9 * r9;
+    r98 = r14 * r23;
+    r98 = r98 * r87;
+    r90 = r14 * r90;
+    r110 = r98 + r90;
+    r94 = r94 + r110;
+    r101 = r40 * r33;
+    r101 = fmaf(r40, r107, r92 * r101);
+    r101 = r101 + r108;
+    r101 = fmaf(r11, r101, r12 * r94);
+    r106 = r95 + r106;
+    r101 = fmaf(r13, r106, r101);
+    r10 = r35 * r10;
+    r106 = 1.0 / r10;
+    r95 = r40 * r106;
+    r104 = r104 * r101;
+    r105 = fmaf(r95, r104, r105);
+    r94 = r8 * r8;
+    r94 = r94 * r101;
+    r105 = fmaf(r95, r94, r105);
+    r94 = r41 + r34;
+    r94 = 1.0 / r94;
+    r34 = rsqrtf(r34);
+    r104 = r9 * r34;
+    r92 = r94 * r104;
+    r111 = r105 * r92;
+    r112 = r9 * r61;
+    r111 = fmaf(r112, r111, r103 * r100);
+    r100 = r25 * r105;
+    r113 = r104 * r103;
+    r59 = r46 * r59;
+    r114 = 1.0 / r59;
+    r115 = r114 * r55;
+    r113 = r113 * r115;
+    r111 = fmaf(r113, r100, r111);
+    r116 = r9 * r9;
+    r117 = r39 * r95;
+    r118 = r48 * r48;
+    r117 = r117 * r118;
+    r116 = r116 * r101;
+    r111 = fmaf(r117, r116, r111);
+    r116 = r8 * r8;
+    r116 = r116 * r105;
+    r116 = r116 * r94;
+    r116 = r116 * r34;
+    r116 = fmaf(r61, r116, r83 * r73);
+    r100 = r8 * r8;
+    r100 = r100 * r101;
+    r116 = fmaf(r117, r100, r116);
+    r119 = r25 * r105;
+    r120 = r64 * r115;
+    r121 = r8 * r34;
+    r120 = r120 * r121;
+    r116 = fmaf(r120, r119, r116);
+    r119 = r111 + r116;
+    r100 = 6.00000000000000000e+00;
+    r122 = r83 * r100;
+    r122 = r122 * r61;
+    r123 = r8 * r8;
+    r123 = r123 * r62;
+    r123 = r123 * r105;
+    r123 = r123 * r94;
+    r123 = r123 * r34;
+    r123 = fmaf(r61, r123, r64 * r122);
+    r122 = r8 * r8;
+    r124 = r48 * r48;
+    r125 = -6.00000000000000000e+00;
+    r124 = r124 * r101;
+    r124 = r124 * r125;
+    r124 = r124 * r39;
+    r124 = r124 * r106;
+    r126 = -3.00000000000000000e+00;
+    r127 = r126 * r105;
+    r123 = fmaf(r120, r127, r123);
+    r123 = fmaf(r124, r122, r123);
+    r123 = r123 + r111;
+    r123 = fmaf(r7, r123, r67 * r119);
+    r111 = r89 * r94;
+    r111 = r111 * r81;
+    r111 = r111 * r121;
+    r121 = r6 * r99;
+    r123 = fmaf(r73, r121, r123);
+    r127 = r48 * r83;
+    r123 = fmaf(r81, r127, r123);
+    r128 = r8 * r48;
+    r128 = r128 * r85;
+    r128 = r128 * r105;
+    r128 = r128 * r39;
+    r128 = r128 * r78;
+    r123 = fmaf(r34, r128, r123);
+    r129 = r6 * r8;
+    r129 = r129 * r105;
+    r129 = r129 * r72;
+    r123 = fmaf(r92, r129, r123);
+    r130 = r48 * r83;
+    r123 = fmaf(r80, r130, r123);
+    r131 = r25 * r8;
+    r131 = r131 * r101;
+    r131 = r131 * r79;
+    r123 = fmaf(r55, r131, r123);
+    r132 = r5 * r14;
+    r132 = r132 * r51;
+    r132 = fmaf(r119, r132, r4 * r119);
+    r65 = r65 * r62;
+    r65 = r65 * r74;
+    r133 = 4.00000000000000000e+00;
+    r66 = r66 * r133;
+    r66 = r66 * r77;
+    r132 = fmaf(r119, r65, r132);
+    r132 = fmaf(r119, r66, r132);
+    r134 = r132 * r80;
+    r123 = fmaf(r64, r134, r123);
+    r135 = r6 * r83;
+    r135 = r135 * r72;
+    r123 = fmaf(r103, r135, r123);
+    r136 = r6 * r8;
+    r136 = r136 * r9;
+    r136 = r136 * r48;
+    r136 = r136 * r48;
+    r136 = r136 * r96;
+    r136 = r136 * r39;
+    r136 = r136 * r106;
+    r137 = r8 * r48;
+    r137 = r137 * r75;
+    r137 = r137 * r85;
+    r137 = r137 * r105;
+    r137 = r137 * r39;
+    r137 = r137 * r78;
+    r123 = fmaf(r34, r137, r123);
+    r138 = r25 * r8;
+    r138 = r138 * r75;
+    r138 = r138 * r101;
+    r138 = r138 * r79;
+    r123 = fmaf(r55, r138, r123);
+    r139 = r8 * r89;
+    r139 = r139 * r105;
+    r139 = r139 * r94;
+    r139 = r139 * r34;
+    r123 = fmaf(r80, r139, r123);
+    r140 = r6 * r40;
+    r140 = r140 * r105;
+    r140 = r140 * r64;
+    r140 = r140 * r104;
+    r123 = fmaf(r115, r140, r123);
+    r123 = fmaf(r105, r111, r123);
+    r123 = fmaf(r101, r136, r123);
+    r140 = r0 * r123;
+    r139 = r9 * r48;
+    r139 = r139 * r99;
+    r139 = r139 * r100;
+    r138 = r62 * r105;
+    r138 = r138 * r92;
+    r138 = fmaf(r112, r138, r61 * r139);
+    r139 = r126 * r113;
+    r137 = r9 * r9;
+    r138 = fmaf(r105, r139, r138);
+    r138 = fmaf(r124, r137, r138);
+    r138 = r138 + r116;
+    r138 = fmaf(r6, r138, r68 * r119);
+    r119 = r48 * r85;
+    r119 = r119 * r39;
+    r119 = r119 * r78;
+    r119 = r119 * r104;
+    r116 = r75 * r119;
+    r124 = r89 * r92;
+    r135 = r80 * r124;
+    r134 = r7 * r8;
+    r134 = r134 * r105;
+    r134 = r134 * r72;
+    r138 = fmaf(r92, r134, r138);
+    r131 = r105 * r81;
+    r138 = fmaf(r124, r131, r138);
+    r130 = r25 * r9;
+    r130 = r130 * r75;
+    r130 = r130 * r101;
+    r130 = r130 * r79;
+    r138 = fmaf(r55, r130, r138);
+    r129 = r9 * r48;
+    r129 = r129 * r132;
+    r138 = fmaf(r80, r129, r138);
+    r128 = r7 * r83;
+    r128 = r128 * r72;
+    r138 = fmaf(r103, r128, r138);
+    r127 = r7 * r8;
+    r127 = r127 * r9;
+    r127 = r127 * r48;
+    r127 = r127 * r48;
+    r127 = r127 * r96;
+    r127 = r127 * r101;
+    r127 = r127 * r39;
+    r138 = fmaf(r106, r127, r138);
+    r121 = r25 * r9;
+    r121 = r121 * r101;
+    r121 = r121 * r79;
+    r138 = fmaf(r55, r121, r138);
+    r101 = r7 * r40;
+    r101 = r101 * r105;
+    r101 = r101 * r64;
+    r101 = r101 * r104;
+    r138 = fmaf(r115, r101, r138);
+    r141 = r48 * r99;
+    r138 = fmaf(r81, r141, r138);
+    r142 = r48 * r99;
+    r138 = fmaf(r80, r142, r138);
+    r138 = fmaf(r105, r116, r138);
+    r138 = fmaf(r105, r135, r138);
+    r138 = fmaf(r99, r84, r138);
+    r138 = fmaf(r105, r119, r138);
+    r142 = r1 * r138;
+    r141 = r8 * r8;
+    r101 = r14 * r8;
+    r90 = r91 + r90;
+    r91 = r14 * r29;
+    r28 = fmaf(r85, r28, r85 * r27);
+    r28 = fmaf(r89, r31, r28);
+    r28 = fmaf(r85, r30, r28);
+    r91 = r91 * r28;
+    r30 = r14 * r23;
+    r31 = r15 * r22;
+    r27 = r18 * r19;
+    r27 = fmaf(r89, r27, r89 * r31);
+    r31 = r17 * r20;
+    r27 = fmaf(r89, r31, r27);
+    r121 = r16 * r21;
+    r27 = fmaf(r85, r121, r27);
+    r30 = fmaf(r27, r30, r91);
+    r90 = r90 + r30;
+    r121 = r26 * r86;
+    r121 = r121 * r96;
+    r31 = r29 * r96;
+    r31 = r31 * r27;
+    r127 = r121 + r31;
+    r127 = fmaf(r11, r127, r13 * r90);
+    r90 = r40 * r33;
+    r90 = fmaf(r40, r97, r27 * r90);
+    r128 = r14 * r23;
+    r128 = r128 * r86;
+    r129 = r14 * r26;
+    r129 = fmaf(r28, r129, r128);
+    r90 = r90 + r129;
+    r127 = fmaf(r12, r90, r127);
+    r101 = r101 * r127;
+    r90 = r8 * r8;
+    r130 = r40 * r26;
+    r130 = fmaf(r93, r130, r88);
+    r130 = r130 + r30;
+    r30 = r14 * r26;
+    r30 = r30 * r27;
+    r131 = r14 * r33;
+    r131 = fmaf(r28, r131, r30);
+    r131 = r131 + r108;
+    r131 = fmaf(r12, r131, r11 * r130);
+    r130 = r23 * r28;
+    r108 = r96 * r130;
+    r121 = r121 + r108;
+    r131 = fmaf(r13, r121, r131);
+    r90 = r90 * r131;
+    r90 = fmaf(r95, r90, r36 * r101);
+    r101 = r9 * r9;
+    r101 = r101 * r131;
+    r90 = fmaf(r95, r101, r90);
+    r121 = r14 * r9;
+    r30 = r109 + r30;
+    r109 = r23 * r40;
+    r30 = fmaf(r93, r109, r30);
+    r93 = r40 * r33;
+    r30 = fmaf(r28, r93, r30);
+    r93 = r14 * r33;
+    r97 = fmaf(r14, r97, r27 * r93);
+    r97 = r97 + r129;
+    r97 = fmaf(r11, r97, r13 * r30);
+    r108 = r31 + r108;
+    r97 = fmaf(r12, r108, r97);
+    r121 = r121 * r97;
+    r90 = fmaf(r36, r121, r90);
+    r141 = r141 * r90;
+    r141 = r141 * r94;
+    r141 = r141 * r34;
+    r121 = r25 * r90;
+    r121 = fmaf(r120, r121, r61 * r141);
+    r141 = r131 * r117;
+    r121 = fmaf(r141, r122, r121);
+    r121 = fmaf(r127, r73, r121);
+    r122 = r97 * r72;
+    r101 = r25 * r90;
+    r101 = fmaf(r113, r101, r103 * r122);
+    r122 = r90 * r92;
+    r101 = fmaf(r112, r122, r101);
+    r101 = fmaf(r141, r137, r101);
+    r122 = r121 + r101;
+    r137 = r8 * r8;
+    r137 = r137 * r62;
+    r137 = r137 * r90;
+    r137 = r137 * r94;
+    r137 = r137 * r34;
+    r141 = r126 * r90;
+    r141 = fmaf(r120, r141, r61 * r137);
+    r137 = r8 * r8;
+    r137 = r137 * r48;
+    r137 = r137 * r48;
+    r137 = r137 * r125;
+    r137 = r137 * r131;
+    r137 = r137 * r39;
+    r141 = fmaf(r106, r137, r141);
+    r108 = r100 * r127;
+    r108 = r108 * r61;
+    r141 = fmaf(r64, r108, r141);
+    r141 = r141 + r101;
+    r141 = fmaf(r7, r141, r67 * r122);
+    r101 = r6 * r127;
+    r101 = r101 * r72;
+    r141 = fmaf(r103, r101, r141);
+    r108 = r8 * r48;
+    r108 = r108 * r85;
+    r108 = r108 * r90;
+    r108 = r108 * r39;
+    r108 = r108 * r78;
+    r141 = fmaf(r34, r108, r141);
+    r137 = r25 * r8;
+    r137 = r137 * r131;
+    r137 = r137 * r79;
+    r141 = fmaf(r55, r137, r141);
+    r31 = r8 * r48;
+    r31 = r31 * r75;
+    r31 = r31 * r85;
+    r31 = r31 * r90;
+    r31 = r31 * r39;
+    r31 = r31 * r78;
+    r141 = fmaf(r34, r31, r141);
+    r30 = r48 * r127;
+    r141 = fmaf(r81, r30, r141);
+    r93 = r6 * r8;
+    r93 = r93 * r90;
+    r93 = r93 * r72;
+    r141 = fmaf(r92, r93, r141);
+    r27 = r25 * r8;
+    r27 = r27 * r75;
+    r27 = r27 * r131;
+    r27 = r27 * r79;
+    r141 = fmaf(r55, r27, r141);
+    r109 = r5 * r14;
+    r109 = r109 * r51;
+    r109 = fmaf(r4, r122, r122 * r109);
+    r109 = fmaf(r122, r66, r109);
+    r109 = fmaf(r122, r65, r109);
+    r134 = r109 * r80;
+    r141 = fmaf(r64, r134, r141);
+    r143 = r8 * r89;
+    r143 = r143 * r90;
+    r143 = r143 * r94;
+    r143 = r143 * r34;
+    r141 = fmaf(r80, r143, r141);
+    r144 = r6 * r40;
+    r144 = r144 * r90;
+    r144 = r144 * r64;
+    r144 = r144 * r104;
+    r141 = fmaf(r115, r144, r141);
+    r145 = r6 * r97;
+    r141 = fmaf(r73, r145, r141);
+    r146 = r48 * r127;
+    r141 = fmaf(r80, r146, r141);
+    r141 = fmaf(r131, r136, r141);
+    r141 = fmaf(r90, r111, r141);
+    r146 = r0 * r141;
+    r145 = r9 * r48;
+    r145 = r145 * r100;
+    r145 = r145 * r97;
+    r145 = fmaf(r90, r139, r61 * r145);
+    r144 = r9 * r9;
+    r144 = r144 * r48;
+    r144 = r144 * r48;
+    r144 = r144 * r125;
+    r144 = r144 * r131;
+    r144 = r144 * r39;
+    r145 = fmaf(r106, r144, r145);
+    r143 = r62 * r90;
+    r143 = r143 * r92;
+    r145 = fmaf(r112, r143, r145);
+    r145 = r145 + r121;
+    r145 = fmaf(r6, r145, r68 * r122);
+    r122 = r25 * r9;
+    r122 = r122 * r131;
+    r122 = r122 * r79;
+    r145 = fmaf(r55, r122, r145);
+    r121 = r48 * r97;
+    r145 = fmaf(r81, r121, r145);
+    r143 = r7 * r127;
+    r143 = r143 * r72;
+    r145 = fmaf(r103, r143, r145);
+    r144 = r9 * r48;
+    r144 = r144 * r109;
+    r145 = fmaf(r80, r144, r145);
+    r134 = r90 * r81;
+    r145 = fmaf(r124, r134, r145);
+    r27 = r7 * r8;
+    r27 = r27 * r90;
+    r27 = r27 * r72;
+    r145 = fmaf(r92, r27, r145);
+    r93 = r25 * r9;
+    r93 = r93 * r75;
+    r93 = r93 * r131;
+    r93 = r93 * r79;
+    r145 = fmaf(r55, r93, r145);
+    r30 = r7 * r8;
+    r30 = r30 * r9;
+    r30 = r30 * r48;
+    r30 = r30 * r48;
+    r30 = r30 * r96;
+    r30 = r30 * r131;
+    r30 = r30 * r39;
+    r145 = fmaf(r106, r30, r145);
+    r131 = r7 * r40;
+    r131 = r131 * r90;
+    r131 = r131 * r64;
+    r131 = r131 * r104;
+    r145 = fmaf(r115, r131, r145);
+    r31 = r48 * r97;
+    r145 = fmaf(r80, r31, r145);
+    r145 = fmaf(r90, r116, r145);
+    r145 = fmaf(r90, r135, r145);
+    r145 = fmaf(r90, r119, r145);
+    r145 = fmaf(r97, r84, r145);
+    r31 = r1 * r145;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r140,
+                                          r142,
+                                          r146,
+                                          r31);
+    r31 = r8 * r8;
+    r146 = r23 * r96;
+    r142 = r16 * r22;
+    r140 = r17 * r19;
+    r140 = fmaf(r85, r140, r89 * r142);
+    r142 = r18 * r20;
+    r140 = fmaf(r89, r142, r140);
+    r131 = r15 * r21;
+    r140 = fmaf(r89, r131, r140);
+    r146 = r146 * r140;
+    r107 = r96 * r107;
+    r131 = r146 + r107;
+    r142 = r14 * r29;
+    r142 = r142 * r140;
+    r128 = r128 + r142;
+    r30 = r40 * r26;
+    r128 = fmaf(r28, r30, r128);
+    r93 = r40 * r33;
+    r128 = fmaf(r87, r93, r128);
+    r128 = fmaf(r11, r128, r13 * r131);
+    r131 = r14 * r33;
+    r131 = fmaf(r14, r130, r140 * r131);
+    r131 = r131 + r102;
+    r128 = fmaf(r12, r131, r128);
+    r31 = r31 * r128;
+    r131 = r14 * r8;
+    r93 = r14 * r26;
+    r93 = r93 * r140;
+    r98 = r98 + r93;
+    r30 = r29 * r40;
+    r98 = fmaf(r28, r30, r98);
+    r98 = r98 + r88;
+    r86 = r29 * r86;
+    r86 = r86 * r96;
+    r107 = r86 + r107;
+    r107 = fmaf(r11, r107, r12 * r98);
+    r98 = r14 * r33;
+    r98 = fmaf(r87, r98, r142);
+    r98 = r98 + r129;
+    r107 = fmaf(r13, r98, r107);
+    r131 = r131 * r107;
+    r131 = fmaf(r36, r131, r95 * r31);
+    r31 = r9 * r9;
+    r31 = r31 * r128;
+    r131 = fmaf(r95, r31, r131);
+    r98 = r14 * r9;
+    r93 = r91 + r93;
+    r93 = r93 + r110;
+    r110 = r40 * r33;
+    r130 = fmaf(r40, r130, r140 * r110);
+    r130 = r130 + r102;
+    r130 = fmaf(r13, r130, r11 * r93);
+    r146 = r86 + r146;
+    r130 = fmaf(r12, r146, r130);
+    r98 = r98 * r130;
+    r131 = fmaf(r36, r98, r131);
+    r98 = r131 * r92;
+    r31 = r130 * r72;
+    r31 = fmaf(r103, r31, r112 * r98);
+    r98 = r9 * r9;
+    r98 = r98 * r128;
+    r31 = fmaf(r117, r98, r31);
+    r146 = r25 * r131;
+    r31 = fmaf(r113, r146, r31);
+    r146 = r8 * r8;
+    r146 = r146 * r128;
+    r98 = r8 * r8;
+    r98 = r98 * r131;
+    r98 = r98 * r94;
+    r98 = r98 * r34;
+    r98 = fmaf(r61, r98, r117 * r146);
+    r146 = r25 * r131;
+    r98 = fmaf(r120, r146, r98);
+    r98 = fmaf(r107, r73, r98);
+    r146 = r31 + r98;
+    r12 = r8 * r8;
+    r12 = r12 * r48;
+    r12 = r12 * r48;
+    r12 = r12 * r125;
+    r12 = r12 * r128;
+    r12 = r12 * r39;
+    r86 = r8 * r8;
+    r86 = r86 * r62;
+    r86 = r86 * r131;
+    r86 = r86 * r94;
+    r86 = r86 * r34;
+    r86 = fmaf(r61, r86, r106 * r12);
+    r12 = r126 * r131;
+    r86 = fmaf(r120, r12, r86);
+    r13 = r100 * r107;
+    r13 = r13 * r61;
+    r86 = fmaf(r64, r13, r86);
+    r86 = r86 + r31;
+    r86 = fmaf(r7, r86, r67 * r146);
+    r31 = r6 * r130;
+    r86 = fmaf(r73, r31, r86);
+    r13 = r48 * r107;
+    r86 = fmaf(r81, r13, r86);
+    r12 = r8 * r89;
+    r12 = r12 * r131;
+    r12 = r12 * r94;
+    r12 = r12 * r34;
+    r86 = fmaf(r80, r12, r86);
+    r93 = r5 * r14;
+    r93 = r93 * r51;
+    r93 = fmaf(r146, r93, r4 * r146);
+    r93 = fmaf(r146, r65, r93);
+    r93 = fmaf(r146, r66, r93);
+    r11 = r93 * r80;
+    r86 = fmaf(r64, r11, r86);
+    r102 = r25 * r8;
+    r102 = r102 * r128;
+    r102 = r102 * r79;
+    r86 = fmaf(r55, r102, r86);
+    r110 = r6 * r8;
+    r110 = r110 * r131;
+    r110 = r110 * r72;
+    r86 = fmaf(r92, r110, r86);
+    r140 = r8 * r48;
+    r140 = r140 * r75;
+    r140 = r140 * r85;
+    r140 = r140 * r131;
+    r140 = r140 * r39;
+    r140 = r140 * r78;
+    r86 = fmaf(r34, r140, r86);
+    r91 = r25 * r8;
+    r91 = r91 * r75;
+    r91 = r91 * r128;
+    r91 = r91 * r79;
+    r86 = fmaf(r55, r91, r86);
+    r129 = r8 * r48;
+    r129 = r129 * r85;
+    r129 = r129 * r131;
+    r129 = r129 * r39;
+    r129 = r129 * r78;
+    r86 = fmaf(r34, r129, r86);
+    r142 = r6 * r40;
+    r142 = r142 * r131;
+    r142 = r142 * r64;
+    r142 = r142 * r104;
+    r86 = fmaf(r115, r142, r86);
+    r87 = r6 * r107;
+    r87 = r87 * r72;
+    r86 = fmaf(r103, r87, r86);
+    r88 = r48 * r107;
+    r86 = fmaf(r80, r88, r86);
+    r86 = fmaf(r128, r136, r86);
+    r86 = fmaf(r131, r111, r86);
+    r88 = r0 * r86;
+    r87 = r62 * r131;
+    r87 = r87 * r92;
+    r142 = r9 * r48;
+    r142 = r142 * r100;
+    r142 = r142 * r130;
+    r142 = fmaf(r61, r142, r112 * r87);
+    r87 = r9 * r9;
+    r87 = r87 * r48;
+    r87 = r87 * r48;
+    r87 = r87 * r125;
+    r87 = r87 * r128;
+    r87 = r87 * r39;
+    r142 = fmaf(r106, r87, r142);
+    r142 = fmaf(r131, r139, r142);
+    r142 = r142 + r98;
+    r142 = fmaf(r6, r142, r68 * r146);
+    r146 = r9 * r48;
+    r146 = r146 * r93;
+    r142 = fmaf(r80, r146, r142);
+    r98 = r48 * r130;
+    r142 = fmaf(r81, r98, r142);
+    r87 = r7 * r8;
+    r87 = r87 * r131;
+    r87 = r87 * r72;
+    r142 = fmaf(r92, r87, r142);
+    r129 = r7 * r8;
+    r129 = r129 * r9;
+    r129 = r129 * r48;
+    r129 = r129 * r48;
+    r129 = r129 * r96;
+    r129 = r129 * r128;
+    r129 = r129 * r39;
+    r142 = fmaf(r106, r129, r142);
+    r91 = r25 * r9;
+    r91 = r91 * r75;
+    r91 = r91 * r128;
+    r91 = r91 * r79;
+    r142 = fmaf(r55, r91, r142);
+    r140 = r131 * r81;
+    r142 = fmaf(r124, r140, r142);
+    r110 = r25 * r9;
+    r110 = r110 * r128;
+    r110 = r110 * r79;
+    r142 = fmaf(r55, r110, r142);
+    r128 = r7 * r40;
+    r128 = r128 * r131;
+    r128 = r128 * r64;
+    r128 = r128 * r104;
+    r142 = fmaf(r115, r128, r142);
+    r102 = r7 * r107;
+    r102 = r102 * r72;
+    r142 = fmaf(r103, r102, r142);
+    r11 = r48 * r130;
+    r142 = fmaf(r80, r11, r142);
+    r142 = fmaf(r130, r84, r142);
+    r142 = fmaf(r131, r119, r142);
+    r142 = fmaf(r131, r135, r142);
+    r142 = fmaf(r131, r116, r142);
+    r11 = r1 * r142;
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r102 = r102 * r48;
+    r102 = r102 * r48;
+    r102 = r102 * r125;
+    r102 = r102 * r39;
+    r128 = r58 * r100;
+    r128 = r128 * r61;
+    r128 = fmaf(r64, r128, r106 * r102);
+    r102 = r24 * r9;
+    r102 = r102 * r9;
+    r110 = r14 * r38;
+    r110 = r110 * r9;
+    r110 = fmaf(r36, r110, r95 * r102);
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r110 = fmaf(r95, r102, r110);
+    r140 = r14 * r58;
+    r140 = r140 * r8;
+    r110 = fmaf(r36, r140, r110);
+    r140 = r126 * r110;
+    r128 = fmaf(r120, r140, r128);
+    r102 = r8 * r8;
+    r102 = r102 * r62;
+    r102 = r102 * r110;
+    r102 = r102 * r94;
+    r102 = r102 * r34;
+    r128 = fmaf(r61, r102, r128);
+    r91 = r24 * r9;
+    r91 = r91 * r9;
+    r129 = r38 * r72;
+    r129 = fmaf(r103, r129, r117 * r91);
+    r91 = r25 * r110;
+    r129 = fmaf(r113, r91, r129);
+    r87 = r110 * r92;
+    r129 = fmaf(r112, r87, r129);
+    r128 = r128 + r129;
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r102 = fmaf(r58, r73, r117 * r102);
+    r140 = r25 * r110;
+    r102 = fmaf(r120, r140, r102);
+    r87 = r8 * r8;
+    r87 = r87 * r110;
+    r87 = r87 * r94;
+    r87 = r87 * r34;
+    r102 = fmaf(r61, r87, r102);
+    r129 = r129 + r102;
+    r128 = fmaf(r67, r129, r7 * r128);
+    r87 = r25 * r24;
+    r87 = r87 * r8;
+    r87 = r87 * r79;
+    r128 = fmaf(r55, r87, r128);
+    r140 = r8 * r48;
+    r140 = r140 * r75;
+    r140 = r140 * r85;
+    r140 = r140 * r110;
+    r140 = r140 * r39;
+    r140 = r140 * r78;
+    r128 = fmaf(r34, r140, r128);
+    r91 = r25 * r24;
+    r91 = r91 * r8;
+    r91 = r91 * r75;
+    r91 = r91 * r79;
+    r128 = fmaf(r55, r91, r128);
+    r98 = r58 * r48;
+    r128 = fmaf(r80, r98, r128);
+    r146 = r6 * r8;
+    r146 = r146 * r110;
+    r146 = r146 * r72;
+    r128 = fmaf(r92, r146, r128);
+    r12 = r6 * r58;
+    r12 = r12 * r72;
+    r128 = fmaf(r103, r12, r128);
+    r13 = r58 * r48;
+    r128 = fmaf(r81, r13, r128);
+    r31 = r8 * r48;
+    r31 = r31 * r85;
+    r31 = r31 * r110;
+    r31 = r31 * r39;
+    r31 = r31 * r78;
+    r128 = fmaf(r34, r31, r128);
+    r30 = r8 * r89;
+    r30 = r30 * r110;
+    r30 = r30 * r94;
+    r30 = r30 * r34;
+    r128 = fmaf(r80, r30, r128);
+    r28 = r5 * r14;
+    r28 = r28 * r51;
+    r28 = fmaf(r4, r129, r129 * r28);
+    r28 = fmaf(r129, r66, r28);
+    r28 = fmaf(r129, r65, r28);
+    r27 = r28 * r80;
+    r128 = fmaf(r64, r27, r128);
+    r134 = r6 * r38;
+    r128 = fmaf(r73, r134, r128);
+    r144 = r6 * r40;
+    r144 = r144 * r110;
+    r144 = r144 * r64;
+    r144 = r144 * r104;
+    r128 = fmaf(r115, r144, r128);
+    r128 = fmaf(r110, r111, r128);
+    r128 = fmaf(r24, r136, r128);
+    r144 = r0 * r128;
+    r134 = r24 * r9;
+    r134 = r134 * r9;
+    r134 = r134 * r48;
+    r134 = r134 * r48;
+    r134 = r134 * r125;
+    r134 = r134 * r39;
+    r27 = r38 * r9;
+    r27 = r27 * r48;
+    r27 = r27 * r100;
+    r27 = fmaf(r61, r27, r106 * r134);
+    r134 = r62 * r110;
+    r134 = r134 * r92;
+    r27 = fmaf(r112, r134, r27);
+    r27 = fmaf(r110, r139, r27);
+    r27 = r27 + r102;
+    r129 = fmaf(r68, r129, r6 * r27);
+    r27 = r9 * r48;
+    r27 = r27 * r28;
+    r129 = fmaf(r80, r27, r129);
+    r102 = r25 * r24;
+    r102 = r102 * r9;
+    r102 = r102 * r79;
+    r129 = fmaf(r55, r102, r129);
+    r134 = r110 * r81;
+    r129 = fmaf(r124, r134, r129);
+    r30 = r7 * r8;
+    r30 = r30 * r110;
+    r30 = r30 * r72;
+    r129 = fmaf(r92, r30, r129);
+    r31 = r38 * r48;
+    r129 = fmaf(r80, r31, r129);
+    r13 = r25 * r24;
+    r13 = r13 * r9;
+    r13 = r13 * r75;
+    r13 = r13 * r79;
+    r129 = fmaf(r55, r13, r129);
+    r12 = r7 * r58;
+    r12 = r12 * r72;
+    r129 = fmaf(r103, r12, r129);
+    r146 = r38 * r48;
+    r129 = fmaf(r81, r146, r129);
+    r98 = r7 * r24;
+    r98 = r98 * r8;
+    r98 = r98 * r9;
+    r98 = r98 * r48;
+    r98 = r98 * r48;
+    r98 = r98 * r96;
+    r98 = r98 * r39;
+    r129 = fmaf(r106, r98, r129);
+    r91 = r7 * r40;
+    r91 = r91 * r110;
+    r91 = r91 * r64;
+    r91 = r91 * r104;
+    r129 = fmaf(r115, r91, r129);
+    r129 = fmaf(r110, r119, r129);
+    r129 = fmaf(r110, r135, r129);
+    r129 = fmaf(r110, r116, r129);
+    r129 = fmaf(r38, r84, r129);
+    r91 = r1 * r129;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r88,
+                                          r11,
+                                          r144,
+                                          r91);
+    r91 = r37 * r9;
+    r91 = r91 * r9;
+    r144 = r14 * r43;
+    r144 = r144 * r9;
+    r144 = fmaf(r36, r144, r95 * r91);
+    r91 = r37 * r8;
+    r91 = r91 * r8;
+    r144 = fmaf(r95, r91, r144);
+    r11 = r14 * r57;
+    r11 = r11 * r8;
+    r144 = fmaf(r36, r11, r144);
+    r11 = r144 * r92;
+    r91 = r37 * r9;
+    r91 = r91 * r9;
+    r91 = fmaf(r117, r91, r112 * r11);
+    r11 = r43 * r72;
+    r91 = fmaf(r103, r11, r91);
+    r88 = r25 * r144;
+    r91 = fmaf(r113, r88, r91);
+    r88 = r8 * r8;
+    r88 = r88 * r144;
+    r88 = r88 * r94;
+    r88 = r88 * r34;
+    r11 = r37 * r8;
+    r11 = r11 * r8;
+    r11 = fmaf(r117, r11, r61 * r88);
+    r88 = r144 * r120;
+    r11 = fmaf(r57, r73, r11);
+    r11 = fmaf(r25, r88, r11);
+    r98 = r91 + r11;
+    r146 = r8 * r8;
+    r146 = r146 * r62;
+    r146 = r146 * r144;
+    r146 = r146 * r94;
+    r146 = r146 * r34;
+    r12 = r37 * r8;
+    r12 = r12 * r8;
+    r12 = r12 * r48;
+    r12 = r12 * r48;
+    r12 = r12 * r125;
+    r12 = r12 * r39;
+    r12 = fmaf(r106, r12, r61 * r146);
+    r146 = r57 * r100;
+    r146 = r146 * r61;
+    r12 = fmaf(r64, r146, r12);
+    r12 = fmaf(r126, r88, r12);
+    r12 = r12 + r91;
+    r12 = fmaf(r7, r12, r67 * r98);
+    r91 = r6 * r57;
+    r91 = r91 * r72;
+    r12 = fmaf(r103, r91, r12);
+    r88 = r57 * r48;
+    r12 = fmaf(r81, r88, r12);
+    r146 = r25 * r37;
+    r146 = r146 * r8;
+    r146 = r146 * r75;
+    r146 = r146 * r79;
+    r12 = fmaf(r55, r146, r12);
+    r13 = r8 * r48;
+    r13 = r13 * r85;
+    r13 = r13 * r144;
+    r13 = r13 * r39;
+    r13 = r13 * r78;
+    r12 = fmaf(r34, r13, r12);
+    r31 = r5 * r14;
+    r31 = r31 * r51;
+    r31 = fmaf(r4, r98, r98 * r31);
+    r31 = fmaf(r98, r66, r31);
+    r31 = fmaf(r98, r65, r31);
+    r30 = r31 * r80;
+    r12 = fmaf(r64, r30, r12);
+    r134 = r6 * r40;
+    r134 = r134 * r144;
+    r134 = r134 * r64;
+    r134 = r134 * r104;
+    r12 = fmaf(r115, r134, r12);
+    r102 = r57 * r48;
+    r12 = fmaf(r80, r102, r12);
+    r27 = r8 * r89;
+    r27 = r27 * r144;
+    r27 = r27 * r94;
+    r27 = r27 * r34;
+    r12 = fmaf(r80, r27, r12);
+    r140 = r6 * r43;
+    r12 = fmaf(r73, r140, r12);
+    r87 = r6 * r8;
+    r87 = r87 * r144;
+    r87 = r87 * r72;
+    r12 = fmaf(r92, r87, r12);
+    r143 = r25 * r37;
+    r143 = r143 * r8;
+    r143 = r143 * r79;
+    r12 = fmaf(r55, r143, r12);
+    r121 = r8 * r48;
+    r121 = r121 * r75;
+    r121 = r121 * r85;
+    r121 = r121 * r144;
+    r121 = r121 * r39;
+    r121 = r121 * r78;
+    r12 = fmaf(r34, r121, r12);
+    r12 = fmaf(r144, r111, r12);
+    r12 = fmaf(r37, r136, r12);
+    r121 = r0 * r12;
+    r143 = r62 * r144;
+    r143 = r143 * r92;
+    r87 = r37 * r9;
+    r87 = r87 * r9;
+    r87 = r87 * r48;
+    r87 = r87 * r48;
+    r87 = r87 * r125;
+    r87 = r87 * r39;
+    r87 = fmaf(r106, r87, r112 * r143);
+    r143 = r43 * r9;
+    r143 = r143 * r48;
+    r143 = r143 * r100;
+    r87 = fmaf(r61, r143, r87);
+    r87 = fmaf(r144, r139, r87);
+    r87 = r87 + r11;
+    r87 = fmaf(r6, r87, r68 * r98);
+    r98 = r25 * r37;
+    r98 = r98 * r9;
+    r98 = r98 * r79;
+    r87 = fmaf(r55, r98, r87);
+    r11 = r7 * r57;
+    r11 = r11 * r72;
+    r87 = fmaf(r103, r11, r87);
+    r143 = r144 * r81;
+    r87 = fmaf(r124, r143, r87);
+    r140 = r7 * r40;
+    r140 = r140 * r144;
+    r140 = r140 * r64;
+    r140 = r140 * r104;
+    r87 = fmaf(r115, r140, r87);
+    r27 = r9 * r48;
+    r27 = r27 * r31;
+    r87 = fmaf(r80, r27, r87);
+    r102 = r7 * r8;
+    r102 = r102 * r144;
+    r102 = r102 * r72;
+    r87 = fmaf(r92, r102, r87);
+    r134 = r43 * r48;
+    r87 = fmaf(r80, r134, r87);
+    r30 = r25 * r37;
+    r30 = r30 * r9;
+    r30 = r30 * r75;
+    r30 = r30 * r79;
+    r87 = fmaf(r55, r30, r87);
+    r13 = r43 * r48;
+    r87 = fmaf(r81, r13, r87);
+    r146 = r7 * r37;
+    r146 = r146 * r8;
+    r146 = r146 * r9;
+    r146 = r146 * r48;
+    r146 = r146 * r48;
+    r146 = r146 * r96;
+    r146 = r146 * r39;
+    r87 = fmaf(r106, r146, r87);
+    r87 = fmaf(r144, r135, r87);
+    r87 = fmaf(r144, r116, r87);
+    r87 = fmaf(r43, r84, r87);
+    r87 = fmaf(r144, r119, r87);
+    r146 = r1 * r87;
+    r13 = r42 * r8;
+    r13 = r13 * r8;
+    r13 = r13 * r48;
+    r13 = r13 * r48;
+    r13 = r13 * r125;
+    r13 = r13 * r39;
+    r30 = r14 * r45;
+    r30 = r30 * r9;
+    r134 = r42 * r9;
+    r134 = r134 * r9;
+    r134 = fmaf(r95, r134, r36 * r30);
+    r30 = r14 * r56;
+    r30 = r30 * r8;
+    r134 = fmaf(r36, r30, r134);
+    r102 = r42 * r8;
+    r102 = r102 * r8;
+    r134 = fmaf(r95, r102, r134);
+    r102 = r126 * r134;
+    r102 = fmaf(r120, r102, r106 * r13);
+    r13 = r56 * r100;
+    r13 = r13 * r61;
+    r102 = fmaf(r64, r13, r102);
+    r30 = r8 * r8;
+    r30 = r30 * r62;
+    r30 = r30 * r134;
+    r30 = r30 * r94;
+    r30 = r30 * r34;
+    r102 = fmaf(r61, r30, r102);
+    r27 = r134 * r92;
+    r140 = r45 * r72;
+    r140 = fmaf(r103, r140, r112 * r27);
+    r27 = r25 * r134;
+    r140 = fmaf(r113, r27, r140);
+    r143 = r42 * r9;
+    r143 = r143 * r9;
+    r140 = fmaf(r117, r143, r140);
+    r102 = r102 + r140;
+    r30 = r42 * r8;
+    r30 = r30 * r8;
+    r13 = r25 * r134;
+    r13 = fmaf(r120, r13, r117 * r30);
+    r30 = r8 * r8;
+    r30 = r30 * r134;
+    r30 = r30 * r94;
+    r30 = r30 * r34;
+    r13 = fmaf(r61, r30, r13);
+    r13 = fmaf(r56, r73, r13);
+    r140 = r140 + r13;
+    r102 = fmaf(r67, r140, r7 * r102);
+    r30 = r8 * r48;
+    r30 = r30 * r75;
+    r30 = r30 * r85;
+    r30 = r30 * r134;
+    r30 = r30 * r39;
+    r30 = r30 * r78;
+    r102 = fmaf(r34, r30, r102);
+    r143 = r6 * r45;
+    r102 = fmaf(r73, r143, r102);
+    r27 = r5 * r14;
+    r27 = r27 * r51;
+    r27 = fmaf(r140, r27, r4 * r140);
+    r27 = fmaf(r140, r66, r27);
+    r27 = fmaf(r140, r65, r27);
+    r11 = r27 * r80;
+    r102 = fmaf(r64, r11, r102);
+    r98 = r56 * r48;
+    r102 = fmaf(r80, r98, r102);
+    r88 = r25 * r42;
+    r88 = r88 * r8;
+    r88 = r88 * r79;
+    r102 = fmaf(r55, r88, r102);
+    r91 = r6 * r8;
+    r91 = r91 * r134;
+    r91 = r91 * r72;
+    r102 = fmaf(r92, r91, r102);
+    r122 = r8 * r48;
+    r122 = r122 * r85;
+    r122 = r122 * r134;
+    r122 = r122 * r39;
+    r122 = r122 * r78;
+    r102 = fmaf(r34, r122, r102);
+    r137 = r6 * r40;
+    r137 = r137 * r134;
+    r137 = r137 * r64;
+    r137 = r137 * r104;
+    r102 = fmaf(r115, r137, r102);
+    r108 = r25 * r42;
+    r108 = r108 * r8;
+    r108 = r108 * r75;
+    r108 = r108 * r79;
+    r102 = fmaf(r55, r108, r102);
+    r101 = r6 * r56;
+    r101 = r101 * r72;
+    r102 = fmaf(r103, r101, r102);
+    r147 = r56 * r48;
+    r102 = fmaf(r81, r147, r102);
+    r148 = r8 * r89;
+    r148 = r148 * r134;
+    r148 = r148 * r94;
+    r148 = r148 * r34;
+    r102 = fmaf(r80, r148, r102);
+    r102 = fmaf(r42, r136, r102);
+    r102 = fmaf(r134, r111, r102);
+    r148 = r0 * r102;
+    r147 = r62 * r134;
+    r147 = r147 * r92;
+    r101 = r45 * r9;
+    r101 = r101 * r48;
+    r101 = r101 * r100;
+    r101 = fmaf(r61, r101, r112 * r147);
+    r147 = r42 * r9;
+    r147 = r147 * r9;
+    r147 = r147 * r48;
+    r147 = r147 * r48;
+    r147 = r147 * r125;
+    r147 = r147 * r39;
+    r101 = fmaf(r106, r147, r101);
+    r101 = fmaf(r134, r139, r101);
+    r101 = r101 + r13;
+    r140 = fmaf(r68, r140, r6 * r101);
+    r101 = r7 * r42;
+    r101 = r101 * r8;
+    r101 = r101 * r9;
+    r101 = r101 * r48;
+    r101 = r101 * r48;
+    r101 = r101 * r96;
+    r101 = r101 * r39;
+    r140 = fmaf(r106, r101, r140);
+    r13 = r134 * r81;
+    r140 = fmaf(r124, r13, r140);
+    r147 = r7 * r8;
+    r147 = r147 * r134;
+    r147 = r147 * r72;
+    r140 = fmaf(r92, r147, r140);
+    r108 = r45 * r48;
+    r140 = fmaf(r81, r108, r140);
+    r137 = r7 * r40;
+    r137 = r137 * r134;
+    r137 = r137 * r64;
+    r137 = r137 * r104;
+    r140 = fmaf(r115, r137, r140);
+    r122 = r25 * r42;
+    r122 = r122 * r9;
+    r122 = r122 * r75;
+    r122 = r122 * r79;
+    r140 = fmaf(r55, r122, r140);
+    r91 = r9 * r48;
+    r91 = r91 * r27;
+    r140 = fmaf(r80, r91, r140);
+    r88 = r45 * r48;
+    r140 = fmaf(r80, r88, r140);
+    r98 = r25 * r42;
+    r98 = r98 * r9;
+    r98 = r98 * r79;
+    r140 = fmaf(r55, r98, r140);
+    r11 = r7 * r56;
+    r11 = r11 * r72;
+    r140 = fmaf(r103, r11, r140);
+    r140 = fmaf(r45, r84, r140);
+    r140 = fmaf(r134, r135, r140);
+    r140 = fmaf(r134, r116, r140);
+    r140 = fmaf(r134, r119, r140);
+    r11 = r1 * r140;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r121,
+                                          r146,
+                                          r148,
+                                          r11);
+    r11 = r0 * r25;
+    r11 = r11 * r2;
+    r148 = r25 * r3;
+    r146 = r1 * r148;
+    r11 = fmaf(r138, r146, r123 * r11);
+    r121 = r0 * r25;
+    r121 = r121 * r2;
+    r121 = fmaf(r145, r146, r141 * r121);
+    r98 = r0 * r25;
+    r98 = r98 * r2;
+    r98 = fmaf(r142, r146, r86 * r98);
+    r88 = r0 * r25;
+    r88 = r88 * r2;
+    r88 = fmaf(r129, r146, r128 * r88);
+    WriteSum4<float, float>((float*)inout_shared, r11, r121, r98, r88);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r0 * r25;
+    r88 = r88 * r2;
+    r88 = fmaf(r87, r146, r12 * r88);
+    r98 = r0 * r25;
+    r98 = r98 * r2;
+    r98 = fmaf(r140, r146, r102 * r98);
+    WriteSum2<float, float>((float*)inout_shared, r88, r98);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r98 = r1 * r1;
+    r88 = r138 * r138;
+    r121 = r123 * r123;
+    r11 = r0 * r0;
+    r121 = fmaf(r11, r121, r98 * r88);
+    r88 = r141 * r141;
+    r91 = r145 * r145;
+    r91 = fmaf(r98, r91, r11 * r88);
+    r88 = r86 * r86;
+    r122 = r142 * r142;
+    r122 = fmaf(r98, r122, r11 * r88);
+    r88 = r129 * r129;
+    r137 = r128 * r128;
+    r137 = fmaf(r11, r137, r98 * r88);
+    WriteSum4<float, float>((float*)inout_shared, r121, r91, r122, r137);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r137 = r87 * r87;
+    r122 = r12 * r12;
+    r122 = fmaf(r11, r122, r98 * r137);
+    r137 = r140 * r140;
+    r91 = r102 * r102;
+    r91 = fmaf(r11, r91, r98 * r137);
+    WriteSum2<float, float>((float*)inout_shared, r122, r91);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r123 * r141;
+    r122 = r138 * r145;
+    r122 = fmaf(r98, r122, r11 * r91);
+    r91 = r123 * r86;
+    r137 = r138 * r142;
+    r137 = fmaf(r98, r137, r11 * r91);
+    r91 = r138 * r129;
+    r121 = r123 * r128;
+    r121 = fmaf(r11, r121, r98 * r91);
+    r91 = r123 * r12;
+    r88 = r138 * r87;
+    r88 = fmaf(r98, r88, r11 * r91);
+    WriteSum4<float, float>((float*)inout_shared, r122, r137, r121, r88);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r123 * r102;
+    r121 = r138 * r140;
+    r121 = fmaf(r98, r121, r11 * r88);
+    r88 = r145 * r142;
+    r137 = r141 * r86;
+    r137 = fmaf(r11, r137, r98 * r88);
+    r88 = r145 * r129;
+    r122 = r141 * r128;
+    r122 = fmaf(r11, r122, r98 * r88);
+    r88 = r145 * r87;
+    r91 = r141 * r12;
+    r91 = fmaf(r11, r91, r98 * r88);
+    WriteSum4<float, float>((float*)inout_shared, r121, r137, r122, r91);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r145 * r140;
+    r122 = r141 * r102;
+    r122 = fmaf(r11, r122, r98 * r91);
+    r91 = r142 * r129;
+    r137 = r86 * r128;
+    r137 = fmaf(r11, r137, r98 * r91);
+    r91 = r142 * r87;
+    r121 = r86 * r12;
+    r121 = fmaf(r11, r121, r98 * r91);
+    r91 = r86 * r102;
+    r88 = r142 * r140;
+    r88 = fmaf(r98, r88, r11 * r91);
+    WriteSum4<float, float>((float*)inout_shared, r122, r137, r121, r88);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r128 * r12;
+    r121 = r129 * r87;
+    r121 = fmaf(r98, r121, r11 * r88);
+    r88 = r128 * r102;
+    r137 = r129 * r140;
+    r137 = fmaf(r98, r137, r11 * r88);
+    r88 = r87 * r140;
+    r122 = r12 * r102;
+    r122 = fmaf(r11, r122, r98 * r88);
+    WriteSum3<float, float>((float*)inout_shared, r121, r137, r122);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r122 = r0 * r51;
+    r122 = r122 * r80;
+    r122 = r122 * r64;
+    r137 = r1 * r9;
+    r137 = r137 * r48;
+    r137 = r137 * r51;
+    r137 = r137 * r80;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r70,
+                                          r69,
+                                          r122,
+                                          r137);
+    r121 = r1 * r82;
+    r88 = r0 * r80;
+    r88 = r88 * r64;
+    r88 = r88 * r74;
+    r91 = r1 * r80;
+    r91 = r91 * r74;
+    r91 = r91 * r103;
+    r108 = r0 * r9;
+    r108 = r108 * r73;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r88,
+                                          r91,
+                                          r108,
+                                          r121);
+    r147 = r0 * r63;
+    r13 = r1 * r9;
+    r13 = r13 * r73;
+    r101 = r0 * r80;
+    r101 = r101 * r64;
+    r101 = r101 * r77;
+    r143 = r1 * r80;
+    r143 = r143 * r103;
+    r143 = r143 * r77;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r147,
+                                          r13,
+                                          r101,
+                                          r143);
+    r30 = r0 * r51;
+    r149 = r1 * r51;
+    r150 = r0 * r80;
+    r150 = r150 * r64;
+    r150 = r150 * r76;
+    r151 = r1 * r80;
+    r151 = r151 * r103;
+    r151 = r151 * r76;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r150,
+                                          r151,
+                                          r30,
+                                          r149);
+    r152 = r25 * r70;
+    r152 = r152 * r2;
+    r153 = r25 * r2;
+    r154 = r69 * r148;
+    WriteSum4<float, float>((float*)inout_shared, r152, r154, r153, r148);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r148 = r9 * r48;
+    r148 = r148 * r51;
+    r148 = r148 * r80;
+    r153 = r0 * r25;
+    r153 = r153 * r51;
+    r153 = r153 * r2;
+    r153 = r153 * r80;
+    r153 = fmaf(r64, r153, r146 * r148);
+    r148 = r80 * r74;
+    r148 = r148 * r103;
+    r154 = r0 * r25;
+    r154 = r154 * r2;
+    r154 = r154 * r80;
+    r154 = r154 * r64;
+    r154 = fmaf(r74, r154, r146 * r148);
+    r148 = r0 * r40;
+    r148 = r148 * r9;
+    r148 = r148 * r2;
+    r148 = r148 * r61;
+    r148 = fmaf(r64, r148, r82 * r146);
+    r152 = r0 * r25;
+    r152 = r152 * r63;
+    r155 = r1 * r40;
+    r155 = r155 * r9;
+    r155 = r155 * r3;
+    r155 = r155 * r61;
+    r155 = fmaf(r64, r155, r2 * r152);
+    WriteSum4<float, float>((float*)inout_shared, r153, r154, r148, r155);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r0 * r25;
+    r155 = r155 * r51;
+    r155 = r155 * r2;
+    r148 = r51 * r146;
+    r154 = r80 * r103;
+    r154 = r154 * r77;
+    r153 = r0 * r25;
+    r153 = r153 * r2;
+    r153 = r153 * r80;
+    r153 = r153 * r64;
+    r153 = fmaf(r77, r153, r146 * r154);
+    r154 = r80 * r103;
+    r154 = r154 * r76;
+    r152 = r0 * r25;
+    r152 = r152 * r2;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    r152 = fmaf(r76, r152, r146 * r154);
+    WriteSum4<float, float>((float*)inout_shared, r153, r152, r155, r148);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r148 = r70 * r70;
+    r155 = r69 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r148, r155, r41, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = r8 * r61;
+    r41 = r41 * r64;
+    r41 = r41 * r74;
+    r155 = r74 * r103;
+    r155 = r155 * r98;
+    r155 = fmaf(r112, r155, r11 * r41);
+    r41 = r8 * r61;
+    r41 = r41 * r64;
+    r41 = r41 * r11;
+    r148 = r103 * r98;
+    r148 = r148 * r76;
+    r148 = fmaf(r112, r148, r76 * r41);
+    r41 = r82 * r82;
+    r152 = r8 * r8;
+    r10 = r35 * r10;
+    r10 = 1.0 / r10;
+    r59 = r46 * r59;
+    r59 = 1.0 / r59;
+    r152 = r152 * r9;
+    r152 = r152 * r9;
+    r152 = r152 * r48;
+    r152 = r152 * r48;
+    r152 = r152 * r133;
+    r152 = r152 * r10;
+    r152 = r152 * r59;
+    r152 = r152 * r118;
+    r41 = fmaf(r11, r152, r98 * r41);
+    r59 = r63 * r11;
+    r152 = fmaf(r98, r152, r63 * r59);
+    WriteSum4<float, float>((float*)inout_shared, r155, r148, r41, r152);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r152 = r74 * r11;
+    r41 = r74 * r98;
+    r155 = r77 * r77;
+    r10 = r8 * r61;
+    r10 = r10 * r64;
+    r10 = r10 * r11;
+    r133 = r103 * r98;
+    r46 = r112 * r133;
+    r35 = fmaf(r155, r46, r155 * r10);
+    r153 = r76 * r76;
+    r153 = fmaf(r46, r153, r10 * r153);
+    WriteSum4<float, float>((float*)inout_shared, r35, r153, r152, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = 0.00000000000000000e+00;
+    r152 = r0 * r51;
+    r152 = r152 * r70;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r41, r70, r41, r152);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r0 * r63;
+    r63 = r63 * r70;
+    r152 = r0 * r70;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    r152 = r152 * r74;
+    r153 = r9 * r73;
+    r153 = r153 * r71;
+    r154 = r0 * r70;
+    r154 = r154 * r80;
+    r154 = r154 * r64;
+    r154 = r154 * r77;
+    WriteSum4<float, float>((float*)inout_shared, r152, r153, r63, r154);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r0 * r51;
+    r154 = r154 * r70;
+    r70 = r80 * r64;
+    r70 = r70 * r76;
+    r70 = r70 * r71;
+    WriteSum4<float, float>((float*)inout_shared, r70, r154, r41, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r1 * r82;
+    r154 = r154 * r69;
+    r70 = r1 * r9;
+    r70 = r70 * r48;
+    r70 = r70 * r51;
+    r70 = r70 * r69;
+    r70 = r70 * r80;
+    r71 = r1 * r69;
+    r71 = r71 * r80;
+    r71 = r71 * r74;
+    r71 = r71 * r103;
+    WriteSum4<float, float>((float*)inout_shared, r69, r70, r71, r154);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r1 * r9;
+    r154 = r154 * r69;
+    r154 = r154 * r73;
+    r71 = r1 * r69;
+    r71 = r71 * r80;
+    r71 = r71 * r103;
+    r71 = r71 * r77;
+    r70 = r1 * r69;
+    r70 = r70 * r80;
+    r70 = r70 * r103;
+    r70 = r70 * r76;
+    WriteSum4<float, float>((float*)inout_shared, r154, r71, r70, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r70 = r1 * r51;
+    r70 = r70 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r70, r41, r122, r88);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r108, r147, r101, r150);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r30, r41, r137, r91);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r121, r13, r143, r151);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r151 = r8 * r61;
+    r151 = r151 * r64;
+    r151 = r151 * r77;
+    r143 = r103 * r77;
+    r143 = r143 * r98;
+    r143 = fmaf(r112, r143, r11 * r151);
+    r151 = r8 * r48;
+    r13 = r14 * r8;
+    r13 = r13 * r106;
+    r13 = r13 * r114;
+    r13 = r13 * r118;
+    r118 = r9 * r13;
+    r151 = r151 * r51;
+    r151 = r151 * r11;
+    r114 = r9 * r48;
+    r114 = r114 * r51;
+    r114 = r114 * r82;
+    r114 = r114 * r80;
+    r114 = fmaf(r98, r114, r118 * r151);
+    WriteSum4<float, float>((float*)inout_shared, r41, r149, r143, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r80 * r64;
+    r114 = r114 * r74;
+    r114 = r114 * r11;
+    r143 = r80 * r64;
+    r143 = r143 * r59;
+    r149 = r9 * r48;
+    r149 = r149 * r51;
+    r149 = r149 * r98;
+    r149 = fmaf(r118, r149, r51 * r143);
+    r151 = r51 * r76;
+    r121 = fmaf(r151, r46, r151 * r10);
+    WriteSum4<float, float>((float*)inout_shared, r149, r148, r121, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r80 * r74;
+    r114 = r114 * r103;
+    r114 = r114 * r98;
+    r148 = r8 * r74;
+    r148 = r148 * r103;
+    r148 = r148 * r11;
+    r149 = r82 * r80;
+    r149 = r149 * r74;
+    r149 = r149 * r103;
+    r149 = fmaf(r98, r149, r13 * r148);
+    r148 = r74 * r133;
+    r148 = fmaf(r118, r148, r74 * r143);
+    WriteSum4<float, float>((float*)inout_shared, r114, r149, r148, r121);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r121 = r80 * r64;
+    r121 = r121 * r77;
+    r121 = r121 * r11;
+    r148 = r80 * r103;
+    r148 = r148 * r77;
+    r148 = r148 * r98;
+    r149 = r9 * r73;
+    r114 = r9 * r82;
+    r114 = r114 * r98;
+    r114 = fmaf(r73, r114, r59 * r149);
+    WriteSum4<float, float>((float*)inout_shared, r35, r121, r148, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r9 * r51;
+    r114 = r114 * r11;
+    r114 = r114 * r73;
+    r148 = r51 * r82;
+    r148 = r148 * r98;
+    r121 = r8 * r103;
+    r121 = r121 * r77;
+    r121 = r121 * r11;
+    r35 = r82 * r80;
+    r35 = r35 * r103;
+    r35 = r35 * r77;
+    r35 = fmaf(r98, r35, r13 * r121);
+    r121 = r8 * r103;
+    r121 = r121 * r11;
+    r121 = r121 * r76;
+    r149 = r82 * r80;
+    r149 = r149 * r103;
+    r149 = r149 * r98;
+    r149 = fmaf(r76, r149, r13 * r121);
+    WriteSum4<float, float>((float*)inout_shared, r35, r149, r114, r148);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r51 * r59;
+    r148 = r9 * r51;
+    r148 = r148 * r98;
+    r148 = r148 * r73;
+    r114 = r77 * r133;
+    r114 = fmaf(r118, r114, r77 * r143);
+    r149 = r76 * r133;
+    r149 = fmaf(r118, r149, r76 * r143);
+    WriteSum4<float, float>((float*)inout_shared, r114, r149, r59, r148);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r148 = r80 * r64;
+    r148 = r148 * r11;
+    r148 = r148 * r76;
+    r59 = r80 * r103;
+    r59 = r59 * r98;
+    r59 = r59 * r76;
+    r149 = r80 * r64;
+    r149 = r149 * r11;
+    r149 = r149 * r151;
+    r155 = r51 * r155;
+    r46 = fmaf(r155, r46, r155 * r10);
+    WriteSum4<float, float>((float*)inout_shared, r46, r148, r59, r149);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r151 = r80 * r151;
+    r151 = r151 * r133;
+    WriteSum2<float, float>((float*)inout_shared, r151, r41);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = r14 * r32;
+    r41 = r41 * r9;
+    r151 = r14 * r53;
+    r151 = r151 * r8;
+    r151 = fmaf(r36, r151, r36 * r41);
+    r41 = r60 * r8;
+    r41 = r41 * r8;
+    r151 = fmaf(r95, r41, r151);
+    r149 = r60 * r9;
+    r149 = r149 * r9;
+    r151 = fmaf(r95, r149, r151);
+    r149 = r25 * r151;
+    r41 = r151 * r92;
+    r41 = fmaf(r112, r41, r113 * r149);
+    r149 = r60 * r9;
+    r149 = r149 * r9;
+    r41 = fmaf(r117, r149, r41);
+    r59 = r32 * r72;
+    r41 = fmaf(r103, r59, r41);
+    r59 = r60 * r8;
+    r59 = r59 * r8;
+    r59 = fmaf(r117, r59, r53 * r73);
+    r149 = r8 * r8;
+    r149 = r149 * r151;
+    r149 = r149 * r94;
+    r149 = r149 * r34;
+    r59 = fmaf(r61, r149, r59);
+    r148 = r25 * r151;
+    r59 = fmaf(r120, r148, r59);
+    r148 = r41 + r59;
+    r149 = r53 * r100;
+    r149 = r149 * r61;
+    r46 = r60 * r8;
+    r46 = r46 * r8;
+    r46 = r46 * r48;
+    r46 = r46 * r48;
+    r46 = r46 * r125;
+    r46 = r46 * r39;
+    r46 = fmaf(r106, r46, r64 * r149);
+    r149 = r8 * r8;
+    r149 = r149 * r62;
+    r149 = r149 * r151;
+    r149 = r149 * r94;
+    r149 = r149 * r34;
+    r46 = fmaf(r61, r149, r46);
+    r155 = r126 * r151;
+    r46 = fmaf(r120, r155, r46);
+    r46 = r46 + r41;
+    r46 = fmaf(r7, r46, r67 * r148);
+    r41 = r8 * r48;
+    r41 = r41 * r75;
+    r41 = r41 * r85;
+    r41 = r41 * r151;
+    r41 = r41 * r39;
+    r41 = r41 * r78;
+    r46 = fmaf(r34, r41, r46);
+    r155 = r6 * r53;
+    r155 = r155 * r72;
+    r46 = fmaf(r103, r155, r46);
+    r149 = r25 * r60;
+    r149 = r149 * r8;
+    r149 = r149 * r79;
+    r46 = fmaf(r55, r149, r46);
+    r10 = r6 * r40;
+    r10 = r10 * r151;
+    r10 = r10 * r64;
+    r10 = r10 * r104;
+    r46 = fmaf(r115, r10, r46);
+    r114 = r6 * r8;
+    r114 = r114 * r151;
+    r114 = r114 * r72;
+    r46 = fmaf(r92, r114, r46);
+    r143 = r8 * r48;
+    r143 = r143 * r85;
+    r143 = r143 * r151;
+    r143 = r143 * r39;
+    r143 = r143 * r78;
+    r46 = fmaf(r34, r143, r46);
+    r118 = r53 * r48;
+    r46 = fmaf(r81, r118, r46);
+    r35 = r53 * r48;
+    r46 = fmaf(r80, r35, r46);
+    r121 = r6 * r32;
+    r46 = fmaf(r73, r121, r46);
+    r13 = r25 * r60;
+    r13 = r13 * r8;
+    r13 = r13 * r75;
+    r13 = r13 * r79;
+    r46 = fmaf(r55, r13, r46);
+    r91 = r5 * r14;
+    r91 = r91 * r51;
+    r91 = fmaf(r148, r91, r4 * r148);
+    r91 = fmaf(r148, r66, r91);
+    r91 = fmaf(r148, r65, r91);
+    r137 = r91 * r80;
+    r46 = fmaf(r64, r137, r46);
+    r30 = r8 * r89;
+    r30 = r30 * r151;
+    r30 = r30 * r94;
+    r30 = r30 * r34;
+    r46 = fmaf(r80, r30, r46);
+    r46 = fmaf(r151, r111, r46);
+    r46 = fmaf(r60, r136, r46);
+    r30 = r0 * r46;
+    r137 = r62 * r151;
+    r137 = r137 * r92;
+    r137 = fmaf(r112, r137, r151 * r139);
+    r13 = r60 * r9;
+    r13 = r13 * r9;
+    r13 = r13 * r48;
+    r13 = r13 * r48;
+    r13 = r13 * r125;
+    r13 = r13 * r39;
+    r137 = fmaf(r106, r13, r137);
+    r121 = r32 * r9;
+    r121 = r121 * r48;
+    r121 = r121 * r100;
+    r137 = fmaf(r61, r121, r137);
+    r137 = r137 + r59;
+    r137 = fmaf(r6, r137, r68 * r148);
+    r148 = r151 * r81;
+    r137 = fmaf(r124, r148, r137);
+    r59 = r25 * r60;
+    r59 = r59 * r9;
+    r59 = r59 * r75;
+    r59 = r59 * r79;
+    r137 = fmaf(r55, r59, r137);
+    r121 = r7 * r53;
+    r121 = r121 * r72;
+    r137 = fmaf(r103, r121, r137);
+    r13 = r7 * r40;
+    r13 = r13 * r151;
+    r13 = r13 * r64;
+    r13 = r13 * r104;
+    r137 = fmaf(r115, r13, r137);
+    r35 = r7 * r8;
+    r35 = r35 * r151;
+    r35 = r35 * r72;
+    r137 = fmaf(r92, r35, r137);
+    r118 = r32 * r48;
+    r137 = fmaf(r81, r118, r137);
+    r143 = r7 * r60;
+    r143 = r143 * r8;
+    r143 = r143 * r9;
+    r143 = r143 * r48;
+    r143 = r143 * r48;
+    r143 = r143 * r96;
+    r143 = r143 * r39;
+    r137 = fmaf(r106, r143, r137);
+    r114 = r25 * r60;
+    r114 = r114 * r9;
+    r114 = r114 * r79;
+    r137 = fmaf(r55, r114, r137);
+    r10 = r32 * r48;
+    r137 = fmaf(r80, r10, r137);
+    r149 = r9 * r48;
+    r149 = r149 * r91;
+    r137 = fmaf(r80, r149, r137);
+    r137 = fmaf(r151, r119, r137);
+    r137 = fmaf(r151, r135, r137);
+    r137 = fmaf(r32, r84, r137);
+    r137 = fmaf(r151, r116, r137);
+    r149 = r1 * r137;
+    r10 = r8 * r8;
+    r114 = r44 * r9;
+    r114 = r114 * r9;
+    r143 = r14 * r50;
+    r143 = r143 * r8;
+    r143 = fmaf(r36, r143, r95 * r114);
+    r114 = r14 * r49;
+    r114 = r114 * r9;
+    r143 = fmaf(r36, r114, r143);
+    r118 = r44 * r8;
+    r118 = r118 * r8;
+    r143 = fmaf(r95, r118, r143);
+    r10 = r10 * r62;
+    r10 = r10 * r143;
+    r10 = r10 * r94;
+    r10 = r10 * r34;
+    r118 = r44 * r8;
+    r118 = r118 * r8;
+    r118 = r118 * r48;
+    r118 = r118 * r48;
+    r118 = r118 * r125;
+    r118 = r118 * r39;
+    r118 = fmaf(r106, r118, r61 * r10);
+    r10 = r126 * r143;
+    r118 = fmaf(r120, r10, r118);
+    r114 = r50 * r100;
+    r114 = r114 * r61;
+    r118 = fmaf(r64, r114, r118);
+    r35 = r25 * r143;
+    r13 = r49 * r72;
+    r13 = fmaf(r103, r13, r113 * r35);
+    r35 = r143 * r92;
+    r13 = fmaf(r112, r35, r13);
+    r121 = r44 * r9;
+    r121 = r121 * r9;
+    r13 = fmaf(r117, r121, r13);
+    r118 = r118 + r13;
+    r114 = r8 * r8;
+    r114 = r114 * r143;
+    r114 = r114 * r94;
+    r114 = r114 * r34;
+    r10 = r44 * r8;
+    r10 = r10 * r8;
+    r10 = fmaf(r117, r10, r61 * r114);
+    r114 = r25 * r143;
+    r10 = fmaf(r120, r114, r10);
+    r10 = fmaf(r50, r73, r10);
+    r13 = r13 + r10;
+    r118 = fmaf(r67, r13, r7 * r118);
+    r114 = r6 * r49;
+    r118 = fmaf(r73, r114, r118);
+    r121 = r8 * r48;
+    r121 = r121 * r85;
+    r121 = r121 * r143;
+    r121 = r121 * r39;
+    r121 = r121 * r78;
+    r118 = fmaf(r34, r121, r118);
+    r35 = r25 * r44;
+    r35 = r35 * r8;
+    r35 = r35 * r79;
+    r118 = fmaf(r55, r35, r118);
+    r59 = r25 * r44;
+    r59 = r59 * r8;
+    r59 = r59 * r75;
+    r59 = r59 * r79;
+    r118 = fmaf(r55, r59, r118);
+    r148 = r50 * r48;
+    r118 = fmaf(r81, r148, r118);
+    r155 = r6 * r40;
+    r155 = r155 * r143;
+    r155 = r155 * r64;
+    r155 = r155 * r104;
+    r118 = fmaf(r115, r155, r118);
+    r41 = r8 * r89;
+    r41 = r41 * r143;
+    r41 = r41 * r94;
+    r41 = r41 * r34;
+    r118 = fmaf(r80, r41, r118);
+    r150 = r50 * r48;
+    r118 = fmaf(r80, r150, r118);
+    r101 = r8 * r48;
+    r101 = r101 * r75;
+    r101 = r101 * r85;
+    r101 = r101 * r143;
+    r101 = r101 * r39;
+    r101 = r101 * r78;
+    r118 = fmaf(r34, r101, r118);
+    r147 = r5 * r14;
+    r147 = r147 * r51;
+    r147 = fmaf(r4, r13, r13 * r147);
+    r147 = fmaf(r13, r66, r147);
+    r147 = fmaf(r13, r65, r147);
+    r108 = r147 * r80;
+    r118 = fmaf(r64, r108, r118);
+    r88 = r6 * r50;
+    r88 = r88 * r72;
+    r118 = fmaf(r103, r88, r118);
+    r122 = r6 * r8;
+    r122 = r122 * r143;
+    r122 = r122 * r72;
+    r118 = fmaf(r92, r122, r118);
+    r118 = fmaf(r44, r136, r118);
+    r118 = fmaf(r143, r111, r118);
+    r122 = r0 * r118;
+    r88 = r49 * r9;
+    r88 = r88 * r48;
+    r88 = r88 * r100;
+    r88 = fmaf(r61, r88, r143 * r139);
+    r108 = r62 * r143;
+    r108 = r108 * r92;
+    r88 = fmaf(r112, r108, r88);
+    r101 = r44 * r9;
+    r101 = r101 * r9;
+    r101 = r101 * r48;
+    r101 = r101 * r48;
+    r101 = r101 * r125;
+    r101 = r101 * r39;
+    r88 = fmaf(r106, r101, r88);
+    r88 = r88 + r10;
+    r13 = fmaf(r68, r13, r6 * r88);
+    r88 = r49 * r48;
+    r13 = fmaf(r81, r88, r13);
+    r10 = r49 * r48;
+    r13 = fmaf(r80, r10, r13);
+    r101 = r7 * r40;
+    r101 = r101 * r143;
+    r101 = r101 * r64;
+    r101 = r101 * r104;
+    r13 = fmaf(r115, r101, r13);
+    r108 = r7 * r44;
+    r108 = r108 * r8;
+    r108 = r108 * r9;
+    r108 = r108 * r48;
+    r108 = r108 * r48;
+    r108 = r108 * r96;
+    r108 = r108 * r39;
+    r13 = fmaf(r106, r108, r13);
+    r150 = r9 * r48;
+    r150 = r150 * r147;
+    r13 = fmaf(r80, r150, r13);
+    r41 = r143 * r81;
+    r13 = fmaf(r124, r41, r13);
+    r155 = r25 * r44;
+    r155 = r155 * r9;
+    r155 = r155 * r75;
+    r155 = r155 * r79;
+    r13 = fmaf(r55, r155, r13);
+    r148 = r25 * r44;
+    r148 = r148 * r9;
+    r148 = r148 * r79;
+    r13 = fmaf(r55, r148, r13);
+    r59 = r7 * r50;
+    r59 = r59 * r72;
+    r13 = fmaf(r103, r59, r13);
+    r35 = r7 * r8;
+    r35 = r35 * r143;
+    r35 = r35 * r72;
+    r13 = fmaf(r92, r35, r13);
+    r13 = fmaf(r49, r84, r13);
+    r13 = fmaf(r143, r119, r13);
+    r13 = fmaf(r143, r135, r13);
+    r13 = fmaf(r143, r116, r13);
+    r35 = r1 * r13;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r30,
+                                          r149,
+                                          r122,
+                                          r35);
+    r35 = r14 * r47;
+    r35 = r35 * r9;
+    r122 = r52 * r9;
+    r122 = r122 * r9;
+    r122 = fmaf(r95, r122, r36 * r35);
+    r35 = r52 * r8;
+    r35 = r35 * r8;
+    r122 = fmaf(r95, r35, r122);
+    r95 = r14 * r54;
+    r95 = r95 * r8;
+    r122 = fmaf(r36, r95, r122);
+    r95 = r25 * r122;
+    r35 = r47 * r72;
+    r35 = fmaf(r103, r35, r113 * r95);
+    r95 = r122 * r92;
+    r35 = fmaf(r112, r95, r35);
+    r113 = r52 * r9;
+    r113 = r113 * r9;
+    r35 = fmaf(r117, r113, r35);
+    r113 = r8 * r8;
+    r113 = r113 * r122;
+    r113 = r113 * r94;
+    r113 = r113 * r34;
+    r113 = fmaf(r61, r113, r54 * r73);
+    r95 = r52 * r8;
+    r95 = r95 * r8;
+    r113 = fmaf(r117, r95, r113);
+    r117 = r25 * r122;
+    r113 = fmaf(r120, r117, r113);
+    r117 = r35 + r113;
+    r95 = r54 * r100;
+    r95 = r95 * r61;
+    r36 = r8 * r8;
+    r36 = r36 * r62;
+    r36 = r36 * r122;
+    r36 = r36 * r94;
+    r36 = r36 * r34;
+    r36 = fmaf(r61, r36, r64 * r95);
+    r95 = r52 * r8;
+    r95 = r95 * r8;
+    r95 = r95 * r48;
+    r95 = r95 * r48;
+    r95 = r95 * r125;
+    r95 = r95 * r39;
+    r36 = fmaf(r106, r95, r36);
+    r149 = r126 * r122;
+    r36 = fmaf(r120, r149, r36);
+    r36 = r36 + r35;
+    r36 = fmaf(r7, r36, r67 * r117);
+    r67 = r5 * r14;
+    r67 = r67 * r51;
+    r4 = fmaf(r4, r117, r117 * r67);
+    r4 = fmaf(r117, r66, r4);
+    r4 = fmaf(r117, r65, r4);
+    r65 = r4 * r80;
+    r36 = fmaf(r64, r65, r36);
+    r66 = r6 * r40;
+    r66 = r66 * r122;
+    r66 = r66 * r64;
+    r66 = r66 * r104;
+    r36 = fmaf(r115, r66, r36);
+    r67 = r6 * r8;
+    r67 = r67 * r122;
+    r67 = r67 * r72;
+    r36 = fmaf(r92, r67, r36);
+    r51 = r25 * r52;
+    r51 = r51 * r8;
+    r51 = r51 * r79;
+    r36 = fmaf(r55, r51, r36);
+    r35 = r8 * r48;
+    r35 = r35 * r85;
+    r35 = r35 * r122;
+    r35 = r35 * r39;
+    r35 = r35 * r78;
+    r36 = fmaf(r34, r35, r36);
+    r149 = r25 * r52;
+    r149 = r149 * r8;
+    r149 = r149 * r75;
+    r149 = r149 * r79;
+    r36 = fmaf(r55, r149, r36);
+    r95 = r54 * r48;
+    r36 = fmaf(r80, r95, r36);
+    r120 = r8 * r48;
+    r120 = r120 * r75;
+    r120 = r120 * r85;
+    r120 = r120 * r122;
+    r120 = r120 * r39;
+    r120 = r120 * r78;
+    r36 = fmaf(r34, r120, r36);
+    r78 = r6 * r47;
+    r36 = fmaf(r73, r78, r36);
+    r85 = r54 * r48;
+    r36 = fmaf(r81, r85, r36);
+    r30 = r8 * r89;
+    r30 = r30 * r122;
+    r30 = r30 * r94;
+    r30 = r30 * r34;
+    r36 = fmaf(r80, r30, r36);
+    r34 = r6 * r54;
+    r34 = r34 * r72;
+    r36 = fmaf(r103, r34, r36);
+    r36 = fmaf(r52, r136, r36);
+    r36 = fmaf(r122, r111, r36);
+    r34 = r0 * r36;
+    r30 = r47 * r9;
+    r30 = r30 * r48;
+    r30 = r30 * r100;
+    r30 = fmaf(r61, r30, r122 * r139);
+    r139 = r62 * r122;
+    r139 = r139 * r92;
+    r30 = fmaf(r112, r139, r30);
+    r112 = r52 * r9;
+    r112 = r112 * r9;
+    r112 = r112 * r48;
+    r112 = r112 * r48;
+    r112 = r112 * r125;
+    r112 = r112 * r39;
+    r30 = fmaf(r106, r112, r30);
+    r30 = r30 + r113;
+    r30 = fmaf(r6, r30, r68 * r117);
+    r117 = r122 * r81;
+    r30 = fmaf(r124, r117, r30);
+    r124 = r25 * r52;
+    r124 = r124 * r9;
+    r124 = r124 * r75;
+    r124 = r124 * r79;
+    r30 = fmaf(r55, r124, r30);
+    r75 = r7 * r52;
+    r75 = r75 * r8;
+    r75 = r75 * r9;
+    r75 = r75 * r48;
+    r75 = r75 * r48;
+    r75 = r75 * r96;
+    r75 = r75 * r39;
+    r30 = fmaf(r106, r75, r30);
+    r106 = r47 * r48;
+    r30 = fmaf(r80, r106, r30);
+    r39 = r7 * r40;
+    r39 = r39 * r122;
+    r39 = r39 * r64;
+    r39 = r39 * r104;
+    r30 = fmaf(r115, r39, r30);
+    r115 = r7 * r8;
+    r115 = r115 * r122;
+    r115 = r115 * r72;
+    r30 = fmaf(r92, r115, r30);
+    r104 = r9 * r48;
+    r104 = r104 * r4;
+    r30 = fmaf(r80, r104, r30);
+    r64 = r47 * r48;
+    r30 = fmaf(r81, r64, r30);
+    r96 = r7 * r54;
+    r96 = r96 * r72;
+    r30 = fmaf(r103, r96, r30);
+    r68 = r25 * r52;
+    r68 = r68 * r9;
+    r68 = r68 * r79;
+    r30 = fmaf(r55, r68, r30);
+    r30 = fmaf(r122, r119, r30);
+    r30 = fmaf(r47, r84, r30);
+    r30 = fmaf(r122, r116, r30);
+    r30 = fmaf(r122, r135, r30);
+    r135 = r1 * r30;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r34,
+                                          r135);
+    r135 = r0 * r25;
+    r135 = r135 * r2;
+    r135 = fmaf(r137, r146, r46 * r135);
+    r34 = r0 * r25;
+    r34 = r34 * r2;
+    r34 = fmaf(r13, r146, r118 * r34);
+    r68 = r0 * r25;
+    r68 = r68 * r2;
+    r146 = fmaf(r30, r146, r36 * r68);
+    WriteSum3<float, float>((float*)inout_shared, r135, r34, r146);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r146 = r137 * r137;
+    r34 = r46 * r46;
+    r34 = fmaf(r11, r34, r98 * r146);
+    r146 = r118 * r118;
+    r135 = r13 * r13;
+    r135 = fmaf(r98, r135, r11 * r146);
+    r146 = r30 * r30;
+    r68 = r36 * r36;
+    r68 = fmaf(r11, r68, r98 * r146);
+    WriteSum3<float, float>((float*)inout_shared, r34, r135, r68);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r137 * r13;
+    r135 = r46 * r118;
+    r135 = fmaf(r11, r135, r98 * r68);
+    r68 = r137 * r30;
+    r34 = r46 * r36;
+    r34 = fmaf(r11, r34, r98 * r68);
+    r68 = r13 * r30;
+    r146 = r118 * r36;
+    r146 = fmaf(r11, r146, r98 * r68);
+    WriteSum3<float, float>((float*)inout_shared, r135, r34, r146);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeResJac(float* pose,
+                            unsigned int pose_num_alloc,
+                            SharedIndex* pose_indices,
+                            float* sensor_from_rig,
+                            unsigned int sensor_from_rig_num_alloc,
+                            float* calib,
+                            unsigned int calib_num_alloc,
+                            SharedIndex* calib_indices,
+                            float* point,
+                            unsigned int point_num_alloc,
+                            SharedIndex* point_indices,
+                            float* pixel,
+                            unsigned int pixel_num_alloc,
+                            float* out_res,
+                            unsigned int out_res_num_alloc,
+                            float* out_pose_jac,
+                            unsigned int out_pose_jac_num_alloc,
+                            float* const out_pose_njtr,
+                            unsigned int out_pose_njtr_num_alloc,
+                            float* const out_pose_precond_diag,
+                            unsigned int out_pose_precond_diag_num_alloc,
+                            float* const out_pose_precond_tril,
+                            unsigned int out_pose_precond_tril_num_alloc,
+                            float* out_calib_jac,
+                            unsigned int out_calib_jac_num_alloc,
+                            float* const out_calib_njtr,
+                            unsigned int out_calib_njtr_num_alloc,
+                            float* const out_calib_precond_diag,
+                            unsigned int out_calib_precond_diag_num_alloc,
+                            float* const out_calib_precond_tril,
+                            unsigned int out_calib_precond_tril_num_alloc,
+                            float* out_point_jac,
+                            unsigned int out_point_jac_num_alloc,
+                            float* const out_point_njtr,
+                            unsigned int out_point_njtr_num_alloc,
+                            float* const out_point_precond_diag,
+                            unsigned int out_point_precond_diag_num_alloc,
+                            float* const out_point_precond_tril,
+                            unsigned int out_point_precond_tril_num_alloc,
+                            size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeResJac(float* pose,
+                            unsigned int pose_num_alloc,
+                            SharedIndex* pose_indices,
+                            float* sensor_from_rig,
+                            unsigned int sensor_from_rig_num_alloc,
+                            float* calib,
+                            unsigned int calib_num_alloc,
+                            SharedIndex* calib_indices,
+                            float* point,
+                            unsigned int point_num_alloc,
+                            SharedIndex* point_indices,
+                            float* pixel,
+                            unsigned int pixel_num_alloc,
+                            float* out_res,
+                            unsigned int out_res_num_alloc,
+                            float* out_pose_jac,
+                            unsigned int out_pose_jac_num_alloc,
+                            float* const out_pose_njtr,
+                            unsigned int out_pose_njtr_num_alloc,
+                            float* const out_pose_precond_diag,
+                            unsigned int out_pose_precond_diag_num_alloc,
+                            float* const out_pose_precond_tril,
+                            unsigned int out_pose_precond_tril_num_alloc,
+                            float* out_calib_jac,
+                            unsigned int out_calib_jac_num_alloc,
+                            float* const out_calib_njtr,
+                            unsigned int out_calib_njtr_num_alloc,
+                            float* const out_calib_precond_diag,
+                            unsigned int out_calib_precond_diag_num_alloc,
+                            float* const out_calib_precond_tril,
+                            unsigned int out_calib_precond_tril_num_alloc,
+                            float* out_point_jac,
+                            unsigned int out_point_jac_num_alloc,
+                            float* const out_point_njtr,
+                            unsigned int out_point_njtr_num_alloc,
+                            float* const out_point_precond_diag,
+                            unsigned int out_point_precond_diag_num_alloc,
+                            float* const out_point_precond_tril,
+                            unsigned int out_point_precond_tril_num_alloc,
+                            size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac_first.cu
@@ -1,0 +1,2795 @@
+#include "kernel_thin_prism_fisheye_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeResJacFirstKernel(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    float* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    float* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    float* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150, r151, r152,
+      r153, r154, r155;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r11,
+                       r12,
+                       r13);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r14 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r15,
+                       r16,
+                       r17,
+                       r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r23 = fmaf(r18, r19, r15 * r22);
+    r24 = r16 * r21;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r17, r20, r23);
+    r24 = r14 * r23;
+    r26 = r17 * r19;
+    r26 = fmaf(r25, r26, r16 * r22);
+    r26 = fmaf(r18, r20, r26);
+    r26 = fmaf(r15, r21, r26);
+    r24 = r24 * r26;
+    r27 = r17 * r22;
+    r28 = r16 * r19;
+    r29 = r27 + r28;
+    r30 = r18 * r21;
+    r31 = r15 * r20;
+    r29 = r29 + r30;
+    r29 = fmaf(r25, r31, r29);
+    r32 = r14 * r29;
+    r33 = fmaf(r16, r20, r15 * r19);
+    r33 = fmaf(r17, r21, r33);
+    r33 = fmaf(r25, r33, r18 * r22);
+    r32 = fmaf(r33, r32, r24);
+    r9 = fmaf(r11, r32, r9);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r34,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r19 * r20;
+    r37 = r37 * r14;
+    r38 = r21 * r22;
+    r38 = fmaf(r14, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r19 * r19;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r20 * r21;
+    r44 = r44 * r14;
+    r45 = r19 * r22;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r14 * r29;
+    r46 = r46 * r26;
+    r47 = r23 * r40;
+    r47 = fmaf(r33, r47, r46);
+    r48 = r23 * r23;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r29 * r29;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r9 = fmaf(r34, r38, r9);
+    r9 = fmaf(r35, r43, r9);
+    r9 = fmaf(r36, r45, r9);
+    r9 = fmaf(r13, r47, r9);
+    r9 = fmaf(r12, r49, r9);
+    r51 = r9 * r9;
+    r52 = r40 * r26;
+    r52 = r52 * r26;
+    r53 = r41 + r52;
+    r53 = r53 + r50;
+    r8 = fmaf(r11, r53, r8);
+    r50 = r29 * r40;
+    r50 = fmaf(r33, r50, r24);
+    r24 = r14 * r29;
+    r24 = r24 * r23;
+    r54 = r14 * r26;
+    r54 = fmaf(r33, r54, r24);
+    r55 = r19 * r21;
+    r55 = r55 * r14;
+    r56 = r20 * r22;
+    r56 = fmaf(r14, r56, r55);
+    r57 = r21 * r22;
+    r57 = fmaf(r40, r57, r37);
+    r37 = r20 * r20;
+    r37 = r37 * r40;
+    r58 = r41 + r37;
+    r58 = r58 + r39;
+    r8 = fmaf(r12, r50, r8);
+    r8 = fmaf(r13, r54, r8);
+    r8 = fmaf(r36, r56, r8);
+    r8 = fmaf(r35, r57, r8);
+    r8 = fmaf(r34, r58, r8);
+    r39 = r8 * r8;
+    r59 = 9.99999999999999955e-07;
+    r60 = r40 * r26;
+    r60 = fmaf(r33, r60, r24);
+    r10 = fmaf(r11, r60, r10);
+    r24 = r20 * r22;
+    r24 = fmaf(r40, r24, r55);
+    r42 = r37 + r42;
+    r37 = r19 * r22;
+    r37 = fmaf(r14, r37, r44);
+    r44 = r14 * r23;
+    r44 = fmaf(r33, r44, r46);
+    r52 = r41 + r52;
+    r52 = r52 + r48;
+    r10 = fmaf(r34, r24, r10);
+    r10 = fmaf(r36, r42, r10);
+    r10 = fmaf(r35, r37, r10);
+    r10 = fmaf(r12, r44, r10);
+    r10 = fmaf(r13, r52, r10);
+    r35 = copysign(1.0, r10);
+    r35 = fmaf(r59, r35, r10);
+    r10 = r35 * r35;
+    r36 = 1.0 / r10;
+    r34 = r9 * r9;
+    r34 = fmaf(r36, r34, r36 * r39);
+    r39 = sqrtf(r34);
+    r48 = atanf(r39);
+    r46 = copysign(1.0, r39);
+    r46 = fmaf(r59, r46, r39);
+    r59 = r46 * r46;
+    r39 = 1.0 / r59;
+    r55 = r48 * r36;
+    r61 = r39 * r55;
+    r51 = r51 * r48;
+    r51 = r51 * r61;
+    r62 = 3.00000000000000000e+00;
+    r63 = r8 * r62;
+    r64 = r8 * r48;
+    r63 = r63 * r61;
+    r63 = fmaf(r64, r63, r51);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r65,
+                       r66,
+                       r67,
+                       r68);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r69 = r8 * r61;
+    r69 = r69 * r64;
+    r51 = r51 + r69;
+    r70 = fmaf(r67, r51, r7 * r63);
+    r71 = r6 * r9;
+    r72 = r14 * r61;
+    r73 = r64 * r72;
+    r70 = fmaf(r73, r71, r70);
+    r74 = r51 * r51;
+    r75 = fmaf(r5, r74, r4 * r51);
+    r76 = r74 * r74;
+    r77 = r51 * r74;
+    r75 = fmaf(r66, r76, r75);
+    r75 = fmaf(r65, r77, r75);
+    r78 = 1.0 / r35;
+    r79 = 1.0 / r46;
+    r80 = r78 * r79;
+    r81 = r75 * r80;
+    r70 = fmaf(r64, r81, r70);
+    r70 = fmaf(r80, r64, r70);
+    r71 = r0 * r70;
+    r2 = r2 + r71;
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r82, r83);
+    r2 = fmaf(r82, r25, r2);
+    r82 = r9 * r9;
+    r82 = r82 * r48;
+    r82 = r82 * r62;
+    r82 = fmaf(r61, r82, r69);
+    r69 = fmaf(r68, r51, r6 * r82);
+    r84 = r7 * r73;
+    r85 = r9 * r48;
+    r69 = fmaf(r80, r85, r69);
+    r86 = r9 * r48;
+    r69 = fmaf(r81, r86, r69);
+    r69 = fmaf(r9, r84, r69);
+    r3 = fmaf(r1, r69, r3);
+    r3 = fmaf(r83, r25, r3);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r3);
+    r83 = fmaf(r3, r3, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r83);
+  if (global_thread_idx < problem_size) {
+    r83 = r23 * r40;
+    r86 = r15 * r22;
+    r85 = -5.00000000000000000e-01;
+    r87 = r18 * r19;
+    r87 = fmaf(r85, r87, r85 * r86);
+    r86 = r17 * r20;
+    r87 = fmaf(r85, r86, r87);
+    r88 = r16 * r21;
+    r89 = 5.00000000000000000e-01;
+    r87 = fmaf(r89, r88, r87);
+    r88 = r18 * r22;
+    r86 = r15 * r19;
+    r86 = fmaf(r85, r86, r89 * r88);
+    r88 = r16 * r20;
+    r86 = fmaf(r85, r88, r86);
+    r90 = r17 * r21;
+    r86 = fmaf(r85, r90, r86);
+    r90 = r33 * r86;
+    r88 = r40 * r90;
+    r83 = fmaf(r87, r83, r88);
+    r91 = r14 * r26;
+    r92 = r16 * r22;
+    r93 = r17 * r19;
+    r93 = fmaf(r89, r93, r85 * r92);
+    r92 = r18 * r20;
+    r93 = fmaf(r85, r92, r93);
+    r94 = r15 * r21;
+    r93 = fmaf(r85, r94, r93);
+    r91 = r91 * r93;
+    r94 = r14 * r29;
+    r92 = fmaf(r89, r28, r89 * r27);
+    r92 = fmaf(r85, r31, r92);
+    r92 = fmaf(r89, r30, r92);
+    r94 = fmaf(r92, r94, r91);
+    r83 = r83 + r94;
+    r95 = r23 * r86;
+    r96 = -4.00000000000000000e+00;
+    r95 = r95 * r96;
+    r97 = r29 * r93;
+    r98 = r96 * r97;
+    r99 = r95 + r98;
+    r99 = fmaf(r12, r99, r13 * r83);
+    r83 = r14 * r23;
+    r83 = r83 * r92;
+    r100 = r14 * r33;
+    r100 = fmaf(r93, r100, r83);
+    r101 = r14 * r26;
+    r101 = r101 * r86;
+    r102 = r14 * r29;
+    r102 = fmaf(r87, r102, r101);
+    r100 = r100 + r102;
+    r99 = fmaf(r11, r100, r99);
+    r100 = r99 * r72;
+    r103 = r9 * r48;
+    r104 = r14 * r9;
+    r104 = r104 * r99;
+    r105 = r14 * r8;
+    r106 = r14 * r33;
+    r107 = r26 * r87;
+    r106 = fmaf(r14, r107, r92 * r106);
+    r108 = r14 * r23;
+    r109 = r14 * r29;
+    r109 = r109 * r86;
+    r108 = fmaf(r93, r108, r109);
+    r106 = r106 + r108;
+    r83 = r101 + r83;
+    r101 = r29 * r40;
+    r83 = fmaf(r87, r101, r83);
+    r110 = r40 * r33;
+    r83 = fmaf(r93, r110, r83);
+    r83 = fmaf(r12, r83, r13 * r106);
+    r106 = r26 * r92;
+    r106 = r106 * r96;
+    r98 = r106 + r98;
+    r83 = fmaf(r11, r98, r83);
+    r105 = r105 * r83;
+    r105 = fmaf(r36, r105, r36 * r104);
+    r104 = r9 * r9;
+    r98 = r14 * r23;
+    r98 = r98 * r87;
+    r90 = r14 * r90;
+    r110 = r98 + r90;
+    r94 = r94 + r110;
+    r101 = r40 * r33;
+    r101 = fmaf(r40, r107, r92 * r101);
+    r101 = r101 + r108;
+    r101 = fmaf(r11, r101, r12 * r94);
+    r106 = r95 + r106;
+    r101 = fmaf(r13, r106, r101);
+    r10 = r35 * r10;
+    r106 = 1.0 / r10;
+    r95 = r40 * r106;
+    r104 = r104 * r101;
+    r105 = fmaf(r95, r104, r105);
+    r94 = r8 * r8;
+    r94 = r94 * r101;
+    r105 = fmaf(r95, r94, r105);
+    r94 = r41 + r34;
+    r94 = 1.0 / r94;
+    r34 = rsqrtf(r34);
+    r104 = r9 * r34;
+    r92 = r94 * r104;
+    r111 = r105 * r92;
+    r112 = r9 * r61;
+    r111 = fmaf(r112, r111, r103 * r100);
+    r100 = r25 * r105;
+    r113 = r104 * r103;
+    r59 = r46 * r59;
+    r114 = 1.0 / r59;
+    r115 = r114 * r55;
+    r113 = r113 * r115;
+    r111 = fmaf(r113, r100, r111);
+    r116 = r9 * r9;
+    r117 = r39 * r95;
+    r118 = r48 * r48;
+    r117 = r117 * r118;
+    r116 = r116 * r101;
+    r111 = fmaf(r117, r116, r111);
+    r116 = r8 * r8;
+    r116 = r116 * r105;
+    r116 = r116 * r94;
+    r116 = r116 * r34;
+    r116 = fmaf(r61, r116, r83 * r73);
+    r100 = r8 * r8;
+    r100 = r100 * r101;
+    r116 = fmaf(r117, r100, r116);
+    r119 = r64 * r115;
+    r120 = r8 * r34;
+    r119 = r119 * r120;
+    r121 = r105 * r119;
+    r116 = fmaf(r25, r121, r116);
+    r100 = r111 + r116;
+    r122 = 6.00000000000000000e+00;
+    r123 = r83 * r122;
+    r123 = r123 * r61;
+    r124 = r8 * r8;
+    r124 = r124 * r62;
+    r124 = r124 * r105;
+    r124 = r124 * r94;
+    r124 = r124 * r34;
+    r124 = fmaf(r61, r124, r64 * r123);
+    r123 = r8 * r8;
+    r125 = r48 * r48;
+    r126 = -6.00000000000000000e+00;
+    r125 = r125 * r101;
+    r125 = r125 * r126;
+    r125 = r125 * r39;
+    r125 = r125 * r106;
+    r127 = -3.00000000000000000e+00;
+    r124 = fmaf(r125, r123, r124);
+    r124 = fmaf(r127, r121, r124);
+    r124 = r124 + r111;
+    r124 = fmaf(r7, r124, r67 * r100);
+    r111 = r89 * r94;
+    r111 = r111 * r81;
+    r111 = r111 * r120;
+    r120 = r6 * r99;
+    r124 = fmaf(r73, r120, r124);
+    r121 = r48 * r83;
+    r124 = fmaf(r81, r121, r124);
+    r128 = r8 * r48;
+    r128 = r128 * r85;
+    r128 = r128 * r105;
+    r128 = r128 * r39;
+    r128 = r128 * r78;
+    r124 = fmaf(r34, r128, r124);
+    r129 = r6 * r8;
+    r129 = r129 * r105;
+    r129 = r129 * r72;
+    r124 = fmaf(r92, r129, r124);
+    r130 = r48 * r83;
+    r124 = fmaf(r80, r130, r124);
+    r131 = r25 * r8;
+    r131 = r131 * r101;
+    r131 = r131 * r79;
+    r124 = fmaf(r55, r131, r124);
+    r132 = r5 * r14;
+    r132 = r132 * r51;
+    r132 = fmaf(r100, r132, r4 * r100);
+    r65 = r65 * r62;
+    r65 = r65 * r74;
+    r133 = 4.00000000000000000e+00;
+    r66 = r66 * r133;
+    r66 = r66 * r77;
+    r132 = fmaf(r100, r65, r132);
+    r132 = fmaf(r100, r66, r132);
+    r134 = r132 * r80;
+    r124 = fmaf(r64, r134, r124);
+    r135 = r6 * r83;
+    r135 = r135 * r72;
+    r124 = fmaf(r103, r135, r124);
+    r136 = r6 * r8;
+    r136 = r136 * r9;
+    r136 = r136 * r48;
+    r136 = r136 * r48;
+    r136 = r136 * r96;
+    r136 = r136 * r39;
+    r136 = r136 * r106;
+    r137 = r8 * r48;
+    r137 = r137 * r75;
+    r137 = r137 * r85;
+    r137 = r137 * r105;
+    r137 = r137 * r39;
+    r137 = r137 * r78;
+    r124 = fmaf(r34, r137, r124);
+    r138 = r25 * r8;
+    r138 = r138 * r75;
+    r138 = r138 * r101;
+    r138 = r138 * r79;
+    r124 = fmaf(r55, r138, r124);
+    r139 = r8 * r89;
+    r139 = r139 * r105;
+    r139 = r139 * r94;
+    r139 = r139 * r34;
+    r124 = fmaf(r80, r139, r124);
+    r140 = r6 * r40;
+    r140 = r140 * r105;
+    r140 = r140 * r64;
+    r140 = r140 * r104;
+    r124 = fmaf(r115, r140, r124);
+    r124 = fmaf(r105, r111, r124);
+    r124 = fmaf(r101, r136, r124);
+    r140 = r0 * r124;
+    r139 = r9 * r48;
+    r139 = r139 * r99;
+    r139 = r139 * r122;
+    r138 = r62 * r105;
+    r138 = r138 * r92;
+    r138 = fmaf(r112, r138, r61 * r139);
+    r139 = r127 * r113;
+    r137 = r9 * r9;
+    r138 = fmaf(r105, r139, r138);
+    r138 = fmaf(r125, r137, r138);
+    r138 = r138 + r116;
+    r138 = fmaf(r6, r138, r68 * r100);
+    r100 = r48 * r85;
+    r100 = r100 * r39;
+    r100 = r100 * r78;
+    r100 = r100 * r104;
+    r116 = r75 * r100;
+    r125 = r89 * r92;
+    r135 = r80 * r125;
+    r134 = r7 * r8;
+    r134 = r134 * r105;
+    r134 = r134 * r72;
+    r138 = fmaf(r92, r134, r138);
+    r131 = r105 * r81;
+    r138 = fmaf(r125, r131, r138);
+    r130 = r25 * r9;
+    r130 = r130 * r75;
+    r130 = r130 * r101;
+    r130 = r130 * r79;
+    r138 = fmaf(r55, r130, r138);
+    r129 = r9 * r48;
+    r129 = r129 * r132;
+    r138 = fmaf(r80, r129, r138);
+    r128 = r7 * r83;
+    r128 = r128 * r72;
+    r138 = fmaf(r103, r128, r138);
+    r121 = r7 * r8;
+    r121 = r121 * r9;
+    r121 = r121 * r48;
+    r121 = r121 * r48;
+    r121 = r121 * r96;
+    r121 = r121 * r101;
+    r121 = r121 * r39;
+    r138 = fmaf(r106, r121, r138);
+    r120 = r25 * r9;
+    r120 = r120 * r101;
+    r120 = r120 * r79;
+    r138 = fmaf(r55, r120, r138);
+    r101 = r7 * r40;
+    r101 = r101 * r105;
+    r101 = r101 * r64;
+    r101 = r101 * r104;
+    r138 = fmaf(r115, r101, r138);
+    r141 = r48 * r99;
+    r138 = fmaf(r81, r141, r138);
+    r142 = r48 * r99;
+    r138 = fmaf(r80, r142, r138);
+    r138 = fmaf(r105, r116, r138);
+    r138 = fmaf(r105, r135, r138);
+    r138 = fmaf(r99, r84, r138);
+    r138 = fmaf(r105, r100, r138);
+    r142 = r1 * r138;
+    r141 = r8 * r8;
+    r101 = r14 * r8;
+    r90 = r91 + r90;
+    r91 = r14 * r29;
+    r28 = fmaf(r85, r28, r85 * r27);
+    r28 = fmaf(r89, r31, r28);
+    r28 = fmaf(r85, r30, r28);
+    r91 = r91 * r28;
+    r30 = r14 * r23;
+    r31 = r15 * r22;
+    r27 = r18 * r19;
+    r27 = fmaf(r89, r27, r89 * r31);
+    r31 = r17 * r20;
+    r27 = fmaf(r89, r31, r27);
+    r120 = r16 * r21;
+    r27 = fmaf(r85, r120, r27);
+    r30 = fmaf(r27, r30, r91);
+    r90 = r90 + r30;
+    r120 = r26 * r86;
+    r120 = r120 * r96;
+    r31 = r29 * r96;
+    r31 = r31 * r27;
+    r121 = r120 + r31;
+    r121 = fmaf(r11, r121, r13 * r90);
+    r90 = r40 * r33;
+    r90 = fmaf(r40, r97, r27 * r90);
+    r128 = r14 * r23;
+    r128 = r128 * r86;
+    r129 = r14 * r26;
+    r129 = fmaf(r28, r129, r128);
+    r90 = r90 + r129;
+    r121 = fmaf(r12, r90, r121);
+    r101 = r101 * r121;
+    r90 = r8 * r8;
+    r130 = r40 * r26;
+    r130 = fmaf(r93, r130, r88);
+    r130 = r130 + r30;
+    r30 = r14 * r26;
+    r30 = r30 * r27;
+    r131 = r14 * r33;
+    r131 = fmaf(r28, r131, r30);
+    r131 = r131 + r108;
+    r131 = fmaf(r12, r131, r11 * r130);
+    r130 = r23 * r28;
+    r108 = r96 * r130;
+    r120 = r120 + r108;
+    r131 = fmaf(r13, r120, r131);
+    r90 = r90 * r131;
+    r90 = fmaf(r95, r90, r36 * r101);
+    r101 = r9 * r9;
+    r101 = r101 * r131;
+    r90 = fmaf(r95, r101, r90);
+    r120 = r14 * r9;
+    r30 = r109 + r30;
+    r109 = r23 * r40;
+    r30 = fmaf(r93, r109, r30);
+    r93 = r40 * r33;
+    r30 = fmaf(r28, r93, r30);
+    r93 = r14 * r33;
+    r97 = fmaf(r14, r97, r27 * r93);
+    r97 = r97 + r129;
+    r97 = fmaf(r11, r97, r13 * r30);
+    r108 = r31 + r108;
+    r97 = fmaf(r12, r108, r97);
+    r120 = r120 * r97;
+    r90 = fmaf(r36, r120, r90);
+    r141 = r141 * r90;
+    r141 = r141 * r94;
+    r141 = r141 * r34;
+    r120 = r25 * r90;
+    r120 = fmaf(r119, r120, r61 * r141);
+    r141 = r8 * r8;
+    r141 = r141 * r131;
+    r120 = fmaf(r117, r141, r120);
+    r120 = fmaf(r121, r73, r120);
+    r141 = r97 * r72;
+    r101 = r25 * r90;
+    r101 = fmaf(r113, r101, r103 * r141);
+    r141 = r9 * r9;
+    r141 = r141 * r131;
+    r101 = fmaf(r117, r141, r101);
+    r108 = r90 * r92;
+    r101 = fmaf(r112, r108, r101);
+    r108 = r120 + r101;
+    r141 = r8 * r8;
+    r141 = r141 * r62;
+    r141 = r141 * r90;
+    r141 = r141 * r94;
+    r141 = r141 * r34;
+    r31 = r127 * r90;
+    r31 = fmaf(r119, r31, r61 * r141);
+    r141 = r8 * r8;
+    r141 = r141 * r48;
+    r141 = r141 * r48;
+    r141 = r141 * r126;
+    r141 = r141 * r131;
+    r141 = r141 * r39;
+    r31 = fmaf(r106, r141, r31);
+    r30 = r122 * r121;
+    r30 = r30 * r61;
+    r31 = fmaf(r64, r30, r31);
+    r31 = r31 + r101;
+    r31 = fmaf(r7, r31, r67 * r108);
+    r101 = r6 * r121;
+    r101 = r101 * r72;
+    r31 = fmaf(r103, r101, r31);
+    r30 = r8 * r48;
+    r30 = r30 * r85;
+    r30 = r30 * r90;
+    r30 = r30 * r39;
+    r30 = r30 * r78;
+    r31 = fmaf(r34, r30, r31);
+    r141 = r25 * r8;
+    r141 = r141 * r131;
+    r141 = r141 * r79;
+    r31 = fmaf(r55, r141, r31);
+    r93 = r8 * r48;
+    r93 = r93 * r75;
+    r93 = r93 * r85;
+    r93 = r93 * r90;
+    r93 = r93 * r39;
+    r93 = r93 * r78;
+    r31 = fmaf(r34, r93, r31);
+    r27 = r48 * r121;
+    r31 = fmaf(r81, r27, r31);
+    r109 = r6 * r8;
+    r109 = r109 * r90;
+    r109 = r109 * r72;
+    r31 = fmaf(r92, r109, r31);
+    r134 = r25 * r8;
+    r134 = r134 * r75;
+    r134 = r134 * r131;
+    r134 = r134 * r79;
+    r31 = fmaf(r55, r134, r31);
+    r143 = r5 * r14;
+    r143 = r143 * r51;
+    r143 = fmaf(r4, r108, r108 * r143);
+    r143 = fmaf(r108, r66, r143);
+    r143 = fmaf(r108, r65, r143);
+    r144 = r143 * r80;
+    r31 = fmaf(r64, r144, r31);
+    r145 = r8 * r89;
+    r145 = r145 * r90;
+    r145 = r145 * r94;
+    r145 = r145 * r34;
+    r31 = fmaf(r80, r145, r31);
+    r146 = r6 * r40;
+    r146 = r146 * r90;
+    r146 = r146 * r64;
+    r146 = r146 * r104;
+    r31 = fmaf(r115, r146, r31);
+    r147 = r6 * r97;
+    r31 = fmaf(r73, r147, r31);
+    r148 = r48 * r121;
+    r31 = fmaf(r80, r148, r31);
+    r31 = fmaf(r131, r136, r31);
+    r31 = fmaf(r90, r111, r31);
+    r148 = r0 * r31;
+    r147 = r9 * r48;
+    r147 = r147 * r122;
+    r147 = r147 * r97;
+    r147 = fmaf(r90, r139, r61 * r147);
+    r146 = r9 * r9;
+    r146 = r146 * r48;
+    r146 = r146 * r48;
+    r146 = r146 * r126;
+    r146 = r146 * r131;
+    r146 = r146 * r39;
+    r147 = fmaf(r106, r146, r147);
+    r145 = r62 * r90;
+    r145 = r145 * r92;
+    r147 = fmaf(r112, r145, r147);
+    r147 = r147 + r120;
+    r147 = fmaf(r6, r147, r68 * r108);
+    r108 = r25 * r9;
+    r108 = r108 * r131;
+    r108 = r108 * r79;
+    r147 = fmaf(r55, r108, r147);
+    r120 = r48 * r97;
+    r147 = fmaf(r81, r120, r147);
+    r145 = r7 * r121;
+    r145 = r145 * r72;
+    r147 = fmaf(r103, r145, r147);
+    r146 = r9 * r48;
+    r146 = r146 * r143;
+    r147 = fmaf(r80, r146, r147);
+    r144 = r90 * r81;
+    r147 = fmaf(r125, r144, r147);
+    r134 = r7 * r8;
+    r134 = r134 * r90;
+    r134 = r134 * r72;
+    r147 = fmaf(r92, r134, r147);
+    r109 = r25 * r9;
+    r109 = r109 * r75;
+    r109 = r109 * r131;
+    r109 = r109 * r79;
+    r147 = fmaf(r55, r109, r147);
+    r27 = r7 * r8;
+    r27 = r27 * r9;
+    r27 = r27 * r48;
+    r27 = r27 * r48;
+    r27 = r27 * r96;
+    r27 = r27 * r131;
+    r27 = r27 * r39;
+    r147 = fmaf(r106, r27, r147);
+    r131 = r7 * r40;
+    r131 = r131 * r90;
+    r131 = r131 * r64;
+    r131 = r131 * r104;
+    r147 = fmaf(r115, r131, r147);
+    r93 = r48 * r97;
+    r147 = fmaf(r80, r93, r147);
+    r147 = fmaf(r90, r116, r147);
+    r147 = fmaf(r90, r135, r147);
+    r147 = fmaf(r90, r100, r147);
+    r147 = fmaf(r97, r84, r147);
+    r93 = r1 * r147;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r140,
+                                          r142,
+                                          r148,
+                                          r93);
+    r93 = r8 * r8;
+    r148 = r23 * r96;
+    r142 = r16 * r22;
+    r140 = r17 * r19;
+    r140 = fmaf(r85, r140, r89 * r142);
+    r142 = r18 * r20;
+    r140 = fmaf(r89, r142, r140);
+    r131 = r15 * r21;
+    r140 = fmaf(r89, r131, r140);
+    r148 = r148 * r140;
+    r107 = r96 * r107;
+    r131 = r148 + r107;
+    r142 = r14 * r29;
+    r142 = r142 * r140;
+    r128 = r128 + r142;
+    r27 = r40 * r26;
+    r128 = fmaf(r28, r27, r128);
+    r109 = r40 * r33;
+    r128 = fmaf(r87, r109, r128);
+    r128 = fmaf(r11, r128, r13 * r131);
+    r131 = r14 * r33;
+    r131 = fmaf(r14, r130, r140 * r131);
+    r131 = r131 + r102;
+    r128 = fmaf(r12, r131, r128);
+    r93 = r93 * r128;
+    r131 = r14 * r8;
+    r109 = r14 * r26;
+    r109 = r109 * r140;
+    r98 = r98 + r109;
+    r27 = r29 * r40;
+    r98 = fmaf(r28, r27, r98);
+    r98 = r98 + r88;
+    r86 = r29 * r86;
+    r86 = r86 * r96;
+    r107 = r86 + r107;
+    r107 = fmaf(r11, r107, r12 * r98);
+    r98 = r14 * r33;
+    r98 = fmaf(r87, r98, r142);
+    r98 = r98 + r129;
+    r107 = fmaf(r13, r98, r107);
+    r131 = r131 * r107;
+    r131 = fmaf(r36, r131, r95 * r93);
+    r93 = r9 * r9;
+    r93 = r93 * r128;
+    r131 = fmaf(r95, r93, r131);
+    r98 = r14 * r9;
+    r109 = r91 + r109;
+    r109 = r109 + r110;
+    r110 = r40 * r33;
+    r130 = fmaf(r40, r130, r140 * r110);
+    r130 = r130 + r102;
+    r130 = fmaf(r13, r130, r11 * r109);
+    r148 = r86 + r148;
+    r130 = fmaf(r12, r148, r130);
+    r98 = r98 * r130;
+    r131 = fmaf(r36, r98, r131);
+    r98 = r131 * r92;
+    r93 = r130 * r72;
+    r93 = fmaf(r103, r93, r112 * r98);
+    r98 = r9 * r9;
+    r98 = r98 * r128;
+    r93 = fmaf(r117, r98, r93);
+    r148 = r25 * r131;
+    r93 = fmaf(r113, r148, r93);
+    r148 = r8 * r8;
+    r148 = r148 * r128;
+    r98 = r8 * r8;
+    r98 = r98 * r131;
+    r98 = r98 * r94;
+    r98 = r98 * r34;
+    r98 = fmaf(r61, r98, r117 * r148);
+    r148 = r25 * r131;
+    r98 = fmaf(r119, r148, r98);
+    r98 = fmaf(r107, r73, r98);
+    r148 = r93 + r98;
+    r12 = r8 * r8;
+    r12 = r12 * r48;
+    r12 = r12 * r48;
+    r12 = r12 * r126;
+    r12 = r12 * r128;
+    r12 = r12 * r39;
+    r86 = r8 * r8;
+    r86 = r86 * r62;
+    r86 = r86 * r131;
+    r86 = r86 * r94;
+    r86 = r86 * r34;
+    r86 = fmaf(r61, r86, r106 * r12);
+    r12 = r127 * r131;
+    r86 = fmaf(r119, r12, r86);
+    r13 = r122 * r107;
+    r13 = r13 * r61;
+    r86 = fmaf(r64, r13, r86);
+    r86 = r86 + r93;
+    r86 = fmaf(r7, r86, r67 * r148);
+    r93 = r6 * r130;
+    r86 = fmaf(r73, r93, r86);
+    r13 = r48 * r107;
+    r86 = fmaf(r81, r13, r86);
+    r12 = r8 * r89;
+    r12 = r12 * r131;
+    r12 = r12 * r94;
+    r12 = r12 * r34;
+    r86 = fmaf(r80, r12, r86);
+    r109 = r5 * r14;
+    r109 = r109 * r51;
+    r109 = fmaf(r148, r109, r4 * r148);
+    r109 = fmaf(r148, r65, r109);
+    r109 = fmaf(r148, r66, r109);
+    r11 = r109 * r80;
+    r86 = fmaf(r64, r11, r86);
+    r102 = r25 * r8;
+    r102 = r102 * r128;
+    r102 = r102 * r79;
+    r86 = fmaf(r55, r102, r86);
+    r110 = r6 * r8;
+    r110 = r110 * r131;
+    r110 = r110 * r72;
+    r86 = fmaf(r92, r110, r86);
+    r140 = r8 * r48;
+    r140 = r140 * r75;
+    r140 = r140 * r85;
+    r140 = r140 * r131;
+    r140 = r140 * r39;
+    r140 = r140 * r78;
+    r86 = fmaf(r34, r140, r86);
+    r91 = r25 * r8;
+    r91 = r91 * r75;
+    r91 = r91 * r128;
+    r91 = r91 * r79;
+    r86 = fmaf(r55, r91, r86);
+    r129 = r8 * r48;
+    r129 = r129 * r85;
+    r129 = r129 * r131;
+    r129 = r129 * r39;
+    r129 = r129 * r78;
+    r86 = fmaf(r34, r129, r86);
+    r142 = r6 * r40;
+    r142 = r142 * r131;
+    r142 = r142 * r64;
+    r142 = r142 * r104;
+    r86 = fmaf(r115, r142, r86);
+    r87 = r6 * r107;
+    r87 = r87 * r72;
+    r86 = fmaf(r103, r87, r86);
+    r88 = r48 * r107;
+    r86 = fmaf(r80, r88, r86);
+    r86 = fmaf(r128, r136, r86);
+    r86 = fmaf(r131, r111, r86);
+    r88 = r0 * r86;
+    r87 = r62 * r131;
+    r87 = r87 * r92;
+    r142 = r9 * r48;
+    r142 = r142 * r122;
+    r142 = r142 * r130;
+    r142 = fmaf(r61, r142, r112 * r87);
+    r87 = r9 * r9;
+    r87 = r87 * r48;
+    r87 = r87 * r48;
+    r87 = r87 * r126;
+    r87 = r87 * r128;
+    r87 = r87 * r39;
+    r142 = fmaf(r106, r87, r142);
+    r142 = fmaf(r131, r139, r142);
+    r142 = r142 + r98;
+    r142 = fmaf(r6, r142, r68 * r148);
+    r148 = r9 * r48;
+    r148 = r148 * r109;
+    r142 = fmaf(r80, r148, r142);
+    r98 = r48 * r130;
+    r142 = fmaf(r81, r98, r142);
+    r87 = r7 * r8;
+    r87 = r87 * r131;
+    r87 = r87 * r72;
+    r142 = fmaf(r92, r87, r142);
+    r129 = r7 * r8;
+    r129 = r129 * r9;
+    r129 = r129 * r48;
+    r129 = r129 * r48;
+    r129 = r129 * r96;
+    r129 = r129 * r128;
+    r129 = r129 * r39;
+    r142 = fmaf(r106, r129, r142);
+    r91 = r25 * r9;
+    r91 = r91 * r75;
+    r91 = r91 * r128;
+    r91 = r91 * r79;
+    r142 = fmaf(r55, r91, r142);
+    r140 = r131 * r81;
+    r142 = fmaf(r125, r140, r142);
+    r110 = r25 * r9;
+    r110 = r110 * r128;
+    r110 = r110 * r79;
+    r142 = fmaf(r55, r110, r142);
+    r128 = r7 * r40;
+    r128 = r128 * r131;
+    r128 = r128 * r64;
+    r128 = r128 * r104;
+    r142 = fmaf(r115, r128, r142);
+    r102 = r7 * r107;
+    r102 = r102 * r72;
+    r142 = fmaf(r103, r102, r142);
+    r11 = r48 * r130;
+    r142 = fmaf(r80, r11, r142);
+    r142 = fmaf(r130, r84, r142);
+    r142 = fmaf(r131, r100, r142);
+    r142 = fmaf(r131, r135, r142);
+    r142 = fmaf(r131, r116, r142);
+    r11 = r1 * r142;
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r102 = r102 * r48;
+    r102 = r102 * r48;
+    r102 = r102 * r126;
+    r102 = r102 * r39;
+    r128 = r58 * r122;
+    r128 = r128 * r61;
+    r128 = fmaf(r64, r128, r106 * r102);
+    r102 = r24 * r9;
+    r102 = r102 * r9;
+    r110 = r14 * r38;
+    r110 = r110 * r9;
+    r110 = fmaf(r36, r110, r95 * r102);
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r110 = fmaf(r95, r102, r110);
+    r140 = r14 * r58;
+    r140 = r140 * r8;
+    r110 = fmaf(r36, r140, r110);
+    r140 = r127 * r110;
+    r128 = fmaf(r119, r140, r128);
+    r102 = r8 * r8;
+    r102 = r102 * r62;
+    r102 = r102 * r110;
+    r102 = r102 * r94;
+    r102 = r102 * r34;
+    r128 = fmaf(r61, r102, r128);
+    r91 = r24 * r9;
+    r91 = r91 * r9;
+    r129 = r38 * r72;
+    r129 = fmaf(r103, r129, r117 * r91);
+    r91 = r25 * r110;
+    r129 = fmaf(r113, r91, r129);
+    r87 = r110 * r92;
+    r129 = fmaf(r112, r87, r129);
+    r128 = r128 + r129;
+    r102 = r24 * r8;
+    r102 = r102 * r8;
+    r102 = fmaf(r58, r73, r117 * r102);
+    r140 = r25 * r110;
+    r102 = fmaf(r119, r140, r102);
+    r87 = r8 * r8;
+    r87 = r87 * r110;
+    r87 = r87 * r94;
+    r87 = r87 * r34;
+    r102 = fmaf(r61, r87, r102);
+    r129 = r129 + r102;
+    r128 = fmaf(r67, r129, r7 * r128);
+    r87 = r25 * r24;
+    r87 = r87 * r8;
+    r87 = r87 * r79;
+    r128 = fmaf(r55, r87, r128);
+    r140 = r8 * r48;
+    r140 = r140 * r75;
+    r140 = r140 * r85;
+    r140 = r140 * r110;
+    r140 = r140 * r39;
+    r140 = r140 * r78;
+    r128 = fmaf(r34, r140, r128);
+    r91 = r25 * r24;
+    r91 = r91 * r8;
+    r91 = r91 * r75;
+    r91 = r91 * r79;
+    r128 = fmaf(r55, r91, r128);
+    r98 = r58 * r48;
+    r128 = fmaf(r80, r98, r128);
+    r148 = r6 * r8;
+    r148 = r148 * r110;
+    r148 = r148 * r72;
+    r128 = fmaf(r92, r148, r128);
+    r12 = r6 * r58;
+    r12 = r12 * r72;
+    r128 = fmaf(r103, r12, r128);
+    r13 = r58 * r48;
+    r128 = fmaf(r81, r13, r128);
+    r93 = r8 * r48;
+    r93 = r93 * r85;
+    r93 = r93 * r110;
+    r93 = r93 * r39;
+    r93 = r93 * r78;
+    r128 = fmaf(r34, r93, r128);
+    r27 = r8 * r89;
+    r27 = r27 * r110;
+    r27 = r27 * r94;
+    r27 = r27 * r34;
+    r128 = fmaf(r80, r27, r128);
+    r28 = r5 * r14;
+    r28 = r28 * r51;
+    r28 = fmaf(r4, r129, r129 * r28);
+    r28 = fmaf(r129, r66, r28);
+    r28 = fmaf(r129, r65, r28);
+    r134 = r28 * r80;
+    r128 = fmaf(r64, r134, r128);
+    r144 = r6 * r38;
+    r128 = fmaf(r73, r144, r128);
+    r146 = r6 * r40;
+    r146 = r146 * r110;
+    r146 = r146 * r64;
+    r146 = r146 * r104;
+    r128 = fmaf(r115, r146, r128);
+    r128 = fmaf(r110, r111, r128);
+    r128 = fmaf(r24, r136, r128);
+    r146 = r0 * r128;
+    r144 = r24 * r9;
+    r144 = r144 * r9;
+    r144 = r144 * r48;
+    r144 = r144 * r48;
+    r144 = r144 * r126;
+    r144 = r144 * r39;
+    r134 = r38 * r9;
+    r134 = r134 * r48;
+    r134 = r134 * r122;
+    r134 = fmaf(r61, r134, r106 * r144);
+    r144 = r62 * r110;
+    r144 = r144 * r92;
+    r134 = fmaf(r112, r144, r134);
+    r134 = fmaf(r110, r139, r134);
+    r134 = r134 + r102;
+    r129 = fmaf(r68, r129, r6 * r134);
+    r134 = r9 * r48;
+    r134 = r134 * r28;
+    r129 = fmaf(r80, r134, r129);
+    r102 = r25 * r24;
+    r102 = r102 * r9;
+    r102 = r102 * r79;
+    r129 = fmaf(r55, r102, r129);
+    r144 = r110 * r81;
+    r129 = fmaf(r125, r144, r129);
+    r27 = r7 * r8;
+    r27 = r27 * r110;
+    r27 = r27 * r72;
+    r129 = fmaf(r92, r27, r129);
+    r93 = r38 * r48;
+    r129 = fmaf(r80, r93, r129);
+    r13 = r25 * r24;
+    r13 = r13 * r9;
+    r13 = r13 * r75;
+    r13 = r13 * r79;
+    r129 = fmaf(r55, r13, r129);
+    r12 = r7 * r58;
+    r12 = r12 * r72;
+    r129 = fmaf(r103, r12, r129);
+    r148 = r38 * r48;
+    r129 = fmaf(r81, r148, r129);
+    r98 = r7 * r24;
+    r98 = r98 * r8;
+    r98 = r98 * r9;
+    r98 = r98 * r48;
+    r98 = r98 * r48;
+    r98 = r98 * r96;
+    r98 = r98 * r39;
+    r129 = fmaf(r106, r98, r129);
+    r91 = r7 * r40;
+    r91 = r91 * r110;
+    r91 = r91 * r64;
+    r91 = r91 * r104;
+    r129 = fmaf(r115, r91, r129);
+    r129 = fmaf(r110, r100, r129);
+    r129 = fmaf(r110, r135, r129);
+    r129 = fmaf(r110, r116, r129);
+    r129 = fmaf(r38, r84, r129);
+    r91 = r1 * r129;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r88,
+                                          r11,
+                                          r146,
+                                          r91);
+    r91 = r37 * r9;
+    r91 = r91 * r9;
+    r146 = r14 * r43;
+    r146 = r146 * r9;
+    r146 = fmaf(r36, r146, r95 * r91);
+    r91 = r37 * r8;
+    r91 = r91 * r8;
+    r146 = fmaf(r95, r91, r146);
+    r11 = r14 * r57;
+    r11 = r11 * r8;
+    r146 = fmaf(r36, r11, r146);
+    r11 = r146 * r92;
+    r91 = r37 * r117;
+    r137 = fmaf(r91, r137, r112 * r11);
+    r11 = r43 * r72;
+    r137 = fmaf(r103, r11, r137);
+    r88 = r25 * r146;
+    r137 = fmaf(r113, r88, r137);
+    r88 = r8 * r8;
+    r88 = r88 * r146;
+    r88 = r88 * r94;
+    r88 = r88 * r34;
+    r123 = fmaf(r91, r123, r61 * r88);
+    r91 = r25 * r146;
+    r123 = fmaf(r119, r91, r123);
+    r123 = fmaf(r57, r73, r123);
+    r91 = r137 + r123;
+    r88 = r8 * r8;
+    r88 = r88 * r62;
+    r88 = r88 * r146;
+    r88 = r88 * r94;
+    r88 = r88 * r34;
+    r11 = r37 * r8;
+    r11 = r11 * r8;
+    r11 = r11 * r48;
+    r11 = r11 * r48;
+    r11 = r11 * r126;
+    r11 = r11 * r39;
+    r11 = fmaf(r106, r11, r61 * r88);
+    r88 = r57 * r122;
+    r88 = r88 * r61;
+    r11 = fmaf(r64, r88, r11);
+    r98 = r127 * r146;
+    r11 = fmaf(r119, r98, r11);
+    r11 = r11 + r137;
+    r11 = fmaf(r7, r11, r67 * r91);
+    r137 = r6 * r57;
+    r137 = r137 * r72;
+    r11 = fmaf(r103, r137, r11);
+    r98 = r57 * r48;
+    r11 = fmaf(r81, r98, r11);
+    r88 = r25 * r37;
+    r88 = r88 * r8;
+    r88 = r88 * r75;
+    r88 = r88 * r79;
+    r11 = fmaf(r55, r88, r11);
+    r148 = r8 * r48;
+    r148 = r148 * r85;
+    r148 = r148 * r146;
+    r148 = r148 * r39;
+    r148 = r148 * r78;
+    r11 = fmaf(r34, r148, r11);
+    r12 = r5 * r14;
+    r12 = r12 * r51;
+    r12 = fmaf(r4, r91, r91 * r12);
+    r12 = fmaf(r91, r66, r12);
+    r12 = fmaf(r91, r65, r12);
+    r13 = r12 * r80;
+    r11 = fmaf(r64, r13, r11);
+    r93 = r6 * r40;
+    r93 = r93 * r146;
+    r93 = r93 * r64;
+    r93 = r93 * r104;
+    r11 = fmaf(r115, r93, r11);
+    r27 = r57 * r48;
+    r11 = fmaf(r80, r27, r11);
+    r144 = r8 * r89;
+    r144 = r144 * r146;
+    r144 = r144 * r94;
+    r144 = r144 * r34;
+    r11 = fmaf(r80, r144, r11);
+    r102 = r6 * r43;
+    r11 = fmaf(r73, r102, r11);
+    r134 = r6 * r8;
+    r134 = r134 * r146;
+    r134 = r134 * r72;
+    r11 = fmaf(r92, r134, r11);
+    r140 = r25 * r37;
+    r140 = r140 * r8;
+    r140 = r140 * r79;
+    r11 = fmaf(r55, r140, r11);
+    r87 = r8 * r48;
+    r87 = r87 * r75;
+    r87 = r87 * r85;
+    r87 = r87 * r146;
+    r87 = r87 * r39;
+    r87 = r87 * r78;
+    r11 = fmaf(r34, r87, r11);
+    r11 = fmaf(r146, r111, r11);
+    r11 = fmaf(r37, r136, r11);
+    r87 = r0 * r11;
+    r140 = r62 * r146;
+    r140 = r140 * r92;
+    r134 = r37 * r9;
+    r134 = r134 * r9;
+    r134 = r134 * r48;
+    r134 = r134 * r48;
+    r134 = r134 * r126;
+    r134 = r134 * r39;
+    r134 = fmaf(r106, r134, r112 * r140);
+    r140 = r43 * r9;
+    r140 = r140 * r48;
+    r140 = r140 * r122;
+    r134 = fmaf(r61, r140, r134);
+    r134 = fmaf(r146, r139, r134);
+    r134 = r134 + r123;
+    r134 = fmaf(r6, r134, r68 * r91);
+    r91 = r25 * r37;
+    r91 = r91 * r9;
+    r91 = r91 * r79;
+    r134 = fmaf(r55, r91, r134);
+    r123 = r7 * r57;
+    r123 = r123 * r72;
+    r134 = fmaf(r103, r123, r134);
+    r140 = r146 * r81;
+    r134 = fmaf(r125, r140, r134);
+    r102 = r7 * r40;
+    r102 = r102 * r146;
+    r102 = r102 * r64;
+    r102 = r102 * r104;
+    r134 = fmaf(r115, r102, r134);
+    r144 = r9 * r48;
+    r144 = r144 * r12;
+    r134 = fmaf(r80, r144, r134);
+    r27 = r7 * r8;
+    r27 = r27 * r146;
+    r27 = r27 * r72;
+    r134 = fmaf(r92, r27, r134);
+    r93 = r43 * r48;
+    r134 = fmaf(r80, r93, r134);
+    r13 = r25 * r37;
+    r13 = r13 * r9;
+    r13 = r13 * r75;
+    r13 = r13 * r79;
+    r134 = fmaf(r55, r13, r134);
+    r148 = r43 * r48;
+    r134 = fmaf(r81, r148, r134);
+    r88 = r7 * r37;
+    r88 = r88 * r8;
+    r88 = r88 * r9;
+    r88 = r88 * r48;
+    r88 = r88 * r48;
+    r88 = r88 * r96;
+    r88 = r88 * r39;
+    r134 = fmaf(r106, r88, r134);
+    r134 = fmaf(r146, r135, r134);
+    r134 = fmaf(r146, r116, r134);
+    r134 = fmaf(r43, r84, r134);
+    r134 = fmaf(r146, r100, r134);
+    r88 = r1 * r134;
+    r148 = r42 * r8;
+    r148 = r148 * r8;
+    r148 = r148 * r48;
+    r148 = r148 * r48;
+    r148 = r148 * r126;
+    r148 = r148 * r39;
+    r13 = r14 * r45;
+    r13 = r13 * r9;
+    r93 = r42 * r9;
+    r93 = r93 * r9;
+    r93 = fmaf(r95, r93, r36 * r13);
+    r13 = r14 * r56;
+    r13 = r13 * r8;
+    r93 = fmaf(r36, r13, r93);
+    r27 = r42 * r8;
+    r27 = r27 * r8;
+    r93 = fmaf(r95, r27, r93);
+    r27 = r127 * r93;
+    r27 = fmaf(r119, r27, r106 * r148);
+    r148 = r56 * r122;
+    r148 = r148 * r61;
+    r27 = fmaf(r64, r148, r27);
+    r13 = r8 * r8;
+    r13 = r13 * r62;
+    r13 = r13 * r93;
+    r13 = r13 * r94;
+    r13 = r13 * r34;
+    r27 = fmaf(r61, r13, r27);
+    r144 = r93 * r92;
+    r102 = r45 * r72;
+    r102 = fmaf(r103, r102, r112 * r144);
+    r144 = r25 * r93;
+    r102 = fmaf(r113, r144, r102);
+    r140 = r42 * r9;
+    r140 = r140 * r9;
+    r102 = fmaf(r117, r140, r102);
+    r27 = r27 + r102;
+    r13 = r42 * r8;
+    r13 = r13 * r8;
+    r148 = r25 * r93;
+    r148 = fmaf(r119, r148, r117 * r13);
+    r13 = r8 * r8;
+    r13 = r13 * r93;
+    r13 = r13 * r94;
+    r13 = r13 * r34;
+    r148 = fmaf(r61, r13, r148);
+    r148 = fmaf(r56, r73, r148);
+    r102 = r102 + r148;
+    r27 = fmaf(r67, r102, r7 * r27);
+    r13 = r8 * r48;
+    r13 = r13 * r75;
+    r13 = r13 * r85;
+    r13 = r13 * r93;
+    r13 = r13 * r39;
+    r13 = r13 * r78;
+    r27 = fmaf(r34, r13, r27);
+    r140 = r6 * r45;
+    r27 = fmaf(r73, r140, r27);
+    r144 = r5 * r14;
+    r144 = r144 * r51;
+    r144 = fmaf(r102, r144, r4 * r102);
+    r144 = fmaf(r102, r66, r144);
+    r144 = fmaf(r102, r65, r144);
+    r123 = r144 * r80;
+    r27 = fmaf(r64, r123, r27);
+    r91 = r56 * r48;
+    r27 = fmaf(r80, r91, r27);
+    r98 = r25 * r42;
+    r98 = r98 * r8;
+    r98 = r98 * r79;
+    r27 = fmaf(r55, r98, r27);
+    r137 = r6 * r8;
+    r137 = r137 * r93;
+    r137 = r137 * r72;
+    r27 = fmaf(r92, r137, r27);
+    r145 = r8 * r48;
+    r145 = r145 * r85;
+    r145 = r145 * r93;
+    r145 = r145 * r39;
+    r145 = r145 * r78;
+    r27 = fmaf(r34, r145, r27);
+    r120 = r6 * r40;
+    r120 = r120 * r93;
+    r120 = r120 * r64;
+    r120 = r120 * r104;
+    r27 = fmaf(r115, r120, r27);
+    r108 = r25 * r42;
+    r108 = r108 * r8;
+    r108 = r108 * r75;
+    r108 = r108 * r79;
+    r27 = fmaf(r55, r108, r27);
+    r141 = r6 * r56;
+    r141 = r141 * r72;
+    r27 = fmaf(r103, r141, r27);
+    r30 = r56 * r48;
+    r27 = fmaf(r81, r30, r27);
+    r101 = r8 * r89;
+    r101 = r101 * r93;
+    r101 = r101 * r94;
+    r101 = r101 * r34;
+    r27 = fmaf(r80, r101, r27);
+    r27 = fmaf(r42, r136, r27);
+    r27 = fmaf(r93, r111, r27);
+    r101 = r0 * r27;
+    r30 = r62 * r93;
+    r30 = r30 * r92;
+    r141 = r45 * r9;
+    r141 = r141 * r48;
+    r141 = r141 * r122;
+    r141 = fmaf(r61, r141, r112 * r30);
+    r30 = r42 * r9;
+    r30 = r30 * r9;
+    r30 = r30 * r48;
+    r30 = r30 * r48;
+    r30 = r30 * r126;
+    r30 = r30 * r39;
+    r141 = fmaf(r106, r30, r141);
+    r141 = fmaf(r93, r139, r141);
+    r141 = r141 + r148;
+    r102 = fmaf(r68, r102, r6 * r141);
+    r141 = r7 * r42;
+    r141 = r141 * r8;
+    r141 = r141 * r9;
+    r141 = r141 * r48;
+    r141 = r141 * r48;
+    r141 = r141 * r96;
+    r141 = r141 * r39;
+    r102 = fmaf(r106, r141, r102);
+    r148 = r93 * r81;
+    r102 = fmaf(r125, r148, r102);
+    r30 = r7 * r8;
+    r30 = r30 * r93;
+    r30 = r30 * r72;
+    r102 = fmaf(r92, r30, r102);
+    r108 = r45 * r48;
+    r102 = fmaf(r81, r108, r102);
+    r120 = r7 * r40;
+    r120 = r120 * r93;
+    r120 = r120 * r64;
+    r120 = r120 * r104;
+    r102 = fmaf(r115, r120, r102);
+    r145 = r25 * r42;
+    r145 = r145 * r9;
+    r145 = r145 * r75;
+    r145 = r145 * r79;
+    r102 = fmaf(r55, r145, r102);
+    r137 = r9 * r48;
+    r137 = r137 * r144;
+    r102 = fmaf(r80, r137, r102);
+    r98 = r45 * r48;
+    r102 = fmaf(r80, r98, r102);
+    r91 = r25 * r42;
+    r91 = r91 * r9;
+    r91 = r91 * r79;
+    r102 = fmaf(r55, r91, r102);
+    r123 = r7 * r56;
+    r123 = r123 * r72;
+    r102 = fmaf(r103, r123, r102);
+    r102 = fmaf(r45, r84, r102);
+    r102 = fmaf(r93, r135, r102);
+    r102 = fmaf(r93, r116, r102);
+    r102 = fmaf(r93, r100, r102);
+    r123 = r1 * r102;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r87,
+                                          r88,
+                                          r101,
+                                          r123);
+    r123 = r0 * r25;
+    r123 = r123 * r2;
+    r101 = r25 * r3;
+    r88 = r1 * r101;
+    r123 = fmaf(r138, r88, r124 * r123);
+    r87 = r0 * r25;
+    r87 = r87 * r2;
+    r87 = fmaf(r147, r88, r31 * r87);
+    r91 = r0 * r25;
+    r91 = r91 * r2;
+    r91 = fmaf(r142, r88, r86 * r91);
+    r98 = r0 * r25;
+    r98 = r98 * r2;
+    r98 = fmaf(r129, r88, r128 * r98);
+    WriteSum4<float, float>((float*)inout_shared, r123, r87, r91, r98);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r98 = r0 * r25;
+    r98 = r98 * r2;
+    r98 = fmaf(r134, r88, r11 * r98);
+    r91 = r0 * r25;
+    r91 = r91 * r2;
+    r91 = fmaf(r102, r88, r27 * r91);
+    WriteSum2<float, float>((float*)inout_shared, r98, r91);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r1 * r1;
+    r98 = r138 * r138;
+    r87 = r124 * r124;
+    r123 = r0 * r0;
+    r87 = fmaf(r123, r87, r91 * r98);
+    r98 = r31 * r31;
+    r137 = r147 * r147;
+    r137 = fmaf(r91, r137, r123 * r98);
+    r98 = r86 * r86;
+    r145 = r142 * r142;
+    r145 = fmaf(r91, r145, r123 * r98);
+    r98 = r129 * r129;
+    r120 = r128 * r128;
+    r120 = fmaf(r123, r120, r91 * r98);
+    WriteSum4<float, float>((float*)inout_shared, r87, r137, r145, r120);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r120 = r134 * r134;
+    r145 = r11 * r11;
+    r145 = fmaf(r123, r145, r91 * r120);
+    r120 = r102 * r102;
+    r137 = r27 * r27;
+    r137 = fmaf(r123, r137, r91 * r120);
+    WriteSum2<float, float>((float*)inout_shared, r145, r137);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r137 = r124 * r31;
+    r145 = r138 * r147;
+    r145 = fmaf(r91, r145, r123 * r137);
+    r137 = r124 * r86;
+    r120 = r138 * r142;
+    r120 = fmaf(r91, r120, r123 * r137);
+    r137 = r138 * r129;
+    r87 = r124 * r128;
+    r87 = fmaf(r123, r87, r91 * r137);
+    r137 = r124 * r11;
+    r98 = r138 * r134;
+    r98 = fmaf(r91, r98, r123 * r137);
+    WriteSum4<float, float>((float*)inout_shared, r145, r120, r87, r98);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r98 = r124 * r27;
+    r87 = r138 * r102;
+    r87 = fmaf(r91, r87, r123 * r98);
+    r98 = r147 * r142;
+    r120 = r31 * r86;
+    r120 = fmaf(r123, r120, r91 * r98);
+    r98 = r147 * r129;
+    r145 = r31 * r128;
+    r145 = fmaf(r123, r145, r91 * r98);
+    r98 = r147 * r134;
+    r137 = r31 * r11;
+    r137 = fmaf(r123, r137, r91 * r98);
+    WriteSum4<float, float>((float*)inout_shared, r87, r120, r145, r137);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r137 = r147 * r102;
+    r145 = r31 * r27;
+    r145 = fmaf(r123, r145, r91 * r137);
+    r137 = r142 * r129;
+    r120 = r86 * r128;
+    r120 = fmaf(r123, r120, r91 * r137);
+    r137 = r142 * r134;
+    r87 = r86 * r11;
+    r87 = fmaf(r123, r87, r91 * r137);
+    r137 = r86 * r27;
+    r98 = r142 * r102;
+    r98 = fmaf(r91, r98, r123 * r137);
+    WriteSum4<float, float>((float*)inout_shared, r145, r120, r87, r98);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r98 = r128 * r11;
+    r87 = r129 * r134;
+    r87 = fmaf(r91, r87, r123 * r98);
+    r98 = r128 * r27;
+    r120 = r129 * r102;
+    r120 = fmaf(r91, r120, r123 * r98);
+    r98 = r134 * r102;
+    r145 = r11 * r27;
+    r145 = fmaf(r123, r145, r91 * r98);
+    WriteSum3<float, float>((float*)inout_shared, r87, r120, r145);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r145 = r0 * r51;
+    r145 = r145 * r80;
+    r145 = r145 * r64;
+    r120 = r1 * r9;
+    r120 = r120 * r48;
+    r120 = r120 * r51;
+    r120 = r120 * r80;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          0 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r70,
+                                          r69,
+                                          r145,
+                                          r120);
+    r87 = r1 * r82;
+    r98 = r0 * r80;
+    r98 = r98 * r64;
+    r98 = r98 * r74;
+    r137 = r1 * r80;
+    r137 = r137 * r74;
+    r137 = r137 * r103;
+    r108 = r0 * r9;
+    r108 = r108 * r73;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          4 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r98,
+                                          r137,
+                                          r108,
+                                          r87);
+    r30 = r0 * r63;
+    r148 = r1 * r9;
+    r148 = r148 * r73;
+    r141 = r0 * r80;
+    r141 = r141 * r64;
+    r141 = r141 * r77;
+    r140 = r1 * r80;
+    r140 = r140 * r103;
+    r140 = r140 * r77;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          8 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r30,
+                                          r148,
+                                          r141,
+                                          r140);
+    r13 = r0 * r51;
+    r149 = r1 * r51;
+    r150 = r0 * r80;
+    r150 = r150 * r64;
+    r150 = r150 * r76;
+    r151 = r1 * r80;
+    r151 = r151 * r103;
+    r151 = r151 * r76;
+    WriteIdx4<1024, float, float, float4>(out_calib_jac,
+                                          12 * out_calib_jac_num_alloc,
+                                          global_thread_idx,
+                                          r150,
+                                          r151,
+                                          r13,
+                                          r149);
+    r152 = r25 * r70;
+    r152 = r152 * r2;
+    r153 = r25 * r2;
+    r154 = r69 * r101;
+    WriteSum4<float, float>((float*)inout_shared, r152, r154, r153, r101);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           0 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r9 * r48;
+    r101 = r101 * r51;
+    r101 = r101 * r80;
+    r153 = r0 * r25;
+    r153 = r153 * r51;
+    r153 = r153 * r2;
+    r153 = r153 * r80;
+    r153 = fmaf(r64, r153, r88 * r101);
+    r101 = r80 * r74;
+    r101 = r101 * r103;
+    r154 = r0 * r25;
+    r154 = r154 * r2;
+    r154 = r154 * r80;
+    r154 = r154 * r64;
+    r154 = fmaf(r74, r154, r88 * r101);
+    r101 = r0 * r40;
+    r101 = r101 * r9;
+    r101 = r101 * r2;
+    r101 = r101 * r61;
+    r101 = fmaf(r64, r101, r82 * r88);
+    r152 = r0 * r25;
+    r152 = r152 * r63;
+    r155 = r1 * r40;
+    r155 = r155 * r9;
+    r155 = r155 * r3;
+    r155 = r155 * r61;
+    r155 = fmaf(r64, r155, r2 * r152);
+    WriteSum4<float, float>((float*)inout_shared, r153, r154, r101, r155);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           4 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r0 * r25;
+    r155 = r155 * r51;
+    r155 = r155 * r2;
+    r101 = r51 * r88;
+    r154 = r80 * r103;
+    r154 = r154 * r77;
+    r153 = r0 * r25;
+    r153 = r153 * r2;
+    r153 = r153 * r80;
+    r153 = r153 * r64;
+    r153 = fmaf(r77, r153, r88 * r154);
+    r154 = r80 * r103;
+    r154 = r154 * r76;
+    r152 = r0 * r25;
+    r152 = r152 * r2;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    r152 = fmaf(r76, r152, r88 * r154);
+    WriteSum4<float, float>((float*)inout_shared, r153, r152, r155, r101);
+  };
+  FlushSumShared<4, float>(out_calib_njtr,
+                           8 * out_calib_njtr_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r70 * r70;
+    r155 = r69 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r101, r155, r41, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           0 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = r8 * r61;
+    r41 = r41 * r64;
+    r41 = r41 * r74;
+    r155 = r74 * r103;
+    r155 = r155 * r91;
+    r155 = fmaf(r112, r155, r123 * r41);
+    r41 = r8 * r61;
+    r41 = r41 * r64;
+    r41 = r41 * r123;
+    r101 = r103 * r91;
+    r101 = r101 * r76;
+    r101 = fmaf(r112, r101, r76 * r41);
+    r41 = r82 * r82;
+    r152 = r8 * r8;
+    r10 = r35 * r10;
+    r10 = 1.0 / r10;
+    r59 = r46 * r59;
+    r59 = 1.0 / r59;
+    r152 = r152 * r9;
+    r152 = r152 * r9;
+    r152 = r152 * r48;
+    r152 = r152 * r48;
+    r152 = r152 * r133;
+    r152 = r152 * r10;
+    r152 = r152 * r59;
+    r152 = r152 * r118;
+    r41 = fmaf(r123, r152, r91 * r41);
+    r59 = r63 * r123;
+    r152 = fmaf(r91, r152, r63 * r59);
+    WriteSum4<float, float>((float*)inout_shared, r155, r101, r41, r152);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           4 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r152 = r74 * r123;
+    r41 = r74 * r91;
+    r155 = r77 * r77;
+    r10 = r8 * r61;
+    r10 = r10 * r64;
+    r10 = r10 * r123;
+    r133 = r103 * r91;
+    r46 = r112 * r133;
+    r35 = fmaf(r155, r46, r155 * r10);
+    r153 = r76 * r76;
+    r153 = fmaf(r46, r153, r10 * r153);
+    WriteSum4<float, float>((float*)inout_shared, r35, r153, r152, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_diag,
+                           8 * out_calib_precond_diag_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = 0.00000000000000000e+00;
+    r152 = r0 * r51;
+    r152 = r152 * r70;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    WriteSum4<float, float>((float*)inout_shared, r41, r70, r41, r152);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           0 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r0 * r63;
+    r63 = r63 * r70;
+    r152 = r0 * r70;
+    r152 = r152 * r80;
+    r152 = r152 * r64;
+    r152 = r152 * r74;
+    r153 = r9 * r73;
+    r153 = r153 * r71;
+    r154 = r0 * r70;
+    r154 = r154 * r80;
+    r154 = r154 * r64;
+    r154 = r154 * r77;
+    WriteSum4<float, float>((float*)inout_shared, r152, r153, r63, r154);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           4 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r0 * r51;
+    r154 = r154 * r70;
+    r70 = r80 * r64;
+    r70 = r70 * r76;
+    r70 = r70 * r71;
+    WriteSum4<float, float>((float*)inout_shared, r70, r154, r41, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           8 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r1 * r82;
+    r154 = r154 * r69;
+    r70 = r1 * r9;
+    r70 = r70 * r48;
+    r70 = r70 * r51;
+    r70 = r70 * r69;
+    r70 = r70 * r80;
+    r71 = r1 * r69;
+    r71 = r71 * r80;
+    r71 = r71 * r74;
+    r71 = r71 * r103;
+    WriteSum4<float, float>((float*)inout_shared, r69, r70, r71, r154);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           12 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r1 * r9;
+    r154 = r154 * r69;
+    r154 = r154 * r73;
+    r71 = r1 * r69;
+    r71 = r71 * r80;
+    r71 = r71 * r103;
+    r71 = r71 * r77;
+    r70 = r1 * r69;
+    r70 = r70 * r80;
+    r70 = r70 * r103;
+    r70 = r70 * r76;
+    WriteSum4<float, float>((float*)inout_shared, r154, r71, r70, r41);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           16 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r70 = r1 * r51;
+    r70 = r70 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r70, r41, r145, r98);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           20 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r108, r30, r141, r150);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           24 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r13, r41, r120, r137);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           28 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum4<float, float>((float*)inout_shared, r87, r148, r140, r151);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           32 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r151 = r8 * r61;
+    r151 = r151 * r64;
+    r151 = r151 * r77;
+    r140 = r103 * r77;
+    r140 = r140 * r91;
+    r140 = fmaf(r112, r140, r123 * r151);
+    r151 = r8 * r48;
+    r148 = r14 * r8;
+    r148 = r148 * r106;
+    r148 = r148 * r114;
+    r148 = r148 * r118;
+    r118 = r9 * r148;
+    r151 = r151 * r51;
+    r151 = r151 * r123;
+    r114 = r9 * r48;
+    r114 = r114 * r51;
+    r114 = r114 * r82;
+    r114 = r114 * r80;
+    r114 = fmaf(r91, r114, r118 * r151);
+    WriteSum4<float, float>((float*)inout_shared, r41, r149, r140, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           36 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r80 * r64;
+    r114 = r114 * r74;
+    r114 = r114 * r123;
+    r140 = r80 * r64;
+    r140 = r140 * r59;
+    r149 = r9 * r48;
+    r149 = r149 * r51;
+    r149 = r149 * r91;
+    r149 = fmaf(r118, r149, r51 * r140);
+    r151 = r51 * r76;
+    r87 = fmaf(r151, r46, r151 * r10);
+    WriteSum4<float, float>((float*)inout_shared, r149, r101, r87, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           40 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r80 * r74;
+    r114 = r114 * r103;
+    r114 = r114 * r91;
+    r101 = r8 * r74;
+    r101 = r101 * r103;
+    r101 = r101 * r123;
+    r149 = r82 * r80;
+    r149 = r149 * r74;
+    r149 = r149 * r103;
+    r149 = fmaf(r91, r149, r148 * r101);
+    r101 = r74 * r133;
+    r101 = fmaf(r118, r101, r74 * r140);
+    WriteSum4<float, float>((float*)inout_shared, r114, r149, r101, r87);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           44 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r87 = r80 * r64;
+    r87 = r87 * r77;
+    r87 = r87 * r123;
+    r101 = r80 * r103;
+    r101 = r101 * r77;
+    r101 = r101 * r91;
+    r149 = r9 * r73;
+    r114 = r9 * r82;
+    r114 = r114 * r91;
+    r114 = fmaf(r73, r114, r59 * r149);
+    WriteSum4<float, float>((float*)inout_shared, r35, r87, r101, r114);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           48 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r9 * r51;
+    r114 = r114 * r123;
+    r114 = r114 * r73;
+    r101 = r51 * r82;
+    r101 = r101 * r91;
+    r87 = r8 * r103;
+    r87 = r87 * r77;
+    r87 = r87 * r123;
+    r35 = r82 * r80;
+    r35 = r35 * r103;
+    r35 = r35 * r77;
+    r35 = fmaf(r91, r35, r148 * r87);
+    r87 = r8 * r103;
+    r87 = r87 * r123;
+    r87 = r87 * r76;
+    r149 = r82 * r80;
+    r149 = r149 * r103;
+    r149 = r149 * r91;
+    r149 = fmaf(r76, r149, r148 * r87);
+    WriteSum4<float, float>((float*)inout_shared, r35, r149, r114, r101);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           52 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r51 * r59;
+    r101 = r9 * r51;
+    r101 = r101 * r91;
+    r101 = r101 * r73;
+    r114 = r77 * r133;
+    r114 = fmaf(r118, r114, r77 * r140);
+    r149 = r76 * r133;
+    r149 = fmaf(r118, r149, r76 * r140);
+    WriteSum4<float, float>((float*)inout_shared, r114, r149, r59, r101);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           56 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r80 * r64;
+    r101 = r101 * r123;
+    r101 = r101 * r76;
+    r59 = r80 * r103;
+    r59 = r59 * r91;
+    r59 = r59 * r76;
+    r149 = r80 * r64;
+    r149 = r149 * r123;
+    r149 = r149 * r151;
+    r155 = r51 * r155;
+    r46 = fmaf(r155, r46, r155 * r10);
+    WriteSum4<float, float>((float*)inout_shared, r46, r101, r59, r149);
+  };
+  FlushSumShared<4, float>(out_calib_precond_tril,
+                           60 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r151 = r80 * r151;
+    r151 = r151 * r133;
+    WriteSum2<float, float>((float*)inout_shared, r151, r41);
+  };
+  FlushSumShared<2, float>(out_calib_precond_tril,
+                           64 * out_calib_precond_tril_num_alloc,
+                           calib_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = r14 * r32;
+    r41 = r41 * r9;
+    r151 = r14 * r53;
+    r151 = r151 * r8;
+    r151 = fmaf(r36, r151, r36 * r41);
+    r41 = r60 * r8;
+    r41 = r41 * r8;
+    r151 = fmaf(r95, r41, r151);
+    r149 = r60 * r9;
+    r149 = r149 * r9;
+    r151 = fmaf(r95, r149, r151);
+    r149 = r25 * r151;
+    r41 = r151 * r92;
+    r41 = fmaf(r112, r41, r113 * r149);
+    r149 = r60 * r9;
+    r149 = r149 * r9;
+    r41 = fmaf(r117, r149, r41);
+    r59 = r32 * r72;
+    r41 = fmaf(r103, r59, r41);
+    r59 = r60 * r8;
+    r59 = r59 * r8;
+    r59 = fmaf(r117, r59, r53 * r73);
+    r149 = r8 * r8;
+    r149 = r149 * r151;
+    r149 = r149 * r94;
+    r149 = r149 * r34;
+    r59 = fmaf(r61, r149, r59);
+    r101 = r25 * r151;
+    r59 = fmaf(r119, r101, r59);
+    r101 = r41 + r59;
+    r149 = r53 * r122;
+    r149 = r149 * r61;
+    r46 = r60 * r8;
+    r46 = r46 * r8;
+    r46 = r46 * r48;
+    r46 = r46 * r48;
+    r46 = r46 * r126;
+    r46 = r46 * r39;
+    r46 = fmaf(r106, r46, r64 * r149);
+    r149 = r8 * r8;
+    r149 = r149 * r62;
+    r149 = r149 * r151;
+    r149 = r149 * r94;
+    r149 = r149 * r34;
+    r46 = fmaf(r61, r149, r46);
+    r155 = r127 * r151;
+    r46 = fmaf(r119, r155, r46);
+    r46 = r46 + r41;
+    r46 = fmaf(r7, r46, r67 * r101);
+    r41 = r8 * r48;
+    r41 = r41 * r75;
+    r41 = r41 * r85;
+    r41 = r41 * r151;
+    r41 = r41 * r39;
+    r41 = r41 * r78;
+    r46 = fmaf(r34, r41, r46);
+    r155 = r6 * r53;
+    r155 = r155 * r72;
+    r46 = fmaf(r103, r155, r46);
+    r149 = r25 * r60;
+    r149 = r149 * r8;
+    r149 = r149 * r79;
+    r46 = fmaf(r55, r149, r46);
+    r10 = r6 * r40;
+    r10 = r10 * r151;
+    r10 = r10 * r64;
+    r10 = r10 * r104;
+    r46 = fmaf(r115, r10, r46);
+    r114 = r6 * r8;
+    r114 = r114 * r151;
+    r114 = r114 * r72;
+    r46 = fmaf(r92, r114, r46);
+    r140 = r8 * r48;
+    r140 = r140 * r85;
+    r140 = r140 * r151;
+    r140 = r140 * r39;
+    r140 = r140 * r78;
+    r46 = fmaf(r34, r140, r46);
+    r118 = r53 * r48;
+    r46 = fmaf(r81, r118, r46);
+    r35 = r53 * r48;
+    r46 = fmaf(r80, r35, r46);
+    r87 = r6 * r32;
+    r46 = fmaf(r73, r87, r46);
+    r148 = r25 * r60;
+    r148 = r148 * r8;
+    r148 = r148 * r75;
+    r148 = r148 * r79;
+    r46 = fmaf(r55, r148, r46);
+    r137 = r5 * r14;
+    r137 = r137 * r51;
+    r137 = fmaf(r101, r137, r4 * r101);
+    r137 = fmaf(r101, r66, r137);
+    r137 = fmaf(r101, r65, r137);
+    r120 = r137 * r80;
+    r46 = fmaf(r64, r120, r46);
+    r13 = r8 * r89;
+    r13 = r13 * r151;
+    r13 = r13 * r94;
+    r13 = r13 * r34;
+    r46 = fmaf(r80, r13, r46);
+    r46 = fmaf(r151, r111, r46);
+    r46 = fmaf(r60, r136, r46);
+    r13 = r0 * r46;
+    r120 = r62 * r151;
+    r120 = r120 * r92;
+    r120 = fmaf(r112, r120, r151 * r139);
+    r148 = r60 * r9;
+    r148 = r148 * r9;
+    r148 = r148 * r48;
+    r148 = r148 * r48;
+    r148 = r148 * r126;
+    r148 = r148 * r39;
+    r120 = fmaf(r106, r148, r120);
+    r87 = r32 * r9;
+    r87 = r87 * r48;
+    r87 = r87 * r122;
+    r120 = fmaf(r61, r87, r120);
+    r120 = r120 + r59;
+    r120 = fmaf(r6, r120, r68 * r101);
+    r101 = r151 * r81;
+    r120 = fmaf(r125, r101, r120);
+    r59 = r25 * r60;
+    r59 = r59 * r9;
+    r59 = r59 * r75;
+    r59 = r59 * r79;
+    r120 = fmaf(r55, r59, r120);
+    r87 = r7 * r53;
+    r87 = r87 * r72;
+    r120 = fmaf(r103, r87, r120);
+    r148 = r7 * r40;
+    r148 = r148 * r151;
+    r148 = r148 * r64;
+    r148 = r148 * r104;
+    r120 = fmaf(r115, r148, r120);
+    r35 = r7 * r8;
+    r35 = r35 * r151;
+    r35 = r35 * r72;
+    r120 = fmaf(r92, r35, r120);
+    r118 = r32 * r48;
+    r120 = fmaf(r81, r118, r120);
+    r140 = r7 * r60;
+    r140 = r140 * r8;
+    r140 = r140 * r9;
+    r140 = r140 * r48;
+    r140 = r140 * r48;
+    r140 = r140 * r96;
+    r140 = r140 * r39;
+    r120 = fmaf(r106, r140, r120);
+    r114 = r25 * r60;
+    r114 = r114 * r9;
+    r114 = r114 * r79;
+    r120 = fmaf(r55, r114, r120);
+    r10 = r32 * r48;
+    r120 = fmaf(r80, r10, r120);
+    r149 = r9 * r48;
+    r149 = r149 * r137;
+    r120 = fmaf(r80, r149, r120);
+    r120 = fmaf(r151, r100, r120);
+    r120 = fmaf(r151, r135, r120);
+    r120 = fmaf(r32, r84, r120);
+    r120 = fmaf(r151, r116, r120);
+    r149 = r1 * r120;
+    r10 = r8 * r8;
+    r114 = r44 * r9;
+    r114 = r114 * r9;
+    r140 = r14 * r50;
+    r140 = r140 * r8;
+    r140 = fmaf(r36, r140, r95 * r114);
+    r114 = r14 * r49;
+    r114 = r114 * r9;
+    r140 = fmaf(r36, r114, r140);
+    r118 = r44 * r8;
+    r118 = r118 * r8;
+    r140 = fmaf(r95, r118, r140);
+    r10 = r10 * r62;
+    r10 = r10 * r140;
+    r10 = r10 * r94;
+    r10 = r10 * r34;
+    r118 = r44 * r8;
+    r118 = r118 * r8;
+    r118 = r118 * r48;
+    r118 = r118 * r48;
+    r118 = r118 * r126;
+    r118 = r118 * r39;
+    r118 = fmaf(r106, r118, r61 * r10);
+    r10 = r127 * r140;
+    r118 = fmaf(r119, r10, r118);
+    r114 = r50 * r122;
+    r114 = r114 * r61;
+    r118 = fmaf(r64, r114, r118);
+    r35 = r25 * r140;
+    r148 = r49 * r72;
+    r148 = fmaf(r103, r148, r113 * r35);
+    r35 = r140 * r92;
+    r148 = fmaf(r112, r35, r148);
+    r87 = r44 * r9;
+    r87 = r87 * r9;
+    r148 = fmaf(r117, r87, r148);
+    r118 = r118 + r148;
+    r114 = r8 * r8;
+    r114 = r114 * r140;
+    r114 = r114 * r94;
+    r114 = r114 * r34;
+    r10 = r44 * r8;
+    r10 = r10 * r8;
+    r10 = fmaf(r117, r10, r61 * r114);
+    r114 = r25 * r140;
+    r10 = fmaf(r119, r114, r10);
+    r10 = fmaf(r50, r73, r10);
+    r148 = r148 + r10;
+    r118 = fmaf(r67, r148, r7 * r118);
+    r114 = r6 * r49;
+    r118 = fmaf(r73, r114, r118);
+    r87 = r8 * r48;
+    r87 = r87 * r85;
+    r87 = r87 * r140;
+    r87 = r87 * r39;
+    r87 = r87 * r78;
+    r118 = fmaf(r34, r87, r118);
+    r35 = r25 * r44;
+    r35 = r35 * r8;
+    r35 = r35 * r79;
+    r118 = fmaf(r55, r35, r118);
+    r59 = r25 * r44;
+    r59 = r59 * r8;
+    r59 = r59 * r75;
+    r59 = r59 * r79;
+    r118 = fmaf(r55, r59, r118);
+    r101 = r50 * r48;
+    r118 = fmaf(r81, r101, r118);
+    r155 = r6 * r40;
+    r155 = r155 * r140;
+    r155 = r155 * r64;
+    r155 = r155 * r104;
+    r118 = fmaf(r115, r155, r118);
+    r41 = r8 * r89;
+    r41 = r41 * r140;
+    r41 = r41 * r94;
+    r41 = r41 * r34;
+    r118 = fmaf(r80, r41, r118);
+    r150 = r50 * r48;
+    r118 = fmaf(r80, r150, r118);
+    r141 = r8 * r48;
+    r141 = r141 * r75;
+    r141 = r141 * r85;
+    r141 = r141 * r140;
+    r141 = r141 * r39;
+    r141 = r141 * r78;
+    r118 = fmaf(r34, r141, r118);
+    r30 = r5 * r14;
+    r30 = r30 * r51;
+    r30 = fmaf(r4, r148, r148 * r30);
+    r30 = fmaf(r148, r66, r30);
+    r30 = fmaf(r148, r65, r30);
+    r108 = r30 * r80;
+    r118 = fmaf(r64, r108, r118);
+    r98 = r6 * r50;
+    r98 = r98 * r72;
+    r118 = fmaf(r103, r98, r118);
+    r145 = r6 * r8;
+    r145 = r145 * r140;
+    r145 = r145 * r72;
+    r118 = fmaf(r92, r145, r118);
+    r118 = fmaf(r44, r136, r118);
+    r118 = fmaf(r140, r111, r118);
+    r145 = r0 * r118;
+    r98 = r49 * r9;
+    r98 = r98 * r48;
+    r98 = r98 * r122;
+    r98 = fmaf(r61, r98, r140 * r139);
+    r108 = r62 * r140;
+    r108 = r108 * r92;
+    r98 = fmaf(r112, r108, r98);
+    r141 = r44 * r9;
+    r141 = r141 * r9;
+    r141 = r141 * r48;
+    r141 = r141 * r48;
+    r141 = r141 * r126;
+    r141 = r141 * r39;
+    r98 = fmaf(r106, r141, r98);
+    r98 = r98 + r10;
+    r148 = fmaf(r68, r148, r6 * r98);
+    r98 = r49 * r48;
+    r148 = fmaf(r81, r98, r148);
+    r10 = r49 * r48;
+    r148 = fmaf(r80, r10, r148);
+    r141 = r7 * r40;
+    r141 = r141 * r140;
+    r141 = r141 * r64;
+    r141 = r141 * r104;
+    r148 = fmaf(r115, r141, r148);
+    r108 = r7 * r44;
+    r108 = r108 * r8;
+    r108 = r108 * r9;
+    r108 = r108 * r48;
+    r108 = r108 * r48;
+    r108 = r108 * r96;
+    r108 = r108 * r39;
+    r148 = fmaf(r106, r108, r148);
+    r150 = r9 * r48;
+    r150 = r150 * r30;
+    r148 = fmaf(r80, r150, r148);
+    r41 = r140 * r81;
+    r148 = fmaf(r125, r41, r148);
+    r155 = r25 * r44;
+    r155 = r155 * r9;
+    r155 = r155 * r75;
+    r155 = r155 * r79;
+    r148 = fmaf(r55, r155, r148);
+    r101 = r25 * r44;
+    r101 = r101 * r9;
+    r101 = r101 * r79;
+    r148 = fmaf(r55, r101, r148);
+    r59 = r7 * r50;
+    r59 = r59 * r72;
+    r148 = fmaf(r103, r59, r148);
+    r35 = r7 * r8;
+    r35 = r35 * r140;
+    r35 = r35 * r72;
+    r148 = fmaf(r92, r35, r148);
+    r148 = fmaf(r49, r84, r148);
+    r148 = fmaf(r140, r100, r148);
+    r148 = fmaf(r140, r135, r148);
+    r148 = fmaf(r140, r116, r148);
+    r35 = r1 * r148;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r13,
+                                          r149,
+                                          r145,
+                                          r35);
+    r35 = r14 * r47;
+    r35 = r35 * r9;
+    r145 = r52 * r9;
+    r145 = r145 * r9;
+    r145 = fmaf(r95, r145, r36 * r35);
+    r35 = r52 * r8;
+    r35 = r35 * r8;
+    r145 = fmaf(r95, r35, r145);
+    r95 = r14 * r54;
+    r95 = r95 * r8;
+    r145 = fmaf(r36, r95, r145);
+    r95 = r25 * r145;
+    r35 = r47 * r72;
+    r35 = fmaf(r103, r35, r113 * r95);
+    r95 = r145 * r92;
+    r35 = fmaf(r112, r95, r35);
+    r113 = r52 * r9;
+    r113 = r113 * r9;
+    r35 = fmaf(r117, r113, r35);
+    r113 = r8 * r8;
+    r113 = r113 * r145;
+    r113 = r113 * r94;
+    r113 = r113 * r34;
+    r113 = fmaf(r61, r113, r54 * r73);
+    r95 = r52 * r8;
+    r95 = r95 * r8;
+    r113 = fmaf(r117, r95, r113);
+    r117 = r25 * r145;
+    r113 = fmaf(r119, r117, r113);
+    r117 = r35 + r113;
+    r95 = r54 * r122;
+    r95 = r95 * r61;
+    r36 = r8 * r8;
+    r36 = r36 * r62;
+    r36 = r36 * r145;
+    r36 = r36 * r94;
+    r36 = r36 * r34;
+    r36 = fmaf(r61, r36, r64 * r95);
+    r95 = r52 * r8;
+    r95 = r95 * r8;
+    r95 = r95 * r48;
+    r95 = r95 * r48;
+    r95 = r95 * r126;
+    r95 = r95 * r39;
+    r36 = fmaf(r106, r95, r36);
+    r149 = r127 * r145;
+    r36 = fmaf(r119, r149, r36);
+    r36 = r36 + r35;
+    r36 = fmaf(r7, r36, r67 * r117);
+    r67 = r5 * r14;
+    r67 = r67 * r51;
+    r4 = fmaf(r4, r117, r117 * r67);
+    r4 = fmaf(r117, r66, r4);
+    r4 = fmaf(r117, r65, r4);
+    r65 = r4 * r80;
+    r36 = fmaf(r64, r65, r36);
+    r66 = r6 * r40;
+    r66 = r66 * r145;
+    r66 = r66 * r64;
+    r66 = r66 * r104;
+    r36 = fmaf(r115, r66, r36);
+    r67 = r6 * r8;
+    r67 = r67 * r145;
+    r67 = r67 * r72;
+    r36 = fmaf(r92, r67, r36);
+    r51 = r25 * r52;
+    r51 = r51 * r8;
+    r51 = r51 * r79;
+    r36 = fmaf(r55, r51, r36);
+    r35 = r8 * r48;
+    r35 = r35 * r85;
+    r35 = r35 * r145;
+    r35 = r35 * r39;
+    r35 = r35 * r78;
+    r36 = fmaf(r34, r35, r36);
+    r149 = r25 * r52;
+    r149 = r149 * r8;
+    r149 = r149 * r75;
+    r149 = r149 * r79;
+    r36 = fmaf(r55, r149, r36);
+    r95 = r54 * r48;
+    r36 = fmaf(r80, r95, r36);
+    r119 = r8 * r48;
+    r119 = r119 * r75;
+    r119 = r119 * r85;
+    r119 = r119 * r145;
+    r119 = r119 * r39;
+    r119 = r119 * r78;
+    r36 = fmaf(r34, r119, r36);
+    r78 = r6 * r47;
+    r36 = fmaf(r73, r78, r36);
+    r85 = r54 * r48;
+    r36 = fmaf(r81, r85, r36);
+    r13 = r8 * r89;
+    r13 = r13 * r145;
+    r13 = r13 * r94;
+    r13 = r13 * r34;
+    r36 = fmaf(r80, r13, r36);
+    r34 = r6 * r54;
+    r34 = r34 * r72;
+    r36 = fmaf(r103, r34, r36);
+    r36 = fmaf(r52, r136, r36);
+    r36 = fmaf(r145, r111, r36);
+    r34 = r0 * r36;
+    r13 = r47 * r9;
+    r13 = r13 * r48;
+    r13 = r13 * r122;
+    r13 = fmaf(r61, r13, r145 * r139);
+    r139 = r62 * r145;
+    r139 = r139 * r92;
+    r13 = fmaf(r112, r139, r13);
+    r112 = r52 * r9;
+    r112 = r112 * r9;
+    r112 = r112 * r48;
+    r112 = r112 * r48;
+    r112 = r112 * r126;
+    r112 = r112 * r39;
+    r13 = fmaf(r106, r112, r13);
+    r13 = r13 + r113;
+    r13 = fmaf(r6, r13, r68 * r117);
+    r117 = r145 * r81;
+    r13 = fmaf(r125, r117, r13);
+    r125 = r25 * r52;
+    r125 = r125 * r9;
+    r125 = r125 * r75;
+    r125 = r125 * r79;
+    r13 = fmaf(r55, r125, r13);
+    r75 = r7 * r52;
+    r75 = r75 * r8;
+    r75 = r75 * r9;
+    r75 = r75 * r48;
+    r75 = r75 * r48;
+    r75 = r75 * r96;
+    r75 = r75 * r39;
+    r13 = fmaf(r106, r75, r13);
+    r106 = r47 * r48;
+    r13 = fmaf(r80, r106, r13);
+    r39 = r7 * r40;
+    r39 = r39 * r145;
+    r39 = r39 * r64;
+    r39 = r39 * r104;
+    r13 = fmaf(r115, r39, r13);
+    r115 = r7 * r8;
+    r115 = r115 * r145;
+    r115 = r115 * r72;
+    r13 = fmaf(r92, r115, r13);
+    r104 = r9 * r48;
+    r104 = r104 * r4;
+    r13 = fmaf(r80, r104, r13);
+    r64 = r47 * r48;
+    r13 = fmaf(r81, r64, r13);
+    r96 = r7 * r54;
+    r96 = r96 * r72;
+    r13 = fmaf(r103, r96, r13);
+    r68 = r25 * r52;
+    r68 = r68 * r9;
+    r68 = r68 * r79;
+    r13 = fmaf(r55, r68, r13);
+    r13 = fmaf(r145, r100, r13);
+    r13 = fmaf(r47, r84, r13);
+    r13 = fmaf(r145, r116, r13);
+    r13 = fmaf(r145, r135, r13);
+    r135 = r1 * r13;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r34,
+                                          r135);
+    r135 = r0 * r25;
+    r135 = r135 * r2;
+    r135 = fmaf(r120, r88, r46 * r135);
+    r34 = r0 * r25;
+    r34 = r34 * r2;
+    r34 = fmaf(r148, r88, r118 * r34);
+    r68 = r0 * r25;
+    r68 = r68 * r2;
+    r88 = fmaf(r13, r88, r36 * r68);
+    WriteSum3<float, float>((float*)inout_shared, r135, r34, r88);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r120 * r120;
+    r34 = r46 * r46;
+    r34 = fmaf(r123, r34, r91 * r88);
+    r88 = r118 * r118;
+    r135 = r148 * r148;
+    r135 = fmaf(r91, r135, r123 * r88);
+    r88 = r13 * r13;
+    r68 = r36 * r36;
+    r68 = fmaf(r123, r68, r91 * r88);
+    WriteSum3<float, float>((float*)inout_shared, r34, r135, r68);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r120 * r148;
+    r135 = r46 * r118;
+    r135 = fmaf(r123, r135, r91 * r68);
+    r68 = r120 * r13;
+    r34 = r46 * r36;
+    r34 = fmaf(r123, r34, r91 * r68);
+    r68 = r148 * r13;
+    r88 = r118 * r36;
+    r88 = fmaf(r123, r88, r91 * r68);
+    WriteSum3<float, float>((float*)inout_shared, r135, r34, r88);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeResJacFirst(float* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 float* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 float* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 float* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 float* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 float* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 float* const out_rTr,
+                                 float* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 float* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 float* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 float* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 float* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 float* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 float* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 float* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 float* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 float* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 float* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 float* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_res_jac_first.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeResJacFirst(float* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 float* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 float* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 float* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 float* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 float* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 float* const out_rTr,
+                                 float* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 float* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 float* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 float* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 float* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 float* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 float* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 float* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 float* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 float* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 float* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 float* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_score.cu
@@ -1,0 +1,331 @@
+#include "kernel_thin_prism_fisheye_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeScoreKernel(float* pose,
+                                unsigned int pose_num_alloc,
+                                SharedIndex* pose_indices,
+                                float* sensor_from_rig,
+                                unsigned int sensor_from_rig_num_alloc,
+                                float* calib,
+                                unsigned int calib_num_alloc,
+                                SharedIndex* calib_indices,
+                                float* point,
+                                unsigned int point_num_alloc,
+                                SharedIndex* point_indices,
+                                float* pixel,
+                                unsigned int pixel_num_alloc,
+                                float* const out_rTr,
+                                size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48;
+  LoadShared<4, float, float>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2,
+                       r3);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r12,
+                       r13,
+                       r14);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r15,
+                       r16,
+                       r17,
+                       r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r19,
+                                         r20,
+                                         r21,
+                                         r22);
+    r23 = fmaf(r18, r19, r15 * r22);
+    r24 = r16 * r21;
+    r25 = -1.00000000000000000e+00;
+    r23 = fmaf(r25, r24, r23);
+    r23 = fmaf(r17, r20, r23);
+    r24 = 2.00000000000000000e+00;
+    r26 = fmaf(r16, r19, r17 * r22);
+    r27 = r15 * r20;
+    r26 = fmaf(r25, r27, r26);
+    r26 = fmaf(r18, r21, r26);
+    r27 = r24 * r26;
+    r28 = r23 * r27;
+    r29 = r17 * r19;
+    r29 = fmaf(r25, r29, r16 * r22);
+    r29 = fmaf(r18, r20, r29);
+    r29 = fmaf(r15, r21, r29);
+    r30 = -2.00000000000000000e+00;
+    r31 = fmaf(r16, r20, r15 * r19);
+    r31 = fmaf(r17, r21, r31);
+    r31 = fmaf(r25, r31, r18 * r22);
+    r18 = r30 * r31;
+    r32 = fmaf(r29, r18, r28);
+    r32 = fmaf(r12, r32, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r33,
+                       r34);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r35 = r19 * r21;
+    r35 = r35 * r24;
+    r36 = r20 * r22;
+    r37 = fmaf(r30, r36, r35);
+    r38 = r20 * r20;
+    r38 = r38 * r30;
+    r39 = 1.00000000000000000e+00;
+    r40 = r19 * r19;
+    r40 = fmaf(r30, r40, r39);
+    r41 = r38 + r40;
+    r42 = r20 * r21;
+    r42 = r42 * r24;
+    r43 = r19 * r22;
+    r43 = fmaf(r24, r43, r42);
+    r44 = r24 * r23;
+    r45 = r29 * r27;
+    r44 = fmaf(r31, r44, r45);
+    r46 = r29 * r29;
+    r46 = r30 * r46;
+    r47 = r39 + r46;
+    r48 = r23 * r23;
+    r48 = r30 * r48;
+    r47 = r47 + r48;
+    r32 = fmaf(r11, r37, r32);
+    r32 = fmaf(r34, r41, r32);
+    r32 = fmaf(r33, r43, r32);
+    r32 = fmaf(r13, r44, r32);
+    r32 = fmaf(r14, r47, r32);
+    r47 = copysign(1.0, r32);
+    r47 = fmaf(r8, r47, r32);
+    r32 = r47 * r47;
+    r32 = 1.0 / r32;
+    r46 = r39 + r46;
+    r44 = r26 * r26;
+    r44 = r44 * r30;
+    r46 = r46 + r44;
+    r46 = fmaf(r12, r46, r9);
+    r9 = r24 * r23;
+    r9 = r9 * r29;
+    r26 = fmaf(r26, r18, r9);
+    r43 = r24 * r29;
+    r43 = fmaf(r31, r43, r28);
+    r36 = fmaf(r24, r36, r35);
+    r35 = r21 * r22;
+    r28 = r19 * r20;
+    r28 = r28 * r24;
+    r35 = fmaf(r30, r35, r28);
+    r38 = r39 + r38;
+    r41 = r21 * r21;
+    r41 = r30 * r41;
+    r38 = r38 + r41;
+    r46 = fmaf(r13, r26, r46);
+    r46 = fmaf(r14, r43, r46);
+    r46 = fmaf(r34, r36, r46);
+    r46 = fmaf(r33, r35, r46);
+    r46 = fmaf(r11, r38, r46);
+    r38 = r46 * r46;
+    r27 = fmaf(r31, r27, r9);
+    r27 = fmaf(r12, r27, r10);
+    r12 = r21 * r22;
+    r12 = fmaf(r24, r12, r28);
+    r40 = r41 + r40;
+    r41 = r19 * r22;
+    r41 = fmaf(r30, r41, r42);
+    r18 = fmaf(r23, r18, r45);
+    r48 = r39 + r48;
+    r48 = r48 + r44;
+    r27 = fmaf(r11, r12, r27);
+    r27 = fmaf(r33, r40, r27);
+    r27 = fmaf(r34, r41, r27);
+    r27 = fmaf(r14, r18, r27);
+    r27 = fmaf(r13, r48, r27);
+    r48 = r27 * r27;
+    r13 = fmaf(r32, r48, r32 * r38);
+    r13 = sqrtf(r13);
+    r18 = copysign(1.0, r13);
+    r18 = fmaf(r8, r18, r13);
+    r8 = r18 * r18;
+    r8 = 1.0 / r8;
+    r8 = r32 * r8;
+    r13 = atanf(r13);
+    r32 = r13 * r13;
+    r8 = r8 * r32;
+    r32 = r8 * r48;
+    r14 = 3.00000000000000000e+00;
+    r14 = r14 * r8;
+    r41 = fmaf(r38, r14, r32);
+  };
+  LoadShared<4, float, float>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       calib_indices_loc[threadIdx.x].target,
+                       r34,
+                       r40,
+                       r33,
+                       r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r8 * r38;
+    r32 = r32 + r38;
+    r33 = fmaf(r33, r32, r7 * r41);
+    r41 = r6 * r24;
+    r41 = r41 * r46;
+    r41 = r41 * r27;
+    r33 = fmaf(r8, r41, r33);
+    r11 = r32 * r32;
+    r5 = fmaf(r5, r11, r4 * r32);
+    r4 = r11 * r11;
+    r11 = r32 * r11;
+    r5 = fmaf(r40, r4, r5);
+    r5 = fmaf(r34, r11, r5);
+    r47 = 1.0 / r47;
+    r47 = r13 * r47;
+    r18 = 1.0 / r18;
+    r47 = r47 * r18;
+    r5 = r5 * r47;
+    r33 = fmaf(r46, r5, r33);
+    r33 = fmaf(r46, r47, r33);
+    r33 = fmaf(r0, r33, r2);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r2);
+    r33 = fmaf(r0, r25, r33);
+    r14 = fmaf(r48, r14, r38);
+    r32 = fmaf(r12, r32, r6 * r14);
+    r12 = r7 * r24;
+    r12 = r12 * r46;
+    r12 = r12 * r27;
+    r32 = fmaf(r8, r12, r32);
+    r32 = fmaf(r27, r47, r32);
+    r32 = fmaf(r27, r5, r32);
+    r32 = fmaf(r1, r32, r3);
+    r32 = fmaf(r2, r25, r32);
+    r32 = fmaf(r32, r32, r33 * r33);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r32);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeScore(float* pose,
+                           unsigned int pose_num_alloc,
+                           SharedIndex* pose_indices,
+                           float* sensor_from_rig,
+                           unsigned int sensor_from_rig_num_alloc,
+                           float* calib,
+                           unsigned int calib_num_alloc,
+                           SharedIndex* calib_indices,
+                           float* point,
+                           unsigned int point_num_alloc,
+                           SharedIndex* point_indices,
+                           float* pixel,
+                           unsigned int pixel_num_alloc,
+                           float* const out_rTr,
+                           size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeScoreKernel<<<n_blocks, 1024>>>(pose,
+                                                  pose_num_alloc,
+                                                  pose_indices,
+                                                  sensor_from_rig,
+                                                  sensor_from_rig_num_alloc,
+                                                  calib,
+                                                  calib_num_alloc,
+                                                  calib_indices,
+                                                  point,
+                                                  point_num_alloc,
+                                                  point_indices,
+                                                  pixel,
+                                                  pixel_num_alloc,
+                                                  out_rTr,
+                                                  problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_score.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeScore(float* pose,
+                           unsigned int pose_num_alloc,
+                           SharedIndex* pose_indices,
+                           float* sensor_from_rig,
+                           unsigned int sensor_from_rig_num_alloc,
+                           float* calib,
+                           unsigned int calib_num_alloc,
+                           SharedIndex* calib_indices,
+                           float* point,
+                           unsigned int point_num_alloc,
+                           SharedIndex* point_indices,
+                           float* pixel,
+                           unsigned int pixel_num_alloc,
+                           float* const out_rTr,
+                           size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,172 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        float* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<2, float, float>(principal_point_njtr,
+                              0 * principal_point_njtr_num_alloc,
+                              principal_point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fmaf(r1, r5, r0 * r4);
+    r7 = fmaf(r3, r5, r2 * r4);
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r8, r9, r10, r11);
+    r12 = fmaf(r9, r5, r8 * r4);
+    r13 = fmaf(r11, r5, r10 * r4);
+    WriteSum4<float, float>((float*)inout_shared, r6, r7, r12, r13);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r13, r12, r7, r6);
+    r14 = fmaf(r12, r5, r13 * r4);
+    r5 = fmaf(r6, r5, r7 * r4);
+    WriteSum2<float, float>((float*)inout_shared, r14, r5);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r5,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = fmaf(r5, r13, r14 * r7);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r7,
+                       r4,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = fmaf(r15, r8, r13);
+    r13 = fmaf(r16, r10, r13);
+    r13 = fmaf(r7, r0, r13);
+    r13 = fmaf(r4, r2, r13);
+    r11 = fmaf(r16, r11, r14 * r6);
+    r11 = fmaf(r15, r9, r11);
+    r11 = fmaf(r7, r1, r11);
+    r11 = fmaf(r4, r3, r11);
+    r11 = fmaf(r5, r12, r11);
+    WriteSum2<float, float>((float*)inout_shared, r13, r11);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.cu
@@ -1,0 +1,1700 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = r33 * r33;
+    r47 = 9.99999999999999955e-07;
+    r51 = r40 * r29;
+    r51 = r51 * r29;
+    r52 = r41 + r51;
+    r52 = r52 + r48;
+    r52 = fmaf(r13, r52, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r53 = r21 * r23;
+    r53 = r53 * r16;
+    r54 = r22 * r24;
+    r54 = fmaf(r16, r54, r53);
+    r55 = r23 * r24;
+    r55 = fmaf(r40, r55, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r52 = fmaf(r14, r10, r52);
+    r52 = fmaf(r15, r48, r52);
+    r52 = fmaf(r36, r54, r52);
+    r52 = fmaf(r35, r55, r52);
+    r52 = fmaf(r11, r42, r52);
+    r48 = r52 * r52;
+    r10 = r40 * r29;
+    r10 = fmaf(r34, r10, r26);
+    r10 = fmaf(r13, r10, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r53);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r51 = r41 + r51;
+    r51 = r51 + r50;
+    r10 = fmaf(r11, r12, r10);
+    r10 = fmaf(r36, r37, r10);
+    r10 = fmaf(r35, r39, r10);
+    r10 = fmaf(r14, r44, r10);
+    r10 = fmaf(r15, r51, r10);
+    r51 = copysign(1.0, r10);
+    r51 = fmaf(r47, r51, r10);
+    r10 = r51 * r51;
+    r44 = 1.0 / r10;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = copysign(1.0, r48);
+    r36 = fmaf(r47, r36, r48);
+    r47 = r36 * r36;
+    r11 = 1.0 / r47;
+    r48 = atanf(r48);
+    r50 = r48 * r44;
+    r46 = r48 * r50;
+    r49 = r49 * r11;
+    r49 = r49 * r46;
+    r53 = r52 * r11;
+    r26 = r52 * r53;
+    r56 = r46 * r26;
+    r57 = r49 + r56;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r58,
+                                         r59,
+                                         r60,
+                                         r61);
+    r62 = 3.00000000000000000e+00;
+    r63 = r62 * r46;
+    r63 = fmaf(r26, r63, r49);
+    r63 = fmaf(r59, r63, r8 * r57);
+    r49 = r58 * r33;
+    r64 = r16 * r46;
+    r49 = r49 * r53;
+    r63 = fmaf(r64, r49, r63);
+    r65 = r57 * r57;
+    r66 = r57 * r65;
+    r67 = fmaf(r60, r66, r6 * r57);
+    r66 = r61 * r66;
+    r67 = fmaf(r57, r66, r67);
+    r67 = fmaf(r7, r65, r67);
+    r61 = 1.0 / r51;
+    r68 = 1.0 / r36;
+    r69 = r61 * r68;
+    r70 = r48 * r69;
+    r71 = r67 * r70;
+    r63 = fmaf(r52, r71, r63);
+    r63 = fmaf(r52, r70, r63);
+    r2 = fmaf(r0, r63, r2);
+    r63 = r33 * r33;
+    r63 = r63 * r62;
+    r63 = r63 * r11;
+    r63 = fmaf(r46, r63, r56);
+    r63 = fmaf(r58, r63, r9 * r57);
+    r56 = r59 * r33;
+    r56 = r56 * r53;
+    r63 = fmaf(r64, r56, r63);
+    r63 = fmaf(r33, r71, r63);
+    r63 = fmaf(r33, r70, r63);
+    r63 = fmaf(r5, r63, r1);
+    r63 = fmaf(r3, r4, r63);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r63);
+    r3 = r52 * r11;
+    r1 = -5.00000000000000000e-01;
+    r56 = rsqrtf(r35);
+    r49 = r16 * r33;
+    r72 = r25 * r40;
+    r73 = r17 * r24;
+    r74 = r20 * r21;
+    r74 = fmaf(r1, r74, r1 * r73);
+    r73 = r19 * r22;
+    r74 = fmaf(r1, r73, r74);
+    r75 = r18 * r23;
+    r76 = 5.00000000000000000e-01;
+    r74 = fmaf(r76, r75, r74);
+    r75 = r20 * r24;
+    r73 = r17 * r21;
+    r73 = fmaf(r1, r73, r76 * r75);
+    r75 = r18 * r22;
+    r73 = fmaf(r1, r75, r73);
+    r77 = r19 * r23;
+    r73 = fmaf(r1, r77, r73);
+    r77 = r34 * r73;
+    r75 = r40 * r77;
+    r72 = fmaf(r74, r72, r75);
+    r78 = r16 * r29;
+    r79 = fmaf(r76, r31, r1 * r27);
+    r79 = fmaf(r1, r28, r79);
+    r79 = fmaf(r1, r30, r79);
+    r78 = r78 * r79;
+    r80 = r16 * r32;
+    r81 = r19 * r24;
+    r82 = r18 * r21;
+    r82 = fmaf(r76, r82, r76 * r81);
+    r81 = r17 * r22;
+    r82 = fmaf(r1, r81, r82);
+    r83 = r20 * r23;
+    r82 = fmaf(r76, r83, r82);
+    r80 = fmaf(r82, r80, r78);
+    r72 = r72 + r80;
+    r83 = r25 * r73;
+    r81 = -4.00000000000000000e+00;
+    r83 = r83 * r81;
+    r84 = r32 * r79;
+    r85 = r81 * r84;
+    r86 = r83 + r85;
+    r86 = fmaf(r14, r86, r15 * r72);
+    r72 = r16 * r25;
+    r72 = r72 * r82;
+    r87 = r16 * r34;
+    r87 = fmaf(r79, r87, r72);
+    r88 = r16 * r29;
+    r88 = r88 * r73;
+    r89 = r16 * r32;
+    r89 = fmaf(r74, r89, r88);
+    r87 = r87 + r89;
+    r86 = fmaf(r13, r87, r86);
+    r49 = r49 * r86;
+    r87 = r16 * r52;
+    r90 = r16 * r34;
+    r91 = r29 * r74;
+    r90 = fmaf(r16, r91, r82 * r90);
+    r92 = r16 * r25;
+    r93 = r16 * r32;
+    r93 = r93 * r73;
+    r92 = fmaf(r79, r92, r93);
+    r90 = r90 + r92;
+    r72 = r88 + r72;
+    r88 = r32 * r40;
+    r72 = fmaf(r74, r88, r72);
+    r94 = r40 * r34;
+    r72 = fmaf(r79, r94, r72);
+    r72 = fmaf(r14, r72, r15 * r90);
+    r90 = r29 * r82;
+    r90 = r90 * r81;
+    r85 = r90 + r85;
+    r72 = fmaf(r13, r85, r72);
+    r87 = r87 * r72;
+    r87 = fmaf(r44, r87, r44 * r49);
+    r49 = r16 * r25;
+    r49 = r49 * r74;
+    r77 = r16 * r77;
+    r85 = r49 + r77;
+    r80 = r80 + r85;
+    r94 = r40 * r34;
+    r94 = fmaf(r40, r91, r82 * r94);
+    r94 = r94 + r92;
+    r94 = fmaf(r13, r94, r14 * r80);
+    r90 = r83 + r90;
+    r94 = fmaf(r15, r90, r94);
+    r90 = r33 * r33;
+    r10 = r51 * r10;
+    r10 = 1.0 / r10;
+    r51 = r40 * r10;
+    r90 = r90 * r51;
+    r83 = r52 * r52;
+    r83 = r83 * r94;
+    r87 = fmaf(r51, r83, r87);
+    r87 = fmaf(r94, r90, r87);
+    r3 = r3 * r48;
+    r3 = r3 * r61;
+    r3 = r3 * r1;
+    r3 = r3 * r56;
+    r3 = r3 * r87;
+    r83 = 6.00000000000000000e+00;
+    r80 = r72 * r83;
+    r80 = r80 * r46;
+    r82 = r62 * r87;
+    r35 = r41 + r35;
+    r35 = 1.0 / r35;
+    r88 = r35 * r50;
+    r82 = r82 * r56;
+    r82 = r82 * r88;
+    r82 = fmaf(r26, r82, r53 * r80);
+    r80 = -6.00000000000000000e+00;
+    r95 = r80 * r10;
+    r96 = r48 * r48;
+    r97 = r26 * r96;
+    r95 = r95 * r97;
+    r98 = r52 * r52;
+    r99 = -3.00000000000000000e+00;
+    r47 = r36 * r47;
+    r47 = 1.0 / r47;
+    r98 = r98 * r99;
+    r98 = r98 * r87;
+    r98 = r98 * r56;
+    r98 = r98 * r47;
+    r82 = fmaf(r46, r98, r82);
+    r36 = r33 * r11;
+    r100 = r64 * r36;
+    r101 = r33 * r56;
+    r102 = r87 * r101;
+    r102 = r102 * r88;
+    r102 = fmaf(r36, r102, r86 * r100);
+    r103 = r4 * r33;
+    r104 = r47 * r46;
+    r104 = r104 * r101;
+    r103 = r103 * r87;
+    r102 = fmaf(r104, r103, r102);
+    r96 = r11 * r96;
+    r96 = r96 * r90;
+    r102 = fmaf(r94, r96, r102);
+    r82 = fmaf(r94, r95, r82);
+    r82 = r82 + r102;
+    r82 = fmaf(r59, r82, r3);
+    r98 = r72 * r53;
+    r103 = r87 * r56;
+    r103 = r103 * r88;
+    r103 = fmaf(r26, r103, r64 * r98);
+    r98 = r94 * r51;
+    r103 = fmaf(r97, r98, r103);
+    r105 = r4 * r52;
+    r105 = r105 * r52;
+    r105 = r105 * r87;
+    r105 = r105 * r56;
+    r105 = r105 * r47;
+    r103 = fmaf(r46, r105, r103);
+    r102 = r102 + r103;
+    r105 = r58 * r87;
+    r98 = r16 * r53;
+    r98 = r98 * r101;
+    r98 = r98 * r88;
+    r82 = fmaf(r98, r105, r82);
+    r106 = r58 * r33;
+    r106 = r106 * r48;
+    r106 = r106 * r48;
+    r106 = r106 * r81;
+    r106 = r106 * r10;
+    r106 = r106 * r53;
+    r107 = r52 * r76;
+    r107 = r107 * r56;
+    r107 = r107 * r35;
+    r107 = r107 * r69;
+    r108 = r67 * r107;
+    r109 = r58 * r72;
+    r82 = fmaf(r100, r109, r82);
+    r110 = r4 * r52;
+    r110 = r110 * r94;
+    r110 = r110 * r68;
+    r82 = fmaf(r50, r110, r82);
+    r111 = r4 * r52;
+    r111 = r111 * r67;
+    r111 = r111 * r94;
+    r111 = r111 * r68;
+    r82 = fmaf(r50, r111, r82);
+    r112 = r58 * r40;
+    r112 = r112 * r52;
+    r112 = r112 * r87;
+    r82 = fmaf(r104, r112, r82);
+    r113 = r7 * r16;
+    r113 = r113 * r57;
+    r113 = fmaf(r102, r113, r6 * r102);
+    r114 = 4.00000000000000000e+00;
+    r66 = r114 * r66;
+    r60 = r60 * r62;
+    r60 = r60 * r65;
+    r113 = fmaf(r102, r66, r113);
+    r113 = fmaf(r102, r60, r113);
+    r65 = r52 * r113;
+    r82 = fmaf(r70, r65, r82);
+    r114 = r58 * r86;
+    r114 = r114 * r53;
+    r82 = fmaf(r64, r114, r82);
+    r82 = fmaf(r8, r102, r82);
+    r82 = fmaf(r67, r3, r82);
+    r82 = fmaf(r94, r106, r82);
+    r82 = fmaf(r87, r108, r82);
+    r82 = fmaf(r72, r70, r82);
+    r82 = fmaf(r87, r107, r82);
+    r82 = fmaf(r72, r71, r82);
+    r114 = r0 * r82;
+    r65 = r33 * r86;
+    r65 = r65 * r83;
+    r65 = r65 * r11;
+    r112 = r62 * r87;
+    r112 = r112 * r101;
+    r112 = r112 * r88;
+    r112 = fmaf(r36, r112, r46 * r65);
+    r65 = r33 * r99;
+    r65 = r65 * r87;
+    r112 = fmaf(r104, r65, r112);
+    r111 = r33 * r33;
+    r111 = r111 * r48;
+    r111 = r111 * r48;
+    r111 = r111 * r94;
+    r111 = r111 * r80;
+    r111 = r111 * r11;
+    r112 = fmaf(r10, r111, r112);
+    r112 = r112 + r103;
+    r102 = fmaf(r9, r102, r58 * r112);
+    r112 = r33 * r11;
+    r112 = r112 * r48;
+    r112 = r112 * r61;
+    r112 = r112 * r1;
+    r112 = r112 * r56;
+    r112 = r112 * r87;
+    r103 = r76 * r87;
+    r103 = r103 * r35;
+    r103 = r103 * r101;
+    r102 = fmaf(r69, r103, r102);
+    r111 = r33 * r113;
+    r102 = fmaf(r70, r111, r102);
+    r65 = r4 * r33;
+    r65 = r65 * r67;
+    r65 = r65 * r94;
+    r65 = r65 * r68;
+    r102 = fmaf(r50, r65, r102);
+    r110 = r59 * r33;
+    r110 = r110 * r48;
+    r110 = r110 * r48;
+    r110 = r110 * r81;
+    r110 = r110 * r94;
+    r110 = r110 * r10;
+    r102 = fmaf(r53, r110, r102);
+    r109 = r59 * r72;
+    r102 = fmaf(r100, r109, r102);
+    r105 = r59 * r87;
+    r102 = fmaf(r98, r105, r102);
+    r3 = r4 * r33;
+    r3 = r3 * r94;
+    r3 = r3 * r68;
+    r102 = fmaf(r50, r3, r102);
+    r115 = r59 * r40;
+    r115 = r115 * r52;
+    r115 = r115 * r104;
+    r116 = r76 * r67;
+    r116 = r116 * r87;
+    r116 = r116 * r35;
+    r116 = r116 * r101;
+    r102 = fmaf(r69, r116, r102);
+    r117 = r59 * r86;
+    r117 = r117 * r53;
+    r102 = fmaf(r64, r117, r102);
+    r102 = r102 + r112;
+    r102 = fmaf(r67, r112, r102);
+    r102 = fmaf(r87, r115, r102);
+    r102 = fmaf(r86, r71, r102);
+    r102 = fmaf(r86, r70, r102);
+    r117 = r5 * r102;
+    r116 = r16 * r52;
+    r77 = r78 + r77;
+    r78 = r16 * r32;
+    r3 = r19 * r24;
+    r105 = r18 * r21;
+    r105 = fmaf(r1, r105, r1 * r3);
+    r3 = r17 * r22;
+    r105 = fmaf(r76, r3, r105);
+    r109 = r20 * r23;
+    r105 = fmaf(r1, r109, r105);
+    r78 = r78 * r105;
+    r109 = r16 * r25;
+    r3 = r17 * r24;
+    r110 = r20 * r21;
+    r110 = fmaf(r76, r110, r76 * r3);
+    r3 = r19 * r22;
+    r110 = fmaf(r76, r3, r110);
+    r65 = r18 * r23;
+    r110 = fmaf(r1, r65, r110);
+    r109 = fmaf(r110, r109, r78);
+    r77 = r77 + r109;
+    r65 = r32 * r81;
+    r65 = r65 * r110;
+    r3 = r29 * r73;
+    r3 = r3 * r81;
+    r111 = r65 + r3;
+    r111 = fmaf(r13, r111, r15 * r77);
+    r77 = r40 * r34;
+    r77 = fmaf(r40, r84, r110 * r77);
+    r112 = r16 * r25;
+    r112 = r112 * r73;
+    r103 = r16 * r29;
+    r103 = fmaf(r105, r103, r112);
+    r77 = r77 + r103;
+    r111 = fmaf(r14, r77, r111);
+    r116 = r116 * r111;
+    r77 = r52 * r52;
+    r118 = r40 * r29;
+    r118 = fmaf(r79, r118, r75);
+    r118 = r118 + r109;
+    r109 = r16 * r29;
+    r109 = r109 * r110;
+    r119 = r16 * r34;
+    r119 = fmaf(r105, r119, r109);
+    r119 = r119 + r92;
+    r119 = fmaf(r14, r119, r13 * r118);
+    r118 = r25 * r105;
+    r92 = r81 * r118;
+    r3 = r3 + r92;
+    r119 = fmaf(r15, r3, r119);
+    r77 = r77 * r119;
+    r77 = fmaf(r51, r77, r44 * r116);
+    r116 = r16 * r33;
+    r3 = r25 * r40;
+    r3 = fmaf(r79, r3, r93);
+    r93 = r40 * r34;
+    r3 = fmaf(r105, r93, r3);
+    r3 = r3 + r109;
+    r93 = r16 * r34;
+    r84 = fmaf(r16, r84, r110 * r93);
+    r84 = r84 + r103;
+    r84 = fmaf(r13, r84, r15 * r3);
+    r92 = r65 + r92;
+    r84 = fmaf(r14, r92, r84);
+    r116 = r116 * r84;
+    r77 = fmaf(r44, r116, r77);
+    r77 = fmaf(r119, r90, r77);
+    r116 = r77 * r56;
+    r116 = r116 * r88;
+    r92 = r4 * r52;
+    r92 = r92 * r52;
+    r92 = r92 * r77;
+    r92 = r92 * r56;
+    r92 = r92 * r47;
+    r92 = fmaf(r46, r92, r26 * r116);
+    r116 = r119 * r51;
+    r92 = fmaf(r97, r116, r92);
+    r65 = r111 * r53;
+    r92 = fmaf(r64, r65, r92);
+    r65 = r4 * r33;
+    r65 = r65 * r77;
+    r65 = fmaf(r104, r65, r84 * r100);
+    r116 = r77 * r101;
+    r116 = r116 * r88;
+    r65 = fmaf(r36, r116, r65);
+    r65 = fmaf(r119, r96, r65);
+    r116 = r92 + r65;
+    r3 = r62 * r77;
+    r3 = r3 * r56;
+    r3 = r3 * r88;
+    r93 = r52 * r52;
+    r110 = r99 * r77;
+    r93 = r93 * r56;
+    r93 = r93 * r47;
+    r93 = r93 * r46;
+    r93 = fmaf(r110, r93, r26 * r3);
+    r3 = r83 * r111;
+    r3 = r3 * r46;
+    r93 = fmaf(r53, r3, r93);
+    r93 = fmaf(r119, r95, r93);
+    r93 = r93 + r65;
+    r93 = fmaf(r59, r93, r8 * r116);
+    r65 = r58 * r84;
+    r65 = r65 * r53;
+    r93 = fmaf(r64, r65, r93);
+    r3 = r48 * r1;
+    r3 = r3 * r77;
+    r3 = r3 * r61;
+    r3 = r3 * r56;
+    r93 = fmaf(r53, r3, r93);
+    r109 = r4 * r52;
+    r109 = r109 * r119;
+    r109 = r109 * r68;
+    r93 = fmaf(r50, r109, r93);
+    r79 = r58 * r40;
+    r79 = r79 * r52;
+    r79 = r79 * r77;
+    r93 = fmaf(r104, r79, r93);
+    r120 = r58 * r77;
+    r93 = fmaf(r98, r120, r93);
+    r121 = r4 * r52;
+    r121 = r121 * r67;
+    r121 = r121 * r119;
+    r121 = r121 * r68;
+    r93 = fmaf(r50, r121, r93);
+    r122 = r111 * r100;
+    r123 = r7 * r16;
+    r123 = r123 * r57;
+    r123 = fmaf(r116, r123, r6 * r116);
+    r123 = fmaf(r116, r66, r123);
+    r123 = fmaf(r116, r60, r123);
+    r124 = r52 * r123;
+    r93 = fmaf(r70, r124, r93);
+    r125 = r48 * r67;
+    r125 = r125 * r1;
+    r125 = r125 * r77;
+    r125 = r125 * r61;
+    r125 = r125 * r56;
+    r93 = fmaf(r53, r125, r93);
+    r93 = fmaf(r119, r106, r93);
+    r93 = fmaf(r77, r108, r93);
+    r93 = fmaf(r111, r71, r93);
+    r93 = fmaf(r77, r107, r93);
+    r93 = fmaf(r58, r122, r93);
+    r93 = fmaf(r111, r70, r93);
+    r125 = r0 * r93;
+    r124 = r33 * r83;
+    r124 = r124 * r84;
+    r124 = r124 * r11;
+    r121 = r33 * r104;
+    r121 = fmaf(r110, r121, r46 * r124);
+    r124 = r33 * r33;
+    r124 = r124 * r48;
+    r124 = r124 * r48;
+    r124 = r124 * r80;
+    r124 = r124 * r119;
+    r124 = r124 * r11;
+    r121 = fmaf(r10, r124, r121);
+    r110 = r62 * r77;
+    r110 = r110 * r101;
+    r110 = r110 * r88;
+    r121 = fmaf(r36, r110, r121);
+    r121 = r121 + r92;
+    r121 = fmaf(r58, r121, r9 * r116);
+    r116 = r4 * r33;
+    r116 = r116 * r119;
+    r116 = r116 * r68;
+    r121 = fmaf(r50, r116, r121);
+    r92 = r59 * r84;
+    r92 = r92 * r53;
+    r121 = fmaf(r64, r92, r121);
+    r110 = r59 * r33;
+    r110 = r110 * r48;
+    r110 = r110 * r48;
+    r110 = r110 * r81;
+    r110 = r110 * r119;
+    r110 = r110 * r10;
+    r121 = fmaf(r53, r110, r121);
+    r124 = r76 * r67;
+    r124 = r124 * r77;
+    r124 = r124 * r35;
+    r124 = r124 * r101;
+    r121 = fmaf(r69, r124, r121);
+    r120 = r48 * r67;
+    r120 = r120 * r1;
+    r120 = r120 * r77;
+    r120 = r120 * r11;
+    r120 = r120 * r61;
+    r121 = fmaf(r101, r120, r121);
+    r79 = r33 * r123;
+    r121 = fmaf(r70, r79, r121);
+    r109 = r76 * r77;
+    r109 = r109 * r35;
+    r109 = r109 * r101;
+    r121 = fmaf(r69, r109, r121);
+    r3 = r48 * r1;
+    r3 = r3 * r77;
+    r3 = r3 * r11;
+    r3 = r3 * r61;
+    r121 = fmaf(r101, r3, r121);
+    r65 = r59 * r77;
+    r121 = fmaf(r98, r65, r121);
+    r126 = r4 * r33;
+    r126 = r126 * r67;
+    r126 = r126 * r119;
+    r126 = r126 * r68;
+    r121 = fmaf(r50, r126, r121);
+    r121 = fmaf(r77, r115, r121);
+    r121 = fmaf(r59, r122, r121);
+    r121 = fmaf(r84, r71, r121);
+    r121 = fmaf(r84, r70, r121);
+    r126 = r5 * r121;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r114,
+                                          r117,
+                                          r125,
+                                          r126);
+    r126 = r52 * r52;
+    r125 = r25 * r81;
+    r31 = fmaf(r1, r31, r76 * r27);
+    r31 = fmaf(r76, r28, r31);
+    r31 = fmaf(r76, r30, r31);
+    r125 = r125 * r31;
+    r91 = r81 * r91;
+    r30 = r125 + r91;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r112 = r112 + r28;
+    r27 = r40 * r29;
+    r112 = fmaf(r105, r27, r112);
+    r117 = r40 * r34;
+    r112 = fmaf(r74, r117, r112);
+    r112 = fmaf(r13, r112, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r118, r31 * r30);
+    r30 = r30 + r89;
+    r112 = fmaf(r14, r30, r112);
+    r126 = r126 * r112;
+    r30 = r16 * r52;
+    r117 = r16 * r29;
+    r117 = r117 * r31;
+    r49 = r49 + r117;
+    r27 = r32 * r40;
+    r49 = fmaf(r105, r27, r49);
+    r49 = r49 + r75;
+    r73 = r32 * r73;
+    r73 = r73 * r81;
+    r91 = r73 + r91;
+    r91 = fmaf(r13, r91, r14 * r49);
+    r49 = r16 * r34;
+    r49 = fmaf(r74, r49, r28);
+    r49 = r49 + r103;
+    r91 = fmaf(r15, r49, r91);
+    r30 = r30 * r91;
+    r30 = fmaf(r44, r30, r51 * r126);
+    r126 = r16 * r33;
+    r117 = r78 + r117;
+    r117 = r117 + r85;
+    r85 = r40 * r34;
+    r118 = fmaf(r40, r118, r31 * r85);
+    r118 = r118 + r89;
+    r118 = fmaf(r15, r118, r13 * r117);
+    r73 = r125 + r73;
+    r118 = fmaf(r14, r73, r118);
+    r126 = r126 * r118;
+    r30 = fmaf(r44, r126, r30);
+    r30 = fmaf(r112, r90, r30);
+    r126 = r30 * r101;
+    r126 = r126 * r88;
+    r126 = fmaf(r118, r100, r36 * r126);
+    r73 = r4 * r33;
+    r73 = r73 * r30;
+    r126 = fmaf(r104, r73, r126);
+    r126 = fmaf(r112, r96, r126);
+    r73 = r112 * r51;
+    r14 = r30 * r56;
+    r14 = r14 * r88;
+    r14 = fmaf(r26, r14, r97 * r73);
+    r73 = r4 * r52;
+    r73 = r73 * r52;
+    r73 = r73 * r30;
+    r73 = r73 * r56;
+    r73 = r73 * r47;
+    r14 = fmaf(r46, r73, r14);
+    r125 = r91 * r53;
+    r14 = fmaf(r64, r125, r14);
+    r125 = r126 + r14;
+    r73 = r62 * r30;
+    r73 = r73 * r56;
+    r73 = r73 * r88;
+    r73 = fmaf(r26, r73, r112 * r95);
+    r15 = r52 * r52;
+    r15 = r15 * r99;
+    r15 = r15 * r30;
+    r15 = r15 * r56;
+    r15 = r15 * r47;
+    r73 = fmaf(r46, r15, r73);
+    r117 = r83 * r91;
+    r117 = r117 * r46;
+    r73 = fmaf(r53, r117, r73);
+    r73 = r73 + r126;
+    r73 = fmaf(r59, r73, r8 * r125);
+    r126 = r7 * r16;
+    r126 = r126 * r57;
+    r126 = fmaf(r125, r126, r6 * r125);
+    r126 = fmaf(r125, r60, r126);
+    r126 = fmaf(r125, r66, r126);
+    r117 = r52 * r126;
+    r73 = fmaf(r70, r117, r73);
+    r15 = r48 * r67;
+    r15 = r15 * r1;
+    r15 = r15 * r30;
+    r15 = r15 * r61;
+    r15 = r15 * r56;
+    r73 = fmaf(r53, r15, r73);
+    r13 = r4 * r52;
+    r13 = r13 * r112;
+    r13 = r13 * r68;
+    r73 = fmaf(r50, r13, r73);
+    r89 = r58 * r40;
+    r89 = r89 * r52;
+    r89 = r89 * r30;
+    r73 = fmaf(r104, r89, r73);
+    r85 = r58 * r91;
+    r73 = fmaf(r100, r85, r73);
+    r31 = r58 * r118;
+    r31 = r31 * r53;
+    r73 = fmaf(r64, r31, r73);
+    r78 = r48 * r1;
+    r78 = r78 * r30;
+    r78 = r78 * r61;
+    r78 = r78 * r56;
+    r73 = fmaf(r53, r78, r73);
+    r49 = r4 * r52;
+    r49 = r49 * r67;
+    r49 = r49 * r112;
+    r49 = r49 * r68;
+    r73 = fmaf(r50, r49, r73);
+    r103 = r58 * r30;
+    r73 = fmaf(r98, r103, r73);
+    r73 = fmaf(r112, r106, r73);
+    r73 = fmaf(r30, r107, r73);
+    r73 = fmaf(r91, r71, r73);
+    r73 = fmaf(r30, r108, r73);
+    r73 = fmaf(r91, r70, r73);
+    r103 = r0 * r73;
+    r49 = r62 * r30;
+    r49 = r49 * r101;
+    r49 = r49 * r88;
+    r78 = r33 * r83;
+    r78 = r78 * r118;
+    r78 = r78 * r11;
+    r78 = fmaf(r46, r78, r36 * r49);
+    r49 = r33 * r33;
+    r49 = r49 * r48;
+    r49 = r49 * r48;
+    r49 = r49 * r80;
+    r49 = r49 * r112;
+    r49 = r49 * r11;
+    r78 = fmaf(r10, r49, r78);
+    r31 = r33 * r99;
+    r31 = r31 * r30;
+    r78 = fmaf(r104, r31, r78);
+    r78 = r78 + r14;
+    r78 = fmaf(r58, r78, r9 * r125);
+    r125 = r59 * r33;
+    r125 = r125 * r48;
+    r125 = r125 * r48;
+    r125 = r125 * r81;
+    r125 = r125 * r112;
+    r125 = r125 * r10;
+    r78 = fmaf(r53, r125, r78);
+    r14 = r48 * r1;
+    r14 = r14 * r30;
+    r14 = r14 * r11;
+    r14 = r14 * r61;
+    r78 = fmaf(r101, r14, r78);
+    r31 = r76 * r30;
+    r31 = r31 * r35;
+    r31 = r31 * r101;
+    r78 = fmaf(r69, r31, r78);
+    r49 = r4 * r33;
+    r49 = r49 * r67;
+    r49 = r49 * r112;
+    r49 = r49 * r68;
+    r78 = fmaf(r50, r49, r78);
+    r85 = r59 * r91;
+    r78 = fmaf(r100, r85, r78);
+    r89 = r48 * r67;
+    r89 = r89 * r1;
+    r89 = r89 * r30;
+    r89 = r89 * r11;
+    r89 = r89 * r61;
+    r78 = fmaf(r101, r89, r78);
+    r13 = r59 * r118;
+    r13 = r13 * r53;
+    r78 = fmaf(r64, r13, r78);
+    r15 = r4 * r33;
+    r15 = r15 * r112;
+    r15 = r15 * r68;
+    r78 = fmaf(r50, r15, r78);
+    r117 = r59 * r30;
+    r78 = fmaf(r98, r117, r78);
+    r28 = r33 * r126;
+    r78 = fmaf(r70, r28, r78);
+    r74 = r76 * r67;
+    r74 = r74 * r30;
+    r74 = r74 * r35;
+    r74 = r74 * r101;
+    r78 = fmaf(r69, r74, r78);
+    r78 = fmaf(r118, r71, r78);
+    r78 = fmaf(r30, r115, r78);
+    r78 = fmaf(r118, r70, r78);
+    r74 = r5 * r78;
+    r28 = r42 * r83;
+    r28 = r28 * r46;
+    r28 = fmaf(r53, r28, r12 * r95);
+    r117 = r52 * r52;
+    r15 = r16 * r38;
+    r15 = r15 * r33;
+    r15 = fmaf(r44, r15, r12 * r90);
+    r13 = r12 * r52;
+    r13 = r13 * r52;
+    r15 = fmaf(r51, r13, r15);
+    r89 = r16 * r42;
+    r89 = r89 * r52;
+    r15 = fmaf(r44, r89, r15);
+    r117 = r117 * r99;
+    r117 = r117 * r15;
+    r117 = r117 * r56;
+    r117 = r117 * r47;
+    r28 = fmaf(r46, r117, r28);
+    r89 = r62 * r15;
+    r89 = r89 * r56;
+    r89 = r89 * r88;
+    r28 = fmaf(r26, r89, r28);
+    r13 = fmaf(r38, r100, r12 * r96);
+    r85 = r4 * r33;
+    r85 = r85 * r15;
+    r13 = fmaf(r104, r85, r13);
+    r49 = r15 * r101;
+    r49 = r49 * r88;
+    r13 = fmaf(r36, r49, r13);
+    r28 = r28 + r13;
+    r89 = r12 * r51;
+    r117 = r42 * r53;
+    r117 = fmaf(r64, r117, r97 * r89);
+    r89 = r4 * r52;
+    r89 = r89 * r52;
+    r89 = r89 * r15;
+    r89 = r89 * r56;
+    r89 = r89 * r47;
+    r117 = fmaf(r46, r89, r117);
+    r49 = r15 * r56;
+    r49 = r49 * r88;
+    r117 = fmaf(r26, r49, r117);
+    r13 = r13 + r117;
+    r28 = fmaf(r8, r13, r59 * r28);
+    r49 = r4 * r12;
+    r49 = r49 * r52;
+    r49 = r49 * r68;
+    r28 = fmaf(r50, r49, r28);
+    r89 = r48 * r67;
+    r89 = r89 * r1;
+    r89 = r89 * r15;
+    r89 = r89 * r61;
+    r89 = r89 * r56;
+    r28 = fmaf(r53, r89, r28);
+    r85 = r58 * r40;
+    r85 = r85 * r52;
+    r85 = r85 * r15;
+    r28 = fmaf(r104, r85, r28);
+    r31 = r15 * r98;
+    r14 = r58 * r42;
+    r28 = fmaf(r100, r14, r28);
+    r125 = r48 * r1;
+    r125 = r125 * r15;
+    r125 = r125 * r61;
+    r125 = r125 * r56;
+    r28 = fmaf(r53, r125, r28);
+    r75 = r58 * r38;
+    r75 = r75 * r53;
+    r28 = fmaf(r64, r75, r28);
+    r27 = r7 * r16;
+    r27 = r27 * r57;
+    r27 = fmaf(r6, r13, r13 * r27);
+    r27 = fmaf(r13, r66, r27);
+    r27 = fmaf(r13, r60, r27);
+    r105 = r52 * r27;
+    r28 = fmaf(r70, r105, r28);
+    r114 = r4 * r12;
+    r114 = r114 * r52;
+    r114 = r114 * r67;
+    r114 = r114 * r68;
+    r28 = fmaf(r50, r114, r28);
+    r28 = fmaf(r42, r70, r28);
+    r28 = fmaf(r42, r71, r28);
+    r28 = fmaf(r58, r31, r28);
+    r28 = fmaf(r15, r108, r28);
+    r28 = fmaf(r12, r106, r28);
+    r28 = fmaf(r15, r107, r28);
+    r114 = r0 * r28;
+    r105 = r12 * r33;
+    r105 = r105 * r33;
+    r105 = r105 * r48;
+    r105 = r105 * r48;
+    r105 = r105 * r80;
+    r105 = r105 * r11;
+    r75 = r38 * r33;
+    r75 = r75 * r83;
+    r75 = r75 * r11;
+    r75 = fmaf(r46, r75, r10 * r105);
+    r105 = r33 * r99;
+    r105 = r105 * r15;
+    r75 = fmaf(r104, r105, r75);
+    r125 = r62 * r15;
+    r125 = r125 * r101;
+    r125 = r125 * r88;
+    r75 = fmaf(r36, r125, r75);
+    r75 = r75 + r117;
+    r13 = fmaf(r9, r13, r58 * r75);
+    r75 = r4 * r12;
+    r75 = r75 * r33;
+    r75 = r75 * r68;
+    r13 = fmaf(r50, r75, r13);
+    r117 = r4 * r12;
+    r117 = r117 * r33;
+    r117 = r117 * r67;
+    r117 = r117 * r68;
+    r13 = fmaf(r50, r117, r13);
+    r125 = r48 * r1;
+    r125 = r125 * r15;
+    r125 = r125 * r11;
+    r125 = r125 * r61;
+    r13 = fmaf(r101, r125, r13);
+    r105 = r48 * r67;
+    r105 = r105 * r1;
+    r105 = r105 * r15;
+    r105 = r105 * r11;
+    r105 = r105 * r61;
+    r13 = fmaf(r101, r105, r13);
+    r14 = r59 * r42;
+    r13 = fmaf(r100, r14, r13);
+    r85 = r76 * r15;
+    r85 = r85 * r35;
+    r85 = r85 * r101;
+    r13 = fmaf(r69, r85, r13);
+    r89 = r59 * r12;
+    r89 = r89 * r33;
+    r89 = r89 * r48;
+    r89 = r89 * r48;
+    r89 = r89 * r81;
+    r89 = r89 * r10;
+    r13 = fmaf(r53, r89, r13);
+    r49 = r59 * r38;
+    r49 = r49 * r53;
+    r13 = fmaf(r64, r49, r13);
+    r122 = r76 * r67;
+    r122 = r122 * r15;
+    r122 = r122 * r35;
+    r122 = r122 * r101;
+    r13 = fmaf(r69, r122, r13);
+    r65 = r33 * r27;
+    r13 = fmaf(r70, r65, r13);
+    r13 = fmaf(r38, r70, r13);
+    r13 = fmaf(r38, r71, r13);
+    r13 = fmaf(r15, r115, r13);
+    r13 = fmaf(r59, r31, r13);
+    r65 = r5 * r13;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r103,
+                                          r74,
+                                          r114,
+                                          r65);
+    r65 = r16 * r43;
+    r65 = r65 * r33;
+    r65 = fmaf(r44, r65, r39 * r90);
+    r114 = r39 * r52;
+    r114 = r114 * r52;
+    r65 = fmaf(r51, r114, r65);
+    r74 = r16 * r55;
+    r74 = r74 * r52;
+    r65 = fmaf(r44, r74, r65);
+    r74 = r65 * r101;
+    r74 = r74 * r88;
+    r74 = fmaf(r39, r96, r36 * r74);
+    r114 = r4 * r33;
+    r114 = r114 * r65;
+    r74 = fmaf(r104, r114, r74);
+    r74 = fmaf(r43, r100, r74);
+    r114 = r65 * r56;
+    r114 = r114 * r88;
+    r103 = r39 * r51;
+    r103 = fmaf(r97, r103, r26 * r114);
+    r114 = r55 * r53;
+    r103 = fmaf(r64, r114, r103);
+    r122 = r4 * r52;
+    r122 = r122 * r52;
+    r122 = r122 * r65;
+    r122 = r122 * r56;
+    r122 = r122 * r47;
+    r103 = fmaf(r46, r122, r103);
+    r122 = r74 + r103;
+    r114 = r62 * r65;
+    r114 = r114 * r56;
+    r114 = r114 * r88;
+    r114 = fmaf(r39, r95, r26 * r114);
+    r49 = r55 * r83;
+    r49 = r49 * r46;
+    r114 = fmaf(r53, r49, r114);
+    r89 = r52 * r52;
+    r89 = r89 * r99;
+    r89 = r89 * r65;
+    r89 = r89 * r56;
+    r89 = r89 * r47;
+    r114 = fmaf(r46, r89, r114);
+    r114 = r114 + r74;
+    r114 = fmaf(r59, r114, r8 * r122);
+    r74 = r7 * r16;
+    r74 = r74 * r57;
+    r74 = fmaf(r122, r74, r6 * r122);
+    r74 = fmaf(r122, r66, r74);
+    r74 = fmaf(r122, r60, r74);
+    r89 = r52 * r74;
+    r114 = fmaf(r70, r89, r114);
+    r49 = r58 * r43;
+    r49 = r49 * r53;
+    r114 = fmaf(r64, r49, r114);
+    r85 = r48 * r1;
+    r85 = r85 * r65;
+    r85 = r85 * r61;
+    r85 = r85 * r56;
+    r114 = fmaf(r53, r85, r114);
+    r14 = r58 * r65;
+    r114 = fmaf(r98, r14, r114);
+    r31 = r58 * r40;
+    r31 = r31 * r52;
+    r31 = r31 * r65;
+    r114 = fmaf(r104, r31, r114);
+    r105 = r48 * r67;
+    r105 = r105 * r1;
+    r105 = r105 * r65;
+    r105 = r105 * r61;
+    r105 = r105 * r56;
+    r114 = fmaf(r53, r105, r114);
+    r125 = r4 * r39;
+    r125 = r125 * r52;
+    r125 = r125 * r68;
+    r114 = fmaf(r50, r125, r114);
+    r117 = r58 * r55;
+    r114 = fmaf(r100, r117, r114);
+    r75 = r4 * r39;
+    r75 = r75 * r52;
+    r75 = r75 * r67;
+    r75 = r75 * r68;
+    r114 = fmaf(r50, r75, r114);
+    r114 = fmaf(r55, r71, r114);
+    r114 = fmaf(r55, r70, r114);
+    r114 = fmaf(r65, r107, r114);
+    r114 = fmaf(r39, r106, r114);
+    r114 = fmaf(r65, r108, r114);
+    r75 = r0 * r114;
+    r117 = r62 * r65;
+    r117 = r117 * r101;
+    r117 = r117 * r88;
+    r125 = r39 * r33;
+    r125 = r125 * r33;
+    r125 = r125 * r48;
+    r125 = r125 * r48;
+    r125 = r125 * r80;
+    r125 = r125 * r11;
+    r125 = fmaf(r10, r125, r36 * r117);
+    r117 = r43 * r33;
+    r117 = r117 * r83;
+    r117 = r117 * r11;
+    r125 = fmaf(r46, r117, r125);
+    r105 = r33 * r99;
+    r105 = r105 * r65;
+    r125 = fmaf(r104, r105, r125);
+    r125 = r125 + r103;
+    r125 = fmaf(r58, r125, r9 * r122);
+    r122 = r59 * r43;
+    r122 = r122 * r53;
+    r125 = fmaf(r64, r122, r125);
+    r103 = r4 * r39;
+    r103 = r103 * r33;
+    r103 = r103 * r68;
+    r125 = fmaf(r50, r103, r125);
+    r105 = r76 * r65;
+    r105 = r105 * r35;
+    r105 = r105 * r101;
+    r125 = fmaf(r69, r105, r125);
+    r117 = r59 * r65;
+    r125 = fmaf(r98, r117, r125);
+    r31 = r76 * r67;
+    r31 = r31 * r65;
+    r31 = r31 * r35;
+    r31 = r31 * r101;
+    r125 = fmaf(r69, r31, r125);
+    r14 = r59 * r39;
+    r14 = r14 * r33;
+    r14 = r14 * r48;
+    r14 = r14 * r48;
+    r14 = r14 * r81;
+    r14 = r14 * r10;
+    r125 = fmaf(r53, r14, r125);
+    r85 = r59 * r55;
+    r125 = fmaf(r100, r85, r125);
+    r49 = r4 * r39;
+    r49 = r49 * r33;
+    r49 = r49 * r67;
+    r49 = r49 * r68;
+    r125 = fmaf(r50, r49, r125);
+    r89 = r48 * r67;
+    r89 = r89 * r1;
+    r89 = r89 * r65;
+    r89 = r89 * r11;
+    r89 = r89 * r61;
+    r125 = fmaf(r101, r89, r125);
+    r3 = r33 * r74;
+    r125 = fmaf(r70, r3, r125);
+    r109 = r48 * r1;
+    r109 = r109 * r65;
+    r109 = r109 * r11;
+    r109 = r109 * r61;
+    r125 = fmaf(r101, r109, r125);
+    r125 = fmaf(r43, r71, r125);
+    r125 = fmaf(r65, r115, r125);
+    r125 = fmaf(r43, r70, r125);
+    r109 = r5 * r125;
+    r3 = r16 * r45;
+    r3 = r3 * r33;
+    r90 = fmaf(r37, r90, r44 * r3);
+    r3 = r16 * r54;
+    r3 = r3 * r52;
+    r90 = fmaf(r44, r3, r90);
+    r44 = r37 * r52;
+    r44 = r44 * r52;
+    r90 = fmaf(r51, r44, r90);
+    r44 = r90 * r101;
+    r44 = r44 * r88;
+    r44 = fmaf(r45, r100, r36 * r44);
+    r3 = r4 * r33;
+    r3 = r3 * r90;
+    r44 = fmaf(r104, r3, r44);
+    r44 = fmaf(r37, r96, r44);
+    r96 = r37 * r51;
+    r3 = r4 * r52;
+    r3 = r3 * r52;
+    r3 = r3 * r90;
+    r3 = r3 * r56;
+    r3 = r3 * r47;
+    r3 = fmaf(r46, r3, r97 * r96);
+    r96 = r54 * r53;
+    r3 = fmaf(r64, r96, r3);
+    r97 = r90 * r56;
+    r97 = r97 * r88;
+    r3 = fmaf(r26, r97, r3);
+    r97 = r44 + r3;
+    r96 = r52 * r52;
+    r96 = r96 * r99;
+    r96 = r96 * r90;
+    r96 = r96 * r56;
+    r96 = r96 * r47;
+    r96 = fmaf(r46, r96, r37 * r95);
+    r95 = r54 * r83;
+    r95 = r95 * r46;
+    r96 = fmaf(r53, r95, r96);
+    r47 = r62 * r90;
+    r47 = r47 * r56;
+    r47 = r47 * r88;
+    r96 = fmaf(r26, r47, r96);
+    r96 = r96 + r44;
+    r96 = fmaf(r59, r96, r8 * r97);
+    r8 = r4 * r37;
+    r8 = r8 * r52;
+    r8 = r8 * r67;
+    r8 = r8 * r68;
+    r96 = fmaf(r50, r8, r96);
+    r44 = r4 * r37;
+    r44 = r44 * r52;
+    r44 = r44 * r68;
+    r96 = fmaf(r50, r44, r96);
+    r47 = r48 * r1;
+    r47 = r47 * r90;
+    r47 = r47 * r61;
+    r47 = r47 * r56;
+    r96 = fmaf(r53, r47, r96);
+    r95 = r58 * r40;
+    r95 = r95 * r52;
+    r95 = r95 * r90;
+    r96 = fmaf(r104, r95, r96);
+    r26 = r58 * r90;
+    r96 = fmaf(r98, r26, r96);
+    r89 = r58 * r45;
+    r89 = r89 * r53;
+    r96 = fmaf(r64, r89, r96);
+    r49 = r58 * r54;
+    r96 = fmaf(r100, r49, r96);
+    r85 = r48 * r67;
+    r85 = r85 * r1;
+    r85 = r85 * r90;
+    r85 = r85 * r61;
+    r85 = r85 * r56;
+    r96 = fmaf(r53, r85, r96);
+    r14 = r7 * r16;
+    r14 = r14 * r57;
+    r6 = fmaf(r6, r97, r97 * r14);
+    r6 = fmaf(r97, r66, r6);
+    r6 = fmaf(r97, r60, r6);
+    r60 = r52 * r6;
+    r96 = fmaf(r70, r60, r96);
+    r96 = fmaf(r54, r70, r96);
+    r96 = fmaf(r54, r71, r96);
+    r96 = fmaf(r90, r108, r96);
+    r96 = fmaf(r90, r107, r96);
+    r96 = fmaf(r37, r106, r96);
+    r106 = r0 * r96;
+    r60 = r62 * r90;
+    r60 = r60 * r101;
+    r60 = r60 * r88;
+    r88 = r45 * r33;
+    r88 = r88 * r83;
+    r88 = r88 * r11;
+    r88 = fmaf(r46, r88, r36 * r60);
+    r60 = r33 * r99;
+    r60 = r60 * r90;
+    r88 = fmaf(r104, r60, r88);
+    r36 = r37 * r33;
+    r36 = r36 * r33;
+    r36 = r36 * r48;
+    r36 = r36 * r48;
+    r36 = r36 * r80;
+    r36 = r36 * r11;
+    r88 = fmaf(r10, r36, r88);
+    r88 = r88 + r3;
+    r88 = fmaf(r58, r88, r9 * r97);
+    r97 = r76 * r67;
+    r97 = r97 * r90;
+    r97 = r97 * r35;
+    r97 = r97 * r101;
+    r88 = fmaf(r69, r97, r88);
+    r9 = r76 * r90;
+    r9 = r9 * r35;
+    r9 = r9 * r101;
+    r88 = fmaf(r69, r9, r88);
+    r69 = r48 * r67;
+    r69 = r69 * r1;
+    r69 = r69 * r90;
+    r69 = r69 * r11;
+    r69 = r69 * r61;
+    r88 = fmaf(r101, r69, r88);
+    r35 = r48 * r1;
+    r35 = r35 * r90;
+    r35 = r35 * r11;
+    r35 = r35 * r61;
+    r88 = fmaf(r101, r35, r88);
+    r61 = r59 * r90;
+    r88 = fmaf(r98, r61, r88);
+    r98 = r59 * r45;
+    r98 = r98 * r53;
+    r88 = fmaf(r64, r98, r88);
+    r64 = r4 * r37;
+    r64 = r64 * r33;
+    r64 = r64 * r67;
+    r64 = r64 * r68;
+    r88 = fmaf(r50, r64, r88);
+    r11 = r59 * r54;
+    r88 = fmaf(r100, r11, r88);
+    r100 = r4 * r37;
+    r100 = r100 * r33;
+    r100 = r100 * r68;
+    r88 = fmaf(r50, r100, r88);
+    r50 = r33 * r6;
+    r88 = fmaf(r70, r50, r88);
+    r68 = r59 * r37;
+    r68 = r68 * r33;
+    r68 = r68 * r48;
+    r68 = r68 * r48;
+    r68 = r68 * r81;
+    r68 = r68 * r10;
+    r88 = fmaf(r53, r68, r88);
+    r88 = fmaf(r45, r71, r88);
+    r88 = fmaf(r90, r115, r88);
+    r88 = fmaf(r45, r70, r88);
+    r68 = r5 * r88;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r75,
+                                          r109,
+                                          r106,
+                                          r68);
+    r68 = r0 * r4;
+    r68 = r68 * r2;
+    r63 = r4 * r63;
+    r106 = r5 * r63;
+    r68 = fmaf(r102, r106, r82 * r68);
+    r109 = r0 * r4;
+    r109 = r109 * r2;
+    r109 = fmaf(r121, r106, r93 * r109);
+    r75 = r0 * r4;
+    r75 = r75 * r2;
+    r75 = fmaf(r78, r106, r73 * r75);
+    r50 = r0 * r4;
+    r50 = r50 * r2;
+    r50 = fmaf(r13, r106, r28 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r68, r109, r75, r50);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r0 * r4;
+    r50 = r50 * r2;
+    r50 = fmaf(r125, r106, r114 * r50);
+    r75 = r0 * r4;
+    r75 = r75 * r2;
+    r106 = fmaf(r88, r106, r96 * r75);
+    WriteSum2<float, float>((float*)inout_shared, r50, r106);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r106 = r0 * r0;
+    r50 = r82 * r106;
+    r5 = r5 * r5;
+    r75 = r102 * r5;
+    r102 = fmaf(r102, r75, r82 * r50);
+    r82 = r93 * r93;
+    r109 = r121 * r121;
+    r109 = fmaf(r5, r109, r106 * r82);
+    r82 = r78 * r78;
+    r68 = r73 * r73;
+    r68 = fmaf(r106, r68, r5 * r82);
+    r82 = r28 * r28;
+    r100 = r13 * r13;
+    r100 = fmaf(r5, r100, r106 * r82);
+    WriteSum4<float, float>((float*)inout_shared, r102, r109, r68, r100);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = r114 * r114;
+    r68 = r125 * r125;
+    r68 = fmaf(r5, r68, r106 * r100);
+    r100 = r88 * r88;
+    r109 = r96 * r96;
+    r109 = fmaf(r106, r109, r5 * r100);
+    WriteSum2<float, float>((float*)inout_shared, r68, r109);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = fmaf(r93, r50, r121 * r75);
+    r68 = fmaf(r78, r75, r73 * r50);
+    r100 = fmaf(r28, r50, r13 * r75);
+    r102 = fmaf(r114, r50, r125 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r109, r68, r100, r102);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = fmaf(r88, r75, r96 * r50);
+    r50 = r121 * r78;
+    r102 = r93 * r73;
+    r102 = fmaf(r106, r102, r5 * r50);
+    r50 = r93 * r28;
+    r100 = r121 * r13;
+    r100 = fmaf(r5, r100, r106 * r50);
+    r50 = r93 * r114;
+    r68 = r121 * r125;
+    r68 = fmaf(r5, r68, r106 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r75, r102, r100, r68);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r121 * r88;
+    r100 = r93 * r96;
+    r100 = fmaf(r106, r100, r5 * r68);
+    r68 = r78 * r13;
+    r102 = r73 * r28;
+    r102 = fmaf(r106, r102, r5 * r68);
+    r68 = r73 * r114;
+    r75 = r78 * r125;
+    r75 = fmaf(r5, r75, r106 * r68);
+    r68 = r78 * r88;
+    r50 = r73 * r96;
+    r50 = fmaf(r106, r50, r5 * r68);
+    WriteSum4<float, float>((float*)inout_shared, r100, r102, r75, r50);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r13 * r125;
+    r75 = r28 * r114;
+    r75 = fmaf(r106, r75, r5 * r50);
+    r50 = r28 * r96;
+    r102 = r13 * r88;
+    r102 = fmaf(r5, r102, r106 * r50);
+    r50 = r125 * r88;
+    r100 = r114 * r96;
+    r100 = fmaf(r106, r100, r5 * r50);
+    WriteSum3<float, float>((float*)inout_shared, r75, r102, r100);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r4 * r2;
+    WriteSum2<float, float>((float*)inout_shared, r2, r63);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r41, r41);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacKernel<<<n_blocks,
+                                                                  1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.cu
@@ -1,0 +1,1758 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = 9.99999999999999955e-07;
+    r47 = r40 * r29;
+    r47 = r47 * r29;
+    r51 = r41 + r47;
+    r51 = r51 + r48;
+    r51 = fmaf(r13, r51, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r52 = r21 * r23;
+    r52 = r52 * r16;
+    r53 = r22 * r24;
+    r53 = fmaf(r16, r53, r52);
+    r54 = r23 * r24;
+    r54 = fmaf(r40, r54, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r51 = fmaf(r14, r10, r51);
+    r51 = fmaf(r15, r48, r51);
+    r51 = fmaf(r36, r53, r51);
+    r51 = fmaf(r35, r54, r51);
+    r51 = fmaf(r11, r42, r51);
+    r48 = r51 * r51;
+    r10 = r40 * r29;
+    r10 = fmaf(r34, r10, r26);
+    r10 = fmaf(r13, r10, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r52);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r47 = r41 + r47;
+    r47 = r47 + r50;
+    r10 = fmaf(r11, r12, r10);
+    r10 = fmaf(r36, r37, r10);
+    r10 = fmaf(r35, r39, r10);
+    r10 = fmaf(r14, r44, r10);
+    r10 = fmaf(r15, r47, r10);
+    r47 = copysign(1.0, r10);
+    r47 = fmaf(r49, r47, r10);
+    r10 = r47 * r47;
+    r44 = 1.0 / r10;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = copysign(1.0, r48);
+    r36 = fmaf(r49, r36, r48);
+    r49 = r36 * r36;
+    r11 = 1.0 / r49;
+    r48 = atanf(r48);
+    r50 = r48 * r44;
+    r46 = r11 * r50;
+    r52 = r33 * r46;
+    r26 = r33 * r48;
+    r52 = r52 * r26;
+    r55 = r51 * r51;
+    r55 = r55 * r48;
+    r55 = r55 * r46;
+    r56 = r52 + r55;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r57,
+                                         r58,
+                                         r59,
+                                         r60);
+    r61 = r51 * r51;
+    r62 = 3.00000000000000000e+00;
+    r61 = r61 * r48;
+    r61 = r61 * r62;
+    r61 = fmaf(r46, r61, r52);
+    r61 = fmaf(r58, r61, r8 * r56);
+    r52 = r16 * r46;
+    r63 = r26 * r52;
+    r64 = r57 * r63;
+    r65 = r56 * r56;
+    r66 = r56 * r65;
+    r67 = fmaf(r59, r66, r6 * r56);
+    r66 = r60 * r66;
+    r67 = fmaf(r56, r66, r67);
+    r67 = fmaf(r7, r65, r67);
+    r60 = 1.0 / r47;
+    r68 = 1.0 / r36;
+    r69 = r60 * r68;
+    r70 = r67 * r69;
+    r71 = r48 * r70;
+    r72 = r51 * r48;
+    r61 = fmaf(r69, r72, r61);
+    r61 = fmaf(r51, r64, r61);
+    r61 = fmaf(r51, r71, r61);
+    r2 = fmaf(r0, r61, r2);
+    r61 = r33 * r62;
+    r61 = r61 * r46;
+    r61 = fmaf(r26, r61, r55);
+    r61 = fmaf(r57, r61, r9 * r56);
+    r55 = r58 * r51;
+    r61 = fmaf(r63, r55, r61);
+    r61 = fmaf(r26, r70, r61);
+    r61 = fmaf(r69, r26, r61);
+    r61 = fmaf(r5, r61, r1);
+    r61 = fmaf(r3, r4, r61);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r61);
+    r3 = fmaf(r61, r61, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r51 * r48;
+    r1 = r16 * r34;
+    r55 = r19 * r24;
+    r72 = 5.00000000000000000e-01;
+    r73 = r18 * r21;
+    r73 = fmaf(r72, r73, r72 * r55);
+    r55 = r17 * r22;
+    r74 = -5.00000000000000000e-01;
+    r73 = fmaf(r74, r55, r73);
+    r75 = r20 * r23;
+    r73 = fmaf(r72, r75, r73);
+    r75 = r17 * r24;
+    r55 = r20 * r21;
+    r55 = fmaf(r74, r55, r74 * r75);
+    r75 = r19 * r22;
+    r55 = fmaf(r74, r75, r55);
+    r76 = r18 * r23;
+    r55 = fmaf(r72, r76, r55);
+    r76 = r29 * r55;
+    r1 = fmaf(r16, r76, r73 * r1);
+    r75 = r16 * r25;
+    r77 = fmaf(r72, r31, r74 * r27);
+    r77 = fmaf(r74, r28, r77);
+    r77 = fmaf(r74, r30, r77);
+    r78 = r16 * r32;
+    r79 = r20 * r24;
+    r80 = r17 * r21;
+    r80 = fmaf(r74, r80, r72 * r79);
+    r79 = r18 * r22;
+    r80 = fmaf(r74, r79, r80);
+    r81 = r19 * r23;
+    r80 = fmaf(r74, r81, r80);
+    r78 = r78 * r80;
+    r75 = fmaf(r77, r75, r78);
+    r1 = r1 + r75;
+    r81 = r16 * r29;
+    r81 = r81 * r80;
+    r79 = r16 * r25;
+    r79 = r79 * r73;
+    r82 = r81 + r79;
+    r83 = r32 * r40;
+    r82 = fmaf(r55, r83, r82);
+    r84 = r40 * r34;
+    r82 = fmaf(r77, r84, r82);
+    r82 = fmaf(r14, r82, r15 * r1);
+    r1 = r29 * r73;
+    r84 = -4.00000000000000000e+00;
+    r1 = r1 * r84;
+    r83 = r32 * r77;
+    r85 = r84 * r83;
+    r86 = r1 + r85;
+    r82 = fmaf(r13, r86, r82);
+    r86 = 6.00000000000000000e+00;
+    r3 = r3 * r82;
+    r3 = r3 * r86;
+    r87 = r16 * r33;
+    r88 = r25 * r40;
+    r89 = r34 * r80;
+    r90 = r40 * r89;
+    r88 = fmaf(r55, r88, r90);
+    r91 = r16 * r29;
+    r91 = r91 * r77;
+    r92 = r16 * r32;
+    r92 = fmaf(r73, r92, r91);
+    r88 = r88 + r92;
+    r93 = r25 * r80;
+    r93 = r93 * r84;
+    r85 = r93 + r85;
+    r85 = fmaf(r14, r85, r15 * r88);
+    r88 = r16 * r34;
+    r88 = fmaf(r77, r88, r79);
+    r79 = r16 * r32;
+    r79 = fmaf(r55, r79, r81);
+    r88 = r88 + r79;
+    r85 = fmaf(r13, r88, r85);
+    r87 = r87 * r85;
+    r88 = r16 * r51;
+    r88 = r88 * r82;
+    r88 = fmaf(r44, r88, r44 * r87);
+    r87 = r33 * r33;
+    r81 = r16 * r25;
+    r81 = r81 * r55;
+    r89 = r16 * r89;
+    r94 = r81 + r89;
+    r92 = r92 + r94;
+    r95 = r40 * r34;
+    r95 = fmaf(r40, r76, r73 * r95);
+    r95 = r95 + r75;
+    r95 = fmaf(r13, r95, r14 * r92);
+    r1 = r93 + r1;
+    r95 = fmaf(r15, r1, r95);
+    r10 = r47 * r10;
+    r10 = 1.0 / r10;
+    r47 = r40 * r10;
+    r87 = r87 * r95;
+    r88 = fmaf(r47, r87, r88);
+    r1 = r51 * r51;
+    r1 = r1 * r95;
+    r88 = fmaf(r47, r1, r88);
+    r1 = r62 * r88;
+    r87 = r51 * r46;
+    r93 = r41 + r35;
+    r93 = 1.0 / r93;
+    r35 = rsqrtf(r35);
+    r92 = r51 * r35;
+    r73 = r93 * r92;
+    r87 = r87 * r73;
+    r1 = fmaf(r87, r1, r46 * r3);
+    r3 = r48 * r48;
+    r96 = -6.00000000000000000e+00;
+    r3 = r3 * r95;
+    r3 = r3 * r96;
+    r3 = r3 * r11;
+    r3 = r3 * r10;
+    r97 = r51 * r51;
+    r97 = r97 * r47;
+    r98 = -3.00000000000000000e+00;
+    r99 = r51 * r48;
+    r100 = r98 * r99;
+    r49 = r36 * r49;
+    r49 = 1.0 / r49;
+    r49 = r49 * r50;
+    r36 = r92 * r49;
+    r100 = r100 * r36;
+    r101 = r33 * r33;
+    r101 = r101 * r88;
+    r101 = r101 * r35;
+    r101 = r101 * r93;
+    r101 = fmaf(r46, r101, r85 * r63);
+    r49 = r26 * r49;
+    r102 = r33 * r35;
+    r49 = r49 * r102;
+    r103 = r88 * r49;
+    r104 = r33 * r33;
+    r104 = r104 * r48;
+    r104 = r104 * r48;
+    r104 = r104 * r95;
+    r104 = r104 * r11;
+    r101 = fmaf(r47, r104, r101);
+    r101 = fmaf(r4, r103, r101);
+    r1 = fmaf(r3, r97, r1);
+    r1 = fmaf(r88, r100, r1);
+    r1 = r1 + r101;
+    r97 = r82 * r52;
+    r97 = fmaf(r88, r87, r99 * r97);
+    r104 = r51 * r51;
+    r104 = r104 * r48;
+    r104 = r104 * r48;
+    r104 = r104 * r95;
+    r104 = r104 * r11;
+    r97 = fmaf(r47, r104, r97);
+    r105 = r4 * r88;
+    r105 = r105 * r99;
+    r97 = fmaf(r36, r105, r97);
+    r101 = r101 + r97;
+    r1 = fmaf(r8, r101, r58 * r1);
+    r105 = r48 * r74;
+    r105 = r105 * r11;
+    r105 = r105 * r60;
+    r105 = r105 * r92;
+    r92 = r67 * r105;
+    r104 = r57 * r33;
+    r104 = r104 * r88;
+    r104 = r104 * r52;
+    r1 = fmaf(r73, r104, r1);
+    r106 = r57 * r51;
+    r106 = r106 * r33;
+    r106 = r106 * r48;
+    r106 = r106 * r48;
+    r106 = r106 * r84;
+    r106 = r106 * r95;
+    r106 = r106 * r11;
+    r1 = fmaf(r10, r106, r1);
+    r107 = r72 * r88;
+    r107 = r107 * r73;
+    r1 = fmaf(r70, r107, r1);
+    r108 = r48 * r82;
+    r1 = fmaf(r69, r108, r1);
+    r109 = r4 * r51;
+    r109 = r109 * r95;
+    r109 = r109 * r68;
+    r1 = fmaf(r50, r109, r1);
+    r110 = r4 * r51;
+    r110 = r110 * r67;
+    r110 = r110 * r95;
+    r110 = r110 * r68;
+    r1 = fmaf(r50, r110, r1);
+    r111 = r72 * r88;
+    r111 = r111 * r69;
+    r1 = fmaf(r73, r111, r1);
+    r112 = r57 * r88;
+    r113 = r40 * r26;
+    r113 = r113 * r36;
+    r1 = fmaf(r113, r112, r1);
+    r114 = r51 * r48;
+    r115 = r7 * r16;
+    r115 = r115 * r56;
+    r115 = fmaf(r101, r115, r6 * r101);
+    r116 = 4.00000000000000000e+00;
+    r66 = r116 * r66;
+    r59 = r59 * r62;
+    r59 = r59 * r65;
+    r115 = fmaf(r101, r66, r115);
+    r115 = fmaf(r101, r59, r115);
+    r114 = r114 * r115;
+    r1 = fmaf(r69, r114, r1);
+    r65 = r57 * r85;
+    r65 = r65 * r52;
+    r1 = fmaf(r99, r65, r1);
+    r1 = fmaf(r88, r92, r1);
+    r1 = fmaf(r88, r105, r1);
+    r1 = fmaf(r82, r64, r1);
+    r1 = fmaf(r82, r71, r1);
+    r65 = r0 * r1;
+    r114 = r85 * r86;
+    r114 = r114 * r46;
+    r112 = r33 * r33;
+    r112 = r112 * r62;
+    r112 = r112 * r88;
+    r112 = r112 * r35;
+    r112 = r112 * r93;
+    r112 = fmaf(r46, r112, r26 * r114);
+    r114 = r40 * r12;
+    r111 = r33 * r33;
+    r114 = r114 * r111;
+    r114 = r114 * r10;
+    r112 = fmaf(r98, r103, r112);
+    r112 = fmaf(r3, r114, r112);
+    r112 = r112 + r97;
+    r101 = fmaf(r9, r101, r57 * r112);
+    r112 = r33 * r72;
+    r112 = r112 * r88;
+    r112 = r112 * r35;
+    r112 = r112 * r93;
+    r101 = fmaf(r69, r112, r101);
+    r97 = r33 * r48;
+    r97 = r97 * r67;
+    r97 = r97 * r74;
+    r97 = r97 * r88;
+    r97 = r97 * r11;
+    r97 = r97 * r60;
+    r101 = fmaf(r35, r97, r101);
+    r3 = r115 * r69;
+    r101 = fmaf(r26, r3, r101);
+    r103 = r4 * r33;
+    r103 = r103 * r67;
+    r103 = r103 * r95;
+    r103 = r103 * r68;
+    r101 = fmaf(r50, r103, r101);
+    r111 = r58 * r51;
+    r111 = r111 * r33;
+    r111 = r111 * r48;
+    r111 = r111 * r48;
+    r111 = r111 * r84;
+    r111 = r111 * r11;
+    r111 = r111 * r10;
+    r110 = r58 * r82;
+    r101 = fmaf(r63, r110, r101);
+    r109 = r58 * r33;
+    r109 = r109 * r88;
+    r109 = r109 * r52;
+    r101 = fmaf(r73, r109, r101);
+    r108 = r4 * r33;
+    r108 = r108 * r95;
+    r108 = r108 * r68;
+    r101 = fmaf(r50, r108, r101);
+    r107 = r58 * r88;
+    r101 = fmaf(r113, r107, r101);
+    r106 = r72 * r93;
+    r106 = r106 * r70;
+    r106 = r106 * r102;
+    r102 = r58 * r85;
+    r102 = r102 * r52;
+    r101 = fmaf(r99, r102, r101);
+    r104 = r33 * r48;
+    r104 = r104 * r74;
+    r104 = r104 * r88;
+    r104 = r104 * r11;
+    r104 = r104 * r60;
+    r101 = fmaf(r35, r104, r101);
+    r116 = r48 * r85;
+    r101 = fmaf(r69, r116, r101);
+    r101 = fmaf(r95, r111, r101);
+    r101 = fmaf(r88, r106, r101);
+    r101 = fmaf(r85, r71, r101);
+    r116 = r5 * r101;
+    r104 = r51 * r51;
+    r102 = r44 * r104;
+    r107 = r16 * r51;
+    r89 = r91 + r89;
+    r91 = r16 * r32;
+    r108 = r19 * r24;
+    r109 = r18 * r21;
+    r109 = fmaf(r74, r109, r74 * r108);
+    r108 = r17 * r22;
+    r109 = fmaf(r72, r108, r109);
+    r110 = r20 * r23;
+    r109 = fmaf(r74, r110, r109);
+    r91 = r91 * r109;
+    r110 = r16 * r25;
+    r108 = r17 * r24;
+    r95 = r20 * r21;
+    r95 = fmaf(r72, r95, r72 * r108);
+    r108 = r19 * r22;
+    r95 = fmaf(r72, r108, r95);
+    r103 = r18 * r23;
+    r95 = fmaf(r74, r103, r95);
+    r110 = fmaf(r95, r110, r91);
+    r89 = r89 + r110;
+    r103 = r32 * r84;
+    r103 = r103 * r95;
+    r108 = r29 * r80;
+    r108 = r108 * r84;
+    r3 = r103 + r108;
+    r3 = fmaf(r13, r3, r15 * r89);
+    r89 = r40 * r34;
+    r89 = fmaf(r40, r83, r95 * r89);
+    r97 = r16 * r25;
+    r97 = r97 * r80;
+    r112 = r16 * r29;
+    r112 = fmaf(r109, r112, r97);
+    r89 = r89 + r112;
+    r3 = fmaf(r14, r89, r3);
+    r107 = r107 * r3;
+    r89 = r51 * r51;
+    r117 = r40 * r29;
+    r117 = fmaf(r77, r117, r90);
+    r117 = r117 + r110;
+    r110 = r16 * r29;
+    r110 = r110 * r95;
+    r118 = r16 * r34;
+    r118 = fmaf(r109, r118, r110);
+    r118 = r118 + r75;
+    r118 = fmaf(r14, r118, r13 * r117);
+    r117 = r25 * r109;
+    r75 = r84 * r117;
+    r108 = r108 + r75;
+    r118 = fmaf(r15, r108, r118);
+    r89 = r89 * r118;
+    r89 = fmaf(r47, r89, r44 * r107);
+    r107 = r33 * r33;
+    r107 = r107 * r118;
+    r89 = fmaf(r47, r107, r89);
+    r108 = r16 * r33;
+    r119 = r25 * r40;
+    r119 = fmaf(r77, r119, r78);
+    r78 = r40 * r34;
+    r119 = fmaf(r109, r78, r119);
+    r119 = r119 + r110;
+    r78 = r16 * r34;
+    r83 = fmaf(r16, r83, r95 * r78);
+    r83 = r83 + r112;
+    r83 = fmaf(r13, r83, r15 * r119);
+    r75 = r103 + r75;
+    r83 = fmaf(r14, r75, r83);
+    r108 = r108 * r83;
+    r89 = fmaf(r44, r108, r89);
+    r102 = r102 * r11;
+    r102 = r102 * r48;
+    r102 = r102 * r35;
+    r102 = r102 * r93;
+    r102 = r102 * r89;
+    r108 = r4 * r89;
+    r108 = r108 * r99;
+    r108 = fmaf(r36, r108, r102);
+    r107 = r51 * r51;
+    r107 = r107 * r48;
+    r107 = r107 * r48;
+    r107 = r107 * r118;
+    r107 = r107 * r11;
+    r108 = fmaf(r47, r107, r108);
+    r75 = r3 * r52;
+    r108 = fmaf(r99, r75, r108);
+    r75 = r4 * r89;
+    r75 = fmaf(r49, r75, r83 * r63);
+    r107 = r33 * r33;
+    r107 = r107 * r48;
+    r107 = r107 * r48;
+    r107 = r107 * r118;
+    r107 = r107 * r11;
+    r75 = fmaf(r47, r107, r75);
+    r103 = r33 * r33;
+    r103 = r103 * r89;
+    r103 = r103 * r35;
+    r103 = r103 * r93;
+    r75 = fmaf(r46, r103, r75);
+    r103 = r108 + r75;
+    r102 = fmaf(r89, r100, r62 * r102);
+    r107 = r51 * r51;
+    r107 = r107 * r48;
+    r107 = r107 * r48;
+    r107 = r107 * r96;
+    r107 = r107 * r118;
+    r107 = r107 * r11;
+    r102 = fmaf(r10, r107, r102);
+    r119 = r51 * r48;
+    r119 = r119 * r86;
+    r119 = r119 * r3;
+    r102 = fmaf(r46, r119, r102);
+    r102 = r102 + r75;
+    r102 = fmaf(r58, r102, r8 * r103);
+    r75 = r57 * r83;
+    r75 = r75 * r52;
+    r102 = fmaf(r99, r75, r102);
+    r119 = r57 * r51;
+    r119 = r119 * r33;
+    r119 = r119 * r48;
+    r119 = r119 * r48;
+    r119 = r119 * r84;
+    r119 = r119 * r118;
+    r119 = r119 * r11;
+    r102 = fmaf(r10, r119, r102);
+    r107 = r4 * r51;
+    r107 = r107 * r118;
+    r107 = r107 * r68;
+    r102 = fmaf(r50, r107, r102);
+    r78 = r72 * r89;
+    r78 = r78 * r73;
+    r102 = fmaf(r70, r78, r102);
+    r95 = r57 * r89;
+    r102 = fmaf(r113, r95, r102);
+    r110 = r57 * r33;
+    r110 = r110 * r89;
+    r110 = r110 * r52;
+    r102 = fmaf(r73, r110, r102);
+    r77 = r72 * r89;
+    r77 = r77 * r69;
+    r102 = fmaf(r73, r77, r102);
+    r120 = r4 * r51;
+    r120 = r120 * r67;
+    r120 = r120 * r118;
+    r120 = r120 * r68;
+    r102 = fmaf(r50, r120, r102);
+    r121 = r51 * r48;
+    r122 = r7 * r16;
+    r122 = r122 * r56;
+    r122 = fmaf(r103, r122, r6 * r103);
+    r122 = fmaf(r103, r66, r122);
+    r122 = fmaf(r103, r59, r122);
+    r121 = r121 * r122;
+    r102 = fmaf(r69, r121, r102);
+    r123 = r48 * r3;
+    r102 = fmaf(r69, r123, r102);
+    r102 = fmaf(r89, r105, r102);
+    r102 = fmaf(r3, r71, r102);
+    r102 = fmaf(r3, r64, r102);
+    r102 = fmaf(r89, r92, r102);
+    r123 = r0 * r102;
+    r121 = r86 * r83;
+    r121 = r121 * r46;
+    r120 = r98 * r89;
+    r120 = fmaf(r49, r120, r26 * r121);
+    r121 = r33 * r33;
+    r121 = r121 * r48;
+    r121 = r121 * r48;
+    r121 = r121 * r96;
+    r121 = r121 * r118;
+    r121 = r121 * r11;
+    r120 = fmaf(r10, r121, r120);
+    r77 = r33 * r33;
+    r77 = r77 * r62;
+    r77 = r77 * r89;
+    r77 = r77 * r35;
+    r77 = r77 * r93;
+    r120 = fmaf(r46, r77, r120);
+    r120 = r120 + r108;
+    r120 = fmaf(r57, r120, r9 * r103);
+    r103 = r4 * r33;
+    r103 = r103 * r118;
+    r103 = r103 * r68;
+    r120 = fmaf(r50, r103, r120);
+    r108 = r58 * r83;
+    r108 = r108 * r52;
+    r120 = fmaf(r99, r108, r120);
+    r77 = r33 * r48;
+    r77 = r77 * r67;
+    r77 = r77 * r74;
+    r77 = r77 * r89;
+    r77 = r77 * r11;
+    r77 = r77 * r60;
+    r120 = fmaf(r35, r77, r120);
+    r121 = r122 * r69;
+    r120 = fmaf(r26, r121, r120);
+    r110 = r33 * r72;
+    r110 = r110 * r89;
+    r110 = r110 * r35;
+    r110 = r110 * r93;
+    r120 = fmaf(r69, r110, r120);
+    r95 = r33 * r48;
+    r95 = r95 * r74;
+    r95 = r95 * r89;
+    r95 = r95 * r11;
+    r95 = r95 * r60;
+    r120 = fmaf(r35, r95, r120);
+    r78 = r58 * r89;
+    r120 = fmaf(r113, r78, r120);
+    r107 = r58 * r33;
+    r107 = r107 * r89;
+    r107 = r107 * r52;
+    r120 = fmaf(r73, r107, r120);
+    r119 = r58 * r3;
+    r120 = fmaf(r63, r119, r120);
+    r75 = r4 * r33;
+    r75 = r75 * r67;
+    r75 = r75 * r118;
+    r75 = r75 * r68;
+    r120 = fmaf(r50, r75, r120);
+    r124 = r48 * r83;
+    r120 = fmaf(r69, r124, r120);
+    r120 = fmaf(r118, r111, r120);
+    r120 = fmaf(r89, r106, r120);
+    r120 = fmaf(r83, r71, r120);
+    r124 = r5 * r120;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r65,
+                                          r116,
+                                          r123,
+                                          r124);
+    r124 = r33 * r33;
+    r123 = r51 * r51;
+    r116 = r25 * r84;
+    r31 = fmaf(r74, r31, r72 * r27);
+    r31 = fmaf(r72, r28, r31);
+    r31 = fmaf(r72, r30, r31);
+    r116 = r116 * r31;
+    r76 = r84 * r76;
+    r30 = r116 + r76;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r97 = r97 + r28;
+    r27 = r40 * r29;
+    r97 = fmaf(r109, r27, r97);
+    r65 = r40 * r34;
+    r97 = fmaf(r55, r65, r97);
+    r97 = fmaf(r13, r97, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r117, r31 * r30);
+    r30 = r30 + r79;
+    r97 = fmaf(r14, r30, r97);
+    r123 = r123 * r97;
+    r30 = r16 * r51;
+    r65 = r16 * r29;
+    r65 = r65 * r31;
+    r81 = r81 + r65;
+    r27 = r32 * r40;
+    r81 = fmaf(r109, r27, r81);
+    r81 = r81 + r90;
+    r80 = r32 * r80;
+    r80 = r80 * r84;
+    r76 = r80 + r76;
+    r76 = fmaf(r13, r76, r14 * r81);
+    r81 = r16 * r34;
+    r81 = fmaf(r55, r81, r28);
+    r81 = r81 + r112;
+    r76 = fmaf(r15, r81, r76);
+    r30 = r30 * r76;
+    r30 = fmaf(r44, r30, r47 * r123);
+    r123 = r33 * r33;
+    r123 = r123 * r97;
+    r30 = fmaf(r47, r123, r30);
+    r81 = r16 * r33;
+    r65 = r91 + r65;
+    r65 = r65 + r94;
+    r94 = r40 * r34;
+    r117 = fmaf(r40, r117, r31 * r94);
+    r117 = r117 + r79;
+    r117 = fmaf(r15, r117, r13 * r65);
+    r80 = r116 + r80;
+    r117 = fmaf(r14, r80, r117);
+    r81 = r81 * r117;
+    r30 = fmaf(r44, r81, r30);
+    r124 = r124 * r30;
+    r124 = r124 * r35;
+    r124 = r124 * r93;
+    r124 = fmaf(r117, r63, r46 * r124);
+    r81 = r33 * r33;
+    r81 = r81 * r48;
+    r81 = r81 * r48;
+    r81 = r81 * r97;
+    r81 = r81 * r11;
+    r124 = fmaf(r47, r81, r124);
+    r123 = r4 * r30;
+    r124 = fmaf(r49, r123, r124);
+    r123 = r51 * r51;
+    r123 = r123 * r48;
+    r123 = r123 * r48;
+    r123 = r123 * r97;
+    r123 = r123 * r11;
+    r123 = fmaf(r30, r87, r47 * r123);
+    r81 = r4 * r30;
+    r81 = r81 * r99;
+    r123 = fmaf(r36, r81, r123);
+    r80 = r76 * r52;
+    r123 = fmaf(r99, r80, r123);
+    r80 = r124 + r123;
+    r81 = r51 * r51;
+    r81 = r81 * r48;
+    r81 = r81 * r48;
+    r81 = r81 * r96;
+    r81 = r81 * r97;
+    r81 = r81 * r11;
+    r14 = r62 * r30;
+    r14 = fmaf(r87, r14, r10 * r81);
+    r81 = r51 * r48;
+    r81 = r81 * r86;
+    r81 = r81 * r76;
+    r14 = fmaf(r46, r81, r14);
+    r14 = fmaf(r30, r100, r14);
+    r14 = r14 + r124;
+    r14 = fmaf(r58, r14, r8 * r80);
+    r124 = r51 * r48;
+    r81 = r7 * r16;
+    r81 = r81 * r56;
+    r81 = fmaf(r80, r81, r6 * r80);
+    r81 = fmaf(r80, r59, r81);
+    r81 = fmaf(r80, r66, r81);
+    r124 = r124 * r81;
+    r14 = fmaf(r69, r124, r14);
+    r116 = r57 * r51;
+    r116 = r116 * r33;
+    r116 = r116 * r48;
+    r116 = r116 * r48;
+    r116 = r116 * r84;
+    r116 = r116 * r97;
+    r116 = r116 * r11;
+    r14 = fmaf(r10, r116, r14);
+    r15 = r72 * r30;
+    r15 = r15 * r69;
+    r14 = fmaf(r73, r15, r14);
+    r65 = r4 * r51;
+    r65 = r65 * r97;
+    r65 = r65 * r68;
+    r14 = fmaf(r50, r65, r14);
+    r13 = r57 * r30;
+    r14 = fmaf(r113, r13, r14);
+    r79 = r72 * r30;
+    r79 = r79 * r73;
+    r14 = fmaf(r70, r79, r14);
+    r94 = r57 * r117;
+    r94 = r94 * r52;
+    r14 = fmaf(r99, r94, r14);
+    r31 = r4 * r51;
+    r31 = r31 * r67;
+    r31 = r31 * r97;
+    r31 = r31 * r68;
+    r14 = fmaf(r50, r31, r14);
+    r91 = r48 * r76;
+    r14 = fmaf(r69, r91, r14);
+    r112 = r57 * r33;
+    r112 = r112 * r30;
+    r112 = r112 * r52;
+    r14 = fmaf(r73, r112, r14);
+    r14 = fmaf(r30, r92, r14);
+    r14 = fmaf(r76, r71, r14);
+    r14 = fmaf(r76, r64, r14);
+    r14 = fmaf(r30, r105, r14);
+    r112 = r0 * r14;
+    r91 = r33 * r33;
+    r91 = r91 * r62;
+    r91 = r91 * r30;
+    r91 = r91 * r35;
+    r91 = r91 * r93;
+    r31 = r86 * r117;
+    r31 = r31 * r46;
+    r31 = fmaf(r26, r31, r46 * r91);
+    r91 = r33 * r33;
+    r91 = r91 * r48;
+    r91 = r91 * r48;
+    r91 = r91 * r96;
+    r91 = r91 * r97;
+    r91 = r91 * r11;
+    r31 = fmaf(r10, r91, r31);
+    r94 = r98 * r30;
+    r31 = fmaf(r49, r94, r31);
+    r31 = r31 + r123;
+    r31 = fmaf(r57, r31, r9 * r80);
+    r80 = r33 * r48;
+    r80 = r80 * r74;
+    r80 = r80 * r30;
+    r80 = r80 * r11;
+    r80 = r80 * r60;
+    r31 = fmaf(r35, r80, r31);
+    r123 = r33 * r72;
+    r123 = r123 * r30;
+    r123 = r123 * r35;
+    r123 = r123 * r93;
+    r31 = fmaf(r69, r123, r31);
+    r94 = r4 * r33;
+    r94 = r94 * r67;
+    r94 = r94 * r97;
+    r94 = r94 * r68;
+    r31 = fmaf(r50, r94, r31);
+    r91 = r58 * r30;
+    r31 = fmaf(r113, r91, r31);
+    r79 = r58 * r76;
+    r31 = fmaf(r63, r79, r31);
+    r13 = r33 * r48;
+    r13 = r13 * r67;
+    r13 = r13 * r74;
+    r13 = r13 * r30;
+    r13 = r13 * r11;
+    r13 = r13 * r60;
+    r31 = fmaf(r35, r13, r31);
+    r65 = r58 * r117;
+    r65 = r65 * r52;
+    r31 = fmaf(r99, r65, r31);
+    r15 = r4 * r33;
+    r15 = r15 * r97;
+    r15 = r15 * r68;
+    r31 = fmaf(r50, r15, r31);
+    r116 = r58 * r33;
+    r116 = r116 * r30;
+    r116 = r116 * r52;
+    r31 = fmaf(r73, r116, r31);
+    r124 = r48 * r117;
+    r31 = fmaf(r69, r124, r31);
+    r28 = r81 * r69;
+    r31 = fmaf(r26, r28, r31);
+    r31 = fmaf(r97, r111, r31);
+    r31 = fmaf(r117, r71, r31);
+    r31 = fmaf(r30, r106, r31);
+    r28 = r5 * r31;
+    r124 = r12 * r51;
+    r124 = r124 * r51;
+    r124 = r124 * r48;
+    r124 = r124 * r48;
+    r124 = r124 * r96;
+    r124 = r124 * r11;
+    r116 = r42 * r51;
+    r116 = r116 * r48;
+    r116 = r116 * r86;
+    r116 = fmaf(r46, r116, r10 * r124);
+    r124 = r40 * r12;
+    r124 = r124 * r104;
+    r124 = r124 * r10;
+    r104 = r114 + r124;
+    r15 = r16 * r38;
+    r15 = r15 * r33;
+    r104 = fmaf(r44, r15, r104);
+    r65 = r16 * r42;
+    r65 = r65 * r51;
+    r104 = fmaf(r44, r65, r104);
+    r65 = r62 * r104;
+    r116 = fmaf(r87, r65, r116);
+    r15 = r48 * r48;
+    r15 = r15 * r11;
+    r114 = fmaf(r38, r63, r114 * r15);
+    r13 = r4 * r104;
+    r114 = fmaf(r49, r13, r114);
+    r79 = r33 * r33;
+    r79 = r79 * r104;
+    r79 = r79 * r35;
+    r79 = r79 * r93;
+    r114 = fmaf(r46, r79, r114);
+    r116 = fmaf(r104, r100, r116);
+    r116 = r116 + r114;
+    r65 = r42 * r52;
+    r65 = fmaf(r99, r65, r15 * r124);
+    r124 = r4 * r104;
+    r124 = r124 * r99;
+    r65 = fmaf(r36, r124, r65);
+    r65 = fmaf(r104, r87, r65);
+    r114 = r114 + r65;
+    r116 = fmaf(r8, r114, r58 * r116);
+    r124 = r4 * r12;
+    r124 = r124 * r51;
+    r124 = r124 * r68;
+    r116 = fmaf(r50, r124, r116);
+    r15 = r42 * r48;
+    r116 = fmaf(r69, r15, r116);
+    r79 = r104 * r113;
+    r13 = r57 * r33;
+    r13 = r13 * r104;
+    r13 = r13 * r52;
+    r116 = fmaf(r73, r13, r116);
+    r91 = r72 * r104;
+    r91 = r91 * r73;
+    r116 = fmaf(r70, r91, r116);
+    r94 = r57 * r12;
+    r94 = r94 * r51;
+    r94 = r94 * r33;
+    r94 = r94 * r48;
+    r94 = r94 * r48;
+    r94 = r94 * r84;
+    r94 = r94 * r11;
+    r116 = fmaf(r10, r94, r116);
+    r123 = r72 * r104;
+    r123 = r123 * r69;
+    r116 = fmaf(r73, r123, r116);
+    r80 = r57 * r38;
+    r80 = r80 * r52;
+    r116 = fmaf(r99, r80, r116);
+    r97 = r51 * r48;
+    r55 = r7 * r16;
+    r55 = r55 * r56;
+    r55 = fmaf(r6, r114, r114 * r55);
+    r55 = fmaf(r114, r66, r55);
+    r55 = fmaf(r114, r59, r55);
+    r97 = r97 * r55;
+    r116 = fmaf(r69, r97, r116);
+    r90 = r4 * r12;
+    r90 = r90 * r51;
+    r90 = r90 * r67;
+    r90 = r90 * r68;
+    r116 = fmaf(r50, r90, r116);
+    r116 = fmaf(r104, r92, r116);
+    r116 = fmaf(r57, r79, r116);
+    r116 = fmaf(r42, r71, r116);
+    r116 = fmaf(r42, r64, r116);
+    r116 = fmaf(r104, r105, r116);
+    r90 = r0 * r116;
+    r97 = r12 * r33;
+    r97 = r97 * r33;
+    r97 = r97 * r48;
+    r97 = r97 * r48;
+    r97 = r97 * r96;
+    r97 = r97 * r11;
+    r80 = r38 * r86;
+    r80 = r80 * r46;
+    r80 = fmaf(r26, r80, r10 * r97);
+    r97 = r98 * r104;
+    r80 = fmaf(r49, r97, r80);
+    r123 = r33 * r33;
+    r123 = r123 * r62;
+    r123 = r123 * r104;
+    r123 = r123 * r35;
+    r123 = r123 * r93;
+    r80 = fmaf(r46, r123, r80);
+    r80 = r80 + r65;
+    r114 = fmaf(r9, r114, r57 * r80);
+    r80 = r4 * r12;
+    r80 = r80 * r33;
+    r80 = r80 * r68;
+    r114 = fmaf(r50, r80, r114);
+    r65 = r4 * r12;
+    r65 = r65 * r33;
+    r65 = r65 * r67;
+    r65 = r65 * r68;
+    r114 = fmaf(r50, r65, r114);
+    r123 = r33 * r48;
+    r123 = r123 * r74;
+    r123 = r123 * r104;
+    r123 = r123 * r11;
+    r123 = r123 * r60;
+    r114 = fmaf(r35, r123, r114);
+    r97 = r33 * r48;
+    r97 = r97 * r67;
+    r97 = r97 * r74;
+    r97 = r97 * r104;
+    r97 = r97 * r11;
+    r97 = r97 * r60;
+    r114 = fmaf(r35, r97, r114);
+    r94 = r38 * r48;
+    r114 = fmaf(r69, r94, r114);
+    r91 = r58 * r33;
+    r91 = r91 * r104;
+    r91 = r91 * r52;
+    r114 = fmaf(r73, r91, r114);
+    r13 = r58 * r42;
+    r114 = fmaf(r63, r13, r114);
+    r15 = r33 * r72;
+    r15 = r15 * r104;
+    r15 = r15 * r35;
+    r15 = r15 * r93;
+    r114 = fmaf(r69, r15, r114);
+    r124 = r58 * r38;
+    r124 = r124 * r52;
+    r114 = fmaf(r99, r124, r114);
+    r27 = r55 * r69;
+    r114 = fmaf(r26, r27, r114);
+    r114 = fmaf(r38, r71, r114);
+    r114 = fmaf(r58, r79, r114);
+    r114 = fmaf(r12, r111, r114);
+    r114 = fmaf(r104, r106, r114);
+    r27 = r5 * r114;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r112,
+                                          r28,
+                                          r90,
+                                          r27);
+    r27 = r33 * r33;
+    r90 = r39 * r33;
+    r90 = r90 * r33;
+    r28 = r16 * r43;
+    r28 = r28 * r33;
+    r28 = fmaf(r44, r28, r47 * r90);
+    r90 = r39 * r51;
+    r90 = r90 * r51;
+    r28 = fmaf(r47, r90, r28);
+    r112 = r16 * r54;
+    r112 = r112 * r51;
+    r28 = fmaf(r44, r112, r28);
+    r27 = r27 * r28;
+    r27 = r27 * r35;
+    r27 = r27 * r93;
+    r112 = r39 * r33;
+    r112 = r112 * r33;
+    r112 = r112 * r48;
+    r112 = r112 * r48;
+    r112 = r112 * r11;
+    r112 = fmaf(r47, r112, r46 * r27);
+    r27 = r4 * r28;
+    r112 = fmaf(r49, r27, r112);
+    r112 = fmaf(r43, r63, r112);
+    r27 = r39 * r51;
+    r27 = r27 * r51;
+    r27 = r27 * r48;
+    r27 = r27 * r48;
+    r27 = r27 * r11;
+    r27 = fmaf(r47, r27, r28 * r87);
+    r90 = r54 * r52;
+    r27 = fmaf(r99, r90, r27);
+    r124 = r4 * r28;
+    r124 = r124 * r99;
+    r27 = fmaf(r36, r124, r27);
+    r124 = r112 + r27;
+    r90 = r62 * r28;
+    r15 = r39 * r51;
+    r15 = r15 * r51;
+    r15 = r15 * r48;
+    r15 = r15 * r48;
+    r15 = r15 * r96;
+    r15 = r15 * r11;
+    r15 = fmaf(r10, r15, r87 * r90);
+    r90 = r54 * r51;
+    r90 = r90 * r48;
+    r90 = r90 * r86;
+    r15 = fmaf(r46, r90, r15);
+    r15 = fmaf(r28, r100, r15);
+    r15 = r15 + r112;
+    r15 = fmaf(r58, r15, r8 * r124);
+    r112 = r51 * r48;
+    r90 = r7 * r16;
+    r90 = r90 * r56;
+    r90 = fmaf(r124, r90, r6 * r124);
+    r90 = fmaf(r124, r66, r90);
+    r90 = fmaf(r124, r59, r90);
+    r112 = r112 * r90;
+    r15 = fmaf(r69, r112, r15);
+    r13 = r57 * r43;
+    r13 = r13 * r52;
+    r15 = fmaf(r99, r13, r15);
+    r91 = r54 * r48;
+    r15 = fmaf(r69, r91, r15);
+    r79 = r57 * r33;
+    r79 = r79 * r28;
+    r79 = r79 * r52;
+    r15 = fmaf(r73, r79, r15);
+    r94 = r72 * r28;
+    r94 = r94 * r69;
+    r15 = fmaf(r73, r94, r15);
+    r97 = r57 * r39;
+    r97 = r97 * r51;
+    r97 = r97 * r33;
+    r97 = r97 * r48;
+    r97 = r97 * r48;
+    r97 = r97 * r84;
+    r97 = r97 * r11;
+    r15 = fmaf(r10, r97, r15);
+    r123 = r57 * r28;
+    r15 = fmaf(r113, r123, r15);
+    r65 = r72 * r28;
+    r65 = r65 * r73;
+    r15 = fmaf(r70, r65, r15);
+    r80 = r4 * r39;
+    r80 = r80 * r51;
+    r80 = r80 * r68;
+    r15 = fmaf(r50, r80, r15);
+    r109 = r4 * r39;
+    r109 = r109 * r51;
+    r109 = r109 * r67;
+    r109 = r109 * r68;
+    r15 = fmaf(r50, r109, r15);
+    r15 = fmaf(r54, r71, r15);
+    r15 = fmaf(r28, r105, r15);
+    r15 = fmaf(r28, r92, r15);
+    r15 = fmaf(r54, r64, r15);
+    r109 = r0 * r15;
+    r80 = r33 * r33;
+    r80 = r80 * r62;
+    r80 = r80 * r28;
+    r80 = r80 * r35;
+    r80 = r80 * r93;
+    r65 = r39 * r33;
+    r65 = r65 * r33;
+    r65 = r65 * r48;
+    r65 = r65 * r48;
+    r65 = r65 * r96;
+    r65 = r65 * r11;
+    r65 = fmaf(r10, r65, r46 * r80);
+    r80 = r43 * r86;
+    r80 = r80 * r46;
+    r65 = fmaf(r26, r80, r65);
+    r123 = r98 * r28;
+    r65 = fmaf(r49, r123, r65);
+    r65 = r65 + r27;
+    r65 = fmaf(r57, r65, r9 * r124);
+    r124 = r58 * r43;
+    r124 = r124 * r52;
+    r65 = fmaf(r99, r124, r65);
+    r27 = r4 * r39;
+    r27 = r27 * r33;
+    r27 = r27 * r68;
+    r65 = fmaf(r50, r27, r65);
+    r123 = r33 * r72;
+    r123 = r123 * r28;
+    r123 = r123 * r35;
+    r123 = r123 * r93;
+    r65 = fmaf(r69, r123, r65);
+    r80 = r58 * r33;
+    r80 = r80 * r28;
+    r80 = r80 * r52;
+    r65 = fmaf(r73, r80, r65);
+    r97 = r58 * r28;
+    r65 = fmaf(r113, r97, r65);
+    r94 = r43 * r48;
+    r65 = fmaf(r69, r94, r65);
+    r79 = r58 * r54;
+    r65 = fmaf(r63, r79, r65);
+    r91 = r4 * r39;
+    r91 = r91 * r33;
+    r91 = r91 * r67;
+    r91 = r91 * r68;
+    r65 = fmaf(r50, r91, r65);
+    r13 = r33 * r48;
+    r13 = r13 * r67;
+    r13 = r13 * r74;
+    r13 = r13 * r28;
+    r13 = r13 * r11;
+    r13 = r13 * r60;
+    r65 = fmaf(r35, r13, r65);
+    r112 = r90 * r69;
+    r65 = fmaf(r26, r112, r65);
+    r75 = r33 * r48;
+    r75 = r75 * r74;
+    r75 = r75 * r28;
+    r75 = r75 * r11;
+    r75 = r75 * r60;
+    r65 = fmaf(r35, r75, r65);
+    r65 = fmaf(r28, r106, r65);
+    r65 = fmaf(r43, r71, r65);
+    r65 = fmaf(r39, r111, r65);
+    r75 = r5 * r65;
+    r112 = r33 * r33;
+    r13 = r16 * r45;
+    r13 = r13 * r33;
+    r91 = r37 * r33;
+    r91 = r91 * r33;
+    r91 = fmaf(r47, r91, r44 * r13);
+    r13 = r16 * r53;
+    r13 = r13 * r51;
+    r91 = fmaf(r44, r13, r91);
+    r44 = r37 * r51;
+    r44 = r44 * r51;
+    r91 = fmaf(r47, r44, r91);
+    r112 = r112 * r91;
+    r112 = r112 * r35;
+    r112 = r112 * r93;
+    r112 = fmaf(r45, r63, r46 * r112);
+    r44 = r4 * r91;
+    r112 = fmaf(r49, r44, r112);
+    r13 = r37 * r33;
+    r13 = r13 * r33;
+    r13 = r13 * r48;
+    r13 = r13 * r48;
+    r13 = r13 * r11;
+    r112 = fmaf(r47, r13, r112);
+    r13 = r37 * r51;
+    r13 = r13 * r51;
+    r13 = r13 * r48;
+    r13 = r13 * r48;
+    r13 = r13 * r11;
+    r44 = r4 * r91;
+    r44 = r44 * r99;
+    r44 = fmaf(r36, r44, r47 * r13);
+    r13 = r53 * r52;
+    r44 = fmaf(r99, r13, r44);
+    r44 = fmaf(r91, r87, r44);
+    r13 = r112 + r44;
+    r36 = r37 * r51;
+    r36 = r36 * r51;
+    r36 = r36 * r48;
+    r36 = r36 * r48;
+    r36 = r36 * r96;
+    r36 = r36 * r11;
+    r100 = fmaf(r91, r100, r10 * r36);
+    r36 = r53 * r51;
+    r36 = r36 * r48;
+    r36 = r36 * r86;
+    r100 = fmaf(r46, r36, r100);
+    r47 = r62 * r91;
+    r100 = fmaf(r87, r47, r100);
+    r100 = r100 + r112;
+    r100 = fmaf(r58, r100, r8 * r13);
+    r8 = r4 * r37;
+    r8 = r8 * r51;
+    r8 = r8 * r67;
+    r8 = r8 * r68;
+    r100 = fmaf(r50, r8, r100);
+    r112 = r53 * r48;
+    r100 = fmaf(r69, r112, r100);
+    r47 = r4 * r37;
+    r47 = r47 * r51;
+    r47 = r47 * r68;
+    r100 = fmaf(r50, r47, r100);
+    r36 = r72 * r91;
+    r36 = r36 * r73;
+    r100 = fmaf(r70, r36, r100);
+    r70 = r57 * r91;
+    r100 = fmaf(r113, r70, r100);
+    r87 = r57 * r33;
+    r87 = r87 * r91;
+    r87 = r87 * r52;
+    r100 = fmaf(r73, r87, r100);
+    r79 = r57 * r45;
+    r79 = r79 * r52;
+    r100 = fmaf(r99, r79, r100);
+    r94 = r72 * r91;
+    r94 = r94 * r69;
+    r100 = fmaf(r73, r94, r100);
+    r97 = r51 * r48;
+    r80 = r7 * r16;
+    r80 = r80 * r56;
+    r6 = fmaf(r6, r13, r13 * r80);
+    r6 = fmaf(r13, r66, r6);
+    r6 = fmaf(r13, r59, r6);
+    r97 = r97 * r6;
+    r100 = fmaf(r69, r97, r100);
+    r59 = r57 * r37;
+    r59 = r59 * r51;
+    r59 = r59 * r33;
+    r59 = r59 * r48;
+    r59 = r59 * r48;
+    r59 = r59 * r84;
+    r59 = r59 * r11;
+    r100 = fmaf(r10, r59, r100);
+    r100 = fmaf(r53, r71, r100);
+    r100 = fmaf(r91, r105, r100);
+    r100 = fmaf(r53, r64, r100);
+    r100 = fmaf(r91, r92, r100);
+    r59 = r0 * r100;
+    r97 = r33 * r33;
+    r97 = r97 * r62;
+    r97 = r97 * r91;
+    r97 = r97 * r35;
+    r97 = r97 * r93;
+    r94 = r45 * r86;
+    r94 = r94 * r46;
+    r94 = fmaf(r26, r94, r46 * r97);
+    r97 = r98 * r91;
+    r94 = fmaf(r49, r97, r94);
+    r49 = r37 * r33;
+    r49 = r49 * r33;
+    r49 = r49 * r48;
+    r49 = r49 * r48;
+    r49 = r49 * r96;
+    r49 = r49 * r11;
+    r94 = fmaf(r10, r49, r94);
+    r94 = r94 + r44;
+    r94 = fmaf(r57, r94, r9 * r13);
+    r13 = r33 * r72;
+    r13 = r13 * r91;
+    r13 = r13 * r35;
+    r13 = r13 * r93;
+    r94 = fmaf(r69, r13, r94);
+    r93 = r33 * r48;
+    r93 = r93 * r67;
+    r93 = r93 * r74;
+    r93 = r93 * r91;
+    r93 = r93 * r11;
+    r93 = r93 * r60;
+    r94 = fmaf(r35, r93, r94);
+    r9 = r33 * r48;
+    r9 = r9 * r74;
+    r9 = r9 * r91;
+    r9 = r9 * r11;
+    r9 = r9 * r60;
+    r94 = fmaf(r35, r9, r94);
+    r35 = r58 * r91;
+    r94 = fmaf(r113, r35, r94);
+    r113 = r58 * r33;
+    r113 = r113 * r91;
+    r113 = r113 * r52;
+    r94 = fmaf(r73, r113, r94);
+    r73 = r58 * r45;
+    r73 = r73 * r52;
+    r94 = fmaf(r99, r73, r94);
+    r99 = r4 * r37;
+    r99 = r99 * r33;
+    r99 = r99 * r67;
+    r99 = r99 * r68;
+    r94 = fmaf(r50, r99, r94);
+    r67 = r58 * r53;
+    r94 = fmaf(r63, r67, r94);
+    r63 = r45 * r48;
+    r94 = fmaf(r69, r63, r94);
+    r60 = r4 * r37;
+    r60 = r60 * r33;
+    r60 = r60 * r68;
+    r94 = fmaf(r50, r60, r94);
+    r50 = r6 * r69;
+    r94 = fmaf(r26, r50, r94);
+    r94 = fmaf(r91, r106, r94);
+    r94 = fmaf(r45, r71, r94);
+    r94 = fmaf(r37, r111, r94);
+    r111 = r5 * r94;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r109,
+                                          r75,
+                                          r59,
+                                          r111);
+    r111 = r0 * r4;
+    r111 = r111 * r2;
+    r61 = r4 * r61;
+    r59 = r5 * r61;
+    r111 = fmaf(r101, r59, r1 * r111);
+    r75 = r0 * r4;
+    r75 = r75 * r2;
+    r75 = fmaf(r120, r59, r102 * r75);
+    r109 = r0 * r4;
+    r109 = r109 * r2;
+    r109 = fmaf(r31, r59, r14 * r109);
+    r50 = r0 * r4;
+    r50 = r50 * r2;
+    r50 = fmaf(r114, r59, r116 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r111, r75, r109, r50);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r0 * r4;
+    r50 = r50 * r2;
+    r50 = fmaf(r65, r59, r15 * r50);
+    r109 = r0 * r4;
+    r109 = r109 * r2;
+    r59 = fmaf(r94, r59, r100 * r109);
+    WriteSum2<float, float>((float*)inout_shared, r50, r59);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r0 * r0;
+    r50 = r1 * r59;
+    r5 = r5 * r5;
+    r109 = r101 * r5;
+    r101 = fmaf(r101, r109, r1 * r50);
+    r1 = r102 * r102;
+    r75 = r120 * r120;
+    r75 = fmaf(r5, r75, r59 * r1);
+    r1 = r31 * r31;
+    r111 = r14 * r14;
+    r111 = fmaf(r59, r111, r5 * r1);
+    r1 = r116 * r116;
+    r60 = r114 * r114;
+    r60 = fmaf(r5, r60, r59 * r1);
+    WriteSum4<float, float>((float*)inout_shared, r101, r75, r111, r60);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r15 * r15;
+    r111 = r65 * r65;
+    r111 = fmaf(r5, r111, r59 * r60);
+    r60 = r94 * r94;
+    r75 = r100 * r100;
+    r75 = fmaf(r59, r75, r5 * r60);
+    WriteSum2<float, float>((float*)inout_shared, r111, r75);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = fmaf(r102, r50, r120 * r109);
+    r111 = fmaf(r31, r109, r14 * r50);
+    r60 = fmaf(r116, r50, r114 * r109);
+    r101 = fmaf(r15, r50, r65 * r109);
+    WriteSum4<float, float>((float*)inout_shared, r75, r111, r60, r101);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = fmaf(r94, r109, r100 * r50);
+    r50 = r120 * r31;
+    r101 = r102 * r14;
+    r101 = fmaf(r59, r101, r5 * r50);
+    r50 = r102 * r116;
+    r60 = r120 * r114;
+    r60 = fmaf(r5, r60, r59 * r50);
+    r50 = r102 * r15;
+    r111 = r120 * r65;
+    r111 = fmaf(r5, r111, r59 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r109, r101, r60, r111);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r111 = r120 * r94;
+    r60 = r102 * r100;
+    r60 = fmaf(r59, r60, r5 * r111);
+    r111 = r31 * r114;
+    r101 = r14 * r116;
+    r101 = fmaf(r59, r101, r5 * r111);
+    r111 = r14 * r15;
+    r109 = r31 * r65;
+    r109 = fmaf(r5, r109, r59 * r111);
+    r111 = r31 * r94;
+    r50 = r14 * r100;
+    r50 = fmaf(r59, r50, r5 * r111);
+    WriteSum4<float, float>((float*)inout_shared, r60, r101, r109, r50);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r114 * r65;
+    r109 = r116 * r15;
+    r109 = fmaf(r59, r109, r5 * r50);
+    r50 = r116 * r100;
+    r101 = r114 * r94;
+    r101 = fmaf(r5, r101, r59 * r50);
+    r50 = r65 * r94;
+    r60 = r15 * r100;
+    r60 = fmaf(r59, r60, r5 * r50);
+    WriteSum3<float, float>((float*)inout_shared, r109, r101, r60);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r4 * r2;
+    WriteSum2<float, float>((float*)inout_shared, r2, r61);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r41, r41);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirstKernel<<<n_blocks,
+                                                                       1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.cu
@@ -1,0 +1,320 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScoreKernel<<<n_blocks,
+                                                                 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,1652 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = r33 * r33;
+    r47 = r40 * r29;
+    r47 = r47 * r29;
+    r51 = r41 + r47;
+    r51 = r51 + r48;
+    r51 = fmaf(r13, r51, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r52 = r21 * r23;
+    r52 = r52 * r16;
+    r53 = r22 * r24;
+    r53 = fmaf(r16, r53, r52);
+    r54 = r23 * r24;
+    r54 = fmaf(r40, r54, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r51 = fmaf(r14, r10, r51);
+    r51 = fmaf(r15, r48, r51);
+    r51 = fmaf(r36, r53, r51);
+    r51 = fmaf(r35, r54, r51);
+    r51 = fmaf(r11, r42, r51);
+    r48 = r51 * r51;
+    r10 = 9.99999999999999955e-07;
+    r55 = r40 * r29;
+    r55 = fmaf(r34, r55, r26);
+    r55 = fmaf(r13, r55, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r52);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r47 = r41 + r47;
+    r47 = r47 + r50;
+    r55 = fmaf(r11, r12, r55);
+    r55 = fmaf(r36, r37, r55);
+    r55 = fmaf(r35, r39, r55);
+    r55 = fmaf(r14, r44, r55);
+    r55 = fmaf(r15, r47, r55);
+    r47 = copysign(1.0, r55);
+    r47 = fmaf(r10, r47, r55);
+    r55 = r47 * r47;
+    r44 = 1.0 / r55;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = atanf(r48);
+    r11 = copysign(1.0, r48);
+    r11 = fmaf(r10, r11, r48);
+    r10 = r11 * r11;
+    r48 = 1.0 / r10;
+    r50 = r36 * r44;
+    r46 = r48 * r50;
+    r49 = r49 * r36;
+    r49 = r49 * r46;
+    r52 = r51 * r46;
+    r26 = r51 * r36;
+    r52 = r52 * r26;
+    r56 = r49 + r52;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r57,
+                                         r58,
+                                         r59,
+                                         r60);
+    r61 = 3.00000000000000000e+00;
+    r62 = r51 * r61;
+    r62 = r62 * r46;
+    r62 = fmaf(r26, r62, r49);
+    r62 = fmaf(r58, r62, r8 * r56);
+    r49 = r16 * r46;
+    r63 = r26 * r49;
+    r64 = r57 * r63;
+    r65 = r56 * r56;
+    r66 = r56 * r65;
+    r67 = fmaf(r59, r66, r6 * r56);
+    r66 = r60 * r66;
+    r67 = fmaf(r56, r66, r67);
+    r67 = fmaf(r7, r65, r67);
+    r60 = 1.0 / r47;
+    r68 = 1.0 / r11;
+    r69 = r60 * r68;
+    r70 = r67 * r69;
+    r62 = fmaf(r33, r64, r62);
+    r62 = fmaf(r26, r70, r62);
+    r62 = fmaf(r69, r26, r62);
+    r2 = fmaf(r0, r62, r2);
+    r62 = r33 * r33;
+    r62 = r62 * r36;
+    r62 = r62 * r61;
+    r62 = fmaf(r46, r62, r52);
+    r62 = fmaf(r57, r62, r9 * r56);
+    r52 = r36 * r70;
+    r71 = r58 * r33;
+    r62 = fmaf(r63, r71, r62);
+    r72 = r33 * r36;
+    r62 = fmaf(r69, r72, r62);
+    r62 = fmaf(r33, r52, r62);
+    r62 = fmaf(r5, r62, r1);
+    r62 = fmaf(r3, r4, r62);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r62);
+    r3 = r0 * r4;
+    r1 = r16 * r34;
+    r72 = r19 * r24;
+    r71 = 5.00000000000000000e-01;
+    r73 = r18 * r21;
+    r73 = fmaf(r71, r73, r71 * r72);
+    r72 = r17 * r22;
+    r74 = -5.00000000000000000e-01;
+    r73 = fmaf(r74, r72, r73);
+    r75 = r20 * r23;
+    r73 = fmaf(r71, r75, r73);
+    r75 = r17 * r24;
+    r72 = r20 * r21;
+    r72 = fmaf(r74, r72, r74 * r75);
+    r75 = r19 * r22;
+    r72 = fmaf(r74, r75, r72);
+    r76 = r18 * r23;
+    r72 = fmaf(r71, r76, r72);
+    r76 = r29 * r72;
+    r1 = fmaf(r16, r76, r73 * r1);
+    r75 = r16 * r25;
+    r77 = fmaf(r71, r31, r74 * r27);
+    r77 = fmaf(r74, r28, r77);
+    r77 = fmaf(r74, r30, r77);
+    r78 = r16 * r32;
+    r79 = r20 * r24;
+    r80 = r17 * r21;
+    r80 = fmaf(r74, r80, r71 * r79);
+    r79 = r18 * r22;
+    r80 = fmaf(r74, r79, r80);
+    r81 = r19 * r23;
+    r80 = fmaf(r74, r81, r80);
+    r78 = r78 * r80;
+    r75 = fmaf(r77, r75, r78);
+    r1 = r1 + r75;
+    r81 = r16 * r29;
+    r81 = r81 * r80;
+    r79 = r16 * r25;
+    r79 = r79 * r73;
+    r82 = r81 + r79;
+    r83 = r32 * r40;
+    r82 = fmaf(r72, r83, r82);
+    r84 = r40 * r34;
+    r82 = fmaf(r77, r84, r82);
+    r82 = fmaf(r14, r82, r15 * r1);
+    r1 = r29 * r73;
+    r84 = -4.00000000000000000e+00;
+    r1 = r1 * r84;
+    r83 = r32 * r77;
+    r85 = r84 * r83;
+    r86 = r1 + r85;
+    r82 = fmaf(r13, r86, r82);
+    r86 = 6.00000000000000000e+00;
+    r87 = r82 * r86;
+    r87 = r87 * r46;
+    r88 = r51 * r51;
+    r89 = r16 * r33;
+    r90 = r25 * r40;
+    r91 = r34 * r80;
+    r92 = r40 * r91;
+    r90 = fmaf(r72, r90, r92);
+    r93 = r16 * r29;
+    r93 = r93 * r77;
+    r94 = r16 * r32;
+    r94 = fmaf(r73, r94, r93);
+    r90 = r90 + r94;
+    r95 = r25 * r80;
+    r95 = r95 * r84;
+    r85 = r95 + r85;
+    r85 = fmaf(r14, r85, r15 * r90);
+    r90 = r16 * r34;
+    r90 = fmaf(r77, r90, r79);
+    r79 = r16 * r32;
+    r79 = fmaf(r72, r79, r81);
+    r90 = r90 + r79;
+    r85 = fmaf(r13, r90, r85);
+    r89 = r89 * r85;
+    r90 = r16 * r51;
+    r90 = r90 * r82;
+    r90 = fmaf(r44, r90, r44 * r89);
+    r89 = r33 * r33;
+    r81 = r16 * r25;
+    r81 = r81 * r72;
+    r91 = r16 * r91;
+    r96 = r81 + r91;
+    r94 = r94 + r96;
+    r97 = r40 * r34;
+    r97 = fmaf(r40, r76, r73 * r97);
+    r97 = r97 + r75;
+    r97 = fmaf(r13, r97, r14 * r94);
+    r1 = r95 + r1;
+    r97 = fmaf(r15, r1, r97);
+    r55 = r47 * r55;
+    r55 = 1.0 / r55;
+    r47 = r40 * r55;
+    r89 = r89 * r97;
+    r90 = fmaf(r47, r89, r90);
+    r1 = r51 * r51;
+    r1 = r1 * r97;
+    r90 = fmaf(r47, r1, r90);
+    r41 = r41 + r35;
+    r41 = 1.0 / r41;
+    r35 = rsqrtf(r35);
+    r88 = r88 * r61;
+    r88 = r88 * r90;
+    r88 = r88 * r41;
+    r88 = r88 * r35;
+    r88 = fmaf(r46, r88, r26 * r87);
+    r87 = r40 * r12;
+    r1 = r51 * r51;
+    r87 = r87 * r1;
+    r87 = r87 * r55;
+    r1 = r36 * r36;
+    r89 = -6.00000000000000000e+00;
+    r1 = r1 * r97;
+    r1 = r1 * r89;
+    r1 = r1 * r48;
+    r1 = r1 * r55;
+    r95 = -3.00000000000000000e+00;
+    r10 = r11 * r10;
+    r10 = 1.0 / r10;
+    r10 = r10 * r50;
+    r11 = r26 * r10;
+    r94 = r51 * r35;
+    r11 = r11 * r94;
+    r73 = r90 * r11;
+    r98 = r85 * r49;
+    r99 = r33 * r36;
+    r100 = r33 * r46;
+    r101 = r33 * r35;
+    r102 = r41 * r101;
+    r100 = r100 * r102;
+    r98 = fmaf(r90, r100, r99 * r98);
+    r103 = r4 * r90;
+    r10 = r101 * r10;
+    r103 = r103 * r99;
+    r98 = fmaf(r10, r103, r98);
+    r104 = r33 * r33;
+    r104 = r104 * r36;
+    r104 = r104 * r36;
+    r104 = r104 * r97;
+    r104 = r104 * r48;
+    r98 = fmaf(r47, r104, r98);
+    r88 = fmaf(r1, r87, r88);
+    r88 = fmaf(r95, r73, r88);
+    r88 = r88 + r98;
+    r104 = r51 * r51;
+    r104 = r104 * r90;
+    r104 = r104 * r41;
+    r104 = r104 * r35;
+    r104 = fmaf(r46, r104, r82 * r63);
+    r103 = r51 * r51;
+    r103 = r103 * r36;
+    r103 = r103 * r36;
+    r103 = r103 * r97;
+    r103 = r103 * r48;
+    r104 = fmaf(r47, r103, r104);
+    r104 = fmaf(r4, r73, r104);
+    r98 = r98 + r104;
+    r88 = fmaf(r8, r98, r58 * r88);
+    r73 = r51 * r36;
+    r73 = r73 * r67;
+    r73 = r73 * r74;
+    r73 = r73 * r90;
+    r73 = r73 * r48;
+    r73 = r73 * r60;
+    r88 = fmaf(r35, r73, r88);
+    r103 = r57 * r51;
+    r103 = r103 * r90;
+    r103 = r103 * r49;
+    r88 = fmaf(r102, r103, r88);
+    r105 = r51 * r36;
+    r105 = r105 * r74;
+    r105 = r105 * r90;
+    r105 = r105 * r48;
+    r105 = r105 * r60;
+    r88 = fmaf(r35, r105, r88);
+    r106 = r57 * r51;
+    r106 = r106 * r33;
+    r106 = r106 * r36;
+    r106 = r106 * r36;
+    r106 = r106 * r84;
+    r106 = r106 * r97;
+    r106 = r106 * r48;
+    r88 = fmaf(r55, r106, r88);
+    r107 = r71 * r41;
+    r107 = r107 * r70;
+    r107 = r107 * r94;
+    r94 = r57 * r82;
+    r94 = r94 * r49;
+    r88 = fmaf(r99, r94, r88);
+    r108 = r36 * r82;
+    r88 = fmaf(r69, r108, r88);
+    r109 = r4 * r51;
+    r109 = r109 * r97;
+    r109 = r109 * r68;
+    r88 = fmaf(r50, r109, r88);
+    r110 = r4 * r51;
+    r110 = r110 * r67;
+    r110 = r110 * r97;
+    r110 = r110 * r68;
+    r88 = fmaf(r50, r110, r88);
+    r111 = r51 * r71;
+    r111 = r111 * r90;
+    r111 = r111 * r41;
+    r111 = r111 * r35;
+    r88 = fmaf(r69, r111, r88);
+    r112 = r57 * r90;
+    r113 = r40 * r26;
+    r113 = r113 * r10;
+    r88 = fmaf(r113, r112, r88);
+    r114 = r7 * r16;
+    r114 = r114 * r56;
+    r114 = fmaf(r98, r114, r6 * r98);
+    r115 = 4.00000000000000000e+00;
+    r66 = r115 * r66;
+    r59 = r59 * r61;
+    r59 = r59 * r65;
+    r114 = fmaf(r98, r66, r114);
+    r114 = fmaf(r98, r59, r114);
+    r65 = r114 * r69;
+    r88 = fmaf(r26, r65, r88);
+    r88 = fmaf(r90, r107, r88);
+    r88 = fmaf(r85, r64, r88);
+    r88 = fmaf(r82, r52, r88);
+    r3 = r3 * r2;
+    r65 = r5 * r4;
+    r65 = r65 * r62;
+    r62 = r33 * r36;
+    r62 = r62 * r85;
+    r62 = r62 * r86;
+    r112 = r61 * r90;
+    r112 = fmaf(r100, r112, r46 * r62);
+    r62 = r95 * r99;
+    r62 = r62 * r10;
+    r111 = r33 * r33;
+    r111 = r111 * r47;
+    r112 = fmaf(r90, r62, r112);
+    r112 = fmaf(r1, r111, r112);
+    r112 = r112 + r104;
+    r98 = fmaf(r9, r98, r57 * r112);
+    r112 = r71 * r90;
+    r112 = r112 * r69;
+    r98 = fmaf(r102, r112, r98);
+    r104 = r36 * r74;
+    r104 = r104 * r48;
+    r104 = r104 * r60;
+    r104 = r104 * r101;
+    r101 = r67 * r104;
+    r111 = r33 * r36;
+    r111 = r111 * r114;
+    r98 = fmaf(r69, r111, r98);
+    r1 = r4 * r33;
+    r1 = r1 * r67;
+    r1 = r1 * r97;
+    r1 = r1 * r68;
+    r98 = fmaf(r50, r1, r98);
+    r110 = r58 * r51;
+    r110 = r110 * r33;
+    r110 = r110 * r36;
+    r110 = r110 * r36;
+    r110 = r110 * r84;
+    r110 = r110 * r48;
+    r110 = r110 * r55;
+    r109 = r58 * r82;
+    r109 = r109 * r49;
+    r98 = fmaf(r99, r109, r98);
+    r108 = r58 * r51;
+    r108 = r108 * r90;
+    r108 = r108 * r49;
+    r98 = fmaf(r102, r108, r98);
+    r94 = r4 * r33;
+    r94 = r94 * r97;
+    r94 = r94 * r68;
+    r98 = fmaf(r50, r94, r98);
+    r106 = r58 * r90;
+    r98 = fmaf(r113, r106, r98);
+    r105 = r71 * r90;
+    r105 = r105 * r102;
+    r98 = fmaf(r70, r105, r98);
+    r103 = r58 * r85;
+    r98 = fmaf(r63, r103, r98);
+    r73 = r36 * r85;
+    r98 = fmaf(r69, r73, r98);
+    r98 = fmaf(r90, r101, r98);
+    r98 = fmaf(r97, r110, r98);
+    r98 = fmaf(r90, r104, r98);
+    r98 = fmaf(r85, r52, r98);
+    r3 = fmaf(r98, r65, r88 * r3);
+    r73 = r0 * r4;
+    r103 = r51 * r51;
+    r105 = r16 * r51;
+    r91 = r93 + r91;
+    r93 = r16 * r32;
+    r106 = r19 * r24;
+    r94 = r18 * r21;
+    r94 = fmaf(r74, r94, r74 * r106);
+    r106 = r17 * r22;
+    r94 = fmaf(r71, r106, r94);
+    r108 = r20 * r23;
+    r94 = fmaf(r74, r108, r94);
+    r93 = r93 * r94;
+    r108 = r16 * r25;
+    r106 = r17 * r24;
+    r109 = r20 * r21;
+    r109 = fmaf(r71, r109, r71 * r106);
+    r106 = r19 * r22;
+    r109 = fmaf(r71, r106, r109);
+    r97 = r18 * r23;
+    r109 = fmaf(r74, r97, r109);
+    r108 = fmaf(r109, r108, r93);
+    r91 = r91 + r108;
+    r97 = r29 * r80;
+    r97 = r97 * r84;
+    r106 = r32 * r84;
+    r106 = r106 * r109;
+    r1 = r97 + r106;
+    r1 = fmaf(r13, r1, r15 * r91);
+    r91 = r40 * r34;
+    r91 = fmaf(r40, r83, r109 * r91);
+    r111 = r16 * r25;
+    r111 = r111 * r80;
+    r112 = r16 * r29;
+    r112 = fmaf(r94, r112, r111);
+    r91 = r91 + r112;
+    r1 = fmaf(r14, r91, r1);
+    r105 = r105 * r1;
+    r91 = r51 * r51;
+    r115 = r40 * r29;
+    r115 = fmaf(r77, r115, r92);
+    r115 = r115 + r108;
+    r108 = r16 * r29;
+    r108 = r108 * r109;
+    r116 = r16 * r34;
+    r116 = fmaf(r94, r116, r108);
+    r116 = r116 + r75;
+    r116 = fmaf(r14, r116, r13 * r115);
+    r115 = r25 * r94;
+    r75 = r84 * r115;
+    r97 = r97 + r75;
+    r116 = fmaf(r15, r97, r116);
+    r91 = r91 * r116;
+    r91 = fmaf(r47, r91, r44 * r105);
+    r105 = r33 * r33;
+    r105 = r105 * r116;
+    r91 = fmaf(r47, r105, r91);
+    r97 = r16 * r33;
+    r108 = r78 + r108;
+    r78 = r25 * r40;
+    r108 = fmaf(r77, r78, r108);
+    r77 = r40 * r34;
+    r108 = fmaf(r94, r77, r108);
+    r77 = r16 * r34;
+    r83 = fmaf(r16, r83, r109 * r77);
+    r83 = r83 + r112;
+    r83 = fmaf(r13, r83, r15 * r108);
+    r75 = r106 + r75;
+    r83 = fmaf(r14, r75, r83);
+    r97 = r97 * r83;
+    r91 = fmaf(r44, r97, r91);
+    r103 = r103 * r91;
+    r103 = r103 * r41;
+    r103 = r103 * r35;
+    r97 = r4 * r91;
+    r97 = fmaf(r11, r97, r46 * r103);
+    r103 = r51 * r51;
+    r103 = r103 * r36;
+    r103 = r103 * r36;
+    r103 = r103 * r116;
+    r103 = r103 * r48;
+    r97 = fmaf(r47, r103, r97);
+    r97 = fmaf(r1, r63, r97);
+    r103 = r83 * r49;
+    r105 = r4 * r91;
+    r105 = r105 * r99;
+    r105 = fmaf(r10, r105, r99 * r103);
+    r103 = r33 * r33;
+    r103 = r103 * r36;
+    r103 = r103 * r36;
+    r103 = r103 * r116;
+    r103 = r103 * r48;
+    r105 = fmaf(r47, r103, r105);
+    r105 = fmaf(r91, r100, r105);
+    r103 = r97 + r105;
+    r75 = r51 * r51;
+    r75 = r75 * r61;
+    r75 = r75 * r91;
+    r75 = r75 * r41;
+    r75 = r75 * r35;
+    r106 = r95 * r91;
+    r106 = fmaf(r11, r106, r46 * r75);
+    r75 = r51 * r51;
+    r75 = r75 * r36;
+    r75 = r75 * r36;
+    r75 = r75 * r89;
+    r75 = r75 * r116;
+    r75 = r75 * r48;
+    r106 = fmaf(r55, r75, r106);
+    r108 = r86 * r1;
+    r108 = r108 * r46;
+    r106 = fmaf(r26, r108, r106);
+    r106 = r106 + r105;
+    r106 = fmaf(r58, r106, r8 * r103);
+    r105 = r57 * r51;
+    r105 = r105 * r33;
+    r105 = r105 * r36;
+    r105 = r105 * r36;
+    r105 = r105 * r84;
+    r105 = r105 * r116;
+    r105 = r105 * r48;
+    r106 = fmaf(r55, r105, r106);
+    r108 = r51 * r36;
+    r108 = r108 * r74;
+    r108 = r108 * r91;
+    r108 = r108 * r48;
+    r108 = r108 * r60;
+    r106 = fmaf(r35, r108, r106);
+    r75 = r4 * r51;
+    r75 = r75 * r116;
+    r75 = r75 * r68;
+    r106 = fmaf(r50, r75, r106);
+    r77 = r57 * r91;
+    r106 = fmaf(r113, r77, r106);
+    r109 = r57 * r51;
+    r109 = r109 * r91;
+    r109 = r109 * r49;
+    r106 = fmaf(r102, r109, r106);
+    r78 = r51 * r71;
+    r78 = r78 * r91;
+    r78 = r78 * r41;
+    r78 = r78 * r35;
+    r106 = fmaf(r69, r78, r106);
+    r117 = r4 * r51;
+    r117 = r117 * r67;
+    r117 = r117 * r116;
+    r117 = r117 * r68;
+    r106 = fmaf(r50, r117, r106);
+    r118 = r57 * r1;
+    r118 = r118 * r49;
+    r106 = fmaf(r99, r118, r106);
+    r119 = r7 * r16;
+    r119 = r119 * r56;
+    r119 = fmaf(r103, r119, r6 * r103);
+    r119 = fmaf(r103, r66, r119);
+    r119 = fmaf(r103, r59, r119);
+    r120 = r119 * r69;
+    r106 = fmaf(r26, r120, r106);
+    r121 = r51 * r36;
+    r121 = r121 * r67;
+    r121 = r121 * r74;
+    r121 = r121 * r91;
+    r121 = r121 * r48;
+    r121 = r121 * r60;
+    r106 = fmaf(r35, r121, r106);
+    r122 = r36 * r1;
+    r106 = fmaf(r69, r122, r106);
+    r106 = fmaf(r83, r64, r106);
+    r106 = fmaf(r91, r107, r106);
+    r106 = fmaf(r1, r52, r106);
+    r73 = r73 * r2;
+    r122 = r33 * r36;
+    r122 = r122 * r86;
+    r122 = r122 * r83;
+    r122 = fmaf(r91, r62, r46 * r122);
+    r121 = r33 * r33;
+    r121 = r121 * r36;
+    r121 = r121 * r36;
+    r121 = r121 * r89;
+    r121 = r121 * r116;
+    r121 = r121 * r48;
+    r122 = fmaf(r55, r121, r122);
+    r120 = r61 * r91;
+    r122 = fmaf(r100, r120, r122);
+    r122 = r122 + r97;
+    r122 = fmaf(r57, r122, r9 * r103);
+    r103 = r4 * r33;
+    r103 = r103 * r116;
+    r103 = r103 * r68;
+    r122 = fmaf(r50, r103, r122);
+    r97 = r58 * r83;
+    r122 = fmaf(r63, r97, r122);
+    r120 = r71 * r91;
+    r120 = r120 * r102;
+    r122 = fmaf(r70, r120, r122);
+    r121 = r33 * r36;
+    r121 = r121 * r119;
+    r122 = fmaf(r69, r121, r122);
+    r118 = r71 * r91;
+    r118 = r118 * r69;
+    r122 = fmaf(r102, r118, r122);
+    r117 = r58 * r91;
+    r122 = fmaf(r113, r117, r122);
+    r78 = r58 * r51;
+    r78 = r78 * r91;
+    r78 = r78 * r49;
+    r122 = fmaf(r102, r78, r122);
+    r109 = r58 * r1;
+    r109 = r109 * r49;
+    r122 = fmaf(r99, r109, r122);
+    r77 = r4 * r33;
+    r77 = r77 * r67;
+    r77 = r77 * r116;
+    r77 = r77 * r68;
+    r122 = fmaf(r50, r77, r122);
+    r75 = r36 * r83;
+    r122 = fmaf(r69, r75, r122);
+    r122 = fmaf(r116, r110, r122);
+    r122 = fmaf(r91, r101, r122);
+    r122 = fmaf(r91, r104, r122);
+    r122 = fmaf(r83, r52, r122);
+    r73 = fmaf(r122, r65, r106 * r73);
+    r75 = r0 * r4;
+    r77 = r51 * r51;
+    r109 = r25 * r84;
+    r31 = fmaf(r74, r31, r71 * r27);
+    r31 = fmaf(r71, r28, r31);
+    r31 = fmaf(r71, r30, r31);
+    r109 = r109 * r31;
+    r76 = r84 * r76;
+    r30 = r109 + r76;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r111 = r111 + r28;
+    r27 = r40 * r29;
+    r111 = fmaf(r94, r27, r111);
+    r78 = r40 * r34;
+    r111 = fmaf(r72, r78, r111);
+    r111 = fmaf(r13, r111, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r115, r31 * r30);
+    r30 = r30 + r79;
+    r111 = fmaf(r14, r30, r111);
+    r77 = r77 * r111;
+    r30 = r16 * r51;
+    r78 = r16 * r29;
+    r78 = r78 * r31;
+    r81 = r81 + r78;
+    r27 = r32 * r40;
+    r81 = fmaf(r94, r27, r81);
+    r81 = r81 + r92;
+    r80 = r32 * r80;
+    r80 = r80 * r84;
+    r76 = r80 + r76;
+    r76 = fmaf(r13, r76, r14 * r81);
+    r81 = r16 * r34;
+    r81 = fmaf(r72, r81, r28);
+    r81 = r81 + r112;
+    r76 = fmaf(r15, r81, r76);
+    r30 = r30 * r76;
+    r30 = fmaf(r44, r30, r47 * r77);
+    r77 = r33 * r33;
+    r77 = r77 * r111;
+    r30 = fmaf(r47, r77, r30);
+    r81 = r16 * r33;
+    r78 = r93 + r78;
+    r78 = r78 + r96;
+    r96 = r40 * r34;
+    r115 = fmaf(r40, r115, r31 * r96);
+    r115 = r115 + r79;
+    r115 = fmaf(r15, r115, r13 * r78);
+    r80 = r109 + r80;
+    r115 = fmaf(r14, r80, r115);
+    r81 = r81 * r115;
+    r30 = fmaf(r44, r81, r30);
+    r81 = r115 * r49;
+    r81 = fmaf(r99, r81, r30 * r100);
+    r77 = r33 * r33;
+    r77 = r77 * r36;
+    r77 = r77 * r36;
+    r77 = r77 * r111;
+    r77 = r77 * r48;
+    r81 = fmaf(r47, r77, r81);
+    r80 = r4 * r30;
+    r80 = r80 * r99;
+    r81 = fmaf(r10, r80, r81);
+    r80 = r51 * r51;
+    r80 = r80 * r36;
+    r80 = r80 * r36;
+    r80 = r80 * r111;
+    r80 = r80 * r48;
+    r77 = r51 * r51;
+    r77 = r77 * r30;
+    r77 = r77 * r41;
+    r77 = r77 * r35;
+    r77 = fmaf(r46, r77, r47 * r80);
+    r80 = r4 * r30;
+    r77 = fmaf(r11, r80, r77);
+    r77 = fmaf(r76, r63, r77);
+    r80 = r81 + r77;
+    r14 = r51 * r51;
+    r14 = r14 * r36;
+    r14 = r14 * r36;
+    r14 = r14 * r89;
+    r14 = r14 * r111;
+    r14 = r14 * r48;
+    r109 = r51 * r51;
+    r109 = r109 * r61;
+    r109 = r109 * r30;
+    r109 = r109 * r41;
+    r109 = r109 * r35;
+    r109 = fmaf(r46, r109, r55 * r14);
+    r14 = r95 * r30;
+    r109 = fmaf(r11, r14, r109);
+    r15 = r86 * r76;
+    r15 = r15 * r46;
+    r109 = fmaf(r26, r15, r109);
+    r109 = r109 + r81;
+    r109 = fmaf(r58, r109, r8 * r80);
+    r81 = r7 * r16;
+    r81 = r81 * r56;
+    r81 = fmaf(r80, r81, r6 * r80);
+    r81 = fmaf(r80, r59, r81);
+    r81 = fmaf(r80, r66, r81);
+    r15 = r81 * r69;
+    r109 = fmaf(r26, r15, r109);
+    r14 = r57 * r51;
+    r14 = r14 * r33;
+    r14 = r14 * r36;
+    r14 = r14 * r36;
+    r14 = r14 * r84;
+    r14 = r14 * r111;
+    r14 = r14 * r48;
+    r109 = fmaf(r55, r14, r109);
+    r78 = r51 * r71;
+    r78 = r78 * r30;
+    r78 = r78 * r41;
+    r78 = r78 * r35;
+    r109 = fmaf(r69, r78, r109);
+    r13 = r51 * r36;
+    r13 = r13 * r67;
+    r13 = r13 * r74;
+    r13 = r13 * r30;
+    r13 = r13 * r48;
+    r13 = r13 * r60;
+    r109 = fmaf(r35, r13, r109);
+    r79 = r4 * r51;
+    r79 = r79 * r111;
+    r79 = r79 * r68;
+    r109 = fmaf(r50, r79, r109);
+    r96 = r57 * r30;
+    r109 = fmaf(r113, r96, r109);
+    r31 = r57 * r76;
+    r31 = r31 * r49;
+    r109 = fmaf(r99, r31, r109);
+    r93 = r51 * r36;
+    r93 = r93 * r74;
+    r93 = r93 * r30;
+    r93 = r93 * r48;
+    r93 = r93 * r60;
+    r109 = fmaf(r35, r93, r109);
+    r112 = r4 * r51;
+    r112 = r112 * r67;
+    r112 = r112 * r111;
+    r112 = r112 * r68;
+    r109 = fmaf(r50, r112, r109);
+    r28 = r36 * r76;
+    r109 = fmaf(r69, r28, r109);
+    r72 = r57 * r51;
+    r72 = r72 * r30;
+    r72 = r72 * r49;
+    r109 = fmaf(r102, r72, r109);
+    r109 = fmaf(r76, r52, r109);
+    r109 = fmaf(r30, r107, r109);
+    r109 = fmaf(r115, r64, r109);
+    r75 = r75 * r2;
+    r72 = r61 * r30;
+    r28 = r33 * r36;
+    r28 = r28 * r86;
+    r28 = r28 * r115;
+    r28 = fmaf(r46, r28, r100 * r72);
+    r72 = r33 * r33;
+    r72 = r72 * r36;
+    r72 = r72 * r36;
+    r72 = r72 * r89;
+    r72 = r72 * r111;
+    r72 = r72 * r48;
+    r28 = fmaf(r55, r72, r28);
+    r28 = fmaf(r30, r62, r28);
+    r28 = r28 + r77;
+    r28 = fmaf(r57, r28, r9 * r80);
+    r80 = r71 * r30;
+    r80 = r80 * r69;
+    r28 = fmaf(r102, r80, r28);
+    r77 = r4 * r33;
+    r77 = r77 * r67;
+    r77 = r77 * r111;
+    r77 = r77 * r68;
+    r28 = fmaf(r50, r77, r28);
+    r72 = r58 * r30;
+    r28 = fmaf(r113, r72, r28);
+    r112 = r58 * r76;
+    r112 = r112 * r49;
+    r28 = fmaf(r99, r112, r28);
+    r93 = r58 * r115;
+    r28 = fmaf(r63, r93, r28);
+    r31 = r4 * r33;
+    r31 = r31 * r111;
+    r31 = r31 * r68;
+    r28 = fmaf(r50, r31, r28);
+    r96 = r58 * r51;
+    r96 = r96 * r30;
+    r96 = r96 * r49;
+    r28 = fmaf(r102, r96, r28);
+    r79 = r36 * r115;
+    r28 = fmaf(r69, r79, r28);
+    r13 = r33 * r36;
+    r13 = r13 * r81;
+    r28 = fmaf(r69, r13, r28);
+    r78 = r71 * r30;
+    r78 = r78 * r102;
+    r28 = fmaf(r70, r78, r28);
+    r28 = fmaf(r111, r110, r28);
+    r28 = fmaf(r30, r104, r28);
+    r28 = fmaf(r115, r52, r28);
+    r28 = fmaf(r30, r101, r28);
+    r75 = fmaf(r28, r65, r109 * r75);
+    r78 = r0 * r4;
+    r13 = r12 * r51;
+    r13 = r13 * r51;
+    r13 = r13 * r36;
+    r13 = r13 * r36;
+    r13 = r13 * r89;
+    r13 = r13 * r48;
+    r79 = r42 * r86;
+    r79 = r79 * r46;
+    r79 = fmaf(r26, r79, r55 * r13);
+    r13 = r40 * r12;
+    r96 = r33 * r33;
+    r13 = r13 * r96;
+    r13 = r13 * r55;
+    r31 = r13 + r87;
+    r93 = r16 * r38;
+    r93 = r93 * r33;
+    r31 = fmaf(r44, r93, r31);
+    r112 = r16 * r42;
+    r112 = r112 * r51;
+    r31 = fmaf(r44, r112, r31);
+    r112 = r95 * r31;
+    r79 = fmaf(r11, r112, r79);
+    r93 = r51 * r51;
+    r93 = r93 * r61;
+    r93 = r93 * r31;
+    r93 = r93 * r41;
+    r93 = r93 * r35;
+    r79 = fmaf(r46, r93, r79);
+    r72 = r36 * r36;
+    r72 = r72 * r48;
+    r77 = r38 * r49;
+    r77 = fmaf(r99, r77, r72 * r13);
+    r13 = r4 * r31;
+    r13 = r13 * r99;
+    r77 = fmaf(r10, r13, r77);
+    r77 = fmaf(r31, r100, r77);
+    r79 = r79 + r77;
+    r72 = fmaf(r42, r63, r87 * r72);
+    r87 = r4 * r31;
+    r72 = fmaf(r11, r87, r72);
+    r93 = r51 * r51;
+    r93 = r93 * r31;
+    r93 = r93 * r41;
+    r93 = r93 * r35;
+    r72 = fmaf(r46, r93, r72);
+    r77 = r77 + r72;
+    r79 = fmaf(r8, r77, r58 * r79);
+    r93 = r4 * r12;
+    r93 = r93 * r51;
+    r93 = r93 * r68;
+    r79 = fmaf(r50, r93, r79);
+    r87 = r42 * r36;
+    r79 = fmaf(r69, r87, r79);
+    r112 = r51 * r36;
+    r112 = r112 * r67;
+    r112 = r112 * r74;
+    r112 = r112 * r31;
+    r112 = r112 * r48;
+    r112 = r112 * r60;
+    r79 = fmaf(r35, r112, r79);
+    r13 = r31 * r113;
+    r80 = r57 * r51;
+    r80 = r80 * r31;
+    r80 = r80 * r49;
+    r79 = fmaf(r102, r80, r79);
+    r111 = r57 * r42;
+    r111 = r111 * r49;
+    r79 = fmaf(r99, r111, r79);
+    r14 = r51 * r36;
+    r14 = r14 * r74;
+    r14 = r14 * r31;
+    r14 = r14 * r48;
+    r14 = r14 * r60;
+    r79 = fmaf(r35, r14, r79);
+    r15 = r57 * r12;
+    r15 = r15 * r51;
+    r15 = r15 * r33;
+    r15 = r15 * r36;
+    r15 = r15 * r36;
+    r15 = r15 * r84;
+    r15 = r15 * r48;
+    r79 = fmaf(r55, r15, r79);
+    r92 = r51 * r71;
+    r92 = r92 * r31;
+    r92 = r92 * r41;
+    r92 = r92 * r35;
+    r79 = fmaf(r69, r92, r79);
+    r27 = r7 * r16;
+    r27 = r27 * r56;
+    r27 = fmaf(r6, r77, r77 * r27);
+    r27 = fmaf(r77, r66, r27);
+    r27 = fmaf(r77, r59, r27);
+    r94 = r27 * r69;
+    r79 = fmaf(r26, r94, r79);
+    r117 = r4 * r12;
+    r117 = r117 * r51;
+    r117 = r117 * r67;
+    r117 = r117 * r68;
+    r79 = fmaf(r50, r117, r79);
+    r79 = fmaf(r57, r13, r79);
+    r79 = fmaf(r42, r52, r79);
+    r79 = fmaf(r31, r107, r79);
+    r79 = fmaf(r38, r64, r79);
+    r78 = r78 * r2;
+    r117 = r12 * r33;
+    r117 = r117 * r33;
+    r117 = r117 * r36;
+    r117 = r117 * r36;
+    r117 = r117 * r89;
+    r117 = r117 * r48;
+    r94 = r38 * r33;
+    r94 = r94 * r36;
+    r94 = r94 * r86;
+    r94 = fmaf(r46, r94, r55 * r117);
+    r117 = r61 * r31;
+    r94 = fmaf(r100, r117, r94);
+    r94 = fmaf(r31, r62, r94);
+    r94 = r94 + r72;
+    r77 = fmaf(r9, r77, r57 * r94);
+    r94 = r4 * r12;
+    r94 = r94 * r33;
+    r94 = r94 * r68;
+    r77 = fmaf(r50, r94, r77);
+    r72 = r4 * r12;
+    r72 = r72 * r33;
+    r72 = r72 * r67;
+    r72 = r72 * r68;
+    r77 = fmaf(r50, r72, r77);
+    r117 = r38 * r36;
+    r77 = fmaf(r69, r117, r77);
+    r92 = r58 * r51;
+    r92 = r92 * r31;
+    r92 = r92 * r49;
+    r77 = fmaf(r102, r92, r77);
+    r15 = r58 * r42;
+    r15 = r15 * r49;
+    r77 = fmaf(r99, r15, r77);
+    r14 = r71 * r31;
+    r14 = r14 * r69;
+    r77 = fmaf(r102, r14, r77);
+    r111 = r58 * r38;
+    r77 = fmaf(r63, r111, r77);
+    r80 = r71 * r31;
+    r80 = r80 * r102;
+    r77 = fmaf(r70, r80, r77);
+    r112 = r33 * r36;
+    r112 = r112 * r27;
+    r77 = fmaf(r69, r112, r77);
+    r77 = fmaf(r31, r104, r77);
+    r77 = fmaf(r31, r101, r77);
+    r77 = fmaf(r38, r52, r77);
+    r77 = fmaf(r58, r13, r77);
+    r77 = fmaf(r12, r110, r77);
+    r78 = fmaf(r77, r65, r79 * r78);
+    WriteSum4<float, float>((float*)inout_shared, r3, r73, r75, r78);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r0 * r4;
+    r75 = r39 * r33;
+    r75 = r75 * r33;
+    r73 = r16 * r43;
+    r73 = r73 * r33;
+    r73 = fmaf(r44, r73, r47 * r75);
+    r75 = r39 * r51;
+    r75 = r75 * r51;
+    r73 = fmaf(r47, r75, r73);
+    r3 = r16 * r54;
+    r3 = r3 * r51;
+    r73 = fmaf(r44, r3, r73);
+    r3 = r39 * r33;
+    r3 = r3 * r33;
+    r3 = r3 * r36;
+    r3 = r3 * r36;
+    r3 = r3 * r48;
+    r3 = fmaf(r47, r3, r73 * r100);
+    r75 = r43 * r49;
+    r3 = fmaf(r99, r75, r3);
+    r112 = r4 * r73;
+    r112 = r112 * r99;
+    r3 = fmaf(r10, r112, r3);
+    r112 = r51 * r51;
+    r112 = r112 * r73;
+    r112 = r112 * r41;
+    r112 = r112 * r35;
+    r75 = r39 * r51;
+    r75 = r75 * r51;
+    r75 = r75 * r36;
+    r75 = r75 * r36;
+    r75 = r75 * r48;
+    r75 = fmaf(r47, r75, r46 * r112);
+    r112 = r4 * r73;
+    r75 = fmaf(r11, r112, r75);
+    r75 = fmaf(r54, r63, r75);
+    r112 = r3 + r75;
+    r80 = r51 * r51;
+    r80 = r80 * r61;
+    r80 = r80 * r73;
+    r80 = r80 * r41;
+    r80 = r80 * r35;
+    r111 = r39 * r51;
+    r111 = r111 * r51;
+    r111 = r111 * r36;
+    r111 = r111 * r36;
+    r111 = r111 * r89;
+    r111 = r111 * r48;
+    r111 = fmaf(r55, r111, r46 * r80);
+    r80 = r54 * r86;
+    r80 = r80 * r46;
+    r111 = fmaf(r26, r80, r111);
+    r14 = r95 * r73;
+    r111 = fmaf(r11, r14, r111);
+    r111 = r111 + r3;
+    r111 = fmaf(r58, r111, r8 * r112);
+    r3 = r7 * r16;
+    r3 = r3 * r56;
+    r3 = fmaf(r112, r3, r6 * r112);
+    r3 = fmaf(r112, r66, r3);
+    r3 = fmaf(r112, r59, r3);
+    r14 = r3 * r69;
+    r111 = fmaf(r26, r14, r111);
+    r80 = r51 * r36;
+    r80 = r80 * r74;
+    r80 = r80 * r73;
+    r80 = r80 * r48;
+    r80 = r80 * r60;
+    r111 = fmaf(r35, r80, r111);
+    r15 = r54 * r36;
+    r111 = fmaf(r69, r15, r111);
+    r92 = r57 * r51;
+    r92 = r92 * r73;
+    r92 = r92 * r49;
+    r111 = fmaf(r102, r92, r111);
+    r13 = r51 * r71;
+    r13 = r13 * r73;
+    r13 = r13 * r41;
+    r13 = r13 * r35;
+    r111 = fmaf(r69, r13, r111);
+    r117 = r57 * r39;
+    r117 = r117 * r51;
+    r117 = r117 * r33;
+    r117 = r117 * r36;
+    r117 = r117 * r36;
+    r117 = r117 * r84;
+    r117 = r117 * r48;
+    r111 = fmaf(r55, r117, r111);
+    r72 = r57 * r73;
+    r111 = fmaf(r113, r72, r111);
+    r94 = r51 * r36;
+    r94 = r94 * r67;
+    r94 = r94 * r74;
+    r94 = r94 * r73;
+    r94 = r94 * r48;
+    r94 = r94 * r60;
+    r111 = fmaf(r35, r94, r111);
+    r87 = r4 * r39;
+    r87 = r87 * r51;
+    r87 = r87 * r68;
+    r111 = fmaf(r50, r87, r111);
+    r93 = r57 * r54;
+    r93 = r93 * r49;
+    r111 = fmaf(r99, r93, r111);
+    r118 = r4 * r39;
+    r118 = r118 * r51;
+    r118 = r118 * r67;
+    r118 = r118 * r68;
+    r111 = fmaf(r50, r118, r111);
+    r111 = fmaf(r54, r52, r111);
+    r111 = fmaf(r43, r64, r111);
+    r111 = fmaf(r73, r107, r111);
+    r78 = r78 * r2;
+    r118 = r61 * r73;
+    r93 = r39 * r33;
+    r93 = r93 * r33;
+    r93 = r93 * r36;
+    r93 = r93 * r36;
+    r93 = r93 * r89;
+    r93 = r93 * r48;
+    r93 = fmaf(r55, r93, r100 * r118);
+    r118 = r43 * r33;
+    r118 = r118 * r36;
+    r118 = r118 * r86;
+    r93 = fmaf(r46, r118, r93);
+    r93 = fmaf(r73, r62, r93);
+    r93 = r93 + r75;
+    r93 = fmaf(r57, r93, r9 * r112);
+    r112 = r58 * r43;
+    r93 = fmaf(r63, r112, r93);
+    r75 = r4 * r39;
+    r75 = r75 * r33;
+    r75 = r75 * r68;
+    r93 = fmaf(r50, r75, r93);
+    r118 = r71 * r73;
+    r118 = r118 * r69;
+    r93 = fmaf(r102, r118, r93);
+    r100 = r58 * r51;
+    r100 = r100 * r73;
+    r100 = r100 * r49;
+    r93 = fmaf(r102, r100, r93);
+    r87 = r71 * r73;
+    r87 = r87 * r102;
+    r93 = fmaf(r70, r87, r93);
+    r94 = r58 * r73;
+    r93 = fmaf(r113, r94, r93);
+    r72 = r43 * r36;
+    r93 = fmaf(r69, r72, r93);
+    r117 = r58 * r54;
+    r117 = r117 * r49;
+    r93 = fmaf(r99, r117, r93);
+    r13 = r4 * r39;
+    r13 = r13 * r33;
+    r13 = r13 * r67;
+    r13 = r13 * r68;
+    r93 = fmaf(r50, r13, r93);
+    r92 = r33 * r36;
+    r92 = r92 * r3;
+    r93 = fmaf(r69, r92, r93);
+    r93 = fmaf(r43, r52, r93);
+    r93 = fmaf(r39, r110, r93);
+    r93 = fmaf(r73, r101, r93);
+    r93 = fmaf(r73, r104, r93);
+    r78 = fmaf(r93, r65, r111 * r78);
+    r92 = r0 * r4;
+    r96 = r44 * r96;
+    r13 = r16 * r45;
+    r13 = r13 * r33;
+    r117 = r37 * r33;
+    r117 = r117 * r33;
+    r117 = fmaf(r47, r117, r44 * r13);
+    r13 = r16 * r53;
+    r13 = r13 * r51;
+    r117 = fmaf(r44, r13, r117);
+    r44 = r37 * r51;
+    r44 = r44 * r51;
+    r117 = fmaf(r47, r44, r117);
+    r96 = r96 * r48;
+    r96 = r96 * r36;
+    r96 = r96 * r41;
+    r96 = r96 * r35;
+    r96 = r96 * r117;
+    r44 = r45 * r49;
+    r44 = fmaf(r99, r44, r96);
+    r13 = r4 * r117;
+    r13 = r13 * r99;
+    r44 = fmaf(r10, r13, r44);
+    r10 = r37 * r33;
+    r10 = r10 * r33;
+    r10 = r10 * r36;
+    r10 = r10 * r36;
+    r10 = r10 * r48;
+    r44 = fmaf(r47, r10, r44);
+    r10 = r37 * r51;
+    r10 = r10 * r51;
+    r10 = r10 * r36;
+    r10 = r10 * r36;
+    r10 = r10 * r48;
+    r13 = r4 * r117;
+    r13 = fmaf(r11, r13, r47 * r10);
+    r10 = r51 * r51;
+    r10 = r10 * r117;
+    r10 = r10 * r41;
+    r10 = r10 * r35;
+    r13 = fmaf(r46, r10, r13);
+    r13 = fmaf(r53, r63, r13);
+    r10 = r44 + r13;
+    r47 = r37 * r51;
+    r47 = r47 * r51;
+    r47 = r47 * r36;
+    r47 = r47 * r36;
+    r47 = r47 * r89;
+    r47 = r47 * r48;
+    r72 = r95 * r117;
+    r72 = fmaf(r11, r72, r55 * r47);
+    r47 = r53 * r86;
+    r47 = r47 * r46;
+    r72 = fmaf(r26, r47, r72);
+    r11 = r51 * r51;
+    r11 = r11 * r61;
+    r11 = r11 * r117;
+    r11 = r11 * r41;
+    r11 = r11 * r35;
+    r72 = fmaf(r46, r11, r72);
+    r72 = r72 + r44;
+    r72 = fmaf(r58, r72, r8 * r10);
+    r8 = r4 * r37;
+    r8 = r8 * r51;
+    r8 = r8 * r67;
+    r8 = r8 * r68;
+    r72 = fmaf(r50, r8, r72);
+    r44 = r53 * r36;
+    r72 = fmaf(r69, r44, r72);
+    r11 = r4 * r37;
+    r11 = r11 * r51;
+    r11 = r11 * r68;
+    r72 = fmaf(r50, r11, r72);
+    r47 = r51 * r36;
+    r47 = r47 * r74;
+    r47 = r47 * r117;
+    r47 = r47 * r48;
+    r47 = r47 * r60;
+    r72 = fmaf(r35, r47, r72);
+    r94 = r57 * r117;
+    r72 = fmaf(r113, r94, r72);
+    r87 = r57 * r51;
+    r87 = r87 * r117;
+    r87 = r87 * r49;
+    r72 = fmaf(r102, r87, r72);
+    r100 = r57 * r53;
+    r100 = r100 * r49;
+    r72 = fmaf(r99, r100, r72);
+    r118 = r51 * r36;
+    r118 = r118 * r67;
+    r118 = r118 * r74;
+    r118 = r118 * r117;
+    r118 = r118 * r48;
+    r118 = r118 * r60;
+    r72 = fmaf(r35, r118, r72);
+    r60 = r51 * r71;
+    r60 = r60 * r117;
+    r60 = r60 * r41;
+    r60 = r60 * r35;
+    r72 = fmaf(r69, r60, r72);
+    r35 = r7 * r16;
+    r35 = r35 * r56;
+    r6 = fmaf(r6, r10, r10 * r35);
+    r6 = fmaf(r10, r66, r6);
+    r6 = fmaf(r10, r59, r6);
+    r59 = r6 * r69;
+    r72 = fmaf(r26, r59, r72);
+    r26 = r57 * r37;
+    r26 = r26 * r51;
+    r26 = r26 * r33;
+    r26 = r26 * r36;
+    r26 = r26 * r36;
+    r26 = r26 * r84;
+    r26 = r26 * r48;
+    r72 = fmaf(r55, r26, r72);
+    r72 = fmaf(r53, r52, r72);
+    r72 = fmaf(r117, r107, r72);
+    r72 = fmaf(r45, r64, r72);
+    r92 = r92 * r2;
+    r2 = r45 * r33;
+    r2 = r2 * r36;
+    r2 = r2 * r86;
+    r2 = fmaf(r46, r2, r61 * r96);
+    r96 = r37 * r33;
+    r96 = r96 * r33;
+    r96 = r96 * r36;
+    r96 = r96 * r36;
+    r96 = r96 * r89;
+    r96 = r96 * r48;
+    r2 = fmaf(r55, r96, r2);
+    r2 = fmaf(r117, r62, r2);
+    r2 = r2 + r13;
+    r2 = fmaf(r57, r2, r9 * r10);
+    r10 = r71 * r117;
+    r10 = r10 * r102;
+    r2 = fmaf(r70, r10, r2);
+    r70 = r71 * r117;
+    r70 = r70 * r69;
+    r2 = fmaf(r102, r70, r2);
+    r9 = r58 * r117;
+    r2 = fmaf(r113, r9, r2);
+    r113 = r58 * r51;
+    r113 = r113 * r117;
+    r113 = r113 * r49;
+    r2 = fmaf(r102, r113, r2);
+    r102 = r58 * r45;
+    r2 = fmaf(r63, r102, r2);
+    r63 = r4 * r37;
+    r63 = r63 * r33;
+    r63 = r63 * r67;
+    r63 = r63 * r68;
+    r2 = fmaf(r50, r63, r2);
+    r67 = r58 * r53;
+    r67 = r67 * r49;
+    r2 = fmaf(r99, r67, r2);
+    r99 = r45 * r36;
+    r2 = fmaf(r69, r99, r2);
+    r13 = r4 * r37;
+    r13 = r13 * r33;
+    r13 = r13 * r68;
+    r2 = fmaf(r50, r13, r2);
+    r50 = r33 * r36;
+    r50 = r50 * r6;
+    r2 = fmaf(r69, r50, r2);
+    r2 = fmaf(r45, r52, r2);
+    r2 = fmaf(r117, r101, r2);
+    r2 = fmaf(r117, r104, r2);
+    r2 = fmaf(r37, r110, r2);
+    r65 = fmaf(r2, r65, r72 * r92);
+    WriteSum2<float, float>((float*)inout_shared, r78, r65);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r0 * r0;
+    r78 = r88 * r65;
+    r5 = r5 * r5;
+    r92 = r98 * r5;
+    r98 = fmaf(r98, r92, r88 * r78);
+    r88 = r106 * r106;
+    r110 = r122 * r122;
+    r110 = fmaf(r5, r110, r65 * r88);
+    r88 = r28 * r28;
+    r50 = r109 * r109;
+    r50 = fmaf(r65, r50, r5 * r88);
+    r88 = r79 * r79;
+    r13 = r77 * r77;
+    r13 = fmaf(r5, r13, r65 * r88);
+    WriteSum4<float, float>((float*)inout_shared, r98, r110, r50, r13);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r111 * r111;
+    r50 = r93 * r93;
+    r50 = fmaf(r5, r50, r65 * r13);
+    r13 = r2 * r2;
+    r110 = r72 * r72;
+    r110 = fmaf(r65, r110, r5 * r13);
+    WriteSum2<float, float>((float*)inout_shared, r50, r110);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r110 = fmaf(r106, r78, r122 * r92);
+    r50 = fmaf(r28, r92, r109 * r78);
+    r13 = fmaf(r79, r78, r77 * r92);
+    r98 = fmaf(r111, r78, r93 * r92);
+    WriteSum4<float, float>((float*)inout_shared, r110, r50, r13, r98);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r92 = fmaf(r2, r92, r72 * r78);
+    r78 = r122 * r28;
+    r98 = r106 * r109;
+    r98 = fmaf(r65, r98, r5 * r78);
+    r78 = r106 * r79;
+    r13 = r122 * r77;
+    r13 = fmaf(r5, r13, r65 * r78);
+    r78 = r106 * r111;
+    r50 = r122 * r93;
+    r50 = fmaf(r5, r50, r65 * r78);
+    WriteSum4<float, float>((float*)inout_shared, r92, r98, r13, r50);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r122 * r2;
+    r13 = r106 * r72;
+    r13 = fmaf(r65, r13, r5 * r50);
+    r50 = r28 * r77;
+    r98 = r109 * r79;
+    r98 = fmaf(r65, r98, r5 * r50);
+    r50 = r109 * r111;
+    r92 = r28 * r93;
+    r92 = fmaf(r5, r92, r65 * r50);
+    r50 = r28 * r2;
+    r78 = r109 * r72;
+    r78 = fmaf(r65, r78, r5 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r13, r98, r92, r78);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r77 * r93;
+    r92 = r79 * r111;
+    r92 = fmaf(r65, r92, r5 * r78);
+    r78 = r79 * r72;
+    r98 = r77 * r2;
+    r98 = fmaf(r5, r98, r65 * r78);
+    r78 = r93 * r2;
+    r13 = r111 * r72;
+    r13 = fmaf(r65, r13, r5 * r78);
+    WriteSum3<float, float>((float*)inout_shared, r92, r98, r13);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,1665 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = r33 * r33;
+    r47 = r40 * r29;
+    r47 = r47 * r29;
+    r51 = r41 + r47;
+    r51 = r51 + r48;
+    r51 = fmaf(r13, r51, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r52 = r21 * r23;
+    r52 = r52 * r16;
+    r53 = r22 * r24;
+    r53 = fmaf(r16, r53, r52);
+    r54 = r23 * r24;
+    r54 = fmaf(r40, r54, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r51 = fmaf(r14, r10, r51);
+    r51 = fmaf(r15, r48, r51);
+    r51 = fmaf(r36, r53, r51);
+    r51 = fmaf(r35, r54, r51);
+    r51 = fmaf(r11, r42, r51);
+    r48 = r51 * r51;
+    r10 = 9.99999999999999955e-07;
+    r55 = r40 * r29;
+    r55 = fmaf(r34, r55, r26);
+    r55 = fmaf(r13, r55, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r52);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r47 = r41 + r47;
+    r47 = r47 + r50;
+    r55 = fmaf(r11, r12, r55);
+    r55 = fmaf(r36, r37, r55);
+    r55 = fmaf(r35, r39, r55);
+    r55 = fmaf(r14, r44, r55);
+    r55 = fmaf(r15, r47, r55);
+    r47 = copysign(1.0, r55);
+    r47 = fmaf(r10, r47, r55);
+    r55 = r47 * r47;
+    r44 = 1.0 / r55;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = atanf(r48);
+    r11 = copysign(1.0, r48);
+    r11 = fmaf(r10, r11, r48);
+    r10 = r11 * r11;
+    r48 = 1.0 / r10;
+    r50 = r36 * r44;
+    r46 = r48 * r50;
+    r49 = r49 * r36;
+    r49 = r49 * r46;
+    r52 = r51 * r46;
+    r26 = r51 * r36;
+    r52 = r52 * r26;
+    r56 = r49 + r52;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r57,
+                                         r58,
+                                         r59,
+                                         r60);
+    r61 = 3.00000000000000000e+00;
+    r62 = r51 * r61;
+    r62 = r62 * r46;
+    r62 = fmaf(r26, r62, r49);
+    r62 = fmaf(r58, r62, r8 * r56);
+    r49 = r16 * r46;
+    r63 = r26 * r49;
+    r64 = r57 * r63;
+    r65 = r56 * r56;
+    r66 = r56 * r65;
+    r67 = fmaf(r59, r66, r6 * r56);
+    r66 = r60 * r66;
+    r67 = fmaf(r56, r66, r67);
+    r67 = fmaf(r7, r65, r67);
+    r60 = 1.0 / r47;
+    r68 = 1.0 / r11;
+    r69 = r60 * r68;
+    r70 = r67 * r69;
+    r62 = fmaf(r33, r64, r62);
+    r62 = fmaf(r26, r70, r62);
+    r62 = fmaf(r69, r26, r62);
+    r2 = fmaf(r0, r62, r2);
+    r62 = r33 * r33;
+    r62 = r62 * r36;
+    r62 = r62 * r61;
+    r62 = fmaf(r46, r62, r52);
+    r62 = fmaf(r57, r62, r9 * r56);
+    r52 = r36 * r70;
+    r71 = r58 * r33;
+    r62 = fmaf(r63, r71, r62);
+    r72 = r33 * r36;
+    r62 = fmaf(r69, r72, r62);
+    r62 = fmaf(r33, r52, r62);
+    r62 = fmaf(r5, r62, r1);
+    r62 = fmaf(r3, r4, r62);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r62);
+    r3 = fmaf(r62, r62, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r0 * r4;
+    r1 = r16 * r34;
+    r72 = r19 * r24;
+    r71 = 5.00000000000000000e-01;
+    r73 = r18 * r21;
+    r73 = fmaf(r71, r73, r71 * r72);
+    r72 = r17 * r22;
+    r74 = -5.00000000000000000e-01;
+    r73 = fmaf(r74, r72, r73);
+    r75 = r20 * r23;
+    r73 = fmaf(r71, r75, r73);
+    r75 = r17 * r24;
+    r72 = r20 * r21;
+    r72 = fmaf(r74, r72, r74 * r75);
+    r75 = r19 * r22;
+    r72 = fmaf(r74, r75, r72);
+    r76 = r18 * r23;
+    r72 = fmaf(r71, r76, r72);
+    r76 = r29 * r72;
+    r1 = fmaf(r16, r76, r73 * r1);
+    r75 = r16 * r25;
+    r77 = fmaf(r71, r31, r74 * r27);
+    r77 = fmaf(r74, r28, r77);
+    r77 = fmaf(r74, r30, r77);
+    r78 = r16 * r32;
+    r79 = r20 * r24;
+    r80 = r17 * r21;
+    r80 = fmaf(r74, r80, r71 * r79);
+    r79 = r18 * r22;
+    r80 = fmaf(r74, r79, r80);
+    r81 = r19 * r23;
+    r80 = fmaf(r74, r81, r80);
+    r78 = r78 * r80;
+    r75 = fmaf(r77, r75, r78);
+    r1 = r1 + r75;
+    r81 = r16 * r29;
+    r81 = r81 * r80;
+    r79 = r16 * r25;
+    r79 = r79 * r73;
+    r82 = r81 + r79;
+    r83 = r32 * r40;
+    r82 = fmaf(r72, r83, r82);
+    r84 = r40 * r34;
+    r82 = fmaf(r77, r84, r82);
+    r82 = fmaf(r14, r82, r15 * r1);
+    r1 = r29 * r73;
+    r84 = -4.00000000000000000e+00;
+    r1 = r1 * r84;
+    r83 = r32 * r77;
+    r85 = r84 * r83;
+    r86 = r1 + r85;
+    r82 = fmaf(r13, r86, r82);
+    r86 = 6.00000000000000000e+00;
+    r87 = r82 * r86;
+    r87 = r87 * r46;
+    r88 = r51 * r51;
+    r89 = r16 * r33;
+    r90 = r25 * r40;
+    r91 = r34 * r80;
+    r92 = r40 * r91;
+    r90 = fmaf(r72, r90, r92);
+    r93 = r16 * r29;
+    r93 = r93 * r77;
+    r94 = r16 * r32;
+    r94 = fmaf(r73, r94, r93);
+    r90 = r90 + r94;
+    r95 = r25 * r80;
+    r95 = r95 * r84;
+    r85 = r95 + r85;
+    r85 = fmaf(r14, r85, r15 * r90);
+    r90 = r16 * r34;
+    r90 = fmaf(r77, r90, r79);
+    r79 = r16 * r32;
+    r79 = fmaf(r72, r79, r81);
+    r90 = r90 + r79;
+    r85 = fmaf(r13, r90, r85);
+    r89 = r89 * r85;
+    r90 = r16 * r51;
+    r90 = r90 * r82;
+    r90 = fmaf(r44, r90, r44 * r89);
+    r89 = r33 * r33;
+    r81 = r16 * r25;
+    r81 = r81 * r72;
+    r91 = r16 * r91;
+    r96 = r81 + r91;
+    r94 = r94 + r96;
+    r97 = r40 * r34;
+    r97 = fmaf(r40, r76, r73 * r97);
+    r97 = r97 + r75;
+    r97 = fmaf(r13, r97, r14 * r94);
+    r1 = r95 + r1;
+    r97 = fmaf(r15, r1, r97);
+    r55 = r47 * r55;
+    r55 = 1.0 / r55;
+    r47 = r40 * r55;
+    r89 = r89 * r97;
+    r90 = fmaf(r47, r89, r90);
+    r1 = r51 * r51;
+    r1 = r1 * r97;
+    r90 = fmaf(r47, r1, r90);
+    r41 = r41 + r35;
+    r41 = 1.0 / r41;
+    r35 = rsqrtf(r35);
+    r88 = r88 * r61;
+    r88 = r88 * r90;
+    r88 = r88 * r41;
+    r88 = r88 * r35;
+    r88 = fmaf(r46, r88, r26 * r87);
+    r87 = r40 * r12;
+    r1 = r51 * r51;
+    r87 = r87 * r1;
+    r87 = r87 * r55;
+    r1 = r36 * r36;
+    r89 = -6.00000000000000000e+00;
+    r1 = r1 * r97;
+    r1 = r1 * r89;
+    r1 = r1 * r48;
+    r1 = r1 * r55;
+    r95 = -3.00000000000000000e+00;
+    r10 = r11 * r10;
+    r10 = 1.0 / r10;
+    r10 = r10 * r50;
+    r11 = r26 * r10;
+    r94 = r51 * r35;
+    r11 = r11 * r94;
+    r73 = r90 * r11;
+    r98 = r85 * r49;
+    r99 = r33 * r36;
+    r100 = r33 * r46;
+    r101 = r33 * r35;
+    r102 = r41 * r101;
+    r100 = r100 * r102;
+    r98 = fmaf(r90, r100, r99 * r98);
+    r103 = r4 * r90;
+    r10 = r101 * r10;
+    r103 = r103 * r99;
+    r98 = fmaf(r10, r103, r98);
+    r104 = r33 * r33;
+    r104 = r104 * r36;
+    r104 = r104 * r36;
+    r104 = r104 * r97;
+    r104 = r104 * r48;
+    r98 = fmaf(r47, r104, r98);
+    r88 = fmaf(r1, r87, r88);
+    r88 = fmaf(r95, r73, r88);
+    r88 = r88 + r98;
+    r104 = r51 * r51;
+    r104 = r104 * r90;
+    r104 = r104 * r41;
+    r104 = r104 * r35;
+    r104 = fmaf(r46, r104, r82 * r63);
+    r103 = r51 * r51;
+    r103 = r103 * r36;
+    r103 = r103 * r36;
+    r103 = r103 * r97;
+    r103 = r103 * r48;
+    r104 = fmaf(r47, r103, r104);
+    r104 = fmaf(r4, r73, r104);
+    r98 = r98 + r104;
+    r88 = fmaf(r8, r98, r58 * r88);
+    r73 = r51 * r36;
+    r73 = r73 * r67;
+    r73 = r73 * r74;
+    r73 = r73 * r90;
+    r73 = r73 * r48;
+    r73 = r73 * r60;
+    r88 = fmaf(r35, r73, r88);
+    r103 = r57 * r51;
+    r103 = r103 * r90;
+    r103 = r103 * r49;
+    r88 = fmaf(r102, r103, r88);
+    r105 = r51 * r36;
+    r105 = r105 * r74;
+    r105 = r105 * r90;
+    r105 = r105 * r48;
+    r105 = r105 * r60;
+    r88 = fmaf(r35, r105, r88);
+    r106 = r57 * r51;
+    r106 = r106 * r33;
+    r106 = r106 * r36;
+    r106 = r106 * r36;
+    r106 = r106 * r84;
+    r106 = r106 * r97;
+    r106 = r106 * r48;
+    r88 = fmaf(r55, r106, r88);
+    r107 = r71 * r41;
+    r107 = r107 * r70;
+    r107 = r107 * r94;
+    r94 = r57 * r82;
+    r94 = r94 * r49;
+    r88 = fmaf(r99, r94, r88);
+    r108 = r36 * r82;
+    r88 = fmaf(r69, r108, r88);
+    r109 = r4 * r51;
+    r109 = r109 * r97;
+    r109 = r109 * r68;
+    r88 = fmaf(r50, r109, r88);
+    r110 = r4 * r51;
+    r110 = r110 * r67;
+    r110 = r110 * r97;
+    r110 = r110 * r68;
+    r88 = fmaf(r50, r110, r88);
+    r111 = r51 * r71;
+    r111 = r111 * r90;
+    r111 = r111 * r41;
+    r111 = r111 * r35;
+    r88 = fmaf(r69, r111, r88);
+    r112 = r57 * r90;
+    r113 = r40 * r26;
+    r113 = r113 * r10;
+    r88 = fmaf(r113, r112, r88);
+    r114 = r7 * r16;
+    r114 = r114 * r56;
+    r114 = fmaf(r98, r114, r6 * r98);
+    r115 = 4.00000000000000000e+00;
+    r66 = r115 * r66;
+    r59 = r59 * r61;
+    r59 = r59 * r65;
+    r114 = fmaf(r98, r66, r114);
+    r114 = fmaf(r98, r59, r114);
+    r65 = r114 * r69;
+    r88 = fmaf(r26, r65, r88);
+    r88 = fmaf(r90, r107, r88);
+    r88 = fmaf(r85, r64, r88);
+    r88 = fmaf(r82, r52, r88);
+    r3 = r3 * r2;
+    r65 = r5 * r4;
+    r65 = r65 * r62;
+    r62 = r33 * r36;
+    r62 = r62 * r85;
+    r62 = r62 * r86;
+    r112 = r61 * r90;
+    r112 = fmaf(r100, r112, r46 * r62);
+    r62 = r95 * r99;
+    r62 = r62 * r10;
+    r111 = r33 * r33;
+    r111 = r111 * r47;
+    r112 = fmaf(r90, r62, r112);
+    r112 = fmaf(r1, r111, r112);
+    r112 = r112 + r104;
+    r98 = fmaf(r9, r98, r57 * r112);
+    r112 = r71 * r90;
+    r112 = r112 * r69;
+    r98 = fmaf(r102, r112, r98);
+    r104 = r36 * r74;
+    r104 = r104 * r48;
+    r104 = r104 * r60;
+    r104 = r104 * r101;
+    r101 = r67 * r104;
+    r1 = r33 * r36;
+    r1 = r1 * r114;
+    r98 = fmaf(r69, r1, r98);
+    r110 = r4 * r33;
+    r110 = r110 * r67;
+    r110 = r110 * r97;
+    r110 = r110 * r68;
+    r98 = fmaf(r50, r110, r98);
+    r109 = r58 * r51;
+    r109 = r109 * r33;
+    r109 = r109 * r36;
+    r109 = r109 * r36;
+    r109 = r109 * r84;
+    r109 = r109 * r48;
+    r109 = r109 * r55;
+    r108 = r58 * r82;
+    r108 = r108 * r49;
+    r98 = fmaf(r99, r108, r98);
+    r94 = r58 * r51;
+    r94 = r94 * r90;
+    r94 = r94 * r49;
+    r98 = fmaf(r102, r94, r98);
+    r106 = r4 * r33;
+    r106 = r106 * r97;
+    r106 = r106 * r68;
+    r98 = fmaf(r50, r106, r98);
+    r105 = r58 * r90;
+    r98 = fmaf(r113, r105, r98);
+    r103 = r71 * r90;
+    r103 = r103 * r102;
+    r98 = fmaf(r70, r103, r98);
+    r73 = r58 * r85;
+    r98 = fmaf(r63, r73, r98);
+    r115 = r36 * r85;
+    r98 = fmaf(r69, r115, r98);
+    r98 = fmaf(r90, r101, r98);
+    r98 = fmaf(r97, r109, r98);
+    r98 = fmaf(r90, r104, r98);
+    r98 = fmaf(r85, r52, r98);
+    r3 = fmaf(r98, r65, r88 * r3);
+    r115 = r0 * r4;
+    r73 = r33 * r33;
+    r73 = r44 * r73;
+    r103 = r16 * r51;
+    r91 = r93 + r91;
+    r93 = r16 * r32;
+    r105 = r19 * r24;
+    r106 = r18 * r21;
+    r106 = fmaf(r74, r106, r74 * r105);
+    r105 = r17 * r22;
+    r106 = fmaf(r71, r105, r106);
+    r94 = r20 * r23;
+    r106 = fmaf(r74, r94, r106);
+    r93 = r93 * r106;
+    r94 = r16 * r25;
+    r105 = r17 * r24;
+    r108 = r20 * r21;
+    r108 = fmaf(r71, r108, r71 * r105);
+    r105 = r19 * r22;
+    r108 = fmaf(r71, r105, r108);
+    r97 = r18 * r23;
+    r108 = fmaf(r74, r97, r108);
+    r94 = fmaf(r108, r94, r93);
+    r91 = r91 + r94;
+    r97 = r29 * r80;
+    r97 = r97 * r84;
+    r105 = r32 * r84;
+    r105 = r105 * r108;
+    r110 = r97 + r105;
+    r110 = fmaf(r13, r110, r15 * r91);
+    r91 = r40 * r34;
+    r91 = fmaf(r40, r83, r108 * r91);
+    r1 = r16 * r25;
+    r1 = r1 * r80;
+    r112 = r16 * r29;
+    r112 = fmaf(r106, r112, r1);
+    r91 = r91 + r112;
+    r110 = fmaf(r14, r91, r110);
+    r103 = r103 * r110;
+    r91 = r51 * r51;
+    r116 = r40 * r29;
+    r116 = fmaf(r77, r116, r92);
+    r116 = r116 + r94;
+    r94 = r16 * r29;
+    r94 = r94 * r108;
+    r117 = r16 * r34;
+    r117 = fmaf(r106, r117, r94);
+    r117 = r117 + r75;
+    r117 = fmaf(r14, r117, r13 * r116);
+    r116 = r25 * r106;
+    r75 = r84 * r116;
+    r97 = r97 + r75;
+    r117 = fmaf(r15, r97, r117);
+    r91 = r91 * r117;
+    r91 = fmaf(r47, r91, r44 * r103);
+    r103 = r33 * r33;
+    r103 = r103 * r117;
+    r91 = fmaf(r47, r103, r91);
+    r97 = r16 * r33;
+    r94 = r78 + r94;
+    r78 = r25 * r40;
+    r94 = fmaf(r77, r78, r94);
+    r77 = r40 * r34;
+    r94 = fmaf(r106, r77, r94);
+    r77 = r16 * r34;
+    r83 = fmaf(r16, r83, r108 * r77);
+    r83 = r83 + r112;
+    r83 = fmaf(r13, r83, r15 * r94);
+    r75 = r105 + r75;
+    r83 = fmaf(r14, r75, r83);
+    r97 = r97 * r83;
+    r91 = fmaf(r44, r97, r91);
+    r73 = r73 * r48;
+    r73 = r73 * r36;
+    r73 = r73 * r41;
+    r73 = r73 * r35;
+    r73 = r73 * r91;
+    r97 = r83 * r49;
+    r97 = fmaf(r99, r97, r73);
+    r103 = r4 * r91;
+    r103 = r103 * r99;
+    r97 = fmaf(r10, r103, r97);
+    r75 = r33 * r33;
+    r75 = r75 * r36;
+    r75 = r75 * r36;
+    r75 = r75 * r117;
+    r75 = r75 * r48;
+    r97 = fmaf(r47, r75, r97);
+    r75 = r51 * r51;
+    r75 = r75 * r91;
+    r75 = r75 * r41;
+    r75 = r75 * r35;
+    r103 = r4 * r91;
+    r103 = fmaf(r11, r103, r46 * r75);
+    r75 = r51 * r51;
+    r75 = r75 * r36;
+    r75 = r75 * r36;
+    r75 = r75 * r117;
+    r75 = r75 * r48;
+    r103 = fmaf(r47, r75, r103);
+    r103 = fmaf(r110, r63, r103);
+    r75 = r97 + r103;
+    r105 = r51 * r51;
+    r105 = r105 * r61;
+    r105 = r105 * r91;
+    r105 = r105 * r41;
+    r105 = r105 * r35;
+    r94 = r95 * r91;
+    r94 = fmaf(r11, r94, r46 * r105);
+    r105 = r51 * r51;
+    r105 = r105 * r36;
+    r105 = r105 * r36;
+    r105 = r105 * r89;
+    r105 = r105 * r117;
+    r105 = r105 * r48;
+    r94 = fmaf(r55, r105, r94);
+    r77 = r86 * r110;
+    r77 = r77 * r46;
+    r94 = fmaf(r26, r77, r94);
+    r94 = r94 + r97;
+    r94 = fmaf(r58, r94, r8 * r75);
+    r97 = r57 * r51;
+    r97 = r97 * r33;
+    r97 = r97 * r36;
+    r97 = r97 * r36;
+    r97 = r97 * r84;
+    r97 = r97 * r117;
+    r97 = r97 * r48;
+    r94 = fmaf(r55, r97, r94);
+    r77 = r51 * r36;
+    r77 = r77 * r74;
+    r77 = r77 * r91;
+    r77 = r77 * r48;
+    r77 = r77 * r60;
+    r94 = fmaf(r35, r77, r94);
+    r105 = r4 * r51;
+    r105 = r105 * r117;
+    r105 = r105 * r68;
+    r94 = fmaf(r50, r105, r94);
+    r108 = r57 * r91;
+    r94 = fmaf(r113, r108, r94);
+    r78 = r57 * r51;
+    r78 = r78 * r91;
+    r78 = r78 * r49;
+    r94 = fmaf(r102, r78, r94);
+    r118 = r51 * r71;
+    r118 = r118 * r91;
+    r118 = r118 * r41;
+    r118 = r118 * r35;
+    r94 = fmaf(r69, r118, r94);
+    r119 = r4 * r51;
+    r119 = r119 * r67;
+    r119 = r119 * r117;
+    r119 = r119 * r68;
+    r94 = fmaf(r50, r119, r94);
+    r120 = r57 * r110;
+    r120 = r120 * r49;
+    r94 = fmaf(r99, r120, r94);
+    r121 = r7 * r16;
+    r121 = r121 * r56;
+    r121 = fmaf(r75, r121, r6 * r75);
+    r121 = fmaf(r75, r66, r121);
+    r121 = fmaf(r75, r59, r121);
+    r122 = r121 * r69;
+    r94 = fmaf(r26, r122, r94);
+    r123 = r51 * r36;
+    r123 = r123 * r67;
+    r123 = r123 * r74;
+    r123 = r123 * r91;
+    r123 = r123 * r48;
+    r123 = r123 * r60;
+    r94 = fmaf(r35, r123, r94);
+    r124 = r36 * r110;
+    r94 = fmaf(r69, r124, r94);
+    r94 = fmaf(r83, r64, r94);
+    r94 = fmaf(r91, r107, r94);
+    r94 = fmaf(r110, r52, r94);
+    r115 = r115 * r2;
+    r124 = r33 * r36;
+    r124 = r124 * r86;
+    r124 = r124 * r83;
+    r124 = fmaf(r91, r62, r46 * r124);
+    r123 = r33 * r33;
+    r123 = r123 * r36;
+    r123 = r123 * r36;
+    r123 = r123 * r89;
+    r123 = r123 * r117;
+    r123 = r123 * r48;
+    r124 = fmaf(r55, r123, r124);
+    r124 = fmaf(r61, r73, r124);
+    r124 = r124 + r103;
+    r124 = fmaf(r57, r124, r9 * r75);
+    r75 = r4 * r33;
+    r75 = r75 * r117;
+    r75 = r75 * r68;
+    r124 = fmaf(r50, r75, r124);
+    r103 = r58 * r83;
+    r124 = fmaf(r63, r103, r124);
+    r73 = r71 * r91;
+    r73 = r73 * r102;
+    r124 = fmaf(r70, r73, r124);
+    r123 = r33 * r36;
+    r123 = r123 * r121;
+    r124 = fmaf(r69, r123, r124);
+    r122 = r71 * r91;
+    r122 = r122 * r69;
+    r124 = fmaf(r102, r122, r124);
+    r120 = r58 * r91;
+    r124 = fmaf(r113, r120, r124);
+    r119 = r58 * r51;
+    r119 = r119 * r91;
+    r119 = r119 * r49;
+    r124 = fmaf(r102, r119, r124);
+    r118 = r58 * r110;
+    r118 = r118 * r49;
+    r124 = fmaf(r99, r118, r124);
+    r78 = r4 * r33;
+    r78 = r78 * r67;
+    r78 = r78 * r117;
+    r78 = r78 * r68;
+    r124 = fmaf(r50, r78, r124);
+    r108 = r36 * r83;
+    r124 = fmaf(r69, r108, r124);
+    r124 = fmaf(r117, r109, r124);
+    r124 = fmaf(r91, r101, r124);
+    r124 = fmaf(r91, r104, r124);
+    r124 = fmaf(r83, r52, r124);
+    r115 = fmaf(r124, r65, r94 * r115);
+    r108 = r0 * r4;
+    r78 = r51 * r51;
+    r118 = r25 * r84;
+    r31 = fmaf(r74, r31, r71 * r27);
+    r31 = fmaf(r71, r28, r31);
+    r31 = fmaf(r71, r30, r31);
+    r118 = r118 * r31;
+    r76 = r84 * r76;
+    r30 = r118 + r76;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r1 = r1 + r28;
+    r27 = r40 * r29;
+    r1 = fmaf(r106, r27, r1);
+    r119 = r40 * r34;
+    r1 = fmaf(r72, r119, r1);
+    r1 = fmaf(r13, r1, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r116, r31 * r30);
+    r30 = r30 + r79;
+    r1 = fmaf(r14, r30, r1);
+    r78 = r78 * r1;
+    r30 = r16 * r51;
+    r119 = r16 * r29;
+    r119 = r119 * r31;
+    r81 = r81 + r119;
+    r27 = r32 * r40;
+    r81 = fmaf(r106, r27, r81);
+    r81 = r81 + r92;
+    r80 = r32 * r80;
+    r80 = r80 * r84;
+    r76 = r80 + r76;
+    r76 = fmaf(r13, r76, r14 * r81);
+    r81 = r16 * r34;
+    r81 = fmaf(r72, r81, r28);
+    r81 = r81 + r112;
+    r76 = fmaf(r15, r81, r76);
+    r30 = r30 * r76;
+    r30 = fmaf(r44, r30, r47 * r78);
+    r78 = r33 * r33;
+    r78 = r78 * r1;
+    r30 = fmaf(r47, r78, r30);
+    r81 = r16 * r33;
+    r119 = r93 + r119;
+    r119 = r119 + r96;
+    r96 = r40 * r34;
+    r116 = fmaf(r40, r116, r31 * r96);
+    r116 = r116 + r79;
+    r116 = fmaf(r15, r116, r13 * r119);
+    r80 = r118 + r80;
+    r116 = fmaf(r14, r80, r116);
+    r81 = r81 * r116;
+    r30 = fmaf(r44, r81, r30);
+    r81 = r116 * r49;
+    r81 = fmaf(r99, r81, r30 * r100);
+    r78 = r33 * r33;
+    r78 = r78 * r36;
+    r78 = r78 * r36;
+    r78 = r78 * r1;
+    r78 = r78 * r48;
+    r81 = fmaf(r47, r78, r81);
+    r80 = r4 * r30;
+    r80 = r80 * r99;
+    r81 = fmaf(r10, r80, r81);
+    r80 = r51 * r51;
+    r80 = r80 * r36;
+    r80 = r80 * r36;
+    r80 = r80 * r1;
+    r80 = r80 * r48;
+    r78 = r51 * r51;
+    r78 = r78 * r30;
+    r78 = r78 * r41;
+    r78 = r78 * r35;
+    r78 = fmaf(r46, r78, r47 * r80);
+    r80 = r4 * r30;
+    r78 = fmaf(r11, r80, r78);
+    r78 = fmaf(r76, r63, r78);
+    r80 = r81 + r78;
+    r14 = r51 * r51;
+    r14 = r14 * r36;
+    r14 = r14 * r36;
+    r14 = r14 * r89;
+    r14 = r14 * r1;
+    r14 = r14 * r48;
+    r118 = r51 * r51;
+    r118 = r118 * r61;
+    r118 = r118 * r30;
+    r118 = r118 * r41;
+    r118 = r118 * r35;
+    r118 = fmaf(r46, r118, r55 * r14);
+    r14 = r95 * r30;
+    r118 = fmaf(r11, r14, r118);
+    r15 = r86 * r76;
+    r15 = r15 * r46;
+    r118 = fmaf(r26, r15, r118);
+    r118 = r118 + r81;
+    r118 = fmaf(r58, r118, r8 * r80);
+    r81 = r7 * r16;
+    r81 = r81 * r56;
+    r81 = fmaf(r80, r81, r6 * r80);
+    r81 = fmaf(r80, r59, r81);
+    r81 = fmaf(r80, r66, r81);
+    r15 = r81 * r69;
+    r118 = fmaf(r26, r15, r118);
+    r14 = r57 * r51;
+    r14 = r14 * r33;
+    r14 = r14 * r36;
+    r14 = r14 * r36;
+    r14 = r14 * r84;
+    r14 = r14 * r1;
+    r14 = r14 * r48;
+    r118 = fmaf(r55, r14, r118);
+    r119 = r51 * r71;
+    r119 = r119 * r30;
+    r119 = r119 * r41;
+    r119 = r119 * r35;
+    r118 = fmaf(r69, r119, r118);
+    r13 = r51 * r36;
+    r13 = r13 * r67;
+    r13 = r13 * r74;
+    r13 = r13 * r30;
+    r13 = r13 * r48;
+    r13 = r13 * r60;
+    r118 = fmaf(r35, r13, r118);
+    r79 = r4 * r51;
+    r79 = r79 * r1;
+    r79 = r79 * r68;
+    r118 = fmaf(r50, r79, r118);
+    r96 = r57 * r30;
+    r118 = fmaf(r113, r96, r118);
+    r31 = r57 * r76;
+    r31 = r31 * r49;
+    r118 = fmaf(r99, r31, r118);
+    r93 = r51 * r36;
+    r93 = r93 * r74;
+    r93 = r93 * r30;
+    r93 = r93 * r48;
+    r93 = r93 * r60;
+    r118 = fmaf(r35, r93, r118);
+    r112 = r4 * r51;
+    r112 = r112 * r67;
+    r112 = r112 * r1;
+    r112 = r112 * r68;
+    r118 = fmaf(r50, r112, r118);
+    r28 = r36 * r76;
+    r118 = fmaf(r69, r28, r118);
+    r72 = r57 * r51;
+    r72 = r72 * r30;
+    r72 = r72 * r49;
+    r118 = fmaf(r102, r72, r118);
+    r118 = fmaf(r76, r52, r118);
+    r118 = fmaf(r30, r107, r118);
+    r118 = fmaf(r116, r64, r118);
+    r108 = r108 * r2;
+    r72 = r61 * r30;
+    r28 = r33 * r36;
+    r28 = r28 * r86;
+    r28 = r28 * r116;
+    r28 = fmaf(r46, r28, r100 * r72);
+    r72 = r33 * r33;
+    r72 = r72 * r36;
+    r72 = r72 * r36;
+    r72 = r72 * r89;
+    r72 = r72 * r1;
+    r72 = r72 * r48;
+    r28 = fmaf(r55, r72, r28);
+    r28 = fmaf(r30, r62, r28);
+    r28 = r28 + r78;
+    r28 = fmaf(r57, r28, r9 * r80);
+    r80 = r71 * r30;
+    r80 = r80 * r69;
+    r28 = fmaf(r102, r80, r28);
+    r78 = r4 * r33;
+    r78 = r78 * r67;
+    r78 = r78 * r1;
+    r78 = r78 * r68;
+    r28 = fmaf(r50, r78, r28);
+    r72 = r58 * r30;
+    r28 = fmaf(r113, r72, r28);
+    r112 = r58 * r76;
+    r112 = r112 * r49;
+    r28 = fmaf(r99, r112, r28);
+    r93 = r58 * r116;
+    r28 = fmaf(r63, r93, r28);
+    r31 = r4 * r33;
+    r31 = r31 * r1;
+    r31 = r31 * r68;
+    r28 = fmaf(r50, r31, r28);
+    r96 = r58 * r51;
+    r96 = r96 * r30;
+    r96 = r96 * r49;
+    r28 = fmaf(r102, r96, r28);
+    r79 = r36 * r116;
+    r28 = fmaf(r69, r79, r28);
+    r13 = r33 * r36;
+    r13 = r13 * r81;
+    r28 = fmaf(r69, r13, r28);
+    r119 = r71 * r30;
+    r119 = r119 * r102;
+    r28 = fmaf(r70, r119, r28);
+    r28 = fmaf(r1, r109, r28);
+    r28 = fmaf(r30, r104, r28);
+    r28 = fmaf(r116, r52, r28);
+    r28 = fmaf(r30, r101, r28);
+    r108 = fmaf(r28, r65, r118 * r108);
+    r119 = r0 * r4;
+    r13 = r12 * r51;
+    r13 = r13 * r51;
+    r13 = r13 * r36;
+    r13 = r13 * r36;
+    r13 = r13 * r89;
+    r13 = r13 * r48;
+    r79 = r42 * r86;
+    r79 = r79 * r46;
+    r79 = fmaf(r26, r79, r55 * r13);
+    r13 = r12 * r47;
+    r96 = fmaf(r13, r111, r87);
+    r31 = r16 * r38;
+    r31 = r31 * r33;
+    r96 = fmaf(r44, r31, r96);
+    r93 = r16 * r42;
+    r93 = r93 * r51;
+    r96 = fmaf(r44, r93, r96);
+    r93 = r95 * r96;
+    r79 = fmaf(r11, r93, r79);
+    r31 = r51 * r51;
+    r31 = r31 * r61;
+    r31 = r31 * r96;
+    r31 = r31 * r41;
+    r31 = r31 * r35;
+    r79 = fmaf(r46, r31, r79);
+    r112 = r13 * r111;
+    r72 = r36 * r36;
+    r72 = r72 * r48;
+    r78 = r38 * r49;
+    r78 = fmaf(r99, r78, r72 * r112);
+    r112 = r4 * r96;
+    r112 = r112 * r99;
+    r78 = fmaf(r10, r112, r78);
+    r78 = fmaf(r96, r100, r78);
+    r79 = r79 + r78;
+    r72 = fmaf(r42, r63, r87 * r72);
+    r87 = r4 * r96;
+    r72 = fmaf(r11, r87, r72);
+    r31 = r51 * r51;
+    r31 = r31 * r96;
+    r31 = r31 * r41;
+    r31 = r31 * r35;
+    r72 = fmaf(r46, r31, r72);
+    r78 = r78 + r72;
+    r79 = fmaf(r8, r78, r58 * r79);
+    r31 = r4 * r12;
+    r31 = r31 * r51;
+    r31 = r31 * r68;
+    r79 = fmaf(r50, r31, r79);
+    r87 = r42 * r36;
+    r79 = fmaf(r69, r87, r79);
+    r93 = r51 * r36;
+    r93 = r93 * r67;
+    r93 = r93 * r74;
+    r93 = r93 * r96;
+    r93 = r93 * r48;
+    r93 = r93 * r60;
+    r79 = fmaf(r35, r93, r79);
+    r112 = r96 * r113;
+    r80 = r57 * r51;
+    r80 = r80 * r96;
+    r80 = r80 * r49;
+    r79 = fmaf(r102, r80, r79);
+    r1 = r57 * r42;
+    r1 = r1 * r49;
+    r79 = fmaf(r99, r1, r79);
+    r14 = r51 * r36;
+    r14 = r14 * r74;
+    r14 = r14 * r96;
+    r14 = r14 * r48;
+    r14 = r14 * r60;
+    r79 = fmaf(r35, r14, r79);
+    r15 = r57 * r12;
+    r15 = r15 * r51;
+    r15 = r15 * r33;
+    r15 = r15 * r36;
+    r15 = r15 * r36;
+    r15 = r15 * r84;
+    r15 = r15 * r48;
+    r79 = fmaf(r55, r15, r79);
+    r92 = r51 * r71;
+    r92 = r92 * r96;
+    r92 = r92 * r41;
+    r92 = r92 * r35;
+    r79 = fmaf(r69, r92, r79);
+    r27 = r7 * r16;
+    r27 = r27 * r56;
+    r27 = fmaf(r6, r78, r78 * r27);
+    r27 = fmaf(r78, r66, r27);
+    r27 = fmaf(r78, r59, r27);
+    r106 = r27 * r69;
+    r79 = fmaf(r26, r106, r79);
+    r120 = r4 * r12;
+    r120 = r120 * r51;
+    r120 = r120 * r67;
+    r120 = r120 * r68;
+    r79 = fmaf(r50, r120, r79);
+    r79 = fmaf(r57, r112, r79);
+    r79 = fmaf(r42, r52, r79);
+    r79 = fmaf(r96, r107, r79);
+    r79 = fmaf(r38, r64, r79);
+    r119 = r119 * r2;
+    r120 = r12 * r33;
+    r120 = r120 * r33;
+    r120 = r120 * r36;
+    r120 = r120 * r36;
+    r120 = r120 * r89;
+    r120 = r120 * r48;
+    r106 = r38 * r33;
+    r106 = r106 * r36;
+    r106 = r106 * r86;
+    r106 = fmaf(r46, r106, r55 * r120);
+    r120 = r61 * r96;
+    r106 = fmaf(r100, r120, r106);
+    r106 = fmaf(r96, r62, r106);
+    r106 = r106 + r72;
+    r78 = fmaf(r9, r78, r57 * r106);
+    r106 = r4 * r12;
+    r106 = r106 * r33;
+    r106 = r106 * r68;
+    r78 = fmaf(r50, r106, r78);
+    r72 = r4 * r12;
+    r72 = r72 * r33;
+    r72 = r72 * r67;
+    r72 = r72 * r68;
+    r78 = fmaf(r50, r72, r78);
+    r120 = r38 * r36;
+    r78 = fmaf(r69, r120, r78);
+    r92 = r58 * r51;
+    r92 = r92 * r96;
+    r92 = r92 * r49;
+    r78 = fmaf(r102, r92, r78);
+    r15 = r58 * r42;
+    r15 = r15 * r49;
+    r78 = fmaf(r99, r15, r78);
+    r14 = r71 * r96;
+    r14 = r14 * r69;
+    r78 = fmaf(r102, r14, r78);
+    r1 = r58 * r38;
+    r78 = fmaf(r63, r1, r78);
+    r80 = r71 * r96;
+    r80 = r80 * r102;
+    r78 = fmaf(r70, r80, r78);
+    r93 = r33 * r36;
+    r93 = r93 * r27;
+    r78 = fmaf(r69, r93, r78);
+    r78 = fmaf(r96, r104, r78);
+    r78 = fmaf(r96, r101, r78);
+    r78 = fmaf(r38, r52, r78);
+    r78 = fmaf(r58, r112, r78);
+    r78 = fmaf(r12, r109, r78);
+    r119 = fmaf(r78, r65, r79 * r119);
+    WriteSum4<float, float>((float*)inout_shared, r3, r115, r108, r119);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r119 = r0 * r4;
+    r108 = r39 * r33;
+    r108 = r108 * r33;
+    r115 = r16 * r43;
+    r115 = r115 * r33;
+    r115 = fmaf(r44, r115, r47 * r108);
+    r108 = r39 * r51;
+    r108 = r108 * r51;
+    r115 = fmaf(r47, r108, r115);
+    r3 = r16 * r54;
+    r3 = r3 * r51;
+    r115 = fmaf(r44, r3, r115);
+    r3 = r39 * r33;
+    r3 = r3 * r33;
+    r3 = r3 * r36;
+    r3 = r3 * r36;
+    r3 = r3 * r48;
+    r3 = fmaf(r47, r3, r115 * r100);
+    r108 = r43 * r49;
+    r3 = fmaf(r99, r108, r3);
+    r93 = r4 * r115;
+    r93 = r93 * r99;
+    r3 = fmaf(r10, r93, r3);
+    r93 = r51 * r51;
+    r93 = r93 * r115;
+    r93 = r93 * r41;
+    r93 = r93 * r35;
+    r108 = r39 * r51;
+    r108 = r108 * r51;
+    r108 = r108 * r36;
+    r108 = r108 * r36;
+    r108 = r108 * r48;
+    r108 = fmaf(r47, r108, r46 * r93);
+    r93 = r4 * r115;
+    r108 = fmaf(r11, r93, r108);
+    r108 = fmaf(r54, r63, r108);
+    r93 = r3 + r108;
+    r80 = r51 * r51;
+    r80 = r80 * r61;
+    r80 = r80 * r115;
+    r80 = r80 * r41;
+    r80 = r80 * r35;
+    r1 = r39 * r51;
+    r1 = r1 * r51;
+    r1 = r1 * r36;
+    r1 = r1 * r36;
+    r1 = r1 * r89;
+    r1 = r1 * r48;
+    r1 = fmaf(r55, r1, r46 * r80);
+    r80 = r54 * r86;
+    r80 = r80 * r46;
+    r1 = fmaf(r26, r80, r1);
+    r14 = r95 * r115;
+    r1 = fmaf(r11, r14, r1);
+    r1 = r1 + r3;
+    r1 = fmaf(r58, r1, r8 * r93);
+    r3 = r7 * r16;
+    r3 = r3 * r56;
+    r3 = fmaf(r93, r3, r6 * r93);
+    r3 = fmaf(r93, r66, r3);
+    r3 = fmaf(r93, r59, r3);
+    r14 = r3 * r69;
+    r1 = fmaf(r26, r14, r1);
+    r80 = r51 * r36;
+    r80 = r80 * r74;
+    r80 = r80 * r115;
+    r80 = r80 * r48;
+    r80 = r80 * r60;
+    r1 = fmaf(r35, r80, r1);
+    r15 = r54 * r36;
+    r1 = fmaf(r69, r15, r1);
+    r92 = r57 * r51;
+    r92 = r92 * r115;
+    r92 = r92 * r49;
+    r1 = fmaf(r102, r92, r1);
+    r112 = r51 * r71;
+    r112 = r112 * r115;
+    r112 = r112 * r41;
+    r112 = r112 * r35;
+    r1 = fmaf(r69, r112, r1);
+    r120 = r57 * r39;
+    r120 = r120 * r51;
+    r120 = r120 * r33;
+    r120 = r120 * r36;
+    r120 = r120 * r36;
+    r120 = r120 * r84;
+    r120 = r120 * r48;
+    r1 = fmaf(r55, r120, r1);
+    r72 = r57 * r115;
+    r1 = fmaf(r113, r72, r1);
+    r106 = r51 * r36;
+    r106 = r106 * r67;
+    r106 = r106 * r74;
+    r106 = r106 * r115;
+    r106 = r106 * r48;
+    r106 = r106 * r60;
+    r1 = fmaf(r35, r106, r1);
+    r87 = r4 * r39;
+    r87 = r87 * r51;
+    r87 = r87 * r68;
+    r1 = fmaf(r50, r87, r1);
+    r31 = r57 * r54;
+    r31 = r31 * r49;
+    r1 = fmaf(r99, r31, r1);
+    r122 = r4 * r39;
+    r122 = r122 * r51;
+    r122 = r122 * r67;
+    r122 = r122 * r68;
+    r1 = fmaf(r50, r122, r1);
+    r1 = fmaf(r54, r52, r1);
+    r1 = fmaf(r43, r64, r1);
+    r1 = fmaf(r115, r107, r1);
+    r119 = r119 * r2;
+    r122 = r61 * r115;
+    r31 = r39 * r33;
+    r31 = r31 * r33;
+    r31 = r31 * r36;
+    r31 = r31 * r36;
+    r31 = r31 * r89;
+    r31 = r31 * r48;
+    r31 = fmaf(r55, r31, r100 * r122);
+    r122 = r43 * r33;
+    r122 = r122 * r36;
+    r122 = r122 * r86;
+    r31 = fmaf(r46, r122, r31);
+    r31 = fmaf(r115, r62, r31);
+    r31 = r31 + r108;
+    r31 = fmaf(r57, r31, r9 * r93);
+    r93 = r58 * r43;
+    r31 = fmaf(r63, r93, r31);
+    r108 = r4 * r39;
+    r108 = r108 * r33;
+    r108 = r108 * r68;
+    r31 = fmaf(r50, r108, r31);
+    r122 = r71 * r115;
+    r122 = r122 * r69;
+    r31 = fmaf(r102, r122, r31);
+    r87 = r58 * r51;
+    r87 = r87 * r115;
+    r87 = r87 * r49;
+    r31 = fmaf(r102, r87, r31);
+    r106 = r71 * r115;
+    r106 = r106 * r102;
+    r31 = fmaf(r70, r106, r31);
+    r72 = r58 * r115;
+    r31 = fmaf(r113, r72, r31);
+    r120 = r43 * r36;
+    r31 = fmaf(r69, r120, r31);
+    r112 = r58 * r54;
+    r112 = r112 * r49;
+    r31 = fmaf(r99, r112, r31);
+    r92 = r4 * r39;
+    r92 = r92 * r33;
+    r92 = r92 * r67;
+    r92 = r92 * r68;
+    r31 = fmaf(r50, r92, r31);
+    r15 = r33 * r36;
+    r15 = r15 * r3;
+    r31 = fmaf(r69, r15, r31);
+    r31 = fmaf(r43, r52, r31);
+    r31 = fmaf(r39, r109, r31);
+    r31 = fmaf(r115, r101, r31);
+    r31 = fmaf(r115, r104, r31);
+    r119 = fmaf(r31, r65, r1 * r119);
+    r15 = r0 * r4;
+    r92 = r16 * r45;
+    r92 = r92 * r33;
+    r112 = r37 * r33;
+    r112 = r112 * r33;
+    r112 = fmaf(r47, r112, r44 * r92);
+    r92 = r16 * r53;
+    r92 = r92 * r51;
+    r112 = fmaf(r44, r92, r112);
+    r44 = r37 * r51;
+    r44 = r44 * r51;
+    r112 = fmaf(r47, r44, r112);
+    r44 = r45 * r49;
+    r44 = fmaf(r99, r44, r112 * r100);
+    r92 = r4 * r112;
+    r92 = r92 * r99;
+    r44 = fmaf(r10, r92, r44);
+    r10 = r37 * r33;
+    r10 = r10 * r33;
+    r10 = r10 * r36;
+    r10 = r10 * r36;
+    r10 = r10 * r48;
+    r44 = fmaf(r47, r10, r44);
+    r10 = r37 * r51;
+    r10 = r10 * r51;
+    r10 = r10 * r36;
+    r10 = r10 * r36;
+    r10 = r10 * r48;
+    r92 = r4 * r112;
+    r92 = fmaf(r11, r92, r47 * r10);
+    r10 = r51 * r51;
+    r10 = r10 * r112;
+    r10 = r10 * r41;
+    r10 = r10 * r35;
+    r92 = fmaf(r46, r10, r92);
+    r92 = fmaf(r53, r63, r92);
+    r10 = r44 + r92;
+    r47 = r37 * r51;
+    r47 = r47 * r51;
+    r47 = r47 * r36;
+    r47 = r47 * r36;
+    r47 = r47 * r89;
+    r47 = r47 * r48;
+    r120 = r95 * r112;
+    r120 = fmaf(r11, r120, r55 * r47);
+    r47 = r53 * r86;
+    r47 = r47 * r46;
+    r120 = fmaf(r26, r47, r120);
+    r11 = r51 * r51;
+    r11 = r11 * r61;
+    r11 = r11 * r112;
+    r11 = r11 * r41;
+    r11 = r11 * r35;
+    r120 = fmaf(r46, r11, r120);
+    r120 = r120 + r44;
+    r120 = fmaf(r58, r120, r8 * r10);
+    r8 = r4 * r37;
+    r8 = r8 * r51;
+    r8 = r8 * r67;
+    r8 = r8 * r68;
+    r120 = fmaf(r50, r8, r120);
+    r44 = r53 * r36;
+    r120 = fmaf(r69, r44, r120);
+    r11 = r4 * r37;
+    r11 = r11 * r51;
+    r11 = r11 * r68;
+    r120 = fmaf(r50, r11, r120);
+    r47 = r51 * r36;
+    r47 = r47 * r74;
+    r47 = r47 * r112;
+    r47 = r47 * r48;
+    r47 = r47 * r60;
+    r120 = fmaf(r35, r47, r120);
+    r72 = r57 * r112;
+    r120 = fmaf(r113, r72, r120);
+    r106 = r57 * r51;
+    r106 = r106 * r112;
+    r106 = r106 * r49;
+    r120 = fmaf(r102, r106, r120);
+    r87 = r57 * r53;
+    r87 = r87 * r49;
+    r120 = fmaf(r99, r87, r120);
+    r122 = r51 * r36;
+    r122 = r122 * r67;
+    r122 = r122 * r74;
+    r122 = r122 * r112;
+    r122 = r122 * r48;
+    r122 = r122 * r60;
+    r120 = fmaf(r35, r122, r120);
+    r60 = r51 * r71;
+    r60 = r60 * r112;
+    r60 = r60 * r41;
+    r60 = r60 * r35;
+    r120 = fmaf(r69, r60, r120);
+    r35 = r7 * r16;
+    r35 = r35 * r56;
+    r6 = fmaf(r6, r10, r10 * r35);
+    r6 = fmaf(r10, r66, r6);
+    r6 = fmaf(r10, r59, r6);
+    r59 = r6 * r69;
+    r120 = fmaf(r26, r59, r120);
+    r26 = r57 * r37;
+    r26 = r26 * r51;
+    r26 = r26 * r33;
+    r26 = r26 * r36;
+    r26 = r26 * r36;
+    r26 = r26 * r84;
+    r26 = r26 * r48;
+    r120 = fmaf(r55, r26, r120);
+    r120 = fmaf(r53, r52, r120);
+    r120 = fmaf(r112, r107, r120);
+    r120 = fmaf(r45, r64, r120);
+    r15 = r15 * r2;
+    r2 = r61 * r112;
+    r26 = r45 * r33;
+    r26 = r26 * r36;
+    r26 = r26 * r86;
+    r26 = fmaf(r46, r26, r100 * r2);
+    r2 = r37 * r33;
+    r2 = r2 * r33;
+    r2 = r2 * r36;
+    r2 = r2 * r36;
+    r2 = r2 * r89;
+    r2 = r2 * r48;
+    r26 = fmaf(r55, r2, r26);
+    r26 = fmaf(r112, r62, r26);
+    r26 = r26 + r92;
+    r26 = fmaf(r57, r26, r9 * r10);
+    r10 = r71 * r112;
+    r10 = r10 * r102;
+    r26 = fmaf(r70, r10, r26);
+    r70 = r71 * r112;
+    r70 = r70 * r69;
+    r26 = fmaf(r102, r70, r26);
+    r9 = r58 * r112;
+    r26 = fmaf(r113, r9, r26);
+    r113 = r58 * r51;
+    r113 = r113 * r112;
+    r113 = r113 * r49;
+    r26 = fmaf(r102, r113, r26);
+    r102 = r58 * r45;
+    r26 = fmaf(r63, r102, r26);
+    r63 = r4 * r37;
+    r63 = r63 * r33;
+    r63 = r63 * r67;
+    r63 = r63 * r68;
+    r26 = fmaf(r50, r63, r26);
+    r67 = r58 * r53;
+    r67 = r67 * r49;
+    r26 = fmaf(r99, r67, r26);
+    r99 = r45 * r36;
+    r26 = fmaf(r69, r99, r26);
+    r92 = r4 * r37;
+    r92 = r92 * r33;
+    r92 = r92 * r68;
+    r26 = fmaf(r50, r92, r26);
+    r50 = r33 * r36;
+    r50 = r50 * r6;
+    r26 = fmaf(r69, r50, r26);
+    r26 = fmaf(r45, r52, r26);
+    r26 = fmaf(r112, r101, r26);
+    r26 = fmaf(r112, r104, r26);
+    r26 = fmaf(r37, r109, r26);
+    r65 = fmaf(r26, r65, r120 * r15);
+    WriteSum2<float, float>((float*)inout_shared, r119, r65);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r0 * r0;
+    r119 = r88 * r65;
+    r5 = r5 * r5;
+    r15 = r98 * r5;
+    r98 = fmaf(r98, r15, r88 * r119);
+    r88 = r94 * r94;
+    r109 = r124 * r124;
+    r109 = fmaf(r5, r109, r65 * r88);
+    r88 = r28 * r28;
+    r50 = r118 * r118;
+    r50 = fmaf(r65, r50, r5 * r88);
+    r88 = r79 * r79;
+    r92 = r78 * r78;
+    r92 = fmaf(r5, r92, r65 * r88);
+    WriteSum4<float, float>((float*)inout_shared, r98, r109, r50, r92);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r92 = r1 * r1;
+    r50 = r31 * r31;
+    r50 = fmaf(r5, r50, r65 * r92);
+    r92 = r26 * r26;
+    r109 = r120 * r120;
+    r109 = fmaf(r65, r109, r5 * r92);
+    WriteSum2<float, float>((float*)inout_shared, r50, r109);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = fmaf(r94, r119, r124 * r15);
+    r50 = fmaf(r28, r15, r118 * r119);
+    r92 = fmaf(r79, r119, r78 * r15);
+    r98 = fmaf(r1, r119, r31 * r15);
+    WriteSum4<float, float>((float*)inout_shared, r109, r50, r92, r98);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r15 = fmaf(r26, r15, r120 * r119);
+    r119 = r124 * r28;
+    r98 = r94 * r118;
+    r98 = fmaf(r65, r98, r5 * r119);
+    r119 = r94 * r79;
+    r92 = r124 * r78;
+    r92 = fmaf(r5, r92, r65 * r119);
+    r119 = r94 * r1;
+    r50 = r124 * r31;
+    r50 = fmaf(r5, r50, r65 * r119);
+    WriteSum4<float, float>((float*)inout_shared, r15, r98, r92, r50);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r124 * r26;
+    r92 = r94 * r120;
+    r92 = fmaf(r65, r92, r5 * r50);
+    r50 = r28 * r78;
+    r98 = r118 * r79;
+    r98 = fmaf(r65, r98, r5 * r50);
+    r50 = r118 * r1;
+    r15 = r28 * r31;
+    r15 = fmaf(r5, r15, r65 * r50);
+    r50 = r28 * r26;
+    r119 = r118 * r120;
+    r119 = fmaf(r65, r119, r5 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r92, r98, r15, r119);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r119 = r78 * r31;
+    r15 = r79 * r1;
+    r15 = fmaf(r65, r15, r5 * r119);
+    r119 = r79 * r120;
+    r98 = r78 * r26;
+    r98 = fmaf(r5, r98, r65 * r119);
+    r119 = r31 * r26;
+    r92 = r1 * r120;
+    r92 = fmaf(r65, r92, r5 * r119);
+    WriteSum3<float, float>((float*)inout_shared, r15, r98, r92);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,306 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,192 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r7, r8);
+    ReadIdx4<1024, float, float, float4>(point_jac,
+                                         0 * point_jac_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    r13 = fmaf(r5, r11, r6 * r7);
+    r13 = fmaf(r4, r9, r13);
+    r5 = fmaf(r5, r12, r6 * r8);
+    r5 = fmaf(r4, r10, r5);
+    r4 = fmaf(r1, r5, r0 * r13);
+    r6 = fmaf(r3, r5, r2 * r13);
+    ReadIdx4<1024, float, float, float4>(pose_jac,
+                                         4 * pose_jac_num_alloc,
+                                         global_thread_idx,
+                                         r14,
+                                         r15,
+                                         r16,
+                                         r17);
+    r18 = fmaf(r15, r5, r14 * r13);
+    r19 = fmaf(r17, r5, r16 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r4, r6, r18, r19);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r19, r18, r6, r4);
+    r20 = fmaf(r18, r5, r19 * r13);
+    r13 = fmaf(r6, r13, r4 * r5);
+    WriteSum2<float, float>((float*)inout_shared, r20, r13);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r13,
+                       r20);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r5,
+                       r21,
+                       r22,
+                       r23);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = fmaf(r23, r17, r20 * r4);
+    r17 = fmaf(r22, r15, r17);
+    r17 = fmaf(r5, r1, r17);
+    r17 = fmaf(r21, r3, r17);
+    r17 = fmaf(r13, r18, r17);
+    r19 = fmaf(r13, r19, r20 * r6);
+    r19 = fmaf(r22, r14, r19);
+    r19 = fmaf(r23, r16, r19);
+    r19 = fmaf(r5, r0, r19);
+    r19 = fmaf(r21, r2, r19);
+    r9 = fmaf(r9, r19, r10 * r17);
+    r11 = fmaf(r11, r19, r12 * r17);
+    r19 = fmaf(r7, r19, r8 * r17);
+    WriteSum3<float, float>((float*)inout_shared, r9, r11, r19);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
@@ -1,0 +1,2217 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = r11 * r11;
+    r53 = 9.99999999999999955e-07;
+    r54 = r41 * r29;
+    r54 = r54 * r29;
+    r55 = r42 + r54;
+    r55 = r55 + r49;
+    r10 = fmaf(r13, r55, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r56 = r16 * r29;
+    r56 = fmaf(r34, r56, r26);
+    r57 = r21 * r23;
+    r57 = r57 * r16;
+    r58 = r22 * r24;
+    r58 = fmaf(r16, r58, r57);
+    r59 = r23 * r24;
+    r59 = fmaf(r41, r59, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r56, r10);
+    r10 = fmaf(r37, r58, r10);
+    r10 = fmaf(r36, r59, r10);
+    r10 = fmaf(r35, r43, r10);
+    r60 = r10 * r10;
+    r61 = r41 * r29;
+    r61 = fmaf(r34, r61, r26);
+    r12 = fmaf(r13, r61, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r57);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r54 = r42 + r54;
+    r54 = r54 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r54, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r53, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r60);
+    r60 = sqrtf(r35);
+    r51 = copysign(1.0, r60);
+    r51 = fmaf(r53, r51, r60);
+    r53 = r51 * r51;
+    r47 = 1.0 / r53;
+    r60 = atanf(r60);
+    r57 = r60 * r37;
+    r62 = r60 * r57;
+    r52 = r52 * r47;
+    r52 = r52 * r62;
+    r63 = r10 * r47;
+    r64 = r10 * r63;
+    r65 = r62 * r64;
+    r66 = r52 + r65;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r67,
+                                         r68,
+                                         r69,
+                                         r70);
+    r71 = 3.00000000000000000e+00;
+    r72 = r71 * r62;
+    r72 = fmaf(r64, r72, r52);
+    r72 = fmaf(r68, r72, r8 * r66);
+    r52 = r67 * r11;
+    r73 = r16 * r62;
+    r52 = r52 * r63;
+    r72 = fmaf(r73, r52, r72);
+    r74 = r66 * r66;
+    r75 = r66 * r74;
+    r76 = fmaf(r69, r75, r6 * r66);
+    r75 = r70 * r75;
+    r76 = fmaf(r66, r75, r76);
+    r76 = fmaf(r7, r74, r76);
+    r70 = 1.0 / r36;
+    r77 = 1.0 / r51;
+    r78 = r70 * r77;
+    r79 = r60 * r78;
+    r80 = r76 * r79;
+    r72 = fmaf(r10, r80, r72);
+    r72 = fmaf(r10, r79, r72);
+    r2 = fmaf(r0, r72, r2);
+    r72 = r11 * r11;
+    r72 = r72 * r71;
+    r72 = r72 * r47;
+    r72 = fmaf(r62, r72, r65);
+    r72 = fmaf(r67, r72, r9 * r66);
+    r65 = r68 * r11;
+    r65 = r65 * r63;
+    r72 = fmaf(r73, r65, r72);
+    r72 = fmaf(r11, r80, r72);
+    r72 = fmaf(r11, r79, r72);
+    r72 = fmaf(r5, r72, r1);
+    r72 = fmaf(r3, r4, r72);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r72);
+    r3 = r10 * r47;
+    r1 = -5.00000000000000000e-01;
+    r65 = rsqrtf(r35);
+    r52 = r16 * r11;
+    r81 = r25 * r41;
+    r82 = r17 * r24;
+    r83 = r20 * r21;
+    r83 = fmaf(r1, r83, r1 * r82);
+    r82 = r19 * r22;
+    r83 = fmaf(r1, r82, r83);
+    r84 = r18 * r23;
+    r85 = 5.00000000000000000e-01;
+    r83 = fmaf(r85, r84, r83);
+    r84 = r20 * r24;
+    r82 = r17 * r21;
+    r82 = fmaf(r1, r82, r85 * r84);
+    r84 = r18 * r22;
+    r82 = fmaf(r1, r84, r82);
+    r86 = r19 * r23;
+    r82 = fmaf(r1, r86, r82);
+    r86 = r34 * r82;
+    r84 = r41 * r86;
+    r81 = fmaf(r83, r81, r84);
+    r87 = r16 * r29;
+    r88 = fmaf(r85, r31, r1 * r27);
+    r88 = fmaf(r1, r28, r88);
+    r88 = fmaf(r1, r30, r88);
+    r87 = r87 * r88;
+    r89 = r16 * r32;
+    r90 = r19 * r24;
+    r91 = r18 * r21;
+    r91 = fmaf(r85, r91, r85 * r90);
+    r90 = r17 * r22;
+    r91 = fmaf(r1, r90, r91);
+    r92 = r20 * r23;
+    r91 = fmaf(r85, r92, r91);
+    r89 = fmaf(r91, r89, r87);
+    r81 = r81 + r89;
+    r92 = r25 * r82;
+    r90 = -4.00000000000000000e+00;
+    r92 = r92 * r90;
+    r93 = r32 * r88;
+    r94 = r90 * r93;
+    r95 = r92 + r94;
+    r95 = fmaf(r14, r95, r15 * r81);
+    r81 = r16 * r25;
+    r81 = r81 * r91;
+    r96 = r16 * r34;
+    r96 = fmaf(r88, r96, r81);
+    r97 = r16 * r29;
+    r97 = r97 * r82;
+    r98 = r16 * r32;
+    r98 = fmaf(r83, r98, r97);
+    r96 = r96 + r98;
+    r95 = fmaf(r13, r96, r95);
+    r52 = r52 * r95;
+    r96 = r16 * r10;
+    r99 = r16 * r34;
+    r100 = r29 * r83;
+    r99 = fmaf(r16, r100, r91 * r99);
+    r101 = r16 * r25;
+    r102 = r16 * r32;
+    r102 = r102 * r82;
+    r101 = fmaf(r88, r101, r102);
+    r99 = r99 + r101;
+    r81 = r97 + r81;
+    r97 = r32 * r41;
+    r81 = fmaf(r83, r97, r81);
+    r103 = r41 * r34;
+    r81 = fmaf(r88, r103, r81);
+    r81 = fmaf(r14, r81, r15 * r99);
+    r99 = r29 * r91;
+    r99 = r99 * r90;
+    r94 = r99 + r94;
+    r81 = fmaf(r13, r94, r81);
+    r96 = r96 * r81;
+    r96 = fmaf(r37, r96, r37 * r52);
+    r52 = r16 * r25;
+    r52 = r52 * r83;
+    r86 = r16 * r86;
+    r94 = r52 + r86;
+    r89 = r89 + r94;
+    r103 = r41 * r34;
+    r103 = fmaf(r41, r100, r91 * r103);
+    r103 = r103 + r101;
+    r103 = fmaf(r13, r103, r14 * r89);
+    r99 = r92 + r99;
+    r103 = fmaf(r15, r99, r103);
+    r99 = r11 * r11;
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r36 = r41 * r12;
+    r99 = r99 * r36;
+    r92 = r10 * r10;
+    r92 = r92 * r103;
+    r96 = fmaf(r36, r92, r96);
+    r96 = fmaf(r103, r99, r96);
+    r3 = r3 * r60;
+    r3 = r3 * r70;
+    r3 = r3 * r1;
+    r3 = r3 * r65;
+    r3 = r3 * r96;
+    r92 = 6.00000000000000000e+00;
+    r89 = r81 * r92;
+    r89 = r89 * r62;
+    r91 = r71 * r96;
+    r35 = r42 + r35;
+    r35 = 1.0 / r35;
+    r42 = r35 * r57;
+    r91 = r91 * r65;
+    r91 = r91 * r42;
+    r91 = fmaf(r64, r91, r63 * r89);
+    r89 = -6.00000000000000000e+00;
+    r97 = r89 * r12;
+    r104 = r60 * r60;
+    r105 = r64 * r104;
+    r97 = r97 * r105;
+    r106 = r10 * r10;
+    r107 = -3.00000000000000000e+00;
+    r53 = r51 * r53;
+    r53 = 1.0 / r53;
+    r106 = r106 * r107;
+    r106 = r106 * r96;
+    r106 = r106 * r65;
+    r106 = r106 * r53;
+    r91 = fmaf(r62, r106, r91);
+    r51 = r11 * r47;
+    r108 = r73 * r51;
+    r109 = r11 * r65;
+    r110 = r96 * r109;
+    r110 = r110 * r42;
+    r110 = fmaf(r51, r110, r95 * r108);
+    r111 = r4 * r11;
+    r112 = r53 * r62;
+    r112 = r112 * r109;
+    r111 = r111 * r96;
+    r110 = fmaf(r112, r111, r110);
+    r104 = r47 * r104;
+    r104 = r104 * r99;
+    r110 = fmaf(r103, r104, r110);
+    r91 = fmaf(r103, r97, r91);
+    r91 = r91 + r110;
+    r91 = fmaf(r68, r91, r3);
+    r106 = r81 * r63;
+    r111 = r96 * r65;
+    r111 = r111 * r42;
+    r111 = fmaf(r64, r111, r73 * r106);
+    r106 = r103 * r36;
+    r111 = fmaf(r105, r106, r111);
+    r113 = r4 * r10;
+    r113 = r113 * r10;
+    r113 = r113 * r96;
+    r113 = r113 * r65;
+    r113 = r113 * r53;
+    r111 = fmaf(r62, r113, r111);
+    r110 = r110 + r111;
+    r113 = r67 * r96;
+    r106 = r16 * r63;
+    r106 = r106 * r109;
+    r106 = r106 * r42;
+    r91 = fmaf(r106, r113, r91);
+    r114 = r67 * r11;
+    r114 = r114 * r60;
+    r114 = r114 * r60;
+    r114 = r114 * r90;
+    r114 = r114 * r12;
+    r114 = r114 * r63;
+    r115 = r10 * r85;
+    r115 = r115 * r65;
+    r115 = r115 * r35;
+    r115 = r115 * r78;
+    r116 = r76 * r115;
+    r117 = r67 * r81;
+    r91 = fmaf(r108, r117, r91);
+    r118 = r4 * r10;
+    r118 = r118 * r103;
+    r118 = r118 * r77;
+    r91 = fmaf(r57, r118, r91);
+    r119 = r4 * r10;
+    r119 = r119 * r76;
+    r119 = r119 * r103;
+    r119 = r119 * r77;
+    r91 = fmaf(r57, r119, r91);
+    r120 = r67 * r41;
+    r120 = r120 * r10;
+    r120 = r120 * r96;
+    r91 = fmaf(r112, r120, r91);
+    r121 = r7 * r16;
+    r121 = r121 * r66;
+    r121 = fmaf(r110, r121, r6 * r110);
+    r122 = 4.00000000000000000e+00;
+    r75 = r122 * r75;
+    r69 = r69 * r71;
+    r69 = r69 * r74;
+    r121 = fmaf(r110, r75, r121);
+    r121 = fmaf(r110, r69, r121);
+    r74 = r10 * r121;
+    r91 = fmaf(r79, r74, r91);
+    r122 = r67 * r95;
+    r122 = r122 * r63;
+    r91 = fmaf(r73, r122, r91);
+    r91 = fmaf(r8, r110, r91);
+    r91 = fmaf(r76, r3, r91);
+    r91 = fmaf(r103, r114, r91);
+    r91 = fmaf(r96, r116, r91);
+    r91 = fmaf(r81, r79, r91);
+    r91 = fmaf(r96, r115, r91);
+    r91 = fmaf(r81, r80, r91);
+    r122 = r0 * r91;
+    r74 = r11 * r95;
+    r74 = r74 * r92;
+    r74 = r74 * r47;
+    r120 = r71 * r96;
+    r120 = r120 * r109;
+    r120 = r120 * r42;
+    r120 = fmaf(r51, r120, r62 * r74);
+    r74 = r11 * r107;
+    r74 = r74 * r96;
+    r120 = fmaf(r112, r74, r120);
+    r119 = r11 * r11;
+    r119 = r119 * r60;
+    r119 = r119 * r60;
+    r119 = r119 * r103;
+    r119 = r119 * r89;
+    r119 = r119 * r47;
+    r120 = fmaf(r12, r119, r120);
+    r120 = r120 + r111;
+    r110 = fmaf(r9, r110, r67 * r120);
+    r120 = r11 * r47;
+    r120 = r120 * r60;
+    r120 = r120 * r70;
+    r120 = r120 * r1;
+    r120 = r120 * r65;
+    r120 = r120 * r96;
+    r111 = r85 * r96;
+    r111 = r111 * r35;
+    r111 = r111 * r109;
+    r110 = fmaf(r78, r111, r110);
+    r119 = r11 * r121;
+    r110 = fmaf(r79, r119, r110);
+    r74 = r4 * r11;
+    r74 = r74 * r76;
+    r74 = r74 * r103;
+    r74 = r74 * r77;
+    r110 = fmaf(r57, r74, r110);
+    r118 = r68 * r11;
+    r118 = r118 * r60;
+    r118 = r118 * r60;
+    r118 = r118 * r90;
+    r118 = r118 * r103;
+    r118 = r118 * r12;
+    r110 = fmaf(r63, r118, r110);
+    r117 = r68 * r81;
+    r110 = fmaf(r108, r117, r110);
+    r113 = r68 * r96;
+    r110 = fmaf(r106, r113, r110);
+    r3 = r4 * r11;
+    r3 = r3 * r103;
+    r3 = r3 * r77;
+    r110 = fmaf(r57, r3, r110);
+    r123 = r68 * r41;
+    r123 = r123 * r10;
+    r123 = r123 * r112;
+    r124 = r85 * r76;
+    r124 = r124 * r96;
+    r124 = r124 * r35;
+    r124 = r124 * r109;
+    r110 = fmaf(r78, r124, r110);
+    r125 = r68 * r95;
+    r125 = r125 * r63;
+    r110 = fmaf(r73, r125, r110);
+    r110 = r110 + r120;
+    r110 = fmaf(r76, r120, r110);
+    r110 = fmaf(r96, r123, r110);
+    r110 = fmaf(r95, r80, r110);
+    r110 = fmaf(r95, r79, r110);
+    r125 = r5 * r110;
+    r124 = r16 * r10;
+    r86 = r87 + r86;
+    r87 = r16 * r32;
+    r3 = r19 * r24;
+    r113 = r18 * r21;
+    r113 = fmaf(r1, r113, r1 * r3);
+    r3 = r17 * r22;
+    r113 = fmaf(r85, r3, r113);
+    r117 = r20 * r23;
+    r113 = fmaf(r1, r117, r113);
+    r87 = r87 * r113;
+    r117 = r16 * r25;
+    r3 = r17 * r24;
+    r118 = r20 * r21;
+    r118 = fmaf(r85, r118, r85 * r3);
+    r3 = r19 * r22;
+    r118 = fmaf(r85, r3, r118);
+    r74 = r18 * r23;
+    r118 = fmaf(r1, r74, r118);
+    r117 = fmaf(r118, r117, r87);
+    r86 = r86 + r117;
+    r74 = r32 * r90;
+    r74 = r74 * r118;
+    r3 = r29 * r82;
+    r3 = r3 * r90;
+    r119 = r74 + r3;
+    r119 = fmaf(r13, r119, r15 * r86);
+    r86 = r41 * r34;
+    r86 = fmaf(r41, r93, r118 * r86);
+    r120 = r16 * r25;
+    r120 = r120 * r82;
+    r111 = r16 * r29;
+    r111 = fmaf(r113, r111, r120);
+    r86 = r86 + r111;
+    r119 = fmaf(r14, r86, r119);
+    r124 = r124 * r119;
+    r86 = r10 * r10;
+    r126 = r41 * r29;
+    r126 = fmaf(r88, r126, r84);
+    r126 = r126 + r117;
+    r117 = r16 * r29;
+    r117 = r117 * r118;
+    r127 = r16 * r34;
+    r127 = fmaf(r113, r127, r117);
+    r127 = r127 + r101;
+    r127 = fmaf(r14, r127, r13 * r126);
+    r126 = r25 * r113;
+    r101 = r90 * r126;
+    r3 = r3 + r101;
+    r127 = fmaf(r15, r3, r127);
+    r86 = r86 * r127;
+    r86 = fmaf(r36, r86, r37 * r124);
+    r124 = r16 * r11;
+    r3 = r25 * r41;
+    r3 = fmaf(r88, r3, r102);
+    r102 = r41 * r34;
+    r3 = fmaf(r113, r102, r3);
+    r3 = r3 + r117;
+    r102 = r16 * r34;
+    r93 = fmaf(r16, r93, r118 * r102);
+    r93 = r93 + r111;
+    r93 = fmaf(r13, r93, r15 * r3);
+    r101 = r74 + r101;
+    r93 = fmaf(r14, r101, r93);
+    r124 = r124 * r93;
+    r86 = fmaf(r37, r124, r86);
+    r86 = fmaf(r127, r99, r86);
+    r124 = r86 * r65;
+    r124 = r124 * r42;
+    r101 = r4 * r10;
+    r101 = r101 * r10;
+    r101 = r101 * r86;
+    r101 = r101 * r65;
+    r101 = r101 * r53;
+    r101 = fmaf(r62, r101, r64 * r124);
+    r124 = r127 * r36;
+    r101 = fmaf(r105, r124, r101);
+    r74 = r119 * r63;
+    r101 = fmaf(r73, r74, r101);
+    r74 = r4 * r11;
+    r74 = r74 * r86;
+    r74 = fmaf(r112, r74, r93 * r108);
+    r124 = r86 * r109;
+    r124 = r124 * r42;
+    r74 = fmaf(r51, r124, r74);
+    r74 = fmaf(r127, r104, r74);
+    r124 = r101 + r74;
+    r3 = r71 * r86;
+    r3 = r3 * r65;
+    r3 = r3 * r42;
+    r102 = r10 * r10;
+    r118 = r107 * r86;
+    r102 = r102 * r65;
+    r102 = r102 * r53;
+    r102 = r102 * r62;
+    r102 = fmaf(r118, r102, r64 * r3);
+    r3 = r92 * r119;
+    r3 = r3 * r62;
+    r102 = fmaf(r63, r3, r102);
+    r102 = fmaf(r127, r97, r102);
+    r102 = r102 + r74;
+    r102 = fmaf(r68, r102, r8 * r124);
+    r74 = r67 * r93;
+    r74 = r74 * r63;
+    r102 = fmaf(r73, r74, r102);
+    r3 = r60 * r1;
+    r3 = r3 * r86;
+    r3 = r3 * r70;
+    r3 = r3 * r65;
+    r102 = fmaf(r63, r3, r102);
+    r117 = r4 * r10;
+    r117 = r117 * r127;
+    r117 = r117 * r77;
+    r102 = fmaf(r57, r117, r102);
+    r88 = r67 * r41;
+    r88 = r88 * r10;
+    r88 = r88 * r86;
+    r102 = fmaf(r112, r88, r102);
+    r128 = r67 * r86;
+    r102 = fmaf(r106, r128, r102);
+    r129 = r4 * r10;
+    r129 = r129 * r76;
+    r129 = r129 * r127;
+    r129 = r129 * r77;
+    r102 = fmaf(r57, r129, r102);
+    r130 = r67 * r119;
+    r102 = fmaf(r108, r130, r102);
+    r131 = r7 * r16;
+    r131 = r131 * r66;
+    r131 = fmaf(r124, r131, r6 * r124);
+    r131 = fmaf(r124, r75, r131);
+    r131 = fmaf(r124, r69, r131);
+    r132 = r10 * r131;
+    r102 = fmaf(r79, r132, r102);
+    r133 = r60 * r76;
+    r133 = r133 * r1;
+    r133 = r133 * r86;
+    r133 = r133 * r70;
+    r133 = r133 * r65;
+    r102 = fmaf(r63, r133, r102);
+    r102 = fmaf(r127, r114, r102);
+    r102 = fmaf(r86, r116, r102);
+    r102 = fmaf(r119, r80, r102);
+    r102 = fmaf(r86, r115, r102);
+    r102 = fmaf(r119, r79, r102);
+    r133 = r0 * r102;
+    r132 = r11 * r92;
+    r132 = r132 * r93;
+    r132 = r132 * r47;
+    r130 = r11 * r112;
+    r130 = fmaf(r118, r130, r62 * r132);
+    r132 = r11 * r11;
+    r132 = r132 * r60;
+    r132 = r132 * r60;
+    r132 = r132 * r89;
+    r132 = r132 * r127;
+    r132 = r132 * r47;
+    r130 = fmaf(r12, r132, r130);
+    r118 = r71 * r86;
+    r118 = r118 * r109;
+    r118 = r118 * r42;
+    r130 = fmaf(r51, r118, r130);
+    r130 = r130 + r101;
+    r130 = fmaf(r67, r130, r9 * r124);
+    r124 = r4 * r11;
+    r124 = r124 * r127;
+    r124 = r124 * r77;
+    r130 = fmaf(r57, r124, r130);
+    r101 = r68 * r93;
+    r101 = r101 * r63;
+    r130 = fmaf(r73, r101, r130);
+    r118 = r68 * r11;
+    r118 = r118 * r60;
+    r118 = r118 * r60;
+    r118 = r118 * r90;
+    r118 = r118 * r127;
+    r118 = r118 * r12;
+    r130 = fmaf(r63, r118, r130);
+    r132 = r85 * r76;
+    r132 = r132 * r86;
+    r132 = r132 * r35;
+    r132 = r132 * r109;
+    r130 = fmaf(r78, r132, r130);
+    r129 = r60 * r76;
+    r129 = r129 * r1;
+    r129 = r129 * r86;
+    r129 = r129 * r47;
+    r129 = r129 * r70;
+    r130 = fmaf(r109, r129, r130);
+    r128 = r11 * r131;
+    r130 = fmaf(r79, r128, r130);
+    r88 = r85 * r86;
+    r88 = r88 * r35;
+    r88 = r88 * r109;
+    r130 = fmaf(r78, r88, r130);
+    r117 = r60 * r1;
+    r117 = r117 * r86;
+    r117 = r117 * r47;
+    r117 = r117 * r70;
+    r130 = fmaf(r109, r117, r130);
+    r3 = r68 * r86;
+    r130 = fmaf(r106, r3, r130);
+    r74 = r68 * r119;
+    r130 = fmaf(r108, r74, r130);
+    r134 = r4 * r11;
+    r134 = r134 * r76;
+    r134 = r134 * r127;
+    r134 = r134 * r77;
+    r130 = fmaf(r57, r134, r130);
+    r130 = fmaf(r86, r123, r130);
+    r130 = fmaf(r93, r80, r130);
+    r130 = fmaf(r93, r79, r130);
+    r134 = r5 * r130;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r122,
+                                          r125,
+                                          r133,
+                                          r134);
+    r134 = r10 * r10;
+    r133 = r25 * r90;
+    r31 = fmaf(r1, r31, r85 * r27);
+    r31 = fmaf(r85, r28, r31);
+    r31 = fmaf(r85, r30, r31);
+    r133 = r133 * r31;
+    r100 = r90 * r100;
+    r30 = r133 + r100;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r120 = r120 + r28;
+    r27 = r41 * r29;
+    r120 = fmaf(r113, r27, r120);
+    r125 = r41 * r34;
+    r120 = fmaf(r83, r125, r120);
+    r120 = fmaf(r13, r120, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r126, r31 * r30);
+    r30 = r30 + r98;
+    r120 = fmaf(r14, r30, r120);
+    r134 = r134 * r120;
+    r30 = r16 * r10;
+    r125 = r16 * r29;
+    r125 = r125 * r31;
+    r52 = r52 + r125;
+    r27 = r32 * r41;
+    r52 = fmaf(r113, r27, r52);
+    r52 = r52 + r84;
+    r82 = r32 * r82;
+    r82 = r82 * r90;
+    r100 = r82 + r100;
+    r100 = fmaf(r13, r100, r14 * r52);
+    r52 = r16 * r34;
+    r52 = fmaf(r83, r52, r28);
+    r52 = r52 + r111;
+    r100 = fmaf(r15, r52, r100);
+    r30 = r30 * r100;
+    r30 = fmaf(r37, r30, r36 * r134);
+    r134 = r16 * r11;
+    r125 = r87 + r125;
+    r125 = r125 + r94;
+    r94 = r41 * r34;
+    r126 = fmaf(r41, r126, r31 * r94);
+    r126 = r126 + r98;
+    r126 = fmaf(r15, r126, r13 * r125);
+    r82 = r133 + r82;
+    r126 = fmaf(r14, r82, r126);
+    r134 = r134 * r126;
+    r30 = fmaf(r37, r134, r30);
+    r30 = fmaf(r120, r99, r30);
+    r134 = r30 * r109;
+    r134 = r134 * r42;
+    r134 = fmaf(r126, r108, r51 * r134);
+    r82 = r4 * r11;
+    r82 = r82 * r30;
+    r134 = fmaf(r112, r82, r134);
+    r134 = fmaf(r120, r104, r134);
+    r82 = r120 * r36;
+    r14 = r30 * r65;
+    r14 = r14 * r42;
+    r14 = fmaf(r64, r14, r105 * r82);
+    r82 = r4 * r10;
+    r82 = r82 * r10;
+    r82 = r82 * r30;
+    r82 = r82 * r65;
+    r82 = r82 * r53;
+    r14 = fmaf(r62, r82, r14);
+    r133 = r100 * r63;
+    r14 = fmaf(r73, r133, r14);
+    r133 = r134 + r14;
+    r82 = r71 * r30;
+    r82 = r82 * r65;
+    r82 = r82 * r42;
+    r82 = fmaf(r64, r82, r120 * r97);
+    r15 = r10 * r10;
+    r15 = r15 * r107;
+    r15 = r15 * r30;
+    r15 = r15 * r65;
+    r15 = r15 * r53;
+    r82 = fmaf(r62, r15, r82);
+    r125 = r92 * r100;
+    r125 = r125 * r62;
+    r82 = fmaf(r63, r125, r82);
+    r82 = r82 + r134;
+    r82 = fmaf(r68, r82, r8 * r133);
+    r134 = r7 * r16;
+    r134 = r134 * r66;
+    r134 = fmaf(r133, r134, r6 * r133);
+    r134 = fmaf(r133, r69, r134);
+    r134 = fmaf(r133, r75, r134);
+    r125 = r10 * r134;
+    r82 = fmaf(r79, r125, r82);
+    r15 = r60 * r76;
+    r15 = r15 * r1;
+    r15 = r15 * r30;
+    r15 = r15 * r70;
+    r15 = r15 * r65;
+    r82 = fmaf(r63, r15, r82);
+    r13 = r4 * r10;
+    r13 = r13 * r120;
+    r13 = r13 * r77;
+    r82 = fmaf(r57, r13, r82);
+    r98 = r67 * r41;
+    r98 = r98 * r10;
+    r98 = r98 * r30;
+    r82 = fmaf(r112, r98, r82);
+    r94 = r67 * r100;
+    r82 = fmaf(r108, r94, r82);
+    r31 = r67 * r126;
+    r31 = r31 * r63;
+    r82 = fmaf(r73, r31, r82);
+    r87 = r60 * r1;
+    r87 = r87 * r30;
+    r87 = r87 * r70;
+    r87 = r87 * r65;
+    r82 = fmaf(r63, r87, r82);
+    r52 = r4 * r10;
+    r52 = r52 * r76;
+    r52 = r52 * r120;
+    r52 = r52 * r77;
+    r82 = fmaf(r57, r52, r82);
+    r111 = r67 * r30;
+    r82 = fmaf(r106, r111, r82);
+    r82 = fmaf(r120, r114, r82);
+    r82 = fmaf(r30, r115, r82);
+    r82 = fmaf(r100, r80, r82);
+    r82 = fmaf(r30, r116, r82);
+    r82 = fmaf(r100, r79, r82);
+    r111 = r0 * r82;
+    r52 = r71 * r30;
+    r52 = r52 * r109;
+    r52 = r52 * r42;
+    r87 = r11 * r92;
+    r87 = r87 * r126;
+    r87 = r87 * r47;
+    r87 = fmaf(r62, r87, r51 * r52);
+    r52 = r11 * r11;
+    r52 = r52 * r60;
+    r52 = r52 * r60;
+    r52 = r52 * r89;
+    r52 = r52 * r120;
+    r52 = r52 * r47;
+    r87 = fmaf(r12, r52, r87);
+    r31 = r11 * r107;
+    r31 = r31 * r30;
+    r87 = fmaf(r112, r31, r87);
+    r87 = r87 + r14;
+    r87 = fmaf(r67, r87, r9 * r133);
+    r133 = r68 * r11;
+    r133 = r133 * r60;
+    r133 = r133 * r60;
+    r133 = r133 * r90;
+    r133 = r133 * r120;
+    r133 = r133 * r12;
+    r87 = fmaf(r63, r133, r87);
+    r14 = r60 * r1;
+    r14 = r14 * r30;
+    r14 = r14 * r47;
+    r14 = r14 * r70;
+    r87 = fmaf(r109, r14, r87);
+    r31 = r85 * r30;
+    r31 = r31 * r35;
+    r31 = r31 * r109;
+    r87 = fmaf(r78, r31, r87);
+    r52 = r4 * r11;
+    r52 = r52 * r76;
+    r52 = r52 * r120;
+    r52 = r52 * r77;
+    r87 = fmaf(r57, r52, r87);
+    r94 = r68 * r100;
+    r87 = fmaf(r108, r94, r87);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r30;
+    r98 = r98 * r47;
+    r98 = r98 * r70;
+    r87 = fmaf(r109, r98, r87);
+    r13 = r68 * r126;
+    r13 = r13 * r63;
+    r87 = fmaf(r73, r13, r87);
+    r15 = r4 * r11;
+    r15 = r15 * r120;
+    r15 = r15 * r77;
+    r87 = fmaf(r57, r15, r87);
+    r125 = r68 * r30;
+    r87 = fmaf(r106, r125, r87);
+    r28 = r11 * r134;
+    r87 = fmaf(r79, r28, r87);
+    r83 = r85 * r76;
+    r83 = r83 * r30;
+    r83 = r83 * r35;
+    r83 = r83 * r109;
+    r87 = fmaf(r78, r83, r87);
+    r87 = fmaf(r126, r80, r87);
+    r87 = fmaf(r30, r123, r87);
+    r87 = fmaf(r126, r79, r87);
+    r83 = r5 * r87;
+    r28 = r43 * r92;
+    r28 = r28 * r62;
+    r28 = fmaf(r63, r28, r26 * r97);
+    r125 = r10 * r10;
+    r15 = r16 * r39;
+    r15 = r15 * r11;
+    r15 = fmaf(r37, r15, r26 * r99);
+    r13 = r26 * r10;
+    r13 = r13 * r10;
+    r15 = fmaf(r36, r13, r15);
+    r98 = r16 * r43;
+    r98 = r98 * r10;
+    r15 = fmaf(r37, r98, r15);
+    r125 = r125 * r107;
+    r125 = r125 * r15;
+    r125 = r125 * r65;
+    r125 = r125 * r53;
+    r28 = fmaf(r62, r125, r28);
+    r98 = r71 * r15;
+    r98 = r98 * r65;
+    r98 = r98 * r42;
+    r28 = fmaf(r64, r98, r28);
+    r13 = fmaf(r39, r108, r26 * r104);
+    r94 = r4 * r11;
+    r94 = r94 * r15;
+    r13 = fmaf(r112, r94, r13);
+    r52 = r15 * r109;
+    r52 = r52 * r42;
+    r13 = fmaf(r51, r52, r13);
+    r28 = r28 + r13;
+    r98 = r26 * r36;
+    r125 = r43 * r63;
+    r125 = fmaf(r73, r125, r105 * r98);
+    r98 = r4 * r10;
+    r98 = r98 * r10;
+    r98 = r98 * r15;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r125 = fmaf(r62, r98, r125);
+    r52 = r15 * r65;
+    r52 = r52 * r42;
+    r125 = fmaf(r64, r52, r125);
+    r13 = r13 + r125;
+    r28 = fmaf(r8, r13, r68 * r28);
+    r52 = r4 * r26;
+    r52 = r52 * r10;
+    r52 = r52 * r77;
+    r28 = fmaf(r57, r52, r28);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r15;
+    r98 = r98 * r70;
+    r98 = r98 * r65;
+    r28 = fmaf(r63, r98, r28);
+    r94 = r67 * r41;
+    r94 = r94 * r10;
+    r94 = r94 * r15;
+    r28 = fmaf(r112, r94, r28);
+    r31 = r15 * r106;
+    r14 = r67 * r43;
+    r28 = fmaf(r108, r14, r28);
+    r133 = r60 * r1;
+    r133 = r133 * r15;
+    r133 = r133 * r70;
+    r133 = r133 * r65;
+    r28 = fmaf(r63, r133, r28);
+    r84 = r67 * r39;
+    r84 = r84 * r63;
+    r28 = fmaf(r73, r84, r28);
+    r27 = r7 * r16;
+    r27 = r27 * r66;
+    r27 = fmaf(r6, r13, r13 * r27);
+    r27 = fmaf(r13, r75, r27);
+    r27 = fmaf(r13, r69, r27);
+    r113 = r10 * r27;
+    r28 = fmaf(r79, r113, r28);
+    r122 = r4 * r26;
+    r122 = r122 * r10;
+    r122 = r122 * r76;
+    r122 = r122 * r77;
+    r28 = fmaf(r57, r122, r28);
+    r28 = fmaf(r43, r79, r28);
+    r28 = fmaf(r43, r80, r28);
+    r28 = fmaf(r67, r31, r28);
+    r28 = fmaf(r15, r116, r28);
+    r28 = fmaf(r26, r114, r28);
+    r28 = fmaf(r15, r115, r28);
+    r122 = r0 * r28;
+    r113 = r26 * r11;
+    r113 = r113 * r11;
+    r113 = r113 * r60;
+    r113 = r113 * r60;
+    r113 = r113 * r89;
+    r113 = r113 * r47;
+    r84 = r39 * r11;
+    r84 = r84 * r92;
+    r84 = r84 * r47;
+    r84 = fmaf(r62, r84, r12 * r113);
+    r113 = r11 * r107;
+    r113 = r113 * r15;
+    r84 = fmaf(r112, r113, r84);
+    r133 = r71 * r15;
+    r133 = r133 * r109;
+    r133 = r133 * r42;
+    r84 = fmaf(r51, r133, r84);
+    r84 = r84 + r125;
+    r13 = fmaf(r9, r13, r67 * r84);
+    r84 = r4 * r26;
+    r84 = r84 * r11;
+    r84 = r84 * r77;
+    r13 = fmaf(r57, r84, r13);
+    r125 = r4 * r26;
+    r125 = r125 * r11;
+    r125 = r125 * r76;
+    r125 = r125 * r77;
+    r13 = fmaf(r57, r125, r13);
+    r133 = r60 * r1;
+    r133 = r133 * r15;
+    r133 = r133 * r47;
+    r133 = r133 * r70;
+    r13 = fmaf(r109, r133, r13);
+    r113 = r60 * r76;
+    r113 = r113 * r1;
+    r113 = r113 * r15;
+    r113 = r113 * r47;
+    r113 = r113 * r70;
+    r13 = fmaf(r109, r113, r13);
+    r14 = r68 * r43;
+    r13 = fmaf(r108, r14, r13);
+    r94 = r85 * r15;
+    r94 = r94 * r35;
+    r94 = r94 * r109;
+    r13 = fmaf(r78, r94, r13);
+    r98 = r68 * r26;
+    r98 = r98 * r11;
+    r98 = r98 * r60;
+    r98 = r98 * r60;
+    r98 = r98 * r90;
+    r98 = r98 * r12;
+    r13 = fmaf(r63, r98, r13);
+    r52 = r68 * r39;
+    r52 = r52 * r63;
+    r13 = fmaf(r73, r52, r13);
+    r74 = r85 * r76;
+    r74 = r74 * r15;
+    r74 = r74 * r35;
+    r74 = r74 * r109;
+    r13 = fmaf(r78, r74, r13);
+    r3 = r11 * r27;
+    r13 = fmaf(r79, r3, r13);
+    r13 = fmaf(r39, r79, r13);
+    r13 = fmaf(r39, r80, r13);
+    r13 = fmaf(r15, r123, r13);
+    r13 = fmaf(r68, r31, r13);
+    r3 = r5 * r13;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r111,
+                                          r83,
+                                          r122,
+                                          r3);
+    r3 = r16 * r44;
+    r3 = r3 * r11;
+    r3 = fmaf(r37, r3, r40 * r99);
+    r122 = r40 * r10;
+    r122 = r122 * r10;
+    r3 = fmaf(r36, r122, r3);
+    r83 = r16 * r59;
+    r83 = r83 * r10;
+    r3 = fmaf(r37, r83, r3);
+    r83 = r3 * r109;
+    r83 = r83 * r42;
+    r83 = fmaf(r40, r104, r51 * r83);
+    r122 = r4 * r11;
+    r122 = r122 * r3;
+    r83 = fmaf(r112, r122, r83);
+    r83 = fmaf(r44, r108, r83);
+    r122 = r3 * r65;
+    r122 = r122 * r42;
+    r111 = r40 * r36;
+    r111 = fmaf(r105, r111, r64 * r122);
+    r122 = r59 * r63;
+    r111 = fmaf(r73, r122, r111);
+    r74 = r4 * r10;
+    r74 = r74 * r10;
+    r74 = r74 * r3;
+    r74 = r74 * r65;
+    r74 = r74 * r53;
+    r111 = fmaf(r62, r74, r111);
+    r74 = r83 + r111;
+    r122 = r71 * r3;
+    r122 = r122 * r65;
+    r122 = r122 * r42;
+    r122 = fmaf(r40, r97, r64 * r122);
+    r52 = r59 * r92;
+    r52 = r52 * r62;
+    r122 = fmaf(r63, r52, r122);
+    r98 = r10 * r10;
+    r98 = r98 * r107;
+    r98 = r98 * r3;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r122 = fmaf(r62, r98, r122);
+    r122 = r122 + r83;
+    r122 = fmaf(r68, r122, r8 * r74);
+    r83 = r7 * r16;
+    r83 = r83 * r66;
+    r83 = fmaf(r74, r83, r6 * r74);
+    r83 = fmaf(r74, r75, r83);
+    r83 = fmaf(r74, r69, r83);
+    r98 = r10 * r83;
+    r122 = fmaf(r79, r98, r122);
+    r52 = r67 * r44;
+    r52 = r52 * r63;
+    r122 = fmaf(r73, r52, r122);
+    r94 = r60 * r1;
+    r94 = r94 * r3;
+    r94 = r94 * r70;
+    r94 = r94 * r65;
+    r122 = fmaf(r63, r94, r122);
+    r14 = r67 * r3;
+    r122 = fmaf(r106, r14, r122);
+    r31 = r67 * r41;
+    r31 = r31 * r10;
+    r31 = r31 * r3;
+    r122 = fmaf(r112, r31, r122);
+    r113 = r60 * r76;
+    r113 = r113 * r1;
+    r113 = r113 * r3;
+    r113 = r113 * r70;
+    r113 = r113 * r65;
+    r122 = fmaf(r63, r113, r122);
+    r133 = r4 * r40;
+    r133 = r133 * r10;
+    r133 = r133 * r77;
+    r122 = fmaf(r57, r133, r122);
+    r125 = r67 * r59;
+    r122 = fmaf(r108, r125, r122);
+    r84 = r4 * r40;
+    r84 = r84 * r10;
+    r84 = r84 * r76;
+    r84 = r84 * r77;
+    r122 = fmaf(r57, r84, r122);
+    r122 = fmaf(r59, r80, r122);
+    r122 = fmaf(r59, r79, r122);
+    r122 = fmaf(r3, r115, r122);
+    r122 = fmaf(r40, r114, r122);
+    r122 = fmaf(r3, r116, r122);
+    r84 = r0 * r122;
+    r125 = r71 * r3;
+    r125 = r125 * r109;
+    r125 = r125 * r42;
+    r133 = r40 * r11;
+    r133 = r133 * r11;
+    r133 = r133 * r60;
+    r133 = r133 * r60;
+    r133 = r133 * r89;
+    r133 = r133 * r47;
+    r133 = fmaf(r12, r133, r51 * r125);
+    r125 = r44 * r11;
+    r125 = r125 * r92;
+    r125 = r125 * r47;
+    r133 = fmaf(r62, r125, r133);
+    r113 = r11 * r107;
+    r113 = r113 * r3;
+    r133 = fmaf(r112, r113, r133);
+    r133 = r133 + r111;
+    r133 = fmaf(r67, r133, r9 * r74);
+    r74 = r68 * r44;
+    r74 = r74 * r63;
+    r133 = fmaf(r73, r74, r133);
+    r111 = r4 * r40;
+    r111 = r111 * r11;
+    r111 = r111 * r77;
+    r133 = fmaf(r57, r111, r133);
+    r113 = r85 * r3;
+    r113 = r113 * r35;
+    r113 = r113 * r109;
+    r133 = fmaf(r78, r113, r133);
+    r125 = r68 * r3;
+    r133 = fmaf(r106, r125, r133);
+    r31 = r85 * r76;
+    r31 = r31 * r3;
+    r31 = r31 * r35;
+    r31 = r31 * r109;
+    r133 = fmaf(r78, r31, r133);
+    r14 = r68 * r40;
+    r14 = r14 * r11;
+    r14 = r14 * r60;
+    r14 = r14 * r60;
+    r14 = r14 * r90;
+    r14 = r14 * r12;
+    r133 = fmaf(r63, r14, r133);
+    r94 = r68 * r59;
+    r133 = fmaf(r108, r94, r133);
+    r52 = r4 * r40;
+    r52 = r52 * r11;
+    r52 = r52 * r76;
+    r52 = r52 * r77;
+    r133 = fmaf(r57, r52, r133);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r3;
+    r98 = r98 * r47;
+    r98 = r98 * r70;
+    r133 = fmaf(r109, r98, r133);
+    r117 = r11 * r83;
+    r133 = fmaf(r79, r117, r133);
+    r88 = r60 * r1;
+    r88 = r88 * r3;
+    r88 = r88 * r47;
+    r88 = r88 * r70;
+    r133 = fmaf(r109, r88, r133);
+    r133 = fmaf(r44, r80, r133);
+    r133 = fmaf(r3, r123, r133);
+    r133 = fmaf(r44, r79, r133);
+    r88 = r5 * r133;
+    r117 = r16 * r46;
+    r117 = r117 * r11;
+    r117 = fmaf(r38, r99, r37 * r117);
+    r98 = r16 * r58;
+    r98 = r98 * r10;
+    r117 = fmaf(r37, r98, r117);
+    r52 = r38 * r10;
+    r52 = r52 * r10;
+    r117 = fmaf(r36, r52, r117);
+    r52 = r117 * r109;
+    r52 = r52 * r42;
+    r52 = fmaf(r46, r108, r51 * r52);
+    r98 = r4 * r11;
+    r98 = r98 * r117;
+    r52 = fmaf(r112, r98, r52);
+    r52 = fmaf(r38, r104, r52);
+    r98 = r38 * r36;
+    r94 = r4 * r10;
+    r94 = r94 * r10;
+    r94 = r94 * r117;
+    r94 = r94 * r65;
+    r94 = r94 * r53;
+    r94 = fmaf(r62, r94, r105 * r98);
+    r98 = r58 * r63;
+    r94 = fmaf(r73, r98, r94);
+    r14 = r117 * r65;
+    r14 = r14 * r42;
+    r94 = fmaf(r64, r14, r94);
+    r14 = r52 + r94;
+    r98 = r10 * r10;
+    r98 = r98 * r107;
+    r98 = r98 * r117;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r98 = fmaf(r62, r98, r38 * r97);
+    r31 = r58 * r92;
+    r31 = r31 * r62;
+    r98 = fmaf(r63, r31, r98);
+    r125 = r71 * r117;
+    r125 = r125 * r65;
+    r125 = r125 * r42;
+    r98 = fmaf(r64, r125, r98);
+    r98 = r98 + r52;
+    r98 = fmaf(r68, r98, r8 * r14);
+    r52 = r4 * r38;
+    r52 = r52 * r10;
+    r52 = r52 * r76;
+    r52 = r52 * r77;
+    r98 = fmaf(r57, r52, r98);
+    r125 = r4 * r38;
+    r125 = r125 * r10;
+    r125 = r125 * r77;
+    r98 = fmaf(r57, r125, r98);
+    r31 = r60 * r1;
+    r31 = r31 * r117;
+    r31 = r31 * r70;
+    r31 = r31 * r65;
+    r98 = fmaf(r63, r31, r98);
+    r113 = r67 * r41;
+    r113 = r113 * r10;
+    r113 = r113 * r117;
+    r98 = fmaf(r112, r113, r98);
+    r111 = r67 * r117;
+    r98 = fmaf(r106, r111, r98);
+    r74 = r67 * r46;
+    r74 = r74 * r63;
+    r98 = fmaf(r73, r74, r98);
+    r128 = r58 * r108;
+    r129 = r60 * r76;
+    r129 = r129 * r1;
+    r129 = r129 * r117;
+    r129 = r129 * r70;
+    r129 = r129 * r65;
+    r98 = fmaf(r63, r129, r98);
+    r132 = r7 * r16;
+    r132 = r132 * r66;
+    r132 = fmaf(r6, r14, r14 * r132);
+    r132 = fmaf(r14, r75, r132);
+    r132 = fmaf(r14, r69, r132);
+    r118 = r10 * r132;
+    r98 = fmaf(r79, r118, r98);
+    r98 = fmaf(r58, r79, r98);
+    r98 = fmaf(r58, r80, r98);
+    r98 = fmaf(r117, r116, r98);
+    r98 = fmaf(r67, r128, r98);
+    r98 = fmaf(r117, r115, r98);
+    r98 = fmaf(r38, r114, r98);
+    r118 = r0 * r98;
+    r129 = r71 * r117;
+    r129 = r129 * r109;
+    r129 = r129 * r42;
+    r74 = r46 * r11;
+    r74 = r74 * r92;
+    r74 = r74 * r47;
+    r74 = fmaf(r62, r74, r51 * r129);
+    r129 = r11 * r107;
+    r129 = r129 * r117;
+    r74 = fmaf(r112, r129, r74);
+    r111 = r38 * r11;
+    r111 = r111 * r11;
+    r111 = r111 * r60;
+    r111 = r111 * r60;
+    r111 = r111 * r89;
+    r111 = r111 * r47;
+    r74 = fmaf(r12, r111, r74);
+    r74 = r74 + r94;
+    r74 = fmaf(r67, r74, r9 * r14);
+    r14 = r85 * r76;
+    r14 = r14 * r117;
+    r14 = r14 * r35;
+    r14 = r14 * r109;
+    r74 = fmaf(r78, r14, r74);
+    r94 = r85 * r117;
+    r94 = r94 * r35;
+    r94 = r94 * r109;
+    r74 = fmaf(r78, r94, r74);
+    r111 = r60 * r76;
+    r111 = r111 * r1;
+    r111 = r111 * r117;
+    r111 = r111 * r47;
+    r111 = r111 * r70;
+    r74 = fmaf(r109, r111, r74);
+    r129 = r60 * r1;
+    r129 = r129 * r117;
+    r129 = r129 * r47;
+    r129 = r129 * r70;
+    r74 = fmaf(r109, r129, r74);
+    r113 = r68 * r117;
+    r74 = fmaf(r106, r113, r74);
+    r31 = r68 * r46;
+    r31 = r31 * r63;
+    r74 = fmaf(r73, r31, r74);
+    r125 = r4 * r38;
+    r125 = r125 * r11;
+    r125 = r125 * r76;
+    r125 = r125 * r77;
+    r74 = fmaf(r57, r125, r74);
+    r52 = r4 * r38;
+    r52 = r52 * r11;
+    r52 = r52 * r77;
+    r74 = fmaf(r57, r52, r74);
+    r101 = r11 * r132;
+    r74 = fmaf(r79, r101, r74);
+    r124 = r68 * r38;
+    r124 = r124 * r11;
+    r124 = r124 * r60;
+    r124 = r124 * r60;
+    r124 = r124 * r90;
+    r124 = r124 * r12;
+    r74 = fmaf(r63, r124, r74);
+    r74 = fmaf(r46, r80, r74);
+    r74 = fmaf(r117, r123, r74);
+    r74 = fmaf(r68, r128, r74);
+    r74 = fmaf(r46, r79, r74);
+    r124 = r5 * r74;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r84,
+                                          r88,
+                                          r118,
+                                          r124);
+    r124 = r0 * r4;
+    r124 = r124 * r2;
+    r118 = r5 * r4;
+    r118 = r118 * r72;
+    r124 = fmaf(r110, r118, r91 * r124);
+    r72 = r0 * r4;
+    r72 = r72 * r2;
+    r72 = fmaf(r130, r118, r102 * r72);
+    r88 = r0 * r4;
+    r88 = r88 * r2;
+    r88 = fmaf(r87, r118, r82 * r88);
+    r84 = r0 * r4;
+    r84 = r84 * r2;
+    r84 = fmaf(r13, r118, r28 * r84);
+    WriteSum4<float, float>((float*)inout_shared, r124, r72, r88, r84);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r84 = r0 * r4;
+    r84 = r84 * r2;
+    r84 = fmaf(r133, r118, r122 * r84);
+    r88 = r0 * r4;
+    r88 = r88 * r2;
+    r88 = fmaf(r74, r118, r98 * r88);
+    WriteSum2<float, float>((float*)inout_shared, r84, r88);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = r0 * r0;
+    r84 = r91 * r88;
+    r72 = r5 * r5;
+    r124 = r110 * r72;
+    r110 = fmaf(r110, r124, r91 * r84);
+    r91 = r102 * r102;
+    r101 = r130 * r130;
+    r101 = fmaf(r72, r101, r88 * r91);
+    r91 = r87 * r87;
+    r52 = r82 * r82;
+    r52 = fmaf(r88, r52, r72 * r91);
+    r91 = r28 * r28;
+    r128 = r13 * r13;
+    r128 = fmaf(r72, r128, r88 * r91);
+    WriteSum4<float, float>((float*)inout_shared, r110, r101, r52, r128);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r122 * r122;
+    r52 = r133 * r133;
+    r52 = fmaf(r72, r52, r88 * r128);
+    r128 = r74 * r74;
+    r101 = r98 * r98;
+    r101 = fmaf(r88, r101, r72 * r128);
+    WriteSum2<float, float>((float*)inout_shared, r52, r101);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = fmaf(r102, r84, r130 * r124);
+    r52 = fmaf(r87, r124, r82 * r84);
+    r128 = fmaf(r28, r84, r13 * r124);
+    r110 = fmaf(r122, r84, r133 * r124);
+    WriteSum4<float, float>((float*)inout_shared, r101, r52, r128, r110);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r124 = fmaf(r74, r124, r98 * r84);
+    r84 = r130 * r87;
+    r110 = r102 * r82;
+    r110 = fmaf(r88, r110, r72 * r84);
+    r84 = r102 * r28;
+    r128 = r130 * r13;
+    r128 = fmaf(r72, r128, r88 * r84);
+    r84 = r102 * r122;
+    r52 = r130 * r133;
+    r52 = fmaf(r72, r52, r88 * r84);
+    WriteSum4<float, float>((float*)inout_shared, r124, r110, r128, r52);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r52 = r130 * r74;
+    r128 = r102 * r98;
+    r128 = fmaf(r88, r128, r72 * r52);
+    r52 = r87 * r13;
+    r110 = r82 * r28;
+    r110 = fmaf(r88, r110, r72 * r52);
+    r52 = r82 * r122;
+    r124 = r87 * r133;
+    r124 = fmaf(r72, r124, r88 * r52);
+    r52 = r87 * r74;
+    r84 = r82 * r98;
+    r84 = fmaf(r88, r84, r72 * r52);
+    WriteSum4<float, float>((float*)inout_shared, r128, r110, r124, r84);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r84 = r13 * r133;
+    r124 = r28 * r122;
+    r124 = fmaf(r88, r124, r72 * r84);
+    r84 = r28 * r98;
+    r110 = r13 * r74;
+    r110 = fmaf(r72, r110, r88 * r84);
+    r84 = r133 * r74;
+    r128 = r122 * r98;
+    r128 = fmaf(r88, r128, r72 * r84);
+    WriteSum3<float, float>((float*)inout_shared, r124, r110, r128);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r55 * r92;
+    r128 = r128 * r62;
+    r128 = fmaf(r61, r97, r63 * r128);
+    r110 = r16 * r33;
+    r110 = r110 * r11;
+    r124 = r16 * r55;
+    r124 = r124 * r10;
+    r124 = fmaf(r37, r124, r37 * r110);
+    r110 = r61 * r10;
+    r110 = r110 * r10;
+    r124 = fmaf(r36, r110, r124);
+    r124 = fmaf(r61, r99, r124);
+    r110 = r71 * r124;
+    r110 = r110 * r65;
+    r110 = r110 * r42;
+    r128 = fmaf(r64, r110, r128);
+    r84 = r10 * r10;
+    r84 = r84 * r107;
+    r84 = r84 * r124;
+    r84 = r84 * r65;
+    r84 = r84 * r53;
+    r128 = fmaf(r62, r84, r128);
+    r52 = r4 * r11;
+    r52 = r52 * r124;
+    r101 = r124 * r109;
+    r101 = r101 * r42;
+    r101 = fmaf(r51, r101, r112 * r52);
+    r101 = fmaf(r61, r104, r101);
+    r101 = fmaf(r33, r108, r101);
+    r128 = r128 + r101;
+    r84 = r55 * r63;
+    r110 = r61 * r36;
+    r110 = fmaf(r105, r110, r73 * r84);
+    r84 = r124 * r65;
+    r84 = r84 * r42;
+    r110 = fmaf(r64, r84, r110);
+    r52 = r4 * r10;
+    r52 = r52 * r10;
+    r52 = r52 * r124;
+    r52 = r52 * r65;
+    r52 = r52 * r53;
+    r110 = fmaf(r62, r52, r110);
+    r101 = r101 + r110;
+    r128 = fmaf(r8, r101, r68 * r128);
+    r52 = r60 * r76;
+    r52 = r52 * r1;
+    r52 = r52 * r124;
+    r52 = r52 * r70;
+    r52 = r52 * r65;
+    r128 = fmaf(r63, r52, r128);
+    r84 = r4 * r61;
+    r84 = r84 * r10;
+    r84 = r84 * r76;
+    r84 = r84 * r77;
+    r128 = fmaf(r57, r84, r128);
+    r91 = r4 * r61;
+    r91 = r91 * r10;
+    r91 = r91 * r77;
+    r128 = fmaf(r57, r91, r128);
+    r125 = r67 * r33;
+    r125 = r125 * r63;
+    r128 = fmaf(r73, r125, r128);
+    r31 = r7 * r16;
+    r31 = r31 * r66;
+    r31 = fmaf(r6, r101, r101 * r31);
+    r31 = fmaf(r101, r75, r31);
+    r31 = fmaf(r101, r69, r31);
+    r113 = r10 * r31;
+    r128 = fmaf(r79, r113, r128);
+    r129 = r60 * r1;
+    r129 = r129 * r124;
+    r129 = r129 * r70;
+    r129 = r129 * r65;
+    r128 = fmaf(r63, r129, r128);
+    r111 = r67 * r41;
+    r111 = r111 * r10;
+    r111 = r111 * r124;
+    r128 = fmaf(r112, r111, r128);
+    r94 = r67 * r55;
+    r128 = fmaf(r108, r94, r128);
+    r14 = r67 * r124;
+    r128 = fmaf(r106, r14, r128);
+    r128 = fmaf(r55, r80, r128);
+    r128 = fmaf(r124, r116, r128);
+    r128 = fmaf(r55, r79, r128);
+    r128 = fmaf(r61, r114, r128);
+    r128 = fmaf(r124, r115, r128);
+    r14 = r0 * r128;
+    r94 = r11 * r107;
+    r94 = r94 * r124;
+    r111 = r71 * r124;
+    r111 = r111 * r109;
+    r111 = r111 * r42;
+    r111 = fmaf(r51, r111, r112 * r94);
+    r94 = r61 * r11;
+    r94 = r94 * r11;
+    r94 = r94 * r60;
+    r94 = r94 * r60;
+    r94 = r94 * r89;
+    r94 = r94 * r47;
+    r111 = fmaf(r12, r94, r111);
+    r129 = r33 * r11;
+    r129 = r129 * r92;
+    r129 = r129 * r47;
+    r111 = fmaf(r62, r129, r111);
+    r111 = r111 + r110;
+    r101 = fmaf(r9, r101, r67 * r111);
+    r111 = r85 * r76;
+    r111 = r111 * r124;
+    r111 = r111 * r35;
+    r111 = r111 * r109;
+    r101 = fmaf(r78, r111, r101);
+    r110 = r60 * r76;
+    r110 = r110 * r1;
+    r110 = r110 * r124;
+    r110 = r110 * r47;
+    r110 = r110 * r70;
+    r101 = fmaf(r109, r110, r101);
+    r129 = r4 * r61;
+    r129 = r129 * r11;
+    r129 = r129 * r76;
+    r129 = r129 * r77;
+    r101 = fmaf(r57, r129, r101);
+    r94 = r68 * r33;
+    r94 = r94 * r63;
+    r101 = fmaf(r73, r94, r101);
+    r113 = r68 * r61;
+    r113 = r113 * r11;
+    r113 = r113 * r60;
+    r113 = r113 * r60;
+    r113 = r113 * r90;
+    r113 = r113 * r12;
+    r101 = fmaf(r63, r113, r101);
+    r125 = r60 * r1;
+    r125 = r125 * r124;
+    r125 = r125 * r47;
+    r125 = r125 * r70;
+    r101 = fmaf(r109, r125, r101);
+    r91 = r68 * r55;
+    r101 = fmaf(r108, r91, r101);
+    r84 = r85 * r124;
+    r84 = r84 * r35;
+    r84 = r84 * r109;
+    r101 = fmaf(r78, r84, r101);
+    r52 = r4 * r61;
+    r52 = r52 * r11;
+    r52 = r52 * r77;
+    r101 = fmaf(r57, r52, r101);
+    r135 = r68 * r124;
+    r101 = fmaf(r106, r135, r101);
+    r136 = r11 * r31;
+    r101 = fmaf(r79, r136, r101);
+    r101 = fmaf(r124, r123, r101);
+    r101 = fmaf(r33, r80, r101);
+    r101 = fmaf(r33, r79, r101);
+    r136 = r5 * r101;
+    r135 = r16 * r49;
+    r135 = r135 * r10;
+    r135 = fmaf(r37, r135, r45 * r99);
+    r52 = r16 * r50;
+    r52 = r52 * r11;
+    r135 = fmaf(r37, r52, r135);
+    r84 = r45 * r10;
+    r84 = r84 * r10;
+    r135 = fmaf(r36, r84, r135);
+    r84 = r135 * r65;
+    r84 = r84 * r42;
+    r52 = r45 * r36;
+    r52 = fmaf(r105, r52, r64 * r84);
+    r84 = r4 * r10;
+    r84 = r84 * r10;
+    r84 = r84 * r135;
+    r84 = r84 * r65;
+    r84 = r84 * r53;
+    r52 = fmaf(r62, r84, r52);
+    r91 = r49 * r63;
+    r52 = fmaf(r73, r91, r52);
+    r91 = r4 * r11;
+    r91 = r91 * r135;
+    r91 = fmaf(r50, r108, r112 * r91);
+    r84 = r135 * r109;
+    r84 = r84 * r42;
+    r91 = fmaf(r51, r84, r91);
+    r91 = fmaf(r45, r104, r91);
+    r84 = r52 + r91;
+    r125 = r71 * r135;
+    r125 = r125 * r65;
+    r125 = r125 * r42;
+    r125 = fmaf(r45, r97, r64 * r125);
+    r113 = r10 * r10;
+    r113 = r113 * r107;
+    r113 = r113 * r135;
+    r113 = r113 * r65;
+    r113 = r113 * r53;
+    r125 = fmaf(r62, r113, r125);
+    r94 = r49 * r92;
+    r94 = r94 * r62;
+    r125 = fmaf(r63, r94, r125);
+    r125 = r125 + r91;
+    r125 = fmaf(r68, r125, r8 * r84);
+    r91 = r67 * r49;
+    r125 = fmaf(r108, r91, r125);
+    r94 = r67 * r41;
+    r94 = r94 * r10;
+    r94 = r94 * r135;
+    r125 = fmaf(r112, r94, r125);
+    r113 = r60 * r1;
+    r113 = r113 * r135;
+    r113 = r113 * r70;
+    r113 = r113 * r65;
+    r125 = fmaf(r63, r113, r125);
+    r129 = r4 * r45;
+    r129 = r129 * r10;
+    r129 = r129 * r77;
+    r125 = fmaf(r57, r129, r125);
+    r110 = r4 * r45;
+    r110 = r110 * r10;
+    r110 = r110 * r76;
+    r110 = r110 * r77;
+    r125 = fmaf(r57, r110, r125);
+    r111 = r7 * r16;
+    r111 = r111 * r66;
+    r111 = fmaf(r84, r111, r6 * r84);
+    r111 = fmaf(r84, r75, r111);
+    r111 = fmaf(r84, r69, r111);
+    r137 = r10 * r111;
+    r125 = fmaf(r79, r137, r125);
+    r138 = r60 * r76;
+    r138 = r138 * r1;
+    r138 = r138 * r135;
+    r138 = r138 * r70;
+    r138 = r138 * r65;
+    r125 = fmaf(r63, r138, r125);
+    r139 = r67 * r50;
+    r139 = r139 * r63;
+    r125 = fmaf(r73, r139, r125);
+    r140 = r67 * r135;
+    r125 = fmaf(r106, r140, r125);
+    r125 = fmaf(r135, r115, r125);
+    r125 = fmaf(r135, r116, r125);
+    r125 = fmaf(r49, r80, r125);
+    r125 = fmaf(r49, r79, r125);
+    r125 = fmaf(r45, r114, r125);
+    r140 = r0 * r125;
+    r139 = r11 * r107;
+    r139 = r139 * r135;
+    r138 = r50 * r11;
+    r138 = r138 * r92;
+    r138 = r138 * r47;
+    r138 = fmaf(r62, r138, r112 * r139);
+    r139 = r71 * r135;
+    r139 = r139 * r109;
+    r139 = r139 * r42;
+    r138 = fmaf(r51, r139, r138);
+    r137 = r45 * r11;
+    r137 = r137 * r11;
+    r137 = r137 * r60;
+    r137 = r137 * r60;
+    r137 = r137 * r89;
+    r137 = r137 * r47;
+    r138 = fmaf(r12, r137, r138);
+    r138 = r138 + r52;
+    r138 = fmaf(r67, r138, r9 * r84);
+    r84 = r68 * r49;
+    r138 = fmaf(r108, r84, r138);
+    r52 = r68 * r135;
+    r138 = fmaf(r106, r52, r138);
+    r137 = r60 * r76;
+    r137 = r137 * r1;
+    r137 = r137 * r135;
+    r137 = r137 * r47;
+    r137 = r137 * r70;
+    r138 = fmaf(r109, r137, r138);
+    r139 = r60 * r1;
+    r139 = r139 * r135;
+    r139 = r139 * r47;
+    r139 = r139 * r70;
+    r138 = fmaf(r109, r139, r138);
+    r110 = r11 * r111;
+    r138 = fmaf(r79, r110, r138);
+    r129 = r4 * r45;
+    r129 = r129 * r11;
+    r129 = r129 * r76;
+    r129 = r129 * r77;
+    r138 = fmaf(r57, r129, r138);
+    r113 = r85 * r135;
+    r113 = r113 * r35;
+    r113 = r113 * r109;
+    r138 = fmaf(r78, r113, r138);
+    r94 = r68 * r50;
+    r94 = r94 * r63;
+    r138 = fmaf(r73, r94, r138);
+    r91 = r85 * r76;
+    r91 = r91 * r135;
+    r91 = r91 * r35;
+    r91 = r91 * r109;
+    r138 = fmaf(r78, r91, r138);
+    r141 = r4 * r45;
+    r141 = r141 * r11;
+    r141 = r141 * r77;
+    r138 = fmaf(r57, r141, r138);
+    r142 = r68 * r45;
+    r142 = r142 * r11;
+    r142 = r142 * r60;
+    r142 = r142 * r60;
+    r142 = r142 * r90;
+    r142 = r142 * r12;
+    r138 = fmaf(r63, r142, r138);
+    r138 = fmaf(r135, r123, r138);
+    r138 = fmaf(r50, r79, r138);
+    r138 = fmaf(r50, r80, r138);
+    r142 = r5 * r138;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r14,
+                                          r136,
+                                          r140,
+                                          r142);
+    r142 = r4 * r11;
+    r140 = r16 * r48;
+    r140 = r140 * r11;
+    r99 = fmaf(r54, r99, r37 * r140);
+    r140 = r54 * r10;
+    r140 = r140 * r10;
+    r99 = fmaf(r36, r140, r99);
+    r136 = r16 * r56;
+    r136 = r136 * r10;
+    r99 = fmaf(r37, r136, r99);
+    r142 = r142 * r99;
+    r142 = fmaf(r48, r108, r112 * r142);
+    r136 = r99 * r109;
+    r136 = r136 * r42;
+    r142 = fmaf(r51, r136, r142);
+    r142 = fmaf(r54, r104, r142);
+    r104 = r56 * r63;
+    r136 = r99 * r65;
+    r136 = r136 * r42;
+    r136 = fmaf(r64, r136, r73 * r104);
+    r104 = r54 * r36;
+    r136 = fmaf(r105, r104, r136);
+    r105 = r4 * r10;
+    r105 = r105 * r10;
+    r105 = r105 * r99;
+    r105 = r105 * r65;
+    r105 = r105 * r53;
+    r136 = fmaf(r62, r105, r136);
+    r105 = r142 + r136;
+    r104 = r56 * r92;
+    r104 = r104 * r62;
+    r140 = r71 * r99;
+    r140 = r140 * r65;
+    r140 = r140 * r42;
+    r140 = fmaf(r64, r140, r63 * r104);
+    r104 = r10 * r10;
+    r104 = r104 * r107;
+    r104 = r104 * r99;
+    r104 = r104 * r65;
+    r104 = r104 * r53;
+    r140 = fmaf(r62, r104, r140);
+    r140 = fmaf(r54, r97, r140);
+    r140 = r140 + r142;
+    r140 = fmaf(r68, r140, r8 * r105);
+    r8 = r67 * r48;
+    r8 = r8 * r63;
+    r140 = fmaf(r73, r8, r140);
+    r142 = r67 * r99;
+    r140 = fmaf(r106, r142, r140);
+    r104 = r60 * r76;
+    r104 = r104 * r1;
+    r104 = r104 * r99;
+    r104 = r104 * r70;
+    r104 = r104 * r65;
+    r140 = fmaf(r63, r104, r140);
+    r97 = r4 * r54;
+    r97 = r97 * r10;
+    r97 = r97 * r76;
+    r97 = r97 * r77;
+    r140 = fmaf(r57, r97, r140);
+    r53 = r7 * r16;
+    r53 = r53 * r66;
+    r53 = fmaf(r105, r53, r6 * r105);
+    r53 = fmaf(r105, r75, r53);
+    r53 = fmaf(r105, r69, r53);
+    r69 = r10 * r53;
+    r140 = fmaf(r79, r69, r140);
+    r75 = r4 * r54;
+    r75 = r75 * r10;
+    r75 = r75 * r77;
+    r140 = fmaf(r57, r75, r140);
+    r6 = r60 * r1;
+    r6 = r6 * r99;
+    r6 = r6 * r70;
+    r6 = r6 * r65;
+    r140 = fmaf(r63, r6, r140);
+    r66 = r67 * r41;
+    r66 = r66 * r10;
+    r66 = r66 * r99;
+    r140 = fmaf(r112, r66, r140);
+    r64 = r67 * r56;
+    r140 = fmaf(r108, r64, r140);
+    r140 = fmaf(r99, r116, r140);
+    r140 = fmaf(r56, r79, r140);
+    r140 = fmaf(r56, r80, r140);
+    r140 = fmaf(r99, r115, r140);
+    r140 = fmaf(r54, r114, r140);
+    r64 = r0 * r140;
+    r114 = r11 * r107;
+    r114 = r114 * r99;
+    r115 = r48 * r11;
+    r115 = r115 * r92;
+    r115 = r115 * r47;
+    r115 = fmaf(r62, r115, r112 * r114);
+    r114 = r71 * r99;
+    r114 = r114 * r109;
+    r114 = r114 * r42;
+    r115 = fmaf(r51, r114, r115);
+    r51 = r54 * r11;
+    r51 = r51 * r11;
+    r51 = r51 * r60;
+    r51 = r51 * r60;
+    r51 = r51 * r89;
+    r51 = r51 * r47;
+    r115 = fmaf(r12, r51, r115);
+    r115 = r115 + r136;
+    r115 = fmaf(r67, r115, r9 * r105);
+    r105 = r68 * r48;
+    r105 = r105 * r63;
+    r115 = fmaf(r73, r105, r115);
+    r73 = r4 * r54;
+    r73 = r73 * r11;
+    r73 = r73 * r76;
+    r73 = r73 * r77;
+    r115 = fmaf(r57, r73, r115);
+    r9 = r60 * r1;
+    r9 = r9 * r99;
+    r9 = r9 * r47;
+    r9 = r9 * r70;
+    r115 = fmaf(r109, r9, r115);
+    r136 = r68 * r99;
+    r115 = fmaf(r106, r136, r115);
+    r106 = r11 * r53;
+    r115 = fmaf(r79, r106, r115);
+    r51 = r68 * r54;
+    r51 = r51 * r11;
+    r51 = r51 * r60;
+    r51 = r51 * r60;
+    r51 = r51 * r90;
+    r51 = r51 * r12;
+    r115 = fmaf(r63, r51, r115);
+    r12 = r60 * r76;
+    r12 = r12 * r1;
+    r12 = r12 * r99;
+    r12 = r12 * r47;
+    r12 = r12 * r70;
+    r115 = fmaf(r109, r12, r115);
+    r70 = r85 * r76;
+    r70 = r70 * r99;
+    r70 = r70 * r35;
+    r70 = r70 * r109;
+    r115 = fmaf(r78, r70, r115);
+    r47 = r68 * r56;
+    r115 = fmaf(r108, r47, r115);
+    r108 = r4 * r54;
+    r108 = r108 * r11;
+    r108 = r108 * r77;
+    r115 = fmaf(r57, r108, r115);
+    r57 = r85 * r99;
+    r57 = r57 * r35;
+    r57 = r57 * r109;
+    r115 = fmaf(r78, r57, r115);
+    r115 = fmaf(r48, r79, r115);
+    r115 = fmaf(r99, r123, r115);
+    r115 = fmaf(r48, r80, r115);
+    r5 = r5 * r115;
+    WriteIdx2<1024, float, float, float2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r64, r5);
+    r5 = r0 * r4;
+    r5 = r5 * r2;
+    r5 = fmaf(r101, r118, r128 * r5);
+    r64 = r0 * r4;
+    r64 = r64 * r2;
+    r64 = fmaf(r138, r118, r125 * r64);
+    r57 = r0 * r4;
+    r57 = r57 * r2;
+    r118 = fmaf(r115, r118, r140 * r57);
+    WriteSum3<float, float>((float*)inout_shared, r5, r64, r118);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r128 * r128;
+    r64 = r101 * r101;
+    r64 = fmaf(r72, r64, r88 * r118);
+    r118 = r138 * r138;
+    r5 = r125 * r125;
+    r5 = fmaf(r88, r5, r72 * r118);
+    r118 = r115 * r115;
+    r57 = r140 * r140;
+    r57 = fmaf(r88, r57, r72 * r118);
+    WriteSum3<float, float>((float*)inout_shared, r64, r5, r57);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r101 * r138;
+    r5 = r128 * r125;
+    r5 = fmaf(r88, r5, r72 * r57);
+    r57 = r128 * r140;
+    r64 = r101 * r115;
+    r64 = fmaf(r72, r64, r88 * r57);
+    r57 = r138 * r115;
+    r118 = r125 * r140;
+    r118 = fmaf(r88, r118, r72 * r57);
+    WriteSum3<float, float>((float*)inout_shared, r5, r64, r118);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_point_jac,
+              out_point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,2334 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = 9.99999999999999955e-07;
+    r53 = r41 * r29;
+    r53 = r53 * r29;
+    r54 = r42 + r53;
+    r54 = r54 + r49;
+    r10 = fmaf(r13, r54, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r55 = r16 * r29;
+    r55 = fmaf(r34, r55, r26);
+    r56 = r21 * r23;
+    r56 = r56 * r16;
+    r57 = r22 * r24;
+    r57 = fmaf(r16, r57, r56);
+    r58 = r23 * r24;
+    r58 = fmaf(r41, r58, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r55, r10);
+    r10 = fmaf(r37, r57, r10);
+    r10 = fmaf(r36, r58, r10);
+    r10 = fmaf(r35, r43, r10);
+    r59 = r10 * r10;
+    r60 = r41 * r29;
+    r60 = fmaf(r34, r60, r26);
+    r12 = fmaf(r13, r60, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r56);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r53 = r42 + r53;
+    r53 = r53 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r53, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r52, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r59);
+    r59 = sqrtf(r35);
+    r51 = copysign(1.0, r59);
+    r51 = fmaf(r52, r51, r59);
+    r52 = r51 * r51;
+    r47 = 1.0 / r52;
+    r59 = atanf(r59);
+    r56 = r59 * r37;
+    r61 = r47 * r56;
+    r62 = r11 * r61;
+    r63 = r11 * r59;
+    r62 = r62 * r63;
+    r64 = r10 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r61;
+    r65 = r62 + r64;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r66,
+                                         r67,
+                                         r68,
+                                         r69);
+    r70 = r10 * r10;
+    r71 = 3.00000000000000000e+00;
+    r70 = r70 * r59;
+    r70 = r70 * r71;
+    r70 = fmaf(r61, r70, r62);
+    r70 = fmaf(r67, r70, r8 * r65);
+    r62 = r16 * r61;
+    r72 = r66 * r62;
+    r73 = r63 * r72;
+    r74 = r65 * r65;
+    r75 = r65 * r74;
+    r76 = fmaf(r68, r75, r6 * r65);
+    r75 = r69 * r75;
+    r76 = fmaf(r65, r75, r76);
+    r76 = fmaf(r7, r74, r76);
+    r69 = 1.0 / r36;
+    r77 = 1.0 / r51;
+    r78 = r69 * r77;
+    r79 = r76 * r78;
+    r80 = r59 * r79;
+    r81 = r10 * r59;
+    r70 = fmaf(r78, r81, r70);
+    r70 = fmaf(r10, r73, r70);
+    r70 = fmaf(r10, r80, r70);
+    r2 = fmaf(r0, r70, r2);
+    r70 = r11 * r71;
+    r70 = r70 * r61;
+    r70 = fmaf(r63, r70, r64);
+    r70 = fmaf(r66, r70, r9 * r65);
+    r64 = r67 * r10;
+    r64 = r64 * r63;
+    r70 = fmaf(r62, r64, r70);
+    r70 = fmaf(r63, r79, r70);
+    r70 = fmaf(r78, r63, r70);
+    r70 = fmaf(r5, r70, r1);
+    r70 = fmaf(r3, r4, r70);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r70);
+    r3 = fmaf(r70, r70, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r10 * r59;
+    r1 = r16 * r34;
+    r64 = r19 * r24;
+    r81 = 5.00000000000000000e-01;
+    r82 = r18 * r21;
+    r82 = fmaf(r81, r82, r81 * r64);
+    r64 = r17 * r22;
+    r83 = -5.00000000000000000e-01;
+    r82 = fmaf(r83, r64, r82);
+    r84 = r20 * r23;
+    r82 = fmaf(r81, r84, r82);
+    r84 = r17 * r24;
+    r64 = r20 * r21;
+    r64 = fmaf(r83, r64, r83 * r84);
+    r84 = r19 * r22;
+    r64 = fmaf(r83, r84, r64);
+    r85 = r18 * r23;
+    r64 = fmaf(r81, r85, r64);
+    r85 = r29 * r64;
+    r1 = fmaf(r16, r85, r82 * r1);
+    r84 = r16 * r25;
+    r86 = fmaf(r81, r31, r83 * r27);
+    r86 = fmaf(r83, r28, r86);
+    r86 = fmaf(r83, r30, r86);
+    r87 = r16 * r32;
+    r88 = r20 * r24;
+    r89 = r17 * r21;
+    r89 = fmaf(r83, r89, r81 * r88);
+    r88 = r18 * r22;
+    r89 = fmaf(r83, r88, r89);
+    r90 = r19 * r23;
+    r89 = fmaf(r83, r90, r89);
+    r87 = r87 * r89;
+    r84 = fmaf(r86, r84, r87);
+    r1 = r1 + r84;
+    r90 = r16 * r29;
+    r90 = r90 * r89;
+    r88 = r16 * r25;
+    r88 = r88 * r82;
+    r91 = r90 + r88;
+    r92 = r32 * r41;
+    r91 = fmaf(r64, r92, r91);
+    r93 = r41 * r34;
+    r91 = fmaf(r86, r93, r91);
+    r91 = fmaf(r14, r91, r15 * r1);
+    r1 = r29 * r82;
+    r93 = -4.00000000000000000e+00;
+    r1 = r1 * r93;
+    r92 = r32 * r86;
+    r94 = r93 * r92;
+    r95 = r1 + r94;
+    r91 = fmaf(r13, r95, r91);
+    r95 = 6.00000000000000000e+00;
+    r3 = r3 * r91;
+    r3 = r3 * r95;
+    r96 = r16 * r11;
+    r97 = r25 * r41;
+    r98 = r34 * r89;
+    r99 = r41 * r98;
+    r97 = fmaf(r64, r97, r99);
+    r100 = r16 * r29;
+    r100 = r100 * r86;
+    r101 = r16 * r32;
+    r101 = fmaf(r82, r101, r100);
+    r97 = r97 + r101;
+    r102 = r25 * r89;
+    r102 = r102 * r93;
+    r94 = r102 + r94;
+    r94 = fmaf(r14, r94, r15 * r97);
+    r97 = r16 * r34;
+    r97 = fmaf(r86, r97, r88);
+    r88 = r16 * r32;
+    r88 = fmaf(r64, r88, r90);
+    r97 = r97 + r88;
+    r94 = fmaf(r13, r97, r94);
+    r96 = r96 * r94;
+    r97 = r16 * r10;
+    r97 = r97 * r91;
+    r97 = fmaf(r37, r97, r37 * r96);
+    r96 = r11 * r11;
+    r90 = r16 * r25;
+    r90 = r90 * r64;
+    r98 = r16 * r98;
+    r103 = r90 + r98;
+    r101 = r101 + r103;
+    r104 = r41 * r34;
+    r104 = fmaf(r41, r85, r82 * r104);
+    r104 = r104 + r84;
+    r104 = fmaf(r13, r104, r14 * r101);
+    r1 = r102 + r1;
+    r104 = fmaf(r15, r1, r104);
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r36 = r41 * r12;
+    r96 = r96 * r104;
+    r97 = fmaf(r36, r96, r97);
+    r1 = r10 * r10;
+    r1 = r1 * r104;
+    r97 = fmaf(r36, r1, r97);
+    r1 = r71 * r97;
+    r96 = r10 * r61;
+    r42 = r42 + r35;
+    r42 = 1.0 / r42;
+    r35 = rsqrtf(r35);
+    r102 = r10 * r35;
+    r101 = r42 * r102;
+    r96 = r96 * r101;
+    r1 = fmaf(r96, r1, r61 * r3);
+    r3 = r59 * r59;
+    r82 = -6.00000000000000000e+00;
+    r3 = r3 * r104;
+    r3 = r3 * r82;
+    r3 = r3 * r47;
+    r3 = r3 * r12;
+    r105 = r10 * r10;
+    r105 = r105 * r36;
+    r52 = r51 * r52;
+    r52 = 1.0 / r52;
+    r52 = r52 * r56;
+    r51 = r102 * r52;
+    r106 = r10 * r59;
+    r107 = -3.00000000000000000e+00;
+    r108 = r107 * r97;
+    r51 = r51 * r106;
+    r1 = fmaf(r108, r51, r1);
+    r109 = r94 * r63;
+    r110 = r11 * r11;
+    r110 = r110 * r97;
+    r110 = r110 * r35;
+    r110 = r110 * r42;
+    r110 = fmaf(r61, r110, r62 * r109);
+    r109 = r4 * r97;
+    r111 = r63 * r52;
+    r112 = r11 * r35;
+    r109 = r109 * r111;
+    r110 = fmaf(r112, r109, r110);
+    r113 = r11 * r11;
+    r113 = r113 * r59;
+    r113 = r113 * r59;
+    r113 = r113 * r104;
+    r113 = r113 * r47;
+    r110 = fmaf(r36, r113, r110);
+    r1 = fmaf(r3, r105, r1);
+    r1 = r1 + r110;
+    r51 = r91 * r62;
+    r51 = fmaf(r97, r96, r106 * r51);
+    r105 = r10 * r10;
+    r105 = r105 * r59;
+    r105 = r105 * r59;
+    r105 = r105 * r104;
+    r105 = r105 * r47;
+    r51 = fmaf(r36, r105, r51);
+    r113 = r4 * r102;
+    r113 = r113 * r52;
+    r113 = r113 * r106;
+    r51 = fmaf(r97, r113, r51);
+    r110 = r110 + r51;
+    r1 = fmaf(r8, r110, r67 * r1);
+    r105 = r59 * r83;
+    r105 = r105 * r47;
+    r105 = r105 * r69;
+    r105 = r105 * r102;
+    r109 = r76 * r105;
+    r114 = r11 * r97;
+    r114 = r114 * r101;
+    r1 = fmaf(r72, r114, r1);
+    r115 = r66 * r10;
+    r115 = r115 * r11;
+    r115 = r115 * r59;
+    r115 = r115 * r59;
+    r115 = r115 * r93;
+    r115 = r115 * r104;
+    r115 = r115 * r47;
+    r1 = fmaf(r12, r115, r1);
+    r116 = r81 * r97;
+    r116 = r116 * r101;
+    r1 = fmaf(r79, r116, r1);
+    r117 = r59 * r91;
+    r1 = fmaf(r78, r117, r1);
+    r118 = r4 * r10;
+    r118 = r118 * r104;
+    r118 = r118 * r77;
+    r1 = fmaf(r56, r118, r1);
+    r119 = r4 * r10;
+    r119 = r119 * r76;
+    r119 = r119 * r104;
+    r119 = r119 * r77;
+    r1 = fmaf(r56, r119, r1);
+    r120 = r81 * r97;
+    r120 = r120 * r78;
+    r1 = fmaf(r101, r120, r1);
+    r121 = r41 * r102;
+    r121 = r121 * r111;
+    r122 = r66 * r121;
+    r123 = r10 * r59;
+    r124 = r7 * r16;
+    r124 = r124 * r65;
+    r124 = fmaf(r110, r124, r6 * r110);
+    r125 = 4.00000000000000000e+00;
+    r75 = r125 * r75;
+    r68 = r68 * r71;
+    r68 = r68 * r74;
+    r124 = fmaf(r110, r75, r124);
+    r124 = fmaf(r110, r68, r124);
+    r123 = r123 * r124;
+    r1 = fmaf(r78, r123, r1);
+    r74 = r94 * r106;
+    r1 = fmaf(r72, r74, r1);
+    r1 = fmaf(r97, r109, r1);
+    r1 = fmaf(r97, r105, r1);
+    r1 = fmaf(r91, r73, r1);
+    r1 = fmaf(r97, r122, r1);
+    r1 = fmaf(r91, r80, r1);
+    r74 = r0 * r1;
+    r123 = r94 * r95;
+    r123 = r123 * r61;
+    r120 = r11 * r11;
+    r120 = r120 * r71;
+    r120 = r120 * r97;
+    r120 = r120 * r35;
+    r120 = r120 * r42;
+    r120 = fmaf(r61, r120, r63 * r123);
+    r123 = r111 * r112;
+    r120 = fmaf(r108, r123, r120);
+    r108 = r41 * r26;
+    r119 = r11 * r11;
+    r108 = r108 * r119;
+    r108 = r108 * r12;
+    r120 = fmaf(r3, r108, r120);
+    r120 = r120 + r51;
+    r110 = fmaf(r9, r110, r66 * r120);
+    r120 = r11 * r81;
+    r120 = r120 * r97;
+    r120 = r120 * r35;
+    r120 = r120 * r42;
+    r110 = fmaf(r78, r120, r110);
+    r51 = r11 * r59;
+    r51 = r51 * r76;
+    r51 = r51 * r83;
+    r51 = r51 * r97;
+    r51 = r51 * r47;
+    r51 = r51 * r69;
+    r110 = fmaf(r35, r51, r110);
+    r3 = r124 * r78;
+    r110 = fmaf(r63, r3, r110);
+    r123 = r4 * r11;
+    r123 = r123 * r76;
+    r123 = r123 * r104;
+    r123 = r123 * r77;
+    r110 = fmaf(r56, r123, r110);
+    r119 = r67 * r10;
+    r119 = r119 * r11;
+    r119 = r119 * r59;
+    r119 = r119 * r59;
+    r119 = r119 * r93;
+    r119 = r119 * r47;
+    r119 = r119 * r12;
+    r118 = r67 * r91;
+    r118 = r118 * r63;
+    r110 = fmaf(r62, r118, r110);
+    r117 = r67 * r11;
+    r117 = r117 * r97;
+    r117 = r117 * r62;
+    r110 = fmaf(r101, r117, r110);
+    r116 = r4 * r11;
+    r116 = r116 * r104;
+    r116 = r116 * r77;
+    r110 = fmaf(r56, r116, r110);
+    r115 = r67 * r97;
+    r110 = fmaf(r121, r115, r110);
+    r114 = r81 * r42;
+    r114 = r114 * r79;
+    r114 = r114 * r112;
+    r125 = r67 * r94;
+    r125 = r125 * r62;
+    r110 = fmaf(r106, r125, r110);
+    r126 = r11 * r59;
+    r126 = r126 * r83;
+    r126 = r126 * r97;
+    r126 = r126 * r47;
+    r126 = r126 * r69;
+    r110 = fmaf(r35, r126, r110);
+    r127 = r59 * r94;
+    r110 = fmaf(r78, r127, r110);
+    r110 = fmaf(r104, r119, r110);
+    r110 = fmaf(r97, r114, r110);
+    r110 = fmaf(r94, r80, r110);
+    r127 = r5 * r110;
+    r126 = r10 * r10;
+    r125 = r37 * r126;
+    r115 = r16 * r10;
+    r98 = r100 + r98;
+    r100 = r16 * r32;
+    r116 = r19 * r24;
+    r117 = r18 * r21;
+    r117 = fmaf(r83, r117, r83 * r116);
+    r116 = r17 * r22;
+    r117 = fmaf(r81, r116, r117);
+    r118 = r20 * r23;
+    r117 = fmaf(r83, r118, r117);
+    r100 = r100 * r117;
+    r118 = r16 * r25;
+    r116 = r17 * r24;
+    r104 = r20 * r21;
+    r104 = fmaf(r81, r104, r81 * r116);
+    r116 = r19 * r22;
+    r104 = fmaf(r81, r116, r104);
+    r123 = r18 * r23;
+    r104 = fmaf(r83, r123, r104);
+    r118 = fmaf(r104, r118, r100);
+    r98 = r98 + r118;
+    r123 = r32 * r93;
+    r123 = r123 * r104;
+    r116 = r29 * r89;
+    r116 = r116 * r93;
+    r3 = r123 + r116;
+    r3 = fmaf(r13, r3, r15 * r98);
+    r98 = r41 * r34;
+    r98 = fmaf(r41, r92, r104 * r98);
+    r51 = r16 * r25;
+    r51 = r51 * r89;
+    r120 = r16 * r29;
+    r120 = fmaf(r117, r120, r51);
+    r98 = r98 + r120;
+    r3 = fmaf(r14, r98, r3);
+    r115 = r115 * r3;
+    r98 = r10 * r10;
+    r128 = r41 * r29;
+    r128 = fmaf(r86, r128, r99);
+    r128 = r128 + r118;
+    r118 = r16 * r29;
+    r118 = r118 * r104;
+    r129 = r16 * r34;
+    r129 = fmaf(r117, r129, r118);
+    r129 = r129 + r84;
+    r129 = fmaf(r14, r129, r13 * r128);
+    r128 = r25 * r117;
+    r84 = r93 * r128;
+    r116 = r116 + r84;
+    r129 = fmaf(r15, r116, r129);
+    r98 = r98 * r129;
+    r98 = fmaf(r36, r98, r37 * r115);
+    r115 = r11 * r11;
+    r115 = r115 * r129;
+    r98 = fmaf(r36, r115, r98);
+    r116 = r16 * r11;
+    r130 = r25 * r41;
+    r130 = fmaf(r86, r130, r87);
+    r87 = r41 * r34;
+    r130 = fmaf(r117, r87, r130);
+    r130 = r130 + r118;
+    r87 = r16 * r34;
+    r92 = fmaf(r16, r92, r104 * r87);
+    r92 = r92 + r120;
+    r92 = fmaf(r13, r92, r15 * r130);
+    r84 = r123 + r84;
+    r92 = fmaf(r14, r84, r92);
+    r116 = r116 * r92;
+    r98 = fmaf(r37, r116, r98);
+    r125 = r125 * r47;
+    r125 = r125 * r59;
+    r125 = r125 * r35;
+    r125 = r125 * r42;
+    r125 = r125 * r98;
+    r116 = fmaf(r98, r113, r125);
+    r115 = r10 * r10;
+    r115 = r115 * r59;
+    r115 = r115 * r59;
+    r115 = r115 * r129;
+    r115 = r115 * r47;
+    r116 = fmaf(r36, r115, r116);
+    r84 = r3 * r62;
+    r116 = fmaf(r106, r84, r116);
+    r84 = r92 * r63;
+    r115 = r4 * r98;
+    r115 = r115 * r111;
+    r115 = fmaf(r112, r115, r62 * r84);
+    r84 = r11 * r11;
+    r84 = r84 * r59;
+    r84 = r84 * r59;
+    r84 = r84 * r129;
+    r84 = r84 * r47;
+    r115 = fmaf(r36, r84, r115);
+    r123 = r11 * r11;
+    r123 = r123 * r98;
+    r123 = r123 * r35;
+    r123 = r123 * r42;
+    r115 = fmaf(r61, r123, r115);
+    r123 = r116 + r115;
+    r84 = r107 * r98;
+    r84 = r84 * r102;
+    r84 = r84 * r52;
+    r84 = fmaf(r106, r84, r71 * r125);
+    r125 = r10 * r10;
+    r125 = r125 * r59;
+    r125 = r125 * r59;
+    r125 = r125 * r82;
+    r125 = r125 * r129;
+    r125 = r125 * r47;
+    r84 = fmaf(r12, r125, r84);
+    r130 = r10 * r59;
+    r130 = r130 * r95;
+    r130 = r130 * r3;
+    r84 = fmaf(r61, r130, r84);
+    r84 = r84 + r115;
+    r84 = fmaf(r67, r84, r8 * r123);
+    r115 = r92 * r106;
+    r84 = fmaf(r72, r115, r84);
+    r130 = r66 * r10;
+    r130 = r130 * r11;
+    r130 = r130 * r59;
+    r130 = r130 * r59;
+    r130 = r130 * r93;
+    r130 = r130 * r129;
+    r130 = r130 * r47;
+    r84 = fmaf(r12, r130, r84);
+    r125 = r4 * r10;
+    r125 = r125 * r129;
+    r125 = r125 * r77;
+    r84 = fmaf(r56, r125, r84);
+    r87 = r81 * r98;
+    r87 = r87 * r101;
+    r84 = fmaf(r79, r87, r84);
+    r104 = r11 * r98;
+    r104 = r104 * r101;
+    r84 = fmaf(r72, r104, r84);
+    r118 = r81 * r98;
+    r118 = r118 * r78;
+    r84 = fmaf(r101, r118, r84);
+    r86 = r4 * r10;
+    r86 = r86 * r76;
+    r86 = r86 * r129;
+    r86 = r86 * r77;
+    r84 = fmaf(r56, r86, r84);
+    r131 = r10 * r59;
+    r132 = r7 * r16;
+    r132 = r132 * r65;
+    r132 = fmaf(r123, r132, r6 * r123);
+    r132 = fmaf(r123, r75, r132);
+    r132 = fmaf(r123, r68, r132);
+    r131 = r131 * r132;
+    r84 = fmaf(r78, r131, r84);
+    r133 = r59 * r3;
+    r84 = fmaf(r78, r133, r84);
+    r84 = fmaf(r98, r105, r84);
+    r84 = fmaf(r3, r80, r84);
+    r84 = fmaf(r98, r122, r84);
+    r84 = fmaf(r3, r73, r84);
+    r84 = fmaf(r98, r109, r84);
+    r133 = r0 * r84;
+    r131 = r95 * r92;
+    r131 = r131 * r61;
+    r86 = r107 * r98;
+    r86 = r86 * r111;
+    r86 = fmaf(r112, r86, r63 * r131);
+    r131 = r11 * r11;
+    r131 = r131 * r59;
+    r131 = r131 * r59;
+    r131 = r131 * r82;
+    r131 = r131 * r129;
+    r131 = r131 * r47;
+    r86 = fmaf(r12, r131, r86);
+    r118 = r11 * r11;
+    r118 = r118 * r71;
+    r118 = r118 * r98;
+    r118 = r118 * r35;
+    r118 = r118 * r42;
+    r86 = fmaf(r61, r118, r86);
+    r86 = r86 + r116;
+    r86 = fmaf(r66, r86, r9 * r123);
+    r123 = r4 * r11;
+    r123 = r123 * r129;
+    r123 = r123 * r77;
+    r86 = fmaf(r56, r123, r86);
+    r116 = r67 * r92;
+    r116 = r116 * r62;
+    r86 = fmaf(r106, r116, r86);
+    r118 = r11 * r59;
+    r118 = r118 * r76;
+    r118 = r118 * r83;
+    r118 = r118 * r98;
+    r118 = r118 * r47;
+    r118 = r118 * r69;
+    r86 = fmaf(r35, r118, r86);
+    r131 = r132 * r78;
+    r86 = fmaf(r63, r131, r86);
+    r104 = r11 * r81;
+    r104 = r104 * r98;
+    r104 = r104 * r35;
+    r104 = r104 * r42;
+    r86 = fmaf(r78, r104, r86);
+    r87 = r11 * r59;
+    r87 = r87 * r83;
+    r87 = r87 * r98;
+    r87 = r87 * r47;
+    r87 = r87 * r69;
+    r86 = fmaf(r35, r87, r86);
+    r125 = r67 * r98;
+    r86 = fmaf(r121, r125, r86);
+    r130 = r67 * r11;
+    r130 = r130 * r98;
+    r130 = r130 * r62;
+    r86 = fmaf(r101, r130, r86);
+    r115 = r67 * r3;
+    r115 = r115 * r63;
+    r86 = fmaf(r62, r115, r86);
+    r134 = r4 * r11;
+    r134 = r134 * r76;
+    r134 = r134 * r129;
+    r134 = r134 * r77;
+    r86 = fmaf(r56, r134, r86);
+    r135 = r59 * r92;
+    r86 = fmaf(r78, r135, r86);
+    r86 = fmaf(r129, r119, r86);
+    r86 = fmaf(r98, r114, r86);
+    r86 = fmaf(r92, r80, r86);
+    r135 = r5 * r86;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r74,
+                                          r127,
+                                          r133,
+                                          r135);
+    r135 = r11 * r11;
+    r133 = r10 * r10;
+    r127 = r25 * r93;
+    r31 = fmaf(r83, r31, r81 * r27);
+    r31 = fmaf(r81, r28, r31);
+    r31 = fmaf(r81, r30, r31);
+    r127 = r127 * r31;
+    r85 = r93 * r85;
+    r30 = r127 + r85;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r51 = r51 + r28;
+    r27 = r41 * r29;
+    r51 = fmaf(r117, r27, r51);
+    r74 = r41 * r34;
+    r51 = fmaf(r64, r74, r51);
+    r51 = fmaf(r13, r51, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r128, r31 * r30);
+    r30 = r30 + r88;
+    r51 = fmaf(r14, r30, r51);
+    r133 = r133 * r51;
+    r30 = r16 * r10;
+    r74 = r16 * r29;
+    r74 = r74 * r31;
+    r90 = r90 + r74;
+    r27 = r32 * r41;
+    r90 = fmaf(r117, r27, r90);
+    r90 = r90 + r99;
+    r89 = r32 * r89;
+    r89 = r89 * r93;
+    r85 = r89 + r85;
+    r85 = fmaf(r13, r85, r14 * r90);
+    r90 = r16 * r34;
+    r90 = fmaf(r64, r90, r28);
+    r90 = r90 + r120;
+    r85 = fmaf(r15, r90, r85);
+    r30 = r30 * r85;
+    r30 = fmaf(r37, r30, r36 * r133);
+    r133 = r11 * r11;
+    r133 = r133 * r51;
+    r30 = fmaf(r36, r133, r30);
+    r90 = r16 * r11;
+    r74 = r100 + r74;
+    r74 = r74 + r103;
+    r103 = r41 * r34;
+    r128 = fmaf(r41, r128, r31 * r103);
+    r128 = r128 + r88;
+    r128 = fmaf(r15, r128, r13 * r74);
+    r89 = r127 + r89;
+    r128 = fmaf(r14, r89, r128);
+    r90 = r90 * r128;
+    r30 = fmaf(r37, r90, r30);
+    r135 = r135 * r30;
+    r135 = r135 * r35;
+    r135 = r135 * r42;
+    r90 = r128 * r63;
+    r90 = fmaf(r62, r90, r61 * r135);
+    r135 = r11 * r11;
+    r135 = r135 * r59;
+    r135 = r135 * r59;
+    r135 = r135 * r51;
+    r135 = r135 * r47;
+    r90 = fmaf(r36, r135, r90);
+    r133 = r4 * r30;
+    r133 = r133 * r111;
+    r90 = fmaf(r112, r133, r90);
+    r133 = r10 * r10;
+    r133 = r133 * r59;
+    r133 = r133 * r59;
+    r133 = r133 * r51;
+    r133 = r133 * r47;
+    r133 = fmaf(r30, r96, r36 * r133);
+    r135 = r85 * r62;
+    r133 = fmaf(r106, r135, r133);
+    r133 = fmaf(r30, r113, r133);
+    r135 = r90 + r133;
+    r89 = r10 * r10;
+    r89 = r89 * r59;
+    r89 = r89 * r59;
+    r89 = r89 * r82;
+    r89 = r89 * r51;
+    r89 = r89 * r47;
+    r14 = r71 * r30;
+    r14 = fmaf(r96, r14, r12 * r89);
+    r89 = r107 * r30;
+    r89 = r89 * r102;
+    r89 = r89 * r52;
+    r14 = fmaf(r106, r89, r14);
+    r127 = r10 * r59;
+    r127 = r127 * r95;
+    r127 = r127 * r85;
+    r14 = fmaf(r61, r127, r14);
+    r14 = r14 + r90;
+    r14 = fmaf(r67, r14, r8 * r135);
+    r90 = r10 * r59;
+    r127 = r7 * r16;
+    r127 = r127 * r65;
+    r127 = fmaf(r135, r127, r6 * r135);
+    r127 = fmaf(r135, r68, r127);
+    r127 = fmaf(r135, r75, r127);
+    r90 = r90 * r127;
+    r14 = fmaf(r78, r90, r14);
+    r89 = r66 * r10;
+    r89 = r89 * r11;
+    r89 = r89 * r59;
+    r89 = r89 * r59;
+    r89 = r89 * r93;
+    r89 = r89 * r51;
+    r89 = r89 * r47;
+    r14 = fmaf(r12, r89, r14);
+    r15 = r81 * r30;
+    r15 = r15 * r78;
+    r14 = fmaf(r101, r15, r14);
+    r74 = r4 * r10;
+    r74 = r74 * r51;
+    r74 = r74 * r77;
+    r14 = fmaf(r56, r74, r14);
+    r13 = r81 * r30;
+    r13 = r13 * r101;
+    r14 = fmaf(r79, r13, r14);
+    r88 = r128 * r106;
+    r14 = fmaf(r72, r88, r14);
+    r103 = r4 * r10;
+    r103 = r103 * r76;
+    r103 = r103 * r51;
+    r103 = r103 * r77;
+    r14 = fmaf(r56, r103, r14);
+    r31 = r59 * r85;
+    r14 = fmaf(r78, r31, r14);
+    r100 = r11 * r30;
+    r100 = r100 * r101;
+    r14 = fmaf(r72, r100, r14);
+    r14 = fmaf(r30, r109, r14);
+    r14 = fmaf(r30, r122, r14);
+    r14 = fmaf(r85, r80, r14);
+    r14 = fmaf(r85, r73, r14);
+    r14 = fmaf(r30, r105, r14);
+    r100 = r0 * r14;
+    r31 = r11 * r11;
+    r31 = r31 * r71;
+    r31 = r31 * r30;
+    r31 = r31 * r35;
+    r31 = r31 * r42;
+    r103 = r95 * r128;
+    r103 = r103 * r61;
+    r103 = fmaf(r63, r103, r61 * r31);
+    r31 = r11 * r11;
+    r31 = r31 * r59;
+    r31 = r31 * r59;
+    r31 = r31 * r82;
+    r31 = r31 * r51;
+    r31 = r31 * r47;
+    r103 = fmaf(r12, r31, r103);
+    r88 = r107 * r30;
+    r88 = r88 * r111;
+    r103 = fmaf(r112, r88, r103);
+    r103 = r103 + r133;
+    r103 = fmaf(r66, r103, r9 * r135);
+    r135 = r11 * r59;
+    r135 = r135 * r83;
+    r135 = r135 * r30;
+    r135 = r135 * r47;
+    r135 = r135 * r69;
+    r103 = fmaf(r35, r135, r103);
+    r133 = r11 * r81;
+    r133 = r133 * r30;
+    r133 = r133 * r35;
+    r133 = r133 * r42;
+    r103 = fmaf(r78, r133, r103);
+    r88 = r4 * r11;
+    r88 = r88 * r76;
+    r88 = r88 * r51;
+    r88 = r88 * r77;
+    r103 = fmaf(r56, r88, r103);
+    r31 = r67 * r30;
+    r103 = fmaf(r121, r31, r103);
+    r13 = r67 * r85;
+    r13 = r13 * r63;
+    r103 = fmaf(r62, r13, r103);
+    r74 = r11 * r59;
+    r74 = r74 * r76;
+    r74 = r74 * r83;
+    r74 = r74 * r30;
+    r74 = r74 * r47;
+    r74 = r74 * r69;
+    r103 = fmaf(r35, r74, r103);
+    r15 = r67 * r128;
+    r15 = r15 * r62;
+    r103 = fmaf(r106, r15, r103);
+    r89 = r4 * r11;
+    r89 = r89 * r51;
+    r89 = r89 * r77;
+    r103 = fmaf(r56, r89, r103);
+    r90 = r67 * r11;
+    r90 = r90 * r30;
+    r90 = r90 * r62;
+    r103 = fmaf(r101, r90, r103);
+    r120 = r59 * r128;
+    r103 = fmaf(r78, r120, r103);
+    r28 = r127 * r78;
+    r103 = fmaf(r63, r28, r103);
+    r103 = fmaf(r51, r119, r103);
+    r103 = fmaf(r128, r80, r103);
+    r103 = fmaf(r30, r114, r103);
+    r28 = r5 * r103;
+    r120 = r26 * r10;
+    r120 = r120 * r10;
+    r120 = r120 * r59;
+    r120 = r120 * r59;
+    r120 = r120 * r82;
+    r120 = r120 * r47;
+    r90 = r43 * r10;
+    r90 = r90 * r59;
+    r90 = r90 * r95;
+    r90 = fmaf(r61, r90, r12 * r120);
+    r120 = r41 * r26;
+    r120 = r120 * r126;
+    r120 = r120 * r12;
+    r126 = r108 + r120;
+    r89 = r16 * r39;
+    r89 = r89 * r11;
+    r126 = fmaf(r37, r89, r126);
+    r15 = r16 * r43;
+    r15 = r15 * r10;
+    r126 = fmaf(r37, r15, r126);
+    r15 = r107 * r126;
+    r15 = r15 * r102;
+    r15 = r15 * r52;
+    r90 = fmaf(r106, r15, r90);
+    r89 = r71 * r126;
+    r90 = fmaf(r96, r89, r90);
+    r74 = r59 * r59;
+    r74 = r74 * r47;
+    r13 = r39 * r63;
+    r13 = fmaf(r62, r13, r108 * r74);
+    r108 = r4 * r126;
+    r108 = r108 * r111;
+    r13 = fmaf(r112, r108, r13);
+    r31 = r11 * r11;
+    r31 = r31 * r126;
+    r31 = r31 * r35;
+    r31 = r31 * r42;
+    r13 = fmaf(r61, r31, r13);
+    r90 = r90 + r13;
+    r89 = r43 * r62;
+    r89 = fmaf(r106, r89, r74 * r120);
+    r89 = fmaf(r126, r113, r89);
+    r89 = fmaf(r126, r96, r89);
+    r13 = r13 + r89;
+    r90 = fmaf(r8, r13, r67 * r90);
+    r120 = r4 * r26;
+    r120 = r120 * r10;
+    r120 = r120 * r77;
+    r90 = fmaf(r56, r120, r90);
+    r74 = r43 * r59;
+    r90 = fmaf(r78, r74, r90);
+    r15 = r11 * r126;
+    r15 = r15 * r101;
+    r90 = fmaf(r72, r15, r90);
+    r31 = r81 * r126;
+    r31 = r31 * r101;
+    r90 = fmaf(r79, r31, r90);
+    r108 = r66 * r26;
+    r108 = r108 * r10;
+    r108 = r108 * r11;
+    r108 = r108 * r59;
+    r108 = r108 * r59;
+    r108 = r108 * r93;
+    r108 = r108 * r47;
+    r90 = fmaf(r12, r108, r90);
+    r88 = r81 * r126;
+    r88 = r88 * r78;
+    r90 = fmaf(r101, r88, r90);
+    r133 = r39 * r106;
+    r90 = fmaf(r72, r133, r90);
+    r135 = r10 * r59;
+    r51 = r7 * r16;
+    r51 = r51 * r65;
+    r51 = fmaf(r6, r13, r13 * r51);
+    r51 = fmaf(r13, r75, r51);
+    r51 = fmaf(r13, r68, r51);
+    r135 = r135 * r51;
+    r90 = fmaf(r78, r135, r90);
+    r64 = r4 * r26;
+    r64 = r64 * r10;
+    r64 = r64 * r76;
+    r64 = r64 * r77;
+    r90 = fmaf(r56, r64, r90);
+    r90 = fmaf(r126, r109, r90);
+    r90 = fmaf(r126, r122, r90);
+    r90 = fmaf(r43, r80, r90);
+    r90 = fmaf(r43, r73, r90);
+    r90 = fmaf(r126, r105, r90);
+    r64 = r0 * r90;
+    r135 = r26 * r11;
+    r135 = r135 * r11;
+    r135 = r135 * r59;
+    r135 = r135 * r59;
+    r135 = r135 * r82;
+    r135 = r135 * r47;
+    r133 = r39 * r95;
+    r133 = r133 * r61;
+    r133 = fmaf(r63, r133, r12 * r135);
+    r135 = r107 * r126;
+    r135 = r135 * r111;
+    r133 = fmaf(r112, r135, r133);
+    r88 = r11 * r11;
+    r88 = r88 * r71;
+    r88 = r88 * r126;
+    r88 = r88 * r35;
+    r88 = r88 * r42;
+    r133 = fmaf(r61, r88, r133);
+    r133 = r133 + r89;
+    r13 = fmaf(r9, r13, r66 * r133);
+    r133 = r4 * r26;
+    r133 = r133 * r11;
+    r133 = r133 * r77;
+    r13 = fmaf(r56, r133, r13);
+    r89 = r4 * r26;
+    r89 = r89 * r11;
+    r89 = r89 * r76;
+    r89 = r89 * r77;
+    r13 = fmaf(r56, r89, r13);
+    r88 = r11 * r59;
+    r88 = r88 * r83;
+    r88 = r88 * r126;
+    r88 = r88 * r47;
+    r88 = r88 * r69;
+    r13 = fmaf(r35, r88, r13);
+    r135 = r11 * r59;
+    r135 = r135 * r76;
+    r135 = r135 * r83;
+    r135 = r135 * r126;
+    r135 = r135 * r47;
+    r135 = r135 * r69;
+    r13 = fmaf(r35, r135, r13);
+    r108 = r39 * r59;
+    r13 = fmaf(r78, r108, r13);
+    r31 = r67 * r126;
+    r13 = fmaf(r121, r31, r13);
+    r15 = r67 * r11;
+    r15 = r15 * r126;
+    r15 = r15 * r62;
+    r13 = fmaf(r101, r15, r13);
+    r74 = r67 * r43;
+    r74 = r74 * r63;
+    r13 = fmaf(r62, r74, r13);
+    r120 = r11 * r81;
+    r120 = r120 * r126;
+    r120 = r120 * r35;
+    r120 = r120 * r42;
+    r13 = fmaf(r78, r120, r13);
+    r99 = r67 * r39;
+    r99 = r99 * r62;
+    r13 = fmaf(r106, r99, r13);
+    r27 = r51 * r78;
+    r13 = fmaf(r63, r27, r13);
+    r13 = fmaf(r39, r80, r13);
+    r13 = fmaf(r26, r119, r13);
+    r13 = fmaf(r126, r114, r13);
+    r27 = r5 * r13;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r100,
+                                          r28,
+                                          r64,
+                                          r27);
+    r27 = r11 * r11;
+    r64 = r40 * r11;
+    r64 = r64 * r11;
+    r28 = r16 * r44;
+    r28 = r28 * r11;
+    r28 = fmaf(r37, r28, r36 * r64);
+    r64 = r40 * r10;
+    r64 = r64 * r10;
+    r28 = fmaf(r36, r64, r28);
+    r100 = r16 * r58;
+    r100 = r100 * r10;
+    r28 = fmaf(r37, r100, r28);
+    r27 = r27 * r28;
+    r27 = r27 * r35;
+    r27 = r27 * r42;
+    r100 = r40 * r11;
+    r100 = r100 * r11;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r100 = fmaf(r36, r100, r61 * r27);
+    r27 = r44 * r63;
+    r100 = fmaf(r62, r27, r100);
+    r64 = r4 * r28;
+    r64 = r64 * r111;
+    r100 = fmaf(r112, r64, r100);
+    r64 = r40 * r10;
+    r64 = r64 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r59;
+    r64 = r64 * r47;
+    r64 = fmaf(r36, r64, r28 * r96);
+    r27 = r58 * r62;
+    r64 = fmaf(r106, r27, r64);
+    r64 = fmaf(r28, r113, r64);
+    r27 = r100 + r64;
+    r99 = r71 * r28;
+    r120 = r40 * r10;
+    r120 = r120 * r10;
+    r120 = r120 * r59;
+    r120 = r120 * r59;
+    r120 = r120 * r82;
+    r120 = r120 * r47;
+    r120 = fmaf(r12, r120, r96 * r99);
+    r99 = r58 * r10;
+    r99 = r99 * r59;
+    r99 = r99 * r95;
+    r120 = fmaf(r61, r99, r120);
+    r74 = r107 * r28;
+    r74 = r74 * r102;
+    r74 = r74 * r52;
+    r120 = fmaf(r106, r74, r120);
+    r120 = r120 + r100;
+    r120 = fmaf(r67, r120, r8 * r27);
+    r100 = r10 * r59;
+    r74 = r7 * r16;
+    r74 = r74 * r65;
+    r74 = fmaf(r27, r74, r6 * r27);
+    r74 = fmaf(r27, r75, r74);
+    r74 = fmaf(r27, r68, r74);
+    r100 = r100 * r74;
+    r120 = fmaf(r78, r100, r120);
+    r99 = r44 * r106;
+    r120 = fmaf(r72, r99, r120);
+    r15 = r58 * r59;
+    r120 = fmaf(r78, r15, r120);
+    r31 = r11 * r28;
+    r31 = r31 * r101;
+    r120 = fmaf(r72, r31, r120);
+    r108 = r81 * r28;
+    r108 = r108 * r78;
+    r120 = fmaf(r101, r108, r120);
+    r135 = r66 * r40;
+    r135 = r135 * r10;
+    r135 = r135 * r11;
+    r135 = r135 * r59;
+    r135 = r135 * r59;
+    r135 = r135 * r93;
+    r135 = r135 * r47;
+    r120 = fmaf(r12, r135, r120);
+    r88 = r81 * r28;
+    r88 = r88 * r101;
+    r120 = fmaf(r79, r88, r120);
+    r89 = r4 * r40;
+    r89 = r89 * r10;
+    r89 = r89 * r77;
+    r120 = fmaf(r56, r89, r120);
+    r133 = r4 * r40;
+    r133 = r133 * r10;
+    r133 = r133 * r76;
+    r133 = r133 * r77;
+    r120 = fmaf(r56, r133, r120);
+    r120 = fmaf(r58, r80, r120);
+    r120 = fmaf(r28, r105, r120);
+    r120 = fmaf(r28, r122, r120);
+    r120 = fmaf(r28, r109, r120);
+    r120 = fmaf(r58, r73, r120);
+    r133 = r0 * r120;
+    r89 = r11 * r11;
+    r89 = r89 * r71;
+    r89 = r89 * r28;
+    r89 = r89 * r35;
+    r89 = r89 * r42;
+    r88 = r40 * r11;
+    r88 = r88 * r11;
+    r88 = r88 * r59;
+    r88 = r88 * r59;
+    r88 = r88 * r82;
+    r88 = r88 * r47;
+    r88 = fmaf(r12, r88, r61 * r89);
+    r89 = r44 * r95;
+    r89 = r89 * r61;
+    r88 = fmaf(r63, r89, r88);
+    r135 = r107 * r28;
+    r135 = r135 * r111;
+    r88 = fmaf(r112, r135, r88);
+    r88 = r88 + r64;
+    r88 = fmaf(r66, r88, r9 * r27);
+    r27 = r67 * r44;
+    r27 = r27 * r62;
+    r88 = fmaf(r106, r27, r88);
+    r64 = r4 * r40;
+    r64 = r64 * r11;
+    r64 = r64 * r77;
+    r88 = fmaf(r56, r64, r88);
+    r135 = r11 * r81;
+    r135 = r135 * r28;
+    r135 = r135 * r35;
+    r135 = r135 * r42;
+    r88 = fmaf(r78, r135, r88);
+    r89 = r67 * r11;
+    r89 = r89 * r28;
+    r89 = r89 * r62;
+    r88 = fmaf(r101, r89, r88);
+    r108 = r67 * r28;
+    r88 = fmaf(r121, r108, r88);
+    r31 = r44 * r59;
+    r88 = fmaf(r78, r31, r88);
+    r15 = r67 * r58;
+    r15 = r15 * r63;
+    r88 = fmaf(r62, r15, r88);
+    r99 = r4 * r40;
+    r99 = r99 * r11;
+    r99 = r99 * r76;
+    r99 = r99 * r77;
+    r88 = fmaf(r56, r99, r88);
+    r100 = r11 * r59;
+    r100 = r100 * r76;
+    r100 = r100 * r83;
+    r100 = r100 * r28;
+    r100 = r100 * r47;
+    r100 = r100 * r69;
+    r88 = fmaf(r35, r100, r88);
+    r117 = r74 * r78;
+    r88 = fmaf(r63, r117, r88);
+    r134 = r11 * r59;
+    r134 = r134 * r83;
+    r134 = r134 * r28;
+    r134 = r134 * r47;
+    r134 = r134 * r69;
+    r88 = fmaf(r35, r134, r88);
+    r88 = fmaf(r28, r114, r88);
+    r88 = fmaf(r44, r80, r88);
+    r88 = fmaf(r40, r119, r88);
+    r134 = r5 * r88;
+    r117 = r11 * r11;
+    r100 = r16 * r46;
+    r100 = r100 * r11;
+    r99 = r38 * r11;
+    r99 = r99 * r11;
+    r99 = fmaf(r36, r99, r37 * r100);
+    r100 = r16 * r57;
+    r100 = r100 * r10;
+    r99 = fmaf(r37, r100, r99);
+    r15 = r38 * r10;
+    r15 = r15 * r10;
+    r99 = fmaf(r36, r15, r99);
+    r117 = r117 * r99;
+    r117 = r117 * r35;
+    r117 = r117 * r42;
+    r15 = r46 * r63;
+    r15 = fmaf(r62, r15, r61 * r117);
+    r117 = r4 * r99;
+    r117 = r117 * r111;
+    r15 = fmaf(r112, r117, r15);
+    r100 = r38 * r11;
+    r100 = r100 * r11;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r15 = fmaf(r36, r100, r15);
+    r100 = r38 * r10;
+    r100 = r100 * r10;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r100 = fmaf(r99, r113, r36 * r100);
+    r117 = r57 * r62;
+    r100 = fmaf(r106, r117, r100);
+    r100 = fmaf(r99, r96, r100);
+    r117 = r15 + r100;
+    r31 = r38 * r10;
+    r31 = r31 * r10;
+    r31 = r31 * r59;
+    r31 = r31 * r59;
+    r31 = r31 * r82;
+    r31 = r31 * r47;
+    r108 = r107 * r99;
+    r108 = r108 * r102;
+    r108 = r108 * r52;
+    r108 = fmaf(r106, r108, r12 * r31);
+    r31 = r57 * r10;
+    r31 = r31 * r59;
+    r31 = r31 * r95;
+    r108 = fmaf(r61, r31, r108);
+    r89 = r71 * r99;
+    r108 = fmaf(r96, r89, r108);
+    r108 = r108 + r15;
+    r108 = fmaf(r67, r108, r8 * r117);
+    r15 = r4 * r38;
+    r15 = r15 * r10;
+    r15 = r15 * r76;
+    r15 = r15 * r77;
+    r108 = fmaf(r56, r15, r108);
+    r89 = r57 * r59;
+    r108 = fmaf(r78, r89, r108);
+    r31 = r4 * r38;
+    r31 = r31 * r10;
+    r31 = r31 * r77;
+    r108 = fmaf(r56, r31, r108);
+    r135 = r81 * r99;
+    r135 = r135 * r101;
+    r108 = fmaf(r79, r135, r108);
+    r64 = r11 * r99;
+    r64 = r64 * r101;
+    r108 = fmaf(r72, r64, r108);
+    r27 = r46 * r106;
+    r108 = fmaf(r72, r27, r108);
+    r115 = r81 * r99;
+    r115 = r115 * r78;
+    r108 = fmaf(r101, r115, r108);
+    r130 = r10 * r59;
+    r125 = r7 * r16;
+    r125 = r125 * r65;
+    r125 = fmaf(r6, r117, r117 * r125);
+    r125 = fmaf(r117, r75, r125);
+    r125 = fmaf(r117, r68, r125);
+    r130 = r130 * r125;
+    r108 = fmaf(r78, r130, r108);
+    r87 = r66 * r38;
+    r87 = r87 * r10;
+    r87 = r87 * r11;
+    r87 = r87 * r59;
+    r87 = r87 * r59;
+    r87 = r87 * r93;
+    r87 = r87 * r47;
+    r108 = fmaf(r12, r87, r108);
+    r108 = fmaf(r57, r80, r108);
+    r108 = fmaf(r99, r105, r108);
+    r108 = fmaf(r99, r122, r108);
+    r108 = fmaf(r57, r73, r108);
+    r108 = fmaf(r99, r109, r108);
+    r87 = r0 * r108;
+    r130 = r11 * r11;
+    r130 = r130 * r71;
+    r130 = r130 * r99;
+    r130 = r130 * r35;
+    r130 = r130 * r42;
+    r115 = r46 * r95;
+    r115 = r115 * r61;
+    r115 = fmaf(r63, r115, r61 * r130);
+    r130 = r107 * r99;
+    r130 = r130 * r111;
+    r115 = fmaf(r112, r130, r115);
+    r27 = r38 * r11;
+    r27 = r27 * r11;
+    r27 = r27 * r59;
+    r27 = r27 * r59;
+    r27 = r27 * r82;
+    r27 = r27 * r47;
+    r115 = fmaf(r12, r27, r115);
+    r115 = r115 + r100;
+    r115 = fmaf(r66, r115, r9 * r117);
+    r117 = r11 * r81;
+    r117 = r117 * r99;
+    r117 = r117 * r35;
+    r117 = r117 * r42;
+    r115 = fmaf(r78, r117, r115);
+    r100 = r11 * r59;
+    r100 = r100 * r76;
+    r100 = r100 * r83;
+    r100 = r100 * r99;
+    r100 = r100 * r47;
+    r100 = r100 * r69;
+    r115 = fmaf(r35, r100, r115);
+    r27 = r11 * r59;
+    r27 = r27 * r83;
+    r27 = r27 * r99;
+    r27 = r27 * r47;
+    r27 = r27 * r69;
+    r115 = fmaf(r35, r27, r115);
+    r130 = r67 * r99;
+    r115 = fmaf(r121, r130, r115);
+    r64 = r67 * r11;
+    r64 = r64 * r99;
+    r64 = r64 * r62;
+    r115 = fmaf(r101, r64, r115);
+    r135 = r67 * r46;
+    r135 = r135 * r62;
+    r115 = fmaf(r106, r135, r115);
+    r31 = r4 * r38;
+    r31 = r31 * r11;
+    r31 = r31 * r76;
+    r31 = r31 * r77;
+    r115 = fmaf(r56, r31, r115);
+    r89 = r67 * r57;
+    r89 = r89 * r63;
+    r115 = fmaf(r62, r89, r115);
+    r15 = r46 * r59;
+    r115 = fmaf(r78, r15, r115);
+    r104 = r4 * r38;
+    r104 = r104 * r11;
+    r104 = r104 * r77;
+    r115 = fmaf(r56, r104, r115);
+    r131 = r125 * r78;
+    r115 = fmaf(r63, r131, r115);
+    r115 = fmaf(r99, r114, r115);
+    r115 = fmaf(r46, r80, r115);
+    r115 = fmaf(r38, r119, r115);
+    r131 = r5 * r115;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r133,
+                                          r134,
+                                          r87,
+                                          r131);
+    r131 = r5 * r4;
+    r131 = r131 * r70;
+    r87 = r0 * r4;
+    r87 = r87 * r2;
+    r87 = fmaf(r1, r87, r110 * r131);
+    r131 = r5 * r4;
+    r131 = r131 * r70;
+    r134 = r0 * r4;
+    r134 = r134 * r2;
+    r134 = fmaf(r84, r134, r86 * r131);
+    r131 = r0 * r4;
+    r131 = r131 * r2;
+    r133 = r5 * r4;
+    r133 = r133 * r70;
+    r133 = fmaf(r103, r133, r14 * r131);
+    r131 = r5 * r4;
+    r131 = r131 * r70;
+    r104 = r0 * r4;
+    r104 = r104 * r2;
+    r104 = fmaf(r90, r104, r13 * r131);
+    WriteSum4<float, float>((float*)inout_shared, r87, r134, r133, r104);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r0 * r4;
+    r104 = r104 * r2;
+    r133 = r5 * r4;
+    r133 = r133 * r70;
+    r133 = fmaf(r88, r133, r120 * r104);
+    r104 = r5 * r4;
+    r104 = r104 * r70;
+    r134 = r0 * r4;
+    r134 = r134 * r2;
+    r134 = fmaf(r108, r134, r115 * r104);
+    WriteSum2<float, float>((float*)inout_shared, r133, r134);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r134 = r0 * r0;
+    r133 = r1 * r134;
+    r104 = r5 * r5;
+    r87 = r110 * r104;
+    r110 = fmaf(r110, r87, r1 * r133);
+    r1 = r84 * r84;
+    r131 = r86 * r86;
+    r131 = fmaf(r104, r131, r134 * r1);
+    r1 = r103 * r103;
+    r15 = r14 * r14;
+    r15 = fmaf(r134, r15, r104 * r1);
+    r1 = r90 * r90;
+    r89 = r13 * r13;
+    r89 = fmaf(r104, r89, r134 * r1);
+    WriteSum4<float, float>((float*)inout_shared, r110, r131, r15, r89);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r89 = r120 * r120;
+    r15 = r88 * r88;
+    r15 = fmaf(r104, r15, r134 * r89);
+    r89 = r115 * r115;
+    r131 = r108 * r108;
+    r131 = fmaf(r134, r131, r104 * r89);
+    WriteSum2<float, float>((float*)inout_shared, r15, r131);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r131 = fmaf(r84, r133, r86 * r87);
+    r15 = fmaf(r103, r87, r14 * r133);
+    r89 = fmaf(r90, r133, r13 * r87);
+    r110 = fmaf(r120, r133, r88 * r87);
+    WriteSum4<float, float>((float*)inout_shared, r131, r15, r89, r110);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r87 = fmaf(r115, r87, r108 * r133);
+    r133 = r86 * r103;
+    r110 = r84 * r14;
+    r110 = fmaf(r134, r110, r104 * r133);
+    r133 = r84 * r90;
+    r89 = r86 * r13;
+    r89 = fmaf(r104, r89, r134 * r133);
+    r133 = r84 * r120;
+    r15 = r86 * r88;
+    r15 = fmaf(r104, r15, r134 * r133);
+    WriteSum4<float, float>((float*)inout_shared, r87, r110, r89, r15);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r15 = r86 * r115;
+    r89 = r84 * r108;
+    r89 = fmaf(r134, r89, r104 * r15);
+    r15 = r103 * r13;
+    r110 = r14 * r90;
+    r110 = fmaf(r134, r110, r104 * r15);
+    r15 = r14 * r120;
+    r87 = r103 * r88;
+    r87 = fmaf(r104, r87, r134 * r15);
+    r15 = r103 * r115;
+    r133 = r14 * r108;
+    r133 = fmaf(r134, r133, r104 * r15);
+    WriteSum4<float, float>((float*)inout_shared, r89, r110, r87, r133);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r133 = r13 * r88;
+    r87 = r90 * r120;
+    r87 = fmaf(r134, r87, r104 * r133);
+    r133 = r90 * r108;
+    r110 = r13 * r115;
+    r110 = fmaf(r104, r110, r134 * r133);
+    r133 = r88 * r115;
+    r89 = r120 * r108;
+    r89 = fmaf(r134, r89, r104 * r133);
+    WriteSum3<float, float>((float*)inout_shared, r87, r110, r89);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r89 = r54 * r10;
+    r89 = r89 * r59;
+    r89 = r89 * r95;
+    r110 = r60 * r10;
+    r110 = r110 * r10;
+    r110 = r110 * r59;
+    r110 = r110 * r59;
+    r110 = r110 * r82;
+    r110 = r110 * r47;
+    r110 = fmaf(r12, r110, r61 * r89);
+    r89 = r16 * r33;
+    r89 = r89 * r11;
+    r87 = r16 * r54;
+    r87 = r87 * r10;
+    r87 = fmaf(r37, r87, r37 * r89);
+    r89 = r60 * r10;
+    r89 = r89 * r10;
+    r87 = fmaf(r36, r89, r87);
+    r133 = r60 * r11;
+    r133 = r133 * r11;
+    r87 = fmaf(r36, r133, r87);
+    r133 = r71 * r87;
+    r110 = fmaf(r96, r133, r110);
+    r89 = r107 * r87;
+    r89 = r89 * r102;
+    r89 = r89 * r52;
+    r110 = fmaf(r106, r89, r110);
+    r15 = r4 * r87;
+    r15 = r15 * r111;
+    r131 = r11 * r11;
+    r131 = r131 * r87;
+    r131 = r131 * r35;
+    r131 = r131 * r42;
+    r131 = fmaf(r61, r131, r112 * r15);
+    r15 = r60 * r11;
+    r15 = r15 * r11;
+    r15 = r15 * r59;
+    r15 = r15 * r59;
+    r15 = r15 * r47;
+    r131 = fmaf(r36, r15, r131);
+    r1 = r33 * r63;
+    r131 = fmaf(r62, r1, r131);
+    r110 = r110 + r131;
+    r89 = r54 * r62;
+    r133 = r60 * r10;
+    r133 = r133 * r10;
+    r133 = r133 * r59;
+    r133 = r133 * r59;
+    r133 = r133 * r47;
+    r133 = fmaf(r36, r133, r106 * r89);
+    r133 = fmaf(r87, r96, r133);
+    r133 = fmaf(r87, r113, r133);
+    r131 = r131 + r133;
+    r110 = fmaf(r8, r131, r67 * r110);
+    r89 = r4 * r60;
+    r89 = r89 * r10;
+    r89 = r89 * r76;
+    r89 = r89 * r77;
+    r110 = fmaf(r56, r89, r110);
+    r1 = r4 * r60;
+    r1 = r1 * r10;
+    r1 = r1 * r77;
+    r110 = fmaf(r56, r1, r110);
+    r15 = r33 * r106;
+    r110 = fmaf(r72, r15, r110);
+    r31 = r10 * r59;
+    r135 = r7 * r16;
+    r135 = r135 * r65;
+    r135 = fmaf(r6, r131, r131 * r135);
+    r135 = fmaf(r131, r75, r135);
+    r135 = fmaf(r131, r68, r135);
+    r31 = r31 * r135;
+    r110 = fmaf(r78, r31, r110);
+    r64 = r81 * r87;
+    r64 = r64 * r101;
+    r110 = fmaf(r79, r64, r110);
+    r130 = r54 * r59;
+    r110 = fmaf(r78, r130, r110);
+    r27 = r66 * r60;
+    r27 = r27 * r10;
+    r27 = r27 * r11;
+    r27 = r27 * r59;
+    r27 = r27 * r59;
+    r27 = r27 * r93;
+    r27 = r27 * r47;
+    r110 = fmaf(r12, r27, r110);
+    r100 = r11 * r87;
+    r100 = r100 * r101;
+    r110 = fmaf(r72, r100, r110);
+    r117 = r81 * r87;
+    r117 = r117 * r78;
+    r110 = fmaf(r101, r117, r110);
+    r110 = fmaf(r54, r80, r110);
+    r110 = fmaf(r87, r109, r110);
+    r110 = fmaf(r87, r105, r110);
+    r110 = fmaf(r87, r122, r110);
+    r110 = fmaf(r54, r73, r110);
+    r117 = r0 * r110;
+    r100 = r107 * r87;
+    r100 = r100 * r111;
+    r27 = r11 * r11;
+    r27 = r27 * r71;
+    r27 = r27 * r87;
+    r27 = r27 * r35;
+    r27 = r27 * r42;
+    r27 = fmaf(r61, r27, r112 * r100);
+    r100 = r60 * r11;
+    r100 = r100 * r11;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r82;
+    r100 = r100 * r47;
+    r27 = fmaf(r12, r100, r27);
+    r130 = r33 * r95;
+    r130 = r130 * r61;
+    r27 = fmaf(r63, r130, r27);
+    r27 = r27 + r133;
+    r131 = fmaf(r9, r131, r66 * r27);
+    r27 = r11 * r59;
+    r27 = r27 * r76;
+    r27 = r27 * r83;
+    r27 = r27 * r87;
+    r27 = r27 * r47;
+    r27 = r27 * r69;
+    r131 = fmaf(r35, r27, r131);
+    r133 = r4 * r60;
+    r133 = r133 * r11;
+    r133 = r133 * r76;
+    r133 = r133 * r77;
+    r131 = fmaf(r56, r133, r131);
+    r130 = r67 * r33;
+    r130 = r130 * r62;
+    r131 = fmaf(r106, r130, r131);
+    r100 = r11 * r59;
+    r100 = r100 * r83;
+    r100 = r100 * r87;
+    r100 = r100 * r47;
+    r100 = r100 * r69;
+    r131 = fmaf(r35, r100, r131);
+    r64 = r67 * r87;
+    r131 = fmaf(r121, r64, r131);
+    r31 = r67 * r54;
+    r31 = r31 * r63;
+    r131 = fmaf(r62, r31, r131);
+    r15 = r11 * r81;
+    r15 = r15 * r87;
+    r15 = r15 * r35;
+    r15 = r15 * r42;
+    r131 = fmaf(r78, r15, r131);
+    r1 = r4 * r60;
+    r1 = r1 * r11;
+    r1 = r1 * r77;
+    r131 = fmaf(r56, r1, r131);
+    r89 = r67 * r11;
+    r89 = r89 * r87;
+    r89 = r89 * r62;
+    r131 = fmaf(r101, r89, r131);
+    r118 = r33 * r59;
+    r131 = fmaf(r78, r118, r131);
+    r129 = r135 * r78;
+    r131 = fmaf(r63, r129, r131);
+    r131 = fmaf(r87, r114, r131);
+    r131 = fmaf(r60, r119, r131);
+    r131 = fmaf(r33, r80, r131);
+    r129 = r5 * r131;
+    r118 = r45 * r11;
+    r118 = r118 * r11;
+    r89 = r16 * r49;
+    r89 = r89 * r10;
+    r89 = fmaf(r37, r89, r36 * r118);
+    r118 = r16 * r50;
+    r118 = r118 * r11;
+    r89 = fmaf(r37, r118, r89);
+    r1 = r45 * r10;
+    r1 = r1 * r10;
+    r89 = fmaf(r36, r1, r89);
+    r1 = r45 * r10;
+    r1 = r1 * r10;
+    r1 = r1 * r59;
+    r1 = r1 * r59;
+    r1 = r1 * r47;
+    r1 = fmaf(r36, r1, r89 * r96);
+    r118 = r49 * r62;
+    r1 = fmaf(r106, r118, r1);
+    r1 = fmaf(r89, r113, r1);
+    r118 = r4 * r89;
+    r118 = r118 * r111;
+    r15 = r50 * r63;
+    r15 = fmaf(r62, r15, r112 * r118);
+    r118 = r11 * r11;
+    r118 = r118 * r89;
+    r118 = r118 * r35;
+    r118 = r118 * r42;
+    r15 = fmaf(r61, r118, r15);
+    r31 = r45 * r11;
+    r31 = r31 * r11;
+    r31 = r31 * r59;
+    r31 = r31 * r59;
+    r31 = r31 * r47;
+    r15 = fmaf(r36, r31, r15);
+    r31 = r1 + r15;
+    r118 = r71 * r89;
+    r64 = r45 * r10;
+    r64 = r64 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r59;
+    r64 = r64 * r82;
+    r64 = r64 * r47;
+    r64 = fmaf(r12, r64, r96 * r118);
+    r118 = r107 * r89;
+    r118 = r118 * r102;
+    r118 = r118 * r52;
+    r64 = fmaf(r106, r118, r64);
+    r100 = r49 * r10;
+    r100 = r100 * r59;
+    r100 = r100 * r95;
+    r64 = fmaf(r61, r100, r64);
+    r64 = r64 + r15;
+    r64 = fmaf(r67, r64, r8 * r31);
+    r15 = r4 * r45;
+    r15 = r15 * r10;
+    r15 = r15 * r77;
+    r64 = fmaf(r56, r15, r64);
+    r100 = r4 * r45;
+    r100 = r100 * r10;
+    r100 = r100 * r76;
+    r100 = r100 * r77;
+    r64 = fmaf(r56, r100, r64);
+    r118 = r10 * r59;
+    r130 = r7 * r16;
+    r130 = r130 * r65;
+    r130 = fmaf(r31, r130, r6 * r31);
+    r130 = fmaf(r31, r75, r130);
+    r130 = fmaf(r31, r68, r130);
+    r118 = r118 * r130;
+    r64 = fmaf(r78, r118, r64);
+    r133 = r81 * r89;
+    r133 = r133 * r78;
+    r64 = fmaf(r101, r133, r64);
+    r27 = r81 * r89;
+    r27 = r27 * r101;
+    r64 = fmaf(r79, r27, r64);
+    r116 = r50 * r106;
+    r64 = fmaf(r72, r116, r64);
+    r123 = r49 * r59;
+    r64 = fmaf(r78, r123, r64);
+    r136 = r66 * r45;
+    r136 = r136 * r10;
+    r136 = r136 * r11;
+    r136 = r136 * r59;
+    r136 = r136 * r59;
+    r136 = r136 * r93;
+    r136 = r136 * r47;
+    r64 = fmaf(r12, r136, r64);
+    r137 = r11 * r89;
+    r137 = r137 * r101;
+    r64 = fmaf(r72, r137, r64);
+    r64 = fmaf(r49, r73, r64);
+    r64 = fmaf(r89, r122, r64);
+    r64 = fmaf(r89, r105, r64);
+    r64 = fmaf(r89, r109, r64);
+    r64 = fmaf(r49, r80, r64);
+    r137 = r0 * r64;
+    r136 = r107 * r89;
+    r136 = r136 * r111;
+    r123 = r50 * r95;
+    r123 = r123 * r61;
+    r123 = fmaf(r63, r123, r112 * r136);
+    r136 = r11 * r11;
+    r136 = r136 * r71;
+    r136 = r136 * r89;
+    r136 = r136 * r35;
+    r136 = r136 * r42;
+    r123 = fmaf(r61, r136, r123);
+    r116 = r45 * r11;
+    r116 = r116 * r11;
+    r116 = r116 * r59;
+    r116 = r116 * r59;
+    r116 = r116 * r82;
+    r116 = r116 * r47;
+    r123 = fmaf(r12, r116, r123);
+    r123 = r123 + r1;
+    r123 = fmaf(r66, r123, r9 * r31);
+    r31 = r67 * r49;
+    r31 = r31 * r63;
+    r123 = fmaf(r62, r31, r123);
+    r1 = r67 * r11;
+    r1 = r1 * r89;
+    r1 = r1 * r62;
+    r123 = fmaf(r101, r1, r123);
+    r116 = r67 * r89;
+    r123 = fmaf(r121, r116, r123);
+    r136 = r11 * r59;
+    r136 = r136 * r76;
+    r136 = r136 * r83;
+    r136 = r136 * r89;
+    r136 = r136 * r47;
+    r136 = r136 * r69;
+    r123 = fmaf(r35, r136, r123);
+    r27 = r11 * r59;
+    r27 = r27 * r83;
+    r27 = r27 * r89;
+    r27 = r27 * r47;
+    r27 = r27 * r69;
+    r123 = fmaf(r35, r27, r123);
+    r133 = r130 * r78;
+    r123 = fmaf(r63, r133, r123);
+    r118 = r50 * r59;
+    r123 = fmaf(r78, r118, r123);
+    r100 = r4 * r45;
+    r100 = r100 * r11;
+    r100 = r100 * r76;
+    r100 = r100 * r77;
+    r123 = fmaf(r56, r100, r123);
+    r15 = r11 * r81;
+    r15 = r15 * r89;
+    r15 = r15 * r35;
+    r15 = r15 * r42;
+    r123 = fmaf(r78, r15, r123);
+    r138 = r67 * r50;
+    r138 = r138 * r62;
+    r123 = fmaf(r106, r138, r123);
+    r139 = r4 * r45;
+    r139 = r139 * r11;
+    r139 = r139 * r77;
+    r123 = fmaf(r56, r139, r123);
+    r123 = fmaf(r50, r80, r123);
+    r123 = fmaf(r89, r114, r123);
+    r123 = fmaf(r45, r119, r123);
+    r139 = r5 * r123;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r117,
+                                          r129,
+                                          r137,
+                                          r139);
+    r139 = r16 * r48;
+    r139 = r139 * r11;
+    r137 = r53 * r11;
+    r137 = r137 * r11;
+    r137 = fmaf(r36, r137, r37 * r139);
+    r139 = r53 * r10;
+    r139 = r139 * r10;
+    r137 = fmaf(r36, r139, r137);
+    r129 = r16 * r55;
+    r129 = r129 * r10;
+    r137 = fmaf(r37, r129, r137);
+    r129 = r4 * r137;
+    r129 = r129 * r111;
+    r139 = r48 * r63;
+    r139 = fmaf(r62, r139, r112 * r129);
+    r129 = r11 * r11;
+    r129 = r129 * r137;
+    r129 = r129 * r35;
+    r129 = r129 * r42;
+    r139 = fmaf(r61, r129, r139);
+    r37 = r53 * r11;
+    r37 = r37 * r11;
+    r37 = r37 * r59;
+    r37 = r37 * r59;
+    r37 = r37 * r47;
+    r139 = fmaf(r36, r37, r139);
+    r37 = r55 * r62;
+    r37 = fmaf(r137, r96, r106 * r37);
+    r129 = r53 * r10;
+    r129 = r129 * r10;
+    r129 = r129 * r59;
+    r129 = r129 * r59;
+    r129 = r129 * r47;
+    r37 = fmaf(r36, r129, r37);
+    r37 = fmaf(r137, r113, r37);
+    r113 = r139 + r37;
+    r129 = r55 * r10;
+    r129 = r129 * r59;
+    r129 = r129 * r95;
+    r36 = r71 * r137;
+    r36 = fmaf(r96, r36, r61 * r129);
+    r129 = r53 * r10;
+    r129 = r129 * r10;
+    r129 = r129 * r59;
+    r129 = r129 * r59;
+    r129 = r129 * r82;
+    r129 = r129 * r47;
+    r36 = fmaf(r12, r129, r36);
+    r96 = r107 * r137;
+    r96 = r96 * r102;
+    r96 = r96 * r52;
+    r36 = fmaf(r106, r96, r36);
+    r36 = r36 + r139;
+    r36 = fmaf(r67, r36, r8 * r113);
+    r8 = r48 * r106;
+    r36 = fmaf(r72, r8, r36);
+    r139 = r11 * r137;
+    r139 = r139 * r101;
+    r36 = fmaf(r72, r139, r36);
+    r72 = r4 * r53;
+    r72 = r72 * r10;
+    r72 = r72 * r76;
+    r72 = r72 * r77;
+    r36 = fmaf(r56, r72, r36);
+    r96 = r10 * r59;
+    r129 = r7 * r16;
+    r129 = r129 * r65;
+    r129 = fmaf(r113, r129, r6 * r113);
+    r129 = fmaf(r113, r75, r129);
+    r129 = fmaf(r113, r68, r129);
+    r96 = r96 * r129;
+    r36 = fmaf(r78, r96, r36);
+    r68 = r81 * r137;
+    r68 = r68 * r101;
+    r36 = fmaf(r79, r68, r36);
+    r79 = r4 * r53;
+    r79 = r79 * r10;
+    r79 = r79 * r77;
+    r36 = fmaf(r56, r79, r36);
+    r75 = r55 * r59;
+    r36 = fmaf(r78, r75, r36);
+    r6 = r81 * r137;
+    r6 = r6 * r78;
+    r36 = fmaf(r101, r6, r36);
+    r65 = r66 * r53;
+    r65 = r65 * r10;
+    r65 = r65 * r11;
+    r65 = r65 * r59;
+    r65 = r65 * r59;
+    r65 = r65 * r93;
+    r65 = r65 * r47;
+    r36 = fmaf(r12, r65, r36);
+    r36 = fmaf(r137, r109, r36);
+    r36 = fmaf(r137, r105, r36);
+    r36 = fmaf(r55, r80, r36);
+    r36 = fmaf(r137, r122, r36);
+    r36 = fmaf(r55, r73, r36);
+    r73 = r0 * r36;
+    r65 = r107 * r137;
+    r65 = r65 * r111;
+    r6 = r48 * r95;
+    r6 = r6 * r61;
+    r6 = fmaf(r63, r6, r112 * r65);
+    r65 = r11 * r11;
+    r65 = r65 * r71;
+    r65 = r65 * r137;
+    r65 = r65 * r35;
+    r65 = r65 * r42;
+    r6 = fmaf(r61, r65, r6);
+    r61 = r53 * r11;
+    r61 = r61 * r11;
+    r61 = r61 * r59;
+    r61 = r61 * r59;
+    r61 = r61 * r82;
+    r61 = r61 * r47;
+    r6 = fmaf(r12, r61, r6);
+    r6 = r6 + r37;
+    r6 = fmaf(r66, r6, r9 * r113);
+    r113 = r67 * r48;
+    r113 = r113 * r62;
+    r6 = fmaf(r106, r113, r6);
+    r9 = r4 * r53;
+    r9 = r9 * r11;
+    r9 = r9 * r76;
+    r9 = r9 * r77;
+    r6 = fmaf(r56, r9, r6);
+    r37 = r11 * r59;
+    r37 = r37 * r83;
+    r37 = r37 * r137;
+    r37 = r37 * r47;
+    r37 = r37 * r69;
+    r6 = fmaf(r35, r37, r6);
+    r61 = r67 * r11;
+    r61 = r61 * r137;
+    r61 = r61 * r62;
+    r6 = fmaf(r101, r61, r6);
+    r101 = r48 * r59;
+    r6 = fmaf(r78, r101, r6);
+    r65 = r129 * r78;
+    r6 = fmaf(r63, r65, r6);
+    r12 = r67 * r137;
+    r6 = fmaf(r121, r12, r6);
+    r121 = r11 * r59;
+    r121 = r121 * r76;
+    r121 = r121 * r83;
+    r121 = r121 * r137;
+    r121 = r121 * r47;
+    r121 = r121 * r69;
+    r6 = fmaf(r35, r121, r6);
+    r69 = r67 * r55;
+    r69 = r69 * r63;
+    r6 = fmaf(r62, r69, r6);
+    r47 = r4 * r53;
+    r47 = r47 * r11;
+    r47 = r47 * r77;
+    r6 = fmaf(r56, r47, r6);
+    r56 = r11 * r81;
+    r56 = r56 * r137;
+    r56 = r56 * r35;
+    r56 = r56 * r42;
+    r6 = fmaf(r78, r56, r6);
+    r6 = fmaf(r53, r119, r6);
+    r6 = fmaf(r137, r114, r6);
+    r6 = fmaf(r48, r80, r6);
+    r56 = r5 * r6;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r73,
+                                          r56);
+    r56 = r5 * r4;
+    r56 = r56 * r70;
+    r73 = r0 * r4;
+    r73 = r73 * r2;
+    r73 = fmaf(r110, r73, r131 * r56);
+    r56 = r0 * r4;
+    r56 = r56 * r2;
+    r47 = r5 * r4;
+    r47 = r47 * r70;
+    r47 = fmaf(r123, r47, r64 * r56);
+    r56 = r0 * r4;
+    r56 = r56 * r2;
+    r2 = r5 * r4;
+    r2 = r2 * r70;
+    r2 = fmaf(r6, r2, r36 * r56);
+    WriteSum3<float, float>((float*)inout_shared, r73, r47, r2);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r110 * r110;
+    r47 = r131 * r131;
+    r47 = fmaf(r104, r47, r134 * r2);
+    r2 = r123 * r123;
+    r73 = r64 * r64;
+    r73 = fmaf(r134, r73, r104 * r2);
+    r2 = r6 * r6;
+    r56 = r36 * r36;
+    r56 = fmaf(r134, r56, r104 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r47, r73, r56);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r131 * r123;
+    r73 = r110 * r64;
+    r73 = fmaf(r134, r73, r104 * r56);
+    r56 = r110 * r36;
+    r47 = r131 * r6;
+    r47 = fmaf(r104, r47, r134 * r56);
+    r56 = r123 * r6;
+    r2 = r64 * r36;
+    r2 = fmaf(r134, r2, r104 * r56);
+    WriteSum3<float, float>((float*)inout_shared, r73, r47, r2);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_point_jac,
+              out_point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.cu
@@ -1,0 +1,323 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScoreKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.cu
@@ -1,0 +1,245 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        float* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<2, float, float>(principal_point_njtr,
+                              0 * principal_point_njtr_num_alloc,
+                              principal_point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5);
+  };
+  __syncthreads();
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r6,
+                       r7,
+                       r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r9, r10);
+    ReadIdx4<1024, float, float, float4>(point_jac,
+                                         0 * point_jac_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13,
+                                         r14);
+    r15 = fmaf(r7, r13, r8 * r9);
+    r15 = fmaf(r6, r11, r15);
+    r16 = r4 + r15;
+    r7 = fmaf(r7, r14, r8 * r10);
+    r7 = fmaf(r6, r12, r7);
+    r6 = r5 + r7;
+    r8 = fmaf(r1, r6, r0 * r16);
+    r17 = fmaf(r3, r6, r2 * r16);
+    ReadIdx4<1024, float, float, float4>(pose_jac,
+                                         4 * pose_jac_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r19,
+                                         r20,
+                                         r21);
+    r22 = fmaf(r19, r6, r18 * r16);
+    r23 = fmaf(r21, r6, r20 * r16);
+    WriteSum4<float, float>((float*)inout_shared, r8, r17, r22, r23);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r23, r22, r17, r8);
+    r24 = fmaf(r22, r6, r23 * r16);
+    r6 = fmaf(r8, r6, r17 * r16);
+    WriteSum2<float, float>((float*)inout_shared, r24, r6);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r6,
+                       r24);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r23 = fmaf(r6, r23, r24 * r17);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r17,
+                       r16,
+                       r25,
+                       r26);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r23 = fmaf(r25, r18, r23);
+    r23 = fmaf(r26, r20, r23);
+    r23 = fmaf(r17, r0, r23);
+    r23 = fmaf(r16, r2, r23);
+    r15 = r23 + r15;
+    r21 = fmaf(r26, r21, r24 * r8);
+    r21 = fmaf(r25, r19, r21);
+    r21 = fmaf(r17, r1, r21);
+    r21 = fmaf(r16, r3, r21);
+    r21 = fmaf(r6, r22, r21);
+    r7 = r21 + r7;
+    WriteSum2<float, float>((float*)inout_shared, r15, r7);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r23 = r4 + r23;
+    r21 = r5 + r21;
+    r12 = fmaf(r12, r21, r11 * r23);
+    r14 = fmaf(r14, r21, r13 * r23);
+    r21 = fmaf(r10, r21, r9 * r23);
+    WriteSum3<float, float>((float*)inout_shared, r12, r14, r21);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirectKernel<<<n_blocks,
+                                                               1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      principal_point_njtr,
+      principal_point_njtr_num_alloc,
+      principal_point_njtr_indices,
+      principal_point_jac,
+      principal_point_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.cu
@@ -1,0 +1,2268 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = r11 * r11;
+    r53 = 9.99999999999999955e-07;
+    r54 = r41 * r29;
+    r54 = r54 * r29;
+    r55 = r42 + r54;
+    r55 = r55 + r49;
+    r10 = fmaf(r13, r55, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r56 = r16 * r29;
+    r56 = fmaf(r34, r56, r26);
+    r57 = r21 * r23;
+    r57 = r57 * r16;
+    r58 = r22 * r24;
+    r58 = fmaf(r16, r58, r57);
+    r59 = r23 * r24;
+    r59 = fmaf(r41, r59, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r56, r10);
+    r10 = fmaf(r37, r58, r10);
+    r10 = fmaf(r36, r59, r10);
+    r10 = fmaf(r35, r43, r10);
+    r60 = r10 * r10;
+    r61 = r41 * r29;
+    r61 = fmaf(r34, r61, r26);
+    r12 = fmaf(r13, r61, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r57);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r54 = r42 + r54;
+    r54 = r54 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r54, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r53, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r60);
+    r60 = sqrtf(r35);
+    r51 = copysign(1.0, r60);
+    r51 = fmaf(r53, r51, r60);
+    r53 = r51 * r51;
+    r47 = 1.0 / r53;
+    r60 = atanf(r60);
+    r57 = r60 * r37;
+    r62 = r60 * r57;
+    r52 = r52 * r47;
+    r52 = r52 * r62;
+    r63 = r10 * r47;
+    r64 = r10 * r63;
+    r65 = r62 * r64;
+    r66 = r52 + r65;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r67,
+                                         r68,
+                                         r69,
+                                         r70);
+    r71 = 3.00000000000000000e+00;
+    r72 = r71 * r62;
+    r72 = fmaf(r64, r72, r52);
+    r72 = fmaf(r68, r72, r8 * r66);
+    r52 = r67 * r11;
+    r73 = r16 * r62;
+    r52 = r52 * r63;
+    r72 = fmaf(r73, r52, r72);
+    r74 = r66 * r66;
+    r75 = r66 * r74;
+    r76 = fmaf(r69, r75, r6 * r66);
+    r75 = r70 * r75;
+    r76 = fmaf(r66, r75, r76);
+    r76 = fmaf(r7, r74, r76);
+    r70 = 1.0 / r36;
+    r77 = 1.0 / r51;
+    r78 = r70 * r77;
+    r79 = r60 * r78;
+    r80 = r76 * r79;
+    r72 = fmaf(r10, r80, r72);
+    r72 = fmaf(r10, r79, r72);
+    r2 = fmaf(r0, r72, r2);
+    r72 = r11 * r11;
+    r72 = r72 * r71;
+    r72 = r72 * r47;
+    r72 = fmaf(r62, r72, r65);
+    r72 = fmaf(r67, r72, r9 * r66);
+    r65 = r68 * r11;
+    r65 = r65 * r63;
+    r72 = fmaf(r73, r65, r72);
+    r72 = fmaf(r11, r80, r72);
+    r72 = fmaf(r11, r79, r72);
+    r72 = fmaf(r5, r72, r1);
+    r72 = fmaf(r3, r4, r72);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r72);
+    r3 = r10 * r47;
+    r1 = -5.00000000000000000e-01;
+    r65 = rsqrtf(r35);
+    r52 = r16 * r11;
+    r81 = r25 * r41;
+    r82 = r17 * r24;
+    r83 = r20 * r21;
+    r83 = fmaf(r1, r83, r1 * r82);
+    r82 = r19 * r22;
+    r83 = fmaf(r1, r82, r83);
+    r84 = r18 * r23;
+    r85 = 5.00000000000000000e-01;
+    r83 = fmaf(r85, r84, r83);
+    r84 = r20 * r24;
+    r82 = r17 * r21;
+    r82 = fmaf(r1, r82, r85 * r84);
+    r84 = r18 * r22;
+    r82 = fmaf(r1, r84, r82);
+    r86 = r19 * r23;
+    r82 = fmaf(r1, r86, r82);
+    r86 = r34 * r82;
+    r84 = r41 * r86;
+    r81 = fmaf(r83, r81, r84);
+    r87 = r16 * r29;
+    r88 = fmaf(r85, r31, r1 * r27);
+    r88 = fmaf(r1, r28, r88);
+    r88 = fmaf(r1, r30, r88);
+    r87 = r87 * r88;
+    r89 = r16 * r32;
+    r90 = r19 * r24;
+    r91 = r18 * r21;
+    r91 = fmaf(r85, r91, r85 * r90);
+    r90 = r17 * r22;
+    r91 = fmaf(r1, r90, r91);
+    r92 = r20 * r23;
+    r91 = fmaf(r85, r92, r91);
+    r89 = fmaf(r91, r89, r87);
+    r81 = r81 + r89;
+    r92 = r25 * r82;
+    r90 = -4.00000000000000000e+00;
+    r92 = r92 * r90;
+    r93 = r32 * r88;
+    r94 = r90 * r93;
+    r95 = r92 + r94;
+    r95 = fmaf(r14, r95, r15 * r81);
+    r81 = r16 * r25;
+    r81 = r81 * r91;
+    r96 = r16 * r34;
+    r96 = fmaf(r88, r96, r81);
+    r97 = r16 * r29;
+    r97 = r97 * r82;
+    r98 = r16 * r32;
+    r98 = fmaf(r83, r98, r97);
+    r96 = r96 + r98;
+    r95 = fmaf(r13, r96, r95);
+    r52 = r52 * r95;
+    r96 = r16 * r10;
+    r99 = r16 * r34;
+    r100 = r29 * r83;
+    r99 = fmaf(r16, r100, r91 * r99);
+    r101 = r16 * r25;
+    r102 = r16 * r32;
+    r102 = r102 * r82;
+    r101 = fmaf(r88, r101, r102);
+    r99 = r99 + r101;
+    r81 = r97 + r81;
+    r97 = r32 * r41;
+    r81 = fmaf(r83, r97, r81);
+    r103 = r41 * r34;
+    r81 = fmaf(r88, r103, r81);
+    r81 = fmaf(r14, r81, r15 * r99);
+    r99 = r29 * r91;
+    r99 = r99 * r90;
+    r94 = r99 + r94;
+    r81 = fmaf(r13, r94, r81);
+    r96 = r96 * r81;
+    r96 = fmaf(r37, r96, r37 * r52);
+    r52 = r16 * r25;
+    r52 = r52 * r83;
+    r86 = r16 * r86;
+    r94 = r52 + r86;
+    r89 = r89 + r94;
+    r103 = r41 * r34;
+    r103 = fmaf(r41, r100, r91 * r103);
+    r103 = r103 + r101;
+    r103 = fmaf(r13, r103, r14 * r89);
+    r99 = r92 + r99;
+    r103 = fmaf(r15, r99, r103);
+    r99 = r11 * r11;
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r36 = r41 * r12;
+    r99 = r99 * r36;
+    r92 = r10 * r10;
+    r92 = r92 * r103;
+    r96 = fmaf(r36, r92, r96);
+    r96 = fmaf(r103, r99, r96);
+    r3 = r3 * r60;
+    r3 = r3 * r70;
+    r3 = r3 * r1;
+    r3 = r3 * r65;
+    r3 = r3 * r96;
+    r92 = 6.00000000000000000e+00;
+    r89 = r81 * r92;
+    r89 = r89 * r62;
+    r91 = r71 * r96;
+    r35 = r42 + r35;
+    r35 = 1.0 / r35;
+    r97 = r35 * r57;
+    r91 = r91 * r65;
+    r91 = r91 * r97;
+    r91 = fmaf(r64, r91, r63 * r89);
+    r89 = -6.00000000000000000e+00;
+    r104 = r89 * r12;
+    r105 = r60 * r60;
+    r106 = r64 * r105;
+    r104 = r104 * r106;
+    r107 = r10 * r10;
+    r108 = -3.00000000000000000e+00;
+    r53 = r51 * r53;
+    r53 = 1.0 / r53;
+    r107 = r107 * r108;
+    r107 = r107 * r96;
+    r107 = r107 * r65;
+    r107 = r107 * r53;
+    r91 = fmaf(r62, r107, r91);
+    r51 = r11 * r47;
+    r109 = r73 * r51;
+    r110 = r11 * r65;
+    r111 = r96 * r110;
+    r111 = r111 * r97;
+    r111 = fmaf(r51, r111, r95 * r109);
+    r112 = r4 * r11;
+    r113 = r53 * r62;
+    r113 = r113 * r110;
+    r112 = r112 * r96;
+    r111 = fmaf(r113, r112, r111);
+    r105 = r47 * r105;
+    r105 = r105 * r99;
+    r111 = fmaf(r103, r105, r111);
+    r91 = fmaf(r103, r104, r91);
+    r91 = r91 + r111;
+    r91 = fmaf(r68, r91, r3);
+    r107 = r81 * r63;
+    r112 = r96 * r65;
+    r112 = r112 * r97;
+    r112 = fmaf(r64, r112, r73 * r107);
+    r107 = r103 * r36;
+    r112 = fmaf(r106, r107, r112);
+    r114 = r4 * r10;
+    r114 = r114 * r10;
+    r114 = r114 * r96;
+    r114 = r114 * r65;
+    r114 = r114 * r53;
+    r112 = fmaf(r62, r114, r112);
+    r111 = r111 + r112;
+    r114 = r67 * r96;
+    r107 = r16 * r63;
+    r107 = r107 * r110;
+    r107 = r107 * r97;
+    r91 = fmaf(r107, r114, r91);
+    r115 = r67 * r11;
+    r115 = r115 * r60;
+    r115 = r115 * r60;
+    r115 = r115 * r90;
+    r115 = r115 * r12;
+    r115 = r115 * r63;
+    r116 = r10 * r85;
+    r116 = r116 * r65;
+    r116 = r116 * r35;
+    r116 = r116 * r78;
+    r117 = r76 * r116;
+    r118 = r67 * r81;
+    r91 = fmaf(r109, r118, r91);
+    r119 = r4 * r10;
+    r119 = r119 * r103;
+    r119 = r119 * r77;
+    r91 = fmaf(r57, r119, r91);
+    r120 = r4 * r10;
+    r120 = r120 * r76;
+    r120 = r120 * r103;
+    r120 = r120 * r77;
+    r91 = fmaf(r57, r120, r91);
+    r121 = r67 * r41;
+    r121 = r121 * r10;
+    r121 = r121 * r96;
+    r91 = fmaf(r113, r121, r91);
+    r122 = r7 * r16;
+    r122 = r122 * r66;
+    r122 = fmaf(r111, r122, r6 * r111);
+    r123 = 4.00000000000000000e+00;
+    r75 = r123 * r75;
+    r69 = r69 * r71;
+    r69 = r69 * r74;
+    r122 = fmaf(r111, r75, r122);
+    r122 = fmaf(r111, r69, r122);
+    r74 = r10 * r122;
+    r91 = fmaf(r79, r74, r91);
+    r123 = r67 * r95;
+    r123 = r123 * r63;
+    r91 = fmaf(r73, r123, r91);
+    r91 = fmaf(r8, r111, r91);
+    r91 = fmaf(r76, r3, r91);
+    r91 = fmaf(r103, r115, r91);
+    r91 = fmaf(r96, r117, r91);
+    r91 = fmaf(r81, r79, r91);
+    r91 = fmaf(r96, r116, r91);
+    r91 = fmaf(r81, r80, r91);
+    r123 = r0 * r91;
+    r74 = r11 * r95;
+    r74 = r74 * r92;
+    r74 = r74 * r47;
+    r121 = r71 * r96;
+    r121 = r121 * r110;
+    r121 = r121 * r97;
+    r121 = fmaf(r51, r121, r62 * r74);
+    r74 = r11 * r108;
+    r74 = r74 * r96;
+    r121 = fmaf(r113, r74, r121);
+    r120 = r11 * r11;
+    r120 = r120 * r60;
+    r120 = r120 * r60;
+    r120 = r120 * r103;
+    r120 = r120 * r89;
+    r120 = r120 * r47;
+    r121 = fmaf(r12, r120, r121);
+    r121 = r121 + r112;
+    r111 = fmaf(r9, r111, r67 * r121);
+    r121 = r11 * r47;
+    r121 = r121 * r60;
+    r121 = r121 * r70;
+    r121 = r121 * r1;
+    r121 = r121 * r65;
+    r121 = r121 * r96;
+    r112 = r85 * r96;
+    r112 = r112 * r35;
+    r112 = r112 * r110;
+    r111 = fmaf(r78, r112, r111);
+    r120 = r11 * r122;
+    r111 = fmaf(r79, r120, r111);
+    r74 = r4 * r11;
+    r74 = r74 * r76;
+    r74 = r74 * r103;
+    r74 = r74 * r77;
+    r111 = fmaf(r57, r74, r111);
+    r119 = r68 * r11;
+    r119 = r119 * r60;
+    r119 = r119 * r60;
+    r119 = r119 * r90;
+    r119 = r119 * r103;
+    r119 = r119 * r12;
+    r111 = fmaf(r63, r119, r111);
+    r118 = r68 * r81;
+    r111 = fmaf(r109, r118, r111);
+    r114 = r68 * r96;
+    r111 = fmaf(r107, r114, r111);
+    r3 = r4 * r11;
+    r3 = r3 * r103;
+    r3 = r3 * r77;
+    r111 = fmaf(r57, r3, r111);
+    r124 = r68 * r41;
+    r124 = r124 * r10;
+    r124 = r124 * r113;
+    r125 = r85 * r76;
+    r125 = r125 * r96;
+    r125 = r125 * r35;
+    r125 = r125 * r110;
+    r111 = fmaf(r78, r125, r111);
+    r126 = r68 * r95;
+    r126 = r126 * r63;
+    r111 = fmaf(r73, r126, r111);
+    r111 = r111 + r121;
+    r111 = fmaf(r76, r121, r111);
+    r111 = fmaf(r96, r124, r111);
+    r111 = fmaf(r95, r80, r111);
+    r111 = fmaf(r95, r79, r111);
+    r126 = r5 * r111;
+    r125 = r16 * r10;
+    r86 = r87 + r86;
+    r87 = r16 * r32;
+    r3 = r19 * r24;
+    r114 = r18 * r21;
+    r114 = fmaf(r1, r114, r1 * r3);
+    r3 = r17 * r22;
+    r114 = fmaf(r85, r3, r114);
+    r118 = r20 * r23;
+    r114 = fmaf(r1, r118, r114);
+    r87 = r87 * r114;
+    r118 = r16 * r25;
+    r3 = r17 * r24;
+    r119 = r20 * r21;
+    r119 = fmaf(r85, r119, r85 * r3);
+    r3 = r19 * r22;
+    r119 = fmaf(r85, r3, r119);
+    r74 = r18 * r23;
+    r119 = fmaf(r1, r74, r119);
+    r118 = fmaf(r119, r118, r87);
+    r86 = r86 + r118;
+    r74 = r32 * r90;
+    r74 = r74 * r119;
+    r3 = r29 * r82;
+    r3 = r3 * r90;
+    r120 = r74 + r3;
+    r120 = fmaf(r13, r120, r15 * r86);
+    r86 = r41 * r34;
+    r86 = fmaf(r41, r93, r119 * r86);
+    r121 = r16 * r25;
+    r121 = r121 * r82;
+    r112 = r16 * r29;
+    r112 = fmaf(r114, r112, r121);
+    r86 = r86 + r112;
+    r120 = fmaf(r14, r86, r120);
+    r125 = r125 * r120;
+    r86 = r10 * r10;
+    r127 = r41 * r29;
+    r127 = fmaf(r88, r127, r84);
+    r127 = r127 + r118;
+    r118 = r16 * r29;
+    r118 = r118 * r119;
+    r128 = r16 * r34;
+    r128 = fmaf(r114, r128, r118);
+    r128 = r128 + r101;
+    r128 = fmaf(r14, r128, r13 * r127);
+    r127 = r25 * r114;
+    r101 = r90 * r127;
+    r3 = r3 + r101;
+    r128 = fmaf(r15, r3, r128);
+    r86 = r86 * r128;
+    r86 = fmaf(r36, r86, r37 * r125);
+    r125 = r16 * r11;
+    r3 = r25 * r41;
+    r3 = fmaf(r88, r3, r102);
+    r102 = r41 * r34;
+    r3 = fmaf(r114, r102, r3);
+    r3 = r3 + r118;
+    r102 = r16 * r34;
+    r93 = fmaf(r16, r93, r119 * r102);
+    r93 = r93 + r112;
+    r93 = fmaf(r13, r93, r15 * r3);
+    r101 = r74 + r101;
+    r93 = fmaf(r14, r101, r93);
+    r125 = r125 * r93;
+    r86 = fmaf(r37, r125, r86);
+    r86 = fmaf(r128, r99, r86);
+    r125 = r86 * r65;
+    r125 = r125 * r97;
+    r101 = r4 * r10;
+    r101 = r101 * r10;
+    r101 = r101 * r86;
+    r101 = r101 * r65;
+    r101 = r101 * r53;
+    r101 = fmaf(r62, r101, r64 * r125);
+    r125 = r128 * r36;
+    r101 = fmaf(r106, r125, r101);
+    r74 = r120 * r63;
+    r101 = fmaf(r73, r74, r101);
+    r74 = r4 * r11;
+    r74 = r74 * r86;
+    r74 = fmaf(r113, r74, r93 * r109);
+    r125 = r86 * r110;
+    r125 = r125 * r97;
+    r74 = fmaf(r51, r125, r74);
+    r74 = fmaf(r128, r105, r74);
+    r125 = r101 + r74;
+    r3 = r71 * r86;
+    r3 = r3 * r65;
+    r3 = r3 * r97;
+    r102 = r10 * r10;
+    r119 = r108 * r86;
+    r102 = r102 * r65;
+    r102 = r102 * r53;
+    r102 = r102 * r62;
+    r102 = fmaf(r119, r102, r64 * r3);
+    r3 = r92 * r120;
+    r3 = r3 * r62;
+    r102 = fmaf(r63, r3, r102);
+    r102 = fmaf(r128, r104, r102);
+    r102 = r102 + r74;
+    r102 = fmaf(r68, r102, r8 * r125);
+    r74 = r67 * r93;
+    r74 = r74 * r63;
+    r102 = fmaf(r73, r74, r102);
+    r3 = r60 * r1;
+    r3 = r3 * r86;
+    r3 = r3 * r70;
+    r3 = r3 * r65;
+    r102 = fmaf(r63, r3, r102);
+    r118 = r4 * r10;
+    r118 = r118 * r128;
+    r118 = r118 * r77;
+    r102 = fmaf(r57, r118, r102);
+    r88 = r67 * r41;
+    r88 = r88 * r10;
+    r88 = r88 * r86;
+    r102 = fmaf(r113, r88, r102);
+    r129 = r67 * r86;
+    r102 = fmaf(r107, r129, r102);
+    r130 = r4 * r10;
+    r130 = r130 * r76;
+    r130 = r130 * r128;
+    r130 = r130 * r77;
+    r102 = fmaf(r57, r130, r102);
+    r131 = r67 * r120;
+    r102 = fmaf(r109, r131, r102);
+    r132 = r7 * r16;
+    r132 = r132 * r66;
+    r132 = fmaf(r125, r132, r6 * r125);
+    r132 = fmaf(r125, r75, r132);
+    r132 = fmaf(r125, r69, r132);
+    r133 = r10 * r132;
+    r102 = fmaf(r79, r133, r102);
+    r134 = r60 * r76;
+    r134 = r134 * r1;
+    r134 = r134 * r86;
+    r134 = r134 * r70;
+    r134 = r134 * r65;
+    r102 = fmaf(r63, r134, r102);
+    r102 = fmaf(r128, r115, r102);
+    r102 = fmaf(r86, r117, r102);
+    r102 = fmaf(r120, r80, r102);
+    r102 = fmaf(r86, r116, r102);
+    r102 = fmaf(r120, r79, r102);
+    r134 = r0 * r102;
+    r133 = r11 * r92;
+    r133 = r133 * r93;
+    r133 = r133 * r47;
+    r131 = r11 * r113;
+    r131 = fmaf(r119, r131, r62 * r133);
+    r133 = r11 * r11;
+    r133 = r133 * r60;
+    r133 = r133 * r60;
+    r133 = r133 * r89;
+    r133 = r133 * r128;
+    r133 = r133 * r47;
+    r131 = fmaf(r12, r133, r131);
+    r119 = r71 * r86;
+    r119 = r119 * r110;
+    r119 = r119 * r97;
+    r131 = fmaf(r51, r119, r131);
+    r131 = r131 + r101;
+    r131 = fmaf(r67, r131, r9 * r125);
+    r125 = r4 * r11;
+    r125 = r125 * r128;
+    r125 = r125 * r77;
+    r131 = fmaf(r57, r125, r131);
+    r101 = r68 * r93;
+    r101 = r101 * r63;
+    r131 = fmaf(r73, r101, r131);
+    r119 = r68 * r11;
+    r119 = r119 * r60;
+    r119 = r119 * r60;
+    r119 = r119 * r90;
+    r119 = r119 * r128;
+    r119 = r119 * r12;
+    r131 = fmaf(r63, r119, r131);
+    r133 = r85 * r76;
+    r133 = r133 * r86;
+    r133 = r133 * r35;
+    r133 = r133 * r110;
+    r131 = fmaf(r78, r133, r131);
+    r130 = r60 * r76;
+    r130 = r130 * r1;
+    r130 = r130 * r86;
+    r130 = r130 * r47;
+    r130 = r130 * r70;
+    r131 = fmaf(r110, r130, r131);
+    r129 = r11 * r132;
+    r131 = fmaf(r79, r129, r131);
+    r88 = r85 * r86;
+    r88 = r88 * r35;
+    r88 = r88 * r110;
+    r131 = fmaf(r78, r88, r131);
+    r118 = r60 * r1;
+    r118 = r118 * r86;
+    r118 = r118 * r47;
+    r118 = r118 * r70;
+    r131 = fmaf(r110, r118, r131);
+    r3 = r68 * r86;
+    r131 = fmaf(r107, r3, r131);
+    r74 = r68 * r120;
+    r131 = fmaf(r109, r74, r131);
+    r135 = r4 * r11;
+    r135 = r135 * r76;
+    r135 = r135 * r128;
+    r135 = r135 * r77;
+    r131 = fmaf(r57, r135, r131);
+    r131 = fmaf(r86, r124, r131);
+    r131 = fmaf(r93, r80, r131);
+    r131 = fmaf(r93, r79, r131);
+    r135 = r5 * r131;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r123,
+                                          r126,
+                                          r134,
+                                          r135);
+    r135 = r10 * r10;
+    r134 = r25 * r90;
+    r31 = fmaf(r1, r31, r85 * r27);
+    r31 = fmaf(r85, r28, r31);
+    r31 = fmaf(r85, r30, r31);
+    r134 = r134 * r31;
+    r100 = r90 * r100;
+    r30 = r134 + r100;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r121 = r121 + r28;
+    r27 = r41 * r29;
+    r121 = fmaf(r114, r27, r121);
+    r126 = r41 * r34;
+    r121 = fmaf(r83, r126, r121);
+    r121 = fmaf(r13, r121, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r127, r31 * r30);
+    r30 = r30 + r98;
+    r121 = fmaf(r14, r30, r121);
+    r135 = r135 * r121;
+    r30 = r16 * r10;
+    r126 = r16 * r29;
+    r126 = r126 * r31;
+    r52 = r52 + r126;
+    r27 = r32 * r41;
+    r52 = fmaf(r114, r27, r52);
+    r52 = r52 + r84;
+    r82 = r32 * r82;
+    r82 = r82 * r90;
+    r100 = r82 + r100;
+    r100 = fmaf(r13, r100, r14 * r52);
+    r52 = r16 * r34;
+    r52 = fmaf(r83, r52, r28);
+    r52 = r52 + r112;
+    r100 = fmaf(r15, r52, r100);
+    r30 = r30 * r100;
+    r30 = fmaf(r37, r30, r36 * r135);
+    r135 = r16 * r11;
+    r126 = r87 + r126;
+    r126 = r126 + r94;
+    r94 = r41 * r34;
+    r127 = fmaf(r41, r127, r31 * r94);
+    r127 = r127 + r98;
+    r127 = fmaf(r15, r127, r13 * r126);
+    r82 = r134 + r82;
+    r127 = fmaf(r14, r82, r127);
+    r135 = r135 * r127;
+    r30 = fmaf(r37, r135, r30);
+    r30 = fmaf(r121, r99, r30);
+    r135 = r30 * r110;
+    r135 = r135 * r97;
+    r135 = fmaf(r127, r109, r51 * r135);
+    r82 = r4 * r11;
+    r82 = r82 * r30;
+    r135 = fmaf(r113, r82, r135);
+    r135 = fmaf(r121, r105, r135);
+    r82 = r121 * r36;
+    r14 = r30 * r65;
+    r14 = r14 * r97;
+    r14 = fmaf(r64, r14, r106 * r82);
+    r82 = r4 * r10;
+    r82 = r82 * r10;
+    r82 = r82 * r30;
+    r82 = r82 * r65;
+    r82 = r82 * r53;
+    r14 = fmaf(r62, r82, r14);
+    r134 = r100 * r63;
+    r14 = fmaf(r73, r134, r14);
+    r134 = r135 + r14;
+    r82 = r71 * r30;
+    r82 = r82 * r65;
+    r82 = r82 * r97;
+    r82 = fmaf(r64, r82, r121 * r104);
+    r15 = r10 * r10;
+    r15 = r15 * r108;
+    r15 = r15 * r30;
+    r15 = r15 * r65;
+    r15 = r15 * r53;
+    r82 = fmaf(r62, r15, r82);
+    r126 = r92 * r100;
+    r126 = r126 * r62;
+    r82 = fmaf(r63, r126, r82);
+    r82 = r82 + r135;
+    r82 = fmaf(r68, r82, r8 * r134);
+    r135 = r7 * r16;
+    r135 = r135 * r66;
+    r135 = fmaf(r134, r135, r6 * r134);
+    r135 = fmaf(r134, r69, r135);
+    r135 = fmaf(r134, r75, r135);
+    r126 = r10 * r135;
+    r82 = fmaf(r79, r126, r82);
+    r15 = r60 * r76;
+    r15 = r15 * r1;
+    r15 = r15 * r30;
+    r15 = r15 * r70;
+    r15 = r15 * r65;
+    r82 = fmaf(r63, r15, r82);
+    r13 = r4 * r10;
+    r13 = r13 * r121;
+    r13 = r13 * r77;
+    r82 = fmaf(r57, r13, r82);
+    r98 = r67 * r41;
+    r98 = r98 * r10;
+    r98 = r98 * r30;
+    r82 = fmaf(r113, r98, r82);
+    r94 = r67 * r100;
+    r82 = fmaf(r109, r94, r82);
+    r31 = r67 * r127;
+    r31 = r31 * r63;
+    r82 = fmaf(r73, r31, r82);
+    r87 = r60 * r1;
+    r87 = r87 * r30;
+    r87 = r87 * r70;
+    r87 = r87 * r65;
+    r82 = fmaf(r63, r87, r82);
+    r52 = r4 * r10;
+    r52 = r52 * r76;
+    r52 = r52 * r121;
+    r52 = r52 * r77;
+    r82 = fmaf(r57, r52, r82);
+    r112 = r67 * r30;
+    r82 = fmaf(r107, r112, r82);
+    r82 = fmaf(r121, r115, r82);
+    r82 = fmaf(r30, r116, r82);
+    r82 = fmaf(r100, r80, r82);
+    r82 = fmaf(r30, r117, r82);
+    r82 = fmaf(r100, r79, r82);
+    r112 = r0 * r82;
+    r52 = r71 * r30;
+    r52 = r52 * r110;
+    r52 = r52 * r97;
+    r87 = r11 * r92;
+    r87 = r87 * r127;
+    r87 = r87 * r47;
+    r87 = fmaf(r62, r87, r51 * r52);
+    r52 = r11 * r11;
+    r52 = r52 * r60;
+    r52 = r52 * r60;
+    r52 = r52 * r89;
+    r52 = r52 * r121;
+    r52 = r52 * r47;
+    r87 = fmaf(r12, r52, r87);
+    r31 = r11 * r108;
+    r31 = r31 * r30;
+    r87 = fmaf(r113, r31, r87);
+    r87 = r87 + r14;
+    r87 = fmaf(r67, r87, r9 * r134);
+    r134 = r68 * r11;
+    r134 = r134 * r60;
+    r134 = r134 * r60;
+    r134 = r134 * r90;
+    r134 = r134 * r121;
+    r134 = r134 * r12;
+    r87 = fmaf(r63, r134, r87);
+    r14 = r60 * r1;
+    r14 = r14 * r30;
+    r14 = r14 * r47;
+    r14 = r14 * r70;
+    r87 = fmaf(r110, r14, r87);
+    r31 = r85 * r30;
+    r31 = r31 * r35;
+    r31 = r31 * r110;
+    r87 = fmaf(r78, r31, r87);
+    r52 = r4 * r11;
+    r52 = r52 * r76;
+    r52 = r52 * r121;
+    r52 = r52 * r77;
+    r87 = fmaf(r57, r52, r87);
+    r94 = r68 * r100;
+    r87 = fmaf(r109, r94, r87);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r30;
+    r98 = r98 * r47;
+    r98 = r98 * r70;
+    r87 = fmaf(r110, r98, r87);
+    r13 = r68 * r127;
+    r13 = r13 * r63;
+    r87 = fmaf(r73, r13, r87);
+    r15 = r4 * r11;
+    r15 = r15 * r121;
+    r15 = r15 * r77;
+    r87 = fmaf(r57, r15, r87);
+    r126 = r68 * r30;
+    r87 = fmaf(r107, r126, r87);
+    r28 = r11 * r135;
+    r87 = fmaf(r79, r28, r87);
+    r83 = r85 * r76;
+    r83 = r83 * r30;
+    r83 = r83 * r35;
+    r83 = r83 * r110;
+    r87 = fmaf(r78, r83, r87);
+    r87 = fmaf(r127, r80, r87);
+    r87 = fmaf(r30, r124, r87);
+    r87 = fmaf(r127, r79, r87);
+    r83 = r5 * r87;
+    r28 = r43 * r92;
+    r28 = r28 * r62;
+    r28 = fmaf(r63, r28, r26 * r104);
+    r126 = r10 * r10;
+    r15 = r16 * r39;
+    r15 = r15 * r11;
+    r15 = fmaf(r37, r15, r26 * r99);
+    r13 = r26 * r10;
+    r13 = r13 * r10;
+    r15 = fmaf(r36, r13, r15);
+    r98 = r16 * r43;
+    r98 = r98 * r10;
+    r15 = fmaf(r37, r98, r15);
+    r126 = r126 * r108;
+    r126 = r126 * r15;
+    r126 = r126 * r65;
+    r126 = r126 * r53;
+    r28 = fmaf(r62, r126, r28);
+    r98 = r71 * r15;
+    r98 = r98 * r65;
+    r98 = r98 * r97;
+    r28 = fmaf(r64, r98, r28);
+    r13 = fmaf(r39, r109, r26 * r105);
+    r94 = r4 * r11;
+    r94 = r94 * r15;
+    r13 = fmaf(r113, r94, r13);
+    r52 = r15 * r110;
+    r52 = r52 * r97;
+    r13 = fmaf(r51, r52, r13);
+    r28 = r28 + r13;
+    r98 = r26 * r36;
+    r126 = r43 * r63;
+    r126 = fmaf(r73, r126, r106 * r98);
+    r98 = r4 * r10;
+    r98 = r98 * r10;
+    r98 = r98 * r15;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r126 = fmaf(r62, r98, r126);
+    r52 = r15 * r65;
+    r52 = r52 * r97;
+    r126 = fmaf(r64, r52, r126);
+    r13 = r13 + r126;
+    r28 = fmaf(r8, r13, r68 * r28);
+    r52 = r4 * r26;
+    r52 = r52 * r10;
+    r52 = r52 * r77;
+    r28 = fmaf(r57, r52, r28);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r15;
+    r98 = r98 * r70;
+    r98 = r98 * r65;
+    r28 = fmaf(r63, r98, r28);
+    r94 = r67 * r41;
+    r94 = r94 * r10;
+    r94 = r94 * r15;
+    r28 = fmaf(r113, r94, r28);
+    r31 = r67 * r15;
+    r28 = fmaf(r107, r31, r28);
+    r14 = r43 * r109;
+    r134 = r60 * r1;
+    r134 = r134 * r15;
+    r134 = r134 * r70;
+    r134 = r134 * r65;
+    r28 = fmaf(r63, r134, r28);
+    r84 = r67 * r39;
+    r84 = r84 * r63;
+    r28 = fmaf(r73, r84, r28);
+    r27 = r7 * r16;
+    r27 = r27 * r66;
+    r27 = fmaf(r6, r13, r13 * r27);
+    r27 = fmaf(r13, r75, r27);
+    r27 = fmaf(r13, r69, r27);
+    r114 = r10 * r27;
+    r28 = fmaf(r79, r114, r28);
+    r123 = r4 * r26;
+    r123 = r123 * r10;
+    r123 = r123 * r76;
+    r123 = r123 * r77;
+    r28 = fmaf(r57, r123, r28);
+    r28 = fmaf(r43, r79, r28);
+    r28 = fmaf(r43, r80, r28);
+    r28 = fmaf(r67, r14, r28);
+    r28 = fmaf(r15, r117, r28);
+    r28 = fmaf(r26, r115, r28);
+    r28 = fmaf(r15, r116, r28);
+    r123 = r0 * r28;
+    r114 = r26 * r11;
+    r114 = r114 * r11;
+    r114 = r114 * r60;
+    r114 = r114 * r60;
+    r114 = r114 * r89;
+    r114 = r114 * r47;
+    r84 = r39 * r11;
+    r84 = r84 * r92;
+    r84 = r84 * r47;
+    r84 = fmaf(r62, r84, r12 * r114);
+    r114 = r11 * r108;
+    r114 = r114 * r15;
+    r84 = fmaf(r113, r114, r84);
+    r134 = r71 * r15;
+    r134 = r134 * r110;
+    r134 = r134 * r97;
+    r84 = fmaf(r51, r134, r84);
+    r84 = r84 + r126;
+    r13 = fmaf(r9, r13, r67 * r84);
+    r84 = r4 * r26;
+    r84 = r84 * r11;
+    r84 = r84 * r77;
+    r13 = fmaf(r57, r84, r13);
+    r126 = r4 * r26;
+    r126 = r126 * r11;
+    r126 = r126 * r76;
+    r126 = r126 * r77;
+    r13 = fmaf(r57, r126, r13);
+    r134 = r60 * r1;
+    r134 = r134 * r15;
+    r134 = r134 * r47;
+    r134 = r134 * r70;
+    r13 = fmaf(r110, r134, r13);
+    r114 = r60 * r76;
+    r114 = r114 * r1;
+    r114 = r114 * r15;
+    r114 = r114 * r47;
+    r114 = r114 * r70;
+    r13 = fmaf(r110, r114, r13);
+    r31 = r68 * r15;
+    r13 = fmaf(r107, r31, r13);
+    r94 = r85 * r15;
+    r94 = r94 * r35;
+    r94 = r94 * r110;
+    r13 = fmaf(r78, r94, r13);
+    r98 = r68 * r26;
+    r98 = r98 * r11;
+    r98 = r98 * r60;
+    r98 = r98 * r60;
+    r98 = r98 * r90;
+    r98 = r98 * r12;
+    r13 = fmaf(r63, r98, r13);
+    r52 = r68 * r39;
+    r52 = r52 * r63;
+    r13 = fmaf(r73, r52, r13);
+    r74 = r85 * r76;
+    r74 = r74 * r15;
+    r74 = r74 * r35;
+    r74 = r74 * r110;
+    r13 = fmaf(r78, r74, r13);
+    r3 = r11 * r27;
+    r13 = fmaf(r79, r3, r13);
+    r13 = fmaf(r39, r79, r13);
+    r13 = fmaf(r39, r80, r13);
+    r13 = fmaf(r15, r124, r13);
+    r13 = fmaf(r68, r14, r13);
+    r3 = r5 * r13;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r112,
+                                          r83,
+                                          r123,
+                                          r3);
+    r3 = r16 * r44;
+    r3 = r3 * r11;
+    r3 = fmaf(r37, r3, r40 * r99);
+    r123 = r40 * r10;
+    r123 = r123 * r10;
+    r3 = fmaf(r36, r123, r3);
+    r83 = r16 * r59;
+    r83 = r83 * r10;
+    r3 = fmaf(r37, r83, r3);
+    r83 = r3 * r110;
+    r83 = r83 * r97;
+    r83 = fmaf(r40, r105, r51 * r83);
+    r123 = r4 * r11;
+    r123 = r123 * r3;
+    r83 = fmaf(r113, r123, r83);
+    r83 = fmaf(r44, r109, r83);
+    r123 = r3 * r65;
+    r123 = r123 * r97;
+    r112 = r40 * r36;
+    r112 = fmaf(r106, r112, r64 * r123);
+    r123 = r59 * r63;
+    r112 = fmaf(r73, r123, r112);
+    r74 = r4 * r10;
+    r74 = r74 * r10;
+    r74 = r74 * r3;
+    r74 = r74 * r65;
+    r74 = r74 * r53;
+    r112 = fmaf(r62, r74, r112);
+    r74 = r83 + r112;
+    r123 = r71 * r3;
+    r123 = r123 * r65;
+    r123 = r123 * r97;
+    r123 = fmaf(r40, r104, r64 * r123);
+    r52 = r59 * r92;
+    r52 = r52 * r62;
+    r123 = fmaf(r63, r52, r123);
+    r98 = r10 * r10;
+    r98 = r98 * r108;
+    r98 = r98 * r3;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r123 = fmaf(r62, r98, r123);
+    r123 = r123 + r83;
+    r123 = fmaf(r68, r123, r8 * r74);
+    r83 = r7 * r16;
+    r83 = r83 * r66;
+    r83 = fmaf(r74, r83, r6 * r74);
+    r83 = fmaf(r74, r75, r83);
+    r83 = fmaf(r74, r69, r83);
+    r98 = r10 * r83;
+    r123 = fmaf(r79, r98, r123);
+    r52 = r67 * r44;
+    r52 = r52 * r63;
+    r123 = fmaf(r73, r52, r123);
+    r94 = r60 * r1;
+    r94 = r94 * r3;
+    r94 = r94 * r70;
+    r94 = r94 * r65;
+    r123 = fmaf(r63, r94, r123);
+    r14 = r67 * r3;
+    r123 = fmaf(r107, r14, r123);
+    r31 = r67 * r41;
+    r31 = r31 * r10;
+    r31 = r31 * r3;
+    r123 = fmaf(r113, r31, r123);
+    r114 = r60 * r76;
+    r114 = r114 * r1;
+    r114 = r114 * r3;
+    r114 = r114 * r70;
+    r114 = r114 * r65;
+    r123 = fmaf(r63, r114, r123);
+    r134 = r4 * r40;
+    r134 = r134 * r10;
+    r134 = r134 * r77;
+    r123 = fmaf(r57, r134, r123);
+    r126 = r67 * r59;
+    r123 = fmaf(r109, r126, r123);
+    r84 = r4 * r40;
+    r84 = r84 * r10;
+    r84 = r84 * r76;
+    r84 = r84 * r77;
+    r123 = fmaf(r57, r84, r123);
+    r123 = fmaf(r59, r80, r123);
+    r123 = fmaf(r59, r79, r123);
+    r123 = fmaf(r3, r116, r123);
+    r123 = fmaf(r40, r115, r123);
+    r123 = fmaf(r3, r117, r123);
+    r84 = r0 * r123;
+    r126 = r71 * r3;
+    r126 = r126 * r110;
+    r126 = r126 * r97;
+    r134 = r40 * r11;
+    r134 = r134 * r11;
+    r134 = r134 * r60;
+    r134 = r134 * r60;
+    r134 = r134 * r89;
+    r134 = r134 * r47;
+    r134 = fmaf(r12, r134, r51 * r126);
+    r126 = r44 * r11;
+    r126 = r126 * r92;
+    r126 = r126 * r47;
+    r134 = fmaf(r62, r126, r134);
+    r114 = r11 * r108;
+    r114 = r114 * r3;
+    r134 = fmaf(r113, r114, r134);
+    r134 = r134 + r112;
+    r134 = fmaf(r67, r134, r9 * r74);
+    r74 = r68 * r44;
+    r74 = r74 * r63;
+    r134 = fmaf(r73, r74, r134);
+    r112 = r4 * r40;
+    r112 = r112 * r11;
+    r112 = r112 * r77;
+    r134 = fmaf(r57, r112, r134);
+    r114 = r85 * r3;
+    r114 = r114 * r35;
+    r114 = r114 * r110;
+    r134 = fmaf(r78, r114, r134);
+    r126 = r68 * r3;
+    r134 = fmaf(r107, r126, r134);
+    r31 = r85 * r76;
+    r31 = r31 * r3;
+    r31 = r31 * r35;
+    r31 = r31 * r110;
+    r134 = fmaf(r78, r31, r134);
+    r14 = r68 * r40;
+    r14 = r14 * r11;
+    r14 = r14 * r60;
+    r14 = r14 * r60;
+    r14 = r14 * r90;
+    r14 = r14 * r12;
+    r134 = fmaf(r63, r14, r134);
+    r94 = r68 * r59;
+    r134 = fmaf(r109, r94, r134);
+    r52 = r4 * r40;
+    r52 = r52 * r11;
+    r52 = r52 * r76;
+    r52 = r52 * r77;
+    r134 = fmaf(r57, r52, r134);
+    r98 = r60 * r76;
+    r98 = r98 * r1;
+    r98 = r98 * r3;
+    r98 = r98 * r47;
+    r98 = r98 * r70;
+    r134 = fmaf(r110, r98, r134);
+    r118 = r11 * r83;
+    r134 = fmaf(r79, r118, r134);
+    r88 = r60 * r1;
+    r88 = r88 * r3;
+    r88 = r88 * r47;
+    r88 = r88 * r70;
+    r134 = fmaf(r110, r88, r134);
+    r134 = fmaf(r44, r80, r134);
+    r134 = fmaf(r3, r124, r134);
+    r134 = fmaf(r44, r79, r134);
+    r88 = r5 * r134;
+    r118 = r16 * r46;
+    r118 = r118 * r11;
+    r118 = fmaf(r38, r99, r37 * r118);
+    r98 = r16 * r58;
+    r98 = r98 * r10;
+    r118 = fmaf(r37, r98, r118);
+    r52 = r38 * r10;
+    r52 = r52 * r10;
+    r118 = fmaf(r36, r52, r118);
+    r52 = r118 * r110;
+    r52 = r52 * r97;
+    r52 = fmaf(r46, r109, r51 * r52);
+    r98 = r4 * r11;
+    r98 = r98 * r118;
+    r52 = fmaf(r113, r98, r52);
+    r52 = fmaf(r38, r105, r52);
+    r98 = r38 * r36;
+    r94 = r4 * r10;
+    r94 = r94 * r10;
+    r94 = r94 * r118;
+    r94 = r94 * r65;
+    r94 = r94 * r53;
+    r94 = fmaf(r62, r94, r106 * r98);
+    r98 = r58 * r63;
+    r94 = fmaf(r73, r98, r94);
+    r14 = r118 * r65;
+    r14 = r14 * r97;
+    r94 = fmaf(r64, r14, r94);
+    r14 = r52 + r94;
+    r98 = r10 * r10;
+    r98 = r98 * r108;
+    r98 = r98 * r118;
+    r98 = r98 * r65;
+    r98 = r98 * r53;
+    r98 = fmaf(r62, r98, r38 * r104);
+    r31 = r58 * r92;
+    r31 = r31 * r62;
+    r98 = fmaf(r63, r31, r98);
+    r126 = r71 * r118;
+    r126 = r126 * r65;
+    r126 = r126 * r97;
+    r98 = fmaf(r64, r126, r98);
+    r98 = r98 + r52;
+    r98 = fmaf(r68, r98, r8 * r14);
+    r52 = r4 * r38;
+    r52 = r52 * r10;
+    r52 = r52 * r76;
+    r52 = r52 * r77;
+    r98 = fmaf(r57, r52, r98);
+    r126 = r4 * r38;
+    r126 = r126 * r10;
+    r126 = r126 * r77;
+    r98 = fmaf(r57, r126, r98);
+    r31 = r60 * r1;
+    r31 = r31 * r118;
+    r31 = r31 * r70;
+    r31 = r31 * r65;
+    r98 = fmaf(r63, r31, r98);
+    r114 = r67 * r41;
+    r114 = r114 * r10;
+    r114 = r114 * r118;
+    r98 = fmaf(r113, r114, r98);
+    r112 = r67 * r118;
+    r98 = fmaf(r107, r112, r98);
+    r74 = r67 * r46;
+    r74 = r74 * r63;
+    r98 = fmaf(r73, r74, r98);
+    r129 = r67 * r58;
+    r98 = fmaf(r109, r129, r98);
+    r130 = r60 * r76;
+    r130 = r130 * r1;
+    r130 = r130 * r118;
+    r130 = r130 * r70;
+    r130 = r130 * r65;
+    r98 = fmaf(r63, r130, r98);
+    r133 = r7 * r16;
+    r133 = r133 * r66;
+    r133 = fmaf(r6, r14, r14 * r133);
+    r133 = fmaf(r14, r75, r133);
+    r133 = fmaf(r14, r69, r133);
+    r119 = r10 * r133;
+    r98 = fmaf(r79, r119, r98);
+    r98 = fmaf(r58, r79, r98);
+    r98 = fmaf(r58, r80, r98);
+    r98 = fmaf(r118, r117, r98);
+    r98 = fmaf(r118, r116, r98);
+    r98 = fmaf(r38, r115, r98);
+    r119 = r0 * r98;
+    r130 = r71 * r118;
+    r130 = r130 * r110;
+    r130 = r130 * r97;
+    r129 = r46 * r11;
+    r129 = r129 * r92;
+    r129 = r129 * r47;
+    r129 = fmaf(r62, r129, r51 * r130);
+    r130 = r11 * r108;
+    r130 = r130 * r118;
+    r129 = fmaf(r113, r130, r129);
+    r74 = r38 * r11;
+    r74 = r74 * r11;
+    r74 = r74 * r60;
+    r74 = r74 * r60;
+    r74 = r74 * r89;
+    r74 = r74 * r47;
+    r129 = fmaf(r12, r74, r129);
+    r129 = r129 + r94;
+    r129 = fmaf(r67, r129, r9 * r14);
+    r14 = r85 * r76;
+    r14 = r14 * r118;
+    r14 = r14 * r35;
+    r14 = r14 * r110;
+    r129 = fmaf(r78, r14, r129);
+    r94 = r85 * r118;
+    r94 = r94 * r35;
+    r94 = r94 * r110;
+    r129 = fmaf(r78, r94, r129);
+    r74 = r60 * r76;
+    r74 = r74 * r1;
+    r74 = r74 * r118;
+    r74 = r74 * r47;
+    r74 = r74 * r70;
+    r129 = fmaf(r110, r74, r129);
+    r130 = r60 * r1;
+    r130 = r130 * r118;
+    r130 = r130 * r47;
+    r130 = r130 * r70;
+    r129 = fmaf(r110, r130, r129);
+    r112 = r68 * r118;
+    r129 = fmaf(r107, r112, r129);
+    r114 = r68 * r46;
+    r114 = r114 * r63;
+    r129 = fmaf(r73, r114, r129);
+    r31 = r4 * r38;
+    r31 = r31 * r11;
+    r31 = r31 * r76;
+    r31 = r31 * r77;
+    r129 = fmaf(r57, r31, r129);
+    r126 = r68 * r58;
+    r129 = fmaf(r109, r126, r129);
+    r52 = r4 * r38;
+    r52 = r52 * r11;
+    r52 = r52 * r77;
+    r129 = fmaf(r57, r52, r129);
+    r101 = r11 * r133;
+    r129 = fmaf(r79, r101, r129);
+    r125 = r68 * r38;
+    r125 = r125 * r11;
+    r125 = r125 * r60;
+    r125 = r125 * r60;
+    r125 = r125 * r90;
+    r125 = r125 * r12;
+    r129 = fmaf(r63, r125, r129);
+    r129 = fmaf(r46, r80, r129);
+    r129 = fmaf(r118, r124, r129);
+    r129 = fmaf(r46, r79, r129);
+    r125 = r5 * r129;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r84,
+                                          r88,
+                                          r119,
+                                          r125);
+    r125 = r0 * r4;
+    r125 = r125 * r2;
+    r72 = r4 * r72;
+    r119 = r5 * r72;
+    r125 = fmaf(r111, r119, r91 * r125);
+    r88 = r0 * r4;
+    r88 = r88 * r2;
+    r88 = fmaf(r131, r119, r102 * r88);
+    r84 = r0 * r4;
+    r84 = r84 * r2;
+    r84 = fmaf(r87, r119, r82 * r84);
+    r101 = r0 * r4;
+    r101 = r101 * r2;
+    r101 = fmaf(r13, r119, r28 * r101);
+    WriteSum4<float, float>((float*)inout_shared, r125, r88, r84, r101);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r0 * r4;
+    r101 = r101 * r2;
+    r101 = fmaf(r134, r119, r123 * r101);
+    r84 = r0 * r4;
+    r84 = r84 * r2;
+    r84 = fmaf(r129, r119, r98 * r84);
+    WriteSum2<float, float>((float*)inout_shared, r101, r84);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r84 = r0 * r0;
+    r101 = r91 * r84;
+    r88 = r5 * r5;
+    r125 = r111 * r88;
+    r111 = fmaf(r111, r125, r91 * r101);
+    r91 = r102 * r102;
+    r52 = r131 * r131;
+    r52 = fmaf(r88, r52, r84 * r91);
+    r91 = r87 * r87;
+    r126 = r82 * r82;
+    r126 = fmaf(r84, r126, r88 * r91);
+    r91 = r28 * r28;
+    r31 = r13 * r13;
+    r31 = fmaf(r88, r31, r84 * r91);
+    WriteSum4<float, float>((float*)inout_shared, r111, r52, r126, r31);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r123 * r123;
+    r126 = r134 * r134;
+    r126 = fmaf(r88, r126, r84 * r31);
+    r31 = r129 * r129;
+    r52 = r98 * r98;
+    r52 = fmaf(r84, r52, r88 * r31);
+    WriteSum2<float, float>((float*)inout_shared, r126, r52);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r52 = fmaf(r102, r101, r131 * r125);
+    r126 = fmaf(r87, r125, r82 * r101);
+    r31 = fmaf(r28, r101, r13 * r125);
+    r111 = fmaf(r123, r101, r134 * r125);
+    WriteSum4<float, float>((float*)inout_shared, r52, r126, r31, r111);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r125 = fmaf(r129, r125, r98 * r101);
+    r101 = r131 * r87;
+    r111 = r102 * r82;
+    r111 = fmaf(r84, r111, r88 * r101);
+    r101 = r102 * r28;
+    r31 = r131 * r13;
+    r31 = fmaf(r88, r31, r84 * r101);
+    r101 = r102 * r123;
+    r126 = r131 * r134;
+    r126 = fmaf(r88, r126, r84 * r101);
+    WriteSum4<float, float>((float*)inout_shared, r125, r111, r31, r126);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r131 * r129;
+    r31 = r102 * r98;
+    r31 = fmaf(r84, r31, r88 * r126);
+    r126 = r87 * r13;
+    r111 = r82 * r28;
+    r111 = fmaf(r84, r111, r88 * r126);
+    r126 = r82 * r123;
+    r125 = r87 * r134;
+    r125 = fmaf(r88, r125, r84 * r126);
+    r126 = r87 * r129;
+    r101 = r82 * r98;
+    r101 = fmaf(r84, r101, r88 * r126);
+    WriteSum4<float, float>((float*)inout_shared, r31, r111, r125, r101);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r13 * r134;
+    r125 = r28 * r123;
+    r125 = fmaf(r84, r125, r88 * r101);
+    r101 = r28 * r98;
+    r111 = r13 * r129;
+    r111 = fmaf(r88, r111, r84 * r101);
+    r101 = r134 * r129;
+    r31 = r123 * r98;
+    r31 = fmaf(r84, r31, r88 * r101);
+    WriteSum3<float, float>((float*)inout_shared, r125, r111, r31);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r4 * r2;
+    WriteSum2<float, float>((float*)inout_shared, r31, r72);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r42, r42);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r55 * r92;
+    r42 = r42 * r62;
+    r42 = fmaf(r61, r104, r63 * r42);
+    r72 = r16 * r33;
+    r72 = r72 * r11;
+    r31 = r16 * r55;
+    r31 = r31 * r10;
+    r31 = fmaf(r37, r31, r37 * r72);
+    r72 = r61 * r10;
+    r72 = r72 * r10;
+    r31 = fmaf(r36, r72, r31);
+    r31 = fmaf(r61, r99, r31);
+    r72 = r71 * r31;
+    r72 = r72 * r65;
+    r72 = r72 * r97;
+    r42 = fmaf(r64, r72, r42);
+    r111 = r10 * r10;
+    r111 = r111 * r108;
+    r111 = r111 * r31;
+    r111 = r111 * r65;
+    r111 = r111 * r53;
+    r42 = fmaf(r62, r111, r42);
+    r125 = r4 * r11;
+    r125 = r125 * r31;
+    r101 = r31 * r110;
+    r101 = r101 * r97;
+    r101 = fmaf(r51, r101, r113 * r125);
+    r101 = fmaf(r61, r105, r101);
+    r101 = fmaf(r33, r109, r101);
+    r42 = r42 + r101;
+    r111 = r55 * r63;
+    r72 = r61 * r36;
+    r72 = fmaf(r106, r72, r73 * r111);
+    r111 = r31 * r65;
+    r111 = r111 * r97;
+    r72 = fmaf(r64, r111, r72);
+    r125 = r4 * r10;
+    r125 = r125 * r10;
+    r125 = r125 * r31;
+    r125 = r125 * r65;
+    r125 = r125 * r53;
+    r72 = fmaf(r62, r125, r72);
+    r101 = r101 + r72;
+    r42 = fmaf(r8, r101, r68 * r42);
+    r125 = r60 * r76;
+    r125 = r125 * r1;
+    r125 = r125 * r31;
+    r125 = r125 * r70;
+    r125 = r125 * r65;
+    r42 = fmaf(r63, r125, r42);
+    r111 = r4 * r61;
+    r111 = r111 * r10;
+    r111 = r111 * r76;
+    r111 = r111 * r77;
+    r42 = fmaf(r57, r111, r42);
+    r126 = r4 * r61;
+    r126 = r126 * r10;
+    r126 = r126 * r77;
+    r42 = fmaf(r57, r126, r42);
+    r52 = r67 * r33;
+    r52 = r52 * r63;
+    r42 = fmaf(r73, r52, r42);
+    r91 = r7 * r16;
+    r91 = r91 * r66;
+    r91 = fmaf(r6, r101, r101 * r91);
+    r91 = fmaf(r101, r75, r91);
+    r91 = fmaf(r101, r69, r91);
+    r114 = r10 * r91;
+    r42 = fmaf(r79, r114, r42);
+    r112 = r60 * r1;
+    r112 = r112 * r31;
+    r112 = r112 * r70;
+    r112 = r112 * r65;
+    r42 = fmaf(r63, r112, r42);
+    r130 = r67 * r41;
+    r130 = r130 * r10;
+    r130 = r130 * r31;
+    r42 = fmaf(r113, r130, r42);
+    r74 = r67 * r55;
+    r42 = fmaf(r109, r74, r42);
+    r94 = r31 * r107;
+    r42 = fmaf(r55, r80, r42);
+    r42 = fmaf(r31, r117, r42);
+    r42 = fmaf(r55, r79, r42);
+    r42 = fmaf(r61, r115, r42);
+    r42 = fmaf(r67, r94, r42);
+    r42 = fmaf(r31, r116, r42);
+    r74 = r0 * r42;
+    r130 = r11 * r108;
+    r130 = r130 * r31;
+    r112 = r71 * r31;
+    r112 = r112 * r110;
+    r112 = r112 * r97;
+    r112 = fmaf(r51, r112, r113 * r130);
+    r130 = r61 * r11;
+    r130 = r130 * r11;
+    r130 = r130 * r60;
+    r130 = r130 * r60;
+    r130 = r130 * r89;
+    r130 = r130 * r47;
+    r112 = fmaf(r12, r130, r112);
+    r114 = r33 * r11;
+    r114 = r114 * r92;
+    r114 = r114 * r47;
+    r112 = fmaf(r62, r114, r112);
+    r112 = r112 + r72;
+    r101 = fmaf(r9, r101, r67 * r112);
+    r112 = r85 * r76;
+    r112 = r112 * r31;
+    r112 = r112 * r35;
+    r112 = r112 * r110;
+    r101 = fmaf(r78, r112, r101);
+    r72 = r60 * r76;
+    r72 = r72 * r1;
+    r72 = r72 * r31;
+    r72 = r72 * r47;
+    r72 = r72 * r70;
+    r101 = fmaf(r110, r72, r101);
+    r114 = r4 * r61;
+    r114 = r114 * r11;
+    r114 = r114 * r76;
+    r114 = r114 * r77;
+    r101 = fmaf(r57, r114, r101);
+    r130 = r68 * r33;
+    r130 = r130 * r63;
+    r101 = fmaf(r73, r130, r101);
+    r52 = r68 * r61;
+    r52 = r52 * r11;
+    r52 = r52 * r60;
+    r52 = r52 * r60;
+    r52 = r52 * r90;
+    r52 = r52 * r12;
+    r101 = fmaf(r63, r52, r101);
+    r126 = r60 * r1;
+    r126 = r126 * r31;
+    r126 = r126 * r47;
+    r126 = r126 * r70;
+    r101 = fmaf(r110, r126, r101);
+    r111 = r68 * r55;
+    r101 = fmaf(r109, r111, r101);
+    r125 = r85 * r31;
+    r125 = r125 * r35;
+    r125 = r125 * r110;
+    r101 = fmaf(r78, r125, r101);
+    r14 = r4 * r61;
+    r14 = r14 * r11;
+    r14 = r14 * r77;
+    r101 = fmaf(r57, r14, r101);
+    r136 = r11 * r91;
+    r101 = fmaf(r79, r136, r101);
+    r101 = fmaf(r31, r124, r101);
+    r101 = fmaf(r33, r80, r101);
+    r101 = fmaf(r68, r94, r101);
+    r101 = fmaf(r33, r79, r101);
+    r136 = r5 * r101;
+    r94 = r16 * r49;
+    r94 = r94 * r10;
+    r94 = fmaf(r37, r94, r45 * r99);
+    r14 = r16 * r50;
+    r14 = r14 * r11;
+    r94 = fmaf(r37, r14, r94);
+    r125 = r45 * r10;
+    r125 = r125 * r10;
+    r94 = fmaf(r36, r125, r94);
+    r125 = r94 * r65;
+    r125 = r125 * r97;
+    r14 = r45 * r36;
+    r14 = fmaf(r106, r14, r64 * r125);
+    r125 = r4 * r10;
+    r125 = r125 * r10;
+    r125 = r125 * r94;
+    r125 = r125 * r65;
+    r125 = r125 * r53;
+    r14 = fmaf(r62, r125, r14);
+    r111 = r49 * r63;
+    r14 = fmaf(r73, r111, r14);
+    r111 = r4 * r11;
+    r111 = r111 * r94;
+    r111 = fmaf(r50, r109, r113 * r111);
+    r125 = r94 * r110;
+    r125 = r125 * r97;
+    r111 = fmaf(r51, r125, r111);
+    r111 = fmaf(r45, r105, r111);
+    r125 = r14 + r111;
+    r126 = r71 * r94;
+    r126 = r126 * r65;
+    r126 = r126 * r97;
+    r126 = fmaf(r45, r104, r64 * r126);
+    r52 = r10 * r10;
+    r52 = r52 * r108;
+    r52 = r52 * r94;
+    r52 = r52 * r65;
+    r52 = r52 * r53;
+    r126 = fmaf(r62, r52, r126);
+    r130 = r49 * r92;
+    r130 = r130 * r62;
+    r126 = fmaf(r63, r130, r126);
+    r126 = r126 + r111;
+    r126 = fmaf(r68, r126, r8 * r125);
+    r111 = r67 * r49;
+    r126 = fmaf(r109, r111, r126);
+    r130 = r67 * r41;
+    r130 = r130 * r10;
+    r130 = r130 * r94;
+    r126 = fmaf(r113, r130, r126);
+    r52 = r60 * r1;
+    r52 = r52 * r94;
+    r52 = r52 * r70;
+    r52 = r52 * r65;
+    r126 = fmaf(r63, r52, r126);
+    r114 = r4 * r45;
+    r114 = r114 * r10;
+    r114 = r114 * r77;
+    r126 = fmaf(r57, r114, r126);
+    r72 = r4 * r45;
+    r72 = r72 * r10;
+    r72 = r72 * r76;
+    r72 = r72 * r77;
+    r126 = fmaf(r57, r72, r126);
+    r112 = r7 * r16;
+    r112 = r112 * r66;
+    r112 = fmaf(r125, r112, r6 * r125);
+    r112 = fmaf(r125, r75, r112);
+    r112 = fmaf(r125, r69, r112);
+    r137 = r10 * r112;
+    r126 = fmaf(r79, r137, r126);
+    r138 = r60 * r76;
+    r138 = r138 * r1;
+    r138 = r138 * r94;
+    r138 = r138 * r70;
+    r138 = r138 * r65;
+    r126 = fmaf(r63, r138, r126);
+    r139 = r67 * r50;
+    r139 = r139 * r63;
+    r126 = fmaf(r73, r139, r126);
+    r140 = r67 * r94;
+    r126 = fmaf(r107, r140, r126);
+    r126 = fmaf(r94, r116, r126);
+    r126 = fmaf(r94, r117, r126);
+    r126 = fmaf(r49, r80, r126);
+    r126 = fmaf(r49, r79, r126);
+    r126 = fmaf(r45, r115, r126);
+    r140 = r0 * r126;
+    r139 = r11 * r108;
+    r139 = r139 * r94;
+    r138 = r50 * r11;
+    r138 = r138 * r92;
+    r138 = r138 * r47;
+    r138 = fmaf(r62, r138, r113 * r139);
+    r139 = r71 * r94;
+    r139 = r139 * r110;
+    r139 = r139 * r97;
+    r138 = fmaf(r51, r139, r138);
+    r137 = r45 * r11;
+    r137 = r137 * r11;
+    r137 = r137 * r60;
+    r137 = r137 * r60;
+    r137 = r137 * r89;
+    r137 = r137 * r47;
+    r138 = fmaf(r12, r137, r138);
+    r138 = r138 + r14;
+    r138 = fmaf(r67, r138, r9 * r125);
+    r125 = r68 * r49;
+    r138 = fmaf(r109, r125, r138);
+    r14 = r68 * r94;
+    r138 = fmaf(r107, r14, r138);
+    r137 = r60 * r76;
+    r137 = r137 * r1;
+    r137 = r137 * r94;
+    r137 = r137 * r47;
+    r137 = r137 * r70;
+    r138 = fmaf(r110, r137, r138);
+    r139 = r60 * r1;
+    r139 = r139 * r94;
+    r139 = r139 * r47;
+    r139 = r139 * r70;
+    r138 = fmaf(r110, r139, r138);
+    r72 = r11 * r112;
+    r138 = fmaf(r79, r72, r138);
+    r114 = r4 * r45;
+    r114 = r114 * r11;
+    r114 = r114 * r76;
+    r114 = r114 * r77;
+    r138 = fmaf(r57, r114, r138);
+    r52 = r85 * r94;
+    r52 = r52 * r35;
+    r52 = r52 * r110;
+    r138 = fmaf(r78, r52, r138);
+    r130 = r68 * r50;
+    r130 = r130 * r63;
+    r138 = fmaf(r73, r130, r138);
+    r111 = r85 * r76;
+    r111 = r111 * r94;
+    r111 = r111 * r35;
+    r111 = r111 * r110;
+    r138 = fmaf(r78, r111, r138);
+    r141 = r4 * r45;
+    r141 = r141 * r11;
+    r141 = r141 * r77;
+    r138 = fmaf(r57, r141, r138);
+    r142 = r68 * r45;
+    r142 = r142 * r11;
+    r142 = r142 * r60;
+    r142 = r142 * r60;
+    r142 = r142 * r90;
+    r142 = r142 * r12;
+    r138 = fmaf(r63, r142, r138);
+    r138 = fmaf(r94, r124, r138);
+    r138 = fmaf(r50, r79, r138);
+    r138 = fmaf(r50, r80, r138);
+    r142 = r5 * r138;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r74,
+                                          r136,
+                                          r140,
+                                          r142);
+    r142 = r4 * r11;
+    r140 = r16 * r48;
+    r140 = r140 * r11;
+    r99 = fmaf(r54, r99, r37 * r140);
+    r140 = r54 * r10;
+    r140 = r140 * r10;
+    r99 = fmaf(r36, r140, r99);
+    r136 = r16 * r56;
+    r136 = r136 * r10;
+    r99 = fmaf(r37, r136, r99);
+    r142 = r142 * r99;
+    r142 = fmaf(r48, r109, r113 * r142);
+    r136 = r99 * r110;
+    r136 = r136 * r97;
+    r142 = fmaf(r51, r136, r142);
+    r142 = fmaf(r54, r105, r142);
+    r105 = r56 * r63;
+    r136 = r99 * r65;
+    r136 = r136 * r97;
+    r136 = fmaf(r64, r136, r73 * r105);
+    r105 = r54 * r36;
+    r136 = fmaf(r106, r105, r136);
+    r106 = r4 * r10;
+    r106 = r106 * r10;
+    r106 = r106 * r99;
+    r106 = r106 * r65;
+    r106 = r106 * r53;
+    r136 = fmaf(r62, r106, r136);
+    r106 = r142 + r136;
+    r105 = r56 * r92;
+    r105 = r105 * r62;
+    r140 = r71 * r99;
+    r140 = r140 * r65;
+    r140 = r140 * r97;
+    r140 = fmaf(r64, r140, r63 * r105);
+    r105 = r10 * r10;
+    r105 = r105 * r108;
+    r105 = r105 * r99;
+    r105 = r105 * r65;
+    r105 = r105 * r53;
+    r140 = fmaf(r62, r105, r140);
+    r140 = fmaf(r54, r104, r140);
+    r140 = r140 + r142;
+    r140 = fmaf(r68, r140, r8 * r106);
+    r8 = r67 * r48;
+    r8 = r8 * r63;
+    r140 = fmaf(r73, r8, r140);
+    r142 = r67 * r99;
+    r140 = fmaf(r107, r142, r140);
+    r105 = r60 * r76;
+    r105 = r105 * r1;
+    r105 = r105 * r99;
+    r105 = r105 * r70;
+    r105 = r105 * r65;
+    r140 = fmaf(r63, r105, r140);
+    r104 = r4 * r54;
+    r104 = r104 * r10;
+    r104 = r104 * r76;
+    r104 = r104 * r77;
+    r140 = fmaf(r57, r104, r140);
+    r53 = r7 * r16;
+    r53 = r53 * r66;
+    r53 = fmaf(r106, r53, r6 * r106);
+    r53 = fmaf(r106, r75, r53);
+    r53 = fmaf(r106, r69, r53);
+    r69 = r10 * r53;
+    r140 = fmaf(r79, r69, r140);
+    r75 = r4 * r54;
+    r75 = r75 * r10;
+    r75 = r75 * r77;
+    r140 = fmaf(r57, r75, r140);
+    r6 = r60 * r1;
+    r6 = r6 * r99;
+    r6 = r6 * r70;
+    r6 = r6 * r65;
+    r140 = fmaf(r63, r6, r140);
+    r66 = r67 * r41;
+    r66 = r66 * r10;
+    r66 = r66 * r99;
+    r140 = fmaf(r113, r66, r140);
+    r64 = r67 * r56;
+    r140 = fmaf(r109, r64, r140);
+    r140 = fmaf(r99, r117, r140);
+    r140 = fmaf(r56, r79, r140);
+    r140 = fmaf(r56, r80, r140);
+    r140 = fmaf(r99, r116, r140);
+    r140 = fmaf(r54, r115, r140);
+    r64 = r0 * r140;
+    r115 = r11 * r108;
+    r115 = r115 * r99;
+    r116 = r48 * r11;
+    r116 = r116 * r92;
+    r116 = r116 * r47;
+    r116 = fmaf(r62, r116, r113 * r115);
+    r115 = r71 * r99;
+    r115 = r115 * r110;
+    r115 = r115 * r97;
+    r116 = fmaf(r51, r115, r116);
+    r51 = r54 * r11;
+    r51 = r51 * r11;
+    r51 = r51 * r60;
+    r51 = r51 * r60;
+    r51 = r51 * r89;
+    r51 = r51 * r47;
+    r116 = fmaf(r12, r51, r116);
+    r116 = r116 + r136;
+    r116 = fmaf(r67, r116, r9 * r106);
+    r106 = r68 * r48;
+    r106 = r106 * r63;
+    r116 = fmaf(r73, r106, r116);
+    r73 = r4 * r54;
+    r73 = r73 * r11;
+    r73 = r73 * r76;
+    r73 = r73 * r77;
+    r116 = fmaf(r57, r73, r116);
+    r9 = r60 * r1;
+    r9 = r9 * r99;
+    r9 = r9 * r47;
+    r9 = r9 * r70;
+    r116 = fmaf(r110, r9, r116);
+    r136 = r68 * r99;
+    r116 = fmaf(r107, r136, r116);
+    r107 = r11 * r53;
+    r116 = fmaf(r79, r107, r116);
+    r51 = r68 * r54;
+    r51 = r51 * r11;
+    r51 = r51 * r60;
+    r51 = r51 * r60;
+    r51 = r51 * r90;
+    r51 = r51 * r12;
+    r116 = fmaf(r63, r51, r116);
+    r12 = r60 * r76;
+    r12 = r12 * r1;
+    r12 = r12 * r99;
+    r12 = r12 * r47;
+    r12 = r12 * r70;
+    r116 = fmaf(r110, r12, r116);
+    r70 = r85 * r76;
+    r70 = r70 * r99;
+    r70 = r70 * r35;
+    r70 = r70 * r110;
+    r116 = fmaf(r78, r70, r116);
+    r47 = r68 * r56;
+    r116 = fmaf(r109, r47, r116);
+    r109 = r4 * r54;
+    r109 = r109 * r11;
+    r109 = r109 * r77;
+    r116 = fmaf(r57, r109, r116);
+    r57 = r85 * r99;
+    r57 = r57 * r35;
+    r57 = r57 * r110;
+    r116 = fmaf(r78, r57, r116);
+    r116 = fmaf(r48, r79, r116);
+    r116 = fmaf(r99, r124, r116);
+    r116 = fmaf(r48, r80, r116);
+    r5 = r5 * r116;
+    WriteIdx2<1024, float, float, float2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r64, r5);
+    r5 = r0 * r4;
+    r5 = r5 * r2;
+    r5 = fmaf(r101, r119, r42 * r5);
+    r64 = r0 * r4;
+    r64 = r64 * r2;
+    r64 = fmaf(r138, r119, r126 * r64);
+    r57 = r0 * r4;
+    r57 = r57 * r2;
+    r119 = fmaf(r116, r119, r140 * r57);
+    WriteSum3<float, float>((float*)inout_shared, r5, r64, r119);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r119 = r42 * r42;
+    r64 = r101 * r101;
+    r64 = fmaf(r88, r64, r84 * r119);
+    r119 = r138 * r138;
+    r5 = r126 * r126;
+    r5 = fmaf(r84, r5, r88 * r119);
+    r119 = r116 * r116;
+    r57 = r140 * r140;
+    r57 = fmaf(r84, r57, r88 * r119);
+    WriteSum3<float, float>((float*)inout_shared, r64, r5, r57);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r101 * r138;
+    r5 = r42 * r126;
+    r5 = fmaf(r84, r5, r88 * r57);
+    r57 = r42 * r140;
+    r64 = r101 * r116;
+    r64 = fmaf(r88, r64, r84 * r57);
+    r57 = r138 * r116;
+    r119 = r126 * r140;
+    r119 = fmaf(r84, r119, r88 * r57);
+    WriteSum3<float, float>((float*)inout_shared, r5, r64, r119);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.cu
@@ -1,0 +1,2367 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = 9.99999999999999955e-07;
+    r53 = r41 * r29;
+    r53 = r53 * r29;
+    r54 = r42 + r53;
+    r54 = r54 + r49;
+    r10 = fmaf(r13, r54, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r55 = r16 * r29;
+    r55 = fmaf(r34, r55, r26);
+    r56 = r21 * r23;
+    r56 = r56 * r16;
+    r57 = r22 * r24;
+    r57 = fmaf(r16, r57, r56);
+    r58 = r23 * r24;
+    r58 = fmaf(r41, r58, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r55, r10);
+    r10 = fmaf(r37, r57, r10);
+    r10 = fmaf(r36, r58, r10);
+    r10 = fmaf(r35, r43, r10);
+    r59 = r10 * r10;
+    r60 = r41 * r29;
+    r60 = fmaf(r34, r60, r26);
+    r12 = fmaf(r13, r60, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r56);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r53 = r42 + r53;
+    r53 = r53 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r53, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r52, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r59);
+    r59 = sqrtf(r35);
+    r51 = copysign(1.0, r59);
+    r51 = fmaf(r52, r51, r59);
+    r52 = r51 * r51;
+    r47 = 1.0 / r52;
+    r59 = atanf(r59);
+    r56 = r59 * r37;
+    r61 = r47 * r56;
+    r62 = r11 * r61;
+    r63 = r11 * r59;
+    r62 = r62 * r63;
+    r64 = r10 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r61;
+    r65 = r62 + r64;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r66,
+                                         r67,
+                                         r68,
+                                         r69);
+    r70 = r10 * r10;
+    r71 = 3.00000000000000000e+00;
+    r70 = r70 * r59;
+    r70 = r70 * r71;
+    r70 = fmaf(r61, r70, r62);
+    r70 = fmaf(r67, r70, r8 * r65);
+    r62 = r16 * r61;
+    r72 = r66 * r62;
+    r73 = r63 * r72;
+    r74 = r65 * r65;
+    r75 = r65 * r74;
+    r76 = fmaf(r68, r75, r6 * r65);
+    r75 = r69 * r75;
+    r76 = fmaf(r65, r75, r76);
+    r76 = fmaf(r7, r74, r76);
+    r69 = 1.0 / r36;
+    r77 = 1.0 / r51;
+    r78 = r69 * r77;
+    r79 = r76 * r78;
+    r80 = r59 * r79;
+    r81 = r10 * r59;
+    r70 = fmaf(r78, r81, r70);
+    r70 = fmaf(r10, r73, r70);
+    r70 = fmaf(r10, r80, r70);
+    r2 = fmaf(r0, r70, r2);
+    r70 = r11 * r71;
+    r70 = r70 * r61;
+    r70 = fmaf(r63, r70, r64);
+    r70 = fmaf(r66, r70, r9 * r65);
+    r64 = r67 * r10;
+    r64 = r64 * r63;
+    r70 = fmaf(r62, r64, r70);
+    r70 = fmaf(r63, r79, r70);
+    r70 = fmaf(r78, r63, r70);
+    r70 = fmaf(r5, r70, r1);
+    r70 = fmaf(r3, r4, r70);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r70);
+    r3 = fmaf(r70, r70, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r10 * r59;
+    r1 = r16 * r34;
+    r64 = r19 * r24;
+    r81 = 5.00000000000000000e-01;
+    r82 = r18 * r21;
+    r82 = fmaf(r81, r82, r81 * r64);
+    r64 = r17 * r22;
+    r83 = -5.00000000000000000e-01;
+    r82 = fmaf(r83, r64, r82);
+    r84 = r20 * r23;
+    r82 = fmaf(r81, r84, r82);
+    r84 = r17 * r24;
+    r64 = r20 * r21;
+    r64 = fmaf(r83, r64, r83 * r84);
+    r84 = r19 * r22;
+    r64 = fmaf(r83, r84, r64);
+    r85 = r18 * r23;
+    r64 = fmaf(r81, r85, r64);
+    r85 = r29 * r64;
+    r1 = fmaf(r16, r85, r82 * r1);
+    r84 = r16 * r25;
+    r86 = fmaf(r81, r31, r83 * r27);
+    r86 = fmaf(r83, r28, r86);
+    r86 = fmaf(r83, r30, r86);
+    r87 = r16 * r32;
+    r88 = r20 * r24;
+    r89 = r17 * r21;
+    r89 = fmaf(r83, r89, r81 * r88);
+    r88 = r18 * r22;
+    r89 = fmaf(r83, r88, r89);
+    r90 = r19 * r23;
+    r89 = fmaf(r83, r90, r89);
+    r87 = r87 * r89;
+    r84 = fmaf(r86, r84, r87);
+    r1 = r1 + r84;
+    r90 = r16 * r29;
+    r90 = r90 * r89;
+    r88 = r16 * r25;
+    r88 = r88 * r82;
+    r91 = r90 + r88;
+    r92 = r32 * r41;
+    r91 = fmaf(r64, r92, r91);
+    r93 = r41 * r34;
+    r91 = fmaf(r86, r93, r91);
+    r91 = fmaf(r14, r91, r15 * r1);
+    r1 = r29 * r82;
+    r93 = -4.00000000000000000e+00;
+    r1 = r1 * r93;
+    r92 = r32 * r86;
+    r94 = r93 * r92;
+    r95 = r1 + r94;
+    r91 = fmaf(r13, r95, r91);
+    r95 = 6.00000000000000000e+00;
+    r3 = r3 * r91;
+    r3 = r3 * r95;
+    r96 = r16 * r11;
+    r97 = r25 * r41;
+    r98 = r34 * r89;
+    r99 = r41 * r98;
+    r97 = fmaf(r64, r97, r99);
+    r100 = r16 * r29;
+    r100 = r100 * r86;
+    r101 = r16 * r32;
+    r101 = fmaf(r82, r101, r100);
+    r97 = r97 + r101;
+    r102 = r25 * r89;
+    r102 = r102 * r93;
+    r94 = r102 + r94;
+    r94 = fmaf(r14, r94, r15 * r97);
+    r97 = r16 * r34;
+    r97 = fmaf(r86, r97, r88);
+    r88 = r16 * r32;
+    r88 = fmaf(r64, r88, r90);
+    r97 = r97 + r88;
+    r94 = fmaf(r13, r97, r94);
+    r96 = r96 * r94;
+    r97 = r16 * r10;
+    r97 = r97 * r91;
+    r97 = fmaf(r37, r97, r37 * r96);
+    r96 = r11 * r11;
+    r90 = r16 * r25;
+    r90 = r90 * r64;
+    r98 = r16 * r98;
+    r103 = r90 + r98;
+    r101 = r101 + r103;
+    r104 = r41 * r34;
+    r104 = fmaf(r41, r85, r82 * r104);
+    r104 = r104 + r84;
+    r104 = fmaf(r13, r104, r14 * r101);
+    r1 = r102 + r1;
+    r104 = fmaf(r15, r1, r104);
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r36 = r41 * r12;
+    r96 = r96 * r104;
+    r97 = fmaf(r36, r96, r97);
+    r1 = r10 * r10;
+    r1 = r1 * r104;
+    r97 = fmaf(r36, r1, r97);
+    r1 = r71 * r97;
+    r96 = r10 * r61;
+    r102 = r42 + r35;
+    r102 = 1.0 / r102;
+    r35 = rsqrtf(r35);
+    r101 = r10 * r35;
+    r82 = r102 * r101;
+    r96 = r96 * r82;
+    r1 = fmaf(r96, r1, r61 * r3);
+    r3 = r59 * r59;
+    r105 = -6.00000000000000000e+00;
+    r3 = r3 * r104;
+    r3 = r3 * r105;
+    r3 = r3 * r47;
+    r3 = r3 * r12;
+    r106 = r10 * r10;
+    r106 = r106 * r36;
+    r107 = -3.00000000000000000e+00;
+    r108 = r107 * r101;
+    r52 = r51 * r52;
+    r52 = 1.0 / r52;
+    r52 = r52 * r56;
+    r51 = r10 * r59;
+    r108 = r108 * r52;
+    r108 = r108 * r51;
+    r109 = r94 * r63;
+    r110 = r11 * r11;
+    r110 = r110 * r97;
+    r110 = r110 * r35;
+    r110 = r110 * r102;
+    r110 = fmaf(r61, r110, r62 * r109);
+    r109 = r4 * r97;
+    r111 = r63 * r52;
+    r112 = r11 * r35;
+    r109 = r109 * r111;
+    r110 = fmaf(r112, r109, r110);
+    r113 = r11 * r11;
+    r113 = r113 * r59;
+    r113 = r113 * r59;
+    r113 = r113 * r104;
+    r113 = r113 * r47;
+    r110 = fmaf(r36, r113, r110);
+    r1 = fmaf(r3, r106, r1);
+    r1 = fmaf(r97, r108, r1);
+    r1 = r1 + r110;
+    r106 = r91 * r62;
+    r106 = fmaf(r97, r96, r51 * r106);
+    r113 = r10 * r10;
+    r113 = r113 * r59;
+    r113 = r113 * r59;
+    r113 = r113 * r104;
+    r113 = r113 * r47;
+    r106 = fmaf(r36, r113, r106);
+    r109 = r4 * r97;
+    r109 = r109 * r101;
+    r109 = r109 * r52;
+    r106 = fmaf(r51, r109, r106);
+    r110 = r110 + r106;
+    r1 = fmaf(r8, r110, r67 * r1);
+    r109 = r59 * r83;
+    r109 = r109 * r47;
+    r109 = r109 * r69;
+    r109 = r109 * r101;
+    r113 = r76 * r109;
+    r114 = r11 * r97;
+    r114 = r114 * r82;
+    r1 = fmaf(r72, r114, r1);
+    r115 = r66 * r10;
+    r115 = r115 * r11;
+    r115 = r115 * r59;
+    r115 = r115 * r59;
+    r115 = r115 * r93;
+    r115 = r115 * r104;
+    r115 = r115 * r47;
+    r1 = fmaf(r12, r115, r1);
+    r116 = r81 * r97;
+    r116 = r116 * r82;
+    r1 = fmaf(r79, r116, r1);
+    r117 = r59 * r91;
+    r1 = fmaf(r78, r117, r1);
+    r118 = r4 * r10;
+    r118 = r118 * r104;
+    r118 = r118 * r77;
+    r1 = fmaf(r56, r118, r1);
+    r119 = r4 * r10;
+    r119 = r119 * r76;
+    r119 = r119 * r104;
+    r119 = r119 * r77;
+    r1 = fmaf(r56, r119, r1);
+    r120 = r81 * r97;
+    r120 = r120 * r78;
+    r1 = fmaf(r82, r120, r1);
+    r121 = r41 * r101;
+    r121 = r121 * r111;
+    r122 = r66 * r121;
+    r123 = r10 * r59;
+    r124 = r7 * r16;
+    r124 = r124 * r65;
+    r124 = fmaf(r110, r124, r6 * r110);
+    r125 = 4.00000000000000000e+00;
+    r75 = r125 * r75;
+    r68 = r68 * r71;
+    r68 = r68 * r74;
+    r124 = fmaf(r110, r75, r124);
+    r124 = fmaf(r110, r68, r124);
+    r123 = r123 * r124;
+    r1 = fmaf(r78, r123, r1);
+    r74 = r94 * r51;
+    r1 = fmaf(r72, r74, r1);
+    r1 = fmaf(r97, r113, r1);
+    r1 = fmaf(r97, r109, r1);
+    r1 = fmaf(r91, r73, r1);
+    r1 = fmaf(r97, r122, r1);
+    r1 = fmaf(r91, r80, r1);
+    r74 = r0 * r1;
+    r123 = r94 * r95;
+    r123 = r123 * r61;
+    r120 = r11 * r11;
+    r120 = r120 * r71;
+    r120 = r120 * r97;
+    r120 = r120 * r35;
+    r120 = r120 * r102;
+    r120 = fmaf(r61, r120, r63 * r123);
+    r123 = r107 * r97;
+    r123 = r123 * r111;
+    r120 = fmaf(r112, r123, r120);
+    r119 = r41 * r26;
+    r118 = r11 * r11;
+    r119 = r119 * r118;
+    r119 = r119 * r12;
+    r120 = fmaf(r3, r119, r120);
+    r120 = r120 + r106;
+    r110 = fmaf(r9, r110, r66 * r120);
+    r120 = r11 * r81;
+    r120 = r120 * r97;
+    r120 = r120 * r35;
+    r120 = r120 * r102;
+    r110 = fmaf(r78, r120, r110);
+    r106 = r11 * r59;
+    r106 = r106 * r76;
+    r106 = r106 * r83;
+    r106 = r106 * r97;
+    r106 = r106 * r47;
+    r106 = r106 * r69;
+    r110 = fmaf(r35, r106, r110);
+    r3 = r124 * r78;
+    r110 = fmaf(r63, r3, r110);
+    r123 = r4 * r11;
+    r123 = r123 * r76;
+    r123 = r123 * r104;
+    r123 = r123 * r77;
+    r110 = fmaf(r56, r123, r110);
+    r118 = r67 * r10;
+    r118 = r118 * r11;
+    r118 = r118 * r59;
+    r118 = r118 * r59;
+    r118 = r118 * r93;
+    r118 = r118 * r47;
+    r118 = r118 * r12;
+    r117 = r67 * r91;
+    r117 = r117 * r63;
+    r110 = fmaf(r62, r117, r110);
+    r116 = r67 * r11;
+    r116 = r116 * r97;
+    r116 = r116 * r62;
+    r110 = fmaf(r82, r116, r110);
+    r115 = r4 * r11;
+    r115 = r115 * r104;
+    r115 = r115 * r77;
+    r110 = fmaf(r56, r115, r110);
+    r114 = r67 * r97;
+    r110 = fmaf(r121, r114, r110);
+    r125 = r81 * r102;
+    r125 = r125 * r79;
+    r125 = r125 * r112;
+    r126 = r67 * r94;
+    r126 = r126 * r62;
+    r110 = fmaf(r51, r126, r110);
+    r127 = r11 * r59;
+    r127 = r127 * r83;
+    r127 = r127 * r97;
+    r127 = r127 * r47;
+    r127 = r127 * r69;
+    r110 = fmaf(r35, r127, r110);
+    r128 = r59 * r94;
+    r110 = fmaf(r78, r128, r110);
+    r110 = fmaf(r104, r118, r110);
+    r110 = fmaf(r97, r125, r110);
+    r110 = fmaf(r94, r80, r110);
+    r128 = r5 * r110;
+    r127 = r10 * r10;
+    r126 = r37 * r127;
+    r114 = r16 * r10;
+    r98 = r100 + r98;
+    r100 = r16 * r32;
+    r115 = r19 * r24;
+    r116 = r18 * r21;
+    r116 = fmaf(r83, r116, r83 * r115);
+    r115 = r17 * r22;
+    r116 = fmaf(r81, r115, r116);
+    r117 = r20 * r23;
+    r116 = fmaf(r83, r117, r116);
+    r100 = r100 * r116;
+    r117 = r16 * r25;
+    r115 = r17 * r24;
+    r104 = r20 * r21;
+    r104 = fmaf(r81, r104, r81 * r115);
+    r115 = r19 * r22;
+    r104 = fmaf(r81, r115, r104);
+    r123 = r18 * r23;
+    r104 = fmaf(r83, r123, r104);
+    r117 = fmaf(r104, r117, r100);
+    r98 = r98 + r117;
+    r123 = r32 * r93;
+    r123 = r123 * r104;
+    r115 = r29 * r89;
+    r115 = r115 * r93;
+    r3 = r123 + r115;
+    r3 = fmaf(r13, r3, r15 * r98);
+    r98 = r41 * r34;
+    r98 = fmaf(r41, r92, r104 * r98);
+    r106 = r16 * r25;
+    r106 = r106 * r89;
+    r120 = r16 * r29;
+    r120 = fmaf(r116, r120, r106);
+    r98 = r98 + r120;
+    r3 = fmaf(r14, r98, r3);
+    r114 = r114 * r3;
+    r98 = r10 * r10;
+    r129 = r41 * r29;
+    r129 = fmaf(r86, r129, r99);
+    r129 = r129 + r117;
+    r117 = r16 * r29;
+    r117 = r117 * r104;
+    r130 = r16 * r34;
+    r130 = fmaf(r116, r130, r117);
+    r130 = r130 + r84;
+    r130 = fmaf(r14, r130, r13 * r129);
+    r129 = r25 * r116;
+    r84 = r93 * r129;
+    r115 = r115 + r84;
+    r130 = fmaf(r15, r115, r130);
+    r98 = r98 * r130;
+    r98 = fmaf(r36, r98, r37 * r114);
+    r114 = r11 * r11;
+    r114 = r114 * r130;
+    r98 = fmaf(r36, r114, r98);
+    r115 = r16 * r11;
+    r131 = r25 * r41;
+    r131 = fmaf(r86, r131, r87);
+    r87 = r41 * r34;
+    r131 = fmaf(r116, r87, r131);
+    r131 = r131 + r117;
+    r87 = r16 * r34;
+    r92 = fmaf(r16, r92, r104 * r87);
+    r92 = r92 + r120;
+    r92 = fmaf(r13, r92, r15 * r131);
+    r84 = r123 + r84;
+    r92 = fmaf(r14, r84, r92);
+    r115 = r115 * r92;
+    r98 = fmaf(r37, r115, r98);
+    r126 = r126 * r47;
+    r126 = r126 * r59;
+    r126 = r126 * r35;
+    r126 = r126 * r102;
+    r126 = r126 * r98;
+    r115 = r4 * r98;
+    r115 = r115 * r101;
+    r115 = r115 * r52;
+    r115 = fmaf(r51, r115, r126);
+    r114 = r10 * r10;
+    r114 = r114 * r59;
+    r114 = r114 * r59;
+    r114 = r114 * r130;
+    r114 = r114 * r47;
+    r115 = fmaf(r36, r114, r115);
+    r84 = r3 * r62;
+    r115 = fmaf(r51, r84, r115);
+    r84 = r92 * r63;
+    r114 = r4 * r98;
+    r114 = r114 * r111;
+    r114 = fmaf(r112, r114, r62 * r84);
+    r84 = r11 * r11;
+    r84 = r84 * r59;
+    r84 = r84 * r59;
+    r84 = r84 * r130;
+    r84 = r84 * r47;
+    r114 = fmaf(r36, r84, r114);
+    r123 = r11 * r11;
+    r123 = r123 * r98;
+    r123 = r123 * r35;
+    r123 = r123 * r102;
+    r114 = fmaf(r61, r123, r114);
+    r123 = r115 + r114;
+    r126 = fmaf(r98, r108, r71 * r126);
+    r84 = r10 * r10;
+    r84 = r84 * r59;
+    r84 = r84 * r59;
+    r84 = r84 * r105;
+    r84 = r84 * r130;
+    r84 = r84 * r47;
+    r126 = fmaf(r12, r84, r126);
+    r131 = r10 * r59;
+    r131 = r131 * r95;
+    r131 = r131 * r3;
+    r126 = fmaf(r61, r131, r126);
+    r126 = r126 + r114;
+    r126 = fmaf(r67, r126, r8 * r123);
+    r114 = r92 * r51;
+    r126 = fmaf(r72, r114, r126);
+    r131 = r66 * r10;
+    r131 = r131 * r11;
+    r131 = r131 * r59;
+    r131 = r131 * r59;
+    r131 = r131 * r93;
+    r131 = r131 * r130;
+    r131 = r131 * r47;
+    r126 = fmaf(r12, r131, r126);
+    r84 = r4 * r10;
+    r84 = r84 * r130;
+    r84 = r84 * r77;
+    r126 = fmaf(r56, r84, r126);
+    r87 = r81 * r98;
+    r87 = r87 * r82;
+    r126 = fmaf(r79, r87, r126);
+    r104 = r11 * r98;
+    r104 = r104 * r82;
+    r126 = fmaf(r72, r104, r126);
+    r117 = r81 * r98;
+    r117 = r117 * r78;
+    r126 = fmaf(r82, r117, r126);
+    r86 = r4 * r10;
+    r86 = r86 * r76;
+    r86 = r86 * r130;
+    r86 = r86 * r77;
+    r126 = fmaf(r56, r86, r126);
+    r132 = r10 * r59;
+    r133 = r7 * r16;
+    r133 = r133 * r65;
+    r133 = fmaf(r123, r133, r6 * r123);
+    r133 = fmaf(r123, r75, r133);
+    r133 = fmaf(r123, r68, r133);
+    r132 = r132 * r133;
+    r126 = fmaf(r78, r132, r126);
+    r134 = r59 * r3;
+    r126 = fmaf(r78, r134, r126);
+    r126 = fmaf(r98, r109, r126);
+    r126 = fmaf(r3, r80, r126);
+    r126 = fmaf(r98, r122, r126);
+    r126 = fmaf(r3, r73, r126);
+    r126 = fmaf(r98, r113, r126);
+    r134 = r0 * r126;
+    r132 = r95 * r92;
+    r132 = r132 * r61;
+    r86 = r107 * r98;
+    r86 = r86 * r111;
+    r86 = fmaf(r112, r86, r63 * r132);
+    r132 = r11 * r11;
+    r132 = r132 * r59;
+    r132 = r132 * r59;
+    r132 = r132 * r105;
+    r132 = r132 * r130;
+    r132 = r132 * r47;
+    r86 = fmaf(r12, r132, r86);
+    r117 = r11 * r11;
+    r117 = r117 * r71;
+    r117 = r117 * r98;
+    r117 = r117 * r35;
+    r117 = r117 * r102;
+    r86 = fmaf(r61, r117, r86);
+    r86 = r86 + r115;
+    r86 = fmaf(r66, r86, r9 * r123);
+    r123 = r4 * r11;
+    r123 = r123 * r130;
+    r123 = r123 * r77;
+    r86 = fmaf(r56, r123, r86);
+    r115 = r67 * r92;
+    r115 = r115 * r62;
+    r86 = fmaf(r51, r115, r86);
+    r117 = r11 * r59;
+    r117 = r117 * r76;
+    r117 = r117 * r83;
+    r117 = r117 * r98;
+    r117 = r117 * r47;
+    r117 = r117 * r69;
+    r86 = fmaf(r35, r117, r86);
+    r132 = r133 * r78;
+    r86 = fmaf(r63, r132, r86);
+    r104 = r11 * r81;
+    r104 = r104 * r98;
+    r104 = r104 * r35;
+    r104 = r104 * r102;
+    r86 = fmaf(r78, r104, r86);
+    r87 = r11 * r59;
+    r87 = r87 * r83;
+    r87 = r87 * r98;
+    r87 = r87 * r47;
+    r87 = r87 * r69;
+    r86 = fmaf(r35, r87, r86);
+    r84 = r67 * r98;
+    r86 = fmaf(r121, r84, r86);
+    r131 = r67 * r11;
+    r131 = r131 * r98;
+    r131 = r131 * r62;
+    r86 = fmaf(r82, r131, r86);
+    r114 = r67 * r3;
+    r114 = r114 * r63;
+    r86 = fmaf(r62, r114, r86);
+    r135 = r4 * r11;
+    r135 = r135 * r76;
+    r135 = r135 * r130;
+    r135 = r135 * r77;
+    r86 = fmaf(r56, r135, r86);
+    r136 = r59 * r92;
+    r86 = fmaf(r78, r136, r86);
+    r86 = fmaf(r130, r118, r86);
+    r86 = fmaf(r98, r125, r86);
+    r86 = fmaf(r92, r80, r86);
+    r136 = r5 * r86;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r74,
+                                          r128,
+                                          r134,
+                                          r136);
+    r136 = r11 * r11;
+    r134 = r10 * r10;
+    r128 = r25 * r93;
+    r31 = fmaf(r83, r31, r81 * r27);
+    r31 = fmaf(r81, r28, r31);
+    r31 = fmaf(r81, r30, r31);
+    r128 = r128 * r31;
+    r85 = r93 * r85;
+    r30 = r128 + r85;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r106 = r106 + r28;
+    r27 = r41 * r29;
+    r106 = fmaf(r116, r27, r106);
+    r74 = r41 * r34;
+    r106 = fmaf(r64, r74, r106);
+    r106 = fmaf(r13, r106, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r129, r31 * r30);
+    r30 = r30 + r88;
+    r106 = fmaf(r14, r30, r106);
+    r134 = r134 * r106;
+    r30 = r16 * r10;
+    r74 = r16 * r29;
+    r74 = r74 * r31;
+    r90 = r90 + r74;
+    r27 = r32 * r41;
+    r90 = fmaf(r116, r27, r90);
+    r90 = r90 + r99;
+    r89 = r32 * r89;
+    r89 = r89 * r93;
+    r85 = r89 + r85;
+    r85 = fmaf(r13, r85, r14 * r90);
+    r90 = r16 * r34;
+    r90 = fmaf(r64, r90, r28);
+    r90 = r90 + r120;
+    r85 = fmaf(r15, r90, r85);
+    r30 = r30 * r85;
+    r30 = fmaf(r37, r30, r36 * r134);
+    r134 = r11 * r11;
+    r134 = r134 * r106;
+    r30 = fmaf(r36, r134, r30);
+    r90 = r16 * r11;
+    r74 = r100 + r74;
+    r74 = r74 + r103;
+    r103 = r41 * r34;
+    r129 = fmaf(r41, r129, r31 * r103);
+    r129 = r129 + r88;
+    r129 = fmaf(r15, r129, r13 * r74);
+    r89 = r128 + r89;
+    r129 = fmaf(r14, r89, r129);
+    r90 = r90 * r129;
+    r30 = fmaf(r37, r90, r30);
+    r136 = r136 * r30;
+    r136 = r136 * r35;
+    r136 = r136 * r102;
+    r90 = r129 * r63;
+    r90 = fmaf(r62, r90, r61 * r136);
+    r136 = r11 * r11;
+    r136 = r136 * r59;
+    r136 = r136 * r59;
+    r136 = r136 * r106;
+    r136 = r136 * r47;
+    r90 = fmaf(r36, r136, r90);
+    r134 = r4 * r30;
+    r134 = r134 * r111;
+    r90 = fmaf(r112, r134, r90);
+    r134 = r10 * r10;
+    r134 = r134 * r59;
+    r134 = r134 * r59;
+    r134 = r134 * r106;
+    r134 = r134 * r47;
+    r134 = fmaf(r30, r96, r36 * r134);
+    r136 = r4 * r30;
+    r136 = r136 * r101;
+    r136 = r136 * r52;
+    r134 = fmaf(r51, r136, r134);
+    r89 = r85 * r62;
+    r134 = fmaf(r51, r89, r134);
+    r89 = r90 + r134;
+    r136 = r10 * r10;
+    r136 = r136 * r59;
+    r136 = r136 * r59;
+    r136 = r136 * r105;
+    r136 = r136 * r106;
+    r136 = r136 * r47;
+    r14 = r71 * r30;
+    r14 = fmaf(r96, r14, r12 * r136);
+    r136 = r10 * r59;
+    r136 = r136 * r95;
+    r136 = r136 * r85;
+    r14 = fmaf(r61, r136, r14);
+    r14 = fmaf(r30, r108, r14);
+    r14 = r14 + r90;
+    r14 = fmaf(r67, r14, r8 * r89);
+    r90 = r10 * r59;
+    r136 = r7 * r16;
+    r136 = r136 * r65;
+    r136 = fmaf(r89, r136, r6 * r89);
+    r136 = fmaf(r89, r68, r136);
+    r136 = fmaf(r89, r75, r136);
+    r90 = r90 * r136;
+    r14 = fmaf(r78, r90, r14);
+    r128 = r66 * r10;
+    r128 = r128 * r11;
+    r128 = r128 * r59;
+    r128 = r128 * r59;
+    r128 = r128 * r93;
+    r128 = r128 * r106;
+    r128 = r128 * r47;
+    r14 = fmaf(r12, r128, r14);
+    r15 = r81 * r30;
+    r15 = r15 * r78;
+    r14 = fmaf(r82, r15, r14);
+    r74 = r4 * r10;
+    r74 = r74 * r106;
+    r74 = r74 * r77;
+    r14 = fmaf(r56, r74, r14);
+    r13 = r81 * r30;
+    r13 = r13 * r82;
+    r14 = fmaf(r79, r13, r14);
+    r88 = r129 * r51;
+    r14 = fmaf(r72, r88, r14);
+    r103 = r4 * r10;
+    r103 = r103 * r76;
+    r103 = r103 * r106;
+    r103 = r103 * r77;
+    r14 = fmaf(r56, r103, r14);
+    r31 = r59 * r85;
+    r14 = fmaf(r78, r31, r14);
+    r100 = r11 * r30;
+    r100 = r100 * r82;
+    r14 = fmaf(r72, r100, r14);
+    r14 = fmaf(r30, r113, r14);
+    r14 = fmaf(r30, r122, r14);
+    r14 = fmaf(r85, r80, r14);
+    r14 = fmaf(r85, r73, r14);
+    r14 = fmaf(r30, r109, r14);
+    r100 = r0 * r14;
+    r31 = r11 * r11;
+    r31 = r31 * r71;
+    r31 = r31 * r30;
+    r31 = r31 * r35;
+    r31 = r31 * r102;
+    r103 = r95 * r129;
+    r103 = r103 * r61;
+    r103 = fmaf(r63, r103, r61 * r31);
+    r31 = r11 * r11;
+    r31 = r31 * r59;
+    r31 = r31 * r59;
+    r31 = r31 * r105;
+    r31 = r31 * r106;
+    r31 = r31 * r47;
+    r103 = fmaf(r12, r31, r103);
+    r88 = r107 * r30;
+    r88 = r88 * r111;
+    r103 = fmaf(r112, r88, r103);
+    r103 = r103 + r134;
+    r103 = fmaf(r66, r103, r9 * r89);
+    r89 = r11 * r59;
+    r89 = r89 * r83;
+    r89 = r89 * r30;
+    r89 = r89 * r47;
+    r89 = r89 * r69;
+    r103 = fmaf(r35, r89, r103);
+    r134 = r11 * r81;
+    r134 = r134 * r30;
+    r134 = r134 * r35;
+    r134 = r134 * r102;
+    r103 = fmaf(r78, r134, r103);
+    r88 = r4 * r11;
+    r88 = r88 * r76;
+    r88 = r88 * r106;
+    r88 = r88 * r77;
+    r103 = fmaf(r56, r88, r103);
+    r31 = r67 * r30;
+    r103 = fmaf(r121, r31, r103);
+    r13 = r67 * r85;
+    r13 = r13 * r63;
+    r103 = fmaf(r62, r13, r103);
+    r74 = r11 * r59;
+    r74 = r74 * r76;
+    r74 = r74 * r83;
+    r74 = r74 * r30;
+    r74 = r74 * r47;
+    r74 = r74 * r69;
+    r103 = fmaf(r35, r74, r103);
+    r15 = r67 * r129;
+    r15 = r15 * r62;
+    r103 = fmaf(r51, r15, r103);
+    r128 = r4 * r11;
+    r128 = r128 * r106;
+    r128 = r128 * r77;
+    r103 = fmaf(r56, r128, r103);
+    r90 = r67 * r11;
+    r90 = r90 * r30;
+    r90 = r90 * r62;
+    r103 = fmaf(r82, r90, r103);
+    r120 = r59 * r129;
+    r103 = fmaf(r78, r120, r103);
+    r28 = r136 * r78;
+    r103 = fmaf(r63, r28, r103);
+    r103 = fmaf(r106, r118, r103);
+    r103 = fmaf(r129, r80, r103);
+    r103 = fmaf(r30, r125, r103);
+    r28 = r5 * r103;
+    r120 = r26 * r10;
+    r120 = r120 * r10;
+    r120 = r120 * r59;
+    r120 = r120 * r59;
+    r120 = r120 * r105;
+    r120 = r120 * r47;
+    r90 = r43 * r10;
+    r90 = r90 * r59;
+    r90 = r90 * r95;
+    r90 = fmaf(r61, r90, r12 * r120);
+    r120 = r41 * r26;
+    r120 = r120 * r127;
+    r120 = r120 * r12;
+    r127 = r119 + r120;
+    r128 = r16 * r39;
+    r128 = r128 * r11;
+    r127 = fmaf(r37, r128, r127);
+    r15 = r16 * r43;
+    r15 = r15 * r10;
+    r127 = fmaf(r37, r15, r127);
+    r15 = r71 * r127;
+    r90 = fmaf(r96, r15, r90);
+    r128 = r59 * r59;
+    r128 = r128 * r47;
+    r74 = r39 * r63;
+    r74 = fmaf(r62, r74, r119 * r128);
+    r119 = r4 * r127;
+    r119 = r119 * r111;
+    r74 = fmaf(r112, r119, r74);
+    r13 = r11 * r11;
+    r13 = r13 * r127;
+    r13 = r13 * r35;
+    r13 = r13 * r102;
+    r74 = fmaf(r61, r13, r74);
+    r90 = fmaf(r127, r108, r90);
+    r90 = r90 + r74;
+    r15 = r43 * r62;
+    r15 = fmaf(r51, r15, r128 * r120);
+    r120 = r4 * r127;
+    r120 = r120 * r101;
+    r120 = r120 * r52;
+    r15 = fmaf(r51, r120, r15);
+    r15 = fmaf(r127, r96, r15);
+    r74 = r74 + r15;
+    r90 = fmaf(r8, r74, r67 * r90);
+    r120 = r4 * r26;
+    r120 = r120 * r10;
+    r120 = r120 * r77;
+    r90 = fmaf(r56, r120, r90);
+    r128 = r43 * r59;
+    r90 = fmaf(r78, r128, r90);
+    r13 = r11 * r127;
+    r13 = r13 * r82;
+    r90 = fmaf(r72, r13, r90);
+    r119 = r81 * r127;
+    r119 = r119 * r82;
+    r90 = fmaf(r79, r119, r90);
+    r31 = r66 * r26;
+    r31 = r31 * r10;
+    r31 = r31 * r11;
+    r31 = r31 * r59;
+    r31 = r31 * r59;
+    r31 = r31 * r93;
+    r31 = r31 * r47;
+    r90 = fmaf(r12, r31, r90);
+    r88 = r81 * r127;
+    r88 = r88 * r78;
+    r90 = fmaf(r82, r88, r90);
+    r134 = r39 * r51;
+    r90 = fmaf(r72, r134, r90);
+    r89 = r10 * r59;
+    r106 = r7 * r16;
+    r106 = r106 * r65;
+    r106 = fmaf(r6, r74, r74 * r106);
+    r106 = fmaf(r74, r75, r106);
+    r106 = fmaf(r74, r68, r106);
+    r89 = r89 * r106;
+    r90 = fmaf(r78, r89, r90);
+    r64 = r4 * r26;
+    r64 = r64 * r10;
+    r64 = r64 * r76;
+    r64 = r64 * r77;
+    r90 = fmaf(r56, r64, r90);
+    r90 = fmaf(r127, r113, r90);
+    r90 = fmaf(r127, r122, r90);
+    r90 = fmaf(r43, r80, r90);
+    r90 = fmaf(r43, r73, r90);
+    r90 = fmaf(r127, r109, r90);
+    r64 = r0 * r90;
+    r89 = r26 * r11;
+    r89 = r89 * r11;
+    r89 = r89 * r59;
+    r89 = r89 * r59;
+    r89 = r89 * r105;
+    r89 = r89 * r47;
+    r134 = r39 * r95;
+    r134 = r134 * r61;
+    r134 = fmaf(r63, r134, r12 * r89);
+    r89 = r107 * r127;
+    r89 = r89 * r111;
+    r134 = fmaf(r112, r89, r134);
+    r88 = r11 * r11;
+    r88 = r88 * r71;
+    r88 = r88 * r127;
+    r88 = r88 * r35;
+    r88 = r88 * r102;
+    r134 = fmaf(r61, r88, r134);
+    r134 = r134 + r15;
+    r74 = fmaf(r9, r74, r66 * r134);
+    r134 = r4 * r26;
+    r134 = r134 * r11;
+    r134 = r134 * r77;
+    r74 = fmaf(r56, r134, r74);
+    r15 = r4 * r26;
+    r15 = r15 * r11;
+    r15 = r15 * r76;
+    r15 = r15 * r77;
+    r74 = fmaf(r56, r15, r74);
+    r88 = r11 * r59;
+    r88 = r88 * r83;
+    r88 = r88 * r127;
+    r88 = r88 * r47;
+    r88 = r88 * r69;
+    r74 = fmaf(r35, r88, r74);
+    r89 = r11 * r59;
+    r89 = r89 * r76;
+    r89 = r89 * r83;
+    r89 = r89 * r127;
+    r89 = r89 * r47;
+    r89 = r89 * r69;
+    r74 = fmaf(r35, r89, r74);
+    r31 = r39 * r59;
+    r74 = fmaf(r78, r31, r74);
+    r119 = r67 * r127;
+    r74 = fmaf(r121, r119, r74);
+    r13 = r67 * r11;
+    r13 = r13 * r127;
+    r13 = r13 * r62;
+    r74 = fmaf(r82, r13, r74);
+    r128 = r67 * r43;
+    r128 = r128 * r63;
+    r74 = fmaf(r62, r128, r74);
+    r120 = r11 * r81;
+    r120 = r120 * r127;
+    r120 = r120 * r35;
+    r120 = r120 * r102;
+    r74 = fmaf(r78, r120, r74);
+    r99 = r67 * r39;
+    r99 = r99 * r62;
+    r74 = fmaf(r51, r99, r74);
+    r27 = r106 * r78;
+    r74 = fmaf(r63, r27, r74);
+    r74 = fmaf(r39, r80, r74);
+    r74 = fmaf(r26, r118, r74);
+    r74 = fmaf(r127, r125, r74);
+    r27 = r5 * r74;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r100,
+                                          r28,
+                                          r64,
+                                          r27);
+    r27 = r11 * r11;
+    r64 = r40 * r11;
+    r64 = r64 * r11;
+    r28 = r16 * r44;
+    r28 = r28 * r11;
+    r28 = fmaf(r37, r28, r36 * r64);
+    r64 = r40 * r10;
+    r64 = r64 * r10;
+    r28 = fmaf(r36, r64, r28);
+    r100 = r16 * r58;
+    r100 = r100 * r10;
+    r28 = fmaf(r37, r100, r28);
+    r27 = r27 * r28;
+    r27 = r27 * r35;
+    r27 = r27 * r102;
+    r100 = r40 * r11;
+    r100 = r100 * r11;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r100 = fmaf(r36, r100, r61 * r27);
+    r27 = r44 * r63;
+    r100 = fmaf(r62, r27, r100);
+    r64 = r4 * r28;
+    r64 = r64 * r111;
+    r100 = fmaf(r112, r64, r100);
+    r64 = r40 * r10;
+    r64 = r64 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r59;
+    r64 = r64 * r47;
+    r64 = fmaf(r36, r64, r28 * r96);
+    r27 = r58 * r62;
+    r64 = fmaf(r51, r27, r64);
+    r99 = r4 * r28;
+    r99 = r99 * r101;
+    r99 = r99 * r52;
+    r64 = fmaf(r51, r99, r64);
+    r99 = r100 + r64;
+    r27 = r71 * r28;
+    r120 = r40 * r10;
+    r120 = r120 * r10;
+    r120 = r120 * r59;
+    r120 = r120 * r59;
+    r120 = r120 * r105;
+    r120 = r120 * r47;
+    r120 = fmaf(r12, r120, r96 * r27);
+    r27 = r58 * r10;
+    r27 = r27 * r59;
+    r27 = r27 * r95;
+    r120 = fmaf(r61, r27, r120);
+    r120 = fmaf(r28, r108, r120);
+    r120 = r120 + r100;
+    r120 = fmaf(r67, r120, r8 * r99);
+    r100 = r10 * r59;
+    r27 = r7 * r16;
+    r27 = r27 * r65;
+    r27 = fmaf(r99, r27, r6 * r99);
+    r27 = fmaf(r99, r75, r27);
+    r27 = fmaf(r99, r68, r27);
+    r100 = r100 * r27;
+    r120 = fmaf(r78, r100, r120);
+    r128 = r44 * r51;
+    r120 = fmaf(r72, r128, r120);
+    r13 = r58 * r59;
+    r120 = fmaf(r78, r13, r120);
+    r119 = r11 * r28;
+    r119 = r119 * r82;
+    r120 = fmaf(r72, r119, r120);
+    r31 = r81 * r28;
+    r31 = r31 * r78;
+    r120 = fmaf(r82, r31, r120);
+    r89 = r66 * r40;
+    r89 = r89 * r10;
+    r89 = r89 * r11;
+    r89 = r89 * r59;
+    r89 = r89 * r59;
+    r89 = r89 * r93;
+    r89 = r89 * r47;
+    r120 = fmaf(r12, r89, r120);
+    r88 = r81 * r28;
+    r88 = r88 * r82;
+    r120 = fmaf(r79, r88, r120);
+    r15 = r4 * r40;
+    r15 = r15 * r10;
+    r15 = r15 * r77;
+    r120 = fmaf(r56, r15, r120);
+    r134 = r4 * r40;
+    r134 = r134 * r10;
+    r134 = r134 * r76;
+    r134 = r134 * r77;
+    r120 = fmaf(r56, r134, r120);
+    r120 = fmaf(r58, r80, r120);
+    r120 = fmaf(r28, r109, r120);
+    r120 = fmaf(r28, r122, r120);
+    r120 = fmaf(r28, r113, r120);
+    r120 = fmaf(r58, r73, r120);
+    r134 = r0 * r120;
+    r15 = r11 * r11;
+    r15 = r15 * r71;
+    r15 = r15 * r28;
+    r15 = r15 * r35;
+    r15 = r15 * r102;
+    r88 = r40 * r11;
+    r88 = r88 * r11;
+    r88 = r88 * r59;
+    r88 = r88 * r59;
+    r88 = r88 * r105;
+    r88 = r88 * r47;
+    r88 = fmaf(r12, r88, r61 * r15);
+    r15 = r44 * r95;
+    r15 = r15 * r61;
+    r88 = fmaf(r63, r15, r88);
+    r89 = r107 * r28;
+    r89 = r89 * r111;
+    r88 = fmaf(r112, r89, r88);
+    r88 = r88 + r64;
+    r88 = fmaf(r66, r88, r9 * r99);
+    r99 = r67 * r44;
+    r99 = r99 * r62;
+    r88 = fmaf(r51, r99, r88);
+    r64 = r4 * r40;
+    r64 = r64 * r11;
+    r64 = r64 * r77;
+    r88 = fmaf(r56, r64, r88);
+    r89 = r11 * r81;
+    r89 = r89 * r28;
+    r89 = r89 * r35;
+    r89 = r89 * r102;
+    r88 = fmaf(r78, r89, r88);
+    r15 = r67 * r11;
+    r15 = r15 * r28;
+    r15 = r15 * r62;
+    r88 = fmaf(r82, r15, r88);
+    r31 = r67 * r28;
+    r88 = fmaf(r121, r31, r88);
+    r119 = r44 * r59;
+    r88 = fmaf(r78, r119, r88);
+    r13 = r67 * r58;
+    r13 = r13 * r63;
+    r88 = fmaf(r62, r13, r88);
+    r128 = r4 * r40;
+    r128 = r128 * r11;
+    r128 = r128 * r76;
+    r128 = r128 * r77;
+    r88 = fmaf(r56, r128, r88);
+    r100 = r11 * r59;
+    r100 = r100 * r76;
+    r100 = r100 * r83;
+    r100 = r100 * r28;
+    r100 = r100 * r47;
+    r100 = r100 * r69;
+    r88 = fmaf(r35, r100, r88);
+    r116 = r27 * r78;
+    r88 = fmaf(r63, r116, r88);
+    r135 = r11 * r59;
+    r135 = r135 * r83;
+    r135 = r135 * r28;
+    r135 = r135 * r47;
+    r135 = r135 * r69;
+    r88 = fmaf(r35, r135, r88);
+    r88 = fmaf(r28, r125, r88);
+    r88 = fmaf(r44, r80, r88);
+    r88 = fmaf(r40, r118, r88);
+    r135 = r5 * r88;
+    r116 = r11 * r11;
+    r100 = r16 * r46;
+    r100 = r100 * r11;
+    r128 = r38 * r11;
+    r128 = r128 * r11;
+    r128 = fmaf(r36, r128, r37 * r100);
+    r100 = r16 * r57;
+    r100 = r100 * r10;
+    r128 = fmaf(r37, r100, r128);
+    r13 = r38 * r10;
+    r13 = r13 * r10;
+    r128 = fmaf(r36, r13, r128);
+    r116 = r116 * r128;
+    r116 = r116 * r35;
+    r116 = r116 * r102;
+    r13 = r46 * r63;
+    r13 = fmaf(r62, r13, r61 * r116);
+    r116 = r4 * r128;
+    r116 = r116 * r111;
+    r13 = fmaf(r112, r116, r13);
+    r100 = r38 * r11;
+    r100 = r100 * r11;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r13 = fmaf(r36, r100, r13);
+    r100 = r38 * r10;
+    r100 = r100 * r10;
+    r100 = r100 * r59;
+    r100 = r100 * r59;
+    r100 = r100 * r47;
+    r116 = r4 * r128;
+    r116 = r116 * r101;
+    r116 = r116 * r52;
+    r116 = fmaf(r51, r116, r36 * r100);
+    r100 = r57 * r62;
+    r116 = fmaf(r51, r100, r116);
+    r116 = fmaf(r128, r96, r116);
+    r100 = r13 + r116;
+    r119 = r38 * r10;
+    r119 = r119 * r10;
+    r119 = r119 * r59;
+    r119 = r119 * r59;
+    r119 = r119 * r105;
+    r119 = r119 * r47;
+    r119 = fmaf(r128, r108, r12 * r119);
+    r31 = r57 * r10;
+    r31 = r31 * r59;
+    r31 = r31 * r95;
+    r119 = fmaf(r61, r31, r119);
+    r15 = r71 * r128;
+    r119 = fmaf(r96, r15, r119);
+    r119 = r119 + r13;
+    r119 = fmaf(r67, r119, r8 * r100);
+    r13 = r4 * r38;
+    r13 = r13 * r10;
+    r13 = r13 * r76;
+    r13 = r13 * r77;
+    r119 = fmaf(r56, r13, r119);
+    r15 = r57 * r59;
+    r119 = fmaf(r78, r15, r119);
+    r31 = r4 * r38;
+    r31 = r31 * r10;
+    r31 = r31 * r77;
+    r119 = fmaf(r56, r31, r119);
+    r89 = r81 * r128;
+    r89 = r89 * r82;
+    r119 = fmaf(r79, r89, r119);
+    r64 = r11 * r128;
+    r64 = r64 * r82;
+    r119 = fmaf(r72, r64, r119);
+    r99 = r46 * r51;
+    r119 = fmaf(r72, r99, r119);
+    r114 = r81 * r128;
+    r114 = r114 * r78;
+    r119 = fmaf(r82, r114, r119);
+    r131 = r10 * r59;
+    r84 = r7 * r16;
+    r84 = r84 * r65;
+    r84 = fmaf(r6, r100, r100 * r84);
+    r84 = fmaf(r100, r75, r84);
+    r84 = fmaf(r100, r68, r84);
+    r131 = r131 * r84;
+    r119 = fmaf(r78, r131, r119);
+    r87 = r66 * r38;
+    r87 = r87 * r10;
+    r87 = r87 * r11;
+    r87 = r87 * r59;
+    r87 = r87 * r59;
+    r87 = r87 * r93;
+    r87 = r87 * r47;
+    r119 = fmaf(r12, r87, r119);
+    r119 = fmaf(r57, r80, r119);
+    r119 = fmaf(r128, r109, r119);
+    r119 = fmaf(r128, r122, r119);
+    r119 = fmaf(r57, r73, r119);
+    r119 = fmaf(r128, r113, r119);
+    r87 = r0 * r119;
+    r131 = r11 * r11;
+    r131 = r131 * r71;
+    r131 = r131 * r128;
+    r131 = r131 * r35;
+    r131 = r131 * r102;
+    r114 = r46 * r95;
+    r114 = r114 * r61;
+    r114 = fmaf(r63, r114, r61 * r131);
+    r131 = r107 * r128;
+    r131 = r131 * r111;
+    r114 = fmaf(r112, r131, r114);
+    r99 = r38 * r11;
+    r99 = r99 * r11;
+    r99 = r99 * r59;
+    r99 = r99 * r59;
+    r99 = r99 * r105;
+    r99 = r99 * r47;
+    r114 = fmaf(r12, r99, r114);
+    r114 = r114 + r116;
+    r114 = fmaf(r66, r114, r9 * r100);
+    r100 = r11 * r81;
+    r100 = r100 * r128;
+    r100 = r100 * r35;
+    r100 = r100 * r102;
+    r114 = fmaf(r78, r100, r114);
+    r116 = r11 * r59;
+    r116 = r116 * r76;
+    r116 = r116 * r83;
+    r116 = r116 * r128;
+    r116 = r116 * r47;
+    r116 = r116 * r69;
+    r114 = fmaf(r35, r116, r114);
+    r99 = r11 * r59;
+    r99 = r99 * r83;
+    r99 = r99 * r128;
+    r99 = r99 * r47;
+    r99 = r99 * r69;
+    r114 = fmaf(r35, r99, r114);
+    r131 = r67 * r128;
+    r114 = fmaf(r121, r131, r114);
+    r64 = r67 * r11;
+    r64 = r64 * r128;
+    r64 = r64 * r62;
+    r114 = fmaf(r82, r64, r114);
+    r89 = r67 * r46;
+    r89 = r89 * r62;
+    r114 = fmaf(r51, r89, r114);
+    r31 = r4 * r38;
+    r31 = r31 * r11;
+    r31 = r31 * r76;
+    r31 = r31 * r77;
+    r114 = fmaf(r56, r31, r114);
+    r15 = r67 * r57;
+    r15 = r15 * r63;
+    r114 = fmaf(r62, r15, r114);
+    r13 = r46 * r59;
+    r114 = fmaf(r78, r13, r114);
+    r104 = r4 * r38;
+    r104 = r104 * r11;
+    r104 = r104 * r77;
+    r114 = fmaf(r56, r104, r114);
+    r132 = r84 * r78;
+    r114 = fmaf(r63, r132, r114);
+    r114 = fmaf(r128, r125, r114);
+    r114 = fmaf(r46, r80, r114);
+    r114 = fmaf(r38, r118, r114);
+    r132 = r5 * r114;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r134,
+                                          r135,
+                                          r87,
+                                          r132);
+    r132 = r0 * r4;
+    r132 = r132 * r2;
+    r70 = r4 * r70;
+    r87 = r5 * r70;
+    r132 = fmaf(r110, r87, r1 * r132);
+    r135 = r0 * r4;
+    r135 = r135 * r2;
+    r135 = fmaf(r86, r87, r126 * r135);
+    r134 = r0 * r4;
+    r134 = r134 * r2;
+    r134 = fmaf(r103, r87, r14 * r134);
+    r104 = r0 * r4;
+    r104 = r104 * r2;
+    r104 = fmaf(r74, r87, r90 * r104);
+    WriteSum4<float, float>((float*)inout_shared, r132, r135, r134, r104);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r0 * r4;
+    r104 = r104 * r2;
+    r104 = fmaf(r88, r87, r120 * r104);
+    r134 = r0 * r4;
+    r134 = r134 * r2;
+    r134 = fmaf(r114, r87, r119 * r134);
+    WriteSum2<float, float>((float*)inout_shared, r104, r134);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r134 = r0 * r0;
+    r104 = r1 * r134;
+    r135 = r5 * r5;
+    r132 = r110 * r135;
+    r110 = fmaf(r110, r132, r1 * r104);
+    r1 = r126 * r126;
+    r13 = r86 * r86;
+    r13 = fmaf(r135, r13, r134 * r1);
+    r1 = r103 * r103;
+    r15 = r14 * r14;
+    r15 = fmaf(r134, r15, r135 * r1);
+    r1 = r90 * r90;
+    r31 = r74 * r74;
+    r31 = fmaf(r135, r31, r134 * r1);
+    WriteSum4<float, float>((float*)inout_shared, r110, r13, r15, r31);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r120 * r120;
+    r15 = r88 * r88;
+    r15 = fmaf(r135, r15, r134 * r31);
+    r31 = r114 * r114;
+    r13 = r119 * r119;
+    r13 = fmaf(r134, r13, r135 * r31);
+    WriteSum2<float, float>((float*)inout_shared, r15, r13);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = fmaf(r126, r104, r86 * r132);
+    r15 = fmaf(r103, r132, r14 * r104);
+    r31 = fmaf(r90, r104, r74 * r132);
+    r110 = fmaf(r120, r104, r88 * r132);
+    WriteSum4<float, float>((float*)inout_shared, r13, r15, r31, r110);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = fmaf(r114, r132, r119 * r104);
+    r104 = r86 * r103;
+    r110 = r126 * r14;
+    r110 = fmaf(r134, r110, r135 * r104);
+    r104 = r126 * r90;
+    r31 = r86 * r74;
+    r31 = fmaf(r135, r31, r134 * r104);
+    r104 = r126 * r120;
+    r15 = r86 * r88;
+    r15 = fmaf(r135, r15, r134 * r104);
+    WriteSum4<float, float>((float*)inout_shared, r132, r110, r31, r15);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r15 = r86 * r114;
+    r31 = r126 * r119;
+    r31 = fmaf(r134, r31, r135 * r15);
+    r15 = r103 * r74;
+    r110 = r14 * r90;
+    r110 = fmaf(r134, r110, r135 * r15);
+    r15 = r14 * r120;
+    r132 = r103 * r88;
+    r132 = fmaf(r135, r132, r134 * r15);
+    r15 = r103 * r114;
+    r104 = r14 * r119;
+    r104 = fmaf(r134, r104, r135 * r15);
+    WriteSum4<float, float>((float*)inout_shared, r31, r110, r132, r104);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r74 * r88;
+    r132 = r90 * r120;
+    r132 = fmaf(r134, r132, r135 * r104);
+    r104 = r90 * r119;
+    r110 = r74 * r114;
+    r110 = fmaf(r135, r110, r134 * r104);
+    r104 = r88 * r114;
+    r31 = r120 * r119;
+    r31 = fmaf(r134, r31, r135 * r104);
+    WriteSum3<float, float>((float*)inout_shared, r132, r110, r31);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r4 * r2;
+    WriteSum2<float, float>((float*)inout_shared, r31, r70);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r42, r42);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r54 * r10;
+    r42 = r42 * r59;
+    r42 = r42 * r95;
+    r70 = r60 * r10;
+    r70 = r70 * r10;
+    r70 = r70 * r59;
+    r70 = r70 * r59;
+    r70 = r70 * r105;
+    r70 = r70 * r47;
+    r70 = fmaf(r12, r70, r61 * r42);
+    r42 = r16 * r33;
+    r42 = r42 * r11;
+    r31 = r16 * r54;
+    r31 = r31 * r10;
+    r31 = fmaf(r37, r31, r37 * r42);
+    r42 = r60 * r10;
+    r42 = r42 * r10;
+    r31 = fmaf(r36, r42, r31);
+    r110 = r60 * r11;
+    r110 = r110 * r11;
+    r31 = fmaf(r36, r110, r31);
+    r110 = r71 * r31;
+    r70 = fmaf(r96, r110, r70);
+    r42 = r4 * r31;
+    r42 = r42 * r111;
+    r132 = r11 * r11;
+    r132 = r132 * r31;
+    r132 = r132 * r35;
+    r132 = r132 * r102;
+    r132 = fmaf(r61, r132, r112 * r42);
+    r42 = r60 * r11;
+    r42 = r42 * r11;
+    r42 = r42 * r59;
+    r42 = r42 * r59;
+    r42 = r42 * r47;
+    r132 = fmaf(r36, r42, r132);
+    r104 = r33 * r63;
+    r132 = fmaf(r62, r104, r132);
+    r70 = fmaf(r31, r108, r70);
+    r70 = r70 + r132;
+    r110 = r54 * r62;
+    r104 = r60 * r10;
+    r104 = r104 * r10;
+    r104 = r104 * r59;
+    r104 = r104 * r59;
+    r104 = r104 * r47;
+    r104 = fmaf(r36, r104, r51 * r110);
+    r110 = r4 * r31;
+    r110 = r110 * r101;
+    r110 = r110 * r52;
+    r104 = fmaf(r51, r110, r104);
+    r104 = fmaf(r31, r96, r104);
+    r132 = r132 + r104;
+    r70 = fmaf(r8, r132, r67 * r70);
+    r110 = r4 * r60;
+    r110 = r110 * r10;
+    r110 = r110 * r76;
+    r110 = r110 * r77;
+    r70 = fmaf(r56, r110, r70);
+    r42 = r4 * r60;
+    r42 = r42 * r10;
+    r42 = r42 * r77;
+    r70 = fmaf(r56, r42, r70);
+    r15 = r33 * r51;
+    r70 = fmaf(r72, r15, r70);
+    r13 = r10 * r59;
+    r1 = r7 * r16;
+    r1 = r1 * r65;
+    r1 = fmaf(r6, r132, r132 * r1);
+    r1 = fmaf(r132, r75, r1);
+    r1 = fmaf(r132, r68, r1);
+    r13 = r13 * r1;
+    r70 = fmaf(r78, r13, r70);
+    r89 = r81 * r31;
+    r89 = r89 * r82;
+    r70 = fmaf(r79, r89, r70);
+    r64 = r54 * r59;
+    r70 = fmaf(r78, r64, r70);
+    r131 = r66 * r60;
+    r131 = r131 * r10;
+    r131 = r131 * r11;
+    r131 = r131 * r59;
+    r131 = r131 * r59;
+    r131 = r131 * r93;
+    r131 = r131 * r47;
+    r70 = fmaf(r12, r131, r70);
+    r99 = r11 * r31;
+    r99 = r99 * r82;
+    r70 = fmaf(r72, r99, r70);
+    r116 = r81 * r31;
+    r116 = r116 * r78;
+    r70 = fmaf(r82, r116, r70);
+    r70 = fmaf(r54, r80, r70);
+    r70 = fmaf(r31, r113, r70);
+    r70 = fmaf(r31, r109, r70);
+    r70 = fmaf(r31, r122, r70);
+    r70 = fmaf(r54, r73, r70);
+    r116 = r0 * r70;
+    r99 = r107 * r31;
+    r99 = r99 * r111;
+    r131 = r11 * r11;
+    r131 = r131 * r71;
+    r131 = r131 * r31;
+    r131 = r131 * r35;
+    r131 = r131 * r102;
+    r131 = fmaf(r61, r131, r112 * r99);
+    r99 = r60 * r11;
+    r99 = r99 * r11;
+    r99 = r99 * r59;
+    r99 = r99 * r59;
+    r99 = r99 * r105;
+    r99 = r99 * r47;
+    r131 = fmaf(r12, r99, r131);
+    r64 = r33 * r95;
+    r64 = r64 * r61;
+    r131 = fmaf(r63, r64, r131);
+    r131 = r131 + r104;
+    r132 = fmaf(r9, r132, r66 * r131);
+    r131 = r11 * r59;
+    r131 = r131 * r76;
+    r131 = r131 * r83;
+    r131 = r131 * r31;
+    r131 = r131 * r47;
+    r131 = r131 * r69;
+    r132 = fmaf(r35, r131, r132);
+    r104 = r4 * r60;
+    r104 = r104 * r11;
+    r104 = r104 * r76;
+    r104 = r104 * r77;
+    r132 = fmaf(r56, r104, r132);
+    r64 = r67 * r33;
+    r64 = r64 * r62;
+    r132 = fmaf(r51, r64, r132);
+    r99 = r11 * r59;
+    r99 = r99 * r83;
+    r99 = r99 * r31;
+    r99 = r99 * r47;
+    r99 = r99 * r69;
+    r132 = fmaf(r35, r99, r132);
+    r89 = r67 * r31;
+    r132 = fmaf(r121, r89, r132);
+    r13 = r67 * r54;
+    r13 = r13 * r63;
+    r132 = fmaf(r62, r13, r132);
+    r15 = r11 * r81;
+    r15 = r15 * r31;
+    r15 = r15 * r35;
+    r15 = r15 * r102;
+    r132 = fmaf(r78, r15, r132);
+    r42 = r4 * r60;
+    r42 = r42 * r11;
+    r42 = r42 * r77;
+    r132 = fmaf(r56, r42, r132);
+    r110 = r67 * r11;
+    r110 = r110 * r31;
+    r110 = r110 * r62;
+    r132 = fmaf(r82, r110, r132);
+    r100 = r33 * r59;
+    r132 = fmaf(r78, r100, r132);
+    r117 = r1 * r78;
+    r132 = fmaf(r63, r117, r132);
+    r132 = fmaf(r31, r125, r132);
+    r132 = fmaf(r60, r118, r132);
+    r132 = fmaf(r33, r80, r132);
+    r117 = r5 * r132;
+    r100 = r45 * r11;
+    r100 = r100 * r11;
+    r110 = r16 * r49;
+    r110 = r110 * r10;
+    r110 = fmaf(r37, r110, r36 * r100);
+    r100 = r16 * r50;
+    r100 = r100 * r11;
+    r110 = fmaf(r37, r100, r110);
+    r42 = r45 * r10;
+    r42 = r42 * r10;
+    r110 = fmaf(r36, r42, r110);
+    r42 = r45 * r10;
+    r42 = r42 * r10;
+    r42 = r42 * r59;
+    r42 = r42 * r59;
+    r42 = r42 * r47;
+    r42 = fmaf(r36, r42, r110 * r96);
+    r100 = r4 * r110;
+    r100 = r100 * r101;
+    r100 = r100 * r52;
+    r42 = fmaf(r51, r100, r42);
+    r15 = r49 * r62;
+    r42 = fmaf(r51, r15, r42);
+    r15 = r4 * r110;
+    r15 = r15 * r111;
+    r100 = r50 * r63;
+    r100 = fmaf(r62, r100, r112 * r15);
+    r15 = r11 * r11;
+    r15 = r15 * r110;
+    r15 = r15 * r35;
+    r15 = r15 * r102;
+    r100 = fmaf(r61, r15, r100);
+    r13 = r45 * r11;
+    r13 = r13 * r11;
+    r13 = r13 * r59;
+    r13 = r13 * r59;
+    r13 = r13 * r47;
+    r100 = fmaf(r36, r13, r100);
+    r13 = r42 + r100;
+    r15 = r71 * r110;
+    r89 = r45 * r10;
+    r89 = r89 * r10;
+    r89 = r89 * r59;
+    r89 = r89 * r59;
+    r89 = r89 * r105;
+    r89 = r89 * r47;
+    r89 = fmaf(r12, r89, r96 * r15);
+    r15 = r49 * r10;
+    r15 = r15 * r59;
+    r15 = r15 * r95;
+    r89 = fmaf(r61, r15, r89);
+    r89 = fmaf(r110, r108, r89);
+    r89 = r89 + r100;
+    r89 = fmaf(r67, r89, r8 * r13);
+    r100 = r4 * r45;
+    r100 = r100 * r10;
+    r100 = r100 * r77;
+    r89 = fmaf(r56, r100, r89);
+    r15 = r4 * r45;
+    r15 = r15 * r10;
+    r15 = r15 * r76;
+    r15 = r15 * r77;
+    r89 = fmaf(r56, r15, r89);
+    r99 = r10 * r59;
+    r64 = r7 * r16;
+    r64 = r64 * r65;
+    r64 = fmaf(r13, r64, r6 * r13);
+    r64 = fmaf(r13, r75, r64);
+    r64 = fmaf(r13, r68, r64);
+    r99 = r99 * r64;
+    r89 = fmaf(r78, r99, r89);
+    r104 = r81 * r110;
+    r104 = r104 * r78;
+    r89 = fmaf(r82, r104, r89);
+    r131 = r81 * r110;
+    r131 = r131 * r82;
+    r89 = fmaf(r79, r131, r89);
+    r130 = r50 * r51;
+    r89 = fmaf(r72, r130, r89);
+    r115 = r49 * r59;
+    r89 = fmaf(r78, r115, r89);
+    r123 = r66 * r45;
+    r123 = r123 * r10;
+    r123 = r123 * r11;
+    r123 = r123 * r59;
+    r123 = r123 * r59;
+    r123 = r123 * r93;
+    r123 = r123 * r47;
+    r89 = fmaf(r12, r123, r89);
+    r137 = r11 * r110;
+    r137 = r137 * r82;
+    r89 = fmaf(r72, r137, r89);
+    r89 = fmaf(r49, r73, r89);
+    r89 = fmaf(r110, r122, r89);
+    r89 = fmaf(r110, r109, r89);
+    r89 = fmaf(r110, r113, r89);
+    r89 = fmaf(r49, r80, r89);
+    r137 = r0 * r89;
+    r123 = r107 * r110;
+    r123 = r123 * r111;
+    r115 = r50 * r95;
+    r115 = r115 * r61;
+    r115 = fmaf(r63, r115, r112 * r123);
+    r123 = r11 * r11;
+    r123 = r123 * r71;
+    r123 = r123 * r110;
+    r123 = r123 * r35;
+    r123 = r123 * r102;
+    r115 = fmaf(r61, r123, r115);
+    r130 = r45 * r11;
+    r130 = r130 * r11;
+    r130 = r130 * r59;
+    r130 = r130 * r59;
+    r130 = r130 * r105;
+    r130 = r130 * r47;
+    r115 = fmaf(r12, r130, r115);
+    r115 = r115 + r42;
+    r115 = fmaf(r66, r115, r9 * r13);
+    r13 = r67 * r49;
+    r13 = r13 * r63;
+    r115 = fmaf(r62, r13, r115);
+    r42 = r67 * r11;
+    r42 = r42 * r110;
+    r42 = r42 * r62;
+    r115 = fmaf(r82, r42, r115);
+    r130 = r67 * r110;
+    r115 = fmaf(r121, r130, r115);
+    r123 = r11 * r59;
+    r123 = r123 * r76;
+    r123 = r123 * r83;
+    r123 = r123 * r110;
+    r123 = r123 * r47;
+    r123 = r123 * r69;
+    r115 = fmaf(r35, r123, r115);
+    r131 = r11 * r59;
+    r131 = r131 * r83;
+    r131 = r131 * r110;
+    r131 = r131 * r47;
+    r131 = r131 * r69;
+    r115 = fmaf(r35, r131, r115);
+    r104 = r64 * r78;
+    r115 = fmaf(r63, r104, r115);
+    r99 = r50 * r59;
+    r115 = fmaf(r78, r99, r115);
+    r15 = r4 * r45;
+    r15 = r15 * r11;
+    r15 = r15 * r76;
+    r15 = r15 * r77;
+    r115 = fmaf(r56, r15, r115);
+    r100 = r11 * r81;
+    r100 = r100 * r110;
+    r100 = r100 * r35;
+    r100 = r100 * r102;
+    r115 = fmaf(r78, r100, r115);
+    r138 = r67 * r50;
+    r138 = r138 * r62;
+    r115 = fmaf(r51, r138, r115);
+    r139 = r4 * r45;
+    r139 = r139 * r11;
+    r139 = r139 * r77;
+    r115 = fmaf(r56, r139, r115);
+    r115 = fmaf(r50, r80, r115);
+    r115 = fmaf(r110, r125, r115);
+    r115 = fmaf(r45, r118, r115);
+    r139 = r5 * r115;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r116,
+                                          r117,
+                                          r137,
+                                          r139);
+    r139 = r16 * r48;
+    r139 = r139 * r11;
+    r137 = r53 * r11;
+    r137 = r137 * r11;
+    r137 = fmaf(r36, r137, r37 * r139);
+    r139 = r53 * r10;
+    r139 = r139 * r10;
+    r137 = fmaf(r36, r139, r137);
+    r117 = r16 * r55;
+    r117 = r117 * r10;
+    r137 = fmaf(r37, r117, r137);
+    r117 = r4 * r137;
+    r117 = r117 * r111;
+    r139 = r48 * r63;
+    r139 = fmaf(r62, r139, r112 * r117);
+    r117 = r11 * r11;
+    r117 = r117 * r137;
+    r117 = r117 * r35;
+    r117 = r117 * r102;
+    r139 = fmaf(r61, r117, r139);
+    r37 = r53 * r11;
+    r37 = r37 * r11;
+    r37 = r37 * r59;
+    r37 = r37 * r59;
+    r37 = r37 * r47;
+    r139 = fmaf(r36, r37, r139);
+    r37 = r55 * r62;
+    r37 = fmaf(r137, r96, r51 * r37);
+    r117 = r53 * r10;
+    r117 = r117 * r10;
+    r117 = r117 * r59;
+    r117 = r117 * r59;
+    r117 = r117 * r47;
+    r37 = fmaf(r36, r117, r37);
+    r36 = r4 * r137;
+    r36 = r36 * r101;
+    r36 = r36 * r52;
+    r37 = fmaf(r51, r36, r37);
+    r36 = r139 + r37;
+    r117 = r55 * r10;
+    r117 = r117 * r59;
+    r117 = r117 * r95;
+    r52 = r71 * r137;
+    r52 = fmaf(r96, r52, r61 * r117);
+    r117 = r53 * r10;
+    r117 = r117 * r10;
+    r117 = r117 * r59;
+    r117 = r117 * r59;
+    r117 = r117 * r105;
+    r117 = r117 * r47;
+    r52 = fmaf(r12, r117, r52);
+    r52 = fmaf(r137, r108, r52);
+    r52 = r52 + r139;
+    r52 = fmaf(r67, r52, r8 * r36);
+    r8 = r48 * r51;
+    r52 = fmaf(r72, r8, r52);
+    r139 = r11 * r137;
+    r139 = r139 * r82;
+    r52 = fmaf(r72, r139, r52);
+    r72 = r4 * r53;
+    r72 = r72 * r10;
+    r72 = r72 * r76;
+    r72 = r72 * r77;
+    r52 = fmaf(r56, r72, r52);
+    r108 = r10 * r59;
+    r117 = r7 * r16;
+    r117 = r117 * r65;
+    r117 = fmaf(r36, r117, r6 * r36);
+    r117 = fmaf(r36, r75, r117);
+    r117 = fmaf(r36, r68, r117);
+    r108 = r108 * r117;
+    r52 = fmaf(r78, r108, r52);
+    r68 = r81 * r137;
+    r68 = r68 * r82;
+    r52 = fmaf(r79, r68, r52);
+    r79 = r4 * r53;
+    r79 = r79 * r10;
+    r79 = r79 * r77;
+    r52 = fmaf(r56, r79, r52);
+    r75 = r55 * r59;
+    r52 = fmaf(r78, r75, r52);
+    r6 = r81 * r137;
+    r6 = r6 * r78;
+    r52 = fmaf(r82, r6, r52);
+    r65 = r66 * r53;
+    r65 = r65 * r10;
+    r65 = r65 * r11;
+    r65 = r65 * r59;
+    r65 = r65 * r59;
+    r65 = r65 * r93;
+    r65 = r65 * r47;
+    r52 = fmaf(r12, r65, r52);
+    r52 = fmaf(r137, r113, r52);
+    r52 = fmaf(r137, r109, r52);
+    r52 = fmaf(r55, r80, r52);
+    r52 = fmaf(r137, r122, r52);
+    r52 = fmaf(r55, r73, r52);
+    r73 = r0 * r52;
+    r65 = r107 * r137;
+    r65 = r65 * r111;
+    r111 = r48 * r95;
+    r111 = r111 * r61;
+    r111 = fmaf(r63, r111, r112 * r65);
+    r65 = r11 * r11;
+    r65 = r65 * r71;
+    r65 = r65 * r137;
+    r65 = r65 * r35;
+    r65 = r65 * r102;
+    r111 = fmaf(r61, r65, r111);
+    r61 = r53 * r11;
+    r61 = r61 * r11;
+    r61 = r61 * r59;
+    r61 = r61 * r59;
+    r61 = r61 * r105;
+    r61 = r61 * r47;
+    r111 = fmaf(r12, r61, r111);
+    r111 = r111 + r37;
+    r111 = fmaf(r66, r111, r9 * r36);
+    r36 = r67 * r48;
+    r36 = r36 * r62;
+    r111 = fmaf(r51, r36, r111);
+    r9 = r4 * r53;
+    r9 = r9 * r11;
+    r9 = r9 * r76;
+    r9 = r9 * r77;
+    r111 = fmaf(r56, r9, r111);
+    r37 = r11 * r59;
+    r37 = r37 * r83;
+    r37 = r37 * r137;
+    r37 = r37 * r47;
+    r37 = r37 * r69;
+    r111 = fmaf(r35, r37, r111);
+    r61 = r67 * r11;
+    r61 = r61 * r137;
+    r61 = r61 * r62;
+    r111 = fmaf(r82, r61, r111);
+    r82 = r48 * r59;
+    r111 = fmaf(r78, r82, r111);
+    r65 = r117 * r78;
+    r111 = fmaf(r63, r65, r111);
+    r12 = r67 * r137;
+    r111 = fmaf(r121, r12, r111);
+    r121 = r11 * r59;
+    r121 = r121 * r76;
+    r121 = r121 * r83;
+    r121 = r121 * r137;
+    r121 = r121 * r47;
+    r121 = r121 * r69;
+    r111 = fmaf(r35, r121, r111);
+    r69 = r67 * r55;
+    r69 = r69 * r63;
+    r111 = fmaf(r62, r69, r111);
+    r47 = r4 * r53;
+    r47 = r47 * r11;
+    r47 = r47 * r77;
+    r111 = fmaf(r56, r47, r111);
+    r56 = r11 * r81;
+    r56 = r56 * r137;
+    r56 = r56 * r35;
+    r56 = r56 * r102;
+    r111 = fmaf(r78, r56, r111);
+    r111 = fmaf(r53, r118, r111);
+    r111 = fmaf(r137, r125, r111);
+    r111 = fmaf(r48, r80, r111);
+    r5 = r5 * r111;
+    WriteIdx2<1024, float, float, float2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r73, r5);
+    r5 = r0 * r4;
+    r5 = r5 * r2;
+    r5 = fmaf(r132, r87, r70 * r5);
+    r73 = r0 * r4;
+    r73 = r73 * r2;
+    r73 = fmaf(r115, r87, r89 * r73);
+    r56 = r0 * r4;
+    r56 = r56 * r2;
+    r87 = fmaf(r111, r87, r52 * r56);
+    WriteSum3<float, float>((float*)inout_shared, r5, r73, r87);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r87 = r70 * r70;
+    r73 = r132 * r132;
+    r73 = fmaf(r135, r73, r134 * r87);
+    r87 = r115 * r115;
+    r5 = r89 * r89;
+    r5 = fmaf(r134, r5, r135 * r87);
+    r87 = r111 * r111;
+    r56 = r52 * r52;
+    r56 = fmaf(r134, r56, r135 * r87);
+    WriteSum3<float, float>((float*)inout_shared, r73, r5, r56);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r132 * r115;
+    r5 = r70 * r89;
+    r5 = fmaf(r134, r5, r135 * r56);
+    r56 = r70 * r52;
+    r73 = r132 * r111;
+    r73 = fmaf(r135, r73, r134 * r56);
+    r56 = r115 * r111;
+    r87 = r89 * r52;
+    r87 = fmaf(r134, r87, r135 * r56);
+    WriteSum3<float, float>((float*)inout_shared, r5, r73, r87);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.cu
@@ -1,0 +1,335 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirectKernel(
+        float* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        float* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.cu
@@ -1,0 +1,318 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r13);
+    r2 = r4 * r2;
+    r13 = r4 * r13;
+    WriteSum2<float, float>((float*)inout_shared, r2, r13);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r39, r39);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_principal_point_precond_diag,
+              out_principal_point_precond_diag_num_alloc,
+              out_principal_point_precond_tril,
+              out_principal_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.cu
@@ -1,0 +1,332 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r13);
+    r3 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r2 = r4 * r2;
+    r13 = r4 * r13;
+    WriteSum2<float, float>((float*)inout_shared, r2, r13);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r39, r39);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_principal_point_precond_diag,
+              out_principal_point_precond_diag_num_alloc,
+              out_principal_point_precond_tril,
+              out_principal_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.cu
@@ -1,0 +1,290 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel(
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
@@ -1,0 +1,864 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r11 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r24, r31, r32);
+    r33 = r17 * r18;
+    r33 = r33 * r16;
+    r34 = r19 * r20;
+    r34 = fmaf(r16, r34, r33);
+    r35 = -2.00000000000000000e+00;
+    r36 = r17 * r17;
+    r36 = r35 * r36;
+    r37 = 1.00000000000000000e+00;
+    r38 = r19 * r19;
+    r38 = fmaf(r35, r38, r37);
+    r39 = r36 + r38;
+    r40 = r18 * r19;
+    r40 = r40 * r16;
+    r41 = r17 * r20;
+    r41 = fmaf(r35, r41, r40);
+    r42 = r16 * r28;
+    r42 = r42 * r27;
+    r43 = r25 * r30;
+    r44 = fmaf(r35, r43, r42);
+    r45 = r28 * r28;
+    r45 = r35 * r45;
+    r46 = r37 + r45;
+    r47 = r25 * r25;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r11 = fmaf(r24, r34, r11);
+    r11 = fmaf(r31, r39, r11);
+    r11 = fmaf(r32, r41, r11);
+    r11 = fmaf(r15, r44, r11);
+    r11 = fmaf(r14, r46, r11);
+    r41 = r11 * r11;
+    r39 = 9.99999999999999955e-07;
+    r34 = r27 * r27;
+    r34 = r35 * r34;
+    r48 = r37 + r34;
+    r48 = r48 + r45;
+    r10 = fmaf(r13, r48, r10);
+    r45 = r28 * r35;
+    r45 = fmaf(r30, r45, r26);
+    r26 = r16 * r28;
+    r26 = r26 * r25;
+    r25 = r16 * r27;
+    r25 = fmaf(r30, r25, r26);
+    r49 = r17 * r19;
+    r49 = r49 * r16;
+    r50 = r18 * r20;
+    r51 = fmaf(r16, r50, r49);
+    r52 = r19 * r20;
+    r52 = fmaf(r35, r52, r33);
+    r33 = r18 * r18;
+    r33 = r33 * r35;
+    r38 = r33 + r38;
+    r10 = fmaf(r14, r45, r10);
+    r10 = fmaf(r15, r25, r10);
+    r10 = fmaf(r32, r51, r10);
+    r10 = fmaf(r31, r52, r10);
+    r10 = fmaf(r24, r38, r10);
+    r38 = r10 * r10;
+    r52 = r35 * r27;
+    r52 = fmaf(r30, r52, r26);
+    r13 = fmaf(r13, r52, r12);
+    r50 = fmaf(r35, r50, r49);
+    r33 = r37 + r33;
+    r33 = r33 + r36;
+    r36 = r17 * r20;
+    r36 = fmaf(r16, r36, r40);
+    r43 = fmaf(r16, r43, r42);
+    r34 = r37 + r34;
+    r34 = r34 + r47;
+    r13 = fmaf(r24, r50, r13);
+    r13 = fmaf(r32, r33, r13);
+    r13 = fmaf(r31, r36, r13);
+    r13 = fmaf(r14, r43, r13);
+    r13 = fmaf(r15, r34, r13);
+    r15 = copysign(1.0, r13);
+    r15 = fmaf(r39, r15, r13);
+    r13 = r15 * r15;
+    r14 = 1.0 / r13;
+    r36 = r11 * r11;
+    r36 = fmaf(r14, r36, r14 * r38);
+    r38 = sqrtf(r36);
+    r31 = copysign(1.0, r38);
+    r31 = fmaf(r39, r31, r38);
+    r39 = r31 * r31;
+    r33 = 1.0 / r39;
+    r38 = atanf(r38);
+    r32 = r38 * r14;
+    r50 = r38 * r32;
+    r41 = r41 * r33;
+    r41 = r41 * r50;
+    r24 = r10 * r33;
+    r47 = r10 * r24;
+    r42 = r50 * r47;
+    r40 = r41 + r42;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r49,
+                                         r12,
+                                         r26,
+                                         r30);
+    r51 = 3.00000000000000000e+00;
+    r53 = r51 * r50;
+    r53 = fmaf(r47, r53, r41);
+    r53 = fmaf(r12, r53, r8 * r40);
+    r41 = r49 * r11;
+    r54 = r16 * r50;
+    r41 = r41 * r24;
+    r53 = fmaf(r54, r41, r53);
+    r55 = r40 * r40;
+    r56 = r40 * r55;
+    r57 = fmaf(r26, r56, r6 * r40);
+    r56 = r30 * r56;
+    r57 = fmaf(r40, r56, r57);
+    r57 = fmaf(r7, r55, r57);
+    r30 = 1.0 / r15;
+    r58 = 1.0 / r31;
+    r59 = r30 * r58;
+    r60 = r38 * r59;
+    r61 = r57 * r60;
+    r53 = fmaf(r10, r61, r53);
+    r53 = fmaf(r10, r60, r53);
+    r2 = fmaf(r0, r53, r2);
+    r53 = r11 * r11;
+    r53 = r53 * r51;
+    r53 = r53 * r33;
+    r53 = fmaf(r50, r53, r42);
+    r53 = fmaf(r49, r53, r9 * r40);
+    r42 = r12 * r11;
+    r42 = r42 * r24;
+    r53 = fmaf(r54, r42, r53);
+    r53 = fmaf(r11, r61, r53);
+    r53 = fmaf(r11, r60, r53);
+    r53 = fmaf(r5, r53, r1);
+    r53 = fmaf(r3, r4, r53);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r53);
+    r3 = r5 * r4;
+    r1 = r11 * r33;
+    r42 = r16 * r29;
+    r42 = r42 * r11;
+    r41 = r16 * r48;
+    r41 = r41 * r10;
+    r41 = fmaf(r14, r41, r14 * r42);
+    r42 = r52 * r10;
+    r13 = r15 * r13;
+    r13 = 1.0 / r13;
+    r15 = r35 * r13;
+    r42 = r42 * r10;
+    r41 = fmaf(r15, r42, r41);
+    r62 = r11 * r11;
+    r62 = r62 * r15;
+    r41 = fmaf(r52, r62, r41);
+    r42 = -5.00000000000000000e-01;
+    r63 = rsqrtf(r36);
+    r1 = r1 * r38;
+    r1 = r1 * r30;
+    r1 = r1 * r41;
+    r1 = r1 * r42;
+    r1 = r1 * r63;
+    r64 = -3.00000000000000000e+00;
+    r65 = r11 * r64;
+    r39 = r31 * r39;
+    r39 = 1.0 / r39;
+    r31 = r39 * r50;
+    r66 = r11 * r63;
+    r31 = r31 * r66;
+    r65 = r65 * r41;
+    r67 = r51 * r41;
+    r36 = r37 + r36;
+    r36 = 1.0 / r36;
+    r37 = r36 * r32;
+    r68 = r11 * r33;
+    r67 = r67 * r66;
+    r67 = r67 * r37;
+    r67 = fmaf(r68, r67, r31 * r65);
+    r65 = r52 * r11;
+    r69 = -6.00000000000000000e+00;
+    r65 = r65 * r11;
+    r65 = r65 * r38;
+    r65 = r65 * r38;
+    r65 = r65 * r69;
+    r65 = r65 * r33;
+    r67 = fmaf(r13, r65, r67);
+    r70 = r29 * r11;
+    r71 = 6.00000000000000000e+00;
+    r70 = r70 * r71;
+    r70 = r70 * r33;
+    r67 = fmaf(r50, r70, r67);
+    r72 = r48 * r24;
+    r73 = r52 * r15;
+    r74 = r38 * r38;
+    r75 = r47 * r74;
+    r73 = fmaf(r75, r73, r54 * r72);
+    r72 = r41 * r63;
+    r72 = r72 * r37;
+    r73 = fmaf(r47, r72, r73);
+    r76 = r4 * r10;
+    r76 = r76 * r10;
+    r76 = r76 * r41;
+    r76 = r76 * r63;
+    r76 = r76 * r39;
+    r73 = fmaf(r50, r76, r73);
+    r67 = r67 + r73;
+    r67 = fmaf(r49, r67, r1);
+    r70 = r4 * r11;
+    r70 = r70 * r41;
+    r65 = r41 * r66;
+    r65 = r65 * r37;
+    r65 = fmaf(r68, r65, r31 * r70);
+    r74 = r33 * r74;
+    r74 = r74 * r62;
+    r70 = r54 * r68;
+    r65 = fmaf(r52, r74, r65);
+    r65 = fmaf(r29, r70, r65);
+    r73 = r73 + r65;
+    r76 = 5.00000000000000000e-01;
+    r72 = r76 * r57;
+    r72 = r72 * r41;
+    r72 = r72 * r36;
+    r72 = r72 * r66;
+    r67 = fmaf(r59, r72, r67);
+    r77 = r11 * r57;
+    r78 = r4 * r52;
+    r78 = r78 * r58;
+    r78 = r78 * r32;
+    r67 = fmaf(r78, r77, r67);
+    r79 = r12 * r29;
+    r79 = r79 * r24;
+    r67 = fmaf(r54, r79, r67);
+    r80 = r12 * r11;
+    r81 = -4.00000000000000000e+00;
+    r80 = r80 * r38;
+    r80 = r80 * r38;
+    r80 = r80 * r81;
+    r80 = r80 * r13;
+    r80 = r80 * r24;
+    r82 = r12 * r35;
+    r82 = r82 * r10;
+    r82 = r82 * r41;
+    r67 = fmaf(r31, r82, r67);
+    r83 = r12 * r48;
+    r67 = fmaf(r70, r83, r67);
+    r84 = r76 * r41;
+    r84 = r84 * r36;
+    r84 = r84 * r66;
+    r67 = fmaf(r59, r84, r67);
+    r85 = r12 * r41;
+    r86 = r16 * r24;
+    r86 = r86 * r66;
+    r86 = r86 * r37;
+    r67 = fmaf(r86, r85, r67);
+    r87 = r7 * r16;
+    r87 = r87 * r40;
+    r87 = fmaf(r6, r73, r73 * r87);
+    r88 = 4.00000000000000000e+00;
+    r56 = r88 * r56;
+    r26 = r26 * r51;
+    r26 = r26 * r55;
+    r87 = fmaf(r73, r56, r87);
+    r87 = fmaf(r73, r26, r87);
+    r55 = r11 * r87;
+    r67 = fmaf(r60, r55, r67);
+    r67 = fmaf(r9, r73, r67);
+    r67 = fmaf(r57, r1, r67);
+    r67 = fmaf(r52, r80, r67);
+    r67 = fmaf(r29, r61, r67);
+    r67 = fmaf(r11, r78, r67);
+    r67 = fmaf(r29, r60, r67);
+    r3 = r3 * r53;
+    r55 = r0 * r4;
+    r85 = r48 * r71;
+    r85 = r85 * r50;
+    r84 = r69 * r13;
+    r84 = r84 * r75;
+    r85 = fmaf(r52, r84, r24 * r85);
+    r83 = r51 * r41;
+    r83 = r83 * r63;
+    r83 = r83 * r37;
+    r85 = fmaf(r47, r83, r85);
+    r82 = r10 * r10;
+    r82 = r82 * r64;
+    r82 = r82 * r41;
+    r82 = r82 * r63;
+    r82 = r82 * r39;
+    r85 = fmaf(r50, r82, r85);
+    r85 = r85 + r65;
+    r73 = fmaf(r8, r73, r12 * r85);
+    r85 = r57 * r63;
+    r65 = r38 * r41;
+    r65 = r65 * r42;
+    r65 = r65 * r30;
+    r85 = r85 * r24;
+    r73 = fmaf(r65, r85, r73);
+    r82 = r10 * r57;
+    r73 = fmaf(r78, r82, r73);
+    r83 = r49 * r29;
+    r83 = r83 * r24;
+    r73 = fmaf(r54, r83, r73);
+    r79 = r10 * r87;
+    r73 = fmaf(r60, r79, r73);
+    r77 = r10 * r76;
+    r77 = r77 * r36;
+    r77 = r77 * r63;
+    r77 = r77 * r59;
+    r1 = r57 * r77;
+    r72 = r63 * r24;
+    r73 = fmaf(r65, r72, r73);
+    r65 = r49 * r52;
+    r65 = r65 * r11;
+    r65 = r65 * r38;
+    r65 = r65 * r38;
+    r65 = r65 * r81;
+    r65 = r65 * r13;
+    r73 = fmaf(r24, r65, r73);
+    r88 = r49 * r35;
+    r88 = r88 * r10;
+    r88 = r88 * r41;
+    r73 = fmaf(r31, r88, r73);
+    r89 = r49 * r70;
+    r90 = r49 * r41;
+    r73 = fmaf(r86, r90, r73);
+    r73 = fmaf(r48, r61, r73);
+    r73 = fmaf(r10, r78, r73);
+    r73 = fmaf(r41, r1, r73);
+    r73 = fmaf(r48, r60, r73);
+    r73 = fmaf(r48, r89, r73);
+    r73 = fmaf(r41, r77, r73);
+    r55 = r55 * r2;
+    r55 = fmaf(r73, r55, r67 * r3);
+    r3 = r0 * r4;
+    r90 = r16 * r45;
+    r90 = r90 * r10;
+    r90 = fmaf(r14, r90, r43 * r62);
+    r88 = r16 * r46;
+    r88 = r88 * r11;
+    r90 = fmaf(r14, r88, r90);
+    r65 = r43 * r10;
+    r65 = r65 * r10;
+    r90 = fmaf(r15, r65, r90);
+    r65 = r90 * r63;
+    r65 = r65 * r37;
+    r88 = r43 * r15;
+    r88 = fmaf(r75, r88, r47 * r65);
+    r65 = r4 * r10;
+    r65 = r65 * r10;
+    r65 = r65 * r90;
+    r65 = r65 * r63;
+    r65 = r65 * r39;
+    r88 = fmaf(r50, r65, r88);
+    r72 = r45 * r24;
+    r88 = fmaf(r54, r72, r88);
+    r72 = r4 * r11;
+    r72 = r72 * r90;
+    r72 = fmaf(r46, r70, r31 * r72);
+    r65 = r90 * r66;
+    r65 = r65 * r37;
+    r72 = fmaf(r68, r65, r72);
+    r72 = fmaf(r43, r74, r72);
+    r65 = r88 + r72;
+    r79 = r51 * r90;
+    r79 = r79 * r63;
+    r79 = r79 * r37;
+    r79 = fmaf(r43, r84, r47 * r79);
+    r83 = r10 * r10;
+    r78 = r64 * r90;
+    r83 = r83 * r63;
+    r83 = r83 * r39;
+    r83 = r83 * r50;
+    r79 = fmaf(r78, r83, r79);
+    r82 = r45 * r71;
+    r82 = r82 * r50;
+    r79 = fmaf(r24, r82, r79);
+    r79 = r79 + r72;
+    r79 = fmaf(r12, r79, r8 * r65);
+    r72 = r49 * r35;
+    r72 = r72 * r10;
+    r72 = r72 * r90;
+    r79 = fmaf(r31, r72, r79);
+    r82 = r38 * r42;
+    r82 = r82 * r90;
+    r82 = r82 * r30;
+    r82 = r82 * r63;
+    r79 = fmaf(r24, r82, r79);
+    r83 = r4 * r43;
+    r83 = r83 * r10;
+    r83 = r83 * r58;
+    r79 = fmaf(r32, r83, r79);
+    r85 = r4 * r43;
+    r85 = r85 * r10;
+    r85 = r85 * r57;
+    r85 = r85 * r58;
+    r79 = fmaf(r32, r85, r79);
+    r91 = r7 * r16;
+    r91 = r91 * r40;
+    r91 = fmaf(r65, r91, r6 * r65);
+    r91 = fmaf(r65, r56, r91);
+    r91 = fmaf(r65, r26, r91);
+    r92 = r10 * r91;
+    r79 = fmaf(r60, r92, r79);
+    r93 = r38 * r57;
+    r93 = r93 * r42;
+    r93 = r93 * r90;
+    r93 = r93 * r30;
+    r93 = r93 * r63;
+    r79 = fmaf(r24, r93, r79);
+    r94 = r49 * r46;
+    r94 = r94 * r24;
+    r79 = fmaf(r54, r94, r79);
+    r95 = r49 * r43;
+    r95 = r95 * r11;
+    r95 = r95 * r38;
+    r95 = r95 * r38;
+    r95 = r95 * r81;
+    r95 = r95 * r13;
+    r79 = fmaf(r24, r95, r79);
+    r96 = r49 * r90;
+    r79 = fmaf(r86, r96, r79);
+    r79 = fmaf(r45, r89, r79);
+    r79 = fmaf(r90, r77, r79);
+    r79 = fmaf(r90, r1, r79);
+    r79 = fmaf(r45, r61, r79);
+    r79 = fmaf(r45, r60, r79);
+    r3 = r3 * r2;
+    r96 = r5 * r4;
+    r95 = r11 * r31;
+    r94 = r46 * r11;
+    r94 = r94 * r71;
+    r94 = r94 * r33;
+    r94 = fmaf(r50, r94, r78 * r95);
+    r95 = r51 * r90;
+    r95 = r95 * r66;
+    r95 = r95 * r37;
+    r94 = fmaf(r68, r95, r94);
+    r78 = r43 * r11;
+    r78 = r78 * r11;
+    r78 = r78 * r38;
+    r78 = r78 * r38;
+    r78 = r78 * r69;
+    r78 = r78 * r33;
+    r94 = fmaf(r13, r78, r94);
+    r94 = r94 + r88;
+    r94 = fmaf(r49, r94, r9 * r65);
+    r65 = r12 * r45;
+    r94 = fmaf(r70, r65, r94);
+    r88 = r12 * r90;
+    r94 = fmaf(r86, r88, r94);
+    r78 = r12 * r35;
+    r78 = r78 * r10;
+    r78 = r78 * r90;
+    r94 = fmaf(r31, r78, r94);
+    r95 = r38 * r57;
+    r95 = r95 * r42;
+    r95 = r95 * r90;
+    r95 = r95 * r33;
+    r95 = r95 * r30;
+    r94 = fmaf(r66, r95, r94);
+    r93 = r38 * r42;
+    r93 = r93 * r90;
+    r93 = r93 * r33;
+    r93 = r93 * r30;
+    r94 = fmaf(r66, r93, r94);
+    r92 = r11 * r91;
+    r94 = fmaf(r60, r92, r94);
+    r85 = r4 * r43;
+    r85 = r85 * r11;
+    r85 = r85 * r57;
+    r85 = r85 * r58;
+    r94 = fmaf(r32, r85, r94);
+    r83 = r76 * r90;
+    r83 = r83 * r36;
+    r83 = r83 * r66;
+    r94 = fmaf(r59, r83, r94);
+    r82 = r12 * r46;
+    r82 = r82 * r24;
+    r94 = fmaf(r54, r82, r94);
+    r72 = r76 * r57;
+    r72 = r72 * r90;
+    r72 = r72 * r36;
+    r72 = r72 * r66;
+    r94 = fmaf(r59, r72, r94);
+    r97 = r4 * r43;
+    r97 = r97 * r11;
+    r97 = r97 * r58;
+    r94 = fmaf(r32, r97, r94);
+    r94 = fmaf(r46, r60, r94);
+    r94 = fmaf(r46, r61, r94);
+    r94 = fmaf(r43, r80, r94);
+    r96 = r96 * r53;
+    r96 = fmaf(r94, r96, r79 * r3);
+    r3 = r0 * r4;
+    r97 = r4 * r11;
+    r72 = r16 * r44;
+    r72 = r72 * r11;
+    r62 = fmaf(r34, r62, r14 * r72);
+    r72 = r34 * r10;
+    r72 = r72 * r10;
+    r62 = fmaf(r15, r72, r62);
+    r82 = r16 * r25;
+    r82 = r82 * r10;
+    r62 = fmaf(r14, r82, r62);
+    r82 = r62 * r31;
+    r97 = fmaf(r44, r70, r82 * r97);
+    r72 = r62 * r66;
+    r72 = r72 * r37;
+    r97 = fmaf(r68, r72, r97);
+    r97 = fmaf(r34, r74, r97);
+    r74 = r25 * r24;
+    r72 = r62 * r63;
+    r72 = r72 * r37;
+    r72 = fmaf(r47, r72, r54 * r74);
+    r74 = r34 * r15;
+    r72 = fmaf(r75, r74, r72);
+    r75 = r4 * r10;
+    r75 = r75 * r10;
+    r75 = r75 * r62;
+    r75 = r75 * r63;
+    r75 = r75 * r39;
+    r72 = fmaf(r50, r75, r72);
+    r75 = r97 + r72;
+    r74 = r25 * r71;
+    r74 = r74 * r50;
+    r14 = r51 * r62;
+    r14 = r14 * r63;
+    r14 = r14 * r37;
+    r14 = fmaf(r47, r14, r24 * r74);
+    r74 = r10 * r10;
+    r74 = r74 * r64;
+    r74 = r74 * r62;
+    r74 = r74 * r63;
+    r74 = r74 * r39;
+    r14 = fmaf(r50, r74, r14);
+    r14 = fmaf(r34, r84, r14);
+    r14 = r14 + r97;
+    r14 = fmaf(r12, r14, r8 * r75);
+    r8 = r49 * r44;
+    r8 = r8 * r24;
+    r14 = fmaf(r54, r8, r14);
+    r97 = r49 * r62;
+    r14 = fmaf(r86, r97, r14);
+    r74 = r38 * r57;
+    r74 = r74 * r42;
+    r74 = r74 * r62;
+    r74 = r74 * r30;
+    r74 = r74 * r63;
+    r14 = fmaf(r24, r74, r14);
+    r84 = r4 * r34;
+    r84 = r84 * r10;
+    r84 = r84 * r57;
+    r84 = r84 * r58;
+    r14 = fmaf(r32, r84, r14);
+    r39 = r7 * r16;
+    r39 = r39 * r40;
+    r39 = fmaf(r75, r39, r6 * r75);
+    r39 = fmaf(r75, r56, r39);
+    r39 = fmaf(r75, r26, r39);
+    r26 = r10 * r39;
+    r14 = fmaf(r60, r26, r14);
+    r56 = r4 * r34;
+    r56 = r56 * r10;
+    r56 = r56 * r58;
+    r14 = fmaf(r32, r56, r14);
+    r6 = r38 * r42;
+    r6 = r6 * r62;
+    r6 = r6 * r30;
+    r6 = r6 * r63;
+    r14 = fmaf(r24, r6, r14);
+    r40 = r35 * r10;
+    r40 = r40 * r82;
+    r47 = r49 * r34;
+    r47 = r47 * r11;
+    r47 = r47 * r38;
+    r47 = r47 * r38;
+    r47 = r47 * r81;
+    r47 = r47 * r13;
+    r14 = fmaf(r24, r47, r14);
+    r14 = fmaf(r62, r1, r14);
+    r14 = fmaf(r25, r60, r14);
+    r14 = fmaf(r25, r61, r14);
+    r14 = fmaf(r49, r40, r14);
+    r14 = fmaf(r62, r77, r14);
+    r14 = fmaf(r25, r89, r14);
+    r3 = r3 * r2;
+    r2 = r5 * r4;
+    r89 = r11 * r64;
+    r47 = r44 * r11;
+    r47 = r47 * r71;
+    r47 = r47 * r33;
+    r47 = fmaf(r50, r47, r82 * r89);
+    r89 = r51 * r62;
+    r89 = r89 * r66;
+    r89 = r89 * r37;
+    r47 = fmaf(r68, r89, r47);
+    r68 = r34 * r11;
+    r68 = r68 * r11;
+    r68 = r68 * r38;
+    r68 = r68 * r38;
+    r68 = r68 * r69;
+    r68 = r68 * r33;
+    r47 = fmaf(r13, r68, r47);
+    r47 = r47 + r72;
+    r47 = fmaf(r49, r47, r9 * r75);
+    r75 = r12 * r44;
+    r75 = r75 * r24;
+    r47 = fmaf(r54, r75, r47);
+    r54 = r4 * r34;
+    r54 = r54 * r11;
+    r54 = r54 * r57;
+    r54 = r54 * r58;
+    r47 = fmaf(r32, r54, r47);
+    r9 = r38 * r42;
+    r9 = r9 * r62;
+    r9 = r9 * r33;
+    r9 = r9 * r30;
+    r47 = fmaf(r66, r9, r47);
+    r72 = r12 * r62;
+    r47 = fmaf(r86, r72, r47);
+    r86 = r11 * r39;
+    r47 = fmaf(r60, r86, r47);
+    r68 = r38 * r57;
+    r68 = r68 * r42;
+    r68 = r68 * r62;
+    r68 = r68 * r33;
+    r68 = r68 * r30;
+    r47 = fmaf(r66, r68, r47);
+    r30 = r76 * r57;
+    r30 = r30 * r62;
+    r30 = r30 * r36;
+    r30 = r30 * r66;
+    r47 = fmaf(r59, r30, r47);
+    r33 = r12 * r25;
+    r47 = fmaf(r70, r33, r47);
+    r70 = r4 * r34;
+    r70 = r70 * r11;
+    r70 = r70 * r58;
+    r47 = fmaf(r32, r70, r47);
+    r32 = r76 * r62;
+    r32 = r32 * r36;
+    r32 = r32 * r66;
+    r47 = fmaf(r59, r32, r47);
+    r47 = fmaf(r44, r60, r47);
+    r47 = fmaf(r12, r40, r47);
+    r47 = fmaf(r34, r80, r47);
+    r47 = fmaf(r44, r61, r47);
+    r2 = r2 * r53;
+    r2 = fmaf(r47, r2, r14 * r3);
+    WriteSum3<float, float>((float*)inout_shared, r55, r96, r2);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r73 * r73;
+    r96 = r0 * r0;
+    r55 = r5 * r5;
+    r3 = r67 * r55;
+    r67 = fmaf(r67, r3, r96 * r2);
+    r2 = r94 * r94;
+    r53 = r79 * r79;
+    r53 = fmaf(r96, r53, r55 * r2);
+    r2 = r47 * r47;
+    r32 = r14 * r96;
+    r14 = fmaf(r14, r32, r55 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r67, r53, r14);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r14 = r73 * r79;
+    r14 = fmaf(r96, r14, r94 * r3);
+    r3 = fmaf(r47, r3, r73 * r32);
+    r96 = r94 * r47;
+    r32 = fmaf(r79, r32, r55 * r96);
+    WriteSum3<float, float>((float*)inout_shared, r14, r3, r32);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,878 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r11 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r24, r31, r32);
+    r33 = r17 * r18;
+    r33 = r33 * r16;
+    r34 = r19 * r20;
+    r34 = fmaf(r16, r34, r33);
+    r35 = -2.00000000000000000e+00;
+    r36 = r17 * r17;
+    r36 = r35 * r36;
+    r37 = 1.00000000000000000e+00;
+    r38 = r19 * r19;
+    r38 = fmaf(r35, r38, r37);
+    r39 = r36 + r38;
+    r40 = r18 * r19;
+    r40 = r40 * r16;
+    r41 = r17 * r20;
+    r41 = fmaf(r35, r41, r40);
+    r42 = r16 * r28;
+    r42 = r42 * r27;
+    r43 = r25 * r30;
+    r44 = fmaf(r35, r43, r42);
+    r45 = r28 * r28;
+    r45 = r35 * r45;
+    r46 = r37 + r45;
+    r47 = r25 * r25;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r11 = fmaf(r24, r34, r11);
+    r11 = fmaf(r31, r39, r11);
+    r11 = fmaf(r32, r41, r11);
+    r11 = fmaf(r15, r44, r11);
+    r11 = fmaf(r14, r46, r11);
+    r41 = r11 * r11;
+    r39 = 9.99999999999999955e-07;
+    r34 = r27 * r27;
+    r34 = r35 * r34;
+    r48 = r37 + r34;
+    r48 = r48 + r45;
+    r10 = fmaf(r13, r48, r10);
+    r45 = r28 * r35;
+    r45 = fmaf(r30, r45, r26);
+    r26 = r16 * r28;
+    r26 = r26 * r25;
+    r25 = r16 * r27;
+    r25 = fmaf(r30, r25, r26);
+    r49 = r17 * r19;
+    r49 = r49 * r16;
+    r50 = r18 * r20;
+    r51 = fmaf(r16, r50, r49);
+    r52 = r19 * r20;
+    r52 = fmaf(r35, r52, r33);
+    r33 = r18 * r18;
+    r33 = r33 * r35;
+    r38 = r33 + r38;
+    r10 = fmaf(r14, r45, r10);
+    r10 = fmaf(r15, r25, r10);
+    r10 = fmaf(r32, r51, r10);
+    r10 = fmaf(r31, r52, r10);
+    r10 = fmaf(r24, r38, r10);
+    r38 = r10 * r10;
+    r52 = r35 * r27;
+    r52 = fmaf(r30, r52, r26);
+    r13 = fmaf(r13, r52, r12);
+    r50 = fmaf(r35, r50, r49);
+    r33 = r37 + r33;
+    r33 = r33 + r36;
+    r36 = r17 * r20;
+    r36 = fmaf(r16, r36, r40);
+    r43 = fmaf(r16, r43, r42);
+    r34 = r37 + r34;
+    r34 = r34 + r47;
+    r13 = fmaf(r24, r50, r13);
+    r13 = fmaf(r32, r33, r13);
+    r13 = fmaf(r31, r36, r13);
+    r13 = fmaf(r14, r43, r13);
+    r13 = fmaf(r15, r34, r13);
+    r15 = copysign(1.0, r13);
+    r15 = fmaf(r39, r15, r13);
+    r13 = r15 * r15;
+    r14 = 1.0 / r13;
+    r36 = r11 * r11;
+    r36 = fmaf(r14, r36, r14 * r38);
+    r38 = sqrtf(r36);
+    r31 = copysign(1.0, r38);
+    r31 = fmaf(r39, r31, r38);
+    r39 = r31 * r31;
+    r33 = 1.0 / r39;
+    r38 = atanf(r38);
+    r32 = r38 * r14;
+    r50 = r38 * r32;
+    r41 = r41 * r33;
+    r41 = r41 * r50;
+    r24 = r10 * r33;
+    r47 = r10 * r24;
+    r42 = r50 * r47;
+    r40 = r41 + r42;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r49,
+                                         r12,
+                                         r26,
+                                         r30);
+    r51 = 3.00000000000000000e+00;
+    r53 = r51 * r50;
+    r53 = fmaf(r47, r53, r41);
+    r53 = fmaf(r12, r53, r8 * r40);
+    r41 = r49 * r11;
+    r54 = r16 * r50;
+    r41 = r41 * r24;
+    r53 = fmaf(r54, r41, r53);
+    r55 = r40 * r40;
+    r56 = r40 * r55;
+    r57 = fmaf(r26, r56, r6 * r40);
+    r56 = r30 * r56;
+    r57 = fmaf(r40, r56, r57);
+    r57 = fmaf(r7, r55, r57);
+    r30 = 1.0 / r15;
+    r58 = 1.0 / r31;
+    r59 = r30 * r58;
+    r60 = r38 * r59;
+    r61 = r57 * r60;
+    r53 = fmaf(r10, r61, r53);
+    r53 = fmaf(r10, r60, r53);
+    r2 = fmaf(r0, r53, r2);
+    r53 = r11 * r11;
+    r53 = r53 * r51;
+    r53 = r53 * r33;
+    r53 = fmaf(r50, r53, r42);
+    r53 = fmaf(r49, r53, r9 * r40);
+    r42 = r12 * r11;
+    r42 = r42 * r24;
+    r53 = fmaf(r54, r42, r53);
+    r53 = fmaf(r11, r61, r53);
+    r53 = fmaf(r11, r60, r53);
+    r53 = fmaf(r5, r53, r1);
+    r53 = fmaf(r3, r4, r53);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r53);
+    r3 = fmaf(r53, r53, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r5 * r4;
+    r1 = r11 * r33;
+    r42 = r16 * r29;
+    r42 = r42 * r11;
+    r41 = r16 * r48;
+    r41 = r41 * r10;
+    r41 = fmaf(r14, r41, r14 * r42);
+    r42 = r52 * r10;
+    r13 = r15 * r13;
+    r13 = 1.0 / r13;
+    r15 = r35 * r13;
+    r42 = r42 * r10;
+    r41 = fmaf(r15, r42, r41);
+    r62 = r11 * r11;
+    r62 = r62 * r15;
+    r41 = fmaf(r52, r62, r41);
+    r42 = -5.00000000000000000e-01;
+    r63 = rsqrtf(r36);
+    r1 = r1 * r38;
+    r1 = r1 * r30;
+    r1 = r1 * r41;
+    r1 = r1 * r42;
+    r1 = r1 * r63;
+    r64 = -3.00000000000000000e+00;
+    r65 = r11 * r64;
+    r39 = r31 * r39;
+    r39 = 1.0 / r39;
+    r31 = r39 * r50;
+    r66 = r11 * r63;
+    r31 = r31 * r66;
+    r65 = r65 * r41;
+    r67 = r51 * r41;
+    r36 = r37 + r36;
+    r36 = 1.0 / r36;
+    r37 = r36 * r32;
+    r68 = r11 * r33;
+    r67 = r67 * r66;
+    r67 = r67 * r37;
+    r67 = fmaf(r68, r67, r31 * r65);
+    r65 = r52 * r11;
+    r69 = -6.00000000000000000e+00;
+    r65 = r65 * r11;
+    r65 = r65 * r38;
+    r65 = r65 * r38;
+    r65 = r65 * r69;
+    r65 = r65 * r33;
+    r67 = fmaf(r13, r65, r67);
+    r70 = r29 * r11;
+    r71 = 6.00000000000000000e+00;
+    r70 = r70 * r71;
+    r70 = r70 * r33;
+    r67 = fmaf(r50, r70, r67);
+    r72 = r48 * r24;
+    r73 = r52 * r15;
+    r74 = r38 * r38;
+    r75 = r47 * r74;
+    r73 = fmaf(r75, r73, r54 * r72);
+    r72 = r41 * r63;
+    r72 = r72 * r37;
+    r73 = fmaf(r47, r72, r73);
+    r76 = r4 * r10;
+    r76 = r76 * r10;
+    r76 = r76 * r41;
+    r76 = r76 * r63;
+    r76 = r76 * r39;
+    r73 = fmaf(r50, r76, r73);
+    r67 = r67 + r73;
+    r67 = fmaf(r49, r67, r1);
+    r70 = r4 * r11;
+    r70 = r70 * r41;
+    r65 = r41 * r66;
+    r65 = r65 * r37;
+    r65 = fmaf(r68, r65, r31 * r70);
+    r74 = r33 * r74;
+    r74 = r74 * r62;
+    r70 = r54 * r68;
+    r65 = fmaf(r52, r74, r65);
+    r65 = fmaf(r29, r70, r65);
+    r73 = r73 + r65;
+    r76 = 5.00000000000000000e-01;
+    r72 = r76 * r57;
+    r72 = r72 * r41;
+    r72 = r72 * r36;
+    r72 = r72 * r66;
+    r67 = fmaf(r59, r72, r67);
+    r77 = r11 * r57;
+    r78 = r4 * r52;
+    r78 = r78 * r58;
+    r78 = r78 * r32;
+    r67 = fmaf(r78, r77, r67);
+    r79 = r12 * r29;
+    r79 = r79 * r24;
+    r67 = fmaf(r54, r79, r67);
+    r80 = r12 * r11;
+    r81 = -4.00000000000000000e+00;
+    r80 = r80 * r38;
+    r80 = r80 * r38;
+    r80 = r80 * r81;
+    r80 = r80 * r13;
+    r80 = r80 * r24;
+    r82 = r12 * r35;
+    r82 = r82 * r10;
+    r82 = r82 * r41;
+    r67 = fmaf(r31, r82, r67);
+    r83 = r12 * r48;
+    r67 = fmaf(r70, r83, r67);
+    r84 = r76 * r41;
+    r84 = r84 * r36;
+    r84 = r84 * r66;
+    r67 = fmaf(r59, r84, r67);
+    r85 = r12 * r41;
+    r86 = r16 * r24;
+    r86 = r86 * r66;
+    r86 = r86 * r37;
+    r67 = fmaf(r86, r85, r67);
+    r87 = r7 * r16;
+    r87 = r87 * r40;
+    r87 = fmaf(r6, r73, r73 * r87);
+    r88 = 4.00000000000000000e+00;
+    r56 = r88 * r56;
+    r26 = r26 * r51;
+    r26 = r26 * r55;
+    r87 = fmaf(r73, r56, r87);
+    r87 = fmaf(r73, r26, r87);
+    r55 = r11 * r87;
+    r67 = fmaf(r60, r55, r67);
+    r67 = fmaf(r9, r73, r67);
+    r67 = fmaf(r57, r1, r67);
+    r67 = fmaf(r52, r80, r67);
+    r67 = fmaf(r29, r61, r67);
+    r67 = fmaf(r11, r78, r67);
+    r67 = fmaf(r29, r60, r67);
+    r3 = r3 * r53;
+    r55 = r0 * r4;
+    r85 = r48 * r71;
+    r85 = r85 * r50;
+    r84 = r69 * r13;
+    r84 = r84 * r75;
+    r85 = fmaf(r52, r84, r24 * r85);
+    r83 = r51 * r41;
+    r83 = r83 * r63;
+    r83 = r83 * r37;
+    r85 = fmaf(r47, r83, r85);
+    r82 = r10 * r10;
+    r82 = r82 * r64;
+    r82 = r82 * r41;
+    r82 = r82 * r63;
+    r82 = r82 * r39;
+    r85 = fmaf(r50, r82, r85);
+    r85 = r85 + r65;
+    r73 = fmaf(r8, r73, r12 * r85);
+    r85 = r57 * r63;
+    r65 = r38 * r41;
+    r65 = r65 * r42;
+    r65 = r65 * r30;
+    r85 = r85 * r24;
+    r73 = fmaf(r65, r85, r73);
+    r82 = r10 * r57;
+    r73 = fmaf(r78, r82, r73);
+    r83 = r49 * r29;
+    r83 = r83 * r24;
+    r73 = fmaf(r54, r83, r73);
+    r79 = r10 * r87;
+    r73 = fmaf(r60, r79, r73);
+    r77 = r10 * r76;
+    r77 = r77 * r36;
+    r77 = r77 * r63;
+    r77 = r77 * r59;
+    r1 = r57 * r77;
+    r72 = r63 * r24;
+    r73 = fmaf(r65, r72, r73);
+    r65 = r49 * r52;
+    r65 = r65 * r11;
+    r65 = r65 * r38;
+    r65 = r65 * r38;
+    r65 = r65 * r81;
+    r65 = r65 * r13;
+    r73 = fmaf(r24, r65, r73);
+    r88 = r49 * r35;
+    r88 = r88 * r10;
+    r88 = r88 * r41;
+    r73 = fmaf(r31, r88, r73);
+    r89 = r49 * r70;
+    r90 = r49 * r41;
+    r73 = fmaf(r86, r90, r73);
+    r73 = fmaf(r48, r61, r73);
+    r73 = fmaf(r10, r78, r73);
+    r73 = fmaf(r41, r1, r73);
+    r73 = fmaf(r48, r60, r73);
+    r73 = fmaf(r48, r89, r73);
+    r73 = fmaf(r41, r77, r73);
+    r55 = r55 * r2;
+    r55 = fmaf(r73, r55, r67 * r3);
+    r3 = r0 * r4;
+    r90 = r16 * r45;
+    r90 = r90 * r10;
+    r90 = fmaf(r14, r90, r43 * r62);
+    r88 = r16 * r46;
+    r88 = r88 * r11;
+    r90 = fmaf(r14, r88, r90);
+    r65 = r43 * r10;
+    r65 = r65 * r10;
+    r90 = fmaf(r15, r65, r90);
+    r65 = r90 * r63;
+    r65 = r65 * r37;
+    r88 = r43 * r15;
+    r88 = fmaf(r75, r88, r47 * r65);
+    r65 = r4 * r10;
+    r65 = r65 * r10;
+    r65 = r65 * r90;
+    r65 = r65 * r63;
+    r65 = r65 * r39;
+    r88 = fmaf(r50, r65, r88);
+    r72 = r45 * r24;
+    r88 = fmaf(r54, r72, r88);
+    r72 = r4 * r11;
+    r72 = r72 * r90;
+    r72 = fmaf(r46, r70, r31 * r72);
+    r65 = r90 * r66;
+    r65 = r65 * r37;
+    r72 = fmaf(r68, r65, r72);
+    r72 = fmaf(r43, r74, r72);
+    r65 = r88 + r72;
+    r79 = r51 * r90;
+    r79 = r79 * r63;
+    r79 = r79 * r37;
+    r79 = fmaf(r43, r84, r47 * r79);
+    r83 = r10 * r10;
+    r78 = r64 * r90;
+    r83 = r83 * r63;
+    r83 = r83 * r39;
+    r83 = r83 * r50;
+    r79 = fmaf(r78, r83, r79);
+    r82 = r45 * r71;
+    r82 = r82 * r50;
+    r79 = fmaf(r24, r82, r79);
+    r79 = r79 + r72;
+    r79 = fmaf(r12, r79, r8 * r65);
+    r72 = r49 * r35;
+    r72 = r72 * r10;
+    r72 = r72 * r90;
+    r79 = fmaf(r31, r72, r79);
+    r82 = r38 * r42;
+    r82 = r82 * r90;
+    r82 = r82 * r30;
+    r82 = r82 * r63;
+    r79 = fmaf(r24, r82, r79);
+    r83 = r4 * r43;
+    r83 = r83 * r10;
+    r83 = r83 * r58;
+    r79 = fmaf(r32, r83, r79);
+    r85 = r4 * r43;
+    r85 = r85 * r10;
+    r85 = r85 * r57;
+    r85 = r85 * r58;
+    r79 = fmaf(r32, r85, r79);
+    r91 = r7 * r16;
+    r91 = r91 * r40;
+    r91 = fmaf(r65, r91, r6 * r65);
+    r91 = fmaf(r65, r56, r91);
+    r91 = fmaf(r65, r26, r91);
+    r92 = r10 * r91;
+    r79 = fmaf(r60, r92, r79);
+    r93 = r38 * r57;
+    r93 = r93 * r42;
+    r93 = r93 * r90;
+    r93 = r93 * r30;
+    r93 = r93 * r63;
+    r79 = fmaf(r24, r93, r79);
+    r94 = r49 * r46;
+    r94 = r94 * r24;
+    r79 = fmaf(r54, r94, r79);
+    r95 = r49 * r43;
+    r95 = r95 * r11;
+    r95 = r95 * r38;
+    r95 = r95 * r38;
+    r95 = r95 * r81;
+    r95 = r95 * r13;
+    r79 = fmaf(r24, r95, r79);
+    r96 = r49 * r90;
+    r79 = fmaf(r86, r96, r79);
+    r79 = fmaf(r45, r89, r79);
+    r79 = fmaf(r90, r77, r79);
+    r79 = fmaf(r90, r1, r79);
+    r79 = fmaf(r45, r61, r79);
+    r79 = fmaf(r45, r60, r79);
+    r3 = r3 * r2;
+    r96 = r5 * r4;
+    r95 = r11 * r31;
+    r94 = r46 * r11;
+    r94 = r94 * r71;
+    r94 = r94 * r33;
+    r94 = fmaf(r50, r94, r78 * r95);
+    r95 = r51 * r90;
+    r95 = r95 * r66;
+    r95 = r95 * r37;
+    r94 = fmaf(r68, r95, r94);
+    r78 = r43 * r11;
+    r78 = r78 * r11;
+    r78 = r78 * r38;
+    r78 = r78 * r38;
+    r78 = r78 * r69;
+    r78 = r78 * r33;
+    r94 = fmaf(r13, r78, r94);
+    r94 = r94 + r88;
+    r94 = fmaf(r49, r94, r9 * r65);
+    r65 = r12 * r45;
+    r94 = fmaf(r70, r65, r94);
+    r88 = r12 * r90;
+    r94 = fmaf(r86, r88, r94);
+    r78 = r12 * r35;
+    r78 = r78 * r10;
+    r78 = r78 * r90;
+    r94 = fmaf(r31, r78, r94);
+    r95 = r38 * r57;
+    r95 = r95 * r42;
+    r95 = r95 * r90;
+    r95 = r95 * r33;
+    r95 = r95 * r30;
+    r94 = fmaf(r66, r95, r94);
+    r93 = r38 * r42;
+    r93 = r93 * r90;
+    r93 = r93 * r33;
+    r93 = r93 * r30;
+    r94 = fmaf(r66, r93, r94);
+    r92 = r11 * r91;
+    r94 = fmaf(r60, r92, r94);
+    r85 = r4 * r43;
+    r85 = r85 * r11;
+    r85 = r85 * r57;
+    r85 = r85 * r58;
+    r94 = fmaf(r32, r85, r94);
+    r83 = r76 * r90;
+    r83 = r83 * r36;
+    r83 = r83 * r66;
+    r94 = fmaf(r59, r83, r94);
+    r82 = r12 * r46;
+    r82 = r82 * r24;
+    r94 = fmaf(r54, r82, r94);
+    r72 = r76 * r57;
+    r72 = r72 * r90;
+    r72 = r72 * r36;
+    r72 = r72 * r66;
+    r94 = fmaf(r59, r72, r94);
+    r97 = r4 * r43;
+    r97 = r97 * r11;
+    r97 = r97 * r58;
+    r94 = fmaf(r32, r97, r94);
+    r94 = fmaf(r46, r60, r94);
+    r94 = fmaf(r46, r61, r94);
+    r94 = fmaf(r43, r80, r94);
+    r96 = r96 * r53;
+    r96 = fmaf(r94, r96, r79 * r3);
+    r3 = r0 * r4;
+    r97 = r4 * r11;
+    r72 = r16 * r44;
+    r72 = r72 * r11;
+    r62 = fmaf(r34, r62, r14 * r72);
+    r72 = r34 * r10;
+    r72 = r72 * r10;
+    r62 = fmaf(r15, r72, r62);
+    r82 = r16 * r25;
+    r82 = r82 * r10;
+    r62 = fmaf(r14, r82, r62);
+    r82 = r62 * r31;
+    r97 = fmaf(r44, r70, r82 * r97);
+    r72 = r62 * r66;
+    r72 = r72 * r37;
+    r97 = fmaf(r68, r72, r97);
+    r97 = fmaf(r34, r74, r97);
+    r74 = r25 * r24;
+    r72 = r62 * r63;
+    r72 = r72 * r37;
+    r72 = fmaf(r47, r72, r54 * r74);
+    r74 = r34 * r15;
+    r72 = fmaf(r75, r74, r72);
+    r75 = r4 * r10;
+    r75 = r75 * r10;
+    r75 = r75 * r62;
+    r75 = r75 * r63;
+    r75 = r75 * r39;
+    r72 = fmaf(r50, r75, r72);
+    r75 = r97 + r72;
+    r74 = r25 * r71;
+    r74 = r74 * r50;
+    r14 = r51 * r62;
+    r14 = r14 * r63;
+    r14 = r14 * r37;
+    r14 = fmaf(r47, r14, r24 * r74);
+    r74 = r10 * r10;
+    r74 = r74 * r64;
+    r74 = r74 * r62;
+    r74 = r74 * r63;
+    r74 = r74 * r39;
+    r14 = fmaf(r50, r74, r14);
+    r14 = fmaf(r34, r84, r14);
+    r14 = r14 + r97;
+    r14 = fmaf(r12, r14, r8 * r75);
+    r8 = r49 * r44;
+    r8 = r8 * r24;
+    r14 = fmaf(r54, r8, r14);
+    r97 = r49 * r62;
+    r14 = fmaf(r86, r97, r14);
+    r74 = r38 * r57;
+    r74 = r74 * r42;
+    r74 = r74 * r62;
+    r74 = r74 * r30;
+    r74 = r74 * r63;
+    r14 = fmaf(r24, r74, r14);
+    r84 = r4 * r34;
+    r84 = r84 * r10;
+    r84 = r84 * r57;
+    r84 = r84 * r58;
+    r14 = fmaf(r32, r84, r14);
+    r39 = r7 * r16;
+    r39 = r39 * r40;
+    r39 = fmaf(r75, r39, r6 * r75);
+    r39 = fmaf(r75, r56, r39);
+    r39 = fmaf(r75, r26, r39);
+    r26 = r10 * r39;
+    r14 = fmaf(r60, r26, r14);
+    r56 = r4 * r34;
+    r56 = r56 * r10;
+    r56 = r56 * r58;
+    r14 = fmaf(r32, r56, r14);
+    r6 = r38 * r42;
+    r6 = r6 * r62;
+    r6 = r6 * r30;
+    r6 = r6 * r63;
+    r14 = fmaf(r24, r6, r14);
+    r40 = r35 * r10;
+    r40 = r40 * r82;
+    r47 = r49 * r34;
+    r47 = r47 * r11;
+    r47 = r47 * r38;
+    r47 = r47 * r38;
+    r47 = r47 * r81;
+    r47 = r47 * r13;
+    r14 = fmaf(r24, r47, r14);
+    r14 = fmaf(r62, r1, r14);
+    r14 = fmaf(r25, r60, r14);
+    r14 = fmaf(r25, r61, r14);
+    r14 = fmaf(r49, r40, r14);
+    r14 = fmaf(r62, r77, r14);
+    r14 = fmaf(r25, r89, r14);
+    r3 = r3 * r2;
+    r2 = r5 * r4;
+    r89 = r11 * r64;
+    r47 = r44 * r11;
+    r47 = r47 * r71;
+    r47 = r47 * r33;
+    r47 = fmaf(r50, r47, r82 * r89);
+    r89 = r51 * r62;
+    r89 = r89 * r66;
+    r89 = r89 * r37;
+    r47 = fmaf(r68, r89, r47);
+    r68 = r34 * r11;
+    r68 = r68 * r11;
+    r68 = r68 * r38;
+    r68 = r68 * r38;
+    r68 = r68 * r69;
+    r68 = r68 * r33;
+    r47 = fmaf(r13, r68, r47);
+    r47 = r47 + r72;
+    r47 = fmaf(r49, r47, r9 * r75);
+    r75 = r12 * r44;
+    r75 = r75 * r24;
+    r47 = fmaf(r54, r75, r47);
+    r54 = r4 * r34;
+    r54 = r54 * r11;
+    r54 = r54 * r57;
+    r54 = r54 * r58;
+    r47 = fmaf(r32, r54, r47);
+    r9 = r38 * r42;
+    r9 = r9 * r62;
+    r9 = r9 * r33;
+    r9 = r9 * r30;
+    r47 = fmaf(r66, r9, r47);
+    r72 = r12 * r62;
+    r47 = fmaf(r86, r72, r47);
+    r86 = r11 * r39;
+    r47 = fmaf(r60, r86, r47);
+    r68 = r38 * r57;
+    r68 = r68 * r42;
+    r68 = r68 * r62;
+    r68 = r68 * r33;
+    r68 = r68 * r30;
+    r47 = fmaf(r66, r68, r47);
+    r30 = r76 * r57;
+    r30 = r30 * r62;
+    r30 = r30 * r36;
+    r30 = r30 * r66;
+    r47 = fmaf(r59, r30, r47);
+    r33 = r12 * r25;
+    r47 = fmaf(r70, r33, r47);
+    r70 = r4 * r34;
+    r70 = r70 * r11;
+    r70 = r70 * r58;
+    r47 = fmaf(r32, r70, r47);
+    r32 = r76 * r62;
+    r32 = r32 * r36;
+    r32 = r32 * r66;
+    r47 = fmaf(r59, r32, r47);
+    r47 = fmaf(r44, r60, r47);
+    r47 = fmaf(r12, r40, r47);
+    r47 = fmaf(r34, r80, r47);
+    r47 = fmaf(r44, r61, r47);
+    r2 = r2 * r53;
+    r2 = fmaf(r47, r2, r14 * r3);
+    WriteSum3<float, float>((float*)inout_shared, r55, r96, r2);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r73 * r73;
+    r96 = r0 * r0;
+    r55 = r67 * r67;
+    r3 = r5 * r5;
+    r55 = fmaf(r3, r55, r96 * r2);
+    r2 = r94 * r94;
+    r53 = r79 * r79;
+    r53 = fmaf(r96, r53, r3 * r2);
+    r2 = r47 * r3;
+    r32 = r14 * r96;
+    r14 = fmaf(r14, r32, r47 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r55, r53, r14);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r14 = r67 * r94;
+    r53 = r73 * r79;
+    r53 = fmaf(r96, r53, r3 * r14);
+    r14 = fmaf(r67, r2, r73 * r32);
+    r32 = fmaf(r79, r32, r94 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r53, r14, r32);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.cu
@@ -1,0 +1,295 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.cu
@@ -1,0 +1,136 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirectKernel(
+        float* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        float* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1,
+                       r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r3, r4);
+    ReadIdx4<1024, float, float, float4>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r5, r6, r7, r8);
+    r9 = fmaf(r1, r7, r2 * r3);
+    r9 = fmaf(r0, r5, r9);
+    r1 = fmaf(r1, r8, r2 * r4);
+    r1 = fmaf(r0, r6, r1);
+    WriteSum2<float, float>((float*)inout_shared, r9, r1);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(principal_point_njtr,
+                              0 * principal_point_njtr_num_alloc,
+                              principal_point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_njtr_indices_loc[threadIdx.x].target,
+                       r1,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r5 = fmaf(r1, r5, r9 * r6);
+    r7 = fmaf(r1, r7, r9 * r8);
+    r3 = fmaf(r1, r3, r9 * r4);
+    WriteSum3<float, float>((float*)inout_shared, r5, r7, r3);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+    float* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    float* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.cu
@@ -1,0 +1,941 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r11 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r24, r31, r32);
+    r33 = r17 * r18;
+    r33 = r33 * r16;
+    r34 = r19 * r20;
+    r34 = fmaf(r16, r34, r33);
+    r35 = -2.00000000000000000e+00;
+    r36 = r17 * r17;
+    r36 = r35 * r36;
+    r37 = 1.00000000000000000e+00;
+    r38 = r19 * r19;
+    r38 = fmaf(r35, r38, r37);
+    r39 = r36 + r38;
+    r40 = r18 * r19;
+    r40 = r40 * r16;
+    r41 = r17 * r20;
+    r41 = fmaf(r35, r41, r40);
+    r42 = r16 * r28;
+    r42 = r42 * r27;
+    r43 = r25 * r30;
+    r44 = fmaf(r35, r43, r42);
+    r45 = r28 * r28;
+    r45 = r35 * r45;
+    r46 = r37 + r45;
+    r47 = r25 * r25;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r11 = fmaf(r24, r34, r11);
+    r11 = fmaf(r31, r39, r11);
+    r11 = fmaf(r32, r41, r11);
+    r11 = fmaf(r15, r44, r11);
+    r11 = fmaf(r14, r46, r11);
+    r41 = r11 * r11;
+    r39 = 9.99999999999999955e-07;
+    r34 = r27 * r27;
+    r34 = r35 * r34;
+    r48 = r37 + r34;
+    r48 = r48 + r45;
+    r10 = fmaf(r13, r48, r10);
+    r45 = r28 * r35;
+    r45 = fmaf(r30, r45, r26);
+    r26 = r16 * r28;
+    r26 = r26 * r25;
+    r25 = r16 * r27;
+    r25 = fmaf(r30, r25, r26);
+    r49 = r17 * r19;
+    r49 = r49 * r16;
+    r50 = r18 * r20;
+    r51 = fmaf(r16, r50, r49);
+    r52 = r19 * r20;
+    r52 = fmaf(r35, r52, r33);
+    r33 = r18 * r18;
+    r33 = r33 * r35;
+    r38 = r33 + r38;
+    r10 = fmaf(r14, r45, r10);
+    r10 = fmaf(r15, r25, r10);
+    r10 = fmaf(r32, r51, r10);
+    r10 = fmaf(r31, r52, r10);
+    r10 = fmaf(r24, r38, r10);
+    r38 = r10 * r10;
+    r52 = r35 * r27;
+    r52 = fmaf(r30, r52, r26);
+    r13 = fmaf(r13, r52, r12);
+    r50 = fmaf(r35, r50, r49);
+    r33 = r37 + r33;
+    r33 = r33 + r36;
+    r36 = r17 * r20;
+    r36 = fmaf(r16, r36, r40);
+    r43 = fmaf(r16, r43, r42);
+    r34 = r37 + r34;
+    r34 = r34 + r47;
+    r13 = fmaf(r24, r50, r13);
+    r13 = fmaf(r32, r33, r13);
+    r13 = fmaf(r31, r36, r13);
+    r13 = fmaf(r14, r43, r13);
+    r13 = fmaf(r15, r34, r13);
+    r15 = copysign(1.0, r13);
+    r15 = fmaf(r39, r15, r13);
+    r13 = r15 * r15;
+    r14 = 1.0 / r13;
+    r36 = r11 * r11;
+    r36 = fmaf(r14, r36, r14 * r38);
+    r38 = sqrtf(r36);
+    r31 = copysign(1.0, r38);
+    r31 = fmaf(r39, r31, r38);
+    r39 = r31 * r31;
+    r33 = 1.0 / r39;
+    r38 = atanf(r38);
+    r32 = r38 * r14;
+    r50 = r38 * r32;
+    r41 = r41 * r33;
+    r41 = r41 * r50;
+    r24 = r10 * r33;
+    r47 = r10 * r24;
+    r42 = r50 * r47;
+    r40 = r41 + r42;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r49,
+                                         r12,
+                                         r26,
+                                         r30);
+    r51 = 3.00000000000000000e+00;
+    r53 = r51 * r50;
+    r53 = fmaf(r47, r53, r41);
+    r53 = fmaf(r12, r53, r8 * r40);
+    r41 = r49 * r11;
+    r54 = r16 * r50;
+    r41 = r41 * r24;
+    r53 = fmaf(r54, r41, r53);
+    r55 = r40 * r40;
+    r56 = r40 * r55;
+    r57 = fmaf(r26, r56, r6 * r40);
+    r56 = r30 * r56;
+    r57 = fmaf(r40, r56, r57);
+    r57 = fmaf(r7, r55, r57);
+    r30 = 1.0 / r15;
+    r58 = 1.0 / r31;
+    r59 = r30 * r58;
+    r60 = r38 * r59;
+    r61 = r57 * r60;
+    r53 = fmaf(r10, r61, r53);
+    r53 = fmaf(r10, r60, r53);
+    r2 = fmaf(r0, r53, r2);
+    r53 = r11 * r11;
+    r53 = r53 * r51;
+    r53 = r53 * r33;
+    r53 = fmaf(r50, r53, r42);
+    r53 = fmaf(r49, r53, r9 * r40);
+    r42 = r12 * r11;
+    r42 = r42 * r24;
+    r53 = fmaf(r54, r42, r53);
+    r53 = fmaf(r11, r61, r53);
+    r53 = fmaf(r11, r60, r53);
+    r53 = fmaf(r5, r53, r1);
+    r53 = fmaf(r3, r4, r53);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r53);
+    r3 = r4 * r2;
+    r1 = r4 * r53;
+    WriteSum2<float, float>((float*)inout_shared, r3, r1);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r37, r37);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = 6.00000000000000000e+00;
+    r3 = r48 * r1;
+    r3 = r3 * r50;
+    r42 = -6.00000000000000000e+00;
+    r13 = r15 * r13;
+    r13 = 1.0 / r13;
+    r15 = r42 * r13;
+    r41 = r38 * r38;
+    r62 = r47 * r41;
+    r15 = r15 * r62;
+    r3 = fmaf(r52, r15, r24 * r3);
+    r63 = r16 * r29;
+    r63 = r63 * r11;
+    r64 = r16 * r48;
+    r64 = r64 * r10;
+    r64 = fmaf(r14, r64, r14 * r63);
+    r63 = r52 * r10;
+    r65 = r35 * r13;
+    r63 = r63 * r10;
+    r64 = fmaf(r65, r63, r64);
+    r66 = r11 * r11;
+    r66 = r66 * r65;
+    r64 = fmaf(r52, r66, r64);
+    r63 = r51 * r64;
+    r67 = rsqrtf(r36);
+    r36 = r37 + r36;
+    r36 = 1.0 / r36;
+    r37 = r36 * r32;
+    r63 = r63 * r67;
+    r63 = r63 * r37;
+    r3 = fmaf(r47, r63, r3);
+    r68 = r10 * r10;
+    r69 = -3.00000000000000000e+00;
+    r39 = r31 * r39;
+    r39 = 1.0 / r39;
+    r68 = r68 * r69;
+    r68 = r68 * r64;
+    r68 = r68 * r67;
+    r68 = r68 * r39;
+    r3 = fmaf(r50, r68, r3);
+    r31 = r4 * r11;
+    r70 = r39 * r50;
+    r71 = r11 * r67;
+    r70 = r70 * r71;
+    r31 = r31 * r64;
+    r72 = r64 * r71;
+    r73 = r11 * r33;
+    r72 = r72 * r37;
+    r72 = fmaf(r73, r72, r70 * r31);
+    r41 = r33 * r41;
+    r41 = r41 * r66;
+    r31 = r54 * r73;
+    r72 = fmaf(r52, r41, r72);
+    r72 = fmaf(r29, r31, r72);
+    r3 = r3 + r72;
+    r68 = r48 * r24;
+    r63 = r52 * r65;
+    r63 = fmaf(r62, r63, r54 * r68);
+    r68 = r64 * r67;
+    r68 = r68 * r37;
+    r63 = fmaf(r47, r68, r63);
+    r74 = r4 * r10;
+    r74 = r74 * r10;
+    r74 = r74 * r64;
+    r74 = r74 * r67;
+    r74 = r74 * r39;
+    r63 = fmaf(r50, r74, r63);
+    r72 = r72 + r63;
+    r3 = fmaf(r8, r72, r12 * r3);
+    r74 = r57 * r67;
+    r68 = -5.00000000000000000e-01;
+    r75 = r38 * r68;
+    r75 = r75 * r64;
+    r75 = r75 * r30;
+    r74 = r74 * r24;
+    r3 = fmaf(r75, r74, r3);
+    r76 = r10 * r57;
+    r77 = r4 * r52;
+    r77 = r77 * r58;
+    r77 = r77 * r32;
+    r3 = fmaf(r77, r76, r3);
+    r78 = r49 * r29;
+    r78 = r78 * r24;
+    r3 = fmaf(r54, r78, r3);
+    r79 = r7 * r16;
+    r79 = r79 * r40;
+    r79 = fmaf(r6, r72, r72 * r79);
+    r80 = 4.00000000000000000e+00;
+    r56 = r80 * r56;
+    r26 = r26 * r51;
+    r26 = r26 * r55;
+    r79 = fmaf(r72, r56, r79);
+    r79 = fmaf(r72, r26, r79);
+    r55 = r10 * r79;
+    r3 = fmaf(r60, r55, r3);
+    r80 = 5.00000000000000000e-01;
+    r81 = r10 * r80;
+    r81 = r81 * r67;
+    r81 = r81 * r36;
+    r81 = r81 * r59;
+    r82 = r57 * r81;
+    r83 = r67 * r24;
+    r3 = fmaf(r75, r83, r3);
+    r75 = r49 * r11;
+    r84 = -4.00000000000000000e+00;
+    r75 = r75 * r38;
+    r75 = r75 * r38;
+    r75 = r75 * r84;
+    r75 = r75 * r13;
+    r75 = r75 * r24;
+    r85 = r49 * r35;
+    r85 = r85 * r10;
+    r85 = r85 * r64;
+    r3 = fmaf(r70, r85, r3);
+    r86 = r49 * r48;
+    r3 = fmaf(r31, r86, r3);
+    r87 = r49 * r64;
+    r88 = r16 * r24;
+    r88 = r88 * r71;
+    r88 = r88 * r37;
+    r3 = fmaf(r88, r87, r3);
+    r3 = fmaf(r48, r61, r3);
+    r3 = fmaf(r10, r77, r3);
+    r3 = fmaf(r64, r82, r3);
+    r3 = fmaf(r48, r60, r3);
+    r3 = fmaf(r52, r75, r3);
+    r3 = fmaf(r64, r81, r3);
+    r87 = r0 * r3;
+    r86 = r11 * r33;
+    r86 = r86 * r38;
+    r86 = r86 * r30;
+    r86 = r86 * r68;
+    r86 = r86 * r64;
+    r86 = r86 * r67;
+    r85 = r11 * r69;
+    r85 = r85 * r64;
+    r83 = r51 * r64;
+    r83 = r83 * r71;
+    r83 = r83 * r37;
+    r83 = fmaf(r73, r83, r70 * r85);
+    r85 = r52 * r11;
+    r85 = r85 * r11;
+    r85 = r85 * r38;
+    r85 = r85 * r38;
+    r85 = r85 * r42;
+    r85 = r85 * r33;
+    r83 = fmaf(r13, r85, r83);
+    r55 = r29 * r11;
+    r55 = r55 * r1;
+    r55 = r55 * r33;
+    r83 = fmaf(r50, r55, r83);
+    r83 = r83 + r63;
+    r83 = fmaf(r49, r83, r86);
+    r63 = r80 * r57;
+    r63 = r63 * r64;
+    r63 = r63 * r36;
+    r63 = r63 * r71;
+    r83 = fmaf(r59, r63, r83);
+    r55 = r11 * r57;
+    r83 = fmaf(r77, r55, r83);
+    r85 = r12 * r29;
+    r85 = r85 * r24;
+    r83 = fmaf(r54, r85, r83);
+    r78 = r12 * r52;
+    r78 = r78 * r11;
+    r78 = r78 * r38;
+    r78 = r78 * r38;
+    r78 = r78 * r84;
+    r78 = r78 * r13;
+    r83 = fmaf(r24, r78, r83);
+    r76 = r12 * r35;
+    r76 = r76 * r10;
+    r76 = r76 * r64;
+    r83 = fmaf(r70, r76, r83);
+    r74 = r12 * r31;
+    r89 = r80 * r64;
+    r89 = r89 * r36;
+    r89 = r89 * r71;
+    r83 = fmaf(r59, r89, r83);
+    r90 = r12 * r64;
+    r83 = fmaf(r88, r90, r83);
+    r91 = r11 * r79;
+    r83 = fmaf(r60, r91, r83);
+    r83 = fmaf(r9, r72, r83);
+    r83 = fmaf(r57, r86, r83);
+    r83 = fmaf(r48, r74, r83);
+    r83 = fmaf(r29, r61, r83);
+    r83 = fmaf(r11, r77, r83);
+    r83 = fmaf(r29, r60, r83);
+    r91 = r5 * r83;
+    r90 = r16 * r45;
+    r90 = r90 * r10;
+    r90 = fmaf(r14, r90, r43 * r66);
+    r77 = r16 * r46;
+    r77 = r77 * r11;
+    r90 = fmaf(r14, r77, r90);
+    r89 = r43 * r10;
+    r89 = r89 * r10;
+    r90 = fmaf(r65, r89, r90);
+    r89 = r90 * r67;
+    r89 = r89 * r37;
+    r77 = r43 * r65;
+    r77 = fmaf(r62, r77, r47 * r89);
+    r89 = r4 * r10;
+    r89 = r89 * r10;
+    r89 = r89 * r90;
+    r89 = r89 * r67;
+    r89 = r89 * r39;
+    r77 = fmaf(r50, r89, r77);
+    r76 = r45 * r24;
+    r77 = fmaf(r54, r76, r77);
+    r76 = r4 * r11;
+    r76 = r76 * r90;
+    r76 = fmaf(r46, r31, r70 * r76);
+    r89 = r90 * r71;
+    r89 = r89 * r37;
+    r76 = fmaf(r73, r89, r76);
+    r76 = fmaf(r43, r41, r76);
+    r89 = r77 + r76;
+    r78 = r51 * r90;
+    r78 = r78 * r67;
+    r78 = r78 * r37;
+    r78 = fmaf(r43, r15, r47 * r78);
+    r85 = r10 * r10;
+    r55 = r69 * r90;
+    r85 = r85 * r67;
+    r85 = r85 * r39;
+    r85 = r85 * r50;
+    r78 = fmaf(r55, r85, r78);
+    r86 = r45 * r1;
+    r86 = r86 * r50;
+    r78 = fmaf(r24, r86, r78);
+    r78 = r78 + r76;
+    r78 = fmaf(r12, r78, r8 * r89);
+    r76 = r49 * r45;
+    r78 = fmaf(r31, r76, r78);
+    r86 = r49 * r35;
+    r86 = r86 * r10;
+    r86 = r86 * r90;
+    r78 = fmaf(r70, r86, r78);
+    r85 = r38 * r68;
+    r85 = r85 * r90;
+    r85 = r85 * r30;
+    r85 = r85 * r67;
+    r78 = fmaf(r24, r85, r78);
+    r63 = r4 * r43;
+    r63 = r63 * r10;
+    r63 = r63 * r58;
+    r78 = fmaf(r32, r63, r78);
+    r72 = r4 * r43;
+    r72 = r72 * r10;
+    r72 = r72 * r57;
+    r72 = r72 * r58;
+    r78 = fmaf(r32, r72, r78);
+    r92 = r7 * r16;
+    r92 = r92 * r40;
+    r92 = fmaf(r89, r92, r6 * r89);
+    r92 = fmaf(r89, r56, r92);
+    r92 = fmaf(r89, r26, r92);
+    r93 = r10 * r92;
+    r78 = fmaf(r60, r93, r78);
+    r94 = r38 * r57;
+    r94 = r94 * r68;
+    r94 = r94 * r90;
+    r94 = r94 * r30;
+    r94 = r94 * r67;
+    r78 = fmaf(r24, r94, r78);
+    r95 = r49 * r46;
+    r95 = r95 * r24;
+    r78 = fmaf(r54, r95, r78);
+    r96 = r49 * r90;
+    r78 = fmaf(r88, r96, r78);
+    r78 = fmaf(r90, r81, r78);
+    r78 = fmaf(r90, r82, r78);
+    r78 = fmaf(r45, r61, r78);
+    r78 = fmaf(r45, r60, r78);
+    r78 = fmaf(r43, r75, r78);
+    r96 = r0 * r78;
+    r95 = r11 * r70;
+    r94 = r46 * r11;
+    r94 = r94 * r1;
+    r94 = r94 * r33;
+    r94 = fmaf(r50, r94, r55 * r95);
+    r95 = r51 * r90;
+    r95 = r95 * r71;
+    r95 = r95 * r37;
+    r94 = fmaf(r73, r95, r94);
+    r55 = r43 * r11;
+    r55 = r55 * r11;
+    r55 = r55 * r38;
+    r55 = r55 * r38;
+    r55 = r55 * r42;
+    r55 = r55 * r33;
+    r94 = fmaf(r13, r55, r94);
+    r94 = r94 + r77;
+    r94 = fmaf(r49, r94, r9 * r89);
+    r89 = r12 * r90;
+    r94 = fmaf(r88, r89, r94);
+    r77 = r12 * r35;
+    r77 = r77 * r10;
+    r77 = r77 * r90;
+    r94 = fmaf(r70, r77, r94);
+    r55 = r38 * r57;
+    r55 = r55 * r68;
+    r55 = r55 * r90;
+    r55 = r55 * r33;
+    r55 = r55 * r30;
+    r94 = fmaf(r71, r55, r94);
+    r95 = r38 * r68;
+    r95 = r95 * r90;
+    r95 = r95 * r33;
+    r95 = r95 * r30;
+    r94 = fmaf(r71, r95, r94);
+    r93 = r11 * r92;
+    r94 = fmaf(r60, r93, r94);
+    r72 = r4 * r43;
+    r72 = r72 * r11;
+    r72 = r72 * r57;
+    r72 = r72 * r58;
+    r94 = fmaf(r32, r72, r94);
+    r63 = r80 * r90;
+    r63 = r63 * r36;
+    r63 = r63 * r71;
+    r94 = fmaf(r59, r63, r94);
+    r85 = r12 * r46;
+    r85 = r85 * r24;
+    r94 = fmaf(r54, r85, r94);
+    r86 = r80 * r57;
+    r86 = r86 * r90;
+    r86 = r86 * r36;
+    r86 = r86 * r71;
+    r94 = fmaf(r59, r86, r94);
+    r76 = r4 * r43;
+    r76 = r76 * r11;
+    r76 = r76 * r58;
+    r94 = fmaf(r32, r76, r94);
+    r97 = r12 * r43;
+    r97 = r97 * r11;
+    r97 = r97 * r38;
+    r97 = r97 * r38;
+    r97 = r97 * r84;
+    r97 = r97 * r13;
+    r94 = fmaf(r24, r97, r94);
+    r94 = fmaf(r45, r74, r94);
+    r94 = fmaf(r46, r60, r94);
+    r94 = fmaf(r46, r61, r94);
+    r97 = r5 * r94;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r87,
+                                          r91,
+                                          r96,
+                                          r97);
+    r97 = r4 * r11;
+    r96 = r16 * r44;
+    r96 = r96 * r11;
+    r66 = fmaf(r34, r66, r14 * r96);
+    r96 = r34 * r10;
+    r96 = r96 * r10;
+    r66 = fmaf(r65, r96, r66);
+    r91 = r16 * r25;
+    r91 = r91 * r10;
+    r66 = fmaf(r14, r91, r66);
+    r91 = r66 * r70;
+    r97 = fmaf(r44, r31, r91 * r97);
+    r96 = r66 * r71;
+    r96 = r96 * r37;
+    r97 = fmaf(r73, r96, r97);
+    r97 = fmaf(r34, r41, r97);
+    r41 = r25 * r24;
+    r96 = r66 * r67;
+    r96 = r96 * r37;
+    r96 = fmaf(r47, r96, r54 * r41);
+    r41 = r34 * r65;
+    r96 = fmaf(r62, r41, r96);
+    r62 = r4 * r10;
+    r62 = r62 * r10;
+    r62 = r62 * r66;
+    r62 = r62 * r67;
+    r62 = r62 * r39;
+    r96 = fmaf(r50, r62, r96);
+    r62 = r97 + r96;
+    r41 = r25 * r1;
+    r41 = r41 * r50;
+    r14 = r51 * r66;
+    r14 = r14 * r67;
+    r14 = r14 * r37;
+    r14 = fmaf(r47, r14, r24 * r41);
+    r41 = r10 * r10;
+    r41 = r41 * r69;
+    r41 = r41 * r66;
+    r41 = r41 * r67;
+    r41 = r41 * r39;
+    r14 = fmaf(r50, r41, r14);
+    r14 = fmaf(r34, r15, r14);
+    r14 = r14 + r97;
+    r14 = fmaf(r12, r14, r8 * r62);
+    r8 = r49 * r44;
+    r8 = r8 * r24;
+    r14 = fmaf(r54, r8, r14);
+    r97 = r49 * r66;
+    r14 = fmaf(r88, r97, r14);
+    r41 = r38 * r57;
+    r41 = r41 * r68;
+    r41 = r41 * r66;
+    r41 = r41 * r30;
+    r41 = r41 * r67;
+    r14 = fmaf(r24, r41, r14);
+    r15 = r4 * r34;
+    r15 = r15 * r10;
+    r15 = r15 * r57;
+    r15 = r15 * r58;
+    r14 = fmaf(r32, r15, r14);
+    r39 = r7 * r16;
+    r39 = r39 * r40;
+    r39 = fmaf(r62, r39, r6 * r62);
+    r39 = fmaf(r62, r56, r39);
+    r39 = fmaf(r62, r26, r39);
+    r26 = r10 * r39;
+    r14 = fmaf(r60, r26, r14);
+    r56 = r4 * r34;
+    r56 = r56 * r10;
+    r56 = r56 * r58;
+    r14 = fmaf(r32, r56, r14);
+    r6 = r38 * r68;
+    r6 = r6 * r66;
+    r6 = r6 * r30;
+    r6 = r6 * r67;
+    r14 = fmaf(r24, r6, r14);
+    r40 = r35 * r10;
+    r40 = r40 * r91;
+    r47 = r49 * r25;
+    r14 = fmaf(r31, r47, r14);
+    r14 = fmaf(r66, r82, r14);
+    r14 = fmaf(r25, r60, r14);
+    r14 = fmaf(r25, r61, r14);
+    r14 = fmaf(r49, r40, r14);
+    r14 = fmaf(r66, r81, r14);
+    r14 = fmaf(r34, r75, r14);
+    r47 = r0 * r14;
+    r75 = r11 * r69;
+    r81 = r44 * r11;
+    r81 = r81 * r1;
+    r81 = r81 * r33;
+    r81 = fmaf(r50, r81, r91 * r75);
+    r75 = r51 * r66;
+    r75 = r75 * r71;
+    r75 = r75 * r37;
+    r81 = fmaf(r73, r75, r81);
+    r73 = r34 * r11;
+    r73 = r73 * r11;
+    r73 = r73 * r38;
+    r73 = r73 * r38;
+    r73 = r73 * r42;
+    r73 = r73 * r33;
+    r81 = fmaf(r13, r73, r81);
+    r81 = r81 + r96;
+    r81 = fmaf(r49, r81, r9 * r62);
+    r62 = r12 * r44;
+    r62 = r62 * r24;
+    r81 = fmaf(r54, r62, r81);
+    r54 = r4 * r34;
+    r54 = r54 * r11;
+    r54 = r54 * r57;
+    r54 = r54 * r58;
+    r81 = fmaf(r32, r54, r81);
+    r9 = r38 * r68;
+    r9 = r9 * r66;
+    r9 = r9 * r33;
+    r9 = r9 * r30;
+    r81 = fmaf(r71, r9, r81);
+    r96 = r12 * r66;
+    r81 = fmaf(r88, r96, r81);
+    r88 = r11 * r39;
+    r81 = fmaf(r60, r88, r81);
+    r73 = r12 * r34;
+    r73 = r73 * r11;
+    r73 = r73 * r38;
+    r73 = r73 * r38;
+    r73 = r73 * r84;
+    r73 = r73 * r13;
+    r81 = fmaf(r24, r73, r81);
+    r13 = r38 * r57;
+    r13 = r13 * r68;
+    r13 = r13 * r66;
+    r13 = r13 * r33;
+    r13 = r13 * r30;
+    r81 = fmaf(r71, r13, r81);
+    r30 = r80 * r57;
+    r30 = r30 * r66;
+    r30 = r30 * r36;
+    r30 = r30 * r71;
+    r81 = fmaf(r59, r30, r81);
+    r33 = r4 * r34;
+    r33 = r33 * r11;
+    r33 = r33 * r58;
+    r81 = fmaf(r32, r33, r81);
+    r32 = r80 * r66;
+    r32 = r32 * r36;
+    r32 = r32 * r71;
+    r81 = fmaf(r59, r32, r81);
+    r81 = fmaf(r44, r60, r81);
+    r81 = fmaf(r12, r40, r81);
+    r81 = fmaf(r44, r61, r81);
+    r81 = fmaf(r25, r74, r81);
+    r32 = r5 * r81;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r47,
+                                          r32);
+    r32 = r5 * r4;
+    r32 = r32 * r53;
+    r47 = r0 * r4;
+    r47 = r47 * r2;
+    r47 = fmaf(r3, r47, r83 * r32);
+    r32 = r0 * r4;
+    r32 = r32 * r2;
+    r33 = r5 * r4;
+    r33 = r33 * r53;
+    r33 = fmaf(r94, r33, r78 * r32);
+    r32 = r0 * r4;
+    r32 = r32 * r2;
+    r2 = r5 * r4;
+    r2 = r2 * r53;
+    r2 = fmaf(r81, r2, r14 * r32);
+    WriteSum3<float, float>((float*)inout_shared, r47, r33, r2);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r3 * r3;
+    r33 = r0 * r0;
+    r47 = r5 * r5;
+    r32 = r83 * r47;
+    r83 = fmaf(r83, r32, r33 * r2);
+    r2 = r94 * r94;
+    r53 = r78 * r33;
+    r78 = fmaf(r78, r53, r47 * r2);
+    r2 = r81 * r81;
+    r74 = r14 * r14;
+    r74 = fmaf(r33, r74, r47 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r83, r78, r74);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = fmaf(r3, r53, r94 * r32);
+    r78 = r3 * r14;
+    r32 = fmaf(r81, r32, r33 * r78);
+    r78 = r94 * r81;
+    r53 = fmaf(r14, r53, r47 * r78);
+    WriteSum3<float, float>((float*)inout_shared, r74, r32, r53);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacKernel<<<n_blocks,
+                                                                 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.cu
@@ -1,0 +1,955 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        float* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        float* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        float* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r11 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r24, r31, r32);
+    r33 = r17 * r18;
+    r33 = r33 * r16;
+    r34 = r19 * r20;
+    r34 = fmaf(r16, r34, r33);
+    r35 = -2.00000000000000000e+00;
+    r36 = r17 * r17;
+    r36 = r35 * r36;
+    r37 = 1.00000000000000000e+00;
+    r38 = r19 * r19;
+    r38 = fmaf(r35, r38, r37);
+    r39 = r36 + r38;
+    r40 = r18 * r19;
+    r40 = r40 * r16;
+    r41 = r17 * r20;
+    r41 = fmaf(r35, r41, r40);
+    r42 = r16 * r28;
+    r42 = r42 * r27;
+    r43 = r25 * r30;
+    r44 = fmaf(r35, r43, r42);
+    r45 = r28 * r28;
+    r45 = r35 * r45;
+    r46 = r37 + r45;
+    r47 = r25 * r25;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r11 = fmaf(r24, r34, r11);
+    r11 = fmaf(r31, r39, r11);
+    r11 = fmaf(r32, r41, r11);
+    r11 = fmaf(r15, r44, r11);
+    r11 = fmaf(r14, r46, r11);
+    r41 = r11 * r11;
+    r39 = 9.99999999999999955e-07;
+    r34 = r27 * r27;
+    r34 = r35 * r34;
+    r48 = r37 + r34;
+    r48 = r48 + r45;
+    r10 = fmaf(r13, r48, r10);
+    r45 = r28 * r35;
+    r45 = fmaf(r30, r45, r26);
+    r26 = r16 * r28;
+    r26 = r26 * r25;
+    r25 = r16 * r27;
+    r25 = fmaf(r30, r25, r26);
+    r49 = r17 * r19;
+    r49 = r49 * r16;
+    r50 = r18 * r20;
+    r51 = fmaf(r16, r50, r49);
+    r52 = r19 * r20;
+    r52 = fmaf(r35, r52, r33);
+    r33 = r18 * r18;
+    r33 = r33 * r35;
+    r38 = r33 + r38;
+    r10 = fmaf(r14, r45, r10);
+    r10 = fmaf(r15, r25, r10);
+    r10 = fmaf(r32, r51, r10);
+    r10 = fmaf(r31, r52, r10);
+    r10 = fmaf(r24, r38, r10);
+    r38 = r10 * r10;
+    r52 = r35 * r27;
+    r52 = fmaf(r30, r52, r26);
+    r13 = fmaf(r13, r52, r12);
+    r50 = fmaf(r35, r50, r49);
+    r33 = r37 + r33;
+    r33 = r33 + r36;
+    r36 = r17 * r20;
+    r36 = fmaf(r16, r36, r40);
+    r43 = fmaf(r16, r43, r42);
+    r34 = r37 + r34;
+    r34 = r34 + r47;
+    r13 = fmaf(r24, r50, r13);
+    r13 = fmaf(r32, r33, r13);
+    r13 = fmaf(r31, r36, r13);
+    r13 = fmaf(r14, r43, r13);
+    r13 = fmaf(r15, r34, r13);
+    r15 = copysign(1.0, r13);
+    r15 = fmaf(r39, r15, r13);
+    r13 = r15 * r15;
+    r14 = 1.0 / r13;
+    r36 = r11 * r11;
+    r36 = fmaf(r14, r36, r14 * r38);
+    r38 = sqrtf(r36);
+    r31 = copysign(1.0, r38);
+    r31 = fmaf(r39, r31, r38);
+    r39 = r31 * r31;
+    r33 = 1.0 / r39;
+    r38 = atanf(r38);
+    r32 = r38 * r14;
+    r50 = r38 * r32;
+    r41 = r41 * r33;
+    r41 = r41 * r50;
+    r24 = r10 * r33;
+    r47 = r10 * r24;
+    r42 = r50 * r47;
+    r40 = r41 + r42;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r49,
+                                         r12,
+                                         r26,
+                                         r30);
+    r51 = 3.00000000000000000e+00;
+    r53 = r51 * r50;
+    r53 = fmaf(r47, r53, r41);
+    r53 = fmaf(r12, r53, r8 * r40);
+    r41 = r49 * r11;
+    r54 = r16 * r50;
+    r41 = r41 * r24;
+    r53 = fmaf(r54, r41, r53);
+    r55 = r40 * r40;
+    r56 = r40 * r55;
+    r57 = fmaf(r26, r56, r6 * r40);
+    r56 = r30 * r56;
+    r57 = fmaf(r40, r56, r57);
+    r57 = fmaf(r7, r55, r57);
+    r30 = 1.0 / r15;
+    r58 = 1.0 / r31;
+    r59 = r30 * r58;
+    r60 = r38 * r59;
+    r61 = r57 * r60;
+    r53 = fmaf(r10, r61, r53);
+    r53 = fmaf(r10, r60, r53);
+    r2 = fmaf(r0, r53, r2);
+    r53 = r11 * r11;
+    r53 = r53 * r51;
+    r53 = r53 * r33;
+    r53 = fmaf(r50, r53, r42);
+    r53 = fmaf(r49, r53, r9 * r40);
+    r42 = r12 * r11;
+    r42 = r42 * r24;
+    r53 = fmaf(r54, r42, r53);
+    r53 = fmaf(r11, r61, r53);
+    r53 = fmaf(r11, r60, r53);
+    r53 = fmaf(r5, r53, r1);
+    r53 = fmaf(r3, r4, r53);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r53);
+    r3 = fmaf(r53, r53, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r4 * r2;
+    r1 = r4 * r53;
+    WriteSum2<float, float>((float*)inout_shared, r3, r1);
+  };
+  FlushSumShared<2, float>(out_principal_point_njtr,
+                           0 * out_principal_point_njtr_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<float, float>((float*)inout_shared, r37, r37);
+  };
+  FlushSumShared<2, float>(out_principal_point_precond_diag,
+                           0 * out_principal_point_precond_diag_num_alloc,
+                           principal_point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r10 * r33;
+    r3 = -5.00000000000000000e-01;
+    r42 = r16 * r29;
+    r42 = r42 * r11;
+    r41 = r16 * r48;
+    r41 = r41 * r10;
+    r41 = fmaf(r14, r41, r14 * r42);
+    r42 = r52 * r10;
+    r13 = r15 * r13;
+    r13 = 1.0 / r13;
+    r15 = r35 * r13;
+    r42 = r42 * r10;
+    r41 = fmaf(r15, r42, r41);
+    r62 = r11 * r11;
+    r62 = r62 * r15;
+    r41 = fmaf(r52, r62, r41);
+    r42 = rsqrtf(r36);
+    r1 = r1 * r38;
+    r1 = r1 * r30;
+    r1 = r1 * r3;
+    r1 = r1 * r41;
+    r1 = r1 * r42;
+    r63 = 6.00000000000000000e+00;
+    r64 = r48 * r63;
+    r64 = r64 * r50;
+    r65 = -6.00000000000000000e+00;
+    r66 = r65 * r13;
+    r67 = r38 * r38;
+    r68 = r47 * r67;
+    r66 = r66 * r68;
+    r64 = fmaf(r52, r66, r24 * r64);
+    r69 = r51 * r41;
+    r36 = r37 + r36;
+    r36 = 1.0 / r36;
+    r37 = r36 * r32;
+    r69 = r69 * r42;
+    r69 = r69 * r37;
+    r64 = fmaf(r47, r69, r64);
+    r70 = r10 * r10;
+    r71 = -3.00000000000000000e+00;
+    r39 = r31 * r39;
+    r39 = 1.0 / r39;
+    r70 = r70 * r71;
+    r70 = r70 * r41;
+    r70 = r70 * r42;
+    r70 = r70 * r39;
+    r64 = fmaf(r50, r70, r64);
+    r31 = r4 * r11;
+    r72 = r39 * r50;
+    r73 = r11 * r42;
+    r72 = r72 * r73;
+    r31 = r31 * r41;
+    r74 = r41 * r73;
+    r75 = r11 * r33;
+    r74 = r74 * r37;
+    r74 = fmaf(r75, r74, r72 * r31);
+    r67 = r33 * r67;
+    r67 = r67 * r62;
+    r31 = r54 * r75;
+    r74 = fmaf(r52, r67, r74);
+    r74 = fmaf(r29, r31, r74);
+    r64 = r64 + r74;
+    r64 = fmaf(r12, r64, r1);
+    r70 = r48 * r24;
+    r69 = r52 * r15;
+    r69 = fmaf(r68, r69, r54 * r70);
+    r70 = r41 * r42;
+    r70 = r70 * r37;
+    r69 = fmaf(r47, r70, r69);
+    r76 = r4 * r10;
+    r76 = r76 * r10;
+    r76 = r76 * r41;
+    r76 = r76 * r42;
+    r76 = r76 * r39;
+    r69 = fmaf(r50, r76, r69);
+    r74 = r74 + r69;
+    r76 = r10 * r57;
+    r70 = r4 * r52;
+    r70 = r70 * r58;
+    r70 = r70 * r32;
+    r64 = fmaf(r70, r76, r64);
+    r77 = r49 * r29;
+    r77 = r77 * r24;
+    r64 = fmaf(r54, r77, r64);
+    r78 = r7 * r16;
+    r78 = r78 * r40;
+    r78 = fmaf(r6, r74, r74 * r78);
+    r79 = 4.00000000000000000e+00;
+    r56 = r79 * r56;
+    r26 = r26 * r51;
+    r26 = r26 * r55;
+    r78 = fmaf(r74, r56, r78);
+    r78 = fmaf(r74, r26, r78);
+    r55 = r10 * r78;
+    r64 = fmaf(r60, r55, r64);
+    r79 = 5.00000000000000000e-01;
+    r80 = r10 * r79;
+    r80 = r80 * r42;
+    r80 = r80 * r36;
+    r80 = r80 * r59;
+    r81 = r57 * r80;
+    r82 = r49 * r11;
+    r83 = -4.00000000000000000e+00;
+    r82 = r82 * r38;
+    r82 = r82 * r38;
+    r82 = r82 * r83;
+    r82 = r82 * r13;
+    r82 = r82 * r24;
+    r84 = r49 * r35;
+    r84 = r84 * r10;
+    r84 = r84 * r41;
+    r64 = fmaf(r72, r84, r64);
+    r85 = r49 * r48;
+    r64 = fmaf(r31, r85, r64);
+    r86 = r49 * r41;
+    r87 = r16 * r24;
+    r87 = r87 * r73;
+    r87 = r87 * r37;
+    r64 = fmaf(r87, r86, r64);
+    r64 = fmaf(r8, r74, r64);
+    r64 = fmaf(r48, r61, r64);
+    r64 = fmaf(r57, r1, r64);
+    r64 = fmaf(r10, r70, r64);
+    r64 = fmaf(r41, r81, r64);
+    r64 = fmaf(r48, r60, r64);
+    r64 = fmaf(r52, r82, r64);
+    r64 = fmaf(r41, r80, r64);
+    r86 = r0 * r64;
+    r85 = r11 * r71;
+    r85 = r85 * r41;
+    r84 = r51 * r41;
+    r84 = r84 * r73;
+    r84 = r84 * r37;
+    r84 = fmaf(r75, r84, r72 * r85);
+    r85 = r52 * r11;
+    r85 = r85 * r11;
+    r85 = r85 * r38;
+    r85 = r85 * r38;
+    r85 = r85 * r65;
+    r85 = r85 * r33;
+    r84 = fmaf(r13, r85, r84);
+    r55 = r29 * r11;
+    r55 = r55 * r63;
+    r55 = r55 * r33;
+    r84 = fmaf(r50, r55, r84);
+    r84 = r84 + r69;
+    r74 = fmaf(r9, r74, r49 * r84);
+    r84 = r79 * r57;
+    r84 = r84 * r41;
+    r84 = r84 * r36;
+    r84 = r84 * r73;
+    r74 = fmaf(r59, r84, r74);
+    r69 = r57 * r33;
+    r55 = r38 * r3;
+    r55 = r55 * r41;
+    r55 = r55 * r30;
+    r69 = r69 * r73;
+    r74 = fmaf(r55, r69, r74);
+    r85 = r11 * r57;
+    r74 = fmaf(r70, r85, r74);
+    r77 = r12 * r29;
+    r77 = r77 * r24;
+    r74 = fmaf(r54, r77, r74);
+    r76 = r12 * r52;
+    r76 = r76 * r11;
+    r76 = r76 * r38;
+    r76 = r76 * r38;
+    r76 = r76 * r83;
+    r76 = r76 * r13;
+    r74 = fmaf(r24, r76, r74);
+    r1 = r33 * r73;
+    r74 = fmaf(r55, r1, r74);
+    r55 = r12 * r35;
+    r55 = r55 * r10;
+    r55 = r55 * r41;
+    r74 = fmaf(r72, r55, r74);
+    r88 = r12 * r31;
+    r89 = r79 * r41;
+    r89 = r89 * r36;
+    r89 = r89 * r73;
+    r74 = fmaf(r59, r89, r74);
+    r90 = r12 * r41;
+    r74 = fmaf(r87, r90, r74);
+    r91 = r11 * r78;
+    r74 = fmaf(r60, r91, r74);
+    r74 = fmaf(r48, r88, r74);
+    r74 = fmaf(r29, r61, r74);
+    r74 = fmaf(r11, r70, r74);
+    r74 = fmaf(r29, r60, r74);
+    r91 = r5 * r74;
+    r90 = r16 * r45;
+    r90 = r90 * r10;
+    r90 = fmaf(r14, r90, r43 * r62);
+    r70 = r16 * r46;
+    r70 = r70 * r11;
+    r90 = fmaf(r14, r70, r90);
+    r89 = r43 * r10;
+    r89 = r89 * r10;
+    r90 = fmaf(r15, r89, r90);
+    r89 = r90 * r42;
+    r89 = r89 * r37;
+    r70 = r43 * r15;
+    r70 = fmaf(r68, r70, r47 * r89);
+    r89 = r4 * r10;
+    r89 = r89 * r10;
+    r89 = r89 * r90;
+    r89 = r89 * r42;
+    r89 = r89 * r39;
+    r70 = fmaf(r50, r89, r70);
+    r55 = r45 * r24;
+    r70 = fmaf(r54, r55, r70);
+    r55 = r4 * r11;
+    r55 = r55 * r90;
+    r55 = fmaf(r46, r31, r72 * r55);
+    r89 = r90 * r73;
+    r89 = r89 * r37;
+    r55 = fmaf(r75, r89, r55);
+    r55 = fmaf(r43, r67, r55);
+    r89 = r70 + r55;
+    r1 = r51 * r90;
+    r1 = r1 * r42;
+    r1 = r1 * r37;
+    r1 = fmaf(r43, r66, r47 * r1);
+    r76 = r10 * r10;
+    r77 = r71 * r90;
+    r76 = r76 * r42;
+    r76 = r76 * r39;
+    r76 = r76 * r50;
+    r1 = fmaf(r77, r76, r1);
+    r85 = r45 * r63;
+    r85 = r85 * r50;
+    r1 = fmaf(r24, r85, r1);
+    r1 = r1 + r55;
+    r1 = fmaf(r12, r1, r8 * r89);
+    r55 = r49 * r45;
+    r1 = fmaf(r31, r55, r1);
+    r85 = r49 * r35;
+    r85 = r85 * r10;
+    r85 = r85 * r90;
+    r1 = fmaf(r72, r85, r1);
+    r76 = r38 * r3;
+    r76 = r76 * r90;
+    r76 = r76 * r30;
+    r76 = r76 * r42;
+    r1 = fmaf(r24, r76, r1);
+    r69 = r4 * r43;
+    r69 = r69 * r10;
+    r69 = r69 * r58;
+    r1 = fmaf(r32, r69, r1);
+    r84 = r4 * r43;
+    r84 = r84 * r10;
+    r84 = r84 * r57;
+    r84 = r84 * r58;
+    r1 = fmaf(r32, r84, r1);
+    r92 = r7 * r16;
+    r92 = r92 * r40;
+    r92 = fmaf(r89, r92, r6 * r89);
+    r92 = fmaf(r89, r56, r92);
+    r92 = fmaf(r89, r26, r92);
+    r93 = r10 * r92;
+    r1 = fmaf(r60, r93, r1);
+    r94 = r38 * r57;
+    r94 = r94 * r3;
+    r94 = r94 * r90;
+    r94 = r94 * r30;
+    r94 = r94 * r42;
+    r1 = fmaf(r24, r94, r1);
+    r95 = r49 * r46;
+    r95 = r95 * r24;
+    r1 = fmaf(r54, r95, r1);
+    r96 = r49 * r90;
+    r1 = fmaf(r87, r96, r1);
+    r1 = fmaf(r90, r80, r1);
+    r1 = fmaf(r90, r81, r1);
+    r1 = fmaf(r45, r61, r1);
+    r1 = fmaf(r45, r60, r1);
+    r1 = fmaf(r43, r82, r1);
+    r96 = r0 * r1;
+    r95 = r11 * r72;
+    r94 = r46 * r11;
+    r94 = r94 * r63;
+    r94 = r94 * r33;
+    r94 = fmaf(r50, r94, r77 * r95);
+    r95 = r51 * r90;
+    r95 = r95 * r73;
+    r95 = r95 * r37;
+    r94 = fmaf(r75, r95, r94);
+    r77 = r43 * r11;
+    r77 = r77 * r11;
+    r77 = r77 * r38;
+    r77 = r77 * r38;
+    r77 = r77 * r65;
+    r77 = r77 * r33;
+    r94 = fmaf(r13, r77, r94);
+    r94 = r94 + r70;
+    r94 = fmaf(r49, r94, r9 * r89);
+    r89 = r12 * r90;
+    r94 = fmaf(r87, r89, r94);
+    r70 = r12 * r35;
+    r70 = r70 * r10;
+    r70 = r70 * r90;
+    r94 = fmaf(r72, r70, r94);
+    r77 = r38 * r57;
+    r77 = r77 * r3;
+    r77 = r77 * r90;
+    r77 = r77 * r33;
+    r77 = r77 * r30;
+    r94 = fmaf(r73, r77, r94);
+    r95 = r38 * r3;
+    r95 = r95 * r90;
+    r95 = r95 * r33;
+    r95 = r95 * r30;
+    r94 = fmaf(r73, r95, r94);
+    r93 = r11 * r92;
+    r94 = fmaf(r60, r93, r94);
+    r84 = r4 * r43;
+    r84 = r84 * r11;
+    r84 = r84 * r57;
+    r84 = r84 * r58;
+    r94 = fmaf(r32, r84, r94);
+    r69 = r79 * r90;
+    r69 = r69 * r36;
+    r69 = r69 * r73;
+    r94 = fmaf(r59, r69, r94);
+    r76 = r12 * r46;
+    r76 = r76 * r24;
+    r94 = fmaf(r54, r76, r94);
+    r85 = r79 * r57;
+    r85 = r85 * r90;
+    r85 = r85 * r36;
+    r85 = r85 * r73;
+    r94 = fmaf(r59, r85, r94);
+    r55 = r4 * r43;
+    r55 = r55 * r11;
+    r55 = r55 * r58;
+    r94 = fmaf(r32, r55, r94);
+    r97 = r12 * r43;
+    r97 = r97 * r11;
+    r97 = r97 * r38;
+    r97 = r97 * r38;
+    r97 = r97 * r83;
+    r97 = r97 * r13;
+    r94 = fmaf(r24, r97, r94);
+    r94 = fmaf(r45, r88, r94);
+    r94 = fmaf(r46, r60, r94);
+    r94 = fmaf(r46, r61, r94);
+    r97 = r5 * r94;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r86,
+                                          r91,
+                                          r96,
+                                          r97);
+    r97 = r4 * r11;
+    r96 = r16 * r44;
+    r96 = r96 * r11;
+    r62 = fmaf(r34, r62, r14 * r96);
+    r96 = r34 * r10;
+    r96 = r96 * r10;
+    r62 = fmaf(r15, r96, r62);
+    r91 = r16 * r25;
+    r91 = r91 * r10;
+    r62 = fmaf(r14, r91, r62);
+    r91 = r62 * r72;
+    r97 = fmaf(r44, r31, r91 * r97);
+    r96 = r62 * r73;
+    r96 = r96 * r37;
+    r97 = fmaf(r75, r96, r97);
+    r97 = fmaf(r34, r67, r97);
+    r67 = r25 * r24;
+    r96 = r62 * r42;
+    r96 = r96 * r37;
+    r96 = fmaf(r47, r96, r54 * r67);
+    r67 = r34 * r15;
+    r96 = fmaf(r68, r67, r96);
+    r68 = r4 * r10;
+    r68 = r68 * r10;
+    r68 = r68 * r62;
+    r68 = r68 * r42;
+    r68 = r68 * r39;
+    r96 = fmaf(r50, r68, r96);
+    r68 = r97 + r96;
+    r67 = r25 * r63;
+    r67 = r67 * r50;
+    r14 = r51 * r62;
+    r14 = r14 * r42;
+    r14 = r14 * r37;
+    r14 = fmaf(r47, r14, r24 * r67);
+    r67 = r10 * r10;
+    r67 = r67 * r71;
+    r67 = r67 * r62;
+    r67 = r67 * r42;
+    r67 = r67 * r39;
+    r14 = fmaf(r50, r67, r14);
+    r14 = fmaf(r34, r66, r14);
+    r14 = r14 + r97;
+    r14 = fmaf(r12, r14, r8 * r68);
+    r8 = r49 * r44;
+    r8 = r8 * r24;
+    r14 = fmaf(r54, r8, r14);
+    r97 = r49 * r62;
+    r14 = fmaf(r87, r97, r14);
+    r67 = r38 * r57;
+    r67 = r67 * r3;
+    r67 = r67 * r62;
+    r67 = r67 * r30;
+    r67 = r67 * r42;
+    r14 = fmaf(r24, r67, r14);
+    r66 = r4 * r34;
+    r66 = r66 * r10;
+    r66 = r66 * r57;
+    r66 = r66 * r58;
+    r14 = fmaf(r32, r66, r14);
+    r39 = r7 * r16;
+    r39 = r39 * r40;
+    r39 = fmaf(r68, r39, r6 * r68);
+    r39 = fmaf(r68, r56, r39);
+    r39 = fmaf(r68, r26, r39);
+    r26 = r10 * r39;
+    r14 = fmaf(r60, r26, r14);
+    r56 = r4 * r34;
+    r56 = r56 * r10;
+    r56 = r56 * r58;
+    r14 = fmaf(r32, r56, r14);
+    r6 = r38 * r3;
+    r6 = r6 * r62;
+    r6 = r6 * r30;
+    r6 = r6 * r42;
+    r14 = fmaf(r24, r6, r14);
+    r40 = r35 * r10;
+    r40 = r40 * r91;
+    r47 = r49 * r25;
+    r14 = fmaf(r31, r47, r14);
+    r14 = fmaf(r62, r81, r14);
+    r14 = fmaf(r25, r60, r14);
+    r14 = fmaf(r25, r61, r14);
+    r14 = fmaf(r49, r40, r14);
+    r14 = fmaf(r62, r80, r14);
+    r14 = fmaf(r34, r82, r14);
+    r47 = r0 * r14;
+    r82 = r11 * r71;
+    r80 = r44 * r11;
+    r80 = r80 * r63;
+    r80 = r80 * r33;
+    r80 = fmaf(r50, r80, r91 * r82);
+    r82 = r51 * r62;
+    r82 = r82 * r73;
+    r82 = r82 * r37;
+    r80 = fmaf(r75, r82, r80);
+    r75 = r34 * r11;
+    r75 = r75 * r11;
+    r75 = r75 * r38;
+    r75 = r75 * r38;
+    r75 = r75 * r65;
+    r75 = r75 * r33;
+    r80 = fmaf(r13, r75, r80);
+    r80 = r80 + r96;
+    r80 = fmaf(r49, r80, r9 * r68);
+    r68 = r12 * r44;
+    r68 = r68 * r24;
+    r80 = fmaf(r54, r68, r80);
+    r54 = r4 * r34;
+    r54 = r54 * r11;
+    r54 = r54 * r57;
+    r54 = r54 * r58;
+    r80 = fmaf(r32, r54, r80);
+    r9 = r38 * r3;
+    r9 = r9 * r62;
+    r9 = r9 * r33;
+    r9 = r9 * r30;
+    r80 = fmaf(r73, r9, r80);
+    r96 = r12 * r62;
+    r80 = fmaf(r87, r96, r80);
+    r87 = r11 * r39;
+    r80 = fmaf(r60, r87, r80);
+    r75 = r12 * r34;
+    r75 = r75 * r11;
+    r75 = r75 * r38;
+    r75 = r75 * r38;
+    r75 = r75 * r83;
+    r75 = r75 * r13;
+    r80 = fmaf(r24, r75, r80);
+    r13 = r38 * r57;
+    r13 = r13 * r3;
+    r13 = r13 * r62;
+    r13 = r13 * r33;
+    r13 = r13 * r30;
+    r80 = fmaf(r73, r13, r80);
+    r30 = r79 * r57;
+    r30 = r30 * r62;
+    r30 = r30 * r36;
+    r30 = r30 * r73;
+    r80 = fmaf(r59, r30, r80);
+    r83 = r4 * r34;
+    r83 = r83 * r11;
+    r83 = r83 * r58;
+    r80 = fmaf(r32, r83, r80);
+    r32 = r79 * r62;
+    r32 = r32 * r36;
+    r32 = r32 * r73;
+    r80 = fmaf(r59, r32, r80);
+    r80 = fmaf(r44, r60, r80);
+    r80 = fmaf(r12, r40, r80);
+    r80 = fmaf(r44, r61, r80);
+    r80 = fmaf(r25, r88, r80);
+    r32 = r5 * r80;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r47,
+                                          r32);
+    r32 = r5 * r4;
+    r32 = r32 * r53;
+    r47 = r0 * r4;
+    r47 = r47 * r2;
+    r47 = fmaf(r64, r47, r74 * r32);
+    r32 = r0 * r4;
+    r32 = r32 * r2;
+    r83 = r5 * r4;
+    r83 = r83 * r53;
+    r83 = fmaf(r94, r83, r1 * r32);
+    r32 = r0 * r4;
+    r32 = r32 * r2;
+    r2 = r5 * r4;
+    r2 = r2 * r53;
+    r2 = fmaf(r80, r2, r14 * r32);
+    WriteSum3<float, float>((float*)inout_shared, r47, r83, r2);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r64 * r64;
+    r83 = r0 * r0;
+    r47 = r5 * r5;
+    r32 = r74 * r47;
+    r74 = fmaf(r74, r32, r83 * r2);
+    r2 = r94 * r94;
+    r53 = r1 * r83;
+    r1 = fmaf(r1, r53, r47 * r2);
+    r2 = r80 * r80;
+    r88 = r14 * r14;
+    r88 = fmaf(r83, r88, r47 * r2);
+    WriteSum3<float, float>((float*)inout_shared, r74, r1, r88);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r88 = fmaf(r64, r53, r94 * r32);
+    r1 = r64 * r14;
+    r32 = fmaf(r80, r32, r83 * r1);
+    r1 = r94 * r80;
+    r53 = fmaf(r14, r53, r47 * r1);
+    WriteSum3<float, float>((float*)inout_shared, r88, r32, r53);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirstKernel<<<n_blocks,
+                                                                      1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    float* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    float* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    float* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.cu
@@ -1,0 +1,308 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+  LoadShared<2, float, float>(principal_point,
+                              0 * principal_point_num_alloc,
+                              principal_point_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       principal_point_indices_loc[threadIdx.x].target,
+                       r0,
+                       r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         0 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r5,
+                                         r6,
+                                         r7);
+    ReadIdx2<1024, float, float, float2>(focal_and_extra,
+                                         8 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9);
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+    ReadIdx4<1024, float, float, float4>(focal_and_extra,
+                                         4 * focal_and_extra_num_alloc,
+                                         global_thread_idx,
+                                         r35,
+                                         r41,
+                                         r34,
+                                         r14);
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScoreKernel<<<n_blocks,
+                                                                1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        float* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        float* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,645 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r29 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r11, r24, r31);
+    r32 = r17 * r18;
+    r32 = r32 * r16;
+    r33 = r19 * r20;
+    r33 = fmaf(r16, r33, r32);
+    r34 = -2.00000000000000000e+00;
+    r35 = r17 * r17;
+    r35 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r19 * r19;
+    r37 = fmaf(r34, r37, r36);
+    r38 = r35 + r37;
+    r39 = r18 * r19;
+    r39 = r39 * r16;
+    r40 = r17 * r20;
+    r40 = fmaf(r34, r40, r39);
+    r41 = r16 * r28;
+    r41 = r41 * r27;
+    r42 = r34 * r30;
+    r43 = fmaf(r25, r42, r41);
+    r44 = r28 * r28;
+    r44 = r34 * r44;
+    r45 = r36 + r44;
+    r46 = r25 * r25;
+    r46 = r34 * r46;
+    r45 = r45 + r46;
+    r29 = fmaf(r11, r33, r29);
+    r29 = fmaf(r24, r38, r29);
+    r29 = fmaf(r31, r40, r29);
+    r29 = fmaf(r15, r43, r29);
+    r29 = fmaf(r14, r45, r29);
+    r45 = r29 * r29;
+    r43 = r27 * r27;
+    r43 = r34 * r43;
+    r40 = r36 + r43;
+    r40 = r40 + r44;
+    r40 = fmaf(r13, r40, r10);
+    r26 = fmaf(r28, r42, r26);
+    r10 = r16 * r28;
+    r10 = r10 * r25;
+    r44 = r16 * r27;
+    r44 = fmaf(r30, r44, r10);
+    r38 = r17 * r19;
+    r38 = r38 * r16;
+    r33 = r18 * r20;
+    r47 = fmaf(r16, r33, r38);
+    r48 = r19 * r20;
+    r48 = fmaf(r34, r48, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r34;
+    r37 = r32 + r37;
+    r40 = fmaf(r14, r26, r40);
+    r40 = fmaf(r15, r44, r40);
+    r40 = fmaf(r31, r47, r40);
+    r40 = fmaf(r24, r48, r40);
+    r40 = fmaf(r11, r37, r40);
+    r37 = r40 * r40;
+    r48 = 9.99999999999999955e-07;
+    r42 = fmaf(r27, r42, r10);
+    r42 = fmaf(r13, r42, r12);
+    r33 = fmaf(r34, r33, r38);
+    r32 = r36 + r32;
+    r32 = r32 + r35;
+    r35 = r17 * r20;
+    r35 = fmaf(r16, r35, r39);
+    r39 = r16 * r25;
+    r39 = fmaf(r30, r39, r41);
+    r43 = r36 + r43;
+    r43 = r43 + r46;
+    r42 = fmaf(r11, r33, r42);
+    r42 = fmaf(r31, r32, r42);
+    r42 = fmaf(r24, r35, r42);
+    r42 = fmaf(r14, r39, r42);
+    r42 = fmaf(r15, r43, r42);
+    r43 = copysign(1.0, r42);
+    r43 = fmaf(r48, r43, r42);
+    r42 = r43 * r43;
+    r15 = 1.0 / r42;
+    r39 = r29 * r29;
+    r39 = fmaf(r15, r39, r15 * r37);
+    r39 = sqrtf(r39);
+    r37 = atanf(r39);
+    r14 = copysign(1.0, r39);
+    r14 = fmaf(r48, r14, r39);
+    r48 = r14 * r14;
+    r39 = 1.0 / r48;
+    r39 = r15 * r39;
+    r15 = r37 * r39;
+    r45 = r45 * r37;
+    r45 = r45 * r15;
+    r35 = r40 * r37;
+    r24 = r40 * r35;
+    r24 = r24 * r15;
+    r32 = r45 + r24;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r31,
+                       r33,
+                       r11,
+                       r46);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = 3.00000000000000000e+00;
+    r41 = r40 * r36;
+    r41 = r41 * r35;
+    r41 = fmaf(r15, r41, r45);
+    r8 = fmaf(r33, r41, r8 * r32);
+    r45 = r29 * r37;
+    r30 = r31 * r45;
+    r38 = r16 * r35;
+    r13 = r39 * r38;
+    r8 = fmaf(r13, r30, r8);
+    r12 = r32 * r32;
+    r10 = r32 * r12;
+    r11 = fmaf(r11, r10, r6 * r32);
+    r6 = r12 * r12;
+    r11 = fmaf(r46, r6, r11);
+    r11 = fmaf(r7, r12, r11);
+    r7 = r11 * r35;
+    r46 = 1.0 / r43;
+    r47 = 1.0 / r14;
+    r44 = r46 * r47;
+    r8 = fmaf(r44, r7, r8);
+    r8 = fmaf(r35, r44, r8);
+    r2 = fmaf(r0, r8, r2);
+    r7 = r29 * r29;
+    r7 = r7 * r37;
+    r7 = r7 * r36;
+    r7 = fmaf(r15, r7, r24);
+    r9 = fmaf(r31, r7, r9 * r32);
+    r24 = r11 * r44;
+    r9 = fmaf(r45, r24, r9);
+    r30 = r33 * r45;
+    r9 = fmaf(r13, r30, r9);
+    r9 = fmaf(r44, r45, r9);
+    r1 = fmaf(r5, r9, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = r4 * r9;
+    r3 = r3 * r1;
+    r30 = r4 * r2;
+    r24 = r8 * r30;
+    r26 = r0 * r35;
+    r49 = r26 * r30;
+    r50 = r44 * r49;
+    r51 = r4 * r32;
+    r52 = r5 * r45;
+    r51 = r51 * r1;
+    r51 = r51 * r44;
+    r51 = fmaf(r52, r51, r32 * r50);
+    r53 = r12 * r44;
+    r54 = r4 * r1;
+    r54 = r54 * r52;
+    r54 = fmaf(r53, r54, r53 * r49);
+    WriteSum4<float, float>((float*)inout_shared, r24, r3, r51, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r5 * r4;
+    r54 = r54 * r7;
+    r51 = r34 * r2;
+    r51 = r51 * r45;
+    r51 = r51 * r26;
+    r51 = fmaf(r39, r51, r1 * r54);
+    r54 = r34 * r1;
+    r54 = r54 * r35;
+    r54 = r54 * r52;
+    r3 = r0 * r41;
+    r3 = fmaf(r30, r3, r39 * r54);
+    r54 = r4 * r1;
+    r54 = r54 * r10;
+    r54 = r54 * r44;
+    r54 = fmaf(r52, r54, r10 * r50);
+    r24 = r4 * r1;
+    r24 = r24 * r44;
+    r24 = r24 * r52;
+    r24 = fmaf(r6, r24, r6 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r51, r3, r54, r24);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r5 * r4;
+    r24 = r24 * r32;
+    r24 = r24 * r1;
+    r54 = r0 * r32;
+    r54 = r54 * r30;
+    WriteSum2<float, float>((float*)inout_shared, r54, r24);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r8 * r8;
+    r54 = r9 * r9;
+    r30 = r29 * r29;
+    r3 = r5 * r5;
+    r30 = r30 * r37;
+    r30 = r30 * r12;
+    r30 = r30 * r15;
+    r51 = r0 * r26;
+    r50 = r40 * r51;
+    r49 = r15 * r50;
+    r30 = fmaf(r12, r49, r3 * r30);
+    r55 = r5 * r52;
+    r56 = r29 * r55;
+    r57 = r6 * r56;
+    r58 = fmaf(r6, r49, r15 * r57);
+    WriteSum4<float, float>((float*)inout_shared, r24, r54, r30, r58);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r29 * r45;
+    r54 = r37 * r37;
+    r24 = 4.00000000000000000e+00;
+    r42 = r43 * r42;
+    r43 = r43 * r42;
+    r43 = 1.0 / r43;
+    r48 = r14 * r48;
+    r14 = r14 * r48;
+    r14 = 1.0 / r14;
+    r54 = r54 * r24;
+    r54 = r54 * r43;
+    r54 = r54 * r14;
+    r30 = r30 * r50;
+    r14 = r7 * r7;
+    r3 = fmaf(r14, r3, r54 * r30);
+    r14 = r40 * r35;
+    r14 = r14 * r56;
+    r30 = r0 * r0;
+    r43 = r41 * r41;
+    r30 = fmaf(r43, r30, r54 * r14);
+    r14 = r15 * r56;
+    r43 = r10 * r10;
+    r14 = fmaf(r43, r49, r43 * r14);
+    r54 = r15 * r56;
+    r24 = r6 * r6;
+    r24 = fmaf(r49, r24, r24 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r3, r30, r14, r24);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r0 * r0;
+    r24 = r24 * r12;
+    r30 = r5 * r5;
+    r30 = r30 * r12;
+    WriteSum2<float, float>((float*)inout_shared, r24, r30);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = 0.00000000000000000e+00;
+    r24 = r32 * r8;
+    r24 = r24 * r44;
+    r24 = r24 * r26;
+    r3 = r8 * r26;
+    r3 = r3 * r53;
+    r54 = r16 * r8;
+    r54 = r54 * r45;
+    r54 = r54 * r26;
+    r54 = r54 * r39;
+    WriteSum4<float, float>((float*)inout_shared, r30, r24, r3, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r0 * r41;
+    r54 = r54 * r8;
+    r3 = r0 * r32;
+    r3 = r3 * r8;
+    r24 = r8 * r10;
+    r24 = r24 * r44;
+    r24 = r24 * r26;
+    r8 = r8 * r44;
+    r8 = r8 * r26;
+    r8 = r8 * r6;
+    WriteSum4<float, float>((float*)inout_shared, r54, r24, r8, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r5 * r7;
+    r3 = r3 * r9;
+    r8 = r32 * r9;
+    r8 = r8 * r44;
+    r8 = r8 * r52;
+    r24 = r9 * r52;
+    r54 = r53 * r24;
+    WriteSum4<float, float>((float*)inout_shared, r30, r8, r54, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r13 * r24;
+    r3 = r9 * r10;
+    r3 = r3 * r44;
+    r3 = r3 * r52;
+    r54 = r9 * r44;
+    r54 = r54 * r52;
+    r54 = r54 * r6;
+    WriteSum4<float, float>((float*)inout_shared, r24, r3, r54, r30);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r5 * r32;
+    r30 = r30 * r9;
+    r9 = r10 * r15;
+    r9 = fmaf(r10, r49, r56 * r9);
+    r54 = r16 * r45;
+    r42 = 1.0 / r42;
+    r42 = r37 * r42;
+    r48 = 1.0 / r48;
+    r42 = r42 * r48;
+    r54 = r54 * r50;
+    r54 = r54 * r42;
+    r50 = r32 * r7;
+    r50 = r50 * r44;
+    r50 = fmaf(r55, r50, r32 * r54);
+    r48 = r32 * r41;
+    r48 = r48 * r44;
+    r3 = r32 * r56;
+    r3 = r3 * r38;
+    r3 = fmaf(r42, r3, r51 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r30, r9, r50, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r40 * r37;
+    r3 = r0 * r0;
+    r37 = r37 * r12;
+    r37 = r37 * r46;
+    r37 = r37 * r47;
+    r37 = r37 * r3;
+    r3 = r55 * r53;
+    r47 = r32 * r6;
+    r46 = r15 * r47;
+    r46 = fmaf(r47, r49, r56 * r46);
+    WriteSum4<float, float>((float*)inout_shared, r58, r46, r37, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r7 * r55;
+    r3 = fmaf(r53, r3, r12 * r54);
+    r53 = r12 * r56;
+    r53 = r53 * r38;
+    r53 = fmaf(r42, r53, r41 * r37);
+    WriteSum4<float, float>((float*)inout_shared, r3, r53, r46, r14);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r14 = r10 * r44;
+    r14 = r14 * r51;
+    r46 = r10 * r44;
+    r46 = r46 * r55;
+    r13 = r55 * r13;
+    r53 = r16 * r41;
+    r53 = r53 * r45;
+    r53 = r53 * r39;
+    r53 = fmaf(r51, r53, r7 * r13);
+    r3 = r7 * r10;
+    r3 = r3 * r44;
+    r3 = fmaf(r55, r3, r10 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r14, r46, r53, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r16 * r32;
+    r3 = r3 * r45;
+    r3 = r3 * r39;
+    r3 = r3 * r51;
+    r39 = r5 * r5;
+    r39 = r39 * r32;
+    r39 = r39 * r7;
+    r53 = r7 * r44;
+    r53 = r53 * r6;
+    r53 = fmaf(r55, r53, r6 * r54);
+    r54 = r41 * r10;
+    r54 = r54 * r44;
+    r46 = r10 * r56;
+    r46 = r46 * r38;
+    r46 = fmaf(r42, r46, r51 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r53, r3, r39, r46);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r0 * r0;
+    r46 = r46 * r32;
+    r46 = r46 * r41;
+    r13 = r32 * r13;
+    r39 = r41 * r44;
+    r39 = r39 * r6;
+    r3 = r38 * r42;
+    r3 = fmaf(r57, r3, r51 * r39);
+    r39 = r15 * r56;
+    r43 = r32 * r43;
+    r43 = fmaf(r49, r43, r43 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r3, r46, r13, r43);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r44 * r6;
+    r43 = r43 * r51;
+    r6 = r44 * r6;
+    r6 = r6 * r55;
+    r51 = r44 * r51;
+    r51 = r51 * r47;
+    r13 = r44 * r55;
+    r13 = r13 * r47;
+    WriteSum4<float, float>((float*)inout_shared, r43, r6, r51, r13);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,659 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r24, r20 * r21);
+    r26 = r19 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r18, r23, r25);
+    r26 = r16 * r25;
+    r27 = r17 * r23;
+    r27 = fmaf(r4, r27, r20 * r22);
+    r27 = fmaf(r18, r24, r27);
+    r27 = fmaf(r19, r21, r27);
+    r26 = r26 * r27;
+    r28 = fmaf(r17, r22, r20 * r23);
+    r29 = r18 * r21;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r29 = r16 * r28;
+    r30 = fmaf(r18, r22, r17 * r21);
+    r30 = fmaf(r19, r23, r30);
+    r30 = fmaf(r4, r30, r20 * r24);
+    r29 = fmaf(r30, r29, r26);
+    r29 = fmaf(r13, r29, r11);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r11, r24, r31);
+    r32 = r17 * r18;
+    r32 = r32 * r16;
+    r33 = r19 * r20;
+    r33 = fmaf(r16, r33, r32);
+    r34 = -2.00000000000000000e+00;
+    r35 = r17 * r17;
+    r35 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r19 * r19;
+    r37 = fmaf(r34, r37, r36);
+    r38 = r35 + r37;
+    r39 = r18 * r19;
+    r39 = r39 * r16;
+    r40 = r17 * r20;
+    r40 = fmaf(r34, r40, r39);
+    r41 = r16 * r28;
+    r41 = r41 * r27;
+    r42 = r34 * r30;
+    r43 = fmaf(r25, r42, r41);
+    r44 = r28 * r28;
+    r44 = r34 * r44;
+    r45 = r36 + r44;
+    r46 = r25 * r25;
+    r46 = r34 * r46;
+    r45 = r45 + r46;
+    r29 = fmaf(r11, r33, r29);
+    r29 = fmaf(r24, r38, r29);
+    r29 = fmaf(r31, r40, r29);
+    r29 = fmaf(r15, r43, r29);
+    r29 = fmaf(r14, r45, r29);
+    r45 = r29 * r29;
+    r43 = r27 * r27;
+    r43 = r34 * r43;
+    r40 = r36 + r43;
+    r40 = r40 + r44;
+    r40 = fmaf(r13, r40, r10);
+    r26 = fmaf(r28, r42, r26);
+    r10 = r16 * r28;
+    r10 = r10 * r25;
+    r44 = r16 * r27;
+    r44 = fmaf(r30, r44, r10);
+    r38 = r17 * r19;
+    r38 = r38 * r16;
+    r33 = r18 * r20;
+    r47 = fmaf(r16, r33, r38);
+    r48 = r19 * r20;
+    r48 = fmaf(r34, r48, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r34;
+    r37 = r32 + r37;
+    r40 = fmaf(r14, r26, r40);
+    r40 = fmaf(r15, r44, r40);
+    r40 = fmaf(r31, r47, r40);
+    r40 = fmaf(r24, r48, r40);
+    r40 = fmaf(r11, r37, r40);
+    r37 = r40 * r40;
+    r48 = 9.99999999999999955e-07;
+    r42 = fmaf(r27, r42, r10);
+    r42 = fmaf(r13, r42, r12);
+    r33 = fmaf(r34, r33, r38);
+    r32 = r36 + r32;
+    r32 = r32 + r35;
+    r35 = r17 * r20;
+    r35 = fmaf(r16, r35, r39);
+    r39 = r16 * r25;
+    r39 = fmaf(r30, r39, r41);
+    r43 = r36 + r43;
+    r43 = r43 + r46;
+    r42 = fmaf(r11, r33, r42);
+    r42 = fmaf(r31, r32, r42);
+    r42 = fmaf(r24, r35, r42);
+    r42 = fmaf(r14, r39, r42);
+    r42 = fmaf(r15, r43, r42);
+    r43 = copysign(1.0, r42);
+    r43 = fmaf(r48, r43, r42);
+    r42 = r43 * r43;
+    r15 = 1.0 / r42;
+    r39 = r29 * r29;
+    r39 = fmaf(r15, r39, r15 * r37);
+    r39 = sqrtf(r39);
+    r37 = atanf(r39);
+    r14 = copysign(1.0, r39);
+    r14 = fmaf(r48, r14, r39);
+    r48 = r14 * r14;
+    r39 = 1.0 / r48;
+    r39 = r15 * r39;
+    r15 = r37 * r39;
+    r45 = r45 * r37;
+    r45 = r45 * r15;
+    r35 = r40 * r37;
+    r24 = r40 * r35;
+    r24 = r24 * r15;
+    r32 = r45 + r24;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r31,
+                       r33,
+                       r11,
+                       r46);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = 3.00000000000000000e+00;
+    r41 = r40 * r36;
+    r41 = r41 * r35;
+    r41 = fmaf(r15, r41, r45);
+    r8 = fmaf(r33, r41, r8 * r32);
+    r45 = r29 * r37;
+    r30 = r31 * r45;
+    r38 = r16 * r35;
+    r13 = r39 * r38;
+    r8 = fmaf(r13, r30, r8);
+    r12 = r32 * r32;
+    r10 = r32 * r12;
+    r11 = fmaf(r11, r10, r6 * r32);
+    r6 = r12 * r12;
+    r11 = fmaf(r46, r6, r11);
+    r11 = fmaf(r7, r12, r11);
+    r7 = r11 * r35;
+    r46 = 1.0 / r43;
+    r47 = 1.0 / r14;
+    r44 = r46 * r47;
+    r8 = fmaf(r44, r7, r8);
+    r8 = fmaf(r35, r44, r8);
+    r2 = fmaf(r0, r8, r2);
+    r7 = r29 * r29;
+    r7 = r7 * r37;
+    r7 = r7 * r36;
+    r7 = fmaf(r15, r7, r24);
+    r9 = fmaf(r31, r7, r9 * r32);
+    r24 = r11 * r44;
+    r9 = fmaf(r45, r24, r9);
+    r30 = r33 * r45;
+    r9 = fmaf(r13, r30, r9);
+    r9 = fmaf(r44, r45, r9);
+    r1 = fmaf(r5, r9, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = fmaf(r1, r1, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r4 * r9;
+    r3 = r3 * r1;
+    r30 = r4 * r2;
+    r24 = r8 * r30;
+    r26 = r0 * r35;
+    r49 = r26 * r30;
+    r50 = r44 * r49;
+    r51 = r4 * r32;
+    r52 = r5 * r45;
+    r51 = r51 * r1;
+    r51 = r51 * r44;
+    r51 = fmaf(r52, r51, r32 * r50);
+    r53 = r12 * r44;
+    r54 = r4 * r1;
+    r54 = r54 * r52;
+    r54 = fmaf(r53, r54, r53 * r49);
+    WriteSum4<float, float>((float*)inout_shared, r24, r3, r51, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r5 * r4;
+    r54 = r54 * r7;
+    r51 = r34 * r2;
+    r51 = r51 * r45;
+    r51 = r51 * r26;
+    r51 = fmaf(r39, r51, r1 * r54);
+    r54 = r34 * r1;
+    r54 = r54 * r35;
+    r54 = r54 * r52;
+    r3 = r0 * r41;
+    r3 = fmaf(r30, r3, r39 * r54);
+    r54 = r4 * r1;
+    r54 = r54 * r10;
+    r54 = r54 * r44;
+    r54 = fmaf(r52, r54, r10 * r50);
+    r24 = r4 * r1;
+    r24 = r24 * r44;
+    r24 = r24 * r52;
+    r24 = fmaf(r6, r24, r6 * r50);
+    WriteSum4<float, float>((float*)inout_shared, r51, r3, r54, r24);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r5 * r4;
+    r24 = r24 * r32;
+    r24 = r24 * r1;
+    r54 = r0 * r32;
+    r54 = r54 * r30;
+    WriteSum2<float, float>((float*)inout_shared, r54, r24);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r8 * r8;
+    r54 = r9 * r9;
+    r30 = r29 * r29;
+    r3 = r5 * r5;
+    r30 = r30 * r37;
+    r30 = r30 * r12;
+    r30 = r30 * r15;
+    r51 = r0 * r26;
+    r50 = r40 * r51;
+    r49 = r15 * r50;
+    r30 = fmaf(r12, r49, r3 * r30);
+    r55 = r5 * r52;
+    r56 = r29 * r55;
+    r57 = r6 * r56;
+    r58 = fmaf(r6, r49, r15 * r57);
+    WriteSum4<float, float>((float*)inout_shared, r24, r54, r30, r58);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r29 * r45;
+    r54 = r37 * r37;
+    r24 = 4.00000000000000000e+00;
+    r42 = r43 * r42;
+    r43 = r43 * r42;
+    r43 = 1.0 / r43;
+    r48 = r14 * r48;
+    r14 = r14 * r48;
+    r14 = 1.0 / r14;
+    r54 = r54 * r24;
+    r54 = r54 * r43;
+    r54 = r54 * r14;
+    r30 = r30 * r50;
+    r14 = r7 * r7;
+    r3 = fmaf(r14, r3, r54 * r30);
+    r14 = r40 * r35;
+    r14 = r14 * r56;
+    r30 = r0 * r0;
+    r43 = r41 * r41;
+    r30 = fmaf(r43, r30, r54 * r14);
+    r14 = r15 * r56;
+    r43 = r10 * r10;
+    r14 = fmaf(r43, r49, r43 * r14);
+    r54 = r15 * r56;
+    r24 = r6 * r6;
+    r24 = fmaf(r49, r24, r24 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r3, r30, r14, r24);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r0 * r0;
+    r24 = r24 * r12;
+    r30 = r5 * r5;
+    r30 = r30 * r12;
+    WriteSum2<float, float>((float*)inout_shared, r24, r30);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = 0.00000000000000000e+00;
+    r24 = r32 * r8;
+    r24 = r24 * r44;
+    r24 = r24 * r26;
+    r3 = r8 * r26;
+    r3 = r3 * r53;
+    r54 = r16 * r8;
+    r54 = r54 * r45;
+    r54 = r54 * r26;
+    r54 = r54 * r39;
+    WriteSum4<float, float>((float*)inout_shared, r30, r24, r3, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r0 * r41;
+    r54 = r54 * r8;
+    r3 = r0 * r32;
+    r3 = r3 * r8;
+    r24 = r8 * r10;
+    r24 = r24 * r44;
+    r24 = r24 * r26;
+    r8 = r8 * r44;
+    r8 = r8 * r26;
+    r8 = r8 * r6;
+    WriteSum4<float, float>((float*)inout_shared, r54, r24, r8, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r5 * r7;
+    r3 = r3 * r9;
+    r8 = r32 * r9;
+    r8 = r8 * r44;
+    r8 = r8 * r52;
+    r24 = r9 * r52;
+    r54 = r53 * r24;
+    WriteSum4<float, float>((float*)inout_shared, r30, r8, r54, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r13 * r24;
+    r3 = r9 * r10;
+    r3 = r3 * r44;
+    r3 = r3 * r52;
+    r54 = r9 * r44;
+    r54 = r54 * r52;
+    r54 = r54 * r6;
+    WriteSum4<float, float>((float*)inout_shared, r24, r3, r54, r30);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r5 * r32;
+    r30 = r30 * r9;
+    r9 = r10 * r15;
+    r9 = fmaf(r10, r49, r56 * r9);
+    r54 = r16 * r45;
+    r42 = 1.0 / r42;
+    r42 = r37 * r42;
+    r48 = 1.0 / r48;
+    r42 = r42 * r48;
+    r54 = r54 * r50;
+    r54 = r54 * r42;
+    r50 = r32 * r7;
+    r50 = r50 * r44;
+    r50 = fmaf(r55, r50, r32 * r54);
+    r48 = r32 * r41;
+    r48 = r48 * r44;
+    r3 = r32 * r56;
+    r3 = r3 * r38;
+    r3 = fmaf(r42, r3, r51 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r30, r9, r50, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r40 * r37;
+    r3 = r0 * r0;
+    r37 = r37 * r12;
+    r37 = r37 * r46;
+    r37 = r37 * r47;
+    r37 = r37 * r3;
+    r3 = r55 * r53;
+    r47 = r32 * r6;
+    r46 = r15 * r47;
+    r46 = fmaf(r47, r49, r56 * r46);
+    WriteSum4<float, float>((float*)inout_shared, r58, r46, r37, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r7 * r55;
+    r3 = fmaf(r53, r3, r12 * r54);
+    r53 = r12 * r56;
+    r53 = r53 * r38;
+    r53 = fmaf(r42, r53, r41 * r37);
+    WriteSum4<float, float>((float*)inout_shared, r3, r53, r46, r14);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r14 = r10 * r44;
+    r14 = r14 * r51;
+    r46 = r10 * r44;
+    r46 = r46 * r55;
+    r13 = r55 * r13;
+    r53 = r16 * r41;
+    r53 = r53 * r45;
+    r53 = r53 * r39;
+    r53 = fmaf(r51, r53, r7 * r13);
+    r3 = r7 * r10;
+    r3 = r3 * r44;
+    r3 = fmaf(r55, r3, r10 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r14, r46, r53, r3);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r16 * r32;
+    r3 = r3 * r45;
+    r3 = r3 * r39;
+    r3 = r3 * r51;
+    r39 = r5 * r5;
+    r39 = r39 * r32;
+    r39 = r39 * r7;
+    r53 = r7 * r44;
+    r53 = r53 * r6;
+    r53 = fmaf(r55, r53, r6 * r54);
+    r54 = r41 * r10;
+    r54 = r54 * r44;
+    r46 = r10 * r56;
+    r46 = r46 * r38;
+    r46 = fmaf(r42, r46, r51 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r53, r3, r39, r46);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r0 * r0;
+    r46 = r46 * r32;
+    r46 = r46 * r41;
+    r13 = r32 * r13;
+    r39 = r41 * r44;
+    r39 = r39 * r6;
+    r3 = r38 * r42;
+    r3 = fmaf(r57, r3, r51 * r39);
+    r39 = r15 * r56;
+    r43 = r32 * r43;
+    r43 = fmaf(r49, r43, r43 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r3, r46, r13, r43);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r44 * r6;
+    r43 = r43 * r51;
+    r6 = r44 * r6;
+    r6 = r6 * r55;
+    r51 = r44 * r51;
+    r51 = r51 * r47;
+    r13 = r44 * r55;
+    r13 = r13 * r47;
+    WriteSum4<float, float>((float*)inout_shared, r43, r6, r51, r13);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,307 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r35,
+                       r41,
+                       r34,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,239 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirectKernel(
+        float* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        float* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         0 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1,
+                                         r2,
+                                         r3);
+  };
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r7, r8);
+    ReadIdx4<1024, float, float, float4>(point_jac,
+                                         0 * point_jac_num_alloc,
+                                         global_thread_idx,
+                                         r9,
+                                         r10,
+                                         r11,
+                                         r12);
+    r13 = fmaf(r5, r11, r6 * r7);
+    r13 = fmaf(r4, r9, r13);
+    r14 = r0 * r13;
+    r5 = fmaf(r5, r12, r6 * r8);
+    r5 = fmaf(r4, r10, r5);
+    r4 = r1 * r5;
+    r6 = fmaf(r3, r5, r2 * r13);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         4 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r15,
+                                         r16,
+                                         r17,
+                                         r18);
+    r19 = fmaf(r16, r5, r15 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r14, r4, r6, r19);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r19 = fmaf(r18, r5, r17 * r13);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         8 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r6,
+                                         r4,
+                                         r14,
+                                         r20);
+    r21 = fmaf(r4, r5, r6 * r13);
+    r22 = fmaf(r20, r5, r14 * r13);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         12 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r23,
+                                         r24,
+                                         r25,
+                                         r26);
+    r27 = fmaf(r24, r5, r23 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r19, r21, r22, r27);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r25 * r13;
+    r5 = r26 * r5;
+    WriteSum2<float, float>((float*)inout_shared, r13, r5);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              0 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r5,
+                       r13,
+                       r27,
+                       r22);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              4 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r21,
+                       r19,
+                       r28,
+                       r29);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = fmaf(r21, r17, r22 * r15);
+  };
+  LoadShared<2, float, float>(focal_and_extra_njtr,
+                              8 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r15,
+                       r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = fmaf(r5, r0, r17);
+    r17 = fmaf(r27, r2, r17);
+    r17 = fmaf(r15, r25, r17);
+    r17 = fmaf(r19, r6, r17);
+    r17 = fmaf(r29, r23, r17);
+    r17 = fmaf(r28, r14, r17);
+    r3 = fmaf(r27, r3, r22 * r16);
+    r3 = fmaf(r21, r18, r3);
+    r3 = fmaf(r13, r1, r3);
+    r3 = fmaf(r29, r24, r3);
+    r3 = fmaf(r28, r20, r3);
+    r3 = fmaf(r30, r26, r3);
+    r3 = fmaf(r19, r4, r3);
+    r10 = fmaf(r10, r3, r9 * r17);
+    r12 = fmaf(r12, r3, r11 * r17);
+    r3 = fmaf(r8, r3, r7 * r17);
+    WriteSum3<float, float>((float*)inout_shared, r10, r12, r3);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.cu
@@ -1,0 +1,1385 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r19,
+                                         r20,
+                                         r21);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r22, r23, r24, r25);
+    r26 = fmaf(r18, r23, r21 * r24);
+    r27 = r19 * r22;
+    r26 = fmaf(r4, r27, r26);
+    r26 = fmaf(r20, r25, r26);
+    r27 = r17 * r26;
+    r28 = fmaf(r18, r25, r21 * r22);
+    r29 = r20 * r23;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r27 = r27 * r28;
+    r29 = -2.00000000000000000e+00;
+    r30 = r18 * r24;
+    r30 = fmaf(r4, r30, r21 * r23);
+    r30 = fmaf(r19, r25, r30);
+    r30 = fmaf(r20, r22, r30);
+    r31 = r29 * r30;
+    r32 = fmaf(r19, r23, r18 * r22);
+    r32 = fmaf(r20, r24, r32);
+    r32 = fmaf(r4, r32, r21 * r25);
+    r31 = fmaf(r32, r31, r27);
+    r13 = fmaf(r14, r31, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r25, r33, r34);
+    r35 = r18 * r20;
+    r35 = r35 * r17;
+    r36 = r19 * r21;
+    r37 = fmaf(r29, r36, r35);
+    r38 = r18 * r18;
+    r38 = r29 * r38;
+    r39 = 1.00000000000000000e+00;
+    r40 = r19 * r19;
+    r40 = fmaf(r29, r40, r39);
+    r41 = r38 + r40;
+    r42 = r19 * r20;
+    r42 = r42 * r17;
+    r43 = r18 * r21;
+    r43 = fmaf(r17, r43, r42);
+    r44 = r17 * r26;
+    r44 = r44 * r30;
+    r45 = r28 * r32;
+    r46 = fmaf(r17, r45, r44);
+    r47 = r30 * r30;
+    r47 = r29 * r47;
+    r48 = r39 + r47;
+    r49 = r28 * r28;
+    r49 = r49 * r29;
+    r48 = r48 + r49;
+    r13 = fmaf(r25, r37, r13);
+    r13 = fmaf(r34, r41, r13);
+    r13 = fmaf(r33, r43, r13);
+    r13 = fmaf(r15, r46, r13);
+    r13 = fmaf(r16, r48, r13);
+    r43 = copysign(1.0, r13);
+    r43 = fmaf(r10, r43, r13);
+    r13 = r43 * r43;
+    r41 = 1.0 / r13;
+    r47 = r39 + r47;
+    r37 = r26 * r26;
+    r37 = r29 * r37;
+    r47 = r47 + r37;
+    r11 = fmaf(r14, r47, r11);
+    r28 = r17 * r28;
+    r28 = r28 * r30;
+    r50 = r26 * r29;
+    r50 = fmaf(r32, r50, r28);
+    r51 = r17 * r30;
+    r51 = fmaf(r32, r51, r27);
+    r36 = fmaf(r17, r36, r35);
+    r35 = r20 * r21;
+    r27 = r18 * r19;
+    r27 = r27 * r17;
+    r35 = fmaf(r29, r35, r27);
+    r52 = r20 * r20;
+    r52 = r29 * r52;
+    r40 = r52 + r40;
+    r11 = fmaf(r15, r50, r11);
+    r11 = fmaf(r16, r51, r11);
+    r11 = fmaf(r34, r36, r11);
+    r11 = fmaf(r33, r35, r11);
+    r11 = fmaf(r25, r40, r11);
+    r40 = r11 * r11;
+    r40 = r41 * r40;
+    r35 = r11 * r11;
+    r36 = r17 * r26;
+    r36 = fmaf(r32, r36, r28);
+    r14 = fmaf(r14, r36, r12);
+    r12 = r20 * r21;
+    r12 = fmaf(r17, r12, r27);
+    r52 = r39 + r52;
+    r52 = r52 + r38;
+    r38 = r18 * r21;
+    r38 = fmaf(r29, r38, r42);
+    r45 = fmaf(r29, r45, r44);
+    r37 = r39 + r37;
+    r37 = r37 + r49;
+    r14 = fmaf(r25, r12, r14);
+    r14 = fmaf(r33, r52, r14);
+    r14 = fmaf(r34, r38, r14);
+    r14 = fmaf(r16, r45, r14);
+    r14 = fmaf(r15, r37, r14);
+    r15 = r14 * r14;
+    r15 = fmaf(r41, r15, r41 * r35);
+    r35 = sqrtf(r15);
+    r16 = copysign(1.0, r35);
+    r16 = fmaf(r10, r16, r35);
+    r10 = r16 * r16;
+    r38 = 1.0 / r10;
+    r35 = atanf(r35);
+    r34 = r35 * r35;
+    r40 = r40 * r38;
+    r40 = r40 * r34;
+    r34 = r14 * r35;
+    r52 = r41 * r38;
+    r33 = r14 * r35;
+    r34 = r34 * r52;
+    r34 = r34 * r33;
+    r12 = r40 + r34;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r25,
+                       r49,
+                       r44,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = 3.00000000000000000e+00;
+    r34 = fmaf(r27, r40, r34);
+    r28 = fmaf(r49, r34, r8 * r12);
+    r32 = r25 * r17;
+    r53 = r11 * r35;
+    r54 = r53 * r52;
+    r32 = r32 * r33;
+    r28 = fmaf(r54, r32, r28);
+    r55 = r12 * r12;
+    r56 = r12 * r55;
+    r57 = fmaf(r44, r56, r6 * r12);
+    r58 = r55 * r55;
+    r57 = fmaf(r42, r58, r57);
+    r57 = fmaf(r7, r55, r57);
+    r59 = 1.0 / r43;
+    r60 = 1.0 / r16;
+    r61 = r59 * r60;
+    r62 = r57 * r61;
+    r28 = fmaf(r53, r62, r28);
+    r28 = fmaf(r53, r61, r28);
+    r2 = fmaf(r0, r28, r2);
+    r32 = r14 * r35;
+    r32 = r32 * r27;
+    r32 = r32 * r52;
+    r32 = fmaf(r33, r32, r40);
+    r63 = fmaf(r25, r32, r9 * r12);
+    r64 = r49 * r17;
+    r64 = r64 * r33;
+    r63 = fmaf(r54, r64, r63);
+    r63 = fmaf(r33, r62, r63);
+    r63 = fmaf(r61, r33, r63);
+    r1 = fmaf(r5, r63, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = r0 * r12;
+    r3 = r3 * r53;
+    r3 = r3 * r61;
+    r64 = r12 * r61;
+    r65 = r5 * r33;
+    r64 = r64 * r65;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r28,
+                                          r63,
+                                          r3,
+                                          r64);
+    r64 = r5 * r32;
+    r3 = r0 * r53;
+    r3 = r3 * r61;
+    r3 = r3 * r55;
+    r66 = r61 * r55;
+    r66 = r66 * r65;
+    r67 = r0 * r17;
+    r67 = r67 * r33;
+    r67 = r67 * r54;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r3,
+                                          r66,
+                                          r67,
+                                          r64);
+    r64 = r0 * r34;
+    r67 = r17 * r54;
+    r67 = r67 * r65;
+    r66 = r0 * r53;
+    r66 = r66 * r61;
+    r66 = r66 * r56;
+    r3 = r61 * r56;
+    r3 = r3 * r65;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r64,
+                                          r67,
+                                          r66,
+                                          r3);
+    r3 = r0 * r12;
+    r66 = r5 * r12;
+    r67 = r0 * r53;
+    r67 = r67 * r61;
+    r67 = r67 * r58;
+    r64 = r61 * r65;
+    r64 = r64 * r58;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r67,
+        r64,
+        r3,
+        r66);
+    r66 = r4 * r63;
+    r66 = r66 * r1;
+    r3 = r4 * r2;
+    r64 = r28 * r3;
+    r67 = r12 * r53;
+    r3 = r0 * r3;
+    r67 = r67 * r61;
+    r68 = r4 * r12;
+    r68 = r68 * r1;
+    r68 = r68 * r61;
+    r68 = fmaf(r65, r68, r3 * r67);
+    r67 = r53 * r61;
+    r67 = r67 * r55;
+    r69 = r4 * r1;
+    r69 = r69 * r61;
+    r69 = r69 * r55;
+    r69 = fmaf(r65, r69, r3 * r67);
+    WriteSum4<float, float>((float*)inout_shared, r64, r66, r68, r69);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r5 * r4;
+    r69 = r69 * r32;
+    r68 = r0 * r29;
+    r68 = r68 * r2;
+    r68 = r68 * r33;
+    r68 = fmaf(r54, r68, r1 * r69);
+    r69 = r29 * r1;
+    r69 = r69 * r54;
+    r69 = fmaf(r34, r3, r65 * r69);
+    r2 = r53 * r61;
+    r2 = r2 * r56;
+    r66 = r4 * r1;
+    r66 = r66 * r61;
+    r66 = r66 * r56;
+    r66 = fmaf(r65, r66, r3 * r2);
+    r2 = r53 * r61;
+    r2 = r2 * r58;
+    r64 = r4 * r1;
+    r64 = r64 * r61;
+    r64 = r64 * r65;
+    r64 = fmaf(r58, r64, r3 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r68, r69, r66, r64);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r5 * r4;
+    r64 = r64 * r12;
+    r64 = r64 * r1;
+    r66 = r12 * r3;
+    WriteSum2<float, float>((float*)inout_shared, r66, r64);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r28 * r28;
+    r66 = r63 * r63;
+    r69 = r14 * r35;
+    r68 = r5 * r65;
+    r69 = r69 * r52;
+    r69 = r69 * r55;
+    r2 = r0 * r0;
+    r40 = r2 * r40;
+    r69 = fmaf(r55, r40, r68 * r69);
+    r67 = r14 * r35;
+    r67 = r67 * r52;
+    r67 = r67 * r58;
+    r67 = fmaf(r58, r40, r68 * r67);
+    WriteSum4<float, float>((float*)inout_shared, r64, r66, r69, r67);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r53 * r2;
+    r66 = r33 * r69;
+    r64 = r11 * r14;
+    r70 = 4.00000000000000000e+00;
+    r13 = r43 * r13;
+    r43 = r43 * r13;
+    r43 = 1.0 / r43;
+    r10 = r16 * r10;
+    r16 = r16 * r10;
+    r16 = 1.0 / r16;
+    r64 = r64 * r35;
+    r64 = r64 * r35;
+    r64 = r64 * r70;
+    r64 = r64 * r43;
+    r64 = r64 * r16;
+    r16 = r5 * r5;
+    r16 = r16 * r32;
+    r16 = fmaf(r32, r16, r64 * r66);
+    r66 = r53 * r68;
+    r43 = r34 * r34;
+    r43 = fmaf(r2, r43, r64 * r66);
+    r66 = r14 * r35;
+    r64 = r56 * r56;
+    r66 = r66 * r52;
+    r66 = r66 * r68;
+    r66 = fmaf(r64, r40, r64 * r66);
+    r71 = r14 * r35;
+    r72 = r58 * r58;
+    r71 = r71 * r52;
+    r71 = r71 * r68;
+    r72 = fmaf(r40, r72, r72 * r71);
+    WriteSum4<float, float>((float*)inout_shared, r16, r43, r66, r72);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r55 * r2;
+    r43 = r5 * r5;
+    r43 = r43 * r55;
+    WriteSum2<float, float>((float*)inout_shared, r72, r43);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = 0.00000000000000000e+00;
+    r72 = r0 * r12;
+    r72 = r72 * r28;
+    r72 = r72 * r53;
+    r72 = r72 * r61;
+    r16 = r0 * r28;
+    r16 = r16 * r53;
+    r16 = r16 * r61;
+    r16 = r16 * r55;
+    r71 = r0 * r17;
+    r71 = r71 * r28;
+    r71 = r71 * r33;
+    r71 = r71 * r54;
+    WriteSum4<float, float>((float*)inout_shared, r43, r72, r16, r71);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r0 * r34;
+    r71 = r71 * r28;
+    r16 = r0 * r12;
+    r16 = r16 * r28;
+    r72 = r0 * r28;
+    r72 = r72 * r53;
+    r72 = r72 * r61;
+    r72 = r72 * r56;
+    r28 = r0 * r28;
+    r28 = r28 * r53;
+    r28 = r28 * r61;
+    r28 = r28 * r58;
+    WriteSum4<float, float>((float*)inout_shared, r71, r72, r28, r16);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r16 = r5 * r32;
+    r16 = r16 * r63;
+    r28 = r12 * r63;
+    r28 = r28 * r61;
+    r28 = r28 * r65;
+    r72 = r63 * r61;
+    r72 = r72 * r55;
+    r72 = r72 * r65;
+    WriteSum4<float, float>((float*)inout_shared, r43, r28, r72, r16);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r16 = r17 * r63;
+    r16 = r16 * r54;
+    r16 = r16 * r65;
+    r72 = r63 * r61;
+    r72 = r72 * r56;
+    r72 = r72 * r65;
+    r28 = r63 * r61;
+    r28 = r28 * r65;
+    r28 = r28 * r58;
+    WriteSum4<float, float>((float*)inout_shared, r16, r72, r28, r43);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r5 * r12;
+    r43 = r43 * r63;
+    r63 = r14 * r35;
+    r63 = r63 * r52;
+    r63 = r63 * r56;
+    r63 = fmaf(r56, r40, r68 * r63);
+    r28 = r11 * r12;
+    r13 = 1.0 / r13;
+    r10 = 1.0 / r10;
+    r72 = r17 * r35;
+    r28 = r28 * r13;
+    r28 = r28 * r10;
+    r28 = r28 * r33;
+    r28 = r28 * r72;
+    r16 = r32 * r68;
+    r65 = r61 * r16;
+    r28 = fmaf(r12, r65, r69 * r28);
+    r71 = r61 * r69;
+    r73 = r34 * r71;
+    r74 = r14 * r12;
+    r74 = r74 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r12 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r43, r63, r28, r74);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r55 * r71;
+    r28 = r61 * r55;
+    r28 = r28 * r68;
+    r63 = r14 * r35;
+    r43 = r12 * r58;
+    r63 = r63 * r52;
+    r63 = r63 * r68;
+    r63 = fmaf(r43, r40, r43 * r63);
+    WriteSum4<float, float>((float*)inout_shared, r67, r63, r74, r28);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r11 * r13;
+    r28 = r28 * r10;
+    r28 = r28 * r33;
+    r28 = r28 * r55;
+    r28 = r28 * r72;
+    r28 = fmaf(r55, r65, r69 * r28);
+    r74 = r14 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r55;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r55 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r28, r74, r63, r66);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r56 * r71;
+    r63 = r61 * r56;
+    r63 = r63 * r68;
+    r74 = r17 * r54;
+    r28 = r17 * r34;
+    r28 = r28 * r33;
+    r28 = r28 * r54;
+    r28 = fmaf(r2, r28, r16 * r74);
+    r74 = r11 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r33;
+    r74 = r74 * r56;
+    r74 = r74 * r72;
+    r74 = fmaf(r56, r65, r69 * r74);
+    WriteSum4<float, float>((float*)inout_shared, r66, r63, r28, r74);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r17 * r12;
+    r74 = r74 * r33;
+    r74 = r74 * r54;
+    r74 = r74 * r2;
+    r28 = r5 * r5;
+    r28 = r28 * r12;
+    r28 = r28 * r32;
+    r32 = r11 * r13;
+    r32 = r32 * r10;
+    r32 = r32 * r33;
+    r32 = r32 * r58;
+    r32 = r32 * r72;
+    r65 = fmaf(r58, r65, r69 * r32);
+    r32 = r14 * r13;
+    r32 = r32 * r10;
+    r32 = r32 * r53;
+    r32 = r32 * r56;
+    r32 = r32 * r72;
+    r32 = fmaf(r68, r32, r56 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r65, r74, r28, r32);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r12 * r34;
+    r32 = r32 * r2;
+    r28 = r17 * r12;
+    r28 = r28 * r54;
+    r28 = r28 * r68;
+    r74 = r14 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r58;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r58 * r73);
+    r73 = r14 * r35;
+    r64 = r12 * r64;
+    r73 = r73 * r52;
+    r73 = r73 * r68;
+    r64 = fmaf(r40, r64, r64 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r74, r32, r28, r64);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r58 * r71;
+    r58 = r61 * r58;
+    r58 = r58 * r68;
+    r71 = r43 * r71;
+    r28 = r61 * r68;
+    r28 = r28 * r43;
+    WriteSum4<float, float>((float*)inout_shared, r64, r58, r71, r28);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r47 * r35;
+    r71 = 6.00000000000000000e+00;
+    r28 = r28 * r71;
+    r58 = r31 * r35;
+    r64 = -6.00000000000000000e+00;
+    r58 = r58 * r64;
+    r58 = r58 * r38;
+    r58 = r58 * r13;
+    r43 = r11 * r53;
+    r28 = fmaf(r58, r43, r54 * r28);
+    r32 = r17 * r36;
+    r32 = r32 * r14;
+    r74 = r17 * r47;
+    r74 = r74 * r11;
+    r74 = fmaf(r41, r74, r41 * r32);
+    r32 = r31 * r11;
+    r40 = r29 * r13;
+    r32 = r32 * r11;
+    r74 = fmaf(r40, r32, r74);
+    r73 = r14 * r14;
+    r73 = r73 * r40;
+    r74 = fmaf(r31, r73, r74);
+    r32 = r27 * r74;
+    r65 = rsqrtf(r15);
+    r15 = r39 + r15;
+    r15 = 1.0 / r15;
+    r15 = r65 * r15;
+    r39 = r11 * r54;
+    r32 = r32 * r15;
+    r28 = fmaf(r39, r32, r28);
+    r63 = r11 * r74;
+    r66 = -3.00000000000000000e+00;
+    r66 = r35 * r66;
+    r66 = r66 * r41;
+    r66 = r66 * r10;
+    r66 = r66 * r65;
+    r63 = r63 * r53;
+    r28 = fmaf(r66, r63, r28);
+    r16 = r4 * r14;
+    r16 = r16 * r14;
+    r16 = r16 * r35;
+    r16 = r16 * r35;
+    r16 = r16 * r74;
+    r16 = r16 * r41;
+    r16 = r16 * r10;
+    r67 = r14 * r15;
+    r75 = r74 * r67;
+    r76 = r52 * r33;
+    r75 = fmaf(r76, r75, r65 * r16);
+    r16 = r35 * r38;
+    r77 = r35 * r73;
+    r16 = r16 * r77;
+    r78 = r72 * r76;
+    r75 = fmaf(r31, r16, r75);
+    r75 = fmaf(r36, r78, r75);
+    r28 = r28 + r75;
+    r63 = r47 * r54;
+    r32 = r31 * r11;
+    r32 = r32 * r35;
+    r32 = r32 * r38;
+    r32 = r32 * r53;
+    r32 = fmaf(r40, r32, r72 * r63);
+    r63 = r74 * r15;
+    r32 = fmaf(r39, r63, r32);
+    r79 = r4 * r11;
+    r79 = r79 * r35;
+    r79 = r79 * r74;
+    r79 = r79 * r41;
+    r79 = r79 * r10;
+    r79 = r79 * r65;
+    r32 = fmaf(r53, r79, r32);
+    r75 = r75 + r32;
+    r28 = fmaf(r8, r75, r49 * r28);
+    r79 = r47 * r35;
+    r28 = fmaf(r62, r79, r28);
+    r63 = -5.00000000000000000e-01;
+    r80 = r63 * r74;
+    r80 = r80 * r38;
+    r80 = r80 * r59;
+    r80 = r80 * r65;
+    r81 = r57 * r80;
+    r82 = r4 * r31;
+    r82 = r82 * r57;
+    r82 = r82 * r41;
+    r82 = r82 * r60;
+    r28 = fmaf(r53, r82, r28);
+    r83 = r4 * r31;
+    r83 = r83 * r41;
+    r83 = r83 * r60;
+    r28 = fmaf(r53, r83, r28);
+    r84 = r25 * r36;
+    r84 = r84 * r54;
+    r28 = fmaf(r72, r84, r28);
+    r85 = r7 * r17;
+    r85 = r85 * r12;
+    r85 = fmaf(r6, r75, r75 * r85);
+    r70 = r42 * r70;
+    r70 = r70 * r56;
+    r44 = r44 * r27;
+    r44 = r44 * r55;
+    r85 = fmaf(r75, r70, r85);
+    r85 = fmaf(r75, r44, r85);
+    r55 = r85 * r53;
+    r28 = fmaf(r61, r55, r28);
+    r56 = r11 * r15;
+    r42 = 5.00000000000000000e-01;
+    r86 = r42 * r62;
+    r56 = r56 * r86;
+    r87 = r47 * r35;
+    r28 = fmaf(r61, r87, r28);
+    r88 = r25 * r31;
+    r89 = -4.00000000000000000e+00;
+    r89 = r89 * r38;
+    r89 = r89 * r13;
+    r89 = r89 * r53;
+    r89 = r89 * r33;
+    r28 = fmaf(r89, r88, r28);
+    r90 = r25 * r29;
+    r90 = r90 * r74;
+    r90 = r90 * r41;
+    r90 = r90 * r10;
+    r90 = r90 * r65;
+    r90 = r90 * r53;
+    r28 = fmaf(r33, r90, r28);
+    r91 = r25 * r78;
+    r92 = r25 * r74;
+    r93 = r17 * r54;
+    r93 = r93 * r67;
+    r28 = fmaf(r93, r92, r28);
+    r94 = r11 * r42;
+    r94 = r94 * r74;
+    r94 = r94 * r61;
+    r28 = fmaf(r15, r94, r28);
+    r28 = fmaf(r53, r81, r28);
+    r28 = fmaf(r74, r56, r28);
+    r28 = fmaf(r53, r80, r28);
+    r28 = fmaf(r47, r91, r28);
+    r94 = r0 * r28;
+    r92 = r74 * r66;
+    r90 = r27 * r74;
+    r90 = r90 * r67;
+    r90 = fmaf(r76, r90, r77 * r92);
+    r92 = r14 * r58;
+    r90 = fmaf(r33, r92, r90);
+    r88 = r36 * r35;
+    r88 = r88 * r71;
+    r88 = r88 * r52;
+    r90 = fmaf(r33, r88, r90);
+    r90 = r90 + r32;
+    r75 = fmaf(r9, r75, r25 * r90);
+    r90 = r74 * r67;
+    r75 = fmaf(r86, r90, r75);
+    r32 = r4 * r31;
+    r32 = r32 * r14;
+    r32 = r32 * r35;
+    r32 = r32 * r57;
+    r32 = r32 * r41;
+    r75 = fmaf(r60, r32, r75);
+    r88 = r49 * r36;
+    r88 = r88 * r54;
+    r75 = fmaf(r72, r88, r75);
+    r92 = r49 * r89;
+    r87 = r14 * r35;
+    r75 = fmaf(r80, r87, r75);
+    r80 = r49 * r29;
+    r80 = r80 * r74;
+    r80 = r80 * r41;
+    r80 = r80 * r10;
+    r80 = r80 * r65;
+    r80 = r80 * r53;
+    r75 = fmaf(r33, r80, r75);
+    r55 = r49 * r47;
+    r75 = fmaf(r78, r55, r75);
+    r84 = r42 * r74;
+    r84 = r84 * r61;
+    r75 = fmaf(r67, r84, r75);
+    r83 = r36 * r35;
+    r75 = fmaf(r62, r83, r75);
+    r82 = r4 * r31;
+    r82 = r82 * r14;
+    r82 = r82 * r35;
+    r82 = r82 * r41;
+    r75 = fmaf(r60, r82, r75);
+    r79 = r49 * r74;
+    r75 = fmaf(r93, r79, r75);
+    r95 = r36 * r35;
+    r75 = fmaf(r61, r95, r75);
+    r96 = r85 * r61;
+    r75 = fmaf(r33, r96, r75);
+    r75 = fmaf(r81, r33, r75);
+    r75 = fmaf(r31, r92, r75);
+    r96 = r5 * r75;
+    r95 = r17 * r50;
+    r95 = r95 * r11;
+    r95 = fmaf(r41, r95, r46 * r73);
+    r79 = r17 * r37;
+    r79 = r79 * r14;
+    r95 = fmaf(r41, r79, r95);
+    r82 = r46 * r11;
+    r82 = r82 * r11;
+    r95 = fmaf(r40, r82, r95);
+    r82 = r95 * r15;
+    r79 = r46 * r11;
+    r79 = r79 * r35;
+    r79 = r79 * r38;
+    r79 = r79 * r53;
+    r79 = fmaf(r40, r79, r39 * r82);
+    r82 = r4 * r11;
+    r82 = r82 * r35;
+    r82 = r82 * r95;
+    r82 = r82 * r41;
+    r82 = r82 * r10;
+    r82 = r82 * r65;
+    r79 = fmaf(r53, r82, r79);
+    r83 = r50 * r54;
+    r79 = fmaf(r72, r83, r79);
+    r83 = r4 * r14;
+    r83 = r83 * r14;
+    r83 = r83 * r35;
+    r83 = r83 * r35;
+    r83 = r83 * r95;
+    r83 = r83 * r41;
+    r83 = r83 * r10;
+    r83 = fmaf(r37, r78, r65 * r83);
+    r82 = r95 * r67;
+    r83 = fmaf(r76, r82, r83);
+    r83 = fmaf(r46, r16, r83);
+    r82 = r79 + r83;
+    r84 = r27 * r95;
+    r84 = r84 * r15;
+    r55 = r46 * r11;
+    r55 = r55 * r35;
+    r55 = r55 * r64;
+    r55 = r55 * r38;
+    r55 = r55 * r13;
+    r55 = fmaf(r53, r55, r39 * r84);
+    r84 = r95 * r66;
+    r80 = r50 * r35;
+    r80 = r80 * r71;
+    r55 = fmaf(r54, r80, r55);
+    r55 = fmaf(r84, r43, r55);
+    r55 = r55 + r83;
+    r55 = fmaf(r49, r55, r8 * r82);
+    r83 = r25 * r29;
+    r83 = r83 * r95;
+    r83 = r83 * r41;
+    r83 = r83 * r10;
+    r83 = r83 * r65;
+    r83 = r83 * r53;
+    r55 = fmaf(r33, r83, r55);
+    r80 = r63 * r95;
+    r80 = r80 * r38;
+    r80 = r80 * r59;
+    r80 = r80 * r65;
+    r55 = fmaf(r53, r80, r55);
+    r43 = r4 * r46;
+    r43 = r43 * r41;
+    r43 = r43 * r60;
+    r55 = fmaf(r53, r43, r55);
+    r87 = r4 * r46;
+    r87 = r87 * r57;
+    r87 = r87 * r41;
+    r87 = r87 * r60;
+    r55 = fmaf(r53, r87, r55);
+    r88 = r7 * r17;
+    r88 = r88 * r12;
+    r88 = fmaf(r82, r88, r6 * r82);
+    r88 = fmaf(r82, r70, r88);
+    r88 = fmaf(r82, r44, r88);
+    r32 = r88 * r53;
+    r55 = fmaf(r61, r32, r55);
+    r81 = r57 * r63;
+    r81 = r81 * r95;
+    r81 = r81 * r38;
+    r81 = r81 * r59;
+    r81 = r81 * r65;
+    r55 = fmaf(r53, r81, r55);
+    r90 = r11 * r42;
+    r90 = r90 * r95;
+    r90 = r90 * r61;
+    r55 = fmaf(r15, r90, r55);
+    r97 = r50 * r35;
+    r55 = fmaf(r62, r97, r55);
+    r98 = r25 * r37;
+    r98 = r98 * r54;
+    r55 = fmaf(r72, r98, r55);
+    r99 = r50 * r35;
+    r55 = fmaf(r61, r99, r55);
+    r100 = r25 * r46;
+    r55 = fmaf(r89, r100, r55);
+    r101 = r25 * r95;
+    r55 = fmaf(r93, r101, r55);
+    r55 = fmaf(r50, r91, r55);
+    r55 = fmaf(r95, r56, r55);
+    r101 = r0 * r55;
+    r100 = r37 * r35;
+    r100 = r100 * r71;
+    r100 = r100 * r52;
+    r100 = fmaf(r33, r100, r77 * r84);
+    r84 = r27 * r95;
+    r84 = r84 * r67;
+    r100 = fmaf(r76, r84, r100);
+    r99 = r46 * r14;
+    r99 = r99 * r14;
+    r99 = r99 * r35;
+    r99 = r99 * r35;
+    r99 = r99 * r64;
+    r99 = r99 * r38;
+    r100 = fmaf(r13, r99, r100);
+    r100 = r100 + r79;
+    r100 = fmaf(r25, r100, r9 * r82);
+    r82 = r49 * r50;
+    r100 = fmaf(r78, r82, r100);
+    r79 = r49 * r95;
+    r100 = fmaf(r93, r79, r100);
+    r99 = r49 * r29;
+    r99 = r99 * r95;
+    r99 = r99 * r41;
+    r99 = r99 * r10;
+    r99 = r99 * r65;
+    r99 = r99 * r53;
+    r100 = fmaf(r33, r99, r100);
+    r84 = r14 * r35;
+    r84 = r84 * r57;
+    r84 = r84 * r63;
+    r84 = r84 * r95;
+    r84 = r84 * r38;
+    r84 = r84 * r59;
+    r100 = fmaf(r65, r84, r100);
+    r98 = r14 * r35;
+    r98 = r98 * r63;
+    r98 = r98 * r95;
+    r98 = r98 * r38;
+    r98 = r98 * r59;
+    r100 = fmaf(r65, r98, r100);
+    r97 = r88 * r61;
+    r100 = fmaf(r33, r97, r100);
+    r90 = r37 * r35;
+    r100 = fmaf(r61, r90, r100);
+    r81 = r4 * r46;
+    r81 = r81 * r14;
+    r81 = r81 * r35;
+    r81 = r81 * r57;
+    r81 = r81 * r41;
+    r100 = fmaf(r60, r81, r100);
+    r32 = r37 * r35;
+    r100 = fmaf(r62, r32, r100);
+    r87 = r42 * r95;
+    r87 = r87 * r61;
+    r100 = fmaf(r67, r87, r100);
+    r43 = r49 * r37;
+    r43 = r43 * r54;
+    r100 = fmaf(r72, r43, r100);
+    r80 = r95 * r67;
+    r100 = fmaf(r86, r80, r100);
+    r83 = r4 * r46;
+    r83 = r83 * r14;
+    r83 = r83 * r35;
+    r83 = r83 * r41;
+    r100 = fmaf(r60, r83, r100);
+    r100 = fmaf(r46, r92, r100);
+    r83 = r5 * r100;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r96,
+                                          r101,
+                                          r83);
+    r83 = r4 * r14;
+    r101 = r17 * r45;
+    r101 = r101 * r14;
+    r73 = fmaf(r48, r73, r41 * r101);
+    r101 = r48 * r11;
+    r101 = r101 * r11;
+    r73 = fmaf(r40, r101, r73);
+    r96 = r17 * r51;
+    r96 = r96 * r11;
+    r73 = fmaf(r41, r96, r73);
+    r83 = r83 * r14;
+    r83 = r83 * r35;
+    r83 = r83 * r35;
+    r83 = r83 * r73;
+    r83 = r83 * r41;
+    r83 = r83 * r10;
+    r83 = fmaf(r45, r78, r65 * r83);
+    r96 = r73 * r67;
+    r83 = fmaf(r76, r96, r83);
+    r83 = fmaf(r48, r16, r83);
+    r16 = r51 * r54;
+    r96 = r73 * r15;
+    r96 = fmaf(r39, r96, r72 * r16);
+    r16 = r48 * r11;
+    r16 = r16 * r35;
+    r16 = r16 * r38;
+    r16 = r16 * r53;
+    r96 = fmaf(r40, r16, r96);
+    r40 = r4 * r11;
+    r40 = r40 * r35;
+    r40 = r40 * r73;
+    r40 = r40 * r41;
+    r40 = r40 * r10;
+    r40 = r40 * r65;
+    r96 = fmaf(r53, r40, r96);
+    r40 = r83 + r96;
+    r16 = r51 * r35;
+    r16 = r16 * r71;
+    r101 = r27 * r73;
+    r101 = r101 * r15;
+    r101 = fmaf(r39, r101, r54 * r16);
+    r16 = r48 * r11;
+    r16 = r16 * r35;
+    r16 = r16 * r64;
+    r16 = r16 * r38;
+    r16 = r16 * r13;
+    r101 = fmaf(r53, r16, r101);
+    r39 = r11 * r73;
+    r39 = r39 * r53;
+    r101 = fmaf(r66, r39, r101);
+    r101 = r101 + r83;
+    r101 = fmaf(r49, r101, r8 * r40);
+    r8 = r25 * r45;
+    r8 = r8 * r54;
+    r101 = fmaf(r72, r8, r101);
+    r93 = r73 * r93;
+    r83 = r57 * r63;
+    r83 = r83 * r73;
+    r83 = r83 * r38;
+    r83 = r83 * r59;
+    r83 = r83 * r65;
+    r101 = fmaf(r53, r83, r101);
+    r39 = r4 * r48;
+    r39 = r39 * r57;
+    r39 = r39 * r41;
+    r39 = r39 * r60;
+    r101 = fmaf(r53, r39, r101);
+    r16 = r7 * r17;
+    r16 = r16 * r12;
+    r16 = fmaf(r40, r16, r6 * r40);
+    r16 = fmaf(r40, r70, r16);
+    r16 = fmaf(r40, r44, r16);
+    r44 = r16 * r53;
+    r101 = fmaf(r61, r44, r101);
+    r70 = r4 * r48;
+    r70 = r70 * r41;
+    r70 = r70 * r60;
+    r101 = fmaf(r53, r70, r101);
+    r6 = r63 * r73;
+    r6 = r6 * r38;
+    r6 = r6 * r59;
+    r6 = r6 * r65;
+    r101 = fmaf(r53, r6, r101);
+    r94 = r51 * r35;
+    r101 = fmaf(r61, r94, r101);
+    r80 = r51 * r35;
+    r101 = fmaf(r62, r80, r101);
+    r43 = r25 * r29;
+    r43 = r43 * r73;
+    r43 = r43 * r41;
+    r43 = r43 * r10;
+    r43 = r43 * r65;
+    r43 = r43 * r53;
+    r101 = fmaf(r33, r43, r101);
+    r87 = r11 * r42;
+    r87 = r87 * r73;
+    r87 = r87 * r61;
+    r101 = fmaf(r15, r87, r101);
+    r32 = r25 * r48;
+    r101 = fmaf(r89, r32, r101);
+    r101 = fmaf(r25, r93, r101);
+    r101 = fmaf(r73, r56, r101);
+    r101 = fmaf(r51, r91, r101);
+    r91 = r0 * r101;
+    r32 = r73 * r66;
+    r87 = r45 * r35;
+    r87 = r87 * r71;
+    r87 = r87 * r52;
+    r87 = fmaf(r33, r87, r77 * r32);
+    r32 = r27 * r73;
+    r32 = r32 * r67;
+    r87 = fmaf(r76, r32, r87);
+    r76 = r48 * r14;
+    r76 = r76 * r14;
+    r76 = r76 * r35;
+    r76 = r76 * r35;
+    r76 = r76 * r64;
+    r76 = r76 * r38;
+    r87 = fmaf(r13, r76, r87);
+    r87 = r87 + r96;
+    r87 = fmaf(r25, r87, r9 * r40);
+    r40 = r49 * r45;
+    r40 = r40 * r54;
+    r87 = fmaf(r72, r40, r87);
+    r72 = r4 * r48;
+    r72 = r72 * r14;
+    r72 = r72 * r35;
+    r72 = r72 * r57;
+    r72 = r72 * r41;
+    r87 = fmaf(r60, r72, r87);
+    r9 = r14 * r35;
+    r9 = r9 * r63;
+    r9 = r9 * r73;
+    r9 = r9 * r38;
+    r9 = r9 * r59;
+    r87 = fmaf(r65, r9, r87);
+    r96 = r45 * r35;
+    r87 = fmaf(r61, r96, r87);
+    r76 = r16 * r61;
+    r87 = fmaf(r33, r76, r87);
+    r32 = r49 * r29;
+    r32 = r32 * r73;
+    r32 = r32 * r41;
+    r32 = r32 * r10;
+    r32 = r32 * r65;
+    r32 = r32 * r53;
+    r87 = fmaf(r33, r32, r87);
+    r10 = r14 * r35;
+    r10 = r10 * r57;
+    r10 = r10 * r63;
+    r10 = r10 * r73;
+    r10 = r10 * r38;
+    r10 = r10 * r59;
+    r87 = fmaf(r65, r10, r87);
+    r65 = r73 * r67;
+    r87 = fmaf(r86, r65, r87);
+    r86 = r45 * r35;
+    r87 = fmaf(r62, r86, r87);
+    r62 = r49 * r51;
+    r87 = fmaf(r78, r62, r87);
+    r78 = r4 * r48;
+    r78 = r78 * r14;
+    r78 = r78 * r35;
+    r78 = r78 * r41;
+    r87 = fmaf(r60, r78, r87);
+    r60 = r42 * r73;
+    r60 = r60 * r61;
+    r87 = fmaf(r67, r60, r87);
+    r87 = fmaf(r49, r93, r87);
+    r87 = fmaf(r48, r92, r87);
+    r60 = r5 * r87;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r91,
+                                          r60);
+    r60 = r5 * r4;
+    r60 = r60 * r1;
+    r60 = fmaf(r28, r3, r75 * r60);
+    r91 = r5 * r4;
+    r91 = r91 * r1;
+    r91 = fmaf(r55, r3, r100 * r91);
+    r78 = r5 * r4;
+    r78 = r78 * r1;
+    r3 = fmaf(r101, r3, r87 * r78);
+    WriteSum3<float, float>((float*)inout_shared, r60, r91, r3);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r28 * r28;
+    r91 = r5 * r5;
+    r60 = r75 * r75;
+    r60 = fmaf(r60, r91, r2 * r3);
+    r3 = r100 * r100;
+    r78 = r55 * r55;
+    r78 = fmaf(r2, r78, r3 * r91);
+    r3 = r87 * r87;
+    r62 = r101 * r101;
+    r62 = fmaf(r2, r62, r3 * r91);
+    WriteSum3<float, float>((float*)inout_shared, r60, r78, r62);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r5 * r5;
+    r62 = r62 * r75;
+    r78 = r28 * r55;
+    r78 = fmaf(r2, r78, r100 * r62);
+    r62 = r28 * r101;
+    r60 = r5 * r5;
+    r60 = r60 * r75;
+    r60 = fmaf(r87, r60, r2 * r62);
+    r62 = r5 * r5;
+    r62 = r62 * r100;
+    r100 = r55 * r101;
+    r100 = fmaf(r2, r100, r87 * r62);
+    WriteSum3<float, float>((float*)inout_shared, r78, r60, r100);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacKernel<<<n_blocks,
+                                                                  1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,1399 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirstKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r17 = 2.00000000000000000e+00;
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r18,
+                                         r19,
+                                         r20,
+                                         r21);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r22, r23, r24, r25);
+    r26 = fmaf(r18, r23, r21 * r24);
+    r27 = r19 * r22;
+    r26 = fmaf(r4, r27, r26);
+    r26 = fmaf(r20, r25, r26);
+    r27 = r17 * r26;
+    r28 = fmaf(r18, r25, r21 * r22);
+    r29 = r20 * r23;
+    r28 = fmaf(r4, r29, r28);
+    r28 = fmaf(r19, r24, r28);
+    r27 = r27 * r28;
+    r29 = -2.00000000000000000e+00;
+    r30 = r18 * r24;
+    r30 = fmaf(r4, r30, r21 * r23);
+    r30 = fmaf(r19, r25, r30);
+    r30 = fmaf(r20, r22, r30);
+    r31 = r29 * r30;
+    r32 = fmaf(r19, r23, r18 * r22);
+    r32 = fmaf(r20, r24, r32);
+    r32 = fmaf(r4, r32, r21 * r25);
+    r31 = fmaf(r32, r31, r27);
+    r13 = fmaf(r14, r31, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r25, r33, r34);
+    r35 = r18 * r20;
+    r35 = r35 * r17;
+    r36 = r19 * r21;
+    r37 = fmaf(r29, r36, r35);
+    r38 = r18 * r18;
+    r38 = r29 * r38;
+    r39 = 1.00000000000000000e+00;
+    r40 = r19 * r19;
+    r40 = fmaf(r29, r40, r39);
+    r41 = r38 + r40;
+    r42 = r19 * r20;
+    r42 = r42 * r17;
+    r43 = r18 * r21;
+    r43 = fmaf(r17, r43, r42);
+    r44 = r17 * r26;
+    r44 = r44 * r30;
+    r45 = r28 * r32;
+    r46 = fmaf(r17, r45, r44);
+    r47 = r30 * r30;
+    r47 = r29 * r47;
+    r48 = r39 + r47;
+    r49 = r28 * r28;
+    r49 = r49 * r29;
+    r48 = r48 + r49;
+    r13 = fmaf(r25, r37, r13);
+    r13 = fmaf(r34, r41, r13);
+    r13 = fmaf(r33, r43, r13);
+    r13 = fmaf(r15, r46, r13);
+    r13 = fmaf(r16, r48, r13);
+    r43 = copysign(1.0, r13);
+    r43 = fmaf(r10, r43, r13);
+    r13 = r43 * r43;
+    r41 = 1.0 / r13;
+    r47 = r39 + r47;
+    r37 = r26 * r26;
+    r37 = r29 * r37;
+    r47 = r47 + r37;
+    r11 = fmaf(r14, r47, r11);
+    r28 = r17 * r28;
+    r28 = r28 * r30;
+    r50 = r26 * r29;
+    r50 = fmaf(r32, r50, r28);
+    r51 = r17 * r30;
+    r51 = fmaf(r32, r51, r27);
+    r36 = fmaf(r17, r36, r35);
+    r35 = r20 * r21;
+    r27 = r18 * r19;
+    r27 = r27 * r17;
+    r35 = fmaf(r29, r35, r27);
+    r52 = r20 * r20;
+    r52 = r29 * r52;
+    r40 = r52 + r40;
+    r11 = fmaf(r15, r50, r11);
+    r11 = fmaf(r16, r51, r11);
+    r11 = fmaf(r34, r36, r11);
+    r11 = fmaf(r33, r35, r11);
+    r11 = fmaf(r25, r40, r11);
+    r40 = r11 * r11;
+    r40 = r41 * r40;
+    r35 = r11 * r11;
+    r36 = r17 * r26;
+    r36 = fmaf(r32, r36, r28);
+    r14 = fmaf(r14, r36, r12);
+    r12 = r20 * r21;
+    r12 = fmaf(r17, r12, r27);
+    r52 = r39 + r52;
+    r52 = r52 + r38;
+    r38 = r18 * r21;
+    r38 = fmaf(r29, r38, r42);
+    r45 = fmaf(r29, r45, r44);
+    r37 = r39 + r37;
+    r37 = r37 + r49;
+    r14 = fmaf(r25, r12, r14);
+    r14 = fmaf(r33, r52, r14);
+    r14 = fmaf(r34, r38, r14);
+    r14 = fmaf(r16, r45, r14);
+    r14 = fmaf(r15, r37, r14);
+    r15 = r14 * r14;
+    r15 = fmaf(r41, r15, r41 * r35);
+    r35 = sqrtf(r15);
+    r16 = copysign(1.0, r35);
+    r16 = fmaf(r10, r16, r35);
+    r10 = r16 * r16;
+    r38 = 1.0 / r10;
+    r35 = atanf(r35);
+    r34 = r35 * r35;
+    r40 = r40 * r38;
+    r40 = r40 * r34;
+    r34 = r14 * r35;
+    r52 = r41 * r38;
+    r33 = r14 * r35;
+    r34 = r34 * r52;
+    r34 = r34 * r33;
+    r12 = r40 + r34;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r25,
+                       r49,
+                       r44,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = 3.00000000000000000e+00;
+    r34 = fmaf(r27, r40, r34);
+    r28 = fmaf(r49, r34, r8 * r12);
+    r32 = r25 * r17;
+    r53 = r11 * r35;
+    r54 = r53 * r52;
+    r32 = r32 * r33;
+    r28 = fmaf(r54, r32, r28);
+    r55 = r12 * r12;
+    r56 = r12 * r55;
+    r57 = fmaf(r44, r56, r6 * r12);
+    r58 = r55 * r55;
+    r57 = fmaf(r42, r58, r57);
+    r57 = fmaf(r7, r55, r57);
+    r59 = 1.0 / r43;
+    r60 = 1.0 / r16;
+    r61 = r59 * r60;
+    r62 = r57 * r61;
+    r28 = fmaf(r53, r62, r28);
+    r28 = fmaf(r53, r61, r28);
+    r2 = fmaf(r0, r28, r2);
+    r32 = r14 * r35;
+    r32 = r32 * r27;
+    r32 = r32 * r52;
+    r32 = fmaf(r33, r32, r40);
+    r63 = fmaf(r25, r32, r9 * r12);
+    r64 = r49 * r17;
+    r64 = r64 * r33;
+    r63 = fmaf(r54, r64, r63);
+    r63 = fmaf(r33, r62, r63);
+    r63 = fmaf(r61, r33, r63);
+    r1 = fmaf(r5, r63, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = fmaf(r1, r1, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r0 * r12;
+    r3 = r3 * r53;
+    r3 = r3 * r61;
+    r64 = r12 * r61;
+    r65 = r5 * r33;
+    r64 = r64 * r65;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r28,
+                                          r63,
+                                          r3,
+                                          r64);
+    r64 = r5 * r32;
+    r3 = r0 * r53;
+    r3 = r3 * r61;
+    r3 = r3 * r55;
+    r66 = r61 * r55;
+    r66 = r66 * r65;
+    r67 = r0 * r17;
+    r67 = r67 * r33;
+    r67 = r67 * r54;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r3,
+                                          r66,
+                                          r67,
+                                          r64);
+    r64 = r0 * r34;
+    r67 = r17 * r54;
+    r67 = r67 * r65;
+    r66 = r0 * r53;
+    r66 = r66 * r61;
+    r66 = r66 * r56;
+    r3 = r61 * r56;
+    r3 = r3 * r65;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r64,
+                                          r67,
+                                          r66,
+                                          r3);
+    r3 = r0 * r12;
+    r66 = r5 * r12;
+    r67 = r0 * r53;
+    r67 = r67 * r61;
+    r67 = r67 * r58;
+    r64 = r61 * r65;
+    r64 = r64 * r58;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r67,
+        r64,
+        r3,
+        r66);
+    r66 = r4 * r63;
+    r66 = r66 * r1;
+    r3 = r4 * r2;
+    r64 = r28 * r3;
+    r67 = r12 * r53;
+    r3 = r0 * r3;
+    r67 = r67 * r61;
+    r68 = r4 * r12;
+    r68 = r68 * r1;
+    r68 = r68 * r61;
+    r68 = fmaf(r65, r68, r3 * r67);
+    r67 = r53 * r61;
+    r67 = r67 * r55;
+    r69 = r4 * r1;
+    r69 = r69 * r61;
+    r69 = r69 * r55;
+    r69 = fmaf(r65, r69, r3 * r67);
+    WriteSum4<float, float>((float*)inout_shared, r64, r66, r68, r69);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r5 * r4;
+    r69 = r69 * r32;
+    r68 = r0 * r29;
+    r68 = r68 * r2;
+    r68 = r68 * r33;
+    r68 = fmaf(r54, r68, r1 * r69);
+    r69 = r29 * r1;
+    r69 = r69 * r54;
+    r69 = fmaf(r34, r3, r65 * r69);
+    r2 = r53 * r61;
+    r2 = r2 * r56;
+    r66 = r4 * r1;
+    r66 = r66 * r61;
+    r66 = r66 * r56;
+    r66 = fmaf(r65, r66, r3 * r2);
+    r2 = r53 * r61;
+    r2 = r2 * r58;
+    r64 = r4 * r1;
+    r64 = r64 * r61;
+    r64 = r64 * r65;
+    r64 = fmaf(r58, r64, r3 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r68, r69, r66, r64);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r5 * r4;
+    r64 = r64 * r12;
+    r64 = r64 * r1;
+    r66 = r12 * r3;
+    WriteSum2<float, float>((float*)inout_shared, r66, r64);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r28 * r28;
+    r66 = r63 * r63;
+    r69 = r14 * r35;
+    r68 = r5 * r65;
+    r69 = r69 * r52;
+    r69 = r69 * r55;
+    r2 = r0 * r0;
+    r40 = r2 * r40;
+    r69 = fmaf(r55, r40, r68 * r69);
+    r67 = r14 * r35;
+    r67 = r67 * r52;
+    r67 = r67 * r58;
+    r67 = fmaf(r58, r40, r68 * r67);
+    WriteSum4<float, float>((float*)inout_shared, r64, r66, r69, r67);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r53 * r2;
+    r66 = r33 * r69;
+    r64 = r11 * r14;
+    r70 = 4.00000000000000000e+00;
+    r13 = r43 * r13;
+    r43 = r43 * r13;
+    r43 = 1.0 / r43;
+    r10 = r16 * r10;
+    r16 = r16 * r10;
+    r16 = 1.0 / r16;
+    r64 = r64 * r35;
+    r64 = r64 * r35;
+    r64 = r64 * r70;
+    r64 = r64 * r43;
+    r64 = r64 * r16;
+    r16 = r5 * r5;
+    r16 = r16 * r32;
+    r16 = fmaf(r32, r16, r64 * r66);
+    r66 = r53 * r68;
+    r43 = r34 * r34;
+    r43 = fmaf(r2, r43, r64 * r66);
+    r66 = r14 * r35;
+    r64 = r56 * r56;
+    r66 = r66 * r52;
+    r66 = r66 * r68;
+    r66 = fmaf(r64, r40, r64 * r66);
+    r71 = r14 * r35;
+    r72 = r58 * r58;
+    r71 = r71 * r52;
+    r71 = r71 * r68;
+    r72 = fmaf(r40, r72, r72 * r71);
+    WriteSum4<float, float>((float*)inout_shared, r16, r43, r66, r72);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r55 * r2;
+    r43 = r5 * r5;
+    r43 = r43 * r55;
+    WriteSum2<float, float>((float*)inout_shared, r72, r43);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = 0.00000000000000000e+00;
+    r72 = r0 * r12;
+    r72 = r72 * r28;
+    r72 = r72 * r53;
+    r72 = r72 * r61;
+    r16 = r0 * r28;
+    r16 = r16 * r53;
+    r16 = r16 * r61;
+    r16 = r16 * r55;
+    r71 = r0 * r17;
+    r71 = r71 * r28;
+    r71 = r71 * r33;
+    r71 = r71 * r54;
+    WriteSum4<float, float>((float*)inout_shared, r43, r72, r16, r71);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r0 * r34;
+    r71 = r71 * r28;
+    r16 = r0 * r12;
+    r16 = r16 * r28;
+    r72 = r0 * r28;
+    r72 = r72 * r53;
+    r72 = r72 * r61;
+    r72 = r72 * r56;
+    r28 = r0 * r28;
+    r28 = r28 * r53;
+    r28 = r28 * r61;
+    r28 = r28 * r58;
+    WriteSum4<float, float>((float*)inout_shared, r71, r72, r28, r16);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r16 = r5 * r32;
+    r16 = r16 * r63;
+    r28 = r12 * r63;
+    r28 = r28 * r61;
+    r28 = r28 * r65;
+    r72 = r63 * r61;
+    r72 = r72 * r55;
+    r72 = r72 * r65;
+    WriteSum4<float, float>((float*)inout_shared, r43, r28, r72, r16);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r16 = r17 * r63;
+    r16 = r16 * r54;
+    r16 = r16 * r65;
+    r72 = r63 * r61;
+    r72 = r72 * r56;
+    r72 = r72 * r65;
+    r28 = r63 * r61;
+    r28 = r28 * r65;
+    r28 = r28 * r58;
+    WriteSum4<float, float>((float*)inout_shared, r16, r72, r28, r43);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r5 * r12;
+    r43 = r43 * r63;
+    r63 = r14 * r35;
+    r63 = r63 * r52;
+    r63 = r63 * r56;
+    r63 = fmaf(r56, r40, r68 * r63);
+    r28 = r11 * r12;
+    r13 = 1.0 / r13;
+    r10 = 1.0 / r10;
+    r72 = r17 * r35;
+    r28 = r28 * r13;
+    r28 = r28 * r10;
+    r28 = r28 * r33;
+    r28 = r28 * r72;
+    r16 = r32 * r68;
+    r65 = r61 * r16;
+    r28 = fmaf(r12, r65, r69 * r28);
+    r71 = r61 * r69;
+    r73 = r34 * r71;
+    r74 = r14 * r12;
+    r74 = r74 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r12 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r43, r63, r28, r74);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r55 * r71;
+    r28 = r61 * r55;
+    r28 = r28 * r68;
+    r63 = r14 * r35;
+    r43 = r12 * r58;
+    r63 = r63 * r52;
+    r63 = r63 * r68;
+    r63 = fmaf(r43, r40, r43 * r63);
+    WriteSum4<float, float>((float*)inout_shared, r67, r63, r74, r28);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r11 * r13;
+    r28 = r28 * r10;
+    r28 = r28 * r33;
+    r28 = r28 * r55;
+    r28 = r28 * r72;
+    r28 = fmaf(r55, r65, r69 * r28);
+    r74 = r14 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r55;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r55 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r28, r74, r63, r66);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r56 * r71;
+    r63 = r61 * r56;
+    r63 = r63 * r68;
+    r74 = r17 * r54;
+    r28 = r17 * r34;
+    r28 = r28 * r33;
+    r28 = r28 * r54;
+    r28 = fmaf(r2, r28, r16 * r74);
+    r74 = r11 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r33;
+    r74 = r74 * r56;
+    r74 = r74 * r72;
+    r74 = fmaf(r56, r65, r69 * r74);
+    WriteSum4<float, float>((float*)inout_shared, r66, r63, r28, r74);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r74 = r17 * r12;
+    r74 = r74 * r33;
+    r74 = r74 * r54;
+    r74 = r74 * r2;
+    r28 = r5 * r5;
+    r28 = r28 * r12;
+    r28 = r28 * r32;
+    r32 = r11 * r13;
+    r32 = r32 * r10;
+    r32 = r32 * r33;
+    r32 = r32 * r58;
+    r32 = r32 * r72;
+    r65 = fmaf(r58, r65, r69 * r32);
+    r32 = r14 * r13;
+    r32 = r32 * r10;
+    r32 = r32 * r53;
+    r32 = r32 * r56;
+    r32 = r32 * r72;
+    r32 = fmaf(r68, r32, r56 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r65, r74, r28, r32);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r12 * r34;
+    r32 = r32 * r2;
+    r28 = r17 * r12;
+    r28 = r28 * r54;
+    r28 = r28 * r68;
+    r74 = r14 * r13;
+    r74 = r74 * r10;
+    r74 = r74 * r53;
+    r74 = r74 * r58;
+    r74 = r74 * r72;
+    r74 = fmaf(r68, r74, r58 * r73);
+    r73 = r14 * r35;
+    r64 = r12 * r64;
+    r73 = r73 * r52;
+    r73 = r73 * r68;
+    r64 = fmaf(r40, r64, r64 * r73);
+    WriteSum4<float, float>((float*)inout_shared, r74, r32, r28, r64);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r58 * r71;
+    r58 = r61 * r58;
+    r58 = r58 * r68;
+    r71 = r43 * r71;
+    r28 = r61 * r68;
+    r28 = r28 * r43;
+    WriteSum4<float, float>((float*)inout_shared, r64, r58, r71, r28);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r47 * r35;
+    r71 = 6.00000000000000000e+00;
+    r28 = r28 * r71;
+    r58 = r31 * r35;
+    r64 = -6.00000000000000000e+00;
+    r58 = r58 * r64;
+    r58 = r58 * r38;
+    r58 = r58 * r13;
+    r43 = r11 * r53;
+    r28 = fmaf(r58, r43, r54 * r28);
+    r32 = r17 * r36;
+    r32 = r32 * r14;
+    r74 = r17 * r47;
+    r74 = r74 * r11;
+    r74 = fmaf(r41, r74, r41 * r32);
+    r32 = r31 * r11;
+    r40 = r29 * r13;
+    r32 = r32 * r11;
+    r74 = fmaf(r40, r32, r74);
+    r73 = r14 * r14;
+    r73 = r73 * r40;
+    r74 = fmaf(r31, r73, r74);
+    r32 = r27 * r74;
+    r65 = rsqrtf(r15);
+    r15 = r39 + r15;
+    r15 = 1.0 / r15;
+    r15 = r65 * r15;
+    r39 = r11 * r54;
+    r32 = r32 * r15;
+    r28 = fmaf(r39, r32, r28);
+    r63 = r11 * r74;
+    r66 = -3.00000000000000000e+00;
+    r66 = r35 * r66;
+    r66 = r66 * r41;
+    r66 = r66 * r10;
+    r66 = r66 * r65;
+    r63 = r63 * r53;
+    r28 = fmaf(r66, r63, r28);
+    r16 = r4 * r14;
+    r16 = r16 * r14;
+    r16 = r16 * r35;
+    r16 = r16 * r35;
+    r16 = r16 * r74;
+    r16 = r16 * r41;
+    r16 = r16 * r10;
+    r67 = r14 * r15;
+    r75 = r74 * r67;
+    r76 = r52 * r33;
+    r75 = fmaf(r76, r75, r65 * r16);
+    r16 = r35 * r38;
+    r77 = r35 * r73;
+    r16 = r16 * r77;
+    r78 = r72 * r76;
+    r75 = fmaf(r31, r16, r75);
+    r75 = fmaf(r36, r78, r75);
+    r28 = r28 + r75;
+    r63 = r47 * r54;
+    r32 = r31 * r11;
+    r32 = r32 * r35;
+    r32 = r32 * r38;
+    r32 = r32 * r53;
+    r32 = fmaf(r40, r32, r72 * r63);
+    r63 = r74 * r15;
+    r32 = fmaf(r39, r63, r32);
+    r79 = r4 * r11;
+    r79 = r79 * r35;
+    r79 = r79 * r74;
+    r79 = r79 * r41;
+    r79 = r79 * r10;
+    r79 = r79 * r65;
+    r32 = fmaf(r53, r79, r32);
+    r75 = r75 + r32;
+    r28 = fmaf(r8, r75, r49 * r28);
+    r79 = r47 * r35;
+    r28 = fmaf(r62, r79, r28);
+    r63 = -5.00000000000000000e-01;
+    r80 = r63 * r74;
+    r80 = r80 * r38;
+    r80 = r80 * r59;
+    r80 = r80 * r65;
+    r81 = r57 * r80;
+    r82 = r4 * r31;
+    r82 = r82 * r57;
+    r82 = r82 * r41;
+    r82 = r82 * r60;
+    r28 = fmaf(r53, r82, r28);
+    r83 = r4 * r31;
+    r83 = r83 * r41;
+    r83 = r83 * r60;
+    r28 = fmaf(r53, r83, r28);
+    r84 = r25 * r36;
+    r84 = r84 * r54;
+    r28 = fmaf(r72, r84, r28);
+    r85 = r7 * r17;
+    r85 = r85 * r12;
+    r85 = fmaf(r6, r75, r75 * r85);
+    r70 = r42 * r70;
+    r70 = r70 * r56;
+    r44 = r44 * r27;
+    r44 = r44 * r55;
+    r85 = fmaf(r75, r70, r85);
+    r85 = fmaf(r75, r44, r85);
+    r55 = r85 * r53;
+    r28 = fmaf(r61, r55, r28);
+    r56 = r11 * r15;
+    r42 = 5.00000000000000000e-01;
+    r86 = r42 * r62;
+    r56 = r56 * r86;
+    r87 = r47 * r35;
+    r28 = fmaf(r61, r87, r28);
+    r88 = -4.00000000000000000e+00;
+    r88 = r88 * r38;
+    r88 = r88 * r13;
+    r88 = r88 * r53;
+    r88 = r88 * r33;
+    r89 = r25 * r88;
+    r90 = r25 * r29;
+    r90 = r90 * r74;
+    r90 = r90 * r41;
+    r90 = r90 * r10;
+    r90 = r90 * r65;
+    r90 = r90 * r53;
+    r28 = fmaf(r33, r90, r28);
+    r91 = r25 * r47;
+    r28 = fmaf(r78, r91, r28);
+    r92 = r25 * r74;
+    r93 = r17 * r54;
+    r93 = r93 * r67;
+    r28 = fmaf(r93, r92, r28);
+    r94 = r11 * r42;
+    r94 = r94 * r74;
+    r94 = r94 * r61;
+    r28 = fmaf(r15, r94, r28);
+    r28 = fmaf(r53, r81, r28);
+    r28 = fmaf(r74, r56, r28);
+    r28 = fmaf(r53, r80, r28);
+    r28 = fmaf(r31, r89, r28);
+    r94 = r0 * r28;
+    r92 = r74 * r66;
+    r91 = r27 * r74;
+    r91 = r91 * r67;
+    r91 = fmaf(r76, r91, r77 * r92);
+    r92 = r14 * r58;
+    r91 = fmaf(r33, r92, r91);
+    r90 = r36 * r35;
+    r90 = r90 * r71;
+    r90 = r90 * r52;
+    r91 = fmaf(r33, r90, r91);
+    r91 = r91 + r32;
+    r75 = fmaf(r9, r75, r25 * r91);
+    r91 = r74 * r67;
+    r75 = fmaf(r86, r91, r75);
+    r32 = r4 * r31;
+    r32 = r32 * r14;
+    r32 = r32 * r35;
+    r32 = r32 * r57;
+    r32 = r32 * r41;
+    r75 = fmaf(r60, r32, r75);
+    r90 = r49 * r36;
+    r90 = r90 * r54;
+    r75 = fmaf(r72, r90, r75);
+    r92 = r49 * r31;
+    r75 = fmaf(r88, r92, r75);
+    r87 = r14 * r35;
+    r75 = fmaf(r80, r87, r75);
+    r80 = r49 * r29;
+    r80 = r80 * r74;
+    r80 = r80 * r41;
+    r80 = r80 * r10;
+    r80 = r80 * r65;
+    r80 = r80 * r53;
+    r75 = fmaf(r33, r80, r75);
+    r55 = r49 * r78;
+    r84 = r42 * r74;
+    r84 = r84 * r61;
+    r75 = fmaf(r67, r84, r75);
+    r83 = r36 * r35;
+    r75 = fmaf(r62, r83, r75);
+    r82 = r4 * r31;
+    r82 = r82 * r14;
+    r82 = r82 * r35;
+    r82 = r82 * r41;
+    r75 = fmaf(r60, r82, r75);
+    r79 = r49 * r74;
+    r75 = fmaf(r93, r79, r75);
+    r95 = r36 * r35;
+    r75 = fmaf(r61, r95, r75);
+    r96 = r85 * r61;
+    r75 = fmaf(r33, r96, r75);
+    r75 = fmaf(r81, r33, r75);
+    r75 = fmaf(r47, r55, r75);
+    r96 = r5 * r75;
+    r95 = r17 * r50;
+    r95 = r95 * r11;
+    r95 = fmaf(r41, r95, r46 * r73);
+    r79 = r17 * r37;
+    r79 = r79 * r14;
+    r95 = fmaf(r41, r79, r95);
+    r82 = r46 * r11;
+    r82 = r82 * r11;
+    r95 = fmaf(r40, r82, r95);
+    r82 = r95 * r15;
+    r79 = r46 * r11;
+    r79 = r79 * r35;
+    r79 = r79 * r38;
+    r79 = r79 * r53;
+    r79 = fmaf(r40, r79, r39 * r82);
+    r82 = r4 * r11;
+    r82 = r82 * r35;
+    r82 = r82 * r95;
+    r82 = r82 * r41;
+    r82 = r82 * r10;
+    r82 = r82 * r65;
+    r79 = fmaf(r53, r82, r79);
+    r83 = r50 * r54;
+    r79 = fmaf(r72, r83, r79);
+    r83 = r4 * r14;
+    r83 = r83 * r14;
+    r83 = r83 * r35;
+    r83 = r83 * r35;
+    r83 = r83 * r95;
+    r83 = r83 * r41;
+    r83 = r83 * r10;
+    r83 = fmaf(r37, r78, r65 * r83);
+    r82 = r95 * r67;
+    r83 = fmaf(r76, r82, r83);
+    r83 = fmaf(r46, r16, r83);
+    r82 = r79 + r83;
+    r84 = r27 * r95;
+    r84 = r84 * r15;
+    r80 = r46 * r11;
+    r80 = r80 * r35;
+    r80 = r80 * r64;
+    r80 = r80 * r38;
+    r80 = r80 * r13;
+    r80 = fmaf(r53, r80, r39 * r84);
+    r84 = r95 * r66;
+    r87 = r50 * r35;
+    r87 = r87 * r71;
+    r80 = fmaf(r54, r87, r80);
+    r80 = fmaf(r84, r43, r80);
+    r80 = r80 + r83;
+    r80 = fmaf(r49, r80, r8 * r82);
+    r83 = r25 * r50;
+    r80 = fmaf(r78, r83, r80);
+    r87 = r25 * r29;
+    r87 = r87 * r95;
+    r87 = r87 * r41;
+    r87 = r87 * r10;
+    r87 = r87 * r65;
+    r87 = r87 * r53;
+    r80 = fmaf(r33, r87, r80);
+    r43 = r63 * r95;
+    r43 = r43 * r38;
+    r43 = r43 * r59;
+    r43 = r43 * r65;
+    r80 = fmaf(r53, r43, r80);
+    r92 = r4 * r46;
+    r92 = r92 * r41;
+    r92 = r92 * r60;
+    r80 = fmaf(r53, r92, r80);
+    r90 = r4 * r46;
+    r90 = r90 * r57;
+    r90 = r90 * r41;
+    r90 = r90 * r60;
+    r80 = fmaf(r53, r90, r80);
+    r32 = r7 * r17;
+    r32 = r32 * r12;
+    r32 = fmaf(r82, r32, r6 * r82);
+    r32 = fmaf(r82, r70, r32);
+    r32 = fmaf(r82, r44, r32);
+    r81 = r32 * r53;
+    r80 = fmaf(r61, r81, r80);
+    r91 = r57 * r63;
+    r91 = r91 * r95;
+    r91 = r91 * r38;
+    r91 = r91 * r59;
+    r91 = r91 * r65;
+    r80 = fmaf(r53, r91, r80);
+    r97 = r11 * r42;
+    r97 = r97 * r95;
+    r97 = r97 * r61;
+    r80 = fmaf(r15, r97, r80);
+    r98 = r50 * r35;
+    r80 = fmaf(r62, r98, r80);
+    r99 = r25 * r37;
+    r99 = r99 * r54;
+    r80 = fmaf(r72, r99, r80);
+    r100 = r50 * r35;
+    r80 = fmaf(r61, r100, r80);
+    r101 = r25 * r95;
+    r80 = fmaf(r93, r101, r80);
+    r80 = fmaf(r95, r56, r80);
+    r80 = fmaf(r46, r89, r80);
+    r101 = r0 * r80;
+    r100 = r37 * r35;
+    r100 = r100 * r71;
+    r100 = r100 * r52;
+    r100 = fmaf(r33, r100, r77 * r84);
+    r84 = r27 * r95;
+    r84 = r84 * r67;
+    r100 = fmaf(r76, r84, r100);
+    r99 = r46 * r14;
+    r99 = r99 * r14;
+    r99 = r99 * r35;
+    r99 = r99 * r35;
+    r99 = r99 * r64;
+    r99 = r99 * r38;
+    r100 = fmaf(r13, r99, r100);
+    r100 = r100 + r79;
+    r100 = fmaf(r25, r100, r9 * r82);
+    r82 = r49 * r95;
+    r100 = fmaf(r93, r82, r100);
+    r79 = r49 * r29;
+    r79 = r79 * r95;
+    r79 = r79 * r41;
+    r79 = r79 * r10;
+    r79 = r79 * r65;
+    r79 = r79 * r53;
+    r100 = fmaf(r33, r79, r100);
+    r99 = r14 * r35;
+    r99 = r99 * r57;
+    r99 = r99 * r63;
+    r99 = r99 * r95;
+    r99 = r99 * r38;
+    r99 = r99 * r59;
+    r100 = fmaf(r65, r99, r100);
+    r84 = r14 * r35;
+    r84 = r84 * r63;
+    r84 = r84 * r95;
+    r84 = r84 * r38;
+    r84 = r84 * r59;
+    r100 = fmaf(r65, r84, r100);
+    r98 = r32 * r61;
+    r100 = fmaf(r33, r98, r100);
+    r97 = r37 * r35;
+    r100 = fmaf(r61, r97, r100);
+    r91 = r4 * r46;
+    r91 = r91 * r14;
+    r91 = r91 * r35;
+    r91 = r91 * r57;
+    r91 = r91 * r41;
+    r100 = fmaf(r60, r91, r100);
+    r81 = r37 * r35;
+    r100 = fmaf(r62, r81, r100);
+    r90 = r42 * r95;
+    r90 = r90 * r61;
+    r100 = fmaf(r67, r90, r100);
+    r92 = r49 * r37;
+    r92 = r92 * r54;
+    r100 = fmaf(r72, r92, r100);
+    r43 = r95 * r67;
+    r100 = fmaf(r86, r43, r100);
+    r87 = r4 * r46;
+    r87 = r87 * r14;
+    r87 = r87 * r35;
+    r87 = r87 * r41;
+    r100 = fmaf(r60, r87, r100);
+    r83 = r49 * r46;
+    r100 = fmaf(r88, r83, r100);
+    r100 = fmaf(r50, r55, r100);
+    r83 = r5 * r100;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r96,
+                                          r101,
+                                          r83);
+    r83 = r4 * r14;
+    r101 = r17 * r45;
+    r101 = r101 * r14;
+    r73 = fmaf(r48, r73, r41 * r101);
+    r101 = r48 * r11;
+    r101 = r101 * r11;
+    r73 = fmaf(r40, r101, r73);
+    r96 = r17 * r51;
+    r96 = r96 * r11;
+    r73 = fmaf(r41, r96, r73);
+    r83 = r83 * r14;
+    r83 = r83 * r35;
+    r83 = r83 * r35;
+    r83 = r83 * r73;
+    r83 = r83 * r41;
+    r83 = r83 * r10;
+    r83 = fmaf(r45, r78, r65 * r83);
+    r96 = r73 * r67;
+    r83 = fmaf(r76, r96, r83);
+    r83 = fmaf(r48, r16, r83);
+    r16 = r51 * r54;
+    r96 = r73 * r15;
+    r96 = fmaf(r39, r96, r72 * r16);
+    r16 = r48 * r11;
+    r16 = r16 * r35;
+    r16 = r16 * r38;
+    r16 = r16 * r53;
+    r96 = fmaf(r40, r16, r96);
+    r40 = r4 * r11;
+    r40 = r40 * r35;
+    r40 = r40 * r73;
+    r40 = r40 * r41;
+    r40 = r40 * r10;
+    r40 = r40 * r65;
+    r96 = fmaf(r53, r40, r96);
+    r40 = r83 + r96;
+    r16 = r51 * r35;
+    r16 = r16 * r71;
+    r101 = r27 * r73;
+    r101 = r101 * r15;
+    r101 = fmaf(r39, r101, r54 * r16);
+    r16 = r48 * r11;
+    r16 = r16 * r35;
+    r16 = r16 * r64;
+    r16 = r16 * r38;
+    r16 = r16 * r13;
+    r101 = fmaf(r53, r16, r101);
+    r39 = r11 * r73;
+    r39 = r39 * r53;
+    r101 = fmaf(r66, r39, r101);
+    r101 = r101 + r83;
+    r101 = fmaf(r49, r101, r8 * r40);
+    r8 = r25 * r45;
+    r8 = r8 * r54;
+    r101 = fmaf(r72, r8, r101);
+    r93 = r73 * r93;
+    r83 = r57 * r63;
+    r83 = r83 * r73;
+    r83 = r83 * r38;
+    r83 = r83 * r59;
+    r83 = r83 * r65;
+    r101 = fmaf(r53, r83, r101);
+    r39 = r4 * r48;
+    r39 = r39 * r57;
+    r39 = r39 * r41;
+    r39 = r39 * r60;
+    r101 = fmaf(r53, r39, r101);
+    r16 = r7 * r17;
+    r16 = r16 * r12;
+    r16 = fmaf(r40, r16, r6 * r40);
+    r16 = fmaf(r40, r70, r16);
+    r16 = fmaf(r40, r44, r16);
+    r44 = r16 * r53;
+    r101 = fmaf(r61, r44, r101);
+    r70 = r4 * r48;
+    r70 = r70 * r41;
+    r70 = r70 * r60;
+    r101 = fmaf(r53, r70, r101);
+    r6 = r63 * r73;
+    r6 = r6 * r38;
+    r6 = r6 * r59;
+    r6 = r6 * r65;
+    r101 = fmaf(r53, r6, r101);
+    r94 = r51 * r35;
+    r101 = fmaf(r61, r94, r101);
+    r87 = r51 * r35;
+    r101 = fmaf(r62, r87, r101);
+    r43 = r25 * r29;
+    r43 = r43 * r73;
+    r43 = r43 * r41;
+    r43 = r43 * r10;
+    r43 = r43 * r65;
+    r43 = r43 * r53;
+    r101 = fmaf(r33, r43, r101);
+    r92 = r11 * r42;
+    r92 = r92 * r73;
+    r92 = r92 * r61;
+    r101 = fmaf(r15, r92, r101);
+    r90 = r25 * r51;
+    r101 = fmaf(r78, r90, r101);
+    r101 = fmaf(r25, r93, r101);
+    r101 = fmaf(r73, r56, r101);
+    r101 = fmaf(r48, r89, r101);
+    r90 = r0 * r101;
+    r89 = r73 * r66;
+    r92 = r45 * r35;
+    r92 = r92 * r71;
+    r92 = r92 * r52;
+    r92 = fmaf(r33, r92, r77 * r89);
+    r89 = r27 * r73;
+    r89 = r89 * r67;
+    r92 = fmaf(r76, r89, r92);
+    r76 = r48 * r14;
+    r76 = r76 * r14;
+    r76 = r76 * r35;
+    r76 = r76 * r35;
+    r76 = r76 * r64;
+    r76 = r76 * r38;
+    r92 = fmaf(r13, r76, r92);
+    r92 = r92 + r96;
+    r92 = fmaf(r25, r92, r9 * r40);
+    r40 = r49 * r45;
+    r40 = r40 * r54;
+    r92 = fmaf(r72, r40, r92);
+    r72 = r4 * r48;
+    r72 = r72 * r14;
+    r72 = r72 * r35;
+    r72 = r72 * r57;
+    r72 = r72 * r41;
+    r92 = fmaf(r60, r72, r92);
+    r9 = r14 * r35;
+    r9 = r9 * r63;
+    r9 = r9 * r73;
+    r9 = r9 * r38;
+    r9 = r9 * r59;
+    r92 = fmaf(r65, r9, r92);
+    r96 = r45 * r35;
+    r92 = fmaf(r61, r96, r92);
+    r76 = r16 * r61;
+    r92 = fmaf(r33, r76, r92);
+    r89 = r49 * r29;
+    r89 = r89 * r73;
+    r89 = r89 * r41;
+    r89 = r89 * r10;
+    r89 = r89 * r65;
+    r89 = r89 * r53;
+    r92 = fmaf(r33, r89, r92);
+    r10 = r49 * r48;
+    r92 = fmaf(r88, r10, r92);
+    r88 = r14 * r35;
+    r88 = r88 * r57;
+    r88 = r88 * r63;
+    r88 = r88 * r73;
+    r88 = r88 * r38;
+    r88 = r88 * r59;
+    r92 = fmaf(r65, r88, r92);
+    r65 = r73 * r67;
+    r92 = fmaf(r86, r65, r92);
+    r86 = r45 * r35;
+    r92 = fmaf(r62, r86, r92);
+    r62 = r4 * r48;
+    r62 = r62 * r14;
+    r62 = r62 * r35;
+    r62 = r62 * r41;
+    r92 = fmaf(r60, r62, r92);
+    r60 = r42 * r73;
+    r60 = r60 * r61;
+    r92 = fmaf(r67, r60, r92);
+    r92 = fmaf(r49, r93, r92);
+    r92 = fmaf(r51, r55, r92);
+    r60 = r5 * r92;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r90,
+                                          r60);
+    r60 = r5 * r4;
+    r60 = r60 * r1;
+    r60 = fmaf(r28, r3, r75 * r60);
+    r90 = r5 * r4;
+    r90 = r90 * r1;
+    r90 = fmaf(r80, r3, r100 * r90);
+    r62 = r5 * r4;
+    r62 = r62 * r1;
+    r3 = fmaf(r101, r3, r92 * r62);
+    WriteSum3<float, float>((float*)inout_shared, r60, r90, r3);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = r28 * r28;
+    r90 = r5 * r5;
+    r60 = r75 * r75;
+    r60 = fmaf(r60, r90, r2 * r3);
+    r3 = r100 * r100;
+    r62 = r80 * r80;
+    r62 = fmaf(r2, r62, r3 * r90);
+    r3 = r92 * r92;
+    r55 = r101 * r101;
+    r55 = fmaf(r2, r55, r3 * r90);
+    WriteSum3<float, float>((float*)inout_shared, r60, r62, r55);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r5 * r5;
+    r55 = r55 * r75;
+    r62 = r28 * r80;
+    r62 = fmaf(r2, r62, r100 * r55);
+    r55 = r28 * r101;
+    r60 = r5 * r5;
+    r60 = r60 * r75;
+    r60 = fmaf(r92, r60, r2 * r55);
+    r55 = r5 * r5;
+    r55 = r55 * r100;
+    r100 = r80 * r101;
+    r100 = fmaf(r2, r100, r92 * r55);
+    WriteSum3<float, float>((float*)inout_shared, r62, r60, r100);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirstKernel<<<n_blocks,
+                                                                       1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.cu
@@ -1,0 +1,325 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScoreKernel(
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* pose,
+        unsigned int pose_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r17,
+                                         r18,
+                                         r19,
+                                         r20);
+    ReadIdx4<1024, float, float, float4>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r21, r22, r23, r24);
+    r25 = fmaf(r17, r22, r20 * r23);
+    r26 = r18 * r21;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r24, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r17, r24, r20 * r21);
+    r28 = r19 * r22;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r18, r23, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r17 * r23;
+    r30 = fmaf(r4, r30, r20 * r22);
+    r30 = fmaf(r18, r24, r30);
+    r30 = fmaf(r19, r21, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r24 = r31 * r32;
+    r33 = fmaf(r30, r24, r29);
+    r33 = fmaf(r14, r33, r13);
+    ReadIdx3<1024, float, float, float4>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r13, r34, r35);
+    r36 = r17 * r19;
+    r36 = r36 * r26;
+    r37 = r18 * r20;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r18 * r18;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r17 * r17;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r18 * r19;
+    r43 = r43 * r26;
+    r44 = r17 * r20;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r24, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r19 * r20;
+    r29 = r17 * r18;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r19 * r19;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r19 * r20;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r17 * r20;
+    r42 = fmaf(r31, r42, r43);
+    r24 = fmaf(r27, r24, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r24, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r24 = copysign(1.0, r15);
+    r24 = fmaf(r10, r24, r15);
+    r10 = r24 * r24;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r35,
+                       r41,
+                       r34,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r24 = 1.0 / r24;
+    r48 = r48 * r24;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScoreKernel<<<n_blocks,
+                                                                 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* pose,
+    unsigned int pose_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,269 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        float* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              0 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         4 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10,
+                                         r11);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         0 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r12,
+                                         r13,
+                                         r14,
+                                         r15);
+    r16 = fmaf(r6, r15, r7 * r9);
+  };
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              4 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         12 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         8 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r25,
+                                         r26,
+                                         r27,
+                                         r28);
+  };
+  LoadShared<2, float, float>(focal_and_extra_njtr,
+                              8 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r29,
+                       r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = fmaf(r17, r11, r16);
+    r16 = fmaf(r5, r13, r16);
+    r16 = fmaf(r20, r22, r16);
+    r16 = fmaf(r19, r28, r16);
+    r16 = fmaf(r30, r24, r16);
+    r16 = fmaf(r18, r26, r16);
+    r17 = fmaf(r17, r10, r7 * r8);
+    r17 = fmaf(r4, r12, r17);
+    r17 = fmaf(r6, r14, r17);
+    r17 = fmaf(r29, r23, r17);
+    r17 = fmaf(r18, r25, r17);
+    r17 = fmaf(r20, r21, r17);
+    r17 = fmaf(r19, r27, r17);
+    r19 = fmaf(r0, r17, r1 * r16);
+    r20 = fmaf(r2, r17, r3 * r16);
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r18, r29, r6, r4);
+    r7 = fmaf(r18, r17, r29 * r16);
+    r30 = fmaf(r6, r17, r4 * r16);
+    WriteSum4<float, float>((float*)inout_shared, r19, r20, r7, r30);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r30, r7, r20, r19);
+    r5 = fmaf(r30, r17, r7 * r16);
+    r17 = fmaf(r20, r17, r19 * r16);
+    WriteSum2<float, float>((float*)inout_shared, r5, r17);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r17,
+                       r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r30 = fmaf(r17, r30, r5 * r20);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r20,
+                       r16,
+                       r31,
+                       r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r30 = fmaf(r31, r18, r30);
+    r30 = fmaf(r32, r6, r30);
+    r30 = fmaf(r20, r0, r30);
+    r30 = fmaf(r16, r2, r30);
+    r12 = r12 * r30;
+    r4 = fmaf(r32, r4, r5 * r19);
+    r4 = fmaf(r31, r29, r4);
+    r4 = fmaf(r20, r1, r4);
+    r4 = fmaf(r16, r3, r4);
+    r4 = fmaf(r17, r7, r4);
+    r13 = r13 * r4;
+    r15 = fmaf(r15, r4, r14 * r30);
+    r9 = fmaf(r9, r4, r8 * r30);
+    WriteSum4<float, float>((float*)inout_shared, r12, r13, r15, r9);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = fmaf(r11, r4, r10 * r30);
+    r26 = fmaf(r26, r4, r25 * r30);
+    r28 = fmaf(r28, r4, r27 * r30);
+    r22 = fmaf(r22, r4, r21 * r30);
+    WriteSum4<float, float>((float*)inout_shared, r11, r26, r28, r22);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r23 * r30;
+    r4 = r24 * r4;
+    WriteSum2<float, float>((float*)inout_shared, r30, r4);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,2213 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = r40 * r29;
+    r49 = r49 * r29;
+    r47 = r41 + r49;
+    r47 = r47 + r48;
+    r47 = fmaf(r13, r47, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r51 = r21 * r23;
+    r51 = r51 * r16;
+    r52 = r22 * r24;
+    r52 = fmaf(r16, r52, r51);
+    r53 = r23 * r24;
+    r53 = fmaf(r40, r53, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r47 = fmaf(r14, r10, r47);
+    r47 = fmaf(r15, r48, r47);
+    r47 = fmaf(r36, r52, r47);
+    r47 = fmaf(r35, r53, r47);
+    r47 = fmaf(r11, r42, r47);
+    r48 = r47 * r47;
+    r10 = 9.99999999999999955e-07;
+    r54 = r40 * r29;
+    r54 = fmaf(r34, r54, r26);
+    r54 = fmaf(r13, r54, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r51);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r49 = r41 + r49;
+    r49 = r49 + r50;
+    r54 = fmaf(r11, r12, r54);
+    r54 = fmaf(r36, r37, r54);
+    r54 = fmaf(r35, r39, r54);
+    r54 = fmaf(r14, r44, r54);
+    r54 = fmaf(r15, r49, r54);
+    r49 = copysign(1.0, r54);
+    r49 = fmaf(r10, r49, r54);
+    r54 = r49 * r49;
+    r44 = 1.0 / r54;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = atanf(r48);
+    r11 = r33 * r36;
+    r50 = copysign(1.0, r48);
+    r50 = fmaf(r10, r50, r48);
+    r10 = r50 * r50;
+    r48 = 1.0 / r10;
+    r46 = r44 * r48;
+    r51 = r33 * r36;
+    r11 = r11 * r46;
+    r11 = r11 * r51;
+    r26 = r47 * r36;
+    r55 = r26 * r46;
+    r56 = r47 * r55;
+    r57 = r36 * r56;
+    r58 = r11 + r57;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r59,
+                       r60,
+                       r61,
+                       r62);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r63 = 3.00000000000000000e+00;
+    r64 = r36 * r63;
+    r64 = fmaf(r56, r64, r11);
+    r11 = fmaf(r60, r64, r8 * r58);
+    r65 = r59 * r16;
+    r65 = r65 * r51;
+    r11 = fmaf(r55, r65, r11);
+    r66 = r58 * r58;
+    r67 = r58 * r66;
+    r68 = fmaf(r61, r67, r6 * r58);
+    r69 = r66 * r66;
+    r68 = fmaf(r62, r69, r68);
+    r68 = fmaf(r7, r66, r68);
+    r70 = 1.0 / r49;
+    r71 = 1.0 / r50;
+    r72 = r70 * r71;
+    r73 = r68 * r72;
+    r11 = fmaf(r26, r73, r11);
+    r11 = fmaf(r26, r72, r11);
+    r2 = fmaf(r0, r11, r2);
+    r65 = r33 * r36;
+    r65 = r65 * r63;
+    r65 = r65 * r46;
+    r65 = fmaf(r51, r65, r57);
+    r57 = fmaf(r59, r65, r9 * r58);
+    r74 = r60 * r16;
+    r74 = r74 * r51;
+    r57 = fmaf(r55, r74, r57);
+    r57 = fmaf(r51, r73, r57);
+    r57 = fmaf(r72, r51, r57);
+    r1 = fmaf(r5, r57, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = r47 * r48;
+    r74 = -5.00000000000000000e-01;
+    r75 = rsqrtf(r35);
+    r76 = r16 * r33;
+    r77 = r25 * r40;
+    r78 = r17 * r24;
+    r79 = r20 * r21;
+    r79 = fmaf(r74, r79, r74 * r78);
+    r78 = r19 * r22;
+    r79 = fmaf(r74, r78, r79);
+    r80 = r18 * r23;
+    r81 = 5.00000000000000000e-01;
+    r79 = fmaf(r81, r80, r79);
+    r80 = r20 * r24;
+    r78 = r17 * r21;
+    r78 = fmaf(r74, r78, r81 * r80);
+    r80 = r18 * r22;
+    r78 = fmaf(r74, r80, r78);
+    r82 = r19 * r23;
+    r78 = fmaf(r74, r82, r78);
+    r82 = r34 * r78;
+    r80 = r40 * r82;
+    r77 = fmaf(r79, r77, r80);
+    r83 = r16 * r29;
+    r84 = fmaf(r81, r31, r74 * r27);
+    r84 = fmaf(r74, r28, r84);
+    r84 = fmaf(r74, r30, r84);
+    r83 = r83 * r84;
+    r85 = r16 * r32;
+    r86 = r19 * r24;
+    r87 = r18 * r21;
+    r87 = fmaf(r81, r87, r81 * r86);
+    r86 = r17 * r22;
+    r87 = fmaf(r74, r86, r87);
+    r88 = r20 * r23;
+    r87 = fmaf(r81, r88, r87);
+    r85 = fmaf(r87, r85, r83);
+    r77 = r77 + r85;
+    r88 = r25 * r78;
+    r86 = -4.00000000000000000e+00;
+    r88 = r88 * r86;
+    r89 = r32 * r84;
+    r90 = r86 * r89;
+    r91 = r88 + r90;
+    r91 = fmaf(r14, r91, r15 * r77);
+    r77 = r16 * r25;
+    r77 = r77 * r87;
+    r92 = r16 * r34;
+    r92 = fmaf(r84, r92, r77);
+    r93 = r16 * r29;
+    r93 = r93 * r78;
+    r94 = r16 * r32;
+    r94 = fmaf(r79, r94, r93);
+    r92 = r92 + r94;
+    r91 = fmaf(r13, r92, r91);
+    r76 = r76 * r91;
+    r92 = r16 * r47;
+    r95 = r16 * r34;
+    r96 = r29 * r79;
+    r95 = fmaf(r16, r96, r87 * r95);
+    r97 = r16 * r25;
+    r98 = r16 * r32;
+    r98 = r98 * r78;
+    r97 = fmaf(r84, r97, r98);
+    r95 = r95 + r97;
+    r77 = r93 + r77;
+    r93 = r32 * r40;
+    r77 = fmaf(r79, r93, r77);
+    r99 = r40 * r34;
+    r77 = fmaf(r84, r99, r77);
+    r77 = fmaf(r14, r77, r15 * r95);
+    r95 = r29 * r87;
+    r95 = r95 * r86;
+    r90 = r95 + r90;
+    r77 = fmaf(r13, r90, r77);
+    r92 = r92 * r77;
+    r92 = fmaf(r44, r92, r44 * r76);
+    r76 = r16 * r25;
+    r76 = r76 * r79;
+    r82 = r16 * r82;
+    r90 = r76 + r82;
+    r85 = r85 + r90;
+    r99 = r40 * r34;
+    r99 = fmaf(r40, r96, r87 * r99);
+    r99 = r99 + r97;
+    r99 = fmaf(r13, r99, r14 * r85);
+    r95 = r88 + r95;
+    r99 = fmaf(r15, r95, r99);
+    r95 = r33 * r33;
+    r54 = r49 * r54;
+    r88 = 1.0 / r54;
+    r85 = r40 * r88;
+    r95 = r95 * r85;
+    r87 = r47 * r47;
+    r87 = r87 * r99;
+    r92 = fmaf(r85, r87, r92);
+    r92 = fmaf(r99, r95, r92);
+    r3 = r3 * r36;
+    r3 = r3 * r70;
+    r3 = r3 * r74;
+    r3 = r3 * r75;
+    r3 = r3 * r92;
+    r87 = r36 * r77;
+    r93 = 6.00000000000000000e+00;
+    r87 = r87 * r93;
+    r100 = r63 * r92;
+    r35 = r41 + r35;
+    r35 = 1.0 / r35;
+    r41 = r75 * r35;
+    r101 = r41 * r56;
+    r100 = fmaf(r101, r100, r55 * r87);
+    r87 = r47 * r26;
+    r102 = r36 * r99;
+    r103 = -6.00000000000000000e+00;
+    r102 = r102 * r103;
+    r102 = r102 * r48;
+    r102 = r102 * r88;
+    r100 = fmaf(r102, r87, r100);
+    r104 = r47 * r26;
+    r105 = -3.00000000000000000e+00;
+    r105 = r36 * r105;
+    r10 = r50 * r10;
+    r106 = 1.0 / r10;
+    r105 = r105 * r44;
+    r105 = r105 * r75;
+    r105 = r105 * r106;
+    r104 = r104 * r105;
+    r107 = r16 * r36;
+    r108 = r46 * r51;
+    r109 = r107 * r108;
+    r110 = r92 * r108;
+    r111 = r33 * r41;
+    r110 = fmaf(r111, r110, r91 * r109);
+    r112 = r4 * r33;
+    r112 = r112 * r33;
+    r112 = r112 * r36;
+    r112 = r112 * r36;
+    r112 = r112 * r92;
+    r112 = r112 * r44;
+    r112 = r112 * r75;
+    r110 = fmaf(r106, r112, r110);
+    r113 = r36 * r95;
+    r114 = r36 * r48;
+    r114 = r114 * r85;
+    r114 = r113 * r114;
+    r110 = fmaf(r99, r114, r110);
+    r100 = fmaf(r92, r104, r100);
+    r100 = r100 + r110;
+    r100 = fmaf(r60, r100, r3);
+    r87 = r77 * r55;
+    r87 = fmaf(r92, r101, r107 * r87);
+    r112 = r47 * r36;
+    r112 = r112 * r99;
+    r112 = r112 * r48;
+    r112 = r112 * r26;
+    r87 = fmaf(r85, r112, r87);
+    r115 = r4 * r47;
+    r115 = r115 * r36;
+    r115 = r115 * r92;
+    r115 = r115 * r44;
+    r115 = r115 * r75;
+    r115 = r115 * r106;
+    r87 = fmaf(r26, r115, r87);
+    r110 = r110 + r87;
+    r115 = r59 * r92;
+    r112 = r16 * r55;
+    r112 = r112 * r111;
+    r100 = fmaf(r112, r115, r100);
+    r116 = r86 * r48;
+    r116 = r116 * r88;
+    r116 = r116 * r26;
+    r116 = r116 * r51;
+    r117 = r59 * r116;
+    r118 = r47 * r92;
+    r119 = r81 * r73;
+    r118 = r118 * r41;
+    r100 = fmaf(r119, r118, r100);
+    r120 = r59 * r77;
+    r100 = fmaf(r109, r120, r100);
+    r121 = r36 * r77;
+    r100 = fmaf(r72, r121, r100);
+    r122 = r4 * r99;
+    r122 = r122 * r44;
+    r122 = r122 * r71;
+    r100 = fmaf(r26, r122, r100);
+    r123 = r4 * r68;
+    r123 = r123 * r99;
+    r123 = r123 * r44;
+    r123 = r123 * r71;
+    r100 = fmaf(r26, r123, r100);
+    r124 = r47 * r81;
+    r124 = r124 * r92;
+    r124 = r124 * r72;
+    r100 = fmaf(r41, r124, r100);
+    r125 = r59 * r40;
+    r125 = r125 * r92;
+    r125 = r125 * r44;
+    r125 = r125 * r75;
+    r125 = r125 * r106;
+    r125 = r125 * r26;
+    r100 = fmaf(r51, r125, r100);
+    r126 = r7 * r16;
+    r126 = r126 * r58;
+    r126 = fmaf(r110, r126, r6 * r110);
+    r127 = 4.00000000000000000e+00;
+    r62 = r62 * r127;
+    r62 = r62 * r67;
+    r61 = r61 * r63;
+    r61 = r61 * r66;
+    r126 = fmaf(r110, r62, r126);
+    r126 = fmaf(r110, r61, r126);
+    r128 = r126 * r26;
+    r100 = fmaf(r72, r128, r100);
+    r129 = r59 * r91;
+    r129 = r129 * r55;
+    r100 = fmaf(r107, r129, r100);
+    r130 = r36 * r77;
+    r100 = fmaf(r73, r130, r100);
+    r100 = fmaf(r8, r110, r100);
+    r100 = fmaf(r68, r3, r100);
+    r100 = fmaf(r99, r117, r100);
+    r130 = r0 * r100;
+    r129 = r36 * r91;
+    r129 = r129 * r93;
+    r129 = r129 * r46;
+    r128 = r63 * r92;
+    r128 = r128 * r108;
+    r128 = fmaf(r111, r128, r51 * r129);
+    r129 = r92 * r105;
+    r128 = fmaf(r113, r129, r128);
+    r125 = r33 * r33;
+    r125 = r125 * r36;
+    r128 = fmaf(r102, r125, r128);
+    r128 = r128 + r87;
+    r110 = fmaf(r9, r110, r59 * r128);
+    r128 = r81 * r92;
+    r128 = r128 * r72;
+    r110 = fmaf(r111, r128, r110);
+    r87 = r74 * r92;
+    r87 = r87 * r48;
+    r87 = r87 * r70;
+    r87 = r87 * r75;
+    r125 = r68 * r87;
+    r110 = fmaf(r51, r125, r110);
+    r129 = r126 * r72;
+    r110 = fmaf(r51, r129, r110);
+    r102 = r4 * r33;
+    r102 = r102 * r36;
+    r102 = r102 * r68;
+    r102 = r102 * r99;
+    r102 = r102 * r44;
+    r110 = fmaf(r71, r102, r110);
+    r124 = r60 * r99;
+    r110 = fmaf(r116, r124, r110);
+    r123 = r60 * r109;
+    r122 = r60 * r92;
+    r110 = fmaf(r112, r122, r110);
+    r121 = r4 * r33;
+    r121 = r121 * r36;
+    r121 = r121 * r99;
+    r121 = r121 * r44;
+    r110 = fmaf(r71, r121, r110);
+    r120 = r60 * r40;
+    r120 = r120 * r92;
+    r120 = r120 * r44;
+    r120 = r120 * r75;
+    r120 = r120 * r106;
+    r120 = r120 * r26;
+    r110 = fmaf(r51, r120, r110);
+    r118 = r111 * r119;
+    r115 = r60 * r91;
+    r115 = r115 * r55;
+    r110 = fmaf(r107, r115, r110);
+    r3 = r36 * r91;
+    r110 = fmaf(r73, r3, r110);
+    r131 = r36 * r91;
+    r110 = fmaf(r72, r131, r110);
+    r110 = fmaf(r77, r123, r110);
+    r110 = fmaf(r92, r118, r110);
+    r110 = fmaf(r87, r51, r110);
+    r131 = r5 * r110;
+    r3 = r16 * r47;
+    r82 = r83 + r82;
+    r83 = r16 * r32;
+    r115 = r19 * r24;
+    r120 = r18 * r21;
+    r120 = fmaf(r74, r120, r74 * r115);
+    r115 = r17 * r22;
+    r120 = fmaf(r81, r115, r120);
+    r121 = r20 * r23;
+    r120 = fmaf(r74, r121, r120);
+    r83 = r83 * r120;
+    r121 = r16 * r25;
+    r115 = r17 * r24;
+    r122 = r20 * r21;
+    r122 = fmaf(r81, r122, r81 * r115);
+    r115 = r19 * r22;
+    r122 = fmaf(r81, r115, r122);
+    r124 = r18 * r23;
+    r122 = fmaf(r74, r124, r122);
+    r121 = fmaf(r122, r121, r83);
+    r82 = r82 + r121;
+    r124 = r32 * r86;
+    r124 = r124 * r122;
+    r115 = r29 * r78;
+    r115 = r115 * r86;
+    r102 = r124 + r115;
+    r102 = fmaf(r13, r102, r15 * r82);
+    r82 = r40 * r34;
+    r82 = fmaf(r40, r89, r122 * r82);
+    r129 = r16 * r25;
+    r129 = r129 * r78;
+    r125 = r16 * r29;
+    r125 = fmaf(r120, r125, r129);
+    r82 = r82 + r125;
+    r102 = fmaf(r14, r82, r102);
+    r3 = r3 * r102;
+    r82 = r47 * r47;
+    r128 = r40 * r29;
+    r128 = fmaf(r84, r128, r80);
+    r128 = r128 + r121;
+    r121 = r16 * r29;
+    r121 = r121 * r122;
+    r132 = r16 * r34;
+    r132 = fmaf(r120, r132, r121);
+    r132 = r132 + r97;
+    r132 = fmaf(r14, r132, r13 * r128);
+    r128 = r25 * r120;
+    r97 = r86 * r128;
+    r115 = r115 + r97;
+    r132 = fmaf(r15, r115, r132);
+    r82 = r82 * r132;
+    r82 = fmaf(r85, r82, r44 * r3);
+    r3 = r16 * r33;
+    r115 = r25 * r40;
+    r115 = fmaf(r84, r115, r98);
+    r98 = r40 * r34;
+    r115 = fmaf(r120, r98, r115);
+    r115 = r115 + r121;
+    r98 = r16 * r34;
+    r89 = fmaf(r16, r89, r122 * r98);
+    r89 = r89 + r125;
+    r89 = fmaf(r13, r89, r15 * r115);
+    r97 = r124 + r97;
+    r89 = fmaf(r14, r97, r89);
+    r3 = r3 * r89;
+    r82 = fmaf(r44, r3, r82);
+    r82 = fmaf(r132, r95, r82);
+    r3 = r4 * r47;
+    r3 = r3 * r36;
+    r3 = r3 * r82;
+    r3 = r3 * r44;
+    r3 = r3 * r75;
+    r3 = r3 * r106;
+    r3 = fmaf(r26, r3, r82 * r101);
+    r97 = r47 * r36;
+    r97 = r97 * r132;
+    r97 = r97 * r48;
+    r97 = r97 * r26;
+    r3 = fmaf(r85, r97, r3);
+    r124 = r102 * r55;
+    r3 = fmaf(r107, r124, r3);
+    r124 = r4 * r33;
+    r124 = r124 * r33;
+    r124 = r124 * r36;
+    r124 = r124 * r36;
+    r124 = r124 * r82;
+    r124 = r124 * r44;
+    r124 = r124 * r75;
+    r124 = fmaf(r106, r124, r89 * r109);
+    r97 = r82 * r108;
+    r124 = fmaf(r111, r97, r124);
+    r124 = fmaf(r132, r114, r124);
+    r97 = r3 + r124;
+    r115 = r63 * r82;
+    r115 = fmaf(r82, r104, r101 * r115);
+    r98 = r47 * r36;
+    r98 = r98 * r103;
+    r98 = r98 * r132;
+    r98 = r98 * r48;
+    r98 = r98 * r88;
+    r115 = fmaf(r26, r98, r115);
+    r122 = r36 * r93;
+    r122 = r122 * r102;
+    r115 = fmaf(r55, r122, r115);
+    r115 = r115 + r124;
+    r115 = fmaf(r60, r115, r8 * r97);
+    r124 = r59 * r89;
+    r124 = r124 * r55;
+    r115 = fmaf(r107, r124, r115);
+    r122 = r74 * r82;
+    r122 = r122 * r48;
+    r122 = r122 * r70;
+    r122 = r122 * r75;
+    r115 = fmaf(r26, r122, r115);
+    r98 = r4 * r132;
+    r98 = r98 * r44;
+    r98 = r98 * r71;
+    r115 = fmaf(r26, r98, r115);
+    r121 = r47 * r82;
+    r121 = r121 * r41;
+    r115 = fmaf(r119, r121, r115);
+    r84 = r36 * r102;
+    r115 = fmaf(r73, r84, r115);
+    r133 = r59 * r40;
+    r133 = r133 * r82;
+    r133 = r133 * r44;
+    r133 = r133 * r75;
+    r133 = r133 * r106;
+    r133 = r133 * r26;
+    r115 = fmaf(r51, r133, r115);
+    r134 = r82 * r112;
+    r135 = r47 * r81;
+    r135 = r135 * r82;
+    r135 = r135 * r72;
+    r115 = fmaf(r41, r135, r115);
+    r136 = r4 * r68;
+    r136 = r136 * r132;
+    r136 = r136 * r44;
+    r136 = r136 * r71;
+    r115 = fmaf(r26, r136, r115);
+    r137 = r59 * r102;
+    r115 = fmaf(r109, r137, r115);
+    r138 = r7 * r16;
+    r138 = r138 * r58;
+    r138 = fmaf(r97, r138, r6 * r97);
+    r138 = fmaf(r97, r62, r138);
+    r138 = fmaf(r97, r61, r138);
+    r139 = r138 * r26;
+    r115 = fmaf(r72, r139, r115);
+    r140 = r68 * r74;
+    r140 = r140 * r82;
+    r140 = r140 * r48;
+    r140 = r140 * r70;
+    r140 = r140 * r75;
+    r115 = fmaf(r26, r140, r115);
+    r141 = r36 * r102;
+    r115 = fmaf(r72, r141, r115);
+    r115 = fmaf(r132, r117, r115);
+    r115 = fmaf(r59, r134, r115);
+    r141 = r0 * r115;
+    r140 = r36 * r93;
+    r140 = r140 * r89;
+    r140 = r140 * r46;
+    r139 = r82 * r105;
+    r139 = fmaf(r113, r139, r51 * r140);
+    r140 = r33 * r33;
+    r140 = r140 * r36;
+    r140 = r140 * r36;
+    r140 = r140 * r103;
+    r140 = r140 * r132;
+    r140 = r140 * r48;
+    r139 = fmaf(r88, r140, r139);
+    r137 = r63 * r82;
+    r137 = r137 * r108;
+    r139 = fmaf(r111, r137, r139);
+    r139 = r139 + r3;
+    r139 = fmaf(r59, r139, r9 * r97);
+    r97 = r4 * r33;
+    r97 = r97 * r36;
+    r97 = r97 * r132;
+    r97 = r97 * r44;
+    r139 = fmaf(r71, r97, r139);
+    r3 = r60 * r89;
+    r3 = r3 * r55;
+    r139 = fmaf(r107, r3, r139);
+    r137 = r60 * r132;
+    r139 = fmaf(r116, r137, r139);
+    r140 = r33 * r36;
+    r140 = r140 * r68;
+    r140 = r140 * r74;
+    r140 = r140 * r82;
+    r140 = r140 * r48;
+    r140 = r140 * r70;
+    r139 = fmaf(r75, r140, r139);
+    r136 = r138 * r72;
+    r139 = fmaf(r51, r136, r139);
+    r135 = r81 * r82;
+    r135 = r135 * r72;
+    r139 = fmaf(r111, r135, r139);
+    r133 = r33 * r36;
+    r133 = r133 * r74;
+    r133 = r133 * r82;
+    r133 = r133 * r48;
+    r133 = r133 * r70;
+    r139 = fmaf(r75, r133, r139);
+    r84 = r60 * r40;
+    r84 = r84 * r82;
+    r84 = r84 * r44;
+    r84 = r84 * r75;
+    r84 = r84 * r106;
+    r84 = r84 * r26;
+    r139 = fmaf(r51, r84, r139);
+    r121 = r36 * r89;
+    r139 = fmaf(r73, r121, r139);
+    r98 = r4 * r33;
+    r98 = r98 * r36;
+    r98 = r98 * r68;
+    r98 = r98 * r132;
+    r98 = r98 * r44;
+    r139 = fmaf(r71, r98, r139);
+    r122 = r36 * r89;
+    r139 = fmaf(r72, r122, r139);
+    r139 = fmaf(r82, r118, r139);
+    r139 = fmaf(r60, r134, r139);
+    r139 = fmaf(r102, r123, r139);
+    r122 = r5 * r139;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r130,
+                                          r131,
+                                          r141,
+                                          r122);
+    r122 = r47 * r47;
+    r141 = r25 * r86;
+    r31 = fmaf(r74, r31, r81 * r27);
+    r31 = fmaf(r81, r28, r31);
+    r31 = fmaf(r81, r30, r31);
+    r141 = r141 * r31;
+    r96 = r86 * r96;
+    r30 = r141 + r96;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r129 = r129 + r28;
+    r27 = r40 * r29;
+    r129 = fmaf(r120, r27, r129);
+    r131 = r40 * r34;
+    r129 = fmaf(r79, r131, r129);
+    r129 = fmaf(r13, r129, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r128, r31 * r30);
+    r30 = r30 + r94;
+    r129 = fmaf(r14, r30, r129);
+    r122 = r122 * r129;
+    r30 = r16 * r47;
+    r131 = r16 * r29;
+    r131 = r131 * r31;
+    r76 = r76 + r131;
+    r27 = r32 * r40;
+    r76 = fmaf(r120, r27, r76);
+    r76 = r76 + r80;
+    r78 = r32 * r78;
+    r78 = r78 * r86;
+    r96 = r78 + r96;
+    r96 = fmaf(r13, r96, r14 * r76);
+    r76 = r16 * r34;
+    r76 = fmaf(r79, r76, r28);
+    r76 = r76 + r125;
+    r96 = fmaf(r15, r76, r96);
+    r30 = r30 * r96;
+    r30 = fmaf(r44, r30, r85 * r122);
+    r122 = r16 * r33;
+    r131 = r83 + r131;
+    r131 = r131 + r90;
+    r90 = r40 * r34;
+    r128 = fmaf(r40, r128, r31 * r90);
+    r128 = r128 + r94;
+    r128 = fmaf(r15, r128, r13 * r131);
+    r78 = r141 + r78;
+    r128 = fmaf(r14, r78, r128);
+    r122 = r122 * r128;
+    r30 = fmaf(r44, r122, r30);
+    r30 = fmaf(r129, r95, r30);
+    r122 = r30 * r108;
+    r122 = fmaf(r128, r109, r111 * r122);
+    r78 = r4 * r33;
+    r78 = r78 * r33;
+    r78 = r78 * r36;
+    r78 = r78 * r36;
+    r78 = r78 * r30;
+    r78 = r78 * r44;
+    r78 = r78 * r75;
+    r122 = fmaf(r106, r78, r122);
+    r122 = fmaf(r129, r114, r122);
+    r78 = r47 * r36;
+    r78 = r78 * r129;
+    r78 = r78 * r48;
+    r78 = r78 * r26;
+    r78 = fmaf(r30, r101, r85 * r78);
+    r14 = r4 * r47;
+    r14 = r14 * r36;
+    r14 = r14 * r30;
+    r14 = r14 * r44;
+    r14 = r14 * r75;
+    r14 = r14 * r106;
+    r78 = fmaf(r26, r14, r78);
+    r141 = r96 * r55;
+    r78 = fmaf(r107, r141, r78);
+    r141 = r122 + r78;
+    r14 = r47 * r36;
+    r14 = r14 * r103;
+    r14 = r14 * r129;
+    r14 = r14 * r48;
+    r14 = r14 * r88;
+    r15 = r63 * r30;
+    r15 = fmaf(r101, r15, r26 * r14);
+    r14 = r36 * r93;
+    r14 = r14 * r96;
+    r15 = fmaf(r55, r14, r15);
+    r15 = fmaf(r30, r104, r15);
+    r15 = r15 + r122;
+    r15 = fmaf(r60, r15, r8 * r141);
+    r122 = r7 * r16;
+    r122 = r122 * r58;
+    r122 = fmaf(r141, r122, r6 * r141);
+    r122 = fmaf(r141, r61, r122);
+    r122 = fmaf(r141, r62, r122);
+    r14 = r122 * r26;
+    r15 = fmaf(r72, r14, r15);
+    r131 = r47 * r81;
+    r131 = r131 * r30;
+    r131 = r131 * r72;
+    r15 = fmaf(r41, r131, r15);
+    r13 = r68 * r74;
+    r13 = r13 * r30;
+    r13 = r13 * r48;
+    r13 = r13 * r70;
+    r13 = r13 * r75;
+    r15 = fmaf(r26, r13, r15);
+    r94 = r4 * r129;
+    r94 = r94 * r44;
+    r94 = r94 * r71;
+    r15 = fmaf(r26, r94, r15);
+    r90 = r59 * r40;
+    r90 = r90 * r30;
+    r90 = r90 * r44;
+    r90 = r90 * r75;
+    r90 = r90 * r106;
+    r90 = r90 * r26;
+    r15 = fmaf(r51, r90, r15);
+    r31 = r36 * r96;
+    r15 = fmaf(r73, r31, r15);
+    r83 = r59 * r96;
+    r15 = fmaf(r109, r83, r15);
+    r76 = r47 * r30;
+    r76 = r76 * r41;
+    r15 = fmaf(r119, r76, r15);
+    r125 = r59 * r128;
+    r125 = r125 * r55;
+    r15 = fmaf(r107, r125, r15);
+    r28 = r74 * r30;
+    r28 = r28 * r48;
+    r28 = r28 * r70;
+    r28 = r28 * r75;
+    r15 = fmaf(r26, r28, r15);
+    r79 = r4 * r68;
+    r79 = r79 * r129;
+    r79 = r79 * r44;
+    r79 = r79 * r71;
+    r15 = fmaf(r26, r79, r15);
+    r86 = r36 * r96;
+    r15 = fmaf(r72, r86, r15);
+    r80 = r59 * r30;
+    r15 = fmaf(r112, r80, r15);
+    r15 = fmaf(r129, r117, r15);
+    r80 = r0 * r15;
+    r86 = r63 * r30;
+    r86 = r86 * r108;
+    r79 = r36 * r93;
+    r79 = r79 * r128;
+    r79 = r79 * r46;
+    r79 = fmaf(r51, r79, r111 * r86);
+    r86 = r33 * r33;
+    r86 = r86 * r36;
+    r86 = r86 * r36;
+    r86 = r86 * r103;
+    r86 = r86 * r129;
+    r86 = r86 * r48;
+    r79 = fmaf(r88, r86, r79);
+    r28 = r30 * r105;
+    r79 = fmaf(r113, r28, r79);
+    r79 = r79 + r78;
+    r79 = fmaf(r59, r79, r9 * r141);
+    r141 = r60 * r129;
+    r79 = fmaf(r116, r141, r79);
+    r78 = r33 * r36;
+    r78 = r78 * r74;
+    r78 = r78 * r30;
+    r78 = r78 * r48;
+    r78 = r78 * r70;
+    r79 = fmaf(r75, r78, r79);
+    r28 = r81 * r30;
+    r28 = r28 * r72;
+    r79 = fmaf(r111, r28, r79);
+    r86 = r4 * r33;
+    r86 = r86 * r36;
+    r86 = r86 * r68;
+    r86 = r86 * r129;
+    r86 = r86 * r44;
+    r79 = fmaf(r71, r86, r79);
+    r125 = r36 * r128;
+    r79 = fmaf(r73, r125, r79);
+    r76 = r60 * r40;
+    r76 = r76 * r30;
+    r76 = r76 * r44;
+    r76 = r76 * r75;
+    r76 = r76 * r106;
+    r76 = r76 * r26;
+    r79 = fmaf(r51, r76, r79);
+    r83 = r33 * r36;
+    r83 = r83 * r68;
+    r83 = r83 * r74;
+    r83 = r83 * r30;
+    r83 = r83 * r48;
+    r83 = r83 * r70;
+    r79 = fmaf(r75, r83, r79);
+    r31 = r60 * r128;
+    r31 = r31 * r55;
+    r79 = fmaf(r107, r31, r79);
+    r90 = r4 * r33;
+    r90 = r90 * r36;
+    r90 = r90 * r129;
+    r90 = r90 * r44;
+    r79 = fmaf(r71, r90, r79);
+    r94 = r60 * r30;
+    r79 = fmaf(r112, r94, r79);
+    r13 = r36 * r128;
+    r79 = fmaf(r72, r13, r79);
+    r131 = r122 * r72;
+    r79 = fmaf(r51, r131, r79);
+    r79 = fmaf(r96, r123, r79);
+    r79 = fmaf(r30, r118, r79);
+    r131 = r5 * r79;
+    r13 = r12 * r47;
+    r13 = r13 * r36;
+    r13 = r13 * r103;
+    r13 = r13 * r48;
+    r13 = r13 * r88;
+    r94 = r42 * r36;
+    r94 = r94 * r93;
+    r94 = fmaf(r55, r94, r26 * r13);
+    r13 = r16 * r38;
+    r13 = r13 * r33;
+    r13 = fmaf(r44, r13, r12 * r95);
+    r90 = r12 * r47;
+    r90 = r90 * r47;
+    r13 = fmaf(r85, r90, r13);
+    r31 = r16 * r42;
+    r31 = r31 * r47;
+    r13 = fmaf(r44, r31, r13);
+    r31 = r63 * r13;
+    r94 = fmaf(r101, r31, r94);
+    r90 = fmaf(r38, r109, r12 * r114);
+    r83 = r4 * r33;
+    r83 = r83 * r33;
+    r83 = r83 * r36;
+    r83 = r83 * r36;
+    r83 = r83 * r13;
+    r83 = r83 * r44;
+    r83 = r83 * r75;
+    r90 = fmaf(r106, r83, r90);
+    r76 = r13 * r108;
+    r90 = fmaf(r111, r76, r90);
+    r94 = fmaf(r13, r104, r94);
+    r94 = r94 + r90;
+    r31 = r12 * r47;
+    r31 = r31 * r36;
+    r31 = r31 * r48;
+    r31 = r31 * r26;
+    r76 = r42 * r55;
+    r76 = fmaf(r107, r76, r85 * r31);
+    r31 = r4 * r47;
+    r31 = r31 * r36;
+    r31 = r31 * r13;
+    r31 = r31 * r44;
+    r31 = r31 * r75;
+    r31 = r31 * r106;
+    r76 = fmaf(r26, r31, r76);
+    r76 = fmaf(r13, r101, r76);
+    r90 = r90 + r76;
+    r94 = fmaf(r8, r90, r60 * r94);
+    r31 = r4 * r12;
+    r31 = r31 * r44;
+    r31 = r31 * r71;
+    r94 = fmaf(r26, r31, r94);
+    r83 = r42 * r36;
+    r94 = fmaf(r72, r83, r94);
+    r125 = r68 * r74;
+    r125 = r125 * r13;
+    r125 = r125 * r48;
+    r125 = r125 * r70;
+    r125 = r125 * r75;
+    r94 = fmaf(r26, r125, r94);
+    r86 = r59 * r40;
+    r86 = r86 * r13;
+    r86 = r86 * r44;
+    r86 = r86 * r75;
+    r86 = r86 * r106;
+    r86 = r86 * r26;
+    r94 = fmaf(r51, r86, r94);
+    r28 = r42 * r36;
+    r94 = fmaf(r73, r28, r94);
+    r78 = r59 * r13;
+    r94 = fmaf(r112, r78, r94);
+    r141 = r59 * r42;
+    r94 = fmaf(r109, r141, r94);
+    r14 = r74 * r13;
+    r14 = r14 * r48;
+    r14 = r14 * r70;
+    r14 = r14 * r75;
+    r94 = fmaf(r26, r14, r94);
+    r27 = r47 * r13;
+    r27 = r27 * r41;
+    r94 = fmaf(r119, r27, r94);
+    r120 = r47 * r81;
+    r120 = r120 * r13;
+    r120 = r120 * r72;
+    r94 = fmaf(r41, r120, r94);
+    r130 = r59 * r38;
+    r130 = r130 * r55;
+    r94 = fmaf(r107, r130, r94);
+    r98 = r7 * r16;
+    r98 = r98 * r58;
+    r98 = fmaf(r6, r90, r90 * r98);
+    r98 = fmaf(r90, r62, r98);
+    r98 = fmaf(r90, r61, r98);
+    r121 = r98 * r26;
+    r94 = fmaf(r72, r121, r94);
+    r134 = r4 * r12;
+    r134 = r134 * r68;
+    r134 = r134 * r44;
+    r134 = r134 * r71;
+    r94 = fmaf(r26, r134, r94);
+    r94 = fmaf(r12, r117, r94);
+    r134 = r0 * r94;
+    r121 = r12 * r33;
+    r121 = r121 * r33;
+    r121 = r121 * r36;
+    r121 = r121 * r36;
+    r121 = r121 * r103;
+    r121 = r121 * r48;
+    r130 = r38 * r36;
+    r130 = r130 * r93;
+    r130 = r130 * r46;
+    r130 = fmaf(r51, r130, r88 * r121);
+    r121 = r13 * r105;
+    r130 = fmaf(r113, r121, r130);
+    r120 = r63 * r13;
+    r120 = r120 * r108;
+    r130 = fmaf(r111, r120, r130);
+    r130 = r130 + r76;
+    r90 = fmaf(r9, r90, r59 * r130);
+    r130 = r4 * r12;
+    r130 = r130 * r33;
+    r130 = r130 * r36;
+    r130 = r130 * r44;
+    r90 = fmaf(r71, r130, r90);
+    r76 = r4 * r12;
+    r76 = r76 * r33;
+    r76 = r76 * r36;
+    r76 = r76 * r68;
+    r76 = r76 * r44;
+    r90 = fmaf(r71, r76, r90);
+    r120 = r33 * r36;
+    r120 = r120 * r74;
+    r120 = r120 * r13;
+    r120 = r120 * r48;
+    r120 = r120 * r70;
+    r90 = fmaf(r75, r120, r90);
+    r121 = r33 * r36;
+    r121 = r121 * r68;
+    r121 = r121 * r74;
+    r121 = r121 * r13;
+    r121 = r121 * r48;
+    r121 = r121 * r70;
+    r90 = fmaf(r75, r121, r90);
+    r27 = r38 * r36;
+    r90 = fmaf(r72, r27, r90);
+    r14 = r38 * r36;
+    r90 = fmaf(r73, r14, r90);
+    r141 = r60 * r40;
+    r141 = r141 * r13;
+    r141 = r141 * r44;
+    r141 = r141 * r75;
+    r141 = r141 * r106;
+    r141 = r141 * r26;
+    r90 = fmaf(r51, r141, r90);
+    r78 = r60 * r13;
+    r90 = fmaf(r112, r78, r90);
+    r28 = r81 * r13;
+    r28 = r28 * r72;
+    r90 = fmaf(r111, r28, r90);
+    r86 = r60 * r12;
+    r90 = fmaf(r116, r86, r90);
+    r125 = r60 * r38;
+    r125 = r125 * r55;
+    r90 = fmaf(r107, r125, r90);
+    r83 = r98 * r72;
+    r90 = fmaf(r51, r83, r90);
+    r90 = fmaf(r42, r123, r90);
+    r90 = fmaf(r13, r118, r90);
+    r83 = r5 * r90;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r80,
+                                          r131,
+                                          r134,
+                                          r83);
+    r83 = r16 * r43;
+    r83 = r83 * r33;
+    r83 = fmaf(r44, r83, r39 * r95);
+    r134 = r39 * r47;
+    r134 = r134 * r47;
+    r83 = fmaf(r85, r134, r83);
+    r131 = r16 * r53;
+    r131 = r131 * r47;
+    r83 = fmaf(r44, r131, r83);
+    r131 = r83 * r108;
+    r131 = fmaf(r39, r114, r111 * r131);
+    r134 = r4 * r33;
+    r134 = r134 * r33;
+    r134 = r134 * r36;
+    r134 = r134 * r36;
+    r134 = r134 * r83;
+    r134 = r134 * r44;
+    r134 = r134 * r75;
+    r131 = fmaf(r106, r134, r131);
+    r131 = fmaf(r43, r109, r131);
+    r134 = r39 * r47;
+    r134 = r134 * r36;
+    r134 = r134 * r48;
+    r134 = r134 * r26;
+    r134 = fmaf(r85, r134, r83 * r101);
+    r80 = r53 * r55;
+    r134 = fmaf(r107, r80, r134);
+    r125 = r4 * r47;
+    r125 = r125 * r36;
+    r125 = r125 * r83;
+    r125 = r125 * r44;
+    r125 = r125 * r75;
+    r125 = r125 * r106;
+    r134 = fmaf(r26, r125, r134);
+    r125 = r131 + r134;
+    r80 = r63 * r83;
+    r86 = r39 * r47;
+    r86 = r86 * r36;
+    r86 = r86 * r103;
+    r86 = r86 * r48;
+    r86 = r86 * r88;
+    r86 = fmaf(r26, r86, r101 * r80);
+    r80 = r53 * r36;
+    r80 = r80 * r93;
+    r86 = fmaf(r55, r80, r86);
+    r86 = fmaf(r83, r104, r86);
+    r86 = r86 + r131;
+    r86 = fmaf(r60, r86, r8 * r125);
+    r131 = r53 * r36;
+    r86 = fmaf(r73, r131, r86);
+    r80 = r7 * r16;
+    r80 = r80 * r58;
+    r80 = fmaf(r125, r80, r6 * r125);
+    r80 = fmaf(r125, r62, r80);
+    r80 = fmaf(r125, r61, r80);
+    r101 = r80 * r26;
+    r86 = fmaf(r72, r101, r86);
+    r28 = r59 * r43;
+    r28 = r28 * r55;
+    r86 = fmaf(r107, r28, r86);
+    r78 = r74 * r83;
+    r78 = r78 * r48;
+    r78 = r78 * r70;
+    r78 = r78 * r75;
+    r86 = fmaf(r26, r78, r86);
+    r141 = r53 * r36;
+    r86 = fmaf(r72, r141, r86);
+    r14 = r59 * r83;
+    r86 = fmaf(r112, r14, r86);
+    r27 = r47 * r81;
+    r27 = r27 * r83;
+    r27 = r27 * r72;
+    r86 = fmaf(r41, r27, r86);
+    r121 = r59 * r40;
+    r121 = r121 * r83;
+    r121 = r121 * r44;
+    r121 = r121 * r75;
+    r121 = r121 * r106;
+    r121 = r121 * r26;
+    r86 = fmaf(r51, r121, r86);
+    r120 = r68 * r74;
+    r120 = r120 * r83;
+    r120 = r120 * r48;
+    r120 = r120 * r70;
+    r120 = r120 * r75;
+    r86 = fmaf(r26, r120, r86);
+    r76 = r47 * r83;
+    r76 = r76 * r41;
+    r86 = fmaf(r119, r76, r86);
+    r130 = r4 * r39;
+    r130 = r130 * r44;
+    r130 = r130 * r71;
+    r86 = fmaf(r26, r130, r86);
+    r31 = r59 * r53;
+    r86 = fmaf(r109, r31, r86);
+    r84 = r4 * r39;
+    r84 = r84 * r68;
+    r84 = r84 * r44;
+    r84 = r84 * r71;
+    r86 = fmaf(r26, r84, r86);
+    r86 = fmaf(r39, r117, r86);
+    r84 = r0 * r86;
+    r31 = r63 * r83;
+    r31 = r31 * r108;
+    r130 = r39 * r33;
+    r130 = r130 * r33;
+    r130 = r130 * r36;
+    r130 = r130 * r36;
+    r130 = r130 * r103;
+    r130 = r130 * r48;
+    r130 = fmaf(r88, r130, r111 * r31);
+    r31 = r43 * r36;
+    r31 = r31 * r93;
+    r31 = r31 * r46;
+    r130 = fmaf(r51, r31, r130);
+    r76 = r83 * r105;
+    r130 = fmaf(r113, r76, r130);
+    r130 = r130 + r134;
+    r130 = fmaf(r59, r130, r9 * r125);
+    r125 = r60 * r43;
+    r125 = r125 * r55;
+    r130 = fmaf(r107, r125, r130);
+    r134 = r4 * r39;
+    r134 = r134 * r33;
+    r134 = r134 * r36;
+    r134 = r134 * r44;
+    r130 = fmaf(r71, r134, r130);
+    r76 = r81 * r83;
+    r76 = r76 * r72;
+    r130 = fmaf(r111, r76, r130);
+    r31 = r60 * r83;
+    r130 = fmaf(r112, r31, r130);
+    r120 = r43 * r36;
+    r130 = fmaf(r73, r120, r130);
+    r121 = r60 * r39;
+    r130 = fmaf(r116, r121, r130);
+    r27 = r60 * r40;
+    r27 = r27 * r83;
+    r27 = r27 * r44;
+    r27 = r27 * r75;
+    r27 = r27 * r106;
+    r27 = r27 * r26;
+    r130 = fmaf(r51, r27, r130);
+    r14 = r43 * r36;
+    r130 = fmaf(r72, r14, r130);
+    r141 = r4 * r39;
+    r141 = r141 * r33;
+    r141 = r141 * r36;
+    r141 = r141 * r68;
+    r141 = r141 * r44;
+    r130 = fmaf(r71, r141, r130);
+    r78 = r33 * r36;
+    r78 = r78 * r68;
+    r78 = r78 * r74;
+    r78 = r78 * r83;
+    r78 = r78 * r48;
+    r78 = r78 * r70;
+    r130 = fmaf(r75, r78, r130);
+    r28 = r80 * r72;
+    r130 = fmaf(r51, r28, r130);
+    r101 = r33 * r36;
+    r101 = r101 * r74;
+    r101 = r101 * r83;
+    r101 = r101 * r48;
+    r101 = r101 * r70;
+    r130 = fmaf(r75, r101, r130);
+    r130 = fmaf(r83, r118, r130);
+    r130 = fmaf(r53, r123, r130);
+    r101 = r5 * r130;
+    r28 = r47 * r47;
+    r28 = r44 * r28;
+    r78 = r16 * r45;
+    r78 = r78 * r33;
+    r95 = fmaf(r37, r95, r44 * r78);
+    r78 = r16 * r52;
+    r78 = r78 * r47;
+    r95 = fmaf(r44, r78, r95);
+    r141 = r37 * r47;
+    r141 = r141 * r47;
+    r95 = fmaf(r85, r141, r95);
+    r28 = r28 * r48;
+    r28 = r28 * r36;
+    r28 = r28 * r75;
+    r28 = r28 * r35;
+    r28 = r28 * r95;
+    r35 = r37 * r47;
+    r35 = r35 * r36;
+    r35 = r35 * r48;
+    r35 = r35 * r26;
+    r35 = fmaf(r85, r35, r28);
+    r85 = r4 * r47;
+    r85 = r85 * r36;
+    r85 = r85 * r95;
+    r85 = r85 * r44;
+    r85 = r85 * r75;
+    r85 = r85 * r106;
+    r35 = fmaf(r26, r85, r35);
+    r141 = r52 * r55;
+    r35 = fmaf(r107, r141, r35);
+    r141 = r95 * r108;
+    r141 = fmaf(r45, r109, r111 * r141);
+    r85 = r4 * r33;
+    r85 = r85 * r33;
+    r85 = r85 * r36;
+    r85 = r85 * r36;
+    r85 = r85 * r95;
+    r85 = r85 * r44;
+    r85 = r85 * r75;
+    r141 = fmaf(r106, r85, r141);
+    r141 = fmaf(r37, r114, r141);
+    r114 = r35 + r141;
+    r85 = r37 * r47;
+    r85 = r85 * r36;
+    r85 = r85 * r103;
+    r85 = r85 * r48;
+    r85 = r85 * r88;
+    r104 = fmaf(r95, r104, r26 * r85);
+    r85 = r52 * r36;
+    r85 = r85 * r93;
+    r104 = fmaf(r55, r85, r104);
+    r104 = fmaf(r63, r28, r104);
+    r104 = r104 + r141;
+    r104 = fmaf(r60, r104, r8 * r114);
+    r8 = r4 * r37;
+    r8 = r8 * r68;
+    r8 = r8 * r44;
+    r8 = r8 * r71;
+    r104 = fmaf(r26, r8, r104);
+    r141 = r52 * r36;
+    r104 = fmaf(r72, r141, r104);
+    r28 = r4 * r37;
+    r28 = r28 * r44;
+    r28 = r28 * r71;
+    r104 = fmaf(r26, r28, r104);
+    r85 = r52 * r36;
+    r104 = fmaf(r73, r85, r104);
+    r78 = r47 * r95;
+    r78 = r78 * r41;
+    r104 = fmaf(r119, r78, r104);
+    r119 = r74 * r95;
+    r119 = r119 * r48;
+    r119 = r119 * r70;
+    r119 = r119 * r75;
+    r104 = fmaf(r26, r119, r104);
+    r14 = r59 * r40;
+    r14 = r14 * r95;
+    r14 = r14 * r44;
+    r14 = r14 * r75;
+    r14 = r14 * r106;
+    r14 = r14 * r26;
+    r104 = fmaf(r51, r14, r104);
+    r27 = r59 * r95;
+    r104 = fmaf(r112, r27, r104);
+    r121 = r59 * r45;
+    r121 = r121 * r55;
+    r104 = fmaf(r107, r121, r104);
+    r120 = r59 * r52;
+    r104 = fmaf(r109, r120, r104);
+    r109 = r68 * r74;
+    r109 = r109 * r95;
+    r109 = r109 * r48;
+    r109 = r109 * r70;
+    r109 = r109 * r75;
+    r104 = fmaf(r26, r109, r104);
+    r31 = r47 * r81;
+    r31 = r31 * r95;
+    r31 = r31 * r72;
+    r104 = fmaf(r41, r31, r104);
+    r41 = r7 * r16;
+    r41 = r41 * r58;
+    r6 = fmaf(r6, r114, r114 * r41);
+    r6 = fmaf(r114, r62, r6);
+    r6 = fmaf(r114, r61, r6);
+    r61 = r6 * r26;
+    r104 = fmaf(r72, r61, r104);
+    r104 = fmaf(r37, r117, r104);
+    r117 = r0 * r104;
+    r61 = r63 * r95;
+    r61 = r61 * r108;
+    r31 = r45 * r36;
+    r31 = r31 * r93;
+    r31 = r31 * r46;
+    r31 = fmaf(r51, r31, r111 * r61);
+    r61 = r95 * r105;
+    r31 = fmaf(r113, r61, r31);
+    r113 = r37 * r33;
+    r113 = r113 * r33;
+    r113 = r113 * r36;
+    r113 = r113 * r36;
+    r113 = r113 * r103;
+    r113 = r113 * r48;
+    r31 = fmaf(r88, r113, r31);
+    r31 = r31 + r35;
+    r31 = fmaf(r59, r31, r9 * r114);
+    r114 = r81 * r95;
+    r114 = r114 * r72;
+    r31 = fmaf(r111, r114, r31);
+    r111 = r45 * r36;
+    r31 = fmaf(r73, r111, r31);
+    r73 = r33 * r36;
+    r73 = r73 * r68;
+    r73 = r73 * r74;
+    r73 = r73 * r95;
+    r73 = r73 * r48;
+    r73 = r73 * r70;
+    r31 = fmaf(r75, r73, r31);
+    r9 = r33 * r36;
+    r9 = r9 * r74;
+    r9 = r9 * r95;
+    r9 = r9 * r48;
+    r9 = r9 * r70;
+    r31 = fmaf(r75, r9, r31);
+    r70 = r60 * r40;
+    r70 = r70 * r95;
+    r70 = r70 * r44;
+    r70 = r70 * r75;
+    r70 = r70 * r106;
+    r70 = r70 * r26;
+    r31 = fmaf(r51, r70, r31);
+    r75 = r60 * r95;
+    r31 = fmaf(r112, r75, r31);
+    r112 = r60 * r45;
+    r112 = r112 * r55;
+    r31 = fmaf(r107, r112, r31);
+    r48 = r4 * r37;
+    r48 = r48 * r33;
+    r48 = r48 * r36;
+    r48 = r48 * r68;
+    r48 = r48 * r44;
+    r31 = fmaf(r71, r48, r31);
+    r35 = r45 * r36;
+    r31 = fmaf(r72, r35, r31);
+    r113 = r4 * r37;
+    r113 = r113 * r33;
+    r113 = r113 * r36;
+    r113 = r113 * r44;
+    r31 = fmaf(r71, r113, r31);
+    r71 = r6 * r72;
+    r31 = fmaf(r51, r71, r31);
+    r44 = r60 * r37;
+    r31 = fmaf(r116, r44, r31);
+    r31 = fmaf(r95, r118, r31);
+    r31 = fmaf(r52, r123, r31);
+    r44 = r5 * r31;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r84,
+                                          r101,
+                                          r117,
+                                          r44);
+    r44 = r0 * r4;
+    r44 = r44 * r2;
+    r117 = r4 * r1;
+    r101 = r5 * r117;
+    r44 = fmaf(r110, r101, r100 * r44);
+    r84 = r0 * r4;
+    r84 = r84 * r2;
+    r84 = fmaf(r139, r101, r115 * r84);
+    r71 = r0 * r4;
+    r71 = r71 * r2;
+    r71 = fmaf(r79, r101, r15 * r71);
+    r113 = r0 * r4;
+    r113 = r113 * r2;
+    r113 = fmaf(r90, r101, r94 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r44, r84, r71, r113);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r0 * r4;
+    r113 = r113 * r2;
+    r113 = fmaf(r130, r101, r86 * r113);
+    r71 = r0 * r4;
+    r71 = r71 * r2;
+    r71 = fmaf(r31, r101, r104 * r71);
+    WriteSum2<float, float>((float*)inout_shared, r113, r71);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r0 * r0;
+    r113 = r100 * r100;
+    r84 = r5 * r5;
+    r44 = r110 * r110;
+    r44 = fmaf(r84, r44, r71 * r113);
+    r113 = r115 * r115;
+    r35 = r139 * r139;
+    r35 = fmaf(r84, r35, r71 * r113);
+    r113 = r79 * r79;
+    r123 = r15 * r15;
+    r123 = fmaf(r71, r123, r84 * r113);
+    r113 = r94 * r94;
+    r48 = r90 * r90;
+    r48 = fmaf(r84, r48, r71 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r44, r35, r123, r48);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r86 * r86;
+    r123 = r130 * r130;
+    r123 = fmaf(r84, r123, r71 * r48);
+    r48 = r31 * r31;
+    r35 = r104 * r104;
+    r35 = fmaf(r71, r35, r84 * r48);
+    WriteSum2<float, float>((float*)inout_shared, r123, r35);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r110 * r139;
+    r123 = r100 * r115;
+    r123 = fmaf(r71, r123, r84 * r35);
+    r35 = r100 * r15;
+    r48 = r110 * r79;
+    r48 = fmaf(r84, r48, r71 * r35);
+    r35 = r110 * r90;
+    r44 = r100 * r94;
+    r44 = fmaf(r71, r44, r84 * r35);
+    r35 = r110 * r130;
+    r113 = r100 * r86;
+    r113 = fmaf(r71, r113, r84 * r35);
+    WriteSum4<float, float>((float*)inout_shared, r123, r48, r44, r113);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r100 * r104;
+    r44 = r110 * r31;
+    r44 = fmaf(r84, r44, r71 * r113);
+    r113 = r139 * r79;
+    r48 = r115 * r15;
+    r48 = fmaf(r71, r48, r84 * r113);
+    r113 = r115 * r94;
+    r123 = r139 * r90;
+    r123 = fmaf(r84, r123, r71 * r113);
+    r113 = r115 * r86;
+    r35 = r139 * r130;
+    r35 = fmaf(r84, r35, r71 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r44, r48, r123, r35);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r139 * r31;
+    r123 = r115 * r104;
+    r123 = fmaf(r71, r123, r84 * r35);
+    r35 = r79 * r90;
+    r48 = r15 * r94;
+    r48 = fmaf(r71, r48, r84 * r35);
+    r35 = r15 * r86;
+    r44 = r79 * r130;
+    r44 = fmaf(r84, r44, r71 * r35);
+    r35 = r79 * r31;
+    r113 = r15 * r104;
+    r113 = fmaf(r71, r113, r84 * r35);
+    WriteSum4<float, float>((float*)inout_shared, r123, r48, r44, r113);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r90 * r130;
+    r44 = r94 * r86;
+    r44 = fmaf(r71, r44, r84 * r113);
+    r113 = r94 * r104;
+    r48 = r90 * r31;
+    r48 = fmaf(r84, r48, r71 * r113);
+    r113 = r130 * r31;
+    r123 = r86 * r104;
+    r123 = fmaf(r71, r123, r84 * r113);
+    WriteSum3<float, float>((float*)inout_shared, r44, r48, r123);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r123 = r0 * r58;
+    r123 = r123 * r26;
+    r123 = r123 * r72;
+    r48 = r5 * r58;
+    r48 = r48 * r72;
+    r48 = r48 * r51;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r11,
+                                          r57,
+                                          r123,
+                                          r48);
+    r48 = r5 * r65;
+    r123 = r0 * r26;
+    r123 = r123 * r72;
+    r123 = r123 * r66;
+    r44 = r5 * r72;
+    r44 = r44 * r51;
+    r44 = r44 * r66;
+    r113 = r0 * r16;
+    r113 = r113 * r51;
+    r113 = r113 * r55;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r123,
+                                          r44,
+                                          r113,
+                                          r48);
+    r48 = r0 * r64;
+    r113 = r5 * r16;
+    r113 = r113 * r51;
+    r113 = r113 * r55;
+    r44 = r0 * r26;
+    r44 = r44 * r72;
+    r44 = r44 * r67;
+    r123 = r5 * r72;
+    r123 = r123 * r51;
+    r123 = r123 * r67;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r48,
+                                          r113,
+                                          r44,
+                                          r123);
+    r123 = r0 * r58;
+    r44 = r5 * r58;
+    r113 = r0 * r26;
+    r113 = r113 * r72;
+    r113 = r113 * r69;
+    r48 = r5 * r72;
+    r48 = r48 * r51;
+    r48 = r48 * r69;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r113,
+        r48,
+        r123,
+        r44);
+    r44 = r4 * r11;
+    r44 = r44 * r2;
+    r117 = r57 * r117;
+    r123 = r0 * r4;
+    r123 = r123 * r58;
+    r123 = r123 * r2;
+    r123 = r123 * r26;
+    r48 = r58 * r72;
+    r48 = r48 * r51;
+    r48 = fmaf(r101, r48, r72 * r123);
+    r123 = r0 * r4;
+    r123 = r123 * r2;
+    r123 = r123 * r26;
+    r123 = r123 * r72;
+    r113 = r72 * r51;
+    r113 = r113 * r66;
+    r113 = fmaf(r101, r113, r66 * r123);
+    WriteSum4<float, float>((float*)inout_shared, r44, r117, r48, r113);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r0 * r40;
+    r113 = r113 * r2;
+    r113 = r113 * r51;
+    r113 = fmaf(r55, r113, r65 * r101);
+    r48 = r0 * r4;
+    r48 = r48 * r64;
+    r117 = r5 * r40;
+    r117 = r117 * r1;
+    r117 = r117 * r51;
+    r117 = fmaf(r55, r117, r2 * r48);
+    r48 = r0 * r4;
+    r48 = r48 * r2;
+    r48 = r48 * r26;
+    r48 = r48 * r72;
+    r1 = r72 * r51;
+    r1 = r1 * r67;
+    r1 = fmaf(r101, r1, r67 * r48);
+    r48 = r0 * r4;
+    r48 = r48 * r2;
+    r48 = r48 * r26;
+    r48 = r48 * r72;
+    r44 = r72 * r51;
+    r44 = r44 * r69;
+    r44 = fmaf(r101, r44, r69 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r113, r117, r1, r44);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r0 * r4;
+    r44 = r44 * r58;
+    r44 = r44 * r2;
+    r101 = r58 * r101;
+    WriteSum2<float, float>((float*)inout_shared, r44, r101);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r11 * r11;
+    r44 = r57 * r57;
+    r2 = r33 * r36;
+    r2 = r2 * r66;
+    r2 = r2 * r84;
+    r1 = r36 * r66;
+    r1 = r1 * r71;
+    r1 = fmaf(r56, r1, r108 * r2);
+    r2 = r33 * r36;
+    r2 = r2 * r84;
+    r2 = r2 * r108;
+    r117 = r36 * r71;
+    r117 = r117 * r69;
+    r117 = fmaf(r56, r117, r69 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r101, r44, r1, r117);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r26 * r71;
+    r44 = r47 * r33;
+    r54 = r49 * r54;
+    r54 = 1.0 / r54;
+    r10 = r50 * r10;
+    r10 = 1.0 / r10;
+    r44 = r44 * r36;
+    r44 = r44 * r36;
+    r44 = r44 * r127;
+    r44 = r44 * r54;
+    r44 = r44 * r10;
+    r44 = r44 * r51;
+    r10 = r65 * r84;
+    r54 = fmaf(r65, r10, r1 * r44);
+    r127 = r26 * r84;
+    r50 = r64 * r64;
+    r50 = fmaf(r71, r50, r44 * r127);
+    r127 = r33 * r36;
+    r44 = r67 * r67;
+    r127 = r127 * r84;
+    r127 = r127 * r108;
+    r49 = r36 * r71;
+    r49 = r49 * r56;
+    r127 = fmaf(r44, r49, r44 * r127);
+    r101 = r69 * r69;
+    r2 = r84 * r108;
+    r2 = r2 * r51;
+    r101 = fmaf(r49, r101, r101 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r54, r50, r127, r101);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r66 * r71;
+    r50 = r66 * r84;
+    WriteSum2<float, float>((float*)inout_shared, r101, r50);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = 0.00000000000000000e+00;
+    r101 = r0 * r58;
+    r101 = r101 * r11;
+    r101 = r101 * r26;
+    r101 = r101 * r72;
+    r54 = r0 * r11;
+    r54 = r54 * r26;
+    r54 = r54 * r72;
+    r54 = r54 * r66;
+    r113 = r0 * r16;
+    r113 = r113 * r11;
+    r113 = r113 * r51;
+    r113 = r113 * r55;
+    WriteSum4<float, float>((float*)inout_shared, r50, r101, r54, r113);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r0 * r64;
+    r113 = r113 * r11;
+    r54 = r0 * r58;
+    r54 = r54 * r11;
+    r101 = r0 * r11;
+    r101 = r101 * r26;
+    r101 = r101 * r72;
+    r101 = r101 * r67;
+    r11 = r0 * r11;
+    r11 = r11 * r26;
+    r11 = r11 * r72;
+    r11 = r11 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r113, r101, r11, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r5 * r65;
+    r65 = r65 * r57;
+    r54 = r5 * r58;
+    r54 = r54 * r57;
+    r54 = r54 * r72;
+    r54 = r54 * r51;
+    r11 = r5 * r57;
+    r11 = r11 * r72;
+    r11 = r11 * r51;
+    r11 = r11 * r66;
+    WriteSum4<float, float>((float*)inout_shared, r50, r54, r11, r65);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r5 * r16;
+    r65 = r65 * r57;
+    r65 = r65 * r51;
+    r65 = r65 * r55;
+    r11 = r5 * r57;
+    r11 = r11 * r72;
+    r11 = r11 * r51;
+    r11 = r11 * r67;
+    r54 = r5 * r57;
+    r54 = r54 * r72;
+    r54 = r54 * r51;
+    r54 = r54 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r65, r11, r54, r50);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r5 * r58;
+    r50 = r50 * r57;
+    r57 = r33 * r36;
+    r57 = r57 * r67;
+    r57 = r57 * r84;
+    r54 = r36 * r67;
+    r54 = r54 * r71;
+    r54 = fmaf(r56, r54, r108 * r57);
+    r57 = r47 * r58;
+    r57 = r57 * r88;
+    r57 = r57 * r106;
+    r57 = r57 * r51;
+    r57 = r57 * r107;
+    r11 = r51 * r10;
+    r65 = r72 * r11;
+    r57 = fmaf(r58, r65, r1 * r57);
+    r101 = r72 * r1;
+    r113 = r64 * r101;
+    r48 = r33 * r58;
+    r48 = r48 * r88;
+    r48 = r48 * r106;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r84;
+    r48 = fmaf(r107, r48, r58 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r50, r54, r57, r48);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r66 * r101;
+    r57 = r72 * r51;
+    r57 = r57 * r66;
+    r57 = r57 * r84;
+    r54 = r33 * r36;
+    r50 = r58 * r69;
+    r54 = r54 * r84;
+    r54 = r54 * r108;
+    r123 = r36 * r71;
+    r123 = r123 * r56;
+    r123 = fmaf(r50, r123, r50 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r117, r123, r48, r57);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r47 * r88;
+    r57 = r57 * r106;
+    r57 = r57 * r51;
+    r57 = r57 * r66;
+    r57 = r57 * r107;
+    r57 = fmaf(r66, r65, r1 * r57);
+    r48 = r33 * r88;
+    r48 = r48 * r106;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r66;
+    r48 = r48 * r84;
+    r48 = fmaf(r107, r48, r66 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r57, r48, r123, r127);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r127 = r67 * r101;
+    r123 = r72 * r51;
+    r123 = r123 * r67;
+    r123 = r123 * r84;
+    r48 = r16 * r55;
+    r57 = r16 * r64;
+    r57 = r57 * r51;
+    r57 = r57 * r55;
+    r57 = fmaf(r71, r57, r11 * r48);
+    r48 = r47 * r88;
+    r48 = r48 * r106;
+    r48 = r48 * r51;
+    r48 = r48 * r67;
+    r48 = r48 * r107;
+    r48 = fmaf(r67, r65, r1 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r127, r123, r57, r48);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r16 * r58;
+    r48 = r48 * r51;
+    r48 = r48 * r55;
+    r48 = r48 * r71;
+    r10 = r58 * r10;
+    r57 = r47 * r88;
+    r57 = r57 * r106;
+    r57 = r57 * r51;
+    r57 = r57 * r107;
+    r57 = r57 * r69;
+    r65 = fmaf(r69, r65, r1 * r57);
+    r57 = r33 * r88;
+    r57 = r57 * r106;
+    r57 = r57 * r26;
+    r57 = r57 * r51;
+    r57 = r57 * r67;
+    r57 = r57 * r84;
+    r57 = fmaf(r107, r57, r67 * r113);
+    WriteSum4<float, float>((float*)inout_shared, r65, r48, r10, r57);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r58 * r64;
+    r57 = r57 * r71;
+    r10 = r16 * r58;
+    r10 = r10 * r51;
+    r10 = r10 * r55;
+    r10 = r10 * r84;
+    r48 = r33 * r88;
+    r48 = r48 * r106;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r84;
+    r48 = r48 * r107;
+    r48 = fmaf(r69, r48, r69 * r113);
+    r44 = r58 * r44;
+    r49 = fmaf(r44, r49, r44 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r48, r57, r10, r49);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r69 * r101;
+    r10 = r72 * r51;
+    r10 = r10 * r84;
+    r10 = r10 * r69;
+    r101 = r50 * r101;
+    r69 = r72 * r51;
+    r69 = r69 * r84;
+    r69 = r69 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r49, r10, r101, r69);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacKernel<<<n_blocks,
+                                                                   1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,2220 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r13, r14, r15);
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r33 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r11,
+                       r35,
+                       r36);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r37 = r21 * r22;
+    r37 = r37 * r16;
+    r38 = r23 * r24;
+    r38 = fmaf(r16, r38, r37);
+    r39 = r21 * r21;
+    r40 = -2.00000000000000000e+00;
+    r39 = r39 * r40;
+    r41 = 1.00000000000000000e+00;
+    r42 = r23 * r23;
+    r42 = fmaf(r40, r42, r41);
+    r43 = r39 + r42;
+    r44 = r22 * r23;
+    r44 = r44 * r16;
+    r45 = r21 * r24;
+    r45 = fmaf(r40, r45, r44);
+    r46 = r16 * r32;
+    r46 = r46 * r29;
+    r47 = r25 * r40;
+    r47 = fmaf(r34, r47, r46);
+    r48 = r32 * r32;
+    r48 = r48 * r40;
+    r49 = r41 + r48;
+    r50 = r25 * r25;
+    r50 = r50 * r40;
+    r49 = r49 + r50;
+    r33 = fmaf(r11, r38, r33);
+    r33 = fmaf(r35, r43, r33);
+    r33 = fmaf(r36, r45, r33);
+    r33 = fmaf(r15, r47, r33);
+    r33 = fmaf(r14, r49, r33);
+    r49 = r40 * r29;
+    r49 = r49 * r29;
+    r47 = r41 + r49;
+    r47 = r47 + r48;
+    r47 = fmaf(r13, r47, r10);
+    r10 = r32 * r40;
+    r10 = fmaf(r34, r10, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r48 = r16 * r29;
+    r48 = fmaf(r34, r48, r26);
+    r51 = r21 * r23;
+    r51 = r51 * r16;
+    r52 = r22 * r24;
+    r52 = fmaf(r16, r52, r51);
+    r53 = r23 * r24;
+    r53 = fmaf(r40, r53, r37);
+    r37 = r22 * r22;
+    r37 = r37 * r40;
+    r42 = r37 + r42;
+    r47 = fmaf(r14, r10, r47);
+    r47 = fmaf(r15, r48, r47);
+    r47 = fmaf(r36, r52, r47);
+    r47 = fmaf(r35, r53, r47);
+    r47 = fmaf(r11, r42, r47);
+    r48 = r47 * r47;
+    r10 = 9.99999999999999955e-07;
+    r54 = r40 * r29;
+    r54 = fmaf(r34, r54, r26);
+    r54 = fmaf(r13, r54, r12);
+    r12 = r22 * r24;
+    r12 = fmaf(r40, r12, r51);
+    r37 = r41 + r37;
+    r37 = r37 + r39;
+    r39 = r21 * r24;
+    r39 = fmaf(r16, r39, r44);
+    r44 = r16 * r25;
+    r44 = fmaf(r34, r44, r46);
+    r49 = r41 + r49;
+    r49 = r49 + r50;
+    r54 = fmaf(r11, r12, r54);
+    r54 = fmaf(r36, r37, r54);
+    r54 = fmaf(r35, r39, r54);
+    r54 = fmaf(r14, r44, r54);
+    r54 = fmaf(r15, r49, r54);
+    r49 = copysign(1.0, r54);
+    r49 = fmaf(r10, r49, r54);
+    r54 = r49 * r49;
+    r44 = 1.0 / r54;
+    r35 = r33 * r33;
+    r35 = fmaf(r44, r35, r44 * r48);
+    r48 = sqrtf(r35);
+    r36 = atanf(r48);
+    r11 = r33 * r36;
+    r50 = copysign(1.0, r48);
+    r50 = fmaf(r10, r50, r48);
+    r10 = r50 * r50;
+    r48 = 1.0 / r10;
+    r46 = r44 * r48;
+    r51 = r33 * r36;
+    r11 = r11 * r46;
+    r11 = r11 * r51;
+    r26 = r47 * r36;
+    r55 = r26 * r46;
+    r56 = r47 * r55;
+    r57 = r36 * r56;
+    r58 = r11 + r57;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r59,
+                       r60,
+                       r61,
+                       r62);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r63 = 3.00000000000000000e+00;
+    r64 = r36 * r63;
+    r64 = fmaf(r56, r64, r11);
+    r11 = fmaf(r60, r64, r8 * r58);
+    r65 = r59 * r16;
+    r65 = r65 * r51;
+    r11 = fmaf(r55, r65, r11);
+    r66 = r58 * r58;
+    r67 = r58 * r66;
+    r68 = fmaf(r61, r67, r6 * r58);
+    r69 = r66 * r66;
+    r68 = fmaf(r62, r69, r68);
+    r68 = fmaf(r7, r66, r68);
+    r70 = 1.0 / r49;
+    r71 = 1.0 / r50;
+    r72 = r70 * r71;
+    r73 = r68 * r72;
+    r11 = fmaf(r26, r73, r11);
+    r11 = fmaf(r26, r72, r11);
+    r2 = fmaf(r0, r11, r2);
+    r65 = r33 * r36;
+    r65 = r65 * r63;
+    r65 = r65 * r46;
+    r65 = fmaf(r51, r65, r57);
+    r57 = fmaf(r59, r65, r9 * r58);
+    r74 = r60 * r16;
+    r74 = r74 * r51;
+    r57 = fmaf(r55, r74, r57);
+    r57 = fmaf(r51, r73, r57);
+    r57 = fmaf(r72, r51, r57);
+    r1 = fmaf(r5, r57, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = fmaf(r1, r1, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r16 * r34;
+    r74 = r19 * r24;
+    r75 = 5.00000000000000000e-01;
+    r76 = r18 * r21;
+    r76 = fmaf(r75, r76, r75 * r74);
+    r74 = r17 * r22;
+    r77 = -5.00000000000000000e-01;
+    r76 = fmaf(r77, r74, r76);
+    r78 = r20 * r23;
+    r76 = fmaf(r75, r78, r76);
+    r78 = r17 * r24;
+    r74 = r20 * r21;
+    r74 = fmaf(r77, r74, r77 * r78);
+    r78 = r19 * r22;
+    r74 = fmaf(r77, r78, r74);
+    r79 = r18 * r23;
+    r74 = fmaf(r75, r79, r74);
+    r79 = r29 * r74;
+    r3 = fmaf(r16, r79, r76 * r3);
+    r78 = r16 * r25;
+    r80 = fmaf(r75, r31, r77 * r27);
+    r80 = fmaf(r77, r28, r80);
+    r80 = fmaf(r77, r30, r80);
+    r81 = r16 * r32;
+    r82 = r20 * r24;
+    r83 = r17 * r21;
+    r83 = fmaf(r77, r83, r75 * r82);
+    r82 = r18 * r22;
+    r83 = fmaf(r77, r82, r83);
+    r84 = r19 * r23;
+    r83 = fmaf(r77, r84, r83);
+    r81 = r81 * r83;
+    r78 = fmaf(r80, r78, r81);
+    r3 = r3 + r78;
+    r84 = r16 * r29;
+    r84 = r84 * r83;
+    r82 = r16 * r25;
+    r82 = r82 * r76;
+    r85 = r84 + r82;
+    r86 = r32 * r40;
+    r85 = fmaf(r74, r86, r85);
+    r87 = r40 * r34;
+    r85 = fmaf(r80, r87, r85);
+    r85 = fmaf(r14, r85, r15 * r3);
+    r3 = r29 * r76;
+    r87 = -4.00000000000000000e+00;
+    r3 = r3 * r87;
+    r86 = r32 * r80;
+    r88 = r87 * r86;
+    r89 = r3 + r88;
+    r85 = fmaf(r13, r89, r85);
+    r89 = r36 * r85;
+    r90 = 6.00000000000000000e+00;
+    r89 = r89 * r90;
+    r91 = r16 * r33;
+    r92 = r25 * r40;
+    r93 = r34 * r83;
+    r94 = r40 * r93;
+    r92 = fmaf(r74, r92, r94);
+    r95 = r16 * r29;
+    r95 = r95 * r80;
+    r96 = r16 * r32;
+    r96 = fmaf(r76, r96, r95);
+    r92 = r92 + r96;
+    r97 = r25 * r83;
+    r97 = r97 * r87;
+    r88 = r97 + r88;
+    r88 = fmaf(r14, r88, r15 * r92);
+    r92 = r16 * r34;
+    r92 = fmaf(r80, r92, r82);
+    r82 = r16 * r32;
+    r82 = fmaf(r74, r82, r84);
+    r92 = r92 + r82;
+    r88 = fmaf(r13, r92, r88);
+    r91 = r91 * r88;
+    r92 = r16 * r47;
+    r92 = r92 * r85;
+    r92 = fmaf(r44, r92, r44 * r91);
+    r91 = r16 * r25;
+    r91 = r91 * r74;
+    r93 = r16 * r93;
+    r84 = r91 + r93;
+    r96 = r96 + r84;
+    r98 = r40 * r34;
+    r98 = fmaf(r40, r79, r76 * r98);
+    r98 = r98 + r78;
+    r98 = fmaf(r13, r98, r14 * r96);
+    r3 = r97 + r3;
+    r98 = fmaf(r15, r3, r98);
+    r3 = r33 * r33;
+    r54 = r49 * r54;
+    r97 = 1.0 / r54;
+    r96 = r40 * r97;
+    r3 = r3 * r96;
+    r76 = r47 * r47;
+    r76 = r76 * r98;
+    r92 = fmaf(r96, r76, r92);
+    r92 = fmaf(r98, r3, r92);
+    r76 = r63 * r92;
+    r99 = rsqrtf(r35);
+    r35 = r41 + r35;
+    r35 = 1.0 / r35;
+    r41 = r99 * r35;
+    r100 = r41 * r56;
+    r76 = fmaf(r100, r76, r55 * r89);
+    r89 = r47 * r26;
+    r101 = r36 * r98;
+    r102 = -6.00000000000000000e+00;
+    r101 = r101 * r102;
+    r101 = r101 * r48;
+    r101 = r101 * r97;
+    r76 = fmaf(r101, r89, r76);
+    r103 = r47 * r26;
+    r104 = -3.00000000000000000e+00;
+    r104 = r36 * r104;
+    r10 = r50 * r10;
+    r105 = 1.0 / r10;
+    r104 = r104 * r44;
+    r104 = r104 * r99;
+    r104 = r104 * r105;
+    r103 = r103 * r104;
+    r106 = r16 * r36;
+    r107 = r46 * r51;
+    r108 = r106 * r107;
+    r109 = r92 * r107;
+    r110 = r33 * r41;
+    r109 = fmaf(r110, r109, r88 * r108);
+    r111 = r4 * r33;
+    r111 = r111 * r33;
+    r111 = r111 * r36;
+    r111 = r111 * r36;
+    r111 = r111 * r92;
+    r111 = r111 * r44;
+    r111 = r111 * r99;
+    r109 = fmaf(r105, r111, r109);
+    r112 = r36 * r3;
+    r113 = r36 * r48;
+    r113 = r113 * r96;
+    r113 = r112 * r113;
+    r109 = fmaf(r98, r113, r109);
+    r76 = fmaf(r92, r103, r76);
+    r76 = r76 + r109;
+    r89 = r85 * r55;
+    r89 = fmaf(r92, r100, r106 * r89);
+    r111 = r47 * r36;
+    r111 = r111 * r98;
+    r111 = r111 * r48;
+    r111 = r111 * r26;
+    r89 = fmaf(r96, r111, r89);
+    r114 = r4 * r47;
+    r114 = r114 * r36;
+    r114 = r114 * r92;
+    r114 = r114 * r44;
+    r114 = r114 * r99;
+    r114 = r114 * r105;
+    r89 = fmaf(r26, r114, r89);
+    r109 = r109 + r89;
+    r76 = fmaf(r8, r109, r60 * r76);
+    r114 = r77 * r92;
+    r114 = r114 * r48;
+    r114 = r114 * r70;
+    r114 = r114 * r99;
+    r111 = r68 * r114;
+    r115 = r59 * r92;
+    r116 = r16 * r55;
+    r116 = r116 * r110;
+    r76 = fmaf(r116, r115, r76);
+    r117 = r87 * r48;
+    r117 = r117 * r97;
+    r117 = r117 * r26;
+    r117 = r117 * r51;
+    r118 = r59 * r117;
+    r119 = r47 * r92;
+    r120 = r75 * r73;
+    r119 = r119 * r41;
+    r76 = fmaf(r120, r119, r76);
+    r121 = r59 * r85;
+    r76 = fmaf(r108, r121, r76);
+    r122 = r36 * r85;
+    r76 = fmaf(r72, r122, r76);
+    r123 = r4 * r98;
+    r123 = r123 * r44;
+    r123 = r123 * r71;
+    r76 = fmaf(r26, r123, r76);
+    r124 = r4 * r68;
+    r124 = r124 * r98;
+    r124 = r124 * r44;
+    r124 = r124 * r71;
+    r76 = fmaf(r26, r124, r76);
+    r125 = r47 * r75;
+    r125 = r125 * r92;
+    r125 = r125 * r72;
+    r76 = fmaf(r41, r125, r76);
+    r126 = r59 * r40;
+    r126 = r126 * r92;
+    r126 = r126 * r44;
+    r126 = r126 * r99;
+    r126 = r126 * r105;
+    r126 = r126 * r26;
+    r76 = fmaf(r51, r126, r76);
+    r127 = r7 * r16;
+    r127 = r127 * r58;
+    r127 = fmaf(r109, r127, r6 * r109);
+    r128 = 4.00000000000000000e+00;
+    r62 = r62 * r128;
+    r62 = r62 * r67;
+    r61 = r61 * r63;
+    r61 = r61 * r66;
+    r127 = fmaf(r109, r62, r127);
+    r127 = fmaf(r109, r61, r127);
+    r129 = r127 * r26;
+    r76 = fmaf(r72, r129, r76);
+    r130 = r59 * r88;
+    r130 = r130 * r55;
+    r76 = fmaf(r106, r130, r76);
+    r131 = r36 * r85;
+    r76 = fmaf(r73, r131, r76);
+    r76 = fmaf(r26, r111, r76);
+    r76 = fmaf(r26, r114, r76);
+    r76 = fmaf(r98, r118, r76);
+    r131 = r0 * r76;
+    r130 = r36 * r88;
+    r130 = r130 * r90;
+    r130 = r130 * r46;
+    r129 = r63 * r92;
+    r129 = r129 * r107;
+    r129 = fmaf(r110, r129, r51 * r130);
+    r130 = r92 * r104;
+    r129 = fmaf(r112, r130, r129);
+    r126 = r33 * r33;
+    r126 = r126 * r36;
+    r129 = fmaf(r101, r126, r129);
+    r129 = r129 + r89;
+    r109 = fmaf(r9, r109, r59 * r129);
+    r129 = r75 * r92;
+    r129 = r129 * r72;
+    r109 = fmaf(r110, r129, r109);
+    r89 = r127 * r72;
+    r109 = fmaf(r51, r89, r109);
+    r126 = r4 * r33;
+    r126 = r126 * r36;
+    r126 = r126 * r68;
+    r126 = r126 * r98;
+    r126 = r126 * r44;
+    r109 = fmaf(r71, r126, r109);
+    r130 = r60 * r98;
+    r109 = fmaf(r117, r130, r109);
+    r101 = r60 * r108;
+    r125 = r60 * r92;
+    r109 = fmaf(r116, r125, r109);
+    r124 = r4 * r33;
+    r124 = r124 * r36;
+    r124 = r124 * r98;
+    r124 = r124 * r44;
+    r109 = fmaf(r71, r124, r109);
+    r123 = r60 * r40;
+    r123 = r123 * r92;
+    r123 = r123 * r44;
+    r123 = r123 * r99;
+    r123 = r123 * r105;
+    r123 = r123 * r26;
+    r109 = fmaf(r51, r123, r109);
+    r122 = r110 * r120;
+    r121 = r60 * r88;
+    r121 = r121 * r55;
+    r109 = fmaf(r106, r121, r109);
+    r119 = r36 * r88;
+    r109 = fmaf(r73, r119, r109);
+    r115 = r36 * r88;
+    r109 = fmaf(r72, r115, r109);
+    r109 = fmaf(r51, r111, r109);
+    r109 = fmaf(r85, r101, r109);
+    r109 = fmaf(r92, r122, r109);
+    r109 = fmaf(r114, r51, r109);
+    r115 = r5 * r109;
+    r119 = r47 * r47;
+    r119 = r44 * r119;
+    r114 = r16 * r47;
+    r93 = r95 + r93;
+    r95 = r16 * r32;
+    r121 = r19 * r24;
+    r123 = r18 * r21;
+    r123 = fmaf(r77, r123, r77 * r121);
+    r121 = r17 * r22;
+    r123 = fmaf(r75, r121, r123);
+    r124 = r20 * r23;
+    r123 = fmaf(r77, r124, r123);
+    r95 = r95 * r123;
+    r124 = r16 * r25;
+    r121 = r17 * r24;
+    r125 = r20 * r21;
+    r125 = fmaf(r75, r125, r75 * r121);
+    r121 = r19 * r22;
+    r125 = fmaf(r75, r121, r125);
+    r130 = r18 * r23;
+    r125 = fmaf(r77, r130, r125);
+    r124 = fmaf(r125, r124, r95);
+    r93 = r93 + r124;
+    r130 = r32 * r87;
+    r130 = r130 * r125;
+    r121 = r29 * r83;
+    r121 = r121 * r87;
+    r126 = r130 + r121;
+    r126 = fmaf(r13, r126, r15 * r93);
+    r93 = r40 * r34;
+    r93 = fmaf(r40, r86, r125 * r93);
+    r89 = r16 * r25;
+    r89 = r89 * r83;
+    r111 = r16 * r29;
+    r111 = fmaf(r123, r111, r89);
+    r93 = r93 + r111;
+    r126 = fmaf(r14, r93, r126);
+    r114 = r114 * r126;
+    r93 = r47 * r47;
+    r129 = r40 * r29;
+    r129 = fmaf(r80, r129, r94);
+    r129 = r129 + r124;
+    r124 = r16 * r29;
+    r124 = r124 * r125;
+    r132 = r16 * r34;
+    r132 = fmaf(r123, r132, r124);
+    r132 = r132 + r78;
+    r132 = fmaf(r14, r132, r13 * r129);
+    r129 = r25 * r123;
+    r78 = r87 * r129;
+    r121 = r121 + r78;
+    r132 = fmaf(r15, r121, r132);
+    r93 = r93 * r132;
+    r93 = fmaf(r96, r93, r44 * r114);
+    r114 = r16 * r33;
+    r121 = r25 * r40;
+    r121 = fmaf(r80, r121, r81);
+    r81 = r40 * r34;
+    r121 = fmaf(r123, r81, r121);
+    r121 = r121 + r124;
+    r81 = r16 * r34;
+    r86 = fmaf(r16, r86, r125 * r81);
+    r86 = r86 + r111;
+    r86 = fmaf(r13, r86, r15 * r121);
+    r78 = r130 + r78;
+    r86 = fmaf(r14, r78, r86);
+    r114 = r114 * r86;
+    r93 = fmaf(r44, r114, r93);
+    r93 = fmaf(r132, r3, r93);
+    r119 = r119 * r48;
+    r119 = r119 * r36;
+    r119 = r119 * r99;
+    r119 = r119 * r35;
+    r119 = r119 * r93;
+    r35 = r4 * r47;
+    r35 = r35 * r36;
+    r35 = r35 * r93;
+    r35 = r35 * r44;
+    r35 = r35 * r99;
+    r35 = r35 * r105;
+    r35 = fmaf(r26, r35, r119);
+    r114 = r47 * r36;
+    r114 = r114 * r132;
+    r114 = r114 * r48;
+    r114 = r114 * r26;
+    r35 = fmaf(r96, r114, r35);
+    r78 = r126 * r55;
+    r35 = fmaf(r106, r78, r35);
+    r78 = r4 * r33;
+    r78 = r78 * r33;
+    r78 = r78 * r36;
+    r78 = r78 * r36;
+    r78 = r78 * r93;
+    r78 = r78 * r44;
+    r78 = r78 * r99;
+    r78 = fmaf(r105, r78, r86 * r108);
+    r114 = r93 * r107;
+    r78 = fmaf(r110, r114, r78);
+    r78 = fmaf(r132, r113, r78);
+    r114 = r35 + r78;
+    r119 = fmaf(r93, r103, r63 * r119);
+    r130 = r47 * r36;
+    r130 = r130 * r102;
+    r130 = r130 * r132;
+    r130 = r130 * r48;
+    r130 = r130 * r97;
+    r119 = fmaf(r26, r130, r119);
+    r121 = r36 * r90;
+    r121 = r121 * r126;
+    r119 = fmaf(r55, r121, r119);
+    r119 = r119 + r78;
+    r119 = fmaf(r60, r119, r8 * r114);
+    r78 = r59 * r86;
+    r78 = r78 * r55;
+    r119 = fmaf(r106, r78, r119);
+    r121 = r77 * r93;
+    r121 = r121 * r48;
+    r121 = r121 * r70;
+    r121 = r121 * r99;
+    r119 = fmaf(r26, r121, r119);
+    r130 = r4 * r132;
+    r130 = r130 * r44;
+    r130 = r130 * r71;
+    r119 = fmaf(r26, r130, r119);
+    r81 = r47 * r93;
+    r81 = r81 * r41;
+    r119 = fmaf(r120, r81, r119);
+    r125 = r36 * r126;
+    r119 = fmaf(r73, r125, r119);
+    r124 = r59 * r40;
+    r124 = r124 * r93;
+    r124 = r124 * r44;
+    r124 = r124 * r99;
+    r124 = r124 * r105;
+    r124 = r124 * r26;
+    r119 = fmaf(r51, r124, r119);
+    r80 = r59 * r93;
+    r119 = fmaf(r116, r80, r119);
+    r133 = r47 * r75;
+    r133 = r133 * r93;
+    r133 = r133 * r72;
+    r119 = fmaf(r41, r133, r119);
+    r134 = r4 * r68;
+    r134 = r134 * r132;
+    r134 = r134 * r44;
+    r134 = r134 * r71;
+    r119 = fmaf(r26, r134, r119);
+    r135 = r59 * r126;
+    r119 = fmaf(r108, r135, r119);
+    r136 = r7 * r16;
+    r136 = r136 * r58;
+    r136 = fmaf(r114, r136, r6 * r114);
+    r136 = fmaf(r114, r62, r136);
+    r136 = fmaf(r114, r61, r136);
+    r137 = r136 * r26;
+    r119 = fmaf(r72, r137, r119);
+    r138 = r68 * r77;
+    r138 = r138 * r93;
+    r138 = r138 * r48;
+    r138 = r138 * r70;
+    r138 = r138 * r99;
+    r119 = fmaf(r26, r138, r119);
+    r139 = r36 * r126;
+    r119 = fmaf(r72, r139, r119);
+    r119 = fmaf(r132, r118, r119);
+    r139 = r0 * r119;
+    r138 = r36 * r90;
+    r138 = r138 * r86;
+    r138 = r138 * r46;
+    r137 = r93 * r104;
+    r137 = fmaf(r112, r137, r51 * r138);
+    r138 = r33 * r33;
+    r138 = r138 * r36;
+    r138 = r138 * r36;
+    r138 = r138 * r102;
+    r138 = r138 * r132;
+    r138 = r138 * r48;
+    r137 = fmaf(r97, r138, r137);
+    r135 = r63 * r93;
+    r135 = r135 * r107;
+    r137 = fmaf(r110, r135, r137);
+    r137 = r137 + r35;
+    r137 = fmaf(r59, r137, r9 * r114);
+    r114 = r4 * r33;
+    r114 = r114 * r36;
+    r114 = r114 * r132;
+    r114 = r114 * r44;
+    r137 = fmaf(r71, r114, r137);
+    r35 = r60 * r86;
+    r35 = r35 * r55;
+    r137 = fmaf(r106, r35, r137);
+    r135 = r60 * r132;
+    r137 = fmaf(r117, r135, r137);
+    r138 = r33 * r36;
+    r138 = r138 * r68;
+    r138 = r138 * r77;
+    r138 = r138 * r93;
+    r138 = r138 * r48;
+    r138 = r138 * r70;
+    r137 = fmaf(r99, r138, r137);
+    r134 = r136 * r72;
+    r137 = fmaf(r51, r134, r137);
+    r133 = r75 * r93;
+    r133 = r133 * r72;
+    r137 = fmaf(r110, r133, r137);
+    r80 = r33 * r36;
+    r80 = r80 * r77;
+    r80 = r80 * r93;
+    r80 = r80 * r48;
+    r80 = r80 * r70;
+    r137 = fmaf(r99, r80, r137);
+    r124 = r60 * r40;
+    r124 = r124 * r93;
+    r124 = r124 * r44;
+    r124 = r124 * r99;
+    r124 = r124 * r105;
+    r124 = r124 * r26;
+    r137 = fmaf(r51, r124, r137);
+    r125 = r60 * r93;
+    r137 = fmaf(r116, r125, r137);
+    r81 = r36 * r86;
+    r137 = fmaf(r73, r81, r137);
+    r130 = r4 * r33;
+    r130 = r130 * r36;
+    r130 = r130 * r68;
+    r130 = r130 * r132;
+    r130 = r130 * r44;
+    r137 = fmaf(r71, r130, r137);
+    r121 = r36 * r86;
+    r137 = fmaf(r72, r121, r137);
+    r137 = fmaf(r93, r122, r137);
+    r137 = fmaf(r126, r101, r137);
+    r121 = r5 * r137;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r131,
+                                          r115,
+                                          r139,
+                                          r121);
+    r121 = r47 * r47;
+    r139 = r25 * r87;
+    r31 = fmaf(r77, r31, r75 * r27);
+    r31 = fmaf(r75, r28, r31);
+    r31 = fmaf(r75, r30, r31);
+    r139 = r139 * r31;
+    r79 = r87 * r79;
+    r30 = r139 + r79;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r89 = r89 + r28;
+    r27 = r40 * r29;
+    r89 = fmaf(r123, r27, r89);
+    r115 = r40 * r34;
+    r89 = fmaf(r74, r115, r89);
+    r89 = fmaf(r13, r89, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r129, r31 * r30);
+    r30 = r30 + r82;
+    r89 = fmaf(r14, r30, r89);
+    r121 = r121 * r89;
+    r30 = r16 * r47;
+    r115 = r16 * r29;
+    r115 = r115 * r31;
+    r91 = r91 + r115;
+    r27 = r32 * r40;
+    r91 = fmaf(r123, r27, r91);
+    r91 = r91 + r94;
+    r83 = r32 * r83;
+    r83 = r83 * r87;
+    r79 = r83 + r79;
+    r79 = fmaf(r13, r79, r14 * r91);
+    r91 = r16 * r34;
+    r91 = fmaf(r74, r91, r28);
+    r91 = r91 + r111;
+    r79 = fmaf(r15, r91, r79);
+    r30 = r30 * r79;
+    r30 = fmaf(r44, r30, r96 * r121);
+    r121 = r16 * r33;
+    r115 = r95 + r115;
+    r115 = r115 + r84;
+    r84 = r40 * r34;
+    r129 = fmaf(r40, r129, r31 * r84);
+    r129 = r129 + r82;
+    r129 = fmaf(r15, r129, r13 * r115);
+    r83 = r139 + r83;
+    r129 = fmaf(r14, r83, r129);
+    r121 = r121 * r129;
+    r30 = fmaf(r44, r121, r30);
+    r30 = fmaf(r89, r3, r30);
+    r121 = r30 * r107;
+    r121 = fmaf(r129, r108, r110 * r121);
+    r83 = r4 * r33;
+    r83 = r83 * r33;
+    r83 = r83 * r36;
+    r83 = r83 * r36;
+    r83 = r83 * r30;
+    r83 = r83 * r44;
+    r83 = r83 * r99;
+    r121 = fmaf(r105, r83, r121);
+    r121 = fmaf(r89, r113, r121);
+    r83 = r47 * r36;
+    r83 = r83 * r89;
+    r83 = r83 * r48;
+    r83 = r83 * r26;
+    r83 = fmaf(r30, r100, r96 * r83);
+    r14 = r4 * r47;
+    r14 = r14 * r36;
+    r14 = r14 * r30;
+    r14 = r14 * r44;
+    r14 = r14 * r99;
+    r14 = r14 * r105;
+    r83 = fmaf(r26, r14, r83);
+    r139 = r79 * r55;
+    r83 = fmaf(r106, r139, r83);
+    r139 = r121 + r83;
+    r14 = r47 * r36;
+    r14 = r14 * r102;
+    r14 = r14 * r89;
+    r14 = r14 * r48;
+    r14 = r14 * r97;
+    r15 = r63 * r30;
+    r15 = fmaf(r100, r15, r26 * r14);
+    r14 = r36 * r90;
+    r14 = r14 * r79;
+    r15 = fmaf(r55, r14, r15);
+    r15 = fmaf(r30, r103, r15);
+    r15 = r15 + r121;
+    r15 = fmaf(r60, r15, r8 * r139);
+    r121 = r7 * r16;
+    r121 = r121 * r58;
+    r121 = fmaf(r139, r121, r6 * r139);
+    r121 = fmaf(r139, r61, r121);
+    r121 = fmaf(r139, r62, r121);
+    r14 = r121 * r26;
+    r15 = fmaf(r72, r14, r15);
+    r115 = r47 * r75;
+    r115 = r115 * r30;
+    r115 = r115 * r72;
+    r15 = fmaf(r41, r115, r15);
+    r13 = r68 * r77;
+    r13 = r13 * r30;
+    r13 = r13 * r48;
+    r13 = r13 * r70;
+    r13 = r13 * r99;
+    r15 = fmaf(r26, r13, r15);
+    r82 = r4 * r89;
+    r82 = r82 * r44;
+    r82 = r82 * r71;
+    r15 = fmaf(r26, r82, r15);
+    r84 = r59 * r40;
+    r84 = r84 * r30;
+    r84 = r84 * r44;
+    r84 = r84 * r99;
+    r84 = r84 * r105;
+    r84 = r84 * r26;
+    r15 = fmaf(r51, r84, r15);
+    r31 = r36 * r79;
+    r15 = fmaf(r73, r31, r15);
+    r95 = r59 * r79;
+    r15 = fmaf(r108, r95, r15);
+    r91 = r47 * r30;
+    r91 = r91 * r41;
+    r15 = fmaf(r120, r91, r15);
+    r111 = r59 * r129;
+    r111 = r111 * r55;
+    r15 = fmaf(r106, r111, r15);
+    r28 = r77 * r30;
+    r28 = r28 * r48;
+    r28 = r28 * r70;
+    r28 = r28 * r99;
+    r15 = fmaf(r26, r28, r15);
+    r74 = r4 * r68;
+    r74 = r74 * r89;
+    r74 = r74 * r44;
+    r74 = r74 * r71;
+    r15 = fmaf(r26, r74, r15);
+    r87 = r36 * r79;
+    r15 = fmaf(r72, r87, r15);
+    r94 = r59 * r30;
+    r15 = fmaf(r116, r94, r15);
+    r15 = fmaf(r89, r118, r15);
+    r94 = r0 * r15;
+    r87 = r63 * r30;
+    r87 = r87 * r107;
+    r74 = r36 * r90;
+    r74 = r74 * r129;
+    r74 = r74 * r46;
+    r74 = fmaf(r51, r74, r110 * r87);
+    r87 = r33 * r33;
+    r87 = r87 * r36;
+    r87 = r87 * r36;
+    r87 = r87 * r102;
+    r87 = r87 * r89;
+    r87 = r87 * r48;
+    r74 = fmaf(r97, r87, r74);
+    r28 = r30 * r104;
+    r74 = fmaf(r112, r28, r74);
+    r74 = r74 + r83;
+    r74 = fmaf(r59, r74, r9 * r139);
+    r139 = r60 * r89;
+    r74 = fmaf(r117, r139, r74);
+    r83 = r33 * r36;
+    r83 = r83 * r77;
+    r83 = r83 * r30;
+    r83 = r83 * r48;
+    r83 = r83 * r70;
+    r74 = fmaf(r99, r83, r74);
+    r28 = r75 * r30;
+    r28 = r28 * r72;
+    r74 = fmaf(r110, r28, r74);
+    r87 = r4 * r33;
+    r87 = r87 * r36;
+    r87 = r87 * r68;
+    r87 = r87 * r89;
+    r87 = r87 * r44;
+    r74 = fmaf(r71, r87, r74);
+    r111 = r36 * r129;
+    r74 = fmaf(r73, r111, r74);
+    r91 = r60 * r40;
+    r91 = r91 * r30;
+    r91 = r91 * r44;
+    r91 = r91 * r99;
+    r91 = r91 * r105;
+    r91 = r91 * r26;
+    r74 = fmaf(r51, r91, r74);
+    r95 = r33 * r36;
+    r95 = r95 * r68;
+    r95 = r95 * r77;
+    r95 = r95 * r30;
+    r95 = r95 * r48;
+    r95 = r95 * r70;
+    r74 = fmaf(r99, r95, r74);
+    r31 = r60 * r129;
+    r31 = r31 * r55;
+    r74 = fmaf(r106, r31, r74);
+    r84 = r4 * r33;
+    r84 = r84 * r36;
+    r84 = r84 * r89;
+    r84 = r84 * r44;
+    r74 = fmaf(r71, r84, r74);
+    r82 = r60 * r30;
+    r74 = fmaf(r116, r82, r74);
+    r13 = r36 * r129;
+    r74 = fmaf(r72, r13, r74);
+    r115 = r121 * r72;
+    r74 = fmaf(r51, r115, r74);
+    r74 = fmaf(r79, r101, r74);
+    r74 = fmaf(r30, r122, r74);
+    r115 = r5 * r74;
+    r13 = r12 * r47;
+    r13 = r13 * r36;
+    r13 = r13 * r102;
+    r13 = r13 * r48;
+    r13 = r13 * r97;
+    r82 = r42 * r36;
+    r82 = r82 * r90;
+    r82 = fmaf(r55, r82, r26 * r13);
+    r13 = r16 * r38;
+    r13 = r13 * r33;
+    r13 = fmaf(r44, r13, r12 * r3);
+    r84 = r12 * r47;
+    r84 = r84 * r47;
+    r13 = fmaf(r96, r84, r13);
+    r31 = r16 * r42;
+    r31 = r31 * r47;
+    r13 = fmaf(r44, r31, r13);
+    r31 = r63 * r13;
+    r82 = fmaf(r100, r31, r82);
+    r84 = fmaf(r38, r108, r12 * r113);
+    r95 = r4 * r33;
+    r95 = r95 * r33;
+    r95 = r95 * r36;
+    r95 = r95 * r36;
+    r95 = r95 * r13;
+    r95 = r95 * r44;
+    r95 = r95 * r99;
+    r84 = fmaf(r105, r95, r84);
+    r91 = r13 * r107;
+    r84 = fmaf(r110, r91, r84);
+    r82 = fmaf(r13, r103, r82);
+    r82 = r82 + r84;
+    r31 = r12 * r47;
+    r31 = r31 * r36;
+    r31 = r31 * r48;
+    r31 = r31 * r26;
+    r91 = r42 * r55;
+    r91 = fmaf(r106, r91, r96 * r31);
+    r31 = r4 * r47;
+    r31 = r31 * r36;
+    r31 = r31 * r13;
+    r31 = r31 * r44;
+    r31 = r31 * r99;
+    r31 = r31 * r105;
+    r91 = fmaf(r26, r31, r91);
+    r91 = fmaf(r13, r100, r91);
+    r84 = r84 + r91;
+    r82 = fmaf(r8, r84, r60 * r82);
+    r31 = r4 * r12;
+    r31 = r31 * r44;
+    r31 = r31 * r71;
+    r82 = fmaf(r26, r31, r82);
+    r95 = r42 * r36;
+    r82 = fmaf(r72, r95, r82);
+    r111 = r68 * r77;
+    r111 = r111 * r13;
+    r111 = r111 * r48;
+    r111 = r111 * r70;
+    r111 = r111 * r99;
+    r82 = fmaf(r26, r111, r82);
+    r87 = r59 * r40;
+    r87 = r87 * r13;
+    r87 = r87 * r44;
+    r87 = r87 * r99;
+    r87 = r87 * r105;
+    r87 = r87 * r26;
+    r82 = fmaf(r51, r87, r82);
+    r28 = r42 * r36;
+    r82 = fmaf(r73, r28, r82);
+    r83 = r59 * r13;
+    r82 = fmaf(r116, r83, r82);
+    r139 = r59 * r42;
+    r82 = fmaf(r108, r139, r82);
+    r14 = r77 * r13;
+    r14 = r14 * r48;
+    r14 = r14 * r70;
+    r14 = r14 * r99;
+    r82 = fmaf(r26, r14, r82);
+    r27 = r47 * r13;
+    r27 = r27 * r41;
+    r82 = fmaf(r120, r27, r82);
+    r123 = r47 * r75;
+    r123 = r123 * r13;
+    r123 = r123 * r72;
+    r82 = fmaf(r41, r123, r82);
+    r131 = r59 * r38;
+    r131 = r131 * r55;
+    r82 = fmaf(r106, r131, r82);
+    r130 = r7 * r16;
+    r130 = r130 * r58;
+    r130 = fmaf(r6, r84, r84 * r130);
+    r130 = fmaf(r84, r62, r130);
+    r130 = fmaf(r84, r61, r130);
+    r81 = r130 * r26;
+    r82 = fmaf(r72, r81, r82);
+    r125 = r4 * r12;
+    r125 = r125 * r68;
+    r125 = r125 * r44;
+    r125 = r125 * r71;
+    r82 = fmaf(r26, r125, r82);
+    r82 = fmaf(r12, r118, r82);
+    r125 = r0 * r82;
+    r81 = r12 * r33;
+    r81 = r81 * r33;
+    r81 = r81 * r36;
+    r81 = r81 * r36;
+    r81 = r81 * r102;
+    r81 = r81 * r48;
+    r131 = r38 * r36;
+    r131 = r131 * r90;
+    r131 = r131 * r46;
+    r131 = fmaf(r51, r131, r97 * r81);
+    r81 = r13 * r104;
+    r131 = fmaf(r112, r81, r131);
+    r123 = r63 * r13;
+    r123 = r123 * r107;
+    r131 = fmaf(r110, r123, r131);
+    r131 = r131 + r91;
+    r84 = fmaf(r9, r84, r59 * r131);
+    r131 = r4 * r12;
+    r131 = r131 * r33;
+    r131 = r131 * r36;
+    r131 = r131 * r44;
+    r84 = fmaf(r71, r131, r84);
+    r91 = r4 * r12;
+    r91 = r91 * r33;
+    r91 = r91 * r36;
+    r91 = r91 * r68;
+    r91 = r91 * r44;
+    r84 = fmaf(r71, r91, r84);
+    r123 = r33 * r36;
+    r123 = r123 * r77;
+    r123 = r123 * r13;
+    r123 = r123 * r48;
+    r123 = r123 * r70;
+    r84 = fmaf(r99, r123, r84);
+    r81 = r33 * r36;
+    r81 = r81 * r68;
+    r81 = r81 * r77;
+    r81 = r81 * r13;
+    r81 = r81 * r48;
+    r81 = r81 * r70;
+    r84 = fmaf(r99, r81, r84);
+    r27 = r38 * r36;
+    r84 = fmaf(r72, r27, r84);
+    r14 = r38 * r36;
+    r84 = fmaf(r73, r14, r84);
+    r139 = r60 * r40;
+    r139 = r139 * r13;
+    r139 = r139 * r44;
+    r139 = r139 * r99;
+    r139 = r139 * r105;
+    r139 = r139 * r26;
+    r84 = fmaf(r51, r139, r84);
+    r83 = r60 * r13;
+    r84 = fmaf(r116, r83, r84);
+    r28 = r75 * r13;
+    r28 = r28 * r72;
+    r84 = fmaf(r110, r28, r84);
+    r87 = r60 * r12;
+    r84 = fmaf(r117, r87, r84);
+    r111 = r60 * r38;
+    r111 = r111 * r55;
+    r84 = fmaf(r106, r111, r84);
+    r95 = r130 * r72;
+    r84 = fmaf(r51, r95, r84);
+    r84 = fmaf(r42, r101, r84);
+    r84 = fmaf(r13, r122, r84);
+    r95 = r5 * r84;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r115,
+                                          r125,
+                                          r95);
+    r95 = r16 * r43;
+    r95 = r95 * r33;
+    r95 = fmaf(r44, r95, r39 * r3);
+    r125 = r39 * r47;
+    r125 = r125 * r47;
+    r95 = fmaf(r96, r125, r95);
+    r115 = r16 * r53;
+    r115 = r115 * r47;
+    r95 = fmaf(r44, r115, r95);
+    r115 = r95 * r107;
+    r115 = fmaf(r39, r113, r110 * r115);
+    r125 = r4 * r33;
+    r125 = r125 * r33;
+    r125 = r125 * r36;
+    r125 = r125 * r36;
+    r125 = r125 * r95;
+    r125 = r125 * r44;
+    r125 = r125 * r99;
+    r115 = fmaf(r105, r125, r115);
+    r115 = fmaf(r43, r108, r115);
+    r125 = r39 * r47;
+    r125 = r125 * r36;
+    r125 = r125 * r48;
+    r125 = r125 * r26;
+    r125 = fmaf(r96, r125, r95 * r100);
+    r94 = r53 * r55;
+    r125 = fmaf(r106, r94, r125);
+    r111 = r4 * r47;
+    r111 = r111 * r36;
+    r111 = r111 * r95;
+    r111 = r111 * r44;
+    r111 = r111 * r99;
+    r111 = r111 * r105;
+    r125 = fmaf(r26, r111, r125);
+    r111 = r115 + r125;
+    r94 = r63 * r95;
+    r87 = r39 * r47;
+    r87 = r87 * r36;
+    r87 = r87 * r102;
+    r87 = r87 * r48;
+    r87 = r87 * r97;
+    r87 = fmaf(r26, r87, r100 * r94);
+    r94 = r53 * r36;
+    r94 = r94 * r90;
+    r87 = fmaf(r55, r94, r87);
+    r87 = fmaf(r95, r103, r87);
+    r87 = r87 + r115;
+    r87 = fmaf(r60, r87, r8 * r111);
+    r115 = r53 * r36;
+    r87 = fmaf(r73, r115, r87);
+    r94 = r7 * r16;
+    r94 = r94 * r58;
+    r94 = fmaf(r111, r94, r6 * r111);
+    r94 = fmaf(r111, r62, r94);
+    r94 = fmaf(r111, r61, r94);
+    r28 = r94 * r26;
+    r87 = fmaf(r72, r28, r87);
+    r83 = r59 * r43;
+    r83 = r83 * r55;
+    r87 = fmaf(r106, r83, r87);
+    r139 = r77 * r95;
+    r139 = r139 * r48;
+    r139 = r139 * r70;
+    r139 = r139 * r99;
+    r87 = fmaf(r26, r139, r87);
+    r14 = r53 * r36;
+    r87 = fmaf(r72, r14, r87);
+    r27 = r59 * r95;
+    r87 = fmaf(r116, r27, r87);
+    r81 = r47 * r75;
+    r81 = r81 * r95;
+    r81 = r81 * r72;
+    r87 = fmaf(r41, r81, r87);
+    r123 = r59 * r40;
+    r123 = r123 * r95;
+    r123 = r123 * r44;
+    r123 = r123 * r99;
+    r123 = r123 * r105;
+    r123 = r123 * r26;
+    r87 = fmaf(r51, r123, r87);
+    r91 = r68 * r77;
+    r91 = r91 * r95;
+    r91 = r91 * r48;
+    r91 = r91 * r70;
+    r91 = r91 * r99;
+    r87 = fmaf(r26, r91, r87);
+    r131 = r47 * r95;
+    r131 = r131 * r41;
+    r87 = fmaf(r120, r131, r87);
+    r31 = r4 * r39;
+    r31 = r31 * r44;
+    r31 = r31 * r71;
+    r87 = fmaf(r26, r31, r87);
+    r124 = r59 * r53;
+    r87 = fmaf(r108, r124, r87);
+    r80 = r4 * r39;
+    r80 = r80 * r68;
+    r80 = r80 * r44;
+    r80 = r80 * r71;
+    r87 = fmaf(r26, r80, r87);
+    r87 = fmaf(r39, r118, r87);
+    r80 = r0 * r87;
+    r124 = r63 * r95;
+    r124 = r124 * r107;
+    r31 = r39 * r33;
+    r31 = r31 * r33;
+    r31 = r31 * r36;
+    r31 = r31 * r36;
+    r31 = r31 * r102;
+    r31 = r31 * r48;
+    r31 = fmaf(r97, r31, r110 * r124);
+    r124 = r43 * r36;
+    r124 = r124 * r90;
+    r124 = r124 * r46;
+    r31 = fmaf(r51, r124, r31);
+    r131 = r95 * r104;
+    r31 = fmaf(r112, r131, r31);
+    r31 = r31 + r125;
+    r31 = fmaf(r59, r31, r9 * r111);
+    r111 = r60 * r43;
+    r111 = r111 * r55;
+    r31 = fmaf(r106, r111, r31);
+    r125 = r4 * r39;
+    r125 = r125 * r33;
+    r125 = r125 * r36;
+    r125 = r125 * r44;
+    r31 = fmaf(r71, r125, r31);
+    r131 = r75 * r95;
+    r131 = r131 * r72;
+    r31 = fmaf(r110, r131, r31);
+    r124 = r60 * r95;
+    r31 = fmaf(r116, r124, r31);
+    r91 = r43 * r36;
+    r31 = fmaf(r73, r91, r31);
+    r123 = r60 * r39;
+    r31 = fmaf(r117, r123, r31);
+    r81 = r60 * r40;
+    r81 = r81 * r95;
+    r81 = r81 * r44;
+    r81 = r81 * r99;
+    r81 = r81 * r105;
+    r81 = r81 * r26;
+    r31 = fmaf(r51, r81, r31);
+    r27 = r43 * r36;
+    r31 = fmaf(r72, r27, r31);
+    r14 = r4 * r39;
+    r14 = r14 * r33;
+    r14 = r14 * r36;
+    r14 = r14 * r68;
+    r14 = r14 * r44;
+    r31 = fmaf(r71, r14, r31);
+    r139 = r33 * r36;
+    r139 = r139 * r68;
+    r139 = r139 * r77;
+    r139 = r139 * r95;
+    r139 = r139 * r48;
+    r139 = r139 * r70;
+    r31 = fmaf(r99, r139, r31);
+    r83 = r94 * r72;
+    r31 = fmaf(r51, r83, r31);
+    r28 = r33 * r36;
+    r28 = r28 * r77;
+    r28 = r28 * r95;
+    r28 = r28 * r48;
+    r28 = r28 * r70;
+    r31 = fmaf(r99, r28, r31);
+    r31 = fmaf(r95, r122, r31);
+    r31 = fmaf(r53, r101, r31);
+    r28 = r5 * r31;
+    r83 = r16 * r45;
+    r83 = r83 * r33;
+    r3 = fmaf(r37, r3, r44 * r83);
+    r83 = r16 * r52;
+    r83 = r83 * r47;
+    r3 = fmaf(r44, r83, r3);
+    r139 = r37 * r47;
+    r139 = r139 * r47;
+    r3 = fmaf(r96, r139, r3);
+    r139 = r3 * r107;
+    r139 = fmaf(r45, r108, r110 * r139);
+    r83 = r4 * r33;
+    r83 = r83 * r33;
+    r83 = r83 * r36;
+    r83 = r83 * r36;
+    r83 = r83 * r3;
+    r83 = r83 * r44;
+    r83 = r83 * r99;
+    r139 = fmaf(r105, r83, r139);
+    r139 = fmaf(r37, r113, r139);
+    r113 = r37 * r47;
+    r113 = r113 * r36;
+    r113 = r113 * r48;
+    r113 = r113 * r26;
+    r83 = r4 * r47;
+    r83 = r83 * r36;
+    r83 = r83 * r3;
+    r83 = r83 * r44;
+    r83 = r83 * r99;
+    r83 = r83 * r105;
+    r83 = fmaf(r26, r83, r96 * r113);
+    r113 = r52 * r55;
+    r83 = fmaf(r106, r113, r83);
+    r83 = fmaf(r3, r100, r83);
+    r113 = r139 + r83;
+    r96 = r37 * r47;
+    r96 = r96 * r36;
+    r96 = r96 * r102;
+    r96 = r96 * r48;
+    r96 = r96 * r97;
+    r103 = fmaf(r3, r103, r26 * r96);
+    r96 = r52 * r36;
+    r96 = r96 * r90;
+    r103 = fmaf(r55, r96, r103);
+    r14 = r63 * r3;
+    r103 = fmaf(r100, r14, r103);
+    r103 = r103 + r139;
+    r103 = fmaf(r60, r103, r8 * r113);
+    r8 = r4 * r37;
+    r8 = r8 * r68;
+    r8 = r8 * r44;
+    r8 = r8 * r71;
+    r103 = fmaf(r26, r8, r103);
+    r139 = r52 * r36;
+    r103 = fmaf(r72, r139, r103);
+    r14 = r4 * r37;
+    r14 = r14 * r44;
+    r14 = r14 * r71;
+    r103 = fmaf(r26, r14, r103);
+    r96 = r52 * r36;
+    r103 = fmaf(r73, r96, r103);
+    r100 = r47 * r3;
+    r100 = r100 * r41;
+    r103 = fmaf(r120, r100, r103);
+    r120 = r77 * r3;
+    r120 = r120 * r48;
+    r120 = r120 * r70;
+    r120 = r120 * r99;
+    r103 = fmaf(r26, r120, r103);
+    r27 = r59 * r40;
+    r27 = r27 * r3;
+    r27 = r27 * r44;
+    r27 = r27 * r99;
+    r27 = r27 * r105;
+    r27 = r27 * r26;
+    r103 = fmaf(r51, r27, r103);
+    r116 = r3 * r116;
+    r81 = r59 * r45;
+    r81 = r81 * r55;
+    r103 = fmaf(r106, r81, r103);
+    r123 = r59 * r52;
+    r103 = fmaf(r108, r123, r103);
+    r108 = r68 * r77;
+    r108 = r108 * r3;
+    r108 = r108 * r48;
+    r108 = r108 * r70;
+    r108 = r108 * r99;
+    r103 = fmaf(r26, r108, r103);
+    r91 = r47 * r75;
+    r91 = r91 * r3;
+    r91 = r91 * r72;
+    r103 = fmaf(r41, r91, r103);
+    r41 = r7 * r16;
+    r41 = r41 * r58;
+    r6 = fmaf(r6, r113, r113 * r41);
+    r6 = fmaf(r113, r62, r6);
+    r6 = fmaf(r113, r61, r6);
+    r61 = r6 * r26;
+    r103 = fmaf(r72, r61, r103);
+    r103 = fmaf(r59, r116, r103);
+    r103 = fmaf(r37, r118, r103);
+    r118 = r0 * r103;
+    r61 = r63 * r3;
+    r61 = r61 * r107;
+    r91 = r45 * r36;
+    r91 = r91 * r90;
+    r91 = r91 * r46;
+    r91 = fmaf(r51, r91, r110 * r61);
+    r61 = r3 * r104;
+    r91 = fmaf(r112, r61, r91);
+    r112 = r37 * r33;
+    r112 = r112 * r33;
+    r112 = r112 * r36;
+    r112 = r112 * r36;
+    r112 = r112 * r102;
+    r112 = r112 * r48;
+    r91 = fmaf(r97, r112, r91);
+    r91 = r91 + r83;
+    r91 = fmaf(r59, r91, r9 * r113);
+    r113 = r75 * r3;
+    r113 = r113 * r72;
+    r91 = fmaf(r110, r113, r91);
+    r110 = r45 * r36;
+    r91 = fmaf(r73, r110, r91);
+    r73 = r33 * r36;
+    r73 = r73 * r68;
+    r73 = r73 * r77;
+    r73 = r73 * r3;
+    r73 = r73 * r48;
+    r73 = r73 * r70;
+    r91 = fmaf(r99, r73, r91);
+    r9 = r33 * r36;
+    r9 = r9 * r77;
+    r9 = r9 * r3;
+    r9 = r9 * r48;
+    r9 = r9 * r70;
+    r91 = fmaf(r99, r9, r91);
+    r70 = r60 * r40;
+    r70 = r70 * r3;
+    r70 = r70 * r44;
+    r70 = r70 * r99;
+    r70 = r70 * r105;
+    r70 = r70 * r26;
+    r91 = fmaf(r51, r70, r91);
+    r99 = r60 * r45;
+    r99 = r99 * r55;
+    r91 = fmaf(r106, r99, r91);
+    r48 = r4 * r37;
+    r48 = r48 * r33;
+    r48 = r48 * r36;
+    r48 = r48 * r68;
+    r48 = r48 * r44;
+    r91 = fmaf(r71, r48, r91);
+    r83 = r45 * r36;
+    r91 = fmaf(r72, r83, r91);
+    r112 = r4 * r37;
+    r112 = r112 * r33;
+    r112 = r112 * r36;
+    r112 = r112 * r44;
+    r91 = fmaf(r71, r112, r91);
+    r71 = r6 * r72;
+    r91 = fmaf(r51, r71, r91);
+    r44 = r60 * r37;
+    r91 = fmaf(r117, r44, r91);
+    r91 = fmaf(r3, r122, r91);
+    r91 = fmaf(r60, r116, r91);
+    r91 = fmaf(r52, r101, r91);
+    r44 = r5 * r91;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r80,
+                                          r28,
+                                          r118,
+                                          r44);
+    r44 = r0 * r4;
+    r44 = r44 * r2;
+    r118 = r4 * r1;
+    r28 = r5 * r118;
+    r44 = fmaf(r109, r28, r76 * r44);
+    r80 = r0 * r4;
+    r80 = r80 * r2;
+    r80 = fmaf(r137, r28, r119 * r80);
+    r71 = r0 * r4;
+    r71 = r71 * r2;
+    r71 = fmaf(r74, r28, r15 * r71);
+    r112 = r0 * r4;
+    r112 = r112 * r2;
+    r112 = fmaf(r84, r28, r82 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r44, r80, r71, r112);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r0 * r4;
+    r112 = r112 * r2;
+    r112 = fmaf(r31, r28, r87 * r112);
+    r71 = r0 * r4;
+    r71 = r71 * r2;
+    r71 = fmaf(r91, r28, r103 * r71);
+    WriteSum2<float, float>((float*)inout_shared, r112, r71);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r0 * r0;
+    r112 = r76 * r76;
+    r80 = r5 * r5;
+    r44 = r109 * r109;
+    r44 = fmaf(r80, r44, r71 * r112);
+    r112 = r119 * r119;
+    r83 = r137 * r137;
+    r83 = fmaf(r80, r83, r71 * r112);
+    r112 = r74 * r74;
+    r101 = r15 * r15;
+    r101 = fmaf(r71, r101, r80 * r112);
+    r112 = r82 * r82;
+    r48 = r84 * r84;
+    r48 = fmaf(r80, r48, r71 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r44, r83, r101, r48);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r87 * r87;
+    r101 = r31 * r31;
+    r101 = fmaf(r80, r101, r71 * r48);
+    r48 = r91 * r91;
+    r83 = r103 * r103;
+    r83 = fmaf(r71, r83, r80 * r48);
+    WriteSum2<float, float>((float*)inout_shared, r101, r83);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r109 * r137;
+    r101 = r76 * r119;
+    r101 = fmaf(r71, r101, r80 * r83);
+    r83 = r76 * r15;
+    r48 = r109 * r74;
+    r48 = fmaf(r80, r48, r71 * r83);
+    r83 = r109 * r84;
+    r44 = r76 * r82;
+    r44 = fmaf(r71, r44, r80 * r83);
+    r83 = r109 * r31;
+    r112 = r76 * r87;
+    r112 = fmaf(r71, r112, r80 * r83);
+    WriteSum4<float, float>((float*)inout_shared, r101, r48, r44, r112);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r76 * r103;
+    r44 = r109 * r91;
+    r44 = fmaf(r80, r44, r71 * r112);
+    r112 = r137 * r74;
+    r48 = r119 * r15;
+    r48 = fmaf(r71, r48, r80 * r112);
+    r112 = r119 * r82;
+    r101 = r137 * r84;
+    r101 = fmaf(r80, r101, r71 * r112);
+    r112 = r119 * r87;
+    r83 = r137 * r31;
+    r83 = fmaf(r80, r83, r71 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r44, r48, r101, r83);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r137 * r91;
+    r101 = r119 * r103;
+    r101 = fmaf(r71, r101, r80 * r83);
+    r83 = r74 * r84;
+    r48 = r15 * r82;
+    r48 = fmaf(r71, r48, r80 * r83);
+    r83 = r15 * r87;
+    r44 = r74 * r31;
+    r44 = fmaf(r80, r44, r71 * r83);
+    r83 = r74 * r91;
+    r112 = r15 * r103;
+    r112 = fmaf(r71, r112, r80 * r83);
+    WriteSum4<float, float>((float*)inout_shared, r101, r48, r44, r112);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r84 * r31;
+    r44 = r82 * r87;
+    r44 = fmaf(r71, r44, r80 * r112);
+    r112 = r82 * r103;
+    r48 = r84 * r91;
+    r48 = fmaf(r80, r48, r71 * r112);
+    r112 = r31 * r91;
+    r101 = r87 * r103;
+    r101 = fmaf(r71, r101, r80 * r112);
+    WriteSum3<float, float>((float*)inout_shared, r44, r48, r101);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r101 = r0 * r58;
+    r101 = r101 * r26;
+    r101 = r101 * r72;
+    r48 = r5 * r58;
+    r48 = r48 * r72;
+    r48 = r48 * r51;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r11,
+                                          r57,
+                                          r101,
+                                          r48);
+    r48 = r5 * r65;
+    r101 = r0 * r26;
+    r101 = r101 * r72;
+    r101 = r101 * r66;
+    r44 = r5 * r72;
+    r44 = r44 * r51;
+    r44 = r44 * r66;
+    r112 = r0 * r16;
+    r112 = r112 * r51;
+    r112 = r112 * r55;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r101,
+                                          r44,
+                                          r112,
+                                          r48);
+    r48 = r0 * r64;
+    r112 = r5 * r16;
+    r112 = r112 * r51;
+    r112 = r112 * r55;
+    r44 = r0 * r26;
+    r44 = r44 * r72;
+    r44 = r44 * r67;
+    r101 = r5 * r72;
+    r101 = r101 * r51;
+    r101 = r101 * r67;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r48,
+                                          r112,
+                                          r44,
+                                          r101);
+    r101 = r0 * r58;
+    r44 = r5 * r58;
+    r112 = r0 * r26;
+    r112 = r112 * r72;
+    r112 = r112 * r69;
+    r48 = r5 * r72;
+    r48 = r48 * r51;
+    r48 = r48 * r69;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r112,
+        r48,
+        r101,
+        r44);
+    r44 = r4 * r11;
+    r44 = r44 * r2;
+    r118 = r57 * r118;
+    r101 = r0 * r4;
+    r101 = r101 * r58;
+    r101 = r101 * r2;
+    r101 = r101 * r26;
+    r48 = r58 * r72;
+    r48 = r48 * r51;
+    r48 = fmaf(r28, r48, r72 * r101);
+    r101 = r0 * r4;
+    r101 = r101 * r2;
+    r101 = r101 * r26;
+    r101 = r101 * r72;
+    r112 = r72 * r51;
+    r112 = r112 * r66;
+    r112 = fmaf(r28, r112, r66 * r101);
+    WriteSum4<float, float>((float*)inout_shared, r44, r118, r48, r112);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r0 * r40;
+    r112 = r112 * r2;
+    r112 = r112 * r51;
+    r112 = fmaf(r55, r112, r65 * r28);
+    r48 = r0 * r4;
+    r48 = r48 * r64;
+    r118 = r5 * r40;
+    r118 = r118 * r1;
+    r118 = r118 * r51;
+    r118 = fmaf(r55, r118, r2 * r48);
+    r48 = r0 * r4;
+    r48 = r48 * r2;
+    r48 = r48 * r26;
+    r48 = r48 * r72;
+    r1 = r72 * r51;
+    r1 = r1 * r67;
+    r1 = fmaf(r28, r1, r67 * r48);
+    r48 = r0 * r4;
+    r48 = r48 * r2;
+    r48 = r48 * r26;
+    r48 = r48 * r72;
+    r44 = r72 * r51;
+    r44 = r44 * r69;
+    r44 = fmaf(r28, r44, r69 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r112, r118, r1, r44);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r0 * r4;
+    r44 = r44 * r58;
+    r44 = r44 * r2;
+    r28 = r58 * r28;
+    WriteSum2<float, float>((float*)inout_shared, r44, r28);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r11 * r11;
+    r44 = r57 * r57;
+    r2 = r33 * r36;
+    r2 = r2 * r66;
+    r2 = r2 * r80;
+    r1 = r36 * r66;
+    r1 = r1 * r71;
+    r1 = fmaf(r56, r1, r107 * r2);
+    r2 = r33 * r36;
+    r2 = r2 * r80;
+    r2 = r2 * r107;
+    r118 = r36 * r71;
+    r118 = r118 * r69;
+    r118 = fmaf(r56, r118, r69 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r28, r44, r1, r118);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r26 * r71;
+    r44 = r47 * r33;
+    r54 = r49 * r54;
+    r54 = 1.0 / r54;
+    r10 = r50 * r10;
+    r10 = 1.0 / r10;
+    r44 = r44 * r36;
+    r44 = r44 * r36;
+    r44 = r44 * r128;
+    r44 = r44 * r54;
+    r44 = r44 * r10;
+    r44 = r44 * r51;
+    r10 = r65 * r80;
+    r54 = fmaf(r65, r10, r1 * r44);
+    r128 = r26 * r80;
+    r50 = r64 * r64;
+    r50 = fmaf(r71, r50, r44 * r128);
+    r128 = r33 * r36;
+    r44 = r67 * r67;
+    r128 = r128 * r80;
+    r128 = r128 * r107;
+    r49 = r36 * r71;
+    r49 = r49 * r56;
+    r128 = fmaf(r44, r49, r44 * r128);
+    r28 = r69 * r69;
+    r2 = r80 * r107;
+    r2 = r2 * r51;
+    r28 = fmaf(r49, r28, r28 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r54, r50, r128, r28);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r28 = r66 * r71;
+    r50 = r66 * r80;
+    WriteSum2<float, float>((float*)inout_shared, r28, r50);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = 0.00000000000000000e+00;
+    r28 = r0 * r58;
+    r28 = r28 * r11;
+    r28 = r28 * r26;
+    r28 = r28 * r72;
+    r54 = r0 * r11;
+    r54 = r54 * r26;
+    r54 = r54 * r72;
+    r54 = r54 * r66;
+    r112 = r0 * r16;
+    r112 = r112 * r11;
+    r112 = r112 * r51;
+    r112 = r112 * r55;
+    WriteSum4<float, float>((float*)inout_shared, r50, r28, r54, r112);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r0 * r64;
+    r112 = r112 * r11;
+    r54 = r0 * r58;
+    r54 = r54 * r11;
+    r28 = r0 * r11;
+    r28 = r28 * r26;
+    r28 = r28 * r72;
+    r28 = r28 * r67;
+    r11 = r0 * r11;
+    r11 = r11 * r26;
+    r11 = r11 * r72;
+    r11 = r11 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r112, r28, r11, r54);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r5 * r65;
+    r65 = r65 * r57;
+    r54 = r5 * r58;
+    r54 = r54 * r57;
+    r54 = r54 * r72;
+    r54 = r54 * r51;
+    r11 = r5 * r57;
+    r11 = r11 * r72;
+    r11 = r11 * r51;
+    r11 = r11 * r66;
+    WriteSum4<float, float>((float*)inout_shared, r50, r54, r11, r65);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r5 * r16;
+    r65 = r65 * r57;
+    r65 = r65 * r51;
+    r65 = r65 * r55;
+    r11 = r5 * r57;
+    r11 = r11 * r72;
+    r11 = r11 * r51;
+    r11 = r11 * r67;
+    r54 = r5 * r57;
+    r54 = r54 * r72;
+    r54 = r54 * r51;
+    r54 = r54 * r69;
+    WriteSum4<float, float>((float*)inout_shared, r65, r11, r54, r50);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r5 * r58;
+    r50 = r50 * r57;
+    r57 = r33 * r36;
+    r57 = r57 * r67;
+    r57 = r57 * r80;
+    r54 = r36 * r67;
+    r54 = r54 * r71;
+    r54 = fmaf(r56, r54, r107 * r57);
+    r57 = r47 * r58;
+    r57 = r57 * r97;
+    r57 = r57 * r105;
+    r57 = r57 * r51;
+    r57 = r57 * r106;
+    r11 = r51 * r10;
+    r65 = r72 * r11;
+    r57 = fmaf(r58, r65, r1 * r57);
+    r28 = r72 * r1;
+    r112 = r64 * r28;
+    r48 = r33 * r58;
+    r48 = r48 * r97;
+    r48 = r48 * r105;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r80;
+    r48 = fmaf(r106, r48, r58 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r50, r54, r57, r48);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r66 * r28;
+    r57 = r72 * r51;
+    r57 = r57 * r66;
+    r57 = r57 * r80;
+    r54 = r33 * r36;
+    r50 = r58 * r69;
+    r54 = r54 * r80;
+    r54 = r54 * r107;
+    r101 = r36 * r71;
+    r101 = r101 * r56;
+    r101 = fmaf(r50, r101, r50 * r54);
+    WriteSum4<float, float>((float*)inout_shared, r118, r101, r48, r57);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r47 * r97;
+    r57 = r57 * r105;
+    r57 = r57 * r51;
+    r57 = r57 * r66;
+    r57 = r57 * r106;
+    r57 = fmaf(r66, r65, r1 * r57);
+    r48 = r33 * r97;
+    r48 = r48 * r105;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r66;
+    r48 = r48 * r80;
+    r48 = fmaf(r106, r48, r66 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r57, r48, r101, r128);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r67 * r28;
+    r101 = r72 * r51;
+    r101 = r101 * r67;
+    r101 = r101 * r80;
+    r48 = r16 * r55;
+    r57 = r16 * r64;
+    r57 = r57 * r51;
+    r57 = r57 * r55;
+    r57 = fmaf(r71, r57, r11 * r48);
+    r48 = r47 * r97;
+    r48 = r48 * r105;
+    r48 = r48 * r51;
+    r48 = r48 * r67;
+    r48 = r48 * r106;
+    r48 = fmaf(r67, r65, r1 * r48);
+    WriteSum4<float, float>((float*)inout_shared, r128, r101, r57, r48);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r16 * r58;
+    r48 = r48 * r51;
+    r48 = r48 * r55;
+    r48 = r48 * r71;
+    r10 = r58 * r10;
+    r57 = r47 * r97;
+    r57 = r57 * r105;
+    r57 = r57 * r51;
+    r57 = r57 * r106;
+    r57 = r57 * r69;
+    r65 = fmaf(r69, r65, r1 * r57);
+    r57 = r33 * r97;
+    r57 = r57 * r105;
+    r57 = r57 * r26;
+    r57 = r57 * r51;
+    r57 = r57 * r67;
+    r57 = r57 * r80;
+    r57 = fmaf(r106, r57, r67 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r65, r48, r10, r57);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r58 * r64;
+    r57 = r57 * r71;
+    r10 = r16 * r58;
+    r10 = r10 * r51;
+    r10 = r10 * r55;
+    r10 = r10 * r80;
+    r48 = r33 * r97;
+    r48 = r48 * r105;
+    r48 = r48 * r26;
+    r48 = r48 * r51;
+    r48 = r48 * r80;
+    r48 = r48 * r106;
+    r48 = fmaf(r69, r48, r69 * r112);
+    r44 = r58 * r44;
+    r49 = fmaf(r44, r49, r44 * r2);
+    WriteSum4<float, float>((float*)inout_shared, r48, r57, r10, r49);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r69 * r28;
+    r10 = r72 * r51;
+    r10 = r10 * r80;
+    r10 = r10 * r69;
+    r28 = r50 * r28;
+    r69 = r72 * r51;
+    r69 = r69 * r80;
+    r69 = r69 * r50;
+    WriteSum4<float, float>((float*)inout_shared, r49, r10, r28, r69);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_focal_and_extra_jac,
+              out_focal_and_extra_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,337 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* point,
+        unsigned int point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+    ReadIdx3<1024, float, float, float4>(
+        point, 0 * point_num_alloc, global_thread_idx, r14, r15, r16);
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r35,
+                       r41,
+                       r34,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScoreKernel<<<n_blocks,
+                                                                  1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* point,
+    unsigned int point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,339 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirectKernel(
+        float* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        float* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        float* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        float* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        float* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        float* point_jac,
+        unsigned int point_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1, r2, r3);
+  };
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              0 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r4,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         4 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r8,
+                                         r9,
+                                         r10,
+                                         r11);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         0 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r12,
+                                         r13,
+                                         r14,
+                                         r15);
+    r16 = fmaf(r6, r15, r7 * r9);
+  };
+  LoadShared<4, float, float>(focal_and_extra_njtr,
+                              4 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         12 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    ReadIdx4<1024, float, float, float4>(focal_and_extra_jac,
+                                         8 * focal_and_extra_jac_num_alloc,
+                                         global_thread_idx,
+                                         r25,
+                                         r26,
+                                         r27,
+                                         r28);
+  };
+  LoadShared<2, float, float>(focal_and_extra_njtr,
+                              8 * focal_and_extra_njtr_num_alloc,
+                              focal_and_extra_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                       r29,
+                       r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = fmaf(r17, r11, r16);
+    r16 = fmaf(r5, r13, r16);
+    r16 = fmaf(r20, r22, r16);
+    r16 = fmaf(r19, r28, r16);
+    r16 = fmaf(r30, r24, r16);
+    r16 = fmaf(r18, r26, r16);
+  };
+  LoadShared<3, float, float>(point_njtr,
+                              0 * point_njtr_num_alloc,
+                              point_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_njtr_indices_loc[threadIdx.x].target,
+                       r30,
+                       r5,
+                       r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r32, r33);
+    ReadIdx4<1024, float, float, float4>(point_jac,
+                                         0 * point_jac_num_alloc,
+                                         global_thread_idx,
+                                         r34,
+                                         r35,
+                                         r36,
+                                         r37);
+    r38 = fmaf(r5, r37, r31 * r33);
+    r38 = fmaf(r30, r35, r38);
+    r39 = r16 + r38;
+    r17 = fmaf(r17, r10, r7 * r8);
+    r17 = fmaf(r4, r12, r17);
+    r17 = fmaf(r6, r14, r17);
+    r17 = fmaf(r29, r23, r17);
+    r17 = fmaf(r18, r25, r17);
+    r17 = fmaf(r20, r21, r17);
+    r17 = fmaf(r19, r27, r17);
+    r5 = fmaf(r5, r36, r31 * r32);
+    r5 = fmaf(r30, r34, r5);
+    r30 = r17 + r5;
+    r31 = fmaf(r0, r30, r1 * r39);
+    r19 = fmaf(r2, r30, r3 * r39);
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r20, r18, r29, r6);
+    r4 = fmaf(r20, r30, r18 * r39);
+    r7 = fmaf(r29, r30, r6 * r39);
+    WriteSum4<float, float>((float*)inout_shared, r31, r19, r4, r7);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r7, r4, r19, r31);
+    r40 = fmaf(r7, r30, r4 * r39);
+    r30 = fmaf(r19, r30, r31 * r39);
+    WriteSum2<float, float>((float*)inout_shared, r40, r30);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_njtr_indices_loc,
+                           (float*)inout_shared);
+  LoadShared<2, float, float>(pose_njtr,
+                              4 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r30,
+                       r40);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = fmaf(r30, r7, r40 * r19);
+  };
+  LoadShared<4, float, float>(pose_njtr,
+                              0 * pose_njtr_num_alloc,
+                              pose_njtr_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_njtr_indices_loc[threadIdx.x].target,
+                       r19,
+                       r39,
+                       r41,
+                       r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = fmaf(r41, r20, r7);
+    r7 = fmaf(r42, r29, r7);
+    r7 = fmaf(r19, r0, r7);
+    r7 = fmaf(r39, r2, r7);
+    r5 = r7 + r5;
+    r12 = r12 * r5;
+    r6 = fmaf(r42, r6, r40 * r31);
+    r6 = fmaf(r41, r18, r6);
+    r6 = fmaf(r19, r1, r6);
+    r6 = fmaf(r39, r3, r6);
+    r6 = fmaf(r30, r4, r6);
+    r38 = r6 + r38;
+    r13 = r13 * r38;
+    r15 = fmaf(r15, r38, r14 * r5);
+    r9 = fmaf(r9, r38, r8 * r5);
+    WriteSum4<float, float>((float*)inout_shared, r12, r13, r15, r9);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = fmaf(r11, r38, r10 * r5);
+    r26 = fmaf(r26, r38, r25 * r5);
+    r28 = fmaf(r28, r38, r27 * r5);
+    r22 = fmaf(r22, r38, r21 * r5);
+    WriteSum4<float, float>((float*)inout_shared, r11, r26, r28, r22);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r5 = r23 * r5;
+    r38 = r24 * r38;
+    WriteSum2<float, float>((float*)inout_shared, r5, r38);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_njtr_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r6 = r16 + r6;
+    r7 = r17 + r7;
+    r34 = fmaf(r34, r7, r35 * r6);
+    r36 = fmaf(r36, r7, r37 * r6);
+    r7 = fmaf(r32, r7, r33 * r6);
+    WriteSum3<float, float>((float*)inout_shared, r34, r36, r7);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_njtr_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirectKernel<<<n_blocks,
+                                                                1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      focal_and_extra_njtr,
+      focal_and_extra_njtr_num_alloc,
+      focal_and_extra_njtr_indices,
+      focal_and_extra_jac,
+      focal_and_extra_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+    float* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    float* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    float* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    float* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    float* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    float* point_jac,
+    unsigned int point_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.cu
@@ -1,0 +1,2710 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointResJacKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = r11 * r11;
+    r53 = 9.99999999999999955e-07;
+    r54 = r41 * r29;
+    r54 = r54 * r29;
+    r55 = r42 + r54;
+    r55 = r55 + r49;
+    r10 = fmaf(r13, r55, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r56 = r16 * r29;
+    r56 = fmaf(r34, r56, r26);
+    r57 = r21 * r23;
+    r57 = r57 * r16;
+    r58 = r22 * r24;
+    r58 = fmaf(r16, r58, r57);
+    r59 = r23 * r24;
+    r59 = fmaf(r41, r59, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r56, r10);
+    r10 = fmaf(r37, r58, r10);
+    r10 = fmaf(r36, r59, r10);
+    r10 = fmaf(r35, r43, r10);
+    r60 = r10 * r10;
+    r61 = r41 * r29;
+    r61 = fmaf(r34, r61, r26);
+    r12 = fmaf(r13, r61, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r57);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r54 = r42 + r54;
+    r54 = r54 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r54, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r53, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r60);
+    r60 = sqrtf(r35);
+    r51 = copysign(1.0, r60);
+    r51 = fmaf(r53, r51, r60);
+    r53 = r51 * r51;
+    r47 = 1.0 / r53;
+    r60 = atanf(r60);
+    r57 = r60 * r37;
+    r62 = r60 * r57;
+    r52 = r52 * r47;
+    r52 = r52 * r62;
+    r63 = r10 * r47;
+    r64 = r10 * r63;
+    r65 = r62 * r64;
+    r66 = r52 + r65;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r67,
+                       r68,
+                       r69,
+                       r70);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r71 = 3.00000000000000000e+00;
+    r72 = r71 * r62;
+    r72 = fmaf(r64, r72, r52);
+    r52 = fmaf(r68, r72, r8 * r66);
+    r73 = 1.0 / r36;
+    r74 = 1.0 / r51;
+    r75 = r73 * r74;
+    r76 = r60 * r75;
+    r77 = r10 * r76;
+    r78 = r67 * r11;
+    r79 = r16 * r62;
+    r78 = r78 * r63;
+    r52 = fmaf(r79, r78, r52);
+    r80 = r66 * r66;
+    r81 = r66 * r80;
+    r82 = fmaf(r69, r81, r6 * r66);
+    r83 = r80 * r80;
+    r82 = fmaf(r70, r83, r82);
+    r82 = fmaf(r7, r80, r82);
+    r84 = r82 * r76;
+    r52 = r52 + r77;
+    r52 = fmaf(r10, r84, r52);
+    r2 = fmaf(r0, r52, r2);
+    r78 = r11 * r11;
+    r78 = r78 * r71;
+    r78 = r78 * r47;
+    r78 = fmaf(r62, r78, r65);
+    r65 = fmaf(r67, r78, r9 * r66);
+    r85 = r68 * r11;
+    r85 = r85 * r63;
+    r65 = fmaf(r79, r85, r65);
+    r65 = fmaf(r11, r84, r65);
+    r65 = fmaf(r11, r76, r65);
+    r1 = fmaf(r5, r65, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = r16 * r34;
+    r85 = r19 * r24;
+    r86 = 5.00000000000000000e-01;
+    r87 = r18 * r21;
+    r87 = fmaf(r86, r87, r86 * r85);
+    r85 = r17 * r22;
+    r88 = -5.00000000000000000e-01;
+    r87 = fmaf(r88, r85, r87);
+    r89 = r20 * r23;
+    r87 = fmaf(r86, r89, r87);
+    r89 = r17 * r24;
+    r85 = r20 * r21;
+    r85 = fmaf(r88, r85, r88 * r89);
+    r89 = r19 * r22;
+    r85 = fmaf(r88, r89, r85);
+    r90 = r18 * r23;
+    r85 = fmaf(r86, r90, r85);
+    r90 = r29 * r85;
+    r3 = fmaf(r16, r90, r87 * r3);
+    r89 = r16 * r25;
+    r91 = fmaf(r86, r31, r88 * r27);
+    r91 = fmaf(r88, r28, r91);
+    r91 = fmaf(r88, r30, r91);
+    r92 = r16 * r32;
+    r93 = r20 * r24;
+    r94 = r17 * r21;
+    r94 = fmaf(r88, r94, r86 * r93);
+    r93 = r18 * r22;
+    r94 = fmaf(r88, r93, r94);
+    r95 = r19 * r23;
+    r94 = fmaf(r88, r95, r94);
+    r92 = r92 * r94;
+    r89 = fmaf(r91, r89, r92);
+    r3 = r3 + r89;
+    r95 = r16 * r29;
+    r95 = r95 * r94;
+    r93 = r16 * r25;
+    r93 = r93 * r87;
+    r96 = r95 + r93;
+    r97 = r32 * r41;
+    r96 = fmaf(r85, r97, r96);
+    r98 = r41 * r34;
+    r96 = fmaf(r91, r98, r96);
+    r96 = fmaf(r14, r96, r15 * r3);
+    r3 = r29 * r87;
+    r98 = -4.00000000000000000e+00;
+    r3 = r3 * r98;
+    r97 = r32 * r91;
+    r99 = r98 * r97;
+    r100 = r3 + r99;
+    r96 = fmaf(r13, r100, r96);
+    r100 = 6.00000000000000000e+00;
+    r101 = r96 * r100;
+    r101 = r101 * r62;
+    r102 = r16 * r11;
+    r103 = r25 * r41;
+    r104 = r34 * r94;
+    r105 = r41 * r104;
+    r103 = fmaf(r85, r103, r105);
+    r106 = r16 * r29;
+    r106 = r106 * r91;
+    r107 = r16 * r32;
+    r107 = fmaf(r87, r107, r106);
+    r103 = r103 + r107;
+    r108 = r25 * r94;
+    r108 = r108 * r98;
+    r99 = r108 + r99;
+    r99 = fmaf(r14, r99, r15 * r103);
+    r103 = r16 * r34;
+    r103 = fmaf(r91, r103, r93);
+    r93 = r16 * r32;
+    r93 = fmaf(r85, r93, r95);
+    r103 = r103 + r93;
+    r99 = fmaf(r13, r103, r99);
+    r102 = r102 * r99;
+    r103 = r16 * r10;
+    r103 = r103 * r96;
+    r103 = fmaf(r37, r103, r37 * r102);
+    r102 = r16 * r25;
+    r102 = r102 * r85;
+    r104 = r16 * r104;
+    r95 = r102 + r104;
+    r107 = r107 + r95;
+    r109 = r41 * r34;
+    r109 = fmaf(r41, r90, r87 * r109);
+    r109 = r109 + r89;
+    r109 = fmaf(r13, r109, r14 * r107);
+    r3 = r108 + r3;
+    r109 = fmaf(r15, r3, r109);
+    r12 = r36 * r12;
+    r3 = 1.0 / r12;
+    r108 = r41 * r3;
+    r107 = r109 * r108;
+    r87 = r11 * r11;
+    r103 = fmaf(r87, r107, r103);
+    r110 = r10 * r10;
+    r110 = r110 * r109;
+    r103 = fmaf(r108, r110, r103);
+    r110 = r71 * r103;
+    r107 = rsqrtf(r35);
+    r35 = r42 + r35;
+    r35 = 1.0 / r35;
+    r42 = r35 * r57;
+    r111 = r107 * r42;
+    r111 = r111 * r64;
+    r110 = fmaf(r111, r110, r63 * r101);
+    r101 = r60 * r60;
+    r112 = r64 * r101;
+    r113 = -6.00000000000000000e+00;
+    r114 = r109 * r113;
+    r114 = r114 * r3;
+    r110 = fmaf(r114, r112, r110);
+    r115 = r10 * r10;
+    r116 = -3.00000000000000000e+00;
+    r53 = r51 * r53;
+    r117 = 1.0 / r53;
+    r115 = r115 * r116;
+    r115 = r115 * r103;
+    r115 = r115 * r107;
+    r115 = r115 * r117;
+    r110 = fmaf(r62, r115, r110);
+    r118 = r11 * r47;
+    r119 = r79 * r118;
+    r120 = r11 * r107;
+    r121 = r103 * r120;
+    r121 = r121 * r42;
+    r121 = fmaf(r118, r121, r99 * r119);
+    r122 = r4 * r11;
+    r123 = r117 * r62;
+    r123 = r123 * r120;
+    r122 = r122 * r103;
+    r121 = fmaf(r123, r122, r121);
+    r124 = r47 * r87;
+    r125 = r108 * r101;
+    r124 = r124 * r125;
+    r121 = fmaf(r109, r124, r121);
+    r110 = r110 + r121;
+    r115 = r96 * r63;
+    r115 = fmaf(r103, r111, r79 * r115);
+    r112 = r109 * r64;
+    r115 = fmaf(r125, r112, r115);
+    r122 = r4 * r10;
+    r122 = r122 * r10;
+    r122 = r122 * r103;
+    r122 = r122 * r107;
+    r122 = r122 * r117;
+    r115 = fmaf(r62, r122, r115);
+    r121 = r121 + r115;
+    r110 = fmaf(r8, r121, r68 * r110);
+    r122 = r10 * r86;
+    r122 = r122 * r73;
+    r122 = r122 * r74;
+    r122 = r122 * r107;
+    r122 = r122 * r103;
+    r122 = r122 * r35;
+    r112 = r60 * r82;
+    r112 = r112 * r88;
+    r112 = r112 * r103;
+    r112 = r112 * r73;
+    r112 = r112 * r107;
+    r110 = fmaf(r63, r112, r110);
+    r126 = r67 * r103;
+    r127 = r16 * r63;
+    r127 = r127 * r120;
+    r127 = r127 * r42;
+    r110 = fmaf(r127, r126, r110);
+    r128 = r60 * r88;
+    r128 = r128 * r103;
+    r128 = r128 * r73;
+    r128 = r128 * r107;
+    r110 = fmaf(r63, r128, r110);
+    r129 = r67 * r11;
+    r129 = r129 * r60;
+    r129 = r129 * r60;
+    r129 = r129 * r98;
+    r129 = r129 * r3;
+    r129 = r129 * r63;
+    r130 = r67 * r96;
+    r110 = fmaf(r119, r130, r110);
+    r131 = r4 * r10;
+    r131 = r131 * r109;
+    r131 = r131 * r74;
+    r110 = fmaf(r57, r131, r110);
+    r132 = r4 * r10;
+    r132 = r132 * r82;
+    r132 = r132 * r109;
+    r132 = r132 * r74;
+    r110 = fmaf(r57, r132, r110);
+    r133 = r67 * r103;
+    r134 = r41 * r10;
+    r134 = r134 * r123;
+    r110 = fmaf(r134, r133, r110);
+    r135 = r7 * r16;
+    r135 = r135 * r66;
+    r135 = fmaf(r121, r135, r6 * r121);
+    r136 = 4.00000000000000000e+00;
+    r70 = r70 * r136;
+    r70 = r70 * r81;
+    r69 = r69 * r71;
+    r69 = r69 * r80;
+    r135 = fmaf(r121, r70, r135);
+    r135 = fmaf(r121, r69, r135);
+    r137 = r10 * r135;
+    r110 = fmaf(r76, r137, r110);
+    r138 = r67 * r99;
+    r138 = r138 * r63;
+    r110 = fmaf(r79, r138, r110);
+    r110 = r110 + r122;
+    r110 = fmaf(r109, r129, r110);
+    r110 = fmaf(r82, r122, r110);
+    r110 = fmaf(r96, r76, r110);
+    r110 = fmaf(r96, r84, r110);
+    r138 = r0 * r110;
+    r137 = r11 * r99;
+    r137 = r137 * r100;
+    r137 = r137 * r47;
+    r133 = r71 * r103;
+    r133 = r133 * r120;
+    r133 = r133 * r42;
+    r133 = fmaf(r118, r133, r62 * r137);
+    r137 = r11 * r116;
+    r137 = r137 * r103;
+    r133 = fmaf(r123, r137, r133);
+    r132 = r11 * r11;
+    r132 = r132 * r60;
+    r132 = r132 * r60;
+    r132 = r132 * r47;
+    r133 = fmaf(r114, r132, r133);
+    r133 = r133 + r115;
+    r121 = fmaf(r9, r121, r67 * r133);
+    r133 = r86 * r103;
+    r133 = r133 * r35;
+    r133 = r133 * r75;
+    r115 = r60 * r88;
+    r115 = r115 * r47;
+    r115 = r115 * r73;
+    r115 = r115 * r120;
+    r132 = r82 * r115;
+    r137 = r11 * r135;
+    r121 = fmaf(r76, r137, r121);
+    r114 = r4 * r11;
+    r114 = r114 * r82;
+    r114 = r114 * r109;
+    r114 = r114 * r74;
+    r121 = fmaf(r57, r114, r121);
+    r131 = r68 * r11;
+    r131 = r131 * r60;
+    r131 = r131 * r60;
+    r131 = r131 * r98;
+    r131 = r131 * r109;
+    r131 = r131 * r3;
+    r121 = fmaf(r63, r131, r121);
+    r130 = r68 * r119;
+    r122 = r68 * r103;
+    r121 = fmaf(r127, r122, r121);
+    r128 = r4 * r11;
+    r128 = r128 * r109;
+    r128 = r128 * r74;
+    r121 = fmaf(r57, r128, r121);
+    r126 = r68 * r103;
+    r121 = fmaf(r134, r126, r121);
+    r112 = r82 * r120;
+    r121 = fmaf(r133, r112, r121);
+    r139 = r68 * r99;
+    r139 = r139 * r63;
+    r121 = fmaf(r79, r139, r121);
+    r121 = fmaf(r120, r133, r121);
+    r121 = fmaf(r103, r132, r121);
+    r121 = fmaf(r96, r130, r121);
+    r121 = fmaf(r103, r115, r121);
+    r121 = fmaf(r99, r84, r121);
+    r121 = fmaf(r99, r76, r121);
+    r139 = r5 * r121;
+    r112 = r16 * r10;
+    r104 = r106 + r104;
+    r106 = r16 * r32;
+    r126 = r19 * r24;
+    r128 = r18 * r21;
+    r128 = fmaf(r88, r128, r88 * r126);
+    r126 = r17 * r22;
+    r128 = fmaf(r86, r126, r128);
+    r122 = r20 * r23;
+    r128 = fmaf(r88, r122, r128);
+    r106 = r106 * r128;
+    r122 = r16 * r25;
+    r126 = r17 * r24;
+    r131 = r20 * r21;
+    r131 = fmaf(r86, r131, r86 * r126);
+    r126 = r19 * r22;
+    r131 = fmaf(r86, r126, r131);
+    r114 = r18 * r23;
+    r131 = fmaf(r88, r114, r131);
+    r122 = fmaf(r131, r122, r106);
+    r104 = r104 + r122;
+    r114 = r32 * r98;
+    r114 = r114 * r131;
+    r126 = r29 * r94;
+    r126 = r126 * r98;
+    r137 = r114 + r126;
+    r137 = fmaf(r13, r137, r15 * r104);
+    r104 = r41 * r34;
+    r104 = fmaf(r41, r97, r131 * r104);
+    r133 = r16 * r25;
+    r133 = r133 * r94;
+    r140 = r16 * r29;
+    r140 = fmaf(r128, r140, r133);
+    r104 = r104 + r140;
+    r137 = fmaf(r14, r104, r137);
+    r112 = r112 * r137;
+    r104 = r10 * r10;
+    r141 = r41 * r29;
+    r141 = fmaf(r91, r141, r105);
+    r141 = r141 + r122;
+    r122 = r16 * r29;
+    r122 = r122 * r131;
+    r142 = r16 * r34;
+    r142 = fmaf(r128, r142, r122);
+    r142 = r142 + r89;
+    r142 = fmaf(r14, r142, r13 * r141);
+    r141 = r25 * r128;
+    r89 = r98 * r141;
+    r126 = r126 + r89;
+    r142 = fmaf(r15, r126, r142);
+    r104 = r104 * r142;
+    r104 = fmaf(r108, r104, r37 * r112);
+    r112 = r142 * r108;
+    r104 = fmaf(r87, r112, r104);
+    r126 = r16 * r11;
+    r143 = r25 * r41;
+    r143 = fmaf(r91, r143, r92);
+    r92 = r41 * r34;
+    r143 = fmaf(r128, r92, r143);
+    r143 = r143 + r122;
+    r92 = r16 * r34;
+    r97 = fmaf(r16, r97, r131 * r92);
+    r97 = r97 + r140;
+    r97 = fmaf(r13, r97, r15 * r143);
+    r89 = r114 + r89;
+    r97 = fmaf(r14, r89, r97);
+    r126 = r126 * r97;
+    r104 = fmaf(r37, r126, r104);
+    r126 = r4 * r10;
+    r126 = r126 * r10;
+    r126 = r126 * r104;
+    r126 = r126 * r107;
+    r126 = r126 * r117;
+    r126 = fmaf(r62, r126, r104 * r111);
+    r112 = r142 * r64;
+    r126 = fmaf(r125, r112, r126);
+    r89 = r137 * r63;
+    r126 = fmaf(r79, r89, r126);
+    r89 = r4 * r11;
+    r89 = r89 * r104;
+    r89 = fmaf(r123, r89, r97 * r119);
+    r112 = r104 * r120;
+    r112 = r112 * r42;
+    r89 = fmaf(r118, r112, r89);
+    r89 = fmaf(r142, r124, r89);
+    r112 = r126 + r89;
+    r114 = r71 * r104;
+    r143 = r10 * r10;
+    r92 = r116 * r104;
+    r143 = r143 * r107;
+    r143 = r143 * r117;
+    r143 = r143 * r62;
+    r143 = fmaf(r92, r143, r111 * r114);
+    r114 = r113 * r142;
+    r114 = r114 * r3;
+    r114 = r114 * r64;
+    r143 = fmaf(r101, r114, r143);
+    r131 = r100 * r137;
+    r131 = r131 * r62;
+    r143 = fmaf(r63, r131, r143);
+    r143 = r143 + r89;
+    r143 = fmaf(r68, r143, r8 * r112);
+    r89 = r67 * r97;
+    r89 = r89 * r63;
+    r143 = fmaf(r79, r89, r143);
+    r131 = r60 * r88;
+    r131 = r131 * r104;
+    r131 = r131 * r73;
+    r131 = r131 * r107;
+    r143 = fmaf(r63, r131, r143);
+    r114 = r4 * r10;
+    r114 = r114 * r142;
+    r114 = r114 * r74;
+    r143 = fmaf(r57, r114, r143);
+    r122 = r10 * r86;
+    r122 = r122 * r82;
+    r122 = r122 * r104;
+    r122 = r122 * r107;
+    r122 = r122 * r35;
+    r143 = fmaf(r75, r122, r143);
+    r91 = r67 * r104;
+    r143 = fmaf(r134, r91, r143);
+    r144 = r67 * r104;
+    r143 = fmaf(r127, r144, r143);
+    r145 = r10 * r86;
+    r145 = r145 * r104;
+    r145 = r145 * r107;
+    r145 = r145 * r35;
+    r143 = fmaf(r75, r145, r143);
+    r146 = r4 * r10;
+    r146 = r146 * r82;
+    r146 = r146 * r142;
+    r146 = r146 * r74;
+    r143 = fmaf(r57, r146, r143);
+    r147 = r67 * r137;
+    r143 = fmaf(r119, r147, r143);
+    r148 = r7 * r16;
+    r148 = r148 * r66;
+    r148 = fmaf(r112, r148, r6 * r112);
+    r148 = fmaf(r112, r70, r148);
+    r148 = fmaf(r112, r69, r148);
+    r149 = r10 * r148;
+    r143 = fmaf(r76, r149, r143);
+    r150 = r60 * r82;
+    r150 = r150 * r88;
+    r150 = r150 * r104;
+    r150 = r150 * r73;
+    r150 = r150 * r107;
+    r143 = fmaf(r63, r150, r143);
+    r143 = fmaf(r142, r129, r143);
+    r143 = fmaf(r137, r84, r143);
+    r143 = fmaf(r137, r76, r143);
+    r150 = r0 * r143;
+    r149 = r11 * r100;
+    r149 = r149 * r97;
+    r149 = r149 * r47;
+    r147 = r11 * r123;
+    r147 = fmaf(r92, r147, r62 * r149);
+    r149 = r11 * r11;
+    r149 = r149 * r60;
+    r149 = r149 * r60;
+    r149 = r149 * r113;
+    r149 = r149 * r142;
+    r149 = r149 * r47;
+    r147 = fmaf(r3, r149, r147);
+    r92 = r71 * r104;
+    r92 = r92 * r120;
+    r92 = r92 * r42;
+    r147 = fmaf(r118, r92, r147);
+    r147 = r147 + r126;
+    r147 = fmaf(r67, r147, r9 * r112);
+    r112 = r4 * r11;
+    r112 = r112 * r142;
+    r112 = r112 * r74;
+    r147 = fmaf(r57, r112, r147);
+    r126 = r68 * r97;
+    r126 = r126 * r63;
+    r147 = fmaf(r79, r126, r147);
+    r92 = r68 * r11;
+    r92 = r92 * r60;
+    r92 = r92 * r60;
+    r92 = r92 * r98;
+    r92 = r92 * r142;
+    r92 = r92 * r3;
+    r147 = fmaf(r63, r92, r147);
+    r149 = r86 * r82;
+    r149 = r149 * r104;
+    r149 = r149 * r35;
+    r149 = r149 * r75;
+    r147 = fmaf(r120, r149, r147);
+    r146 = r11 * r148;
+    r147 = fmaf(r76, r146, r147);
+    r145 = r86 * r104;
+    r145 = r145 * r35;
+    r145 = r145 * r75;
+    r147 = fmaf(r120, r145, r147);
+    r144 = r68 * r104;
+    r147 = fmaf(r134, r144, r147);
+    r91 = r68 * r104;
+    r147 = fmaf(r127, r91, r147);
+    r122 = r4 * r11;
+    r122 = r122 * r82;
+    r122 = r122 * r142;
+    r122 = r122 * r74;
+    r147 = fmaf(r57, r122, r147);
+    r147 = fmaf(r104, r132, r147);
+    r147 = fmaf(r104, r115, r147);
+    r147 = fmaf(r137, r130, r147);
+    r147 = fmaf(r97, r84, r147);
+    r147 = fmaf(r97, r76, r147);
+    r122 = r5 * r147;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r138,
+                                          r139,
+                                          r150,
+                                          r122);
+    r122 = r10 * r10;
+    r150 = r25 * r98;
+    r31 = fmaf(r88, r31, r86 * r27);
+    r31 = fmaf(r86, r28, r31);
+    r31 = fmaf(r86, r30, r31);
+    r150 = r150 * r31;
+    r90 = r98 * r90;
+    r30 = r150 + r90;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r133 = r133 + r28;
+    r27 = r41 * r29;
+    r133 = fmaf(r128, r27, r133);
+    r139 = r41 * r34;
+    r133 = fmaf(r85, r139, r133);
+    r133 = fmaf(r13, r133, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r141, r31 * r30);
+    r30 = r30 + r93;
+    r133 = fmaf(r14, r30, r133);
+    r122 = r122 * r133;
+    r30 = r16 * r10;
+    r139 = r16 * r29;
+    r139 = r139 * r31;
+    r102 = r102 + r139;
+    r27 = r32 * r41;
+    r102 = fmaf(r128, r27, r102);
+    r102 = r102 + r105;
+    r94 = r32 * r94;
+    r94 = r94 * r98;
+    r90 = r94 + r90;
+    r90 = fmaf(r13, r90, r14 * r102);
+    r102 = r16 * r34;
+    r102 = fmaf(r85, r102, r28);
+    r102 = r102 + r140;
+    r90 = fmaf(r15, r102, r90);
+    r30 = r30 * r90;
+    r30 = fmaf(r37, r30, r108 * r122);
+    r122 = r133 * r108;
+    r30 = fmaf(r87, r122, r30);
+    r102 = r16 * r11;
+    r139 = r106 + r139;
+    r139 = r139 + r95;
+    r95 = r41 * r34;
+    r141 = fmaf(r41, r141, r31 * r95);
+    r141 = r141 + r93;
+    r141 = fmaf(r15, r141, r13 * r139);
+    r94 = r150 + r94;
+    r141 = fmaf(r14, r94, r141);
+    r102 = r102 * r141;
+    r30 = fmaf(r37, r102, r30);
+    r102 = r30 * r120;
+    r102 = r102 * r42;
+    r102 = fmaf(r141, r119, r118 * r102);
+    r122 = r4 * r11;
+    r122 = r122 * r30;
+    r102 = fmaf(r123, r122, r102);
+    r102 = fmaf(r133, r124, r102);
+    r122 = r133 * r64;
+    r122 = fmaf(r30, r111, r125 * r122);
+    r94 = r4 * r10;
+    r94 = r94 * r10;
+    r94 = r94 * r30;
+    r94 = r94 * r107;
+    r94 = r94 * r117;
+    r122 = fmaf(r62, r94, r122);
+    r14 = r90 * r63;
+    r122 = fmaf(r79, r14, r122);
+    r14 = r102 + r122;
+    r94 = r113 * r133;
+    r94 = r94 * r3;
+    r94 = r94 * r64;
+    r150 = r71 * r30;
+    r150 = fmaf(r111, r150, r101 * r94);
+    r94 = r10 * r10;
+    r94 = r94 * r116;
+    r94 = r94 * r30;
+    r94 = r94 * r107;
+    r94 = r94 * r117;
+    r150 = fmaf(r62, r94, r150);
+    r15 = r100 * r90;
+    r15 = r15 * r62;
+    r150 = fmaf(r63, r15, r150);
+    r150 = r150 + r102;
+    r150 = fmaf(r68, r150, r8 * r14);
+    r102 = r7 * r16;
+    r102 = r102 * r66;
+    r102 = fmaf(r14, r102, r6 * r14);
+    r102 = fmaf(r14, r69, r102);
+    r102 = fmaf(r14, r70, r102);
+    r15 = r10 * r102;
+    r150 = fmaf(r76, r15, r150);
+    r94 = r10 * r86;
+    r94 = r94 * r30;
+    r94 = r94 * r107;
+    r94 = r94 * r35;
+    r150 = fmaf(r75, r94, r150);
+    r139 = r60 * r82;
+    r139 = r139 * r88;
+    r139 = r139 * r30;
+    r139 = r139 * r73;
+    r139 = r139 * r107;
+    r150 = fmaf(r63, r139, r150);
+    r13 = r4 * r10;
+    r13 = r13 * r133;
+    r13 = r13 * r74;
+    r150 = fmaf(r57, r13, r150);
+    r93 = r67 * r30;
+    r150 = fmaf(r134, r93, r150);
+    r95 = r67 * r90;
+    r150 = fmaf(r119, r95, r150);
+    r31 = r10 * r86;
+    r31 = r31 * r82;
+    r31 = r31 * r30;
+    r31 = r31 * r107;
+    r31 = r31 * r35;
+    r150 = fmaf(r75, r31, r150);
+    r106 = r67 * r141;
+    r106 = r106 * r63;
+    r150 = fmaf(r79, r106, r150);
+    r140 = r60 * r88;
+    r140 = r140 * r30;
+    r140 = r140 * r73;
+    r140 = r140 * r107;
+    r150 = fmaf(r63, r140, r150);
+    r28 = r4 * r10;
+    r28 = r28 * r82;
+    r28 = r28 * r133;
+    r28 = r28 * r74;
+    r150 = fmaf(r57, r28, r150);
+    r85 = r67 * r30;
+    r150 = fmaf(r127, r85, r150);
+    r150 = fmaf(r133, r129, r150);
+    r150 = fmaf(r90, r84, r150);
+    r150 = fmaf(r90, r76, r150);
+    r85 = r0 * r150;
+    r28 = r71 * r30;
+    r28 = r28 * r120;
+    r28 = r28 * r42;
+    r140 = r11 * r100;
+    r140 = r140 * r141;
+    r140 = r140 * r47;
+    r140 = fmaf(r62, r140, r118 * r28);
+    r28 = r11 * r11;
+    r28 = r28 * r60;
+    r28 = r28 * r60;
+    r28 = r28 * r113;
+    r28 = r28 * r133;
+    r28 = r28 * r47;
+    r140 = fmaf(r3, r28, r140);
+    r106 = r11 * r116;
+    r106 = r106 * r30;
+    r140 = fmaf(r123, r106, r140);
+    r140 = r140 + r122;
+    r140 = fmaf(r67, r140, r9 * r14);
+    r14 = r68 * r11;
+    r14 = r14 * r60;
+    r14 = r14 * r60;
+    r14 = r14 * r98;
+    r14 = r14 * r133;
+    r14 = r14 * r3;
+    r140 = fmaf(r63, r14, r140);
+    r122 = r86 * r30;
+    r122 = r122 * r35;
+    r122 = r122 * r75;
+    r140 = fmaf(r120, r122, r140);
+    r106 = r4 * r11;
+    r106 = r106 * r82;
+    r106 = r106 * r133;
+    r106 = r106 * r74;
+    r140 = fmaf(r57, r106, r140);
+    r28 = r68 * r30;
+    r140 = fmaf(r134, r28, r140);
+    r31 = r68 * r141;
+    r31 = r31 * r63;
+    r140 = fmaf(r79, r31, r140);
+    r95 = r4 * r11;
+    r95 = r95 * r133;
+    r95 = r95 * r74;
+    r140 = fmaf(r57, r95, r140);
+    r93 = r68 * r30;
+    r140 = fmaf(r127, r93, r140);
+    r13 = r11 * r102;
+    r140 = fmaf(r76, r13, r140);
+    r139 = r86 * r82;
+    r139 = r139 * r30;
+    r139 = r139 * r35;
+    r139 = r139 * r75;
+    r140 = fmaf(r120, r139, r140);
+    r140 = fmaf(r30, r115, r140);
+    r140 = fmaf(r141, r84, r140);
+    r140 = fmaf(r90, r130, r140);
+    r140 = fmaf(r30, r132, r140);
+    r140 = fmaf(r141, r76, r140);
+    r139 = r5 * r140;
+    r13 = r26 * r113;
+    r13 = r13 * r3;
+    r13 = r13 * r64;
+    r93 = r43 * r100;
+    r93 = r93 * r62;
+    r93 = fmaf(r63, r93, r101 * r13);
+    r13 = r10 * r10;
+    r95 = r26 * r108;
+    r31 = r16 * r39;
+    r31 = r31 * r11;
+    r31 = fmaf(r37, r31, r87 * r95);
+    r95 = r26 * r10;
+    r95 = r95 * r10;
+    r31 = fmaf(r108, r95, r31);
+    r28 = r16 * r43;
+    r28 = r28 * r10;
+    r31 = fmaf(r37, r28, r31);
+    r13 = r13 * r116;
+    r13 = r13 * r31;
+    r13 = r13 * r107;
+    r13 = r13 * r117;
+    r93 = fmaf(r62, r13, r93);
+    r28 = r71 * r31;
+    r93 = fmaf(r111, r28, r93);
+    r95 = fmaf(r39, r119, r26 * r124);
+    r106 = r4 * r11;
+    r106 = r106 * r31;
+    r95 = fmaf(r123, r106, r95);
+    r122 = r31 * r120;
+    r122 = r122 * r42;
+    r95 = fmaf(r118, r122, r95);
+    r93 = r93 + r95;
+    r28 = r26 * r64;
+    r13 = r43 * r63;
+    r13 = fmaf(r79, r13, r125 * r28);
+    r28 = r4 * r10;
+    r28 = r28 * r10;
+    r28 = r28 * r31;
+    r28 = r28 * r107;
+    r28 = r28 * r117;
+    r13 = fmaf(r62, r28, r13);
+    r13 = fmaf(r31, r111, r13);
+    r95 = r95 + r13;
+    r93 = fmaf(r8, r95, r68 * r93);
+    r28 = r4 * r26;
+    r28 = r28 * r10;
+    r28 = r28 * r74;
+    r93 = fmaf(r57, r28, r93);
+    r122 = r60 * r82;
+    r122 = r122 * r88;
+    r122 = r122 * r31;
+    r122 = r122 * r73;
+    r122 = r122 * r107;
+    r93 = fmaf(r63, r122, r93);
+    r106 = r67 * r31;
+    r93 = fmaf(r134, r106, r93);
+    r14 = r31 * r127;
+    r94 = r67 * r43;
+    r93 = fmaf(r119, r94, r93);
+    r15 = r60 * r88;
+    r15 = r15 * r31;
+    r15 = r15 * r73;
+    r15 = r15 * r107;
+    r93 = fmaf(r63, r15, r93);
+    r105 = r10 * r86;
+    r105 = r105 * r82;
+    r105 = r105 * r31;
+    r105 = r105 * r107;
+    r105 = r105 * r35;
+    r93 = fmaf(r75, r105, r93);
+    r27 = r10 * r86;
+    r27 = r27 * r31;
+    r27 = r27 * r107;
+    r27 = r27 * r35;
+    r93 = fmaf(r75, r27, r93);
+    r128 = r67 * r39;
+    r128 = r128 * r63;
+    r93 = fmaf(r79, r128, r93);
+    r138 = r7 * r16;
+    r138 = r138 * r66;
+    r138 = fmaf(r6, r95, r95 * r138);
+    r138 = fmaf(r95, r70, r138);
+    r138 = fmaf(r95, r69, r138);
+    r91 = r10 * r138;
+    r93 = fmaf(r76, r91, r93);
+    r144 = r4 * r26;
+    r144 = r144 * r10;
+    r144 = r144 * r82;
+    r144 = r144 * r74;
+    r93 = fmaf(r57, r144, r93);
+    r93 = fmaf(r43, r76, r93);
+    r93 = fmaf(r43, r84, r93);
+    r93 = fmaf(r67, r14, r93);
+    r93 = fmaf(r26, r129, r93);
+    r144 = r0 * r93;
+    r91 = r26 * r11;
+    r91 = r91 * r11;
+    r91 = r91 * r60;
+    r91 = r91 * r60;
+    r91 = r91 * r113;
+    r91 = r91 * r47;
+    r128 = r39 * r11;
+    r128 = r128 * r100;
+    r128 = r128 * r47;
+    r128 = fmaf(r62, r128, r3 * r91);
+    r91 = r11 * r116;
+    r91 = r91 * r31;
+    r128 = fmaf(r123, r91, r128);
+    r27 = r71 * r31;
+    r27 = r27 * r120;
+    r27 = r27 * r42;
+    r128 = fmaf(r118, r27, r128);
+    r128 = r128 + r13;
+    r95 = fmaf(r9, r95, r67 * r128);
+    r128 = r4 * r26;
+    r128 = r128 * r11;
+    r128 = r128 * r74;
+    r95 = fmaf(r57, r128, r95);
+    r13 = r4 * r26;
+    r13 = r13 * r11;
+    r13 = r13 * r82;
+    r13 = r13 * r74;
+    r95 = fmaf(r57, r13, r95);
+    r27 = r68 * r31;
+    r95 = fmaf(r134, r27, r95);
+    r91 = r86 * r31;
+    r91 = r91 * r35;
+    r91 = r91 * r75;
+    r95 = fmaf(r120, r91, r95);
+    r105 = r68 * r26;
+    r105 = r105 * r11;
+    r105 = r105 * r60;
+    r105 = r105 * r60;
+    r105 = r105 * r98;
+    r105 = r105 * r3;
+    r95 = fmaf(r63, r105, r95);
+    r15 = r68 * r39;
+    r15 = r15 * r63;
+    r95 = fmaf(r79, r15, r95);
+    r94 = r86 * r82;
+    r94 = r94 * r31;
+    r94 = r94 * r35;
+    r94 = r94 * r75;
+    r95 = fmaf(r120, r94, r95);
+    r106 = r11 * r138;
+    r95 = fmaf(r76, r106, r95);
+    r95 = fmaf(r31, r115, r95);
+    r95 = fmaf(r31, r132, r95);
+    r95 = fmaf(r39, r76, r95);
+    r95 = fmaf(r39, r84, r95);
+    r95 = fmaf(r68, r14, r95);
+    r95 = fmaf(r43, r130, r95);
+    r106 = r5 * r95;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r85,
+                                          r139,
+                                          r144,
+                                          r106);
+    r106 = r40 * r108;
+    r144 = r16 * r44;
+    r144 = r144 * r11;
+    r144 = fmaf(r37, r144, r87 * r106);
+    r106 = r40 * r10;
+    r106 = r106 * r10;
+    r144 = fmaf(r108, r106, r144);
+    r139 = r16 * r59;
+    r139 = r139 * r10;
+    r144 = fmaf(r37, r139, r144);
+    r139 = r144 * r120;
+    r139 = r139 * r42;
+    r139 = fmaf(r40, r124, r118 * r139);
+    r106 = r4 * r11;
+    r106 = r106 * r144;
+    r139 = fmaf(r123, r106, r139);
+    r139 = fmaf(r44, r119, r139);
+    r106 = r40 * r64;
+    r106 = fmaf(r125, r106, r144 * r111);
+    r85 = r59 * r63;
+    r106 = fmaf(r79, r85, r106);
+    r94 = r4 * r10;
+    r94 = r94 * r10;
+    r94 = r94 * r144;
+    r94 = r94 * r107;
+    r94 = r94 * r117;
+    r106 = fmaf(r62, r94, r106);
+    r94 = r139 + r106;
+    r85 = r71 * r144;
+    r15 = r40 * r113;
+    r15 = r15 * r3;
+    r15 = r15 * r64;
+    r15 = fmaf(r101, r15, r111 * r85);
+    r85 = r59 * r100;
+    r85 = r85 * r62;
+    r15 = fmaf(r63, r85, r15);
+    r105 = r10 * r10;
+    r105 = r105 * r116;
+    r105 = r105 * r144;
+    r105 = r105 * r107;
+    r105 = r105 * r117;
+    r15 = fmaf(r62, r105, r15);
+    r15 = r15 + r139;
+    r15 = fmaf(r68, r15, r8 * r94);
+    r139 = r7 * r16;
+    r139 = r139 * r66;
+    r139 = fmaf(r94, r139, r6 * r94);
+    r139 = fmaf(r94, r70, r139);
+    r139 = fmaf(r94, r69, r139);
+    r105 = r10 * r139;
+    r15 = fmaf(r76, r105, r15);
+    r85 = r67 * r44;
+    r85 = r85 * r63;
+    r15 = fmaf(r79, r85, r15);
+    r91 = r60 * r88;
+    r91 = r91 * r144;
+    r91 = r91 * r73;
+    r91 = r91 * r107;
+    r15 = fmaf(r63, r91, r15);
+    r14 = r67 * r144;
+    r15 = fmaf(r127, r14, r15);
+    r27 = r10 * r86;
+    r27 = r27 * r144;
+    r27 = r27 * r107;
+    r27 = r27 * r35;
+    r15 = fmaf(r75, r27, r15);
+    r13 = r67 * r144;
+    r15 = fmaf(r134, r13, r15);
+    r128 = r60 * r82;
+    r128 = r128 * r88;
+    r128 = r128 * r144;
+    r128 = r128 * r73;
+    r128 = r128 * r107;
+    r15 = fmaf(r63, r128, r15);
+    r122 = r10 * r86;
+    r122 = r122 * r82;
+    r122 = r122 * r144;
+    r122 = r122 * r107;
+    r122 = r122 * r35;
+    r15 = fmaf(r75, r122, r15);
+    r28 = r4 * r40;
+    r28 = r28 * r10;
+    r28 = r28 * r74;
+    r15 = fmaf(r57, r28, r15);
+    r145 = r67 * r59;
+    r15 = fmaf(r119, r145, r15);
+    r146 = r4 * r40;
+    r146 = r146 * r10;
+    r146 = r146 * r82;
+    r146 = r146 * r74;
+    r15 = fmaf(r57, r146, r15);
+    r15 = fmaf(r59, r84, r15);
+    r15 = fmaf(r59, r76, r15);
+    r15 = fmaf(r40, r129, r15);
+    r146 = r0 * r15;
+    r145 = r71 * r144;
+    r145 = r145 * r120;
+    r145 = r145 * r42;
+    r28 = r40 * r11;
+    r28 = r28 * r11;
+    r28 = r28 * r60;
+    r28 = r28 * r60;
+    r28 = r28 * r113;
+    r28 = r28 * r47;
+    r28 = fmaf(r3, r28, r118 * r145);
+    r145 = r44 * r11;
+    r145 = r145 * r100;
+    r145 = r145 * r47;
+    r28 = fmaf(r62, r145, r28);
+    r122 = r11 * r116;
+    r122 = r122 * r144;
+    r28 = fmaf(r123, r122, r28);
+    r28 = r28 + r106;
+    r28 = fmaf(r67, r28, r9 * r94);
+    r94 = r68 * r44;
+    r94 = r94 * r63;
+    r28 = fmaf(r79, r94, r28);
+    r106 = r4 * r40;
+    r106 = r106 * r11;
+    r106 = r106 * r74;
+    r28 = fmaf(r57, r106, r28);
+    r122 = r86 * r144;
+    r122 = r122 * r35;
+    r122 = r122 * r75;
+    r28 = fmaf(r120, r122, r28);
+    r145 = r68 * r144;
+    r28 = fmaf(r127, r145, r28);
+    r128 = r86 * r82;
+    r128 = r128 * r144;
+    r128 = r128 * r35;
+    r128 = r128 * r75;
+    r28 = fmaf(r120, r128, r28);
+    r13 = r68 * r40;
+    r13 = r13 * r11;
+    r13 = r13 * r60;
+    r13 = r13 * r60;
+    r13 = r13 * r98;
+    r13 = r13 * r3;
+    r28 = fmaf(r63, r13, r28);
+    r27 = r68 * r144;
+    r28 = fmaf(r134, r27, r28);
+    r14 = r4 * r40;
+    r14 = r14 * r11;
+    r14 = r14 * r82;
+    r14 = r14 * r74;
+    r28 = fmaf(r57, r14, r28);
+    r91 = r11 * r139;
+    r28 = fmaf(r76, r91, r28);
+    r28 = fmaf(r44, r84, r28);
+    r28 = fmaf(r44, r76, r28);
+    r28 = fmaf(r59, r130, r28);
+    r28 = fmaf(r144, r132, r28);
+    r28 = fmaf(r144, r115, r28);
+    r91 = r5 * r28;
+    r14 = r16 * r46;
+    r14 = r14 * r11;
+    r27 = r38 * r108;
+    r27 = fmaf(r87, r27, r37 * r14);
+    r14 = r16 * r58;
+    r14 = r14 * r10;
+    r27 = fmaf(r37, r14, r27);
+    r13 = r38 * r10;
+    r13 = r13 * r10;
+    r27 = fmaf(r108, r13, r27);
+    r13 = r27 * r120;
+    r13 = r13 * r42;
+    r13 = fmaf(r46, r119, r118 * r13);
+    r14 = r4 * r11;
+    r14 = r14 * r27;
+    r13 = fmaf(r123, r14, r13);
+    r13 = fmaf(r38, r124, r13);
+    r14 = r38 * r64;
+    r128 = r4 * r10;
+    r128 = r128 * r10;
+    r128 = r128 * r27;
+    r128 = r128 * r107;
+    r128 = r128 * r117;
+    r128 = fmaf(r62, r128, r125 * r14);
+    r14 = r58 * r63;
+    r128 = fmaf(r79, r14, r128);
+    r128 = fmaf(r27, r111, r128);
+    r14 = r13 + r128;
+    r145 = r38 * r113;
+    r145 = r145 * r3;
+    r145 = r145 * r64;
+    r122 = r10 * r10;
+    r122 = r122 * r116;
+    r122 = r122 * r27;
+    r122 = r122 * r107;
+    r122 = r122 * r117;
+    r122 = fmaf(r62, r122, r101 * r145);
+    r145 = r58 * r100;
+    r145 = r145 * r62;
+    r122 = fmaf(r63, r145, r122);
+    r106 = r71 * r27;
+    r122 = fmaf(r111, r106, r122);
+    r122 = r122 + r13;
+    r122 = fmaf(r68, r122, r8 * r14);
+    r13 = r4 * r38;
+    r13 = r13 * r10;
+    r13 = r13 * r82;
+    r13 = r13 * r74;
+    r122 = fmaf(r57, r13, r122);
+    r106 = r4 * r38;
+    r106 = r106 * r10;
+    r106 = r106 * r74;
+    r122 = fmaf(r57, r106, r122);
+    r145 = r10 * r86;
+    r145 = r145 * r82;
+    r145 = r145 * r27;
+    r145 = r145 * r107;
+    r145 = r145 * r35;
+    r122 = fmaf(r75, r145, r122);
+    r94 = r60 * r88;
+    r94 = r94 * r27;
+    r94 = r94 * r73;
+    r94 = r94 * r107;
+    r122 = fmaf(r63, r94, r122);
+    r85 = r67 * r27;
+    r122 = fmaf(r134, r85, r122);
+    r105 = r67 * r27;
+    r122 = fmaf(r127, r105, r122);
+    r149 = r67 * r46;
+    r149 = r149 * r63;
+    r122 = fmaf(r79, r149, r122);
+    r92 = r67 * r58;
+    r122 = fmaf(r119, r92, r122);
+    r126 = r60 * r82;
+    r126 = r126 * r88;
+    r126 = r126 * r27;
+    r126 = r126 * r73;
+    r126 = r126 * r107;
+    r122 = fmaf(r63, r126, r122);
+    r112 = r10 * r86;
+    r112 = r112 * r27;
+    r112 = r112 * r107;
+    r112 = r112 * r35;
+    r122 = fmaf(r75, r112, r122);
+    r114 = r7 * r16;
+    r114 = r114 * r66;
+    r114 = fmaf(r6, r14, r14 * r114);
+    r114 = fmaf(r14, r70, r114);
+    r114 = fmaf(r14, r69, r114);
+    r131 = r10 * r114;
+    r122 = fmaf(r76, r131, r122);
+    r122 = fmaf(r58, r76, r122);
+    r122 = fmaf(r58, r84, r122);
+    r122 = fmaf(r38, r129, r122);
+    r131 = r0 * r122;
+    r112 = r71 * r27;
+    r112 = r112 * r120;
+    r112 = r112 * r42;
+    r126 = r46 * r11;
+    r126 = r126 * r100;
+    r126 = r126 * r47;
+    r126 = fmaf(r62, r126, r118 * r112);
+    r112 = r11 * r116;
+    r112 = r112 * r27;
+    r126 = fmaf(r123, r112, r126);
+    r92 = r38 * r11;
+    r92 = r92 * r11;
+    r92 = r92 * r60;
+    r92 = r92 * r60;
+    r92 = r92 * r113;
+    r92 = r92 * r47;
+    r126 = fmaf(r3, r92, r126);
+    r126 = r126 + r128;
+    r126 = fmaf(r67, r126, r9 * r14);
+    r14 = r86 * r82;
+    r14 = r14 * r27;
+    r14 = r14 * r35;
+    r14 = r14 * r75;
+    r126 = fmaf(r120, r14, r126);
+    r128 = r86 * r27;
+    r128 = r128 * r35;
+    r128 = r128 * r75;
+    r126 = fmaf(r120, r128, r126);
+    r92 = r68 * r27;
+    r126 = fmaf(r134, r92, r126);
+    r112 = r68 * r27;
+    r126 = fmaf(r127, r112, r126);
+    r149 = r68 * r46;
+    r149 = r149 * r63;
+    r126 = fmaf(r79, r149, r126);
+    r105 = r4 * r38;
+    r105 = r105 * r11;
+    r105 = r105 * r82;
+    r105 = r105 * r74;
+    r126 = fmaf(r57, r105, r126);
+    r85 = r4 * r38;
+    r85 = r85 * r11;
+    r85 = r85 * r74;
+    r126 = fmaf(r57, r85, r126);
+    r94 = r11 * r114;
+    r126 = fmaf(r76, r94, r126);
+    r145 = r68 * r38;
+    r145 = r145 * r11;
+    r145 = r145 * r60;
+    r145 = r145 * r60;
+    r145 = r145 * r98;
+    r145 = r145 * r3;
+    r126 = fmaf(r63, r145, r126);
+    r126 = fmaf(r46, r84, r126);
+    r126 = fmaf(r27, r132, r126);
+    r126 = fmaf(r27, r115, r126);
+    r126 = fmaf(r58, r130, r126);
+    r126 = fmaf(r46, r76, r126);
+    r145 = r5 * r126;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r146,
+                                          r91,
+                                          r131,
+                                          r145);
+    r145 = r0 * r4;
+    r145 = r145 * r2;
+    r131 = r4 * r1;
+    r91 = r5 * r131;
+    r145 = fmaf(r121, r91, r110 * r145);
+    r146 = r0 * r4;
+    r146 = r146 * r2;
+    r146 = fmaf(r147, r91, r143 * r146);
+    r94 = r0 * r4;
+    r94 = r94 * r2;
+    r94 = fmaf(r140, r91, r150 * r94);
+    r85 = r0 * r4;
+    r85 = r85 * r2;
+    r85 = fmaf(r95, r91, r93 * r85);
+    WriteSum4<float, float>((float*)inout_shared, r145, r146, r94, r85);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r0 * r4;
+    r85 = r85 * r2;
+    r85 = fmaf(r28, r91, r15 * r85);
+    r94 = r0 * r4;
+    r94 = r94 * r2;
+    r94 = fmaf(r126, r91, r122 * r94);
+    WriteSum2<float, float>((float*)inout_shared, r85, r94);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r0 * r0;
+    r85 = r110 * r110;
+    r146 = r5 * r5;
+    r145 = r121 * r121;
+    r145 = fmaf(r146, r145, r94 * r85);
+    r85 = r143 * r143;
+    r105 = r147 * r147;
+    r105 = fmaf(r146, r105, r94 * r85);
+    r85 = r140 * r140;
+    r149 = r150 * r150;
+    r149 = fmaf(r94, r149, r146 * r85);
+    r85 = r93 * r93;
+    r112 = r95 * r95;
+    r112 = fmaf(r146, r112, r94 * r85);
+    WriteSum4<float, float>((float*)inout_shared, r145, r105, r149, r112);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r112 = r15 * r15;
+    r149 = r28 * r28;
+    r149 = fmaf(r146, r149, r94 * r112);
+    r112 = r126 * r126;
+    r105 = r122 * r122;
+    r105 = fmaf(r94, r105, r146 * r112);
+    WriteSum2<float, float>((float*)inout_shared, r149, r105);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r121 * r147;
+    r149 = r110 * r143;
+    r149 = fmaf(r94, r149, r146 * r105);
+    r105 = r110 * r150;
+    r112 = r121 * r140;
+    r112 = fmaf(r146, r112, r94 * r105);
+    r105 = r121 * r95;
+    r145 = r110 * r93;
+    r145 = fmaf(r94, r145, r146 * r105);
+    r105 = r121 * r28;
+    r85 = r110 * r15;
+    r85 = fmaf(r94, r85, r146 * r105);
+    WriteSum4<float, float>((float*)inout_shared, r149, r112, r145, r85);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r110 * r122;
+    r145 = r121 * r126;
+    r145 = fmaf(r146, r145, r94 * r85);
+    r85 = r147 * r140;
+    r112 = r143 * r150;
+    r112 = fmaf(r94, r112, r146 * r85);
+    r85 = r143 * r93;
+    r149 = r147 * r95;
+    r149 = fmaf(r146, r149, r94 * r85);
+    r85 = r143 * r15;
+    r105 = r147 * r28;
+    r105 = fmaf(r146, r105, r94 * r85);
+    WriteSum4<float, float>((float*)inout_shared, r145, r112, r149, r105);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r147 * r126;
+    r149 = r143 * r122;
+    r149 = fmaf(r94, r149, r146 * r105);
+    r105 = r140 * r95;
+    r112 = r150 * r93;
+    r112 = fmaf(r94, r112, r146 * r105);
+    r105 = r150 * r15;
+    r145 = r140 * r28;
+    r145 = fmaf(r146, r145, r94 * r105);
+    r105 = r140 * r126;
+    r85 = r150 * r122;
+    r85 = fmaf(r94, r85, r146 * r105);
+    WriteSum4<float, float>((float*)inout_shared, r149, r112, r145, r85);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r95 * r28;
+    r145 = r93 * r15;
+    r145 = fmaf(r94, r145, r146 * r85);
+    r85 = r93 * r122;
+    r112 = r95 * r126;
+    r112 = fmaf(r146, r112, r94 * r85);
+    r85 = r28 * r126;
+    r149 = r15 * r122;
+    r149 = fmaf(r94, r149, r146 * r85);
+    WriteSum3<float, float>((float*)inout_shared, r145, r112, r149);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r149 = r0 * r10;
+    r149 = r149 * r66;
+    r149 = r149 * r76;
+    r112 = r5 * r11;
+    r112 = r112 * r66;
+    r112 = r112 * r76;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r52,
+                                          r65,
+                                          r149,
+                                          r112);
+    r112 = r5 * r78;
+    r149 = r0 * r10;
+    r149 = r149 * r76;
+    r149 = r149 * r80;
+    r145 = r5 * r11;
+    r145 = r145 * r76;
+    r145 = r145 * r80;
+    r85 = r0 * r11;
+    r85 = r85 * r63;
+    r85 = r85 * r79;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r149,
+                                          r145,
+                                          r85,
+                                          r112);
+    r112 = r0 * r72;
+    r85 = r5 * r11;
+    r85 = r85 * r63;
+    r85 = r85 * r79;
+    r145 = r0 * r10;
+    r145 = r145 * r76;
+    r145 = r145 * r81;
+    r149 = r5 * r11;
+    r149 = r149 * r76;
+    r149 = r149 * r81;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r112,
+                                          r85,
+                                          r145,
+                                          r149);
+    r149 = r0 * r66;
+    r145 = r5 * r66;
+    r85 = r0 * r10;
+    r85 = r85 * r76;
+    r85 = r85 * r83;
+    r112 = r5 * r11;
+    r112 = r112 * r76;
+    r112 = r112 * r83;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r85,
+        r112,
+        r149,
+        r145);
+    r145 = r4 * r52;
+    r145 = r145 * r2;
+    r131 = r65 * r131;
+    r149 = r0 * r4;
+    r149 = r149 * r10;
+    r149 = r149 * r66;
+    r149 = r149 * r2;
+    r112 = r11 * r66;
+    r112 = r112 * r76;
+    r112 = fmaf(r91, r112, r76 * r149);
+    r149 = r0 * r4;
+    r149 = r149 * r10;
+    r149 = r149 * r2;
+    r149 = r149 * r76;
+    r85 = r11 * r76;
+    r85 = r85 * r80;
+    r85 = fmaf(r91, r85, r80 * r149);
+    WriteSum4<float, float>((float*)inout_shared, r145, r131, r112, r85);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r0 * r41;
+    r85 = r85 * r11;
+    r85 = r85 * r2;
+    r85 = r85 * r62;
+    r85 = fmaf(r63, r85, r78 * r91);
+    r112 = r0 * r4;
+    r112 = r112 * r72;
+    r131 = r5 * r41;
+    r131 = r131 * r11;
+    r131 = r131 * r1;
+    r131 = r131 * r62;
+    r131 = fmaf(r63, r131, r2 * r112);
+    r112 = r0 * r4;
+    r112 = r112 * r10;
+    r112 = r112 * r2;
+    r112 = r112 * r76;
+    r1 = r11 * r76;
+    r1 = r1 * r81;
+    r1 = fmaf(r91, r1, r81 * r112);
+    r112 = r0 * r4;
+    r112 = r112 * r10;
+    r112 = r112 * r2;
+    r112 = r112 * r76;
+    r145 = r11 * r76;
+    r145 = r145 * r83;
+    r145 = fmaf(r91, r145, r83 * r112);
+    WriteSum4<float, float>((float*)inout_shared, r85, r131, r1, r145);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r145 = r0 * r4;
+    r145 = r145 * r66;
+    r145 = r145 * r2;
+    r1 = r66 * r91;
+    WriteSum2<float, float>((float*)inout_shared, r145, r1);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r52 * r52;
+    r145 = r65 * r65;
+    r131 = r11 * r62;
+    r131 = r131 * r80;
+    r131 = r131 * r146;
+    r85 = r62 * r80;
+    r85 = r85 * r94;
+    r85 = fmaf(r64, r85, r118 * r131);
+    r131 = r11 * r62;
+    r131 = r131 * r146;
+    r131 = r131 * r118;
+    r112 = r62 * r94;
+    r112 = r112 * r64;
+    r112 = fmaf(r83, r112, r83 * r131);
+    WriteSum4<float, float>((float*)inout_shared, r1, r145, r85, r112);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r10 * r10;
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r53 = r51 * r53;
+    r53 = 1.0 / r53;
+    r85 = r85 * r60;
+    r85 = r85 * r60;
+    r85 = r85 * r136;
+    r85 = r85 * r12;
+    r85 = r85 * r53;
+    r85 = r85 * r101;
+    r85 = r85 * r87;
+    r53 = r78 * r146;
+    r12 = fmaf(r78, r53, r94 * r85);
+    r136 = r72 * r94;
+    r85 = fmaf(r72, r136, r146 * r85);
+    r51 = r81 * r81;
+    r36 = r11 * r62;
+    r36 = r36 * r146;
+    r36 = r36 * r118;
+    r145 = r62 * r94;
+    r145 = r145 * r64;
+    r145 = fmaf(r51, r145, r51 * r36);
+    r1 = r83 * r83;
+    r131 = r62 * r94;
+    r131 = r131 * r64;
+    r1 = fmaf(r1, r131, r36 * r1);
+    WriteSum4<float, float>((float*)inout_shared, r12, r85, r145, r1);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r80 * r94;
+    r85 = r80 * r146;
+    WriteSum2<float, float>((float*)inout_shared, r1, r85);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = 0.00000000000000000e+00;
+    r1 = r0 * r10;
+    r1 = r1 * r66;
+    r1 = r1 * r52;
+    r1 = r1 * r76;
+    r12 = r0 * r10;
+    r12 = r12 * r52;
+    r12 = r12 * r76;
+    r12 = r12 * r80;
+    r149 = r0 * r11;
+    r149 = r149 * r52;
+    r149 = r149 * r63;
+    r149 = r149 * r79;
+    WriteSum4<float, float>((float*)inout_shared, r85, r1, r12, r149);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r0 * r72;
+    r72 = r72 * r52;
+    r149 = r0 * r66;
+    r149 = r149 * r52;
+    r12 = r0 * r10;
+    r12 = r12 * r52;
+    r12 = r12 * r76;
+    r12 = r12 * r81;
+    r1 = r0 * r10;
+    r1 = r1 * r52;
+    r1 = r1 * r76;
+    r1 = r1 * r83;
+    WriteSum4<float, float>((float*)inout_shared, r72, r12, r1, r149);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r5 * r78;
+    r78 = r78 * r65;
+    r149 = r5 * r11;
+    r149 = r149 * r66;
+    r149 = r149 * r65;
+    r149 = r149 * r76;
+    r1 = r5 * r11;
+    r1 = r1 * r65;
+    r1 = r1 * r76;
+    r1 = r1 * r80;
+    WriteSum4<float, float>((float*)inout_shared, r85, r149, r1, r78);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r5 * r11;
+    r78 = r78 * r65;
+    r78 = r78 * r63;
+    r78 = r78 * r79;
+    r1 = r5 * r11;
+    r1 = r1 * r65;
+    r1 = r1 * r76;
+    r1 = r1 * r81;
+    r149 = r5 * r11;
+    r149 = r149 * r65;
+    r149 = r149 * r76;
+    r149 = r149 * r83;
+    WriteSum4<float, float>((float*)inout_shared, r78, r1, r149, r85);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r5 * r66;
+    r85 = r85 * r65;
+    r65 = r11 * r62;
+    r65 = r65 * r81;
+    r65 = r65 * r146;
+    r149 = r62 * r81;
+    r149 = r149 * r94;
+    r149 = fmaf(r64, r149, r118 * r65);
+    r65 = r16 * r10;
+    r65 = r65 * r10;
+    r65 = r65 * r11;
+    r65 = r65 * r60;
+    r65 = r65 * r66;
+    r65 = r65 * r3;
+    r65 = r65 * r117;
+    r65 = r65 * r94;
+    r1 = r11 * r53;
+    r78 = r76 * r1;
+    r65 = fmaf(r66, r78, r101 * r65);
+    r12 = r136 * r77;
+    r72 = r16 * r10;
+    r72 = r72 * r60;
+    r72 = r72 * r66;
+    r72 = r72 * r3;
+    r72 = r72 * r117;
+    r72 = r72 * r146;
+    r72 = r72 * r101;
+    r72 = fmaf(r87, r72, r66 * r12);
+    WriteSum4<float, float>((float*)inout_shared, r85, r149, r65, r72);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r10 * r76;
+    r72 = r72 * r80;
+    r72 = r72 * r94;
+    r65 = r11 * r76;
+    r65 = r65 * r80;
+    r65 = r65 * r146;
+    r149 = r66 * r83;
+    r85 = r62 * r94;
+    r85 = r85 * r64;
+    r85 = fmaf(r149, r85, r149 * r36);
+    WriteSum4<float, float>((float*)inout_shared, r112, r85, r72, r65);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r16 * r10;
+    r65 = r65 * r10;
+    r65 = r65 * r11;
+    r65 = r65 * r60;
+    r65 = r65 * r3;
+    r65 = r65 * r117;
+    r65 = r65 * r80;
+    r65 = r65 * r94;
+    r65 = fmaf(r80, r78, r101 * r65);
+    r72 = r16 * r10;
+    r72 = r72 * r60;
+    r72 = r72 * r3;
+    r72 = r72 * r117;
+    r72 = r72 * r80;
+    r72 = r72 * r146;
+    r72 = r72 * r101;
+    r72 = fmaf(r87, r72, r80 * r12);
+    WriteSum4<float, float>((float*)inout_shared, r65, r72, r85, r145);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r145 = r10 * r76;
+    r145 = r145 * r81;
+    r145 = r145 * r94;
+    r85 = r11 * r76;
+    r85 = r85 * r81;
+    r85 = r85 * r146;
+    r72 = r63 * r79;
+    r65 = r11 * r136;
+    r65 = fmaf(r72, r65, r1 * r72);
+    r72 = r16 * r10;
+    r72 = r72 * r10;
+    r72 = r72 * r11;
+    r72 = r72 * r60;
+    r72 = r72 * r3;
+    r72 = r72 * r117;
+    r72 = r72 * r81;
+    r72 = r72 * r94;
+    r72 = fmaf(r81, r78, r101 * r72);
+    WriteSum4<float, float>((float*)inout_shared, r145, r85, r65, r72);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r11 * r66;
+    r72 = r72 * r63;
+    r72 = r72 * r79;
+    r72 = r72 * r94;
+    r53 = r66 * r53;
+    r65 = r16 * r10;
+    r65 = r65 * r10;
+    r65 = r65 * r11;
+    r65 = r65 * r60;
+    r65 = r65 * r3;
+    r65 = r65 * r117;
+    r65 = r65 * r94;
+    r65 = r65 * r101;
+    r78 = fmaf(r83, r78, r83 * r65);
+    r65 = r16 * r10;
+    r65 = r65 * r60;
+    r65 = r65 * r3;
+    r65 = r65 * r117;
+    r65 = r65 * r81;
+    r65 = r65 * r146;
+    r65 = r65 * r101;
+    r65 = fmaf(r87, r65, r81 * r12);
+    WriteSum4<float, float>((float*)inout_shared, r78, r72, r53, r65);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r66 * r136;
+    r53 = r11 * r66;
+    r53 = r53 * r63;
+    r53 = r53 * r79;
+    r53 = r53 * r146;
+    r72 = r16 * r10;
+    r72 = r72 * r60;
+    r72 = r72 * r3;
+    r72 = r72 * r117;
+    r72 = r72 * r146;
+    r72 = r72 * r101;
+    r72 = r72 * r83;
+    r72 = fmaf(r87, r72, r83 * r12);
+    r51 = r66 * r51;
+    r131 = fmaf(r51, r131, r51 * r36);
+    WriteSum4<float, float>((float*)inout_shared, r72, r65, r53, r131);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r131 = r10 * r76;
+    r131 = r131 * r94;
+    r131 = r131 * r83;
+    r53 = r11 * r76;
+    r53 = r53 * r146;
+    r53 = r53 * r83;
+    r83 = r94 * r149;
+    r83 = r83 * r77;
+    r77 = r11 * r76;
+    r77 = r77 * r146;
+    r77 = r77 * r149;
+    WriteSum4<float, float>((float*)inout_shared, r131, r53, r83, r77);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r77 = r55 * r100;
+    r77 = r77 * r62;
+    r83 = r61 * r113;
+    r83 = r83 * r3;
+    r83 = r83 * r64;
+    r83 = fmaf(r101, r83, r63 * r77);
+    r77 = r16 * r33;
+    r77 = r77 * r11;
+    r53 = r16 * r55;
+    r53 = r53 * r10;
+    r53 = fmaf(r37, r53, r37 * r77);
+    r77 = r61 * r10;
+    r77 = r77 * r10;
+    r53 = fmaf(r108, r77, r53);
+    r131 = r61 * r108;
+    r53 = fmaf(r87, r131, r53);
+    r131 = r71 * r53;
+    r83 = fmaf(r111, r131, r83);
+    r77 = r10 * r10;
+    r77 = r77 * r116;
+    r77 = r77 * r53;
+    r77 = r77 * r107;
+    r77 = r77 * r117;
+    r83 = fmaf(r62, r77, r83);
+    r149 = r4 * r11;
+    r149 = r149 * r53;
+    r65 = r53 * r120;
+    r65 = r65 * r42;
+    r65 = fmaf(r118, r65, r123 * r149);
+    r65 = fmaf(r61, r124, r65);
+    r65 = fmaf(r33, r119, r65);
+    r83 = r83 + r65;
+    r77 = r55 * r63;
+    r131 = r61 * r64;
+    r131 = fmaf(r125, r131, r79 * r77);
+    r77 = r4 * r10;
+    r77 = r77 * r10;
+    r77 = r77 * r53;
+    r77 = r77 * r107;
+    r77 = r77 * r117;
+    r131 = fmaf(r62, r77, r131);
+    r131 = fmaf(r53, r111, r131);
+    r65 = r65 + r131;
+    r83 = fmaf(r8, r65, r68 * r83);
+    r77 = r60 * r82;
+    r77 = r77 * r88;
+    r77 = r77 * r53;
+    r77 = r77 * r73;
+    r77 = r77 * r107;
+    r83 = fmaf(r63, r77, r83);
+    r149 = r4 * r61;
+    r149 = r149 * r10;
+    r149 = r149 * r82;
+    r149 = r149 * r74;
+    r83 = fmaf(r57, r149, r83);
+    r72 = r4 * r61;
+    r72 = r72 * r10;
+    r72 = r72 * r74;
+    r83 = fmaf(r57, r72, r83);
+    r51 = r67 * r33;
+    r51 = r51 * r63;
+    r83 = fmaf(r79, r51, r83);
+    r36 = r7 * r16;
+    r36 = r36 * r66;
+    r36 = fmaf(r6, r65, r65 * r36);
+    r36 = fmaf(r65, r70, r36);
+    r36 = fmaf(r65, r69, r36);
+    r12 = r10 * r36;
+    r83 = fmaf(r76, r12, r83);
+    r78 = r10 * r86;
+    r78 = r78 * r82;
+    r78 = r78 * r53;
+    r78 = r78 * r107;
+    r78 = r78 * r35;
+    r83 = fmaf(r75, r78, r83);
+    r85 = r60 * r88;
+    r85 = r85 * r53;
+    r85 = r85 * r73;
+    r85 = r85 * r107;
+    r83 = fmaf(r63, r85, r83);
+    r145 = r53 * r134;
+    r1 = r67 * r55;
+    r83 = fmaf(r119, r1, r83);
+    r112 = r67 * r53;
+    r83 = fmaf(r127, r112, r83);
+    r52 = r10 * r86;
+    r52 = r52 * r53;
+    r52 = r52 * r107;
+    r52 = r52 * r35;
+    r83 = fmaf(r75, r52, r83);
+    r83 = fmaf(r55, r84, r83);
+    r83 = fmaf(r55, r76, r83);
+    r83 = fmaf(r61, r129, r83);
+    r83 = fmaf(r67, r145, r83);
+    r52 = r0 * r83;
+    r112 = r11 * r116;
+    r112 = r112 * r53;
+    r1 = r71 * r53;
+    r1 = r1 * r120;
+    r1 = r1 * r42;
+    r1 = fmaf(r118, r1, r123 * r112);
+    r112 = r61 * r11;
+    r112 = r112 * r11;
+    r112 = r112 * r60;
+    r112 = r112 * r60;
+    r112 = r112 * r113;
+    r112 = r112 * r47;
+    r1 = fmaf(r3, r112, r1);
+    r85 = r33 * r11;
+    r85 = r85 * r100;
+    r85 = r85 * r47;
+    r1 = fmaf(r62, r85, r1);
+    r1 = r1 + r131;
+    r65 = fmaf(r9, r65, r67 * r1);
+    r1 = r86 * r82;
+    r1 = r1 * r53;
+    r1 = r1 * r35;
+    r1 = r1 * r75;
+    r65 = fmaf(r120, r1, r65);
+    r131 = r4 * r61;
+    r131 = r131 * r11;
+    r131 = r131 * r82;
+    r131 = r131 * r74;
+    r65 = fmaf(r57, r131, r65);
+    r85 = r68 * r33;
+    r85 = r85 * r63;
+    r65 = fmaf(r79, r85, r65);
+    r112 = r68 * r61;
+    r112 = r112 * r11;
+    r112 = r112 * r60;
+    r112 = r112 * r60;
+    r112 = r112 * r98;
+    r112 = r112 * r3;
+    r65 = fmaf(r63, r112, r65);
+    r78 = r86 * r53;
+    r78 = r78 * r35;
+    r78 = r78 * r75;
+    r65 = fmaf(r120, r78, r65);
+    r12 = r4 * r61;
+    r12 = r12 * r11;
+    r12 = r12 * r74;
+    r65 = fmaf(r57, r12, r65);
+    r51 = r68 * r53;
+    r65 = fmaf(r127, r51, r65);
+    r72 = r11 * r36;
+    r65 = fmaf(r76, r72, r65);
+    r65 = fmaf(r53, r132, r65);
+    r65 = fmaf(r53, r115, r65);
+    r65 = fmaf(r68, r145, r65);
+    r65 = fmaf(r55, r130, r65);
+    r65 = fmaf(r33, r84, r65);
+    r65 = fmaf(r33, r76, r65);
+    r72 = r5 * r65;
+    r51 = r45 * r108;
+    r12 = r16 * r49;
+    r12 = r12 * r10;
+    r12 = fmaf(r37, r12, r87 * r51);
+    r51 = r16 * r50;
+    r51 = r51 * r11;
+    r12 = fmaf(r37, r51, r12);
+    r78 = r45 * r10;
+    r78 = r78 * r10;
+    r12 = fmaf(r108, r78, r12);
+    r78 = r45 * r64;
+    r78 = fmaf(r125, r78, r12 * r111);
+    r51 = r4 * r10;
+    r51 = r51 * r10;
+    r51 = r51 * r12;
+    r51 = r51 * r107;
+    r51 = r51 * r117;
+    r78 = fmaf(r62, r51, r78);
+    r145 = r49 * r63;
+    r78 = fmaf(r79, r145, r78);
+    r145 = r4 * r11;
+    r145 = r145 * r12;
+    r145 = fmaf(r50, r119, r123 * r145);
+    r51 = r12 * r120;
+    r51 = r51 * r42;
+    r145 = fmaf(r118, r51, r145);
+    r145 = fmaf(r45, r124, r145);
+    r51 = r78 + r145;
+    r112 = r71 * r12;
+    r85 = r45 * r113;
+    r85 = r85 * r3;
+    r85 = r85 * r64;
+    r85 = fmaf(r101, r85, r111 * r112);
+    r112 = r10 * r10;
+    r112 = r112 * r116;
+    r112 = r112 * r12;
+    r112 = r112 * r107;
+    r112 = r112 * r117;
+    r85 = fmaf(r62, r112, r85);
+    r111 = r49 * r100;
+    r111 = r111 * r62;
+    r85 = fmaf(r63, r111, r85);
+    r85 = r85 + r145;
+    r85 = fmaf(r68, r85, r8 * r51);
+    r145 = r67 * r49;
+    r85 = fmaf(r119, r145, r85);
+    r111 = r67 * r12;
+    r85 = fmaf(r134, r111, r85);
+    r112 = r60 * r88;
+    r112 = r112 * r12;
+    r112 = r112 * r73;
+    r112 = r112 * r107;
+    r85 = fmaf(r63, r112, r85);
+    r131 = r4 * r45;
+    r131 = r131 * r10;
+    r131 = r131 * r74;
+    r85 = fmaf(r57, r131, r85);
+    r1 = r4 * r45;
+    r1 = r1 * r10;
+    r1 = r1 * r82;
+    r1 = r1 * r74;
+    r85 = fmaf(r57, r1, r85);
+    r149 = r7 * r16;
+    r149 = r149 * r66;
+    r149 = fmaf(r51, r149, r6 * r51);
+    r149 = fmaf(r51, r70, r149);
+    r149 = fmaf(r51, r69, r149);
+    r77 = r10 * r149;
+    r85 = fmaf(r76, r77, r85);
+    r105 = r60 * r82;
+    r105 = r105 * r88;
+    r105 = r105 * r12;
+    r105 = r105 * r73;
+    r105 = r105 * r107;
+    r85 = fmaf(r63, r105, r85);
+    r92 = r10 * r86;
+    r92 = r92 * r12;
+    r92 = r92 * r107;
+    r92 = r92 * r35;
+    r85 = fmaf(r75, r92, r85);
+    r128 = r10 * r86;
+    r128 = r128 * r82;
+    r128 = r128 * r12;
+    r128 = r128 * r107;
+    r128 = r128 * r35;
+    r85 = fmaf(r75, r128, r85);
+    r14 = r67 * r50;
+    r14 = r14 * r63;
+    r85 = fmaf(r79, r14, r85);
+    r106 = r67 * r12;
+    r85 = fmaf(r127, r106, r85);
+    r85 = fmaf(r49, r84, r85);
+    r85 = fmaf(r49, r76, r85);
+    r85 = fmaf(r45, r129, r85);
+    r106 = r0 * r85;
+    r14 = r11 * r116;
+    r14 = r14 * r12;
+    r128 = r50 * r11;
+    r128 = r128 * r100;
+    r128 = r128 * r47;
+    r128 = fmaf(r62, r128, r123 * r14);
+    r14 = r71 * r12;
+    r14 = r14 * r120;
+    r14 = r14 * r42;
+    r128 = fmaf(r118, r14, r128);
+    r92 = r45 * r11;
+    r92 = r92 * r11;
+    r92 = r92 * r60;
+    r92 = r92 * r60;
+    r92 = r92 * r113;
+    r92 = r92 * r47;
+    r128 = fmaf(r3, r92, r128);
+    r128 = r128 + r78;
+    r128 = fmaf(r67, r128, r9 * r51);
+    r51 = r68 * r12;
+    r128 = fmaf(r127, r51, r128);
+    r78 = r68 * r12;
+    r128 = fmaf(r134, r78, r128);
+    r92 = r11 * r149;
+    r128 = fmaf(r76, r92, r128);
+    r14 = r4 * r45;
+    r14 = r14 * r11;
+    r14 = r14 * r82;
+    r14 = r14 * r74;
+    r128 = fmaf(r57, r14, r128);
+    r105 = r86 * r12;
+    r105 = r105 * r35;
+    r105 = r105 * r75;
+    r128 = fmaf(r120, r105, r128);
+    r77 = r68 * r50;
+    r77 = r77 * r63;
+    r128 = fmaf(r79, r77, r128);
+    r1 = r86 * r82;
+    r1 = r1 * r12;
+    r1 = r1 * r35;
+    r1 = r1 * r75;
+    r128 = fmaf(r120, r1, r128);
+    r131 = r4 * r45;
+    r131 = r131 * r11;
+    r131 = r131 * r74;
+    r128 = fmaf(r57, r131, r128);
+    r112 = r68 * r45;
+    r112 = r112 * r11;
+    r112 = r112 * r60;
+    r112 = r112 * r60;
+    r112 = r112 * r98;
+    r112 = r112 * r3;
+    r128 = fmaf(r63, r112, r128);
+    r128 = fmaf(r49, r130, r128);
+    r128 = fmaf(r12, r132, r128);
+    r128 = fmaf(r12, r115, r128);
+    r128 = fmaf(r50, r76, r128);
+    r128 = fmaf(r50, r84, r128);
+    r112 = r5 * r128;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r52,
+                                          r72,
+                                          r106,
+                                          r112);
+    r112 = r10 * r10;
+    r112 = r37 * r112;
+    r106 = r16 * r48;
+    r106 = r106 * r11;
+    r72 = r54 * r108;
+    r72 = fmaf(r87, r72, r37 * r106);
+    r106 = r54 * r10;
+    r106 = r106 * r10;
+    r72 = fmaf(r108, r106, r72);
+    r87 = r16 * r56;
+    r87 = r87 * r10;
+    r72 = fmaf(r37, r87, r72);
+    r112 = r112 * r47;
+    r112 = r112 * r60;
+    r112 = r112 * r107;
+    r112 = r112 * r35;
+    r112 = r112 * r72;
+    r87 = r56 * r63;
+    r87 = fmaf(r79, r87, r112);
+    r106 = r54 * r64;
+    r87 = fmaf(r125, r106, r87);
+    r125 = r4 * r10;
+    r125 = r125 * r10;
+    r125 = r125 * r72;
+    r125 = r125 * r107;
+    r125 = r125 * r117;
+    r87 = fmaf(r62, r125, r87);
+    r125 = r4 * r11;
+    r125 = r125 * r72;
+    r125 = fmaf(r48, r119, r123 * r125);
+    r106 = r72 * r120;
+    r106 = r106 * r42;
+    r125 = fmaf(r118, r106, r125);
+    r125 = fmaf(r54, r124, r125);
+    r124 = r87 + r125;
+    r106 = r56 * r100;
+    r106 = r106 * r62;
+    r112 = fmaf(r71, r112, r63 * r106);
+    r106 = r54 * r113;
+    r106 = r106 * r3;
+    r106 = r106 * r64;
+    r112 = fmaf(r101, r106, r112);
+    r37 = r10 * r10;
+    r37 = r37 * r116;
+    r37 = r37 * r72;
+    r37 = r37 * r107;
+    r37 = r37 * r117;
+    r112 = fmaf(r62, r37, r112);
+    r112 = r112 + r125;
+    r112 = fmaf(r68, r112, r8 * r124);
+    r8 = r67 * r48;
+    r8 = r8 * r63;
+    r112 = fmaf(r79, r8, r112);
+    r125 = r67 * r72;
+    r112 = fmaf(r127, r125, r112);
+    r37 = r60 * r82;
+    r37 = r37 * r88;
+    r37 = r37 * r72;
+    r37 = r37 * r73;
+    r37 = r37 * r107;
+    r112 = fmaf(r63, r37, r112);
+    r106 = r4 * r54;
+    r106 = r106 * r10;
+    r106 = r106 * r82;
+    r106 = r106 * r74;
+    r112 = fmaf(r57, r106, r112);
+    r117 = r7 * r16;
+    r117 = r117 * r66;
+    r117 = fmaf(r124, r117, r6 * r124);
+    r117 = fmaf(r124, r70, r117);
+    r117 = fmaf(r124, r69, r117);
+    r69 = r10 * r117;
+    r112 = fmaf(r76, r69, r112);
+    r70 = r10 * r86;
+    r70 = r70 * r82;
+    r70 = r70 * r72;
+    r70 = r70 * r107;
+    r70 = r70 * r35;
+    r112 = fmaf(r75, r70, r112);
+    r6 = r4 * r54;
+    r6 = r6 * r10;
+    r6 = r6 * r74;
+    r112 = fmaf(r57, r6, r112);
+    r52 = r60 * r88;
+    r52 = r52 * r72;
+    r52 = r52 * r73;
+    r52 = r52 * r107;
+    r112 = fmaf(r63, r52, r112);
+    r73 = r67 * r72;
+    r112 = fmaf(r134, r73, r112);
+    r131 = r10 * r86;
+    r131 = r131 * r72;
+    r131 = r131 * r107;
+    r131 = r131 * r35;
+    r112 = fmaf(r75, r131, r112);
+    r107 = r67 * r56;
+    r112 = fmaf(r119, r107, r112);
+    r112 = fmaf(r56, r76, r112);
+    r112 = fmaf(r56, r84, r112);
+    r112 = fmaf(r54, r129, r112);
+    r107 = r0 * r112;
+    r129 = r11 * r116;
+    r129 = r129 * r72;
+    r131 = r48 * r11;
+    r131 = r131 * r100;
+    r131 = r131 * r47;
+    r131 = fmaf(r62, r131, r123 * r129);
+    r129 = r71 * r72;
+    r129 = r129 * r120;
+    r129 = r129 * r42;
+    r131 = fmaf(r118, r129, r131);
+    r118 = r54 * r11;
+    r118 = r118 * r11;
+    r118 = r118 * r60;
+    r118 = r118 * r60;
+    r118 = r118 * r113;
+    r118 = r118 * r47;
+    r131 = fmaf(r3, r118, r131);
+    r131 = r131 + r87;
+    r131 = fmaf(r67, r131, r9 * r124);
+    r124 = r68 * r48;
+    r124 = r124 * r63;
+    r131 = fmaf(r79, r124, r131);
+    r79 = r4 * r54;
+    r79 = r79 * r11;
+    r79 = r79 * r82;
+    r79 = r79 * r74;
+    r131 = fmaf(r57, r79, r131);
+    r9 = r68 * r72;
+    r131 = fmaf(r127, r9, r131);
+    r127 = r11 * r117;
+    r131 = fmaf(r76, r127, r131);
+    r87 = r68 * r72;
+    r131 = fmaf(r134, r87, r131);
+    r134 = r68 * r54;
+    r134 = r134 * r11;
+    r134 = r134 * r60;
+    r134 = r134 * r60;
+    r134 = r134 * r98;
+    r134 = r134 * r3;
+    r131 = fmaf(r63, r134, r131);
+    r3 = r86 * r82;
+    r3 = r3 * r72;
+    r3 = r3 * r35;
+    r3 = r3 * r75;
+    r131 = fmaf(r120, r3, r131);
+    r98 = r4 * r54;
+    r98 = r98 * r11;
+    r98 = r98 * r74;
+    r131 = fmaf(r57, r98, r131);
+    r57 = r86 * r72;
+    r57 = r57 * r35;
+    r57 = r57 * r75;
+    r131 = fmaf(r120, r57, r131);
+    r131 = fmaf(r72, r115, r131);
+    r131 = fmaf(r48, r76, r131);
+    r131 = fmaf(r72, r132, r131);
+    r131 = fmaf(r48, r84, r131);
+    r131 = fmaf(r56, r130, r131);
+    r57 = r5 * r131;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r107,
+                                          r57);
+    r57 = r0 * r4;
+    r57 = r57 * r2;
+    r57 = fmaf(r65, r91, r83 * r57);
+    r107 = r0 * r4;
+    r107 = r107 * r2;
+    r107 = fmaf(r128, r91, r85 * r107);
+    r98 = r0 * r4;
+    r98 = r98 * r2;
+    r91 = fmaf(r131, r91, r112 * r98);
+    WriteSum3<float, float>((float*)inout_shared, r57, r107, r91);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r83 * r83;
+    r107 = r65 * r65;
+    r107 = fmaf(r146, r107, r94 * r91);
+    r91 = r128 * r128;
+    r57 = r85 * r85;
+    r57 = fmaf(r94, r57, r146 * r91);
+    r91 = r131 * r131;
+    r98 = r112 * r112;
+    r98 = fmaf(r94, r98, r146 * r91);
+    WriteSum3<float, float>((float*)inout_shared, r107, r57, r98);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r98 = r65 * r128;
+    r57 = r83 * r85;
+    r57 = fmaf(r94, r57, r146 * r98);
+    r98 = r83 * r112;
+    r107 = r65 * r131;
+    r107 = fmaf(r146, r107, r94 * r98);
+    r98 = r128 * r131;
+    r91 = r85 * r112;
+    r91 = fmaf(r94, r91, r146 * r98);
+    WriteSum3<float, float>((float*)inout_shared, r57, r107, r91);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,2772 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointResJacFirstKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* out_res,
+        unsigned int out_res_num_alloc,
+        float* const out_rTr,
+        float* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        float* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        float* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        float* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        float* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        float* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        float* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        float* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        float* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        float* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        float* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        float* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r10,
+                                         r11,
+                                         r12);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r13,
+                       r14,
+                       r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = 2.00000000000000000e+00;
+  };
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r20, r21, r17 * r24);
+    r26 = r18 * r23;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r19, r22, r25);
+    r26 = r16 * r25;
+    r27 = r18 * r24;
+    r28 = r20 * r22;
+    r29 = r27 + r28;
+    r30 = r17 * r23;
+    r31 = r19 * r21;
+    r29 = r29 + r30;
+    r29 = fmaf(r4, r31, r29);
+    r26 = r26 * r29;
+    r32 = fmaf(r18, r21, r19 * r24);
+    r33 = r17 * r22;
+    r32 = fmaf(r4, r33, r32);
+    r32 = fmaf(r20, r23, r32);
+    r33 = r16 * r32;
+    r34 = fmaf(r18, r22, r17 * r21);
+    r34 = fmaf(r19, r23, r34);
+    r34 = fmaf(r4, r34, r20 * r24);
+    r33 = fmaf(r34, r33, r26);
+    r11 = fmaf(r13, r33, r11);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r35,
+                       r36,
+                       r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r21 * r22;
+    r38 = r38 * r16;
+    r39 = r23 * r24;
+    r39 = fmaf(r16, r39, r38);
+    r40 = r21 * r21;
+    r41 = -2.00000000000000000e+00;
+    r40 = r40 * r41;
+    r42 = 1.00000000000000000e+00;
+    r43 = r23 * r23;
+    r43 = fmaf(r41, r43, r42);
+    r44 = r40 + r43;
+    r45 = r22 * r23;
+    r45 = r45 * r16;
+    r46 = r21 * r24;
+    r46 = fmaf(r41, r46, r45);
+    r47 = r16 * r32;
+    r47 = r47 * r29;
+    r48 = r25 * r41;
+    r48 = fmaf(r34, r48, r47);
+    r49 = r32 * r32;
+    r49 = r49 * r41;
+    r50 = r42 + r49;
+    r51 = r25 * r25;
+    r51 = r51 * r41;
+    r50 = r50 + r51;
+    r11 = fmaf(r35, r39, r11);
+    r11 = fmaf(r36, r44, r11);
+    r11 = fmaf(r37, r46, r11);
+    r11 = fmaf(r15, r48, r11);
+    r11 = fmaf(r14, r50, r11);
+    r52 = 9.99999999999999955e-07;
+    r53 = r41 * r29;
+    r53 = r53 * r29;
+    r54 = r42 + r53;
+    r54 = r54 + r49;
+    r10 = fmaf(r13, r54, r10);
+    r49 = r32 * r41;
+    r49 = fmaf(r34, r49, r26);
+    r26 = r16 * r32;
+    r26 = r26 * r25;
+    r55 = r16 * r29;
+    r55 = fmaf(r34, r55, r26);
+    r56 = r21 * r23;
+    r56 = r56 * r16;
+    r57 = r22 * r24;
+    r57 = fmaf(r16, r57, r56);
+    r58 = r23 * r24;
+    r58 = fmaf(r41, r58, r38);
+    r38 = r22 * r22;
+    r38 = r38 * r41;
+    r43 = r38 + r43;
+    r10 = fmaf(r14, r49, r10);
+    r10 = fmaf(r15, r55, r10);
+    r10 = fmaf(r37, r57, r10);
+    r10 = fmaf(r36, r58, r10);
+    r10 = fmaf(r35, r43, r10);
+    r59 = r10 * r10;
+    r60 = r41 * r29;
+    r60 = fmaf(r34, r60, r26);
+    r12 = fmaf(r13, r60, r12);
+    r26 = r22 * r24;
+    r26 = fmaf(r41, r26, r56);
+    r38 = r42 + r38;
+    r38 = r38 + r40;
+    r40 = r21 * r24;
+    r40 = fmaf(r16, r40, r45);
+    r45 = r16 * r25;
+    r45 = fmaf(r34, r45, r47);
+    r53 = r42 + r53;
+    r53 = r53 + r51;
+    r12 = fmaf(r35, r26, r12);
+    r12 = fmaf(r37, r38, r12);
+    r12 = fmaf(r36, r40, r12);
+    r12 = fmaf(r14, r45, r12);
+    r12 = fmaf(r15, r53, r12);
+    r36 = copysign(1.0, r12);
+    r36 = fmaf(r52, r36, r12);
+    r12 = r36 * r36;
+    r37 = 1.0 / r12;
+    r35 = r11 * r11;
+    r35 = fmaf(r37, r35, r37 * r59);
+    r59 = sqrtf(r35);
+    r51 = copysign(1.0, r59);
+    r51 = fmaf(r52, r51, r59);
+    r52 = r51 * r51;
+    r47 = 1.0 / r52;
+    r59 = atanf(r59);
+    r56 = r59 * r37;
+    r61 = r47 * r56;
+    r62 = r11 * r61;
+    r63 = r11 * r59;
+    r62 = r62 * r63;
+    r64 = r10 * r10;
+    r64 = r64 * r59;
+    r64 = r64 * r61;
+    r65 = r62 + r64;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r66,
+                       r67,
+                       r68,
+                       r69);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r70 = r10 * r10;
+    r71 = 3.00000000000000000e+00;
+    r70 = r70 * r59;
+    r70 = r70 * r71;
+    r70 = fmaf(r61, r70, r62);
+    r62 = fmaf(r67, r70, r8 * r65);
+    r72 = r66 * r10;
+    r73 = r16 * r61;
+    r74 = r63 * r73;
+    r62 = fmaf(r74, r72, r62);
+    r75 = r10 * r59;
+    r76 = r65 * r65;
+    r77 = r65 * r76;
+    r78 = fmaf(r68, r77, r6 * r65);
+    r79 = r76 * r76;
+    r78 = fmaf(r69, r79, r78);
+    r78 = fmaf(r7, r76, r78);
+    r80 = 1.0 / r36;
+    r81 = 1.0 / r51;
+    r82 = r80 * r81;
+    r83 = r78 * r82;
+    r62 = fmaf(r83, r75, r62);
+    r84 = r10 * r59;
+    r62 = fmaf(r82, r84, r62);
+    r84 = r0 * r62;
+    r2 = r2 + r84;
+    r75 = r11 * r71;
+    r75 = r75 * r61;
+    r75 = fmaf(r63, r75, r64);
+    r64 = fmaf(r66, r75, r9 * r65);
+    r72 = r67 * r74;
+    r64 = fmaf(r63, r83, r64);
+    r64 = fmaf(r10, r72, r64);
+    r64 = fmaf(r82, r63, r64);
+    r1 = fmaf(r5, r64, r1);
+    r1 = fmaf(r3, r4, r1);
+    WriteIdx2<1024, float, float, float2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r2, r1);
+    r3 = fmaf(r1, r1, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r3);
+  if (global_thread_idx < problem_size) {
+    r3 = r10 * r59;
+    r85 = r16 * r34;
+    r86 = r19 * r24;
+    r87 = 5.00000000000000000e-01;
+    r88 = r18 * r21;
+    r88 = fmaf(r87, r88, r87 * r86);
+    r86 = r17 * r22;
+    r89 = -5.00000000000000000e-01;
+    r88 = fmaf(r89, r86, r88);
+    r90 = r20 * r23;
+    r88 = fmaf(r87, r90, r88);
+    r90 = r17 * r24;
+    r86 = r20 * r21;
+    r86 = fmaf(r89, r86, r89 * r90);
+    r90 = r19 * r22;
+    r86 = fmaf(r89, r90, r86);
+    r91 = r18 * r23;
+    r86 = fmaf(r87, r91, r86);
+    r91 = r29 * r86;
+    r85 = fmaf(r16, r91, r88 * r85);
+    r90 = r16 * r25;
+    r92 = fmaf(r87, r31, r89 * r27);
+    r92 = fmaf(r89, r28, r92);
+    r92 = fmaf(r89, r30, r92);
+    r93 = r16 * r32;
+    r94 = r20 * r24;
+    r95 = r17 * r21;
+    r95 = fmaf(r89, r95, r87 * r94);
+    r94 = r18 * r22;
+    r95 = fmaf(r89, r94, r95);
+    r96 = r19 * r23;
+    r95 = fmaf(r89, r96, r95);
+    r93 = r93 * r95;
+    r90 = fmaf(r92, r90, r93);
+    r85 = r85 + r90;
+    r96 = r16 * r29;
+    r96 = r96 * r95;
+    r94 = r16 * r25;
+    r94 = r94 * r88;
+    r97 = r96 + r94;
+    r98 = r32 * r41;
+    r97 = fmaf(r86, r98, r97);
+    r99 = r41 * r34;
+    r97 = fmaf(r92, r99, r97);
+    r97 = fmaf(r14, r97, r15 * r85);
+    r85 = r29 * r88;
+    r99 = -4.00000000000000000e+00;
+    r85 = r85 * r99;
+    r98 = r32 * r92;
+    r100 = r99 * r98;
+    r101 = r85 + r100;
+    r97 = fmaf(r13, r101, r97);
+    r101 = 6.00000000000000000e+00;
+    r3 = r3 * r97;
+    r3 = r3 * r101;
+    r102 = r16 * r11;
+    r103 = r25 * r41;
+    r104 = r34 * r95;
+    r105 = r41 * r104;
+    r103 = fmaf(r86, r103, r105);
+    r106 = r16 * r29;
+    r106 = r106 * r92;
+    r107 = r16 * r32;
+    r107 = fmaf(r88, r107, r106);
+    r103 = r103 + r107;
+    r108 = r25 * r95;
+    r108 = r108 * r99;
+    r100 = r108 + r100;
+    r100 = fmaf(r14, r100, r15 * r103);
+    r103 = r16 * r34;
+    r103 = fmaf(r92, r103, r94);
+    r94 = r16 * r32;
+    r94 = fmaf(r86, r94, r96);
+    r103 = r103 + r94;
+    r100 = fmaf(r13, r103, r100);
+    r102 = r102 * r100;
+    r103 = r16 * r10;
+    r103 = r103 * r97;
+    r103 = fmaf(r37, r103, r37 * r102);
+    r102 = r11 * r11;
+    r96 = r16 * r25;
+    r96 = r96 * r86;
+    r104 = r16 * r104;
+    r109 = r96 + r104;
+    r107 = r107 + r109;
+    r110 = r41 * r34;
+    r110 = fmaf(r41, r91, r88 * r110);
+    r110 = r110 + r90;
+    r110 = fmaf(r13, r110, r14 * r107);
+    r85 = r108 + r85;
+    r110 = fmaf(r15, r85, r110);
+    r12 = r36 * r12;
+    r85 = 1.0 / r12;
+    r108 = r41 * r85;
+    r102 = r102 * r110;
+    r103 = fmaf(r108, r102, r103);
+    r107 = r10 * r10;
+    r107 = r107 * r110;
+    r103 = fmaf(r108, r107, r103);
+    r107 = r71 * r103;
+    r42 = r42 + r35;
+    r42 = 1.0 / r42;
+    r35 = rsqrtf(r35);
+    r102 = r10 * r35;
+    r88 = r42 * r102;
+    r111 = r10 * r61;
+    r107 = r107 * r88;
+    r107 = fmaf(r111, r107, r61 * r3);
+    r3 = r10 * r10;
+    r112 = r59 * r59;
+    r113 = -6.00000000000000000e+00;
+    r112 = r112 * r110;
+    r112 = r112 * r113;
+    r112 = r112 * r47;
+    r112 = r112 * r85;
+    r114 = -3.00000000000000000e+00;
+    r115 = r10 * r59;
+    r116 = r102 * r115;
+    r52 = r51 * r52;
+    r117 = 1.0 / r52;
+    r118 = r117 * r56;
+    r116 = r116 * r118;
+    r119 = r114 * r116;
+    r120 = r11 * r11;
+    r120 = r120 * r103;
+    r120 = r120 * r35;
+    r120 = r120 * r42;
+    r120 = fmaf(r61, r120, r100 * r74);
+    r121 = r4 * r103;
+    r122 = r63 * r118;
+    r123 = r11 * r35;
+    r122 = r122 * r123;
+    r120 = fmaf(r122, r121, r120);
+    r124 = r11 * r11;
+    r125 = r47 * r108;
+    r126 = r59 * r59;
+    r125 = r125 * r126;
+    r124 = r124 * r110;
+    r120 = fmaf(r125, r124, r120);
+    r107 = fmaf(r112, r3, r107);
+    r107 = fmaf(r103, r119, r107);
+    r107 = r107 + r120;
+    r124 = r97 * r73;
+    r121 = r103 * r88;
+    r121 = fmaf(r111, r121, r115 * r124);
+    r124 = r10 * r10;
+    r124 = r124 * r110;
+    r121 = fmaf(r125, r124, r121);
+    r127 = r4 * r103;
+    r121 = fmaf(r116, r127, r121);
+    r120 = r120 + r121;
+    r107 = fmaf(r8, r120, r67 * r107);
+    r127 = r59 * r89;
+    r127 = r127 * r47;
+    r127 = r127 * r80;
+    r127 = r127 * r102;
+    r124 = r78 * r127;
+    r128 = r66 * r11;
+    r128 = r128 * r103;
+    r128 = r128 * r73;
+    r107 = fmaf(r88, r128, r107);
+    r129 = r66 * r10;
+    r129 = r129 * r11;
+    r129 = r129 * r59;
+    r129 = r129 * r59;
+    r129 = r129 * r99;
+    r129 = r129 * r47;
+    r129 = r129 * r85;
+    r130 = r103 * r83;
+    r131 = r87 * r88;
+    r107 = fmaf(r131, r130, r107);
+    r132 = r66 * r97;
+    r107 = fmaf(r74, r132, r107);
+    r133 = r59 * r97;
+    r107 = fmaf(r82, r133, r107);
+    r134 = r4 * r10;
+    r134 = r134 * r110;
+    r134 = r134 * r81;
+    r107 = fmaf(r56, r134, r107);
+    r135 = r4 * r10;
+    r135 = r135 * r78;
+    r135 = r135 * r110;
+    r135 = r135 * r81;
+    r107 = fmaf(r56, r135, r107);
+    r136 = r82 * r131;
+    r137 = r66 * r41;
+    r137 = r137 * r103;
+    r137 = r137 * r63;
+    r137 = r137 * r102;
+    r107 = fmaf(r118, r137, r107);
+    r138 = r10 * r59;
+    r139 = r7 * r16;
+    r139 = r139 * r65;
+    r139 = fmaf(r120, r139, r6 * r120);
+    r140 = 4.00000000000000000e+00;
+    r69 = r69 * r140;
+    r69 = r69 * r77;
+    r68 = r68 * r71;
+    r68 = r68 * r76;
+    r139 = fmaf(r120, r69, r139);
+    r139 = fmaf(r120, r68, r139);
+    r138 = r138 * r139;
+    r107 = fmaf(r82, r138, r107);
+    r141 = r66 * r100;
+    r141 = r141 * r73;
+    r107 = fmaf(r115, r141, r107);
+    r142 = r59 * r97;
+    r107 = fmaf(r83, r142, r107);
+    r107 = fmaf(r103, r124, r107);
+    r107 = fmaf(r103, r127, r107);
+    r107 = fmaf(r110, r129, r107);
+    r107 = fmaf(r103, r136, r107);
+    r142 = r0 * r107;
+    r141 = r100 * r101;
+    r141 = r141 * r61;
+    r138 = r11 * r11;
+    r138 = r138 * r71;
+    r138 = r138 * r103;
+    r138 = r138 * r35;
+    r138 = r138 * r42;
+    r138 = fmaf(r61, r138, r63 * r141);
+    r141 = r114 * r103;
+    r138 = fmaf(r122, r141, r138);
+    r137 = r11 * r11;
+    r138 = fmaf(r112, r137, r138);
+    r138 = r138 + r121;
+    r120 = fmaf(r9, r120, r66 * r138);
+    r138 = r11 * r87;
+    r138 = r138 * r103;
+    r138 = r138 * r35;
+    r138 = r138 * r42;
+    r120 = fmaf(r82, r138, r120);
+    r121 = r11 * r59;
+    r121 = r121 * r78;
+    r121 = r121 * r89;
+    r121 = r121 * r103;
+    r121 = r121 * r47;
+    r121 = r121 * r80;
+    r120 = fmaf(r35, r121, r120);
+    r112 = r139 * r82;
+    r120 = fmaf(r63, r112, r120);
+    r141 = r4 * r11;
+    r141 = r141 * r78;
+    r141 = r141 * r110;
+    r141 = r141 * r81;
+    r120 = fmaf(r56, r141, r120);
+    r135 = r67 * r10;
+    r135 = r135 * r11;
+    r135 = r135 * r59;
+    r135 = r135 * r59;
+    r135 = r135 * r99;
+    r135 = r135 * r110;
+    r135 = r135 * r47;
+    r120 = fmaf(r85, r135, r120);
+    r134 = r67 * r11;
+    r134 = r134 * r103;
+    r134 = r134 * r73;
+    r120 = fmaf(r88, r134, r120);
+    r133 = r4 * r11;
+    r133 = r133 * r110;
+    r133 = r133 * r81;
+    r120 = fmaf(r56, r133, r120);
+    r110 = r67 * r41;
+    r110 = r110 * r103;
+    r110 = r110 * r63;
+    r110 = r110 * r102;
+    r120 = fmaf(r118, r110, r120);
+    r132 = r87 * r42;
+    r132 = r132 * r83;
+    r132 = r132 * r123;
+    r123 = r67 * r100;
+    r123 = r123 * r73;
+    r120 = fmaf(r115, r123, r120);
+    r130 = r11 * r59;
+    r130 = r130 * r89;
+    r130 = r130 * r103;
+    r130 = r130 * r47;
+    r130 = r130 * r80;
+    r120 = fmaf(r35, r130, r120);
+    r128 = r59 * r100;
+    r120 = fmaf(r83, r128, r120);
+    r143 = r59 * r100;
+    r120 = fmaf(r82, r143, r120);
+    r120 = fmaf(r97, r72, r120);
+    r120 = fmaf(r103, r132, r120);
+    r143 = r5 * r120;
+    r128 = r16 * r10;
+    r104 = r106 + r104;
+    r106 = r16 * r32;
+    r130 = r19 * r24;
+    r123 = r18 * r21;
+    r123 = fmaf(r89, r123, r89 * r130);
+    r130 = r17 * r22;
+    r123 = fmaf(r87, r130, r123);
+    r110 = r20 * r23;
+    r123 = fmaf(r89, r110, r123);
+    r106 = r106 * r123;
+    r110 = r16 * r25;
+    r130 = r17 * r24;
+    r133 = r20 * r21;
+    r133 = fmaf(r87, r133, r87 * r130);
+    r130 = r19 * r22;
+    r133 = fmaf(r87, r130, r133);
+    r134 = r18 * r23;
+    r133 = fmaf(r89, r134, r133);
+    r110 = fmaf(r133, r110, r106);
+    r104 = r104 + r110;
+    r134 = r32 * r99;
+    r134 = r134 * r133;
+    r130 = r29 * r95;
+    r130 = r130 * r99;
+    r135 = r134 + r130;
+    r135 = fmaf(r13, r135, r15 * r104);
+    r104 = r41 * r34;
+    r104 = fmaf(r41, r98, r133 * r104);
+    r141 = r16 * r25;
+    r141 = r141 * r95;
+    r112 = r16 * r29;
+    r112 = fmaf(r123, r112, r141);
+    r104 = r104 + r112;
+    r135 = fmaf(r14, r104, r135);
+    r128 = r128 * r135;
+    r104 = r10 * r10;
+    r121 = r41 * r29;
+    r121 = fmaf(r92, r121, r105);
+    r121 = r121 + r110;
+    r110 = r16 * r29;
+    r110 = r110 * r133;
+    r138 = r16 * r34;
+    r138 = fmaf(r123, r138, r110);
+    r138 = r138 + r90;
+    r138 = fmaf(r14, r138, r13 * r121);
+    r121 = r25 * r123;
+    r90 = r99 * r121;
+    r130 = r130 + r90;
+    r138 = fmaf(r15, r130, r138);
+    r104 = r104 * r138;
+    r104 = fmaf(r108, r104, r37 * r128);
+    r128 = r11 * r11;
+    r128 = r128 * r138;
+    r104 = fmaf(r108, r128, r104);
+    r130 = r16 * r11;
+    r144 = r25 * r41;
+    r144 = fmaf(r92, r144, r93);
+    r93 = r41 * r34;
+    r144 = fmaf(r123, r93, r144);
+    r144 = r144 + r110;
+    r93 = r16 * r34;
+    r98 = fmaf(r16, r98, r133 * r93);
+    r98 = r98 + r112;
+    r98 = fmaf(r13, r98, r15 * r144);
+    r90 = r134 + r90;
+    r98 = fmaf(r14, r90, r98);
+    r130 = r130 * r98;
+    r104 = fmaf(r37, r130, r104);
+    r130 = r104 * r88;
+    r128 = r4 * r104;
+    r128 = fmaf(r116, r128, r111 * r130);
+    r130 = r10 * r10;
+    r130 = r130 * r138;
+    r128 = fmaf(r125, r130, r128);
+    r90 = r135 * r73;
+    r128 = fmaf(r115, r90, r128);
+    r90 = r4 * r104;
+    r90 = fmaf(r122, r90, r98 * r74);
+    r130 = r11 * r11;
+    r130 = r130 * r138;
+    r90 = fmaf(r125, r130, r90);
+    r134 = r11 * r11;
+    r134 = r134 * r104;
+    r134 = r134 * r35;
+    r134 = r134 * r42;
+    r90 = fmaf(r61, r134, r90);
+    r134 = r128 + r90;
+    r130 = r71 * r104;
+    r130 = r130 * r88;
+    r130 = fmaf(r104, r119, r111 * r130);
+    r144 = r10 * r10;
+    r144 = r144 * r59;
+    r144 = r144 * r59;
+    r144 = r144 * r113;
+    r144 = r144 * r138;
+    r144 = r144 * r47;
+    r130 = fmaf(r85, r144, r130);
+    r93 = r10 * r59;
+    r93 = r93 * r101;
+    r93 = r93 * r135;
+    r130 = fmaf(r61, r93, r130);
+    r130 = r130 + r90;
+    r130 = fmaf(r67, r130, r8 * r134);
+    r90 = r66 * r98;
+    r90 = r90 * r73;
+    r130 = fmaf(r115, r90, r130);
+    r93 = r4 * r10;
+    r93 = r93 * r138;
+    r93 = r93 * r81;
+    r130 = fmaf(r56, r93, r130);
+    r144 = r104 * r83;
+    r130 = fmaf(r131, r144, r130);
+    r133 = r59 * r135;
+    r130 = fmaf(r83, r133, r130);
+    r110 = r66 * r41;
+    r110 = r110 * r104;
+    r110 = r110 * r63;
+    r110 = r110 * r102;
+    r130 = fmaf(r118, r110, r130);
+    r92 = r66 * r11;
+    r92 = r92 * r104;
+    r92 = r92 * r73;
+    r130 = fmaf(r88, r92, r130);
+    r145 = r4 * r10;
+    r145 = r145 * r78;
+    r145 = r145 * r138;
+    r145 = r145 * r81;
+    r130 = fmaf(r56, r145, r130);
+    r146 = r66 * r135;
+    r130 = fmaf(r74, r146, r130);
+    r147 = r10 * r59;
+    r148 = r7 * r16;
+    r148 = r148 * r65;
+    r148 = fmaf(r134, r148, r6 * r134);
+    r148 = fmaf(r134, r69, r148);
+    r148 = fmaf(r134, r68, r148);
+    r147 = r147 * r148;
+    r130 = fmaf(r82, r147, r130);
+    r149 = r59 * r135;
+    r130 = fmaf(r82, r149, r130);
+    r130 = fmaf(r138, r129, r130);
+    r130 = fmaf(r104, r127, r130);
+    r130 = fmaf(r104, r136, r130);
+    r130 = fmaf(r104, r124, r130);
+    r149 = r0 * r130;
+    r147 = r101 * r98;
+    r147 = r147 * r61;
+    r146 = r114 * r104;
+    r146 = fmaf(r122, r146, r63 * r147);
+    r147 = r11 * r11;
+    r147 = r147 * r59;
+    r147 = r147 * r59;
+    r147 = r147 * r113;
+    r147 = r147 * r138;
+    r147 = r147 * r47;
+    r146 = fmaf(r85, r147, r146);
+    r145 = r11 * r11;
+    r145 = r145 * r71;
+    r145 = r145 * r104;
+    r145 = r145 * r35;
+    r145 = r145 * r42;
+    r146 = fmaf(r61, r145, r146);
+    r146 = r146 + r128;
+    r146 = fmaf(r66, r146, r9 * r134);
+    r134 = r4 * r11;
+    r134 = r134 * r138;
+    r134 = r134 * r81;
+    r146 = fmaf(r56, r134, r146);
+    r128 = r67 * r98;
+    r128 = r128 * r73;
+    r146 = fmaf(r115, r128, r146);
+    r145 = r67 * r10;
+    r145 = r145 * r11;
+    r145 = r145 * r59;
+    r145 = r145 * r59;
+    r145 = r145 * r99;
+    r145 = r145 * r138;
+    r145 = r145 * r47;
+    r146 = fmaf(r85, r145, r146);
+    r147 = r11 * r59;
+    r147 = r147 * r78;
+    r147 = r147 * r89;
+    r147 = r147 * r104;
+    r147 = r147 * r47;
+    r147 = r147 * r80;
+    r146 = fmaf(r35, r147, r146);
+    r92 = r148 * r82;
+    r146 = fmaf(r63, r92, r146);
+    r110 = r11 * r87;
+    r110 = r110 * r104;
+    r110 = r110 * r35;
+    r110 = r110 * r42;
+    r146 = fmaf(r82, r110, r146);
+    r133 = r11 * r59;
+    r133 = r133 * r89;
+    r133 = r133 * r104;
+    r133 = r133 * r47;
+    r133 = r133 * r80;
+    r146 = fmaf(r35, r133, r146);
+    r144 = r67 * r41;
+    r144 = r144 * r104;
+    r144 = r144 * r63;
+    r144 = r144 * r102;
+    r146 = fmaf(r118, r144, r146);
+    r93 = r67 * r11;
+    r93 = r93 * r104;
+    r93 = r93 * r73;
+    r146 = fmaf(r88, r93, r146);
+    r90 = r59 * r98;
+    r146 = fmaf(r83, r90, r146);
+    r150 = r4 * r11;
+    r150 = r150 * r78;
+    r150 = r150 * r138;
+    r150 = r150 * r81;
+    r146 = fmaf(r56, r150, r146);
+    r138 = r59 * r98;
+    r146 = fmaf(r82, r138, r146);
+    r146 = fmaf(r104, r132, r146);
+    r146 = fmaf(r135, r72, r146);
+    r138 = r5 * r146;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          0 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r142,
+                                          r143,
+                                          r149,
+                                          r138);
+    r138 = r11 * r11;
+    r149 = r10 * r10;
+    r143 = r25 * r99;
+    r31 = fmaf(r89, r31, r87 * r27);
+    r31 = fmaf(r87, r28, r31);
+    r31 = fmaf(r87, r30, r31);
+    r143 = r143 * r31;
+    r91 = r99 * r91;
+    r30 = r143 + r91;
+    r28 = r16 * r32;
+    r28 = r28 * r31;
+    r141 = r141 + r28;
+    r27 = r41 * r29;
+    r141 = fmaf(r123, r27, r141);
+    r142 = r41 * r34;
+    r141 = fmaf(r86, r142, r141);
+    r141 = fmaf(r13, r141, r15 * r30);
+    r30 = r16 * r34;
+    r30 = fmaf(r16, r121, r31 * r30);
+    r30 = r30 + r94;
+    r141 = fmaf(r14, r30, r141);
+    r149 = r149 * r141;
+    r30 = r16 * r10;
+    r142 = r16 * r29;
+    r142 = r142 * r31;
+    r96 = r96 + r142;
+    r27 = r32 * r41;
+    r96 = fmaf(r123, r27, r96);
+    r96 = r96 + r105;
+    r95 = r32 * r95;
+    r95 = r95 * r99;
+    r91 = r95 + r91;
+    r91 = fmaf(r13, r91, r14 * r96);
+    r96 = r16 * r34;
+    r96 = fmaf(r86, r96, r28);
+    r96 = r96 + r112;
+    r91 = fmaf(r15, r96, r91);
+    r30 = r30 * r91;
+    r30 = fmaf(r37, r30, r108 * r149);
+    r149 = r11 * r11;
+    r149 = r149 * r141;
+    r30 = fmaf(r108, r149, r30);
+    r96 = r16 * r11;
+    r142 = r106 + r142;
+    r142 = r142 + r109;
+    r109 = r41 * r34;
+    r121 = fmaf(r41, r121, r31 * r109);
+    r121 = r121 + r94;
+    r121 = fmaf(r15, r121, r13 * r142);
+    r95 = r143 + r95;
+    r121 = fmaf(r14, r95, r121);
+    r96 = r96 * r121;
+    r30 = fmaf(r37, r96, r30);
+    r138 = r138 * r30;
+    r138 = r138 * r35;
+    r138 = r138 * r42;
+    r138 = fmaf(r121, r74, r61 * r138);
+    r96 = r11 * r11;
+    r96 = r96 * r141;
+    r138 = fmaf(r125, r96, r138);
+    r149 = r4 * r30;
+    r138 = fmaf(r122, r149, r138);
+    r149 = r10 * r10;
+    r149 = r149 * r141;
+    r96 = r30 * r88;
+    r96 = fmaf(r111, r96, r125 * r149);
+    r149 = r4 * r30;
+    r96 = fmaf(r116, r149, r96);
+    r95 = r91 * r73;
+    r96 = fmaf(r115, r95, r96);
+    r95 = r138 + r96;
+    r149 = r10 * r10;
+    r149 = r149 * r59;
+    r149 = r149 * r59;
+    r149 = r149 * r113;
+    r149 = r149 * r141;
+    r149 = r149 * r47;
+    r14 = r71 * r30;
+    r14 = r14 * r88;
+    r14 = fmaf(r111, r14, r85 * r149);
+    r149 = r10 * r59;
+    r149 = r149 * r101;
+    r149 = r149 * r91;
+    r14 = fmaf(r61, r149, r14);
+    r14 = fmaf(r30, r119, r14);
+    r14 = r14 + r138;
+    r14 = fmaf(r67, r14, r8 * r95);
+    r138 = r10 * r59;
+    r149 = r7 * r16;
+    r149 = r149 * r65;
+    r149 = fmaf(r95, r149, r6 * r95);
+    r149 = fmaf(r95, r68, r149);
+    r149 = fmaf(r95, r69, r149);
+    r138 = r138 * r149;
+    r14 = fmaf(r82, r138, r14);
+    r143 = r4 * r10;
+    r143 = r143 * r141;
+    r143 = r143 * r81;
+    r14 = fmaf(r56, r143, r14);
+    r15 = r66 * r41;
+    r15 = r15 * r30;
+    r15 = r15 * r63;
+    r15 = r15 * r102;
+    r14 = fmaf(r118, r15, r14);
+    r142 = r59 * r91;
+    r14 = fmaf(r83, r142, r14);
+    r13 = r66 * r91;
+    r14 = fmaf(r74, r13, r14);
+    r94 = r30 * r83;
+    r14 = fmaf(r131, r94, r14);
+    r109 = r66 * r121;
+    r109 = r109 * r73;
+    r14 = fmaf(r115, r109, r14);
+    r31 = r4 * r10;
+    r31 = r31 * r78;
+    r31 = r31 * r141;
+    r31 = r31 * r81;
+    r14 = fmaf(r56, r31, r14);
+    r106 = r59 * r91;
+    r14 = fmaf(r82, r106, r14);
+    r112 = r66 * r11;
+    r112 = r112 * r30;
+    r112 = r112 * r73;
+    r14 = fmaf(r88, r112, r14);
+    r14 = fmaf(r141, r129, r14);
+    r14 = fmaf(r30, r136, r14);
+    r14 = fmaf(r30, r124, r14);
+    r14 = fmaf(r30, r127, r14);
+    r112 = r0 * r14;
+    r106 = r11 * r11;
+    r106 = r106 * r71;
+    r106 = r106 * r30;
+    r106 = r106 * r35;
+    r106 = r106 * r42;
+    r31 = r101 * r121;
+    r31 = r31 * r61;
+    r31 = fmaf(r63, r31, r61 * r106);
+    r106 = r11 * r11;
+    r106 = r106 * r59;
+    r106 = r106 * r59;
+    r106 = r106 * r113;
+    r106 = r106 * r141;
+    r106 = r106 * r47;
+    r31 = fmaf(r85, r106, r31);
+    r109 = r114 * r30;
+    r31 = fmaf(r122, r109, r31);
+    r31 = r31 + r96;
+    r31 = fmaf(r66, r31, r9 * r95);
+    r95 = r67 * r10;
+    r95 = r95 * r11;
+    r95 = r95 * r59;
+    r95 = r95 * r59;
+    r95 = r95 * r99;
+    r95 = r95 * r141;
+    r95 = r95 * r47;
+    r31 = fmaf(r85, r95, r31);
+    r96 = r11 * r59;
+    r96 = r96 * r89;
+    r96 = r96 * r30;
+    r96 = r96 * r47;
+    r96 = r96 * r80;
+    r31 = fmaf(r35, r96, r31);
+    r109 = r11 * r87;
+    r109 = r109 * r30;
+    r109 = r109 * r35;
+    r109 = r109 * r42;
+    r31 = fmaf(r82, r109, r31);
+    r106 = r4 * r11;
+    r106 = r106 * r78;
+    r106 = r106 * r141;
+    r106 = r106 * r81;
+    r31 = fmaf(r56, r106, r31);
+    r94 = r59 * r121;
+    r31 = fmaf(r83, r94, r31);
+    r13 = r67 * r41;
+    r13 = r13 * r30;
+    r13 = r13 * r63;
+    r13 = r13 * r102;
+    r31 = fmaf(r118, r13, r31);
+    r142 = r11 * r59;
+    r142 = r142 * r78;
+    r142 = r142 * r89;
+    r142 = r142 * r30;
+    r142 = r142 * r47;
+    r142 = r142 * r80;
+    r31 = fmaf(r35, r142, r31);
+    r15 = r67 * r121;
+    r15 = r15 * r73;
+    r31 = fmaf(r115, r15, r31);
+    r143 = r4 * r11;
+    r143 = r143 * r141;
+    r143 = r143 * r81;
+    r31 = fmaf(r56, r143, r31);
+    r141 = r67 * r11;
+    r141 = r141 * r30;
+    r141 = r141 * r73;
+    r31 = fmaf(r88, r141, r31);
+    r138 = r59 * r121;
+    r31 = fmaf(r82, r138, r31);
+    r28 = r149 * r82;
+    r31 = fmaf(r63, r28, r31);
+    r31 = fmaf(r91, r72, r31);
+    r31 = fmaf(r30, r132, r31);
+    r28 = r5 * r31;
+    r138 = r26 * r10;
+    r138 = r138 * r10;
+    r138 = r138 * r59;
+    r138 = r138 * r59;
+    r138 = r138 * r113;
+    r138 = r138 * r47;
+    r141 = r43 * r10;
+    r141 = r141 * r59;
+    r141 = r141 * r101;
+    r141 = fmaf(r61, r141, r85 * r138);
+    r138 = r26 * r11;
+    r138 = r138 * r11;
+    r143 = r16 * r39;
+    r143 = r143 * r11;
+    r143 = fmaf(r37, r143, r108 * r138);
+    r138 = r26 * r10;
+    r138 = r138 * r10;
+    r143 = fmaf(r108, r138, r143);
+    r15 = r16 * r43;
+    r15 = r15 * r10;
+    r143 = fmaf(r37, r15, r143);
+    r15 = r71 * r143;
+    r15 = r15 * r88;
+    r141 = fmaf(r111, r15, r141);
+    r138 = r26 * r11;
+    r138 = r138 * r11;
+    r138 = fmaf(r39, r74, r125 * r138);
+    r142 = r4 * r143;
+    r138 = fmaf(r122, r142, r138);
+    r13 = r11 * r11;
+    r13 = r13 * r143;
+    r13 = r13 * r35;
+    r13 = r13 * r42;
+    r138 = fmaf(r61, r13, r138);
+    r141 = fmaf(r143, r119, r141);
+    r141 = r141 + r138;
+    r15 = r26 * r10;
+    r15 = r15 * r10;
+    r13 = r43 * r73;
+    r13 = fmaf(r115, r13, r125 * r15);
+    r15 = r4 * r143;
+    r13 = fmaf(r116, r15, r13);
+    r142 = r143 * r88;
+    r13 = fmaf(r111, r142, r13);
+    r138 = r138 + r13;
+    r141 = fmaf(r8, r138, r67 * r141);
+    r142 = r4 * r26;
+    r142 = r142 * r10;
+    r142 = r142 * r81;
+    r141 = fmaf(r56, r142, r141);
+    r15 = r43 * r59;
+    r141 = fmaf(r82, r15, r141);
+    r94 = r66 * r41;
+    r94 = r94 * r143;
+    r94 = r94 * r63;
+    r94 = r94 * r102;
+    r141 = fmaf(r118, r94, r141);
+    r106 = r43 * r59;
+    r141 = fmaf(r83, r106, r141);
+    r109 = r66 * r11;
+    r109 = r109 * r143;
+    r109 = r109 * r73;
+    r141 = fmaf(r88, r109, r141);
+    r96 = r66 * r43;
+    r141 = fmaf(r74, r96, r141);
+    r95 = r143 * r83;
+    r141 = fmaf(r131, r95, r141);
+    r86 = r66 * r39;
+    r86 = r86 * r73;
+    r141 = fmaf(r115, r86, r141);
+    r105 = r10 * r59;
+    r27 = r7 * r16;
+    r27 = r27 * r65;
+    r27 = fmaf(r6, r138, r138 * r27);
+    r27 = fmaf(r138, r69, r27);
+    r27 = fmaf(r138, r68, r27);
+    r105 = r105 * r27;
+    r141 = fmaf(r82, r105, r141);
+    r123 = r4 * r26;
+    r123 = r123 * r10;
+    r123 = r123 * r78;
+    r123 = r123 * r81;
+    r141 = fmaf(r56, r123, r141);
+    r141 = fmaf(r143, r124, r141);
+    r141 = fmaf(r143, r127, r141);
+    r141 = fmaf(r26, r129, r141);
+    r141 = fmaf(r143, r136, r141);
+    r123 = r0 * r141;
+    r105 = r26 * r11;
+    r105 = r105 * r11;
+    r105 = r105 * r59;
+    r105 = r105 * r59;
+    r105 = r105 * r113;
+    r105 = r105 * r47;
+    r86 = r39 * r101;
+    r86 = r86 * r61;
+    r86 = fmaf(r63, r86, r85 * r105);
+    r105 = r114 * r143;
+    r86 = fmaf(r122, r105, r86);
+    r95 = r11 * r11;
+    r95 = r95 * r71;
+    r95 = r95 * r143;
+    r95 = r95 * r35;
+    r95 = r95 * r42;
+    r86 = fmaf(r61, r95, r86);
+    r86 = r86 + r13;
+    r138 = fmaf(r9, r138, r66 * r86);
+    r86 = r4 * r26;
+    r86 = r86 * r11;
+    r86 = r86 * r81;
+    r138 = fmaf(r56, r86, r138);
+    r13 = r4 * r26;
+    r13 = r13 * r11;
+    r13 = r13 * r78;
+    r13 = r13 * r81;
+    r138 = fmaf(r56, r13, r138);
+    r95 = r11 * r59;
+    r95 = r95 * r89;
+    r95 = r95 * r143;
+    r95 = r95 * r47;
+    r95 = r95 * r80;
+    r138 = fmaf(r35, r95, r138);
+    r105 = r11 * r59;
+    r105 = r105 * r78;
+    r105 = r105 * r89;
+    r105 = r105 * r143;
+    r105 = r105 * r47;
+    r105 = r105 * r80;
+    r138 = fmaf(r35, r105, r138);
+    r96 = r39 * r59;
+    r138 = fmaf(r82, r96, r138);
+    r109 = r39 * r59;
+    r138 = fmaf(r83, r109, r138);
+    r106 = r67 * r41;
+    r106 = r106 * r143;
+    r106 = r106 * r63;
+    r106 = r106 * r102;
+    r138 = fmaf(r118, r106, r138);
+    r94 = r67 * r11;
+    r94 = r94 * r143;
+    r94 = r94 * r73;
+    r138 = fmaf(r88, r94, r138);
+    r15 = r11 * r87;
+    r15 = r15 * r143;
+    r15 = r15 * r35;
+    r15 = r15 * r42;
+    r138 = fmaf(r82, r15, r138);
+    r142 = r67 * r26;
+    r142 = r142 * r10;
+    r142 = r142 * r11;
+    r142 = r142 * r59;
+    r142 = r142 * r59;
+    r142 = r142 * r99;
+    r142 = r142 * r47;
+    r138 = fmaf(r85, r142, r138);
+    r150 = r67 * r39;
+    r150 = r150 * r73;
+    r138 = fmaf(r115, r150, r138);
+    r90 = r27 * r82;
+    r138 = fmaf(r63, r90, r138);
+    r138 = fmaf(r43, r72, r138);
+    r138 = fmaf(r143, r132, r138);
+    r90 = r5 * r138;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          4 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r112,
+                                          r28,
+                                          r123,
+                                          r90);
+    r90 = r11 * r11;
+    r123 = r40 * r11;
+    r123 = r123 * r11;
+    r28 = r16 * r44;
+    r28 = r28 * r11;
+    r28 = fmaf(r37, r28, r108 * r123);
+    r123 = r40 * r10;
+    r123 = r123 * r10;
+    r28 = fmaf(r108, r123, r28);
+    r112 = r16 * r58;
+    r112 = r112 * r10;
+    r28 = fmaf(r37, r112, r28);
+    r90 = r90 * r28;
+    r90 = r90 * r35;
+    r90 = r90 * r42;
+    r112 = r40 * r125;
+    r137 = fmaf(r112, r137, r61 * r90);
+    r90 = r4 * r28;
+    r137 = fmaf(r122, r90, r137);
+    r137 = fmaf(r44, r74, r137);
+    r90 = r28 * r88;
+    r3 = fmaf(r112, r3, r111 * r90);
+    r112 = r58 * r73;
+    r3 = fmaf(r115, r112, r3);
+    r90 = r4 * r28;
+    r3 = fmaf(r116, r90, r3);
+    r90 = r137 + r3;
+    r112 = r71 * r28;
+    r112 = r112 * r88;
+    r123 = r40 * r10;
+    r123 = r123 * r10;
+    r123 = r123 * r59;
+    r123 = r123 * r59;
+    r123 = r123 * r113;
+    r123 = r123 * r47;
+    r123 = fmaf(r85, r123, r111 * r112);
+    r112 = r58 * r10;
+    r112 = r112 * r59;
+    r112 = r112 * r101;
+    r123 = fmaf(r61, r112, r123);
+    r123 = fmaf(r28, r119, r123);
+    r123 = r123 + r137;
+    r123 = fmaf(r67, r123, r8 * r90);
+    r137 = r58 * r59;
+    r123 = fmaf(r83, r137, r123);
+    r112 = r10 * r59;
+    r150 = r7 * r16;
+    r150 = r150 * r65;
+    r150 = fmaf(r90, r150, r6 * r90);
+    r150 = fmaf(r90, r69, r150);
+    r150 = fmaf(r90, r68, r150);
+    r112 = r112 * r150;
+    r123 = fmaf(r82, r112, r123);
+    r142 = r66 * r44;
+    r142 = r142 * r73;
+    r123 = fmaf(r115, r142, r123);
+    r15 = r58 * r59;
+    r123 = fmaf(r82, r15, r123);
+    r94 = r66 * r11;
+    r94 = r94 * r28;
+    r94 = r94 * r73;
+    r123 = fmaf(r88, r94, r123);
+    r106 = r66 * r41;
+    r106 = r106 * r28;
+    r106 = r106 * r63;
+    r106 = r106 * r102;
+    r123 = fmaf(r118, r106, r123);
+    r109 = r28 * r83;
+    r123 = fmaf(r131, r109, r123);
+    r96 = r4 * r40;
+    r96 = r96 * r10;
+    r96 = r96 * r81;
+    r123 = fmaf(r56, r96, r123);
+    r105 = r66 * r58;
+    r123 = fmaf(r74, r105, r123);
+    r95 = r4 * r40;
+    r95 = r95 * r10;
+    r95 = r95 * r78;
+    r95 = r95 * r81;
+    r123 = fmaf(r56, r95, r123);
+    r123 = fmaf(r28, r127, r123);
+    r123 = fmaf(r28, r136, r123);
+    r123 = fmaf(r40, r129, r123);
+    r123 = fmaf(r28, r124, r123);
+    r95 = r0 * r123;
+    r105 = r11 * r11;
+    r105 = r105 * r71;
+    r105 = r105 * r28;
+    r105 = r105 * r35;
+    r105 = r105 * r42;
+    r96 = r40 * r11;
+    r96 = r96 * r11;
+    r96 = r96 * r59;
+    r96 = r96 * r59;
+    r96 = r96 * r113;
+    r96 = r96 * r47;
+    r96 = fmaf(r85, r96, r61 * r105);
+    r105 = r44 * r101;
+    r105 = r105 * r61;
+    r96 = fmaf(r63, r105, r96);
+    r109 = r114 * r28;
+    r96 = fmaf(r122, r109, r96);
+    r96 = r96 + r3;
+    r96 = fmaf(r66, r96, r9 * r90);
+    r90 = r67 * r44;
+    r90 = r90 * r73;
+    r96 = fmaf(r115, r90, r96);
+    r3 = r4 * r40;
+    r3 = r3 * r11;
+    r3 = r3 * r81;
+    r96 = fmaf(r56, r3, r96);
+    r109 = r11 * r87;
+    r109 = r109 * r28;
+    r109 = r109 * r35;
+    r109 = r109 * r42;
+    r96 = fmaf(r82, r109, r96);
+    r105 = r67 * r11;
+    r105 = r105 * r28;
+    r105 = r105 * r73;
+    r96 = fmaf(r88, r105, r96);
+    r106 = r44 * r59;
+    r96 = fmaf(r83, r106, r96);
+    r94 = r67 * r40;
+    r94 = r94 * r10;
+    r94 = r94 * r11;
+    r94 = r94 * r59;
+    r94 = r94 * r59;
+    r94 = r94 * r99;
+    r94 = r94 * r47;
+    r96 = fmaf(r85, r94, r96);
+    r15 = r67 * r41;
+    r15 = r15 * r28;
+    r15 = r15 * r63;
+    r15 = r15 * r102;
+    r96 = fmaf(r118, r15, r96);
+    r142 = r44 * r59;
+    r96 = fmaf(r82, r142, r96);
+    r112 = r4 * r40;
+    r112 = r112 * r11;
+    r112 = r112 * r78;
+    r112 = r112 * r81;
+    r96 = fmaf(r56, r112, r96);
+    r137 = r11 * r59;
+    r137 = r137 * r78;
+    r137 = r137 * r89;
+    r137 = r137 * r28;
+    r137 = r137 * r47;
+    r137 = r137 * r80;
+    r96 = fmaf(r35, r137, r96);
+    r13 = r150 * r82;
+    r96 = fmaf(r63, r13, r96);
+    r86 = r11 * r59;
+    r86 = r86 * r89;
+    r86 = r86 * r28;
+    r86 = r86 * r47;
+    r86 = r86 * r80;
+    r96 = fmaf(r35, r86, r96);
+    r96 = fmaf(r28, r132, r96);
+    r96 = fmaf(r58, r72, r96);
+    r86 = r5 * r96;
+    r13 = r11 * r11;
+    r137 = r16 * r46;
+    r137 = r137 * r11;
+    r112 = r38 * r11;
+    r112 = r112 * r11;
+    r112 = fmaf(r108, r112, r37 * r137);
+    r137 = r16 * r57;
+    r137 = r137 * r10;
+    r112 = fmaf(r37, r137, r112);
+    r142 = r38 * r10;
+    r142 = r142 * r10;
+    r112 = fmaf(r108, r142, r112);
+    r13 = r13 * r112;
+    r13 = r13 * r35;
+    r13 = r13 * r42;
+    r13 = fmaf(r46, r74, r61 * r13);
+    r142 = r4 * r112;
+    r13 = fmaf(r122, r142, r13);
+    r137 = r38 * r11;
+    r137 = r137 * r11;
+    r13 = fmaf(r125, r137, r13);
+    r137 = r38 * r10;
+    r137 = r137 * r10;
+    r142 = r4 * r112;
+    r142 = fmaf(r116, r142, r125 * r137);
+    r137 = r57 * r73;
+    r142 = fmaf(r115, r137, r142);
+    r15 = r112 * r88;
+    r142 = fmaf(r111, r15, r142);
+    r15 = r13 + r142;
+    r137 = r38 * r10;
+    r137 = r137 * r10;
+    r137 = r137 * r59;
+    r137 = r137 * r59;
+    r137 = r137 * r113;
+    r137 = r137 * r47;
+    r137 = fmaf(r112, r119, r85 * r137);
+    r94 = r57 * r10;
+    r94 = r94 * r59;
+    r94 = r94 * r101;
+    r137 = fmaf(r61, r94, r137);
+    r106 = r71 * r112;
+    r106 = r106 * r88;
+    r137 = fmaf(r111, r106, r137);
+    r137 = r137 + r13;
+    r137 = fmaf(r67, r137, r8 * r15);
+    r13 = r4 * r38;
+    r13 = r13 * r10;
+    r13 = r13 * r78;
+    r13 = r13 * r81;
+    r137 = fmaf(r56, r13, r137);
+    r106 = r57 * r59;
+    r137 = fmaf(r82, r106, r137);
+    r94 = r4 * r38;
+    r94 = r94 * r10;
+    r94 = r94 * r81;
+    r137 = fmaf(r56, r94, r137);
+    r105 = r57 * r59;
+    r137 = fmaf(r83, r105, r137);
+    r109 = r112 * r83;
+    r137 = fmaf(r131, r109, r137);
+    r3 = r66 * r41;
+    r3 = r3 * r112;
+    r3 = r3 * r63;
+    r3 = r3 * r102;
+    r137 = fmaf(r118, r3, r137);
+    r90 = r66 * r11;
+    r90 = r90 * r112;
+    r90 = r90 * r73;
+    r137 = fmaf(r88, r90, r137);
+    r93 = r66 * r46;
+    r93 = r93 * r73;
+    r137 = fmaf(r115, r93, r137);
+    r144 = r66 * r57;
+    r137 = fmaf(r74, r144, r137);
+    r133 = r10 * r59;
+    r110 = r7 * r16;
+    r110 = r110 * r65;
+    r110 = fmaf(r6, r15, r15 * r110);
+    r110 = fmaf(r15, r69, r110);
+    r110 = fmaf(r15, r68, r110);
+    r133 = r133 * r110;
+    r137 = fmaf(r82, r133, r137);
+    r137 = fmaf(r112, r127, r137);
+    r137 = fmaf(r112, r124, r137);
+    r137 = fmaf(r112, r136, r137);
+    r137 = fmaf(r38, r129, r137);
+    r133 = r0 * r137;
+    r144 = r11 * r11;
+    r144 = r144 * r71;
+    r144 = r144 * r112;
+    r144 = r144 * r35;
+    r144 = r144 * r42;
+    r93 = r46 * r101;
+    r93 = r93 * r61;
+    r93 = fmaf(r63, r93, r61 * r144);
+    r144 = r114 * r112;
+    r93 = fmaf(r122, r144, r93);
+    r90 = r38 * r11;
+    r90 = r90 * r11;
+    r90 = r90 * r59;
+    r90 = r90 * r59;
+    r90 = r90 * r113;
+    r90 = r90 * r47;
+    r93 = fmaf(r85, r90, r93);
+    r93 = r93 + r142;
+    r93 = fmaf(r66, r93, r9 * r15);
+    r15 = r11 * r87;
+    r15 = r15 * r112;
+    r15 = r15 * r35;
+    r15 = r15 * r42;
+    r93 = fmaf(r82, r15, r93);
+    r142 = r46 * r59;
+    r93 = fmaf(r83, r142, r93);
+    r90 = r11 * r59;
+    r90 = r90 * r78;
+    r90 = r90 * r89;
+    r90 = r90 * r112;
+    r90 = r90 * r47;
+    r90 = r90 * r80;
+    r93 = fmaf(r35, r90, r93);
+    r144 = r11 * r59;
+    r144 = r144 * r89;
+    r144 = r144 * r112;
+    r144 = r144 * r47;
+    r144 = r144 * r80;
+    r93 = fmaf(r35, r144, r93);
+    r3 = r67 * r41;
+    r3 = r3 * r112;
+    r3 = r3 * r63;
+    r3 = r3 * r102;
+    r93 = fmaf(r118, r3, r93);
+    r109 = r67 * r11;
+    r109 = r109 * r112;
+    r109 = r109 * r73;
+    r93 = fmaf(r88, r109, r93);
+    r105 = r67 * r46;
+    r105 = r105 * r73;
+    r93 = fmaf(r115, r105, r93);
+    r94 = r4 * r38;
+    r94 = r94 * r11;
+    r94 = r94 * r78;
+    r94 = r94 * r81;
+    r93 = fmaf(r56, r94, r93);
+    r106 = r46 * r59;
+    r93 = fmaf(r82, r106, r93);
+    r13 = r4 * r38;
+    r13 = r13 * r11;
+    r13 = r13 * r81;
+    r93 = fmaf(r56, r13, r93);
+    r92 = r110 * r82;
+    r93 = fmaf(r63, r92, r93);
+    r147 = r67 * r38;
+    r147 = r147 * r10;
+    r147 = r147 * r11;
+    r147 = r147 * r59;
+    r147 = r147 * r59;
+    r147 = r147 * r99;
+    r147 = r147 * r47;
+    r93 = fmaf(r85, r147, r93);
+    r93 = fmaf(r112, r132, r93);
+    r93 = fmaf(r57, r72, r93);
+    r147 = r5 * r93;
+    WriteIdx4<1024, float, float, float4>(out_pose_jac,
+                                          8 * out_pose_jac_num_alloc,
+                                          global_thread_idx,
+                                          r95,
+                                          r86,
+                                          r133,
+                                          r147);
+    r147 = r0 * r4;
+    r147 = r147 * r2;
+    r133 = r4 * r1;
+    r86 = r5 * r133;
+    r147 = fmaf(r120, r86, r107 * r147);
+    r95 = r0 * r4;
+    r95 = r95 * r2;
+    r95 = fmaf(r146, r86, r130 * r95);
+    r92 = r0 * r4;
+    r92 = r92 * r2;
+    r92 = fmaf(r31, r86, r14 * r92);
+    r13 = r0 * r4;
+    r13 = r13 * r2;
+    r13 = fmaf(r138, r86, r141 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r147, r95, r92, r13);
+  };
+  FlushSumShared<4, float>(out_pose_njtr,
+                           0 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r0 * r4;
+    r13 = r13 * r2;
+    r13 = fmaf(r96, r86, r123 * r13);
+    r92 = r0 * r4;
+    r92 = r92 * r2;
+    r92 = fmaf(r93, r86, r137 * r92);
+    WriteSum2<float, float>((float*)inout_shared, r13, r92);
+  };
+  FlushSumShared<2, float>(out_pose_njtr,
+                           4 * out_pose_njtr_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r92 = r0 * r0;
+    r13 = r107 * r107;
+    r95 = r5 * r5;
+    r147 = r120 * r120;
+    r147 = fmaf(r95, r147, r92 * r13);
+    r13 = r130 * r130;
+    r106 = r146 * r146;
+    r106 = fmaf(r95, r106, r92 * r13);
+    r13 = r31 * r31;
+    r94 = r14 * r14;
+    r94 = fmaf(r92, r94, r95 * r13);
+    r13 = r141 * r141;
+    r105 = r138 * r138;
+    r105 = fmaf(r95, r105, r92 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r147, r106, r94, r105);
+  };
+  FlushSumShared<4, float>(out_pose_precond_diag,
+                           0 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r123 * r123;
+    r94 = r96 * r96;
+    r94 = fmaf(r95, r94, r92 * r105);
+    r105 = r93 * r93;
+    r106 = r137 * r137;
+    r106 = fmaf(r92, r106, r95 * r105);
+    WriteSum2<float, float>((float*)inout_shared, r94, r106);
+  };
+  FlushSumShared<2, float>(out_pose_precond_diag,
+                           4 * out_pose_precond_diag_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r106 = r120 * r146;
+    r94 = r107 * r130;
+    r94 = fmaf(r92, r94, r95 * r106);
+    r106 = r107 * r14;
+    r105 = r120 * r31;
+    r105 = fmaf(r95, r105, r92 * r106);
+    r106 = r120 * r138;
+    r147 = r107 * r141;
+    r147 = fmaf(r92, r147, r95 * r106);
+    r106 = r120 * r96;
+    r13 = r107 * r123;
+    r13 = fmaf(r92, r13, r95 * r106);
+    WriteSum4<float, float>((float*)inout_shared, r94, r105, r147, r13);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           0 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r107 * r137;
+    r147 = r120 * r93;
+    r147 = fmaf(r95, r147, r92 * r13);
+    r13 = r146 * r31;
+    r105 = r130 * r14;
+    r105 = fmaf(r92, r105, r95 * r13);
+    r13 = r130 * r141;
+    r94 = r146 * r138;
+    r94 = fmaf(r95, r94, r92 * r13);
+    r13 = r130 * r123;
+    r106 = r146 * r96;
+    r106 = fmaf(r95, r106, r92 * r13);
+    WriteSum4<float, float>((float*)inout_shared, r147, r105, r94, r106);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           4 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r106 = r146 * r93;
+    r94 = r130 * r137;
+    r94 = fmaf(r92, r94, r95 * r106);
+    r106 = r31 * r138;
+    r105 = r14 * r141;
+    r105 = fmaf(r92, r105, r95 * r106);
+    r106 = r14 * r123;
+    r147 = r31 * r96;
+    r147 = fmaf(r95, r147, r92 * r106);
+    r106 = r31 * r93;
+    r13 = r14 * r137;
+    r13 = fmaf(r92, r13, r95 * r106);
+    WriteSum4<float, float>((float*)inout_shared, r94, r105, r147, r13);
+  };
+  FlushSumShared<4, float>(out_pose_precond_tril,
+                           8 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r138 * r96;
+    r147 = r141 * r123;
+    r147 = fmaf(r92, r147, r95 * r13);
+    r13 = r141 * r137;
+    r105 = r138 * r93;
+    r105 = fmaf(r95, r105, r92 * r13);
+    r13 = r96 * r93;
+    r94 = r123 * r137;
+    r94 = fmaf(r92, r94, r95 * r13);
+    WriteSum3<float, float>((float*)inout_shared, r147, r105, r94);
+  };
+  FlushSumShared<3, float>(out_pose_precond_tril,
+                           12 * out_pose_precond_tril_num_alloc,
+                           pose_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r0 * r10;
+    r94 = r94 * r59;
+    r94 = r94 * r65;
+    r94 = r94 * r82;
+    r105 = r5 * r65;
+    r105 = r105 * r82;
+    r105 = r105 * r63;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          0 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r62,
+                                          r64,
+                                          r94,
+                                          r105);
+    r105 = r5 * r75;
+    r94 = r0 * r82;
+    r94 = r94 * r76;
+    r94 = r94 * r115;
+    r147 = r5 * r82;
+    r147 = r147 * r63;
+    r147 = r147 * r76;
+    r13 = r0 * r10;
+    r13 = r13 * r74;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          4 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r147,
+                                          r13,
+                                          r105);
+    r105 = r0 * r70;
+    r13 = r5 * r10;
+    r13 = r13 * r74;
+    r147 = r0 * r82;
+    r147 = r147 * r115;
+    r147 = r147 * r77;
+    r94 = r5 * r82;
+    r94 = r94 * r63;
+    r94 = r94 * r77;
+    WriteIdx4<1024, float, float, float4>(out_focal_and_extra_jac,
+                                          8 * out_focal_and_extra_jac_num_alloc,
+                                          global_thread_idx,
+                                          r105,
+                                          r13,
+                                          r147,
+                                          r94);
+    r94 = r0 * r65;
+    r147 = r5 * r65;
+    r13 = r0 * r82;
+    r13 = r13 * r115;
+    r13 = r13 * r79;
+    r105 = r5 * r82;
+    r105 = r105 * r63;
+    r105 = r105 * r79;
+    WriteIdx4<1024, float, float, float4>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r13,
+        r105,
+        r94,
+        r147);
+    r147 = r4 * r62;
+    r147 = r147 * r2;
+    r133 = r64 * r133;
+    r94 = r0 * r4;
+    r94 = r94 * r10;
+    r94 = r94 * r59;
+    r94 = r94 * r65;
+    r94 = r94 * r2;
+    r105 = r65 * r82;
+    r105 = r105 * r63;
+    r105 = fmaf(r86, r105, r82 * r94);
+    r94 = r0 * r4;
+    r94 = r94 * r2;
+    r94 = r94 * r82;
+    r94 = r94 * r76;
+    r13 = r82 * r63;
+    r13 = r13 * r76;
+    r13 = fmaf(r86, r13, r115 * r94);
+    WriteSum4<float, float>((float*)inout_shared, r147, r133, r105, r13);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           0 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r0 * r41;
+    r13 = r13 * r10;
+    r13 = r13 * r2;
+    r13 = r13 * r61;
+    r13 = fmaf(r63, r13, r75 * r86);
+    r105 = r0 * r4;
+    r105 = r105 * r70;
+    r133 = r5 * r41;
+    r133 = r133 * r10;
+    r133 = r133 * r1;
+    r133 = r133 * r61;
+    r133 = fmaf(r63, r133, r2 * r105);
+    r105 = r0 * r4;
+    r105 = r105 * r2;
+    r105 = r105 * r82;
+    r105 = r105 * r115;
+    r1 = r82 * r63;
+    r1 = r1 * r77;
+    r1 = fmaf(r86, r1, r77 * r105);
+    r105 = r0 * r4;
+    r105 = r105 * r2;
+    r105 = r105 * r82;
+    r105 = r105 * r115;
+    r147 = r82 * r63;
+    r147 = r147 * r79;
+    r147 = fmaf(r86, r147, r79 * r105);
+    WriteSum4<float, float>((float*)inout_shared, r13, r133, r1, r147);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_njtr,
+                           4 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r0 * r4;
+    r147 = r147 * r65;
+    r147 = r147 * r2;
+    r1 = r65 * r86;
+    WriteSum2<float, float>((float*)inout_shared, r147, r1);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_njtr,
+                           8 * out_focal_and_extra_njtr_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r62 * r62;
+    r147 = r64 * r64;
+    r133 = r11 * r61;
+    r133 = r133 * r63;
+    r133 = r133 * r76;
+    r13 = r76 * r115;
+    r13 = r13 * r92;
+    r13 = fmaf(r111, r13, r95 * r133);
+    r133 = r11 * r61;
+    r133 = r133 * r63;
+    r133 = r133 * r95;
+    r105 = r115 * r92;
+    r105 = r105 * r79;
+    r105 = fmaf(r111, r105, r79 * r133);
+    WriteSum4<float, float>((float*)inout_shared, r1, r147, r13, r105);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           0 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r10 * r10;
+    r12 = r36 * r12;
+    r12 = 1.0 / r12;
+    r52 = r51 * r52;
+    r52 = 1.0 / r52;
+    r13 = r13 * r11;
+    r13 = r13 * r11;
+    r13 = r13 * r59;
+    r13 = r13 * r59;
+    r13 = r13 * r140;
+    r13 = r13 * r12;
+    r13 = r13 * r52;
+    r13 = r13 * r126;
+    r52 = r75 * r95;
+    r12 = fmaf(r75, r52, r92 * r13);
+    r140 = r70 * r70;
+    r140 = fmaf(r92, r140, r95 * r13);
+    r13 = r77 * r77;
+    r51 = r11 * r61;
+    r51 = r51 * r63;
+    r51 = r51 * r95;
+    r36 = r115 * r92;
+    r147 = r111 * r36;
+    r1 = fmaf(r13, r147, r13 * r51);
+    r133 = r79 * r79;
+    r133 = fmaf(r147, r133, r51 * r133);
+    WriteSum4<float, float>((float*)inout_shared, r12, r140, r1, r133);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_diag,
+                           4 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r133 = r76 * r92;
+    r140 = r76 * r95;
+    WriteSum2<float, float>((float*)inout_shared, r133, r140);
+  };
+  FlushSumShared<2, float>(out_focal_and_extra_precond_diag,
+                           8 * out_focal_and_extra_precond_diag_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r140 = 0.00000000000000000e+00;
+    r133 = r0 * r10;
+    r133 = r133 * r59;
+    r133 = r133 * r65;
+    r133 = r133 * r62;
+    r133 = r133 * r82;
+    r12 = r0 * r62;
+    r12 = r12 * r82;
+    r12 = r12 * r76;
+    r12 = r12 * r115;
+    r94 = r10 * r74;
+    r94 = r94 * r84;
+    WriteSum4<float, float>((float*)inout_shared, r140, r133, r12, r94);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           0 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r0 * r70;
+    r94 = r94 * r62;
+    r12 = r0 * r65;
+    r12 = r12 * r62;
+    r62 = r0 * r62;
+    r62 = r62 * r82;
+    r62 = r62 * r115;
+    r62 = r62 * r77;
+    r133 = r82 * r115;
+    r133 = r133 * r79;
+    r133 = r133 * r84;
+    WriteSum4<float, float>((float*)inout_shared, r94, r62, r133, r12);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           4 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = r5 * r75;
+    r75 = r75 * r64;
+    r12 = r5 * r65;
+    r12 = r12 * r64;
+    r12 = r12 * r82;
+    r12 = r12 * r63;
+    r133 = r5 * r64;
+    r133 = r133 * r82;
+    r133 = r133 * r63;
+    r133 = r133 * r76;
+    WriteSum4<float, float>((float*)inout_shared, r140, r12, r133, r75);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           8 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = r5 * r10;
+    r75 = r75 * r64;
+    r75 = r75 * r74;
+    r133 = r5 * r64;
+    r133 = r133 * r82;
+    r133 = r133 * r63;
+    r133 = r133 * r77;
+    r12 = r5 * r64;
+    r12 = r12 * r82;
+    r12 = r12 * r63;
+    r12 = r12 * r79;
+    WriteSum4<float, float>((float*)inout_shared, r75, r133, r12, r140);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           12 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r140 = r5 * r65;
+    r140 = r140 * r64;
+    r64 = r11 * r61;
+    r64 = r64 * r63;
+    r64 = r64 * r77;
+    r12 = r115 * r77;
+    r12 = r12 * r92;
+    r12 = fmaf(r111, r12, r95 * r64);
+    r64 = r10 * r59;
+    r133 = r16 * r11;
+    r133 = r133 * r85;
+    r133 = r133 * r117;
+    r133 = r133 * r126;
+    r126 = r10 * r133;
+    r64 = r64 * r65;
+    r64 = r64 * r92;
+    r117 = r82 * r63;
+    r117 = r117 * r52;
+    r64 = fmaf(r65, r117, r126 * r64);
+    r75 = r10 * r59;
+    r75 = r75 * r65;
+    r75 = r75 * r70;
+    r75 = r75 * r82;
+    r62 = r11 * r59;
+    r62 = r62 * r65;
+    r62 = r62 * r95;
+    r62 = fmaf(r126, r62, r92 * r75);
+    WriteSum4<float, float>((float*)inout_shared, r140, r12, r64, r62);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           16 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r82 * r76;
+    r62 = r62 * r115;
+    r62 = r62 * r92;
+    r64 = r82 * r63;
+    r64 = r64 * r76;
+    r64 = r64 * r95;
+    r12 = r65 * r79;
+    r140 = fmaf(r12, r147, r12 * r51);
+    WriteSum4<float, float>((float*)inout_shared, r105, r140, r62, r64);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           20 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r76 * r36;
+    r64 = fmaf(r76, r117, r126 * r64);
+    r62 = r70 * r82;
+    r62 = r62 * r76;
+    r62 = r62 * r115;
+    r105 = r11 * r76;
+    r105 = r105 * r115;
+    r105 = r105 * r95;
+    r105 = fmaf(r133, r105, r92 * r62);
+    WriteSum4<float, float>((float*)inout_shared, r64, r105, r140, r1);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           24 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r82 * r115;
+    r1 = r1 * r77;
+    r1 = r1 * r92;
+    r140 = r82 * r63;
+    r140 = r140 * r77;
+    r140 = r140 * r95;
+    r105 = r10 * r74;
+    r64 = r10 * r70;
+    r64 = r64 * r92;
+    r64 = fmaf(r74, r64, r52 * r105);
+    r105 = r77 * r36;
+    r105 = fmaf(r77, r117, r126 * r105);
+    WriteSum4<float, float>((float*)inout_shared, r1, r140, r64, r105);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           28 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r10 * r65;
+    r105 = r105 * r92;
+    r105 = r105 * r74;
+    r52 = r65 * r52;
+    r64 = r79 * r36;
+    r117 = fmaf(r79, r117, r126 * r64);
+    r64 = r70 * r82;
+    r64 = r64 * r115;
+    r64 = r64 * r77;
+    r126 = r11 * r115;
+    r126 = r126 * r77;
+    r126 = r126 * r95;
+    r126 = fmaf(r133, r126, r92 * r64);
+    WriteSum4<float, float>((float*)inout_shared, r117, r105, r52, r126);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           32 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r65 * r70;
+    r126 = r126 * r92;
+    r52 = r10 * r65;
+    r52 = r52 * r95;
+    r52 = r52 * r74;
+    r105 = r70 * r82;
+    r105 = r105 * r115;
+    r105 = r105 * r92;
+    r117 = r11 * r115;
+    r117 = r117 * r95;
+    r117 = r117 * r79;
+    r117 = fmaf(r133, r117, r79 * r105);
+    r13 = r65 * r13;
+    r147 = fmaf(r13, r147, r13 * r51);
+    WriteSum4<float, float>((float*)inout_shared, r117, r126, r52, r147);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           36 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r82 * r115;
+    r147 = r147 * r92;
+    r147 = r147 * r79;
+    r52 = r82 * r63;
+    r52 = r52 * r95;
+    r52 = r52 * r79;
+    r126 = r82 * r12;
+    r126 = r126 * r36;
+    r117 = r82 * r63;
+    r117 = r117 * r95;
+    r117 = r117 * r12;
+    WriteSum4<float, float>((float*)inout_shared, r147, r52, r126, r117);
+  };
+  FlushSumShared<4, float>(out_focal_and_extra_precond_tril,
+                           40 * out_focal_and_extra_precond_tril_num_alloc,
+                           focal_and_extra_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r117 = r54 * r10;
+    r117 = r117 * r59;
+    r117 = r117 * r101;
+    r126 = r60 * r10;
+    r126 = r126 * r10;
+    r126 = r126 * r59;
+    r126 = r126 * r59;
+    r126 = r126 * r113;
+    r126 = r126 * r47;
+    r126 = fmaf(r85, r126, r61 * r117);
+    r117 = r16 * r33;
+    r117 = r117 * r11;
+    r52 = r16 * r54;
+    r52 = r52 * r10;
+    r52 = fmaf(r37, r52, r37 * r117);
+    r117 = r60 * r10;
+    r117 = r117 * r10;
+    r52 = fmaf(r108, r117, r52);
+    r147 = r60 * r11;
+    r147 = r147 * r11;
+    r52 = fmaf(r108, r147, r52);
+    r147 = r71 * r52;
+    r147 = r147 * r88;
+    r126 = fmaf(r111, r147, r126);
+    r117 = r4 * r52;
+    r12 = r11 * r11;
+    r12 = r12 * r52;
+    r12 = r12 * r35;
+    r12 = r12 * r42;
+    r12 = fmaf(r61, r12, r122 * r117);
+    r117 = r60 * r11;
+    r117 = r117 * r11;
+    r12 = fmaf(r125, r117, r12);
+    r12 = fmaf(r33, r74, r12);
+    r126 = fmaf(r52, r119, r126);
+    r126 = r126 + r12;
+    r147 = r54 * r73;
+    r117 = r60 * r10;
+    r117 = r117 * r10;
+    r117 = fmaf(r125, r117, r115 * r147);
+    r147 = r52 * r88;
+    r117 = fmaf(r111, r147, r117);
+    r13 = r4 * r52;
+    r117 = fmaf(r116, r13, r117);
+    r12 = r12 + r117;
+    r126 = fmaf(r8, r12, r67 * r126);
+    r13 = r54 * r59;
+    r126 = fmaf(r83, r13, r126);
+    r147 = r4 * r60;
+    r147 = r147 * r10;
+    r147 = r147 * r78;
+    r147 = r147 * r81;
+    r126 = fmaf(r56, r147, r126);
+    r51 = r4 * r60;
+    r51 = r51 * r10;
+    r51 = r51 * r81;
+    r126 = fmaf(r56, r51, r126);
+    r105 = r66 * r33;
+    r105 = r105 * r73;
+    r126 = fmaf(r115, r105, r126);
+    r133 = r10 * r59;
+    r64 = r7 * r16;
+    r64 = r64 * r65;
+    r64 = fmaf(r6, r12, r12 * r64);
+    r64 = fmaf(r12, r69, r64);
+    r64 = fmaf(r12, r68, r64);
+    r133 = r133 * r64;
+    r126 = fmaf(r82, r133, r126);
+    r140 = r52 * r83;
+    r126 = fmaf(r131, r140, r126);
+    r1 = r54 * r59;
+    r126 = fmaf(r82, r1, r126);
+    r62 = r66 * r41;
+    r62 = r62 * r52;
+    r62 = r62 * r63;
+    r62 = r62 * r102;
+    r126 = fmaf(r118, r62, r126);
+    r75 = r66 * r54;
+    r126 = fmaf(r74, r75, r126);
+    r94 = r66 * r11;
+    r94 = r94 * r52;
+    r94 = r94 * r73;
+    r126 = fmaf(r88, r94, r126);
+    r126 = fmaf(r52, r124, r126);
+    r126 = fmaf(r52, r127, r126);
+    r126 = fmaf(r60, r129, r126);
+    r126 = fmaf(r52, r136, r126);
+    r94 = r0 * r126;
+    r75 = r114 * r52;
+    r62 = r11 * r11;
+    r62 = r62 * r71;
+    r62 = r62 * r52;
+    r62 = r62 * r35;
+    r62 = r62 * r42;
+    r62 = fmaf(r61, r62, r122 * r75);
+    r75 = r60 * r11;
+    r75 = r75 * r11;
+    r75 = r75 * r59;
+    r75 = r75 * r59;
+    r75 = r75 * r113;
+    r75 = r75 * r47;
+    r62 = fmaf(r85, r75, r62);
+    r1 = r33 * r101;
+    r1 = r1 * r61;
+    r62 = fmaf(r63, r1, r62);
+    r62 = r62 + r117;
+    r12 = fmaf(r9, r12, r66 * r62);
+    r62 = r11 * r59;
+    r62 = r62 * r78;
+    r62 = r62 * r89;
+    r62 = r62 * r52;
+    r62 = r62 * r47;
+    r62 = r62 * r80;
+    r12 = fmaf(r35, r62, r12);
+    r117 = r4 * r60;
+    r117 = r117 * r11;
+    r117 = r117 * r78;
+    r117 = r117 * r81;
+    r12 = fmaf(r56, r117, r12);
+    r1 = r67 * r33;
+    r1 = r1 * r73;
+    r12 = fmaf(r115, r1, r12);
+    r75 = r67 * r60;
+    r75 = r75 * r10;
+    r75 = r75 * r11;
+    r75 = r75 * r59;
+    r75 = r75 * r59;
+    r75 = r75 * r99;
+    r75 = r75 * r47;
+    r12 = fmaf(r85, r75, r12);
+    r140 = r11 * r59;
+    r140 = r140 * r89;
+    r140 = r140 * r52;
+    r140 = r140 * r47;
+    r140 = r140 * r80;
+    r12 = fmaf(r35, r140, r12);
+    r133 = r67 * r41;
+    r133 = r133 * r52;
+    r133 = r133 * r63;
+    r133 = r133 * r102;
+    r12 = fmaf(r118, r133, r12);
+    r105 = r11 * r87;
+    r105 = r105 * r52;
+    r105 = r105 * r35;
+    r105 = r105 * r42;
+    r12 = fmaf(r82, r105, r12);
+    r51 = r33 * r59;
+    r12 = fmaf(r83, r51, r12);
+    r147 = r4 * r60;
+    r147 = r147 * r11;
+    r147 = r147 * r81;
+    r12 = fmaf(r56, r147, r12);
+    r13 = r67 * r11;
+    r13 = r13 * r52;
+    r13 = r13 * r73;
+    r12 = fmaf(r88, r13, r12);
+    r84 = r33 * r59;
+    r12 = fmaf(r82, r84, r12);
+    r106 = r64 * r82;
+    r12 = fmaf(r63, r106, r12);
+    r12 = fmaf(r52, r132, r12);
+    r12 = fmaf(r54, r72, r12);
+    r106 = r5 * r12;
+    r84 = r45 * r11;
+    r84 = r84 * r11;
+    r13 = r16 * r49;
+    r13 = r13 * r10;
+    r13 = fmaf(r37, r13, r108 * r84);
+    r84 = r16 * r50;
+    r84 = r84 * r11;
+    r13 = fmaf(r37, r84, r13);
+    r147 = r45 * r10;
+    r147 = r147 * r10;
+    r13 = fmaf(r108, r147, r13);
+    r147 = r13 * r88;
+    r84 = r45 * r10;
+    r84 = r84 * r10;
+    r84 = fmaf(r125, r84, r111 * r147);
+    r147 = r4 * r13;
+    r84 = fmaf(r116, r147, r84);
+    r51 = r49 * r73;
+    r84 = fmaf(r115, r51, r84);
+    r51 = r13 * r122;
+    r147 = fmaf(r50, r74, r4 * r51);
+    r105 = r11 * r11;
+    r105 = r105 * r13;
+    r105 = r105 * r35;
+    r105 = r105 * r42;
+    r147 = fmaf(r61, r105, r147);
+    r133 = r45 * r11;
+    r133 = r133 * r11;
+    r147 = fmaf(r125, r133, r147);
+    r133 = r84 + r147;
+    r105 = r71 * r13;
+    r105 = r105 * r88;
+    r140 = r45 * r10;
+    r140 = r140 * r10;
+    r140 = r140 * r59;
+    r140 = r140 * r59;
+    r140 = r140 * r113;
+    r140 = r140 * r47;
+    r140 = fmaf(r85, r140, r111 * r105);
+    r105 = r49 * r10;
+    r105 = r105 * r59;
+    r105 = r105 * r101;
+    r140 = fmaf(r61, r105, r140);
+    r140 = fmaf(r13, r119, r140);
+    r140 = r140 + r147;
+    r140 = fmaf(r67, r140, r8 * r133);
+    r147 = r66 * r49;
+    r140 = fmaf(r74, r147, r140);
+    r105 = r66 * r41;
+    r105 = r105 * r13;
+    r105 = r105 * r63;
+    r105 = r105 * r102;
+    r140 = fmaf(r118, r105, r140);
+    r75 = r4 * r45;
+    r75 = r75 * r10;
+    r75 = r75 * r81;
+    r140 = fmaf(r56, r75, r140);
+    r1 = r4 * r45;
+    r1 = r1 * r10;
+    r1 = r1 * r78;
+    r1 = r1 * r81;
+    r140 = fmaf(r56, r1, r140);
+    r117 = r10 * r59;
+    r62 = r7 * r16;
+    r62 = r62 * r65;
+    r62 = fmaf(r133, r62, r6 * r133);
+    r62 = fmaf(r133, r69, r62);
+    r62 = fmaf(r133, r68, r62);
+    r117 = r117 * r62;
+    r140 = fmaf(r82, r117, r140);
+    r109 = r13 * r83;
+    r140 = fmaf(r131, r109, r140);
+    r3 = r49 * r59;
+    r140 = fmaf(r83, r3, r140);
+    r144 = r66 * r50;
+    r144 = r144 * r73;
+    r140 = fmaf(r115, r144, r140);
+    r90 = r49 * r59;
+    r140 = fmaf(r82, r90, r140);
+    r142 = r66 * r11;
+    r142 = r142 * r13;
+    r142 = r142 * r73;
+    r140 = fmaf(r88, r142, r140);
+    r140 = fmaf(r13, r127, r140);
+    r140 = fmaf(r13, r124, r140);
+    r140 = fmaf(r13, r136, r140);
+    r140 = fmaf(r45, r129, r140);
+    r142 = r0 * r140;
+    r90 = r50 * r101;
+    r90 = r90 * r61;
+    r90 = fmaf(r63, r90, r114 * r51);
+    r51 = r11 * r11;
+    r51 = r51 * r71;
+    r51 = r51 * r13;
+    r51 = r51 * r35;
+    r51 = r51 * r42;
+    r90 = fmaf(r61, r51, r90);
+    r144 = r45 * r11;
+    r144 = r144 * r11;
+    r144 = r144 * r59;
+    r144 = r144 * r59;
+    r144 = r144 * r113;
+    r144 = r144 * r47;
+    r90 = fmaf(r85, r144, r90);
+    r90 = r90 + r84;
+    r90 = fmaf(r66, r90, r9 * r133);
+    r133 = r67 * r11;
+    r133 = r133 * r13;
+    r133 = r133 * r73;
+    r90 = fmaf(r88, r133, r90);
+    r84 = r67 * r41;
+    r84 = r84 * r13;
+    r84 = r84 * r63;
+    r84 = r84 * r102;
+    r90 = fmaf(r118, r84, r90);
+    r144 = r11 * r59;
+    r144 = r144 * r78;
+    r144 = r144 * r89;
+    r144 = r144 * r13;
+    r144 = r144 * r47;
+    r144 = r144 * r80;
+    r90 = fmaf(r35, r144, r90);
+    r51 = r11 * r59;
+    r51 = r51 * r89;
+    r51 = r51 * r13;
+    r51 = r51 * r47;
+    r51 = r51 * r80;
+    r90 = fmaf(r35, r51, r90);
+    r3 = r62 * r82;
+    r90 = fmaf(r63, r3, r90);
+    r109 = r50 * r59;
+    r90 = fmaf(r82, r109, r90);
+    r117 = r4 * r45;
+    r117 = r117 * r11;
+    r117 = r117 * r78;
+    r117 = r117 * r81;
+    r90 = fmaf(r56, r117, r90);
+    r1 = r50 * r59;
+    r90 = fmaf(r83, r1, r90);
+    r75 = r11 * r87;
+    r75 = r75 * r13;
+    r75 = r75 * r35;
+    r75 = r75 * r42;
+    r90 = fmaf(r82, r75, r90);
+    r105 = r67 * r50;
+    r105 = r105 * r73;
+    r90 = fmaf(r115, r105, r90);
+    r147 = r4 * r45;
+    r147 = r147 * r11;
+    r147 = r147 * r81;
+    r90 = fmaf(r56, r147, r90);
+    r15 = r67 * r45;
+    r15 = r15 * r10;
+    r15 = r15 * r11;
+    r15 = r15 * r59;
+    r15 = r15 * r59;
+    r15 = r15 * r99;
+    r15 = r15 * r47;
+    r90 = fmaf(r85, r15, r90);
+    r90 = fmaf(r49, r72, r90);
+    r90 = fmaf(r13, r132, r90);
+    r15 = r5 * r90;
+    WriteIdx4<1024, float, float, float4>(out_point_jac,
+                                          0 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r106,
+                                          r142,
+                                          r15);
+    r15 = r16 * r48;
+    r15 = r15 * r11;
+    r142 = r53 * r11;
+    r142 = r142 * r11;
+    r142 = fmaf(r108, r142, r37 * r15);
+    r15 = r53 * r10;
+    r15 = r15 * r10;
+    r142 = fmaf(r108, r15, r142);
+    r108 = r16 * r55;
+    r108 = r108 * r10;
+    r142 = fmaf(r37, r108, r142);
+    r108 = r4 * r142;
+    r108 = fmaf(r48, r74, r122 * r108);
+    r15 = r11 * r11;
+    r15 = r15 * r142;
+    r15 = r15 * r35;
+    r15 = r15 * r42;
+    r108 = fmaf(r61, r15, r108);
+    r37 = r53 * r11;
+    r37 = r37 * r11;
+    r108 = fmaf(r125, r37, r108);
+    r37 = r55 * r73;
+    r15 = r142 * r88;
+    r15 = fmaf(r111, r15, r115 * r37);
+    r37 = r53 * r10;
+    r37 = r37 * r10;
+    r15 = fmaf(r125, r37, r15);
+    r125 = r4 * r142;
+    r15 = fmaf(r116, r125, r15);
+    r125 = r108 + r15;
+    r37 = r55 * r10;
+    r37 = r37 * r59;
+    r37 = r37 * r101;
+    r116 = r71 * r142;
+    r116 = r116 * r88;
+    r116 = fmaf(r111, r116, r61 * r37);
+    r37 = r53 * r10;
+    r37 = r37 * r10;
+    r37 = r37 * r59;
+    r37 = r37 * r59;
+    r37 = r37 * r113;
+    r37 = r37 * r47;
+    r116 = fmaf(r85, r37, r116);
+    r116 = fmaf(r142, r119, r116);
+    r116 = r116 + r108;
+    r116 = fmaf(r67, r116, r8 * r125);
+    r8 = r66 * r48;
+    r8 = r8 * r73;
+    r116 = fmaf(r115, r8, r116);
+    r108 = r66 * r11;
+    r108 = r108 * r142;
+    r108 = r108 * r73;
+    r116 = fmaf(r88, r108, r116);
+    r119 = r4 * r53;
+    r119 = r119 * r10;
+    r119 = r119 * r78;
+    r119 = r119 * r81;
+    r116 = fmaf(r56, r119, r116);
+    r37 = r10 * r59;
+    r111 = r7 * r16;
+    r111 = r111 * r65;
+    r111 = fmaf(r125, r111, r6 * r125);
+    r111 = fmaf(r125, r69, r111);
+    r111 = fmaf(r125, r68, r111);
+    r37 = r37 * r111;
+    r116 = fmaf(r82, r37, r116);
+    r68 = r142 * r83;
+    r116 = fmaf(r131, r68, r116);
+    r131 = r4 * r53;
+    r131 = r131 * r10;
+    r131 = r131 * r81;
+    r116 = fmaf(r56, r131, r116);
+    r69 = r55 * r59;
+    r116 = fmaf(r82, r69, r116);
+    r6 = r55 * r59;
+    r116 = fmaf(r83, r6, r116);
+    r106 = r66 * r41;
+    r106 = r106 * r142;
+    r106 = r106 * r63;
+    r106 = r106 * r102;
+    r116 = fmaf(r118, r106, r116);
+    r94 = r66 * r55;
+    r116 = fmaf(r74, r94, r116);
+    r116 = fmaf(r142, r124, r116);
+    r116 = fmaf(r142, r127, r116);
+    r116 = fmaf(r142, r136, r116);
+    r116 = fmaf(r53, r129, r116);
+    r94 = r0 * r116;
+    r129 = r114 * r142;
+    r136 = r48 * r101;
+    r136 = r136 * r61;
+    r136 = fmaf(r63, r136, r122 * r129);
+    r129 = r11 * r11;
+    r129 = r129 * r71;
+    r129 = r129 * r142;
+    r129 = r129 * r35;
+    r129 = r129 * r42;
+    r136 = fmaf(r61, r129, r136);
+    r122 = r53 * r11;
+    r122 = r122 * r11;
+    r122 = r122 * r59;
+    r122 = r122 * r59;
+    r122 = r122 * r113;
+    r122 = r122 * r47;
+    r136 = fmaf(r85, r122, r136);
+    r136 = r136 + r15;
+    r136 = fmaf(r66, r136, r9 * r125);
+    r125 = r67 * r48;
+    r125 = r125 * r73;
+    r136 = fmaf(r115, r125, r136);
+    r9 = r4 * r53;
+    r9 = r9 * r11;
+    r9 = r9 * r78;
+    r9 = r9 * r81;
+    r136 = fmaf(r56, r9, r136);
+    r15 = r11 * r59;
+    r15 = r15 * r89;
+    r15 = r15 * r142;
+    r15 = r15 * r47;
+    r15 = r15 * r80;
+    r136 = fmaf(r35, r15, r136);
+    r122 = r67 * r11;
+    r122 = r122 * r142;
+    r122 = r122 * r73;
+    r136 = fmaf(r88, r122, r136);
+    r129 = r48 * r59;
+    r136 = fmaf(r82, r129, r136);
+    r113 = r111 * r82;
+    r136 = fmaf(r63, r113, r136);
+    r106 = r67 * r41;
+    r106 = r106 * r142;
+    r106 = r106 * r63;
+    r106 = r106 * r102;
+    r136 = fmaf(r118, r106, r136);
+    r118 = r67 * r53;
+    r118 = r118 * r10;
+    r118 = r118 * r11;
+    r118 = r118 * r59;
+    r118 = r118 * r59;
+    r118 = r118 * r99;
+    r118 = r118 * r47;
+    r136 = fmaf(r85, r118, r136);
+    r85 = r11 * r59;
+    r85 = r85 * r78;
+    r85 = r85 * r89;
+    r85 = r85 * r142;
+    r85 = r85 * r47;
+    r85 = r85 * r80;
+    r136 = fmaf(r35, r85, r136);
+    r80 = r48 * r59;
+    r136 = fmaf(r83, r80, r136);
+    r47 = r4 * r53;
+    r47 = r47 * r11;
+    r47 = r47 * r81;
+    r136 = fmaf(r56, r47, r136);
+    r56 = r11 * r87;
+    r56 = r56 * r142;
+    r56 = r56 * r35;
+    r56 = r56 * r42;
+    r136 = fmaf(r82, r56, r136);
+    r136 = fmaf(r142, r132, r136);
+    r136 = fmaf(r55, r72, r136);
+    r56 = r5 * r136;
+    WriteIdx2<1024, float, float, float2>(out_point_jac,
+                                          4 * out_point_jac_num_alloc,
+                                          global_thread_idx,
+                                          r94,
+                                          r56);
+    r56 = r0 * r4;
+    r56 = r56 * r2;
+    r56 = fmaf(r12, r86, r126 * r56);
+    r94 = r0 * r4;
+    r94 = r94 * r2;
+    r94 = fmaf(r90, r86, r140 * r94);
+    r47 = r0 * r4;
+    r47 = r47 * r2;
+    r86 = fmaf(r136, r86, r116 * r47);
+    WriteSum3<float, float>((float*)inout_shared, r56, r94, r86);
+  };
+  FlushSumShared<3, float>(out_point_njtr,
+                           0 * out_point_njtr_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r126 * r126;
+    r94 = r12 * r12;
+    r94 = fmaf(r95, r94, r92 * r86);
+    r86 = r90 * r90;
+    r56 = r140 * r140;
+    r56 = fmaf(r92, r56, r95 * r86);
+    r86 = r136 * r136;
+    r47 = r116 * r116;
+    r47 = fmaf(r92, r47, r95 * r86);
+    WriteSum3<float, float>((float*)inout_shared, r94, r56, r47);
+  };
+  FlushSumShared<3, float>(out_point_precond_diag,
+                           0 * out_point_precond_diag_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r12 * r90;
+    r56 = r126 * r140;
+    r56 = fmaf(r92, r56, r95 * r47);
+    r47 = r126 * r116;
+    r94 = r12 * r136;
+    r94 = fmaf(r95, r94, r92 * r47);
+    r47 = r90 * r136;
+    r86 = r140 * r116;
+    r86 = fmaf(r92, r86, r95 * r47);
+    WriteSum3<float, float>((float*)inout_shared, r56, r94, r86);
+  };
+  FlushSumShared<3, float>(out_point_precond_tril,
+                           0 * out_point_precond_tril_num_alloc,
+                           point_indices_loc,
+                           (float*)inout_shared);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* out_res,
+    unsigned int out_res_num_alloc,
+    float* const out_rTr,
+    float* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    float* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    float* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    float* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    float* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    float* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    float* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    float* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    float* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    float* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    float* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    float* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_score.cu
@@ -1,0 +1,352 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointScoreKernel(
+        float* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        float* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        float* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        float* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        float* pixel,
+        unsigned int pixel_num_alloc,
+        float* principal_point,
+        unsigned int principal_point_num_alloc,
+        float* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ float out_rTr_local[1];
+
+  float r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, float, float, float2>(principal_point,
+                                         0 * principal_point_num_alloc,
+                                         global_thread_idx,
+                                         r0,
+                                         r1);
+    ReadIdx2<1024, float, float, float2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r3);
+    r4 = -1.00000000000000000e+00;
+    r2 = fmaf(r2, r4, r0);
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              0 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r0,
+                       r5,
+                       r6,
+                       r7);
+  };
+  __syncthreads();
+  LoadShared<2, float, float>(focal_and_extra,
+                              8 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r8,
+                       r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 9.99999999999999955e-07;
+    ReadIdx3<1024, float, float, float4>(sensor_from_rig,
+                                         4 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r11,
+                                         r12,
+                                         r13);
+  };
+  LoadShared<3, float, float>(
+      point, 0 * point_num_alloc, point_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       point_indices_loc[threadIdx.x].target,
+                       r14,
+                       r15,
+                       r16);
+  };
+  __syncthreads();
+  LoadShared<4, float, float>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r17,
+                       r18,
+                       r19,
+                       r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx4<1024, float, float, float4>(sensor_from_rig,
+                                         0 * sensor_from_rig_num_alloc,
+                                         global_thread_idx,
+                                         r21,
+                                         r22,
+                                         r23,
+                                         r24);
+    r25 = fmaf(r18, r21, r19 * r24);
+    r26 = r17 * r22;
+    r25 = fmaf(r4, r26, r25);
+    r25 = fmaf(r20, r23, r25);
+    r26 = 2.00000000000000000e+00;
+    r27 = fmaf(r20, r21, r17 * r24);
+    r28 = r18 * r23;
+    r27 = fmaf(r4, r28, r27);
+    r27 = fmaf(r19, r22, r27);
+    r28 = r26 * r27;
+    r29 = r25 * r28;
+    r30 = r19 * r21;
+    r30 = fmaf(r4, r30, r18 * r24);
+    r30 = fmaf(r20, r22, r30);
+    r30 = fmaf(r17, r23, r30);
+    r31 = -2.00000000000000000e+00;
+    r32 = fmaf(r18, r22, r17 * r21);
+    r32 = fmaf(r19, r23, r32);
+    r32 = fmaf(r4, r32, r20 * r24);
+    r20 = r31 * r32;
+    r33 = fmaf(r30, r20, r29);
+    r33 = fmaf(r14, r33, r13);
+  };
+  LoadShared<3, float, float>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared3<float>((float*)inout_shared,
+                       pose_indices_loc[threadIdx.x].target,
+                       r13,
+                       r34,
+                       r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r23;
+    r36 = r36 * r26;
+    r37 = r22 * r24;
+    r38 = fmaf(r31, r37, r36);
+    r39 = 1.00000000000000000e+00;
+    r40 = r22 * r22;
+    r40 = r40 * r31;
+    r41 = r39 + r40;
+    r42 = r21 * r21;
+    r42 = r31 * r42;
+    r41 = r41 + r42;
+    r43 = r22 * r23;
+    r43 = r43 * r26;
+    r44 = r21 * r24;
+    r44 = fmaf(r26, r44, r43);
+    r45 = r26 * r25;
+    r45 = r45 * r30;
+    r46 = fmaf(r32, r28, r45);
+    r47 = r30 * r30;
+    r47 = r31 * r47;
+    r48 = r39 + r47;
+    r49 = r27 * r27;
+    r49 = r49 * r31;
+    r48 = r48 + r49;
+    r33 = fmaf(r13, r38, r33);
+    r33 = fmaf(r35, r41, r33);
+    r33 = fmaf(r34, r44, r33);
+    r33 = fmaf(r15, r46, r33);
+    r33 = fmaf(r16, r48, r33);
+    r48 = copysign(1.0, r33);
+    r48 = fmaf(r10, r48, r33);
+    r33 = r48 * r48;
+    r33 = 1.0 / r33;
+    r47 = r39 + r47;
+    r46 = r25 * r25;
+    r46 = r31 * r46;
+    r47 = r47 + r46;
+    r47 = fmaf(r14, r47, r11);
+    r28 = r30 * r28;
+    r11 = fmaf(r25, r20, r28);
+    r44 = r26 * r30;
+    r44 = fmaf(r32, r44, r29);
+    r37 = fmaf(r26, r37, r36);
+    r36 = r23 * r24;
+    r29 = r21 * r22;
+    r29 = r29 * r26;
+    r36 = fmaf(r31, r36, r29);
+    r41 = r23 * r23;
+    r41 = fmaf(r31, r41, r39);
+    r40 = r40 + r41;
+    r47 = fmaf(r15, r11, r47);
+    r47 = fmaf(r16, r44, r47);
+    r47 = fmaf(r35, r37, r47);
+    r47 = fmaf(r34, r36, r47);
+    r47 = fmaf(r13, r40, r47);
+    r40 = r47 * r47;
+    r36 = r26 * r25;
+    r36 = fmaf(r32, r36, r28);
+    r36 = fmaf(r14, r36, r12);
+    r14 = r23 * r24;
+    r14 = fmaf(r26, r14, r29);
+    r41 = r42 + r41;
+    r42 = r21 * r24;
+    r42 = fmaf(r31, r42, r43);
+    r20 = fmaf(r27, r20, r45);
+    r46 = r39 + r46;
+    r46 = r46 + r49;
+    r36 = fmaf(r13, r14, r36);
+    r36 = fmaf(r34, r41, r36);
+    r36 = fmaf(r35, r42, r36);
+    r36 = fmaf(r16, r20, r36);
+    r36 = fmaf(r15, r46, r36);
+    r46 = r36 * r36;
+    r15 = fmaf(r33, r46, r33 * r40);
+    r15 = sqrtf(r15);
+    r20 = copysign(1.0, r15);
+    r20 = fmaf(r10, r20, r15);
+    r10 = r20 * r20;
+    r10 = 1.0 / r10;
+    r10 = r33 * r10;
+    r15 = atanf(r15);
+    r33 = r15 * r15;
+    r10 = r10 * r33;
+    r33 = r10 * r46;
+    r16 = r10 * r40;
+    r42 = r33 + r16;
+  };
+  LoadShared<4, float, float>(focal_and_extra,
+                              4 * focal_and_extra_num_alloc,
+                              focal_and_extra_indices_loc,
+                              (float*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared4<float>((float*)inout_shared,
+                       focal_and_extra_indices_loc[threadIdx.x].target,
+                       r35,
+                       r41,
+                       r34,
+                       r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r13 = 3.00000000000000000e+00;
+    r13 = r13 * r10;
+    r40 = fmaf(r40, r13, r33);
+    r40 = fmaf(r41, r40, r8 * r42);
+    r8 = r35 * r26;
+    r8 = r8 * r47;
+    r8 = r8 * r36;
+    r40 = fmaf(r10, r8, r40);
+    r33 = r42 * r42;
+    r49 = r42 * r33;
+    r49 = fmaf(r34, r49, r6 * r42);
+    r34 = r33 * r33;
+    r49 = fmaf(r14, r34, r49);
+    r49 = fmaf(r7, r33, r49);
+    r48 = 1.0 / r48;
+    r48 = r15 * r48;
+    r20 = 1.0 / r20;
+    r48 = r48 * r20;
+    r49 = r49 * r48;
+    r40 = fmaf(r47, r49, r40);
+    r40 = fmaf(r47, r48, r40);
+    r2 = fmaf(r0, r40, r2);
+    r13 = fmaf(r46, r13, r16);
+    r13 = fmaf(r35, r13, r9 * r42);
+    r42 = r41 * r26;
+    r42 = r42 * r47;
+    r42 = r42 * r36;
+    r13 = fmaf(r10, r42, r13);
+    r13 = fmaf(r36, r49, r13);
+    r13 = fmaf(r36, r48, r13);
+    r13 = fmaf(r5, r13, r1);
+    r13 = fmaf(r3, r4, r13);
+    r13 = fmaf(r13, r13, r2 * r2);
+  };
+  SumStore<float>(out_rTr_local,
+                  (float*)inout_shared,
+                  0,
+                  global_thread_idx < problem_size,
+                  r13);
+  SumFlushFinal<float>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/kernel_thin_prism_fisheye_split_fixed_principal_point_score.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointScore(
+    float* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    float* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    float* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    float* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    float* pixel,
+    unsigned int pixel_num_alloc,
+    float* principal_point,
+    unsigned int principal_point_num_alloc,
+    float* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f32/solver.cc
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/solver.cc
@@ -122,6 +122,58 @@
 #include "kernel_SimpleRadialPrincipalPoint_update_r_first.h"
 #include "kernel_SimpleRadialPrincipalPoint_update_step.h"
 #include "kernel_SimpleRadialPrincipalPoint_update_step_first.h"
+#include "kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyeCalib_normalize.h"
+#include "kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyeCalib_retract.h"
+#include "kernel_ThinPrismFisheyeCalib_start_w.h"
+#include "kernel_ThinPrismFisheyeCalib_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyeCalib_update_Mp.h"
+#include "kernel_ThinPrismFisheyeCalib_update_p.h"
+#include "kernel_ThinPrismFisheyeCalib_update_r.h"
+#include "kernel_ThinPrismFisheyeCalib_update_r_first.h"
+#include "kernel_ThinPrismFisheyeCalib_update_step.h"
+#include "kernel_ThinPrismFisheyeCalib_update_step_first.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_normalize.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_retract.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_p.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h"
+#include "kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyePose_normalize.h"
+#include "kernel_ThinPrismFisheyePose_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyePose_retract.h"
+#include "kernel_ThinPrismFisheyePose_start_w.h"
+#include "kernel_ThinPrismFisheyePose_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyePose_update_Mp.h"
+#include "kernel_ThinPrismFisheyePose_update_p.h"
+#include "kernel_ThinPrismFisheyePose_update_r.h"
+#include "kernel_ThinPrismFisheyePose_update_r_first.h"
+#include "kernel_ThinPrismFisheyePose_update_step.h"
+#include "kernel_ThinPrismFisheyePose_update_step_first.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_normalize.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_retract.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_p.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h"
 #include "kernel_pinhole_fixed_point_jtjnjtr_direct.h"
 #include "kernel_pinhole_fixed_point_res_jac.h"
 #include "kernel_pinhole_fixed_point_res_jac_first.h"
@@ -242,6 +294,66 @@
 #include "kernel_simple_radial_split_fixed_principal_point_res_jac.h"
 #include "kernel_simple_radial_split_fixed_principal_point_res_jac_first.h"
 #include "kernel_simple_radial_split_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_score.h"
+#include "kernel_thin_prism_fisheye_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_res_jac.h"
+#include "kernel_thin_prism_fisheye_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_score.h"
 #include "shared_indices.h"
 #include "solver_tools.h"
 #include "sort_indices.h"
@@ -286,6 +398,10 @@ GraphSolver::GraphSolver(
     size_t SimpleRadialFocalAndExtra_num_max,
     size_t SimpleRadialPose_num_max,
     size_t SimpleRadialPrincipalPoint_num_max,
+    size_t ThinPrismFisheyeCalib_num_max,
+    size_t ThinPrismFisheyeFocalAndExtra_num_max,
+    size_t ThinPrismFisheyePose_num_max,
+    size_t ThinPrismFisheyePrincipalPoint_num_max,
     size_t simple_radial_num_max,
     size_t simple_radial_fixed_pose_num_max,
     size_t simple_radial_fixed_point_num_max,
@@ -294,6 +410,10 @@ GraphSolver::GraphSolver(
     size_t pinhole_fixed_pose_num_max,
     size_t pinhole_fixed_point_num_max,
     size_t pinhole_fixed_pose_fixed_point_num_max,
+    size_t thin_prism_fisheye_num_max,
+    size_t thin_prism_fisheye_fixed_pose_num_max,
+    size_t thin_prism_fisheye_fixed_point_num_max,
+    size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max,
     size_t simple_radial_split_fixed_focal_and_extra_num_max,
     size_t simple_radial_split_fixed_principal_point_num_max,
     size_t simple_radial_split_fixed_pose_fixed_focal_and_extra_num_max,
@@ -321,6 +441,22 @@ GraphSolver::GraphSolver(
     size_t pinhole_split_fixed_pose_fixed_focal_fixed_point_num_max,
     size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
     size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max,
+    size_t thin_prism_fisheye_split_fixed_principal_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max,
+    size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max,
     int device_id)
     : params_(params),
       device_id_(device_id),
@@ -342,6 +478,17 @@ GraphSolver::GraphSolver(
       SimpleRadialPose_num_max_(SimpleRadialPose_num_max),
       SimpleRadialPrincipalPoint_num_(SimpleRadialPrincipalPoint_num_max),
       SimpleRadialPrincipalPoint_num_max_(SimpleRadialPrincipalPoint_num_max),
+      ThinPrismFisheyeCalib_num_(ThinPrismFisheyeCalib_num_max),
+      ThinPrismFisheyeCalib_num_max_(ThinPrismFisheyeCalib_num_max),
+      ThinPrismFisheyeFocalAndExtra_num_(ThinPrismFisheyeFocalAndExtra_num_max),
+      ThinPrismFisheyeFocalAndExtra_num_max_(
+          ThinPrismFisheyeFocalAndExtra_num_max),
+      ThinPrismFisheyePose_num_(ThinPrismFisheyePose_num_max),
+      ThinPrismFisheyePose_num_max_(ThinPrismFisheyePose_num_max),
+      ThinPrismFisheyePrincipalPoint_num_(
+          ThinPrismFisheyePrincipalPoint_num_max),
+      ThinPrismFisheyePrincipalPoint_num_max_(
+          ThinPrismFisheyePrincipalPoint_num_max),
       simple_radial_num_(simple_radial_num_max),
       simple_radial_num_max_(simple_radial_num_max),
       simple_radial_fixed_pose_num_(simple_radial_fixed_pose_num_max),
@@ -362,6 +509,19 @@ GraphSolver::GraphSolver(
           pinhole_fixed_pose_fixed_point_num_max),
       pinhole_fixed_pose_fixed_point_num_max_(
           pinhole_fixed_pose_fixed_point_num_max),
+      thin_prism_fisheye_num_(thin_prism_fisheye_num_max),
+      thin_prism_fisheye_num_max_(thin_prism_fisheye_num_max),
+      thin_prism_fisheye_fixed_pose_num_(thin_prism_fisheye_fixed_pose_num_max),
+      thin_prism_fisheye_fixed_pose_num_max_(
+          thin_prism_fisheye_fixed_pose_num_max),
+      thin_prism_fisheye_fixed_point_num_(
+          thin_prism_fisheye_fixed_point_num_max),
+      thin_prism_fisheye_fixed_point_num_max_(
+          thin_prism_fisheye_fixed_point_num_max),
+      thin_prism_fisheye_fixed_pose_fixed_point_num_(
+          thin_prism_fisheye_fixed_pose_fixed_point_num_max),
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_(
+          thin_prism_fisheye_fixed_pose_fixed_point_num_max),
       simple_radial_split_fixed_focal_and_extra_num_(
           simple_radial_split_fixed_focal_and_extra_num_max),
       simple_radial_split_fixed_focal_and_extra_num_max_(
@@ -447,7 +607,51 @@ GraphSolver::GraphSolver(
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_(
           pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max),
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_(
-          pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max) {
+          pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max) {
   indices_valid_ = false;
   if (params.pcg_rel_error_exit <= 0.0f) {
     throw std::runtime_error("params.pcg_rel_error_exit must be positive");
@@ -536,6 +740,36 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__storage_new_best_ =
       assign_and_increment<float>(
           origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_current_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_check_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_new_best_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_current_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_check_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_current_ = assign_and_increment<float>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_check_ = assign_and_increment<float>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_new_best_ = assign_and_increment<float>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_current_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_check_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   facs__simple_radial__args__pose__idx_shared_ =
       assign_and_increment<SharedIndex>(
           origin_ptr_, offset, 1 * simple_radial_num_, 4);
@@ -657,6 +891,80 @@ GraphSolver::GraphSolver(
   facs__pinhole_fixed_pose_fixed_point__args__point__data_ =
       assign_and_increment<float>(
           origin_ptr_, offset, 4 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__pixel__data_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 4 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__args__pose__idx_shared_ =
       assign_and_increment<SharedIndex>(
           origin_ptr_,
@@ -1409,6 +1717,406 @@ GraphSolver::GraphSolver(
           offset,
           4 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   marker__scratch_inout_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   facs__simple_radial__res_ = assign_and_increment<float>(
@@ -1430,6 +2138,18 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * pinhole_fixed_point_num_, 4);
   facs__pinhole_fixed_pose_fixed_point__res_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__res_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__res_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__res_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__res_ =
       assign_and_increment<float>(
           origin_ptr_,
@@ -1553,6 +2273,72 @@ GraphSolver::GraphSolver(
           offset,
           2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   facs__simple_radial__args__pose__jac_ = assign_and_increment<float>(
       origin_ptr_, offset, 12 * simple_radial_num_, 4);
   facs__simple_radial__args__calib__jac_ = assign_and_increment<float>(
@@ -1593,6 +2379,30 @@ GraphSolver::GraphSolver(
   facs__pinhole_fixed_pose_fixed_point__args__calib__jac_ =
       assign_and_increment<float>(
           origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__args__pose__jac_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__calib__jac_ = assign_and_increment<float>(
+      origin_ptr_, offset, 16 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__point__jac_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__calib__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 16 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 6 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 12 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__calib__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 16 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__args__pose__jac_ =
       assign_and_increment<float>(
           origin_ptr_,
@@ -1817,6 +2627,129 @@ GraphSolver::GraphSolver(
           offset,
           12 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          16 *
+              thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__jac_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          12 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   nodes__PinholeCalib__z_ = assign_and_increment<float>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
   nodes__PinholeCalib__z_end__ =
@@ -1852,6 +2785,22 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__z_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__z_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__z_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__z_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__z_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__z_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__z_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__z_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__z_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__z_end__ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__p_ = assign_and_increment<float>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
@@ -1889,6 +2838,22 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__p_end__ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__p_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__p_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__p_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__p_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__p_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__p_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__p_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__p_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__step_ = assign_and_increment<float>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
   nodes__PinholeCalib__step_end__ =
@@ -1925,6 +2890,22 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__step_end__ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__step_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__step_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__step_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__step_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__step_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__step_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__step_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__step_end__ =
+      assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   marker__w_start_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__w_ = assign_and_increment<float>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
@@ -1944,6 +2925,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__w_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__w_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__w_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__w_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__w_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__w_end_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 1);
   marker__r_0_start_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
@@ -1965,6 +2954,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__r_0_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__r_0_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__r_0_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__r_0_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__r_0_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__r_0_end_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   marker__r_k_start_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
@@ -1986,6 +2983,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__r_k_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__r_k_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__r_k_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__r_k_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__r_k_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__r_k_end_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   marker__Mp_start_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
@@ -2007,6 +3012,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__Mp_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__Mp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__Mp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__Mp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__Mp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__Mp_end_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
   marker__precond_start_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 4);
@@ -2048,6 +3061,26 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__precond_tril_ =
       assign_and_increment<float>(
           origin_ptr_, offset, 1 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__precond_diag_ = assign_and_increment<float>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__precond_tril_ = assign_and_increment<float>(
+      origin_ptr_, offset, 66 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 45 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__precond_diag_ = assign_and_increment<float>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__precond_tril_ = assign_and_increment<float>(
+      origin_ptr_, offset, 16 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__precond_diag_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__precond_tril_ =
+      assign_and_increment<float>(
+          origin_ptr_, offset, 1 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__precond_end_ =
       assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 1);
   marker__jp_start_ =
@@ -2068,6 +3101,18 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * pinhole_fixed_point_num_, 4);
   facs__pinhole_fixed_pose_fixed_point__jp_ = assign_and_increment<float>(
       origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__jp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__jp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__jp_ = assign_and_increment<float>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__jp_ =
       assign_and_increment<float>(
           origin_ptr_,
@@ -2188,6 +3233,72 @@ GraphSolver::GraphSolver(
           offset,
           2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<float>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   marker__jp_end_ = assign_and_increment<float>(origin_ptr_, offset, 0 * 0, 1);
   solver__current_diag_ =
       assign_and_increment<float>(origin_ptr_, offset, 1 * 1, 1);
@@ -2240,6 +3351,7 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
       std::chrono::steady_clock::now();
   std::chrono::time_point<std::chrono::steady_clock> t_prev = t0;
   score_best = DoResJacFirst();
+  result.initial_score = score_best;
   if (print_progress) {
     printf("                                 score_init: % .6e\n", score_best);
   }
@@ -2292,6 +3404,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                   nodes__SimpleRadialPose__storage_new_best_);
         std::swap(nodes__SimpleRadialPrincipalPoint__storage_check_,
                   nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyeCalib__storage_check_,
+                  nodes__ThinPrismFisheyeCalib__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+                  nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyePose__storage_check_,
+                  nodes__ThinPrismFisheyePose__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+                  nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
         score_best_pcg = score_new_pcg;
         if (params_.pcg_rel_score_exit != -1.0f &&
             score_best_pcg < score_best * params_.pcg_rel_score_exit) {
@@ -2324,6 +3444,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                 nodes__SimpleRadialPose__storage_new_best_);
       std::swap(nodes__SimpleRadialPrincipalPoint__storage_check_,
                 nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeCalib__storage_check_,
+                nodes__ThinPrismFisheyeCalib__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+                nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePose__storage_check_,
+                nodes__ThinPrismFisheyePose__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+                nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
     }
 
     const float diag_current = diag;
@@ -2356,6 +3484,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                 nodes__SimpleRadialPose__storage_new_best_);
       std::swap(nodes__SimpleRadialPrincipalPoint__storage_current_,
                 nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeCalib__storage_current_,
+                nodes__ThinPrismFisheyeCalib__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+                nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePose__storage_current_,
+                nodes__ThinPrismFisheyePose__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+                nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
 
     } else {
       quality = 0.0f;
@@ -2688,6 +3824,144 @@ float GraphSolver::DoResJacFirst() {
       nodes__PinholeCalib__precond_tril_,
       PinholeCalib_num_,
       pinhole_fixed_pose_fixed_point_num_);
+
+  ThinPrismFisheyeResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye__args__pose__idx_shared_,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye__args__point__idx_shared_,
+      facs__thin_prism_fisheye__args__pixel__data_,
+      thin_prism_fisheye_num_max_,
+
+      facs__thin_prism_fisheye__res_,
+      thin_prism_fisheye_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye__args__pose__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye__args__calib__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye__args__point__jac_,
+      thin_prism_fisheye_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_num_);
+
+  ThinPrismFisheyeFixedPoseResJacFirst(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose__res_,
+      thin_prism_fisheye_fixed_pose_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+
+  ThinPrismFisheyeFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_point__res_,
+      thin_prism_fisheye_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
+
+  ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__res_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
 
   SimpleRadialSplitFixedFocalAndExtraResJacFirst(
       nodes__SimpleRadialPose__storage_current_,
@@ -3450,6 +4724,387 @@ float GraphSolver::DoResJacFirst() {
       nodes__PinholePose__precond_tril_,
       PinholePose_num_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      solver__res_tot_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__r_0_start_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__Mp_start_);
   return 0.5 * ReadCuMem(solver__res_tot_);
@@ -3730,6 +5385,143 @@ void GraphSolver::DoResJac() {
       nodes__PinholeCalib__precond_tril_,
       PinholeCalib_num_,
       pinhole_fixed_pose_fixed_point_num_);
+
+  ThinPrismFisheyeResJac(nodes__ThinPrismFisheyePose__storage_current_,
+                         ThinPrismFisheyePose_num_max_,
+                         facs__thin_prism_fisheye__args__pose__idx_shared_,
+                         facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+                         thin_prism_fisheye_num_max_,
+                         nodes__ThinPrismFisheyeCalib__storage_current_,
+                         ThinPrismFisheyeCalib_num_max_,
+                         facs__thin_prism_fisheye__args__calib__idx_shared_,
+                         nodes__Point__storage_current_,
+                         Point_num_max_,
+                         facs__thin_prism_fisheye__args__point__idx_shared_,
+                         facs__thin_prism_fisheye__args__pixel__data_,
+                         thin_prism_fisheye_num_max_,
+
+                         facs__thin_prism_fisheye__res_,
+                         thin_prism_fisheye_num_,
+
+                         facs__thin_prism_fisheye__args__pose__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__ThinPrismFisheyePose__r_k_,
+                         ThinPrismFisheyePose_num_,
+                         nodes__ThinPrismFisheyePose__precond_diag_,
+                         ThinPrismFisheyePose_num_,
+                         nodes__ThinPrismFisheyePose__precond_tril_,
+                         ThinPrismFisheyePose_num_,
+                         facs__thin_prism_fisheye__args__calib__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__ThinPrismFisheyeCalib__r_k_,
+                         ThinPrismFisheyeCalib_num_,
+                         nodes__ThinPrismFisheyeCalib__precond_diag_,
+                         ThinPrismFisheyeCalib_num_,
+                         nodes__ThinPrismFisheyeCalib__precond_tril_,
+                         ThinPrismFisheyeCalib_num_,
+                         facs__thin_prism_fisheye__args__point__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__Point__r_k_,
+                         Point_num_,
+                         nodes__Point__precond_diag_,
+                         Point_num_,
+                         nodes__Point__precond_tril_,
+                         Point_num_,
+                         thin_prism_fisheye_num_);
+
+  ThinPrismFisheyeFixedPoseResJac(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose__res_,
+      thin_prism_fisheye_fixed_pose_num_,
+
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+
+  ThinPrismFisheyeFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_point__res_,
+      thin_prism_fisheye_fixed_point_num_,
+
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
+
+  ThinPrismFisheyeFixedPoseFixedPointResJac(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__res_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_,
+
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
 
   SimpleRadialSplitFixedFocalAndExtraResJac(
       nodes__SimpleRadialPose__storage_current_,
@@ -4492,6 +6284,387 @@ void GraphSolver::DoResJac() {
       nodes__PinholePose__precond_tril_,
       PinholePose_num_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__r_0_start_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__Mp_start_);
 }
@@ -4605,6 +6778,56 @@ void GraphSolver::DoNormalize() {
       z,
       SimpleRadialPrincipalPoint_num_,
       SimpleRadialPrincipalPoint_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyeCalib__p_
+                     : nodes__ThinPrismFisheyeCalib__z_;
+  ThinPrismFisheyeCalibNormalize(nodes__ThinPrismFisheyeCalib__precond_diag_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 nodes__ThinPrismFisheyeCalib__precond_tril_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 nodes__ThinPrismFisheyeCalib__r_k_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 solver__current_diag_,
+                                 z,
+                                 ThinPrismFisheyeCalib_num_,
+                                 ThinPrismFisheyeCalib_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyeFocalAndExtra__p_
+                     : nodes__ThinPrismFisheyeFocalAndExtra__z_;
+  ThinPrismFisheyeFocalAndExtraNormalize(
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__current_diag_,
+      z,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyePose__p_
+                     : nodes__ThinPrismFisheyePose__z_;
+  ThinPrismFisheyePoseNormalize(nodes__ThinPrismFisheyePose__precond_diag_,
+                                ThinPrismFisheyePose_num_,
+                                nodes__ThinPrismFisheyePose__precond_tril_,
+                                ThinPrismFisheyePose_num_,
+                                nodes__ThinPrismFisheyePose__r_k_,
+                                ThinPrismFisheyePose_num_,
+                                solver__current_diag_,
+                                z,
+                                ThinPrismFisheyePose_num_,
+                                ThinPrismFisheyePose_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyePrincipalPoint__p_
+                     : nodes__ThinPrismFisheyePrincipalPoint__z_;
+  ThinPrismFisheyePrincipalPointNormalize(
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__current_diag_,
+      z,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateMp() {
@@ -4698,6 +6921,48 @@ void GraphSolver::DoUpdateMp() {
                                      nodes__SimpleRadialPrincipalPoint__w_,
                                      SimpleRadialPrincipalPoint_num_,
                                      SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateMp(nodes__ThinPrismFisheyeCalib__r_k_,
+                                ThinPrismFisheyeCalib_num_,
+                                nodes__ThinPrismFisheyeCalib__Mp_,
+                                ThinPrismFisheyeCalib_num_,
+                                solver__beta_,
+                                nodes__ThinPrismFisheyeCalib__Mp_,
+                                ThinPrismFisheyeCalib_num_,
+                                nodes__ThinPrismFisheyeCalib__w_,
+                                ThinPrismFisheyeCalib_num_,
+                                ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateMp(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__Mp_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyeFocalAndExtra__Mp_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateMp(nodes__ThinPrismFisheyePose__r_k_,
+                               ThinPrismFisheyePose_num_,
+                               nodes__ThinPrismFisheyePose__Mp_,
+                               ThinPrismFisheyePose_num_,
+                               solver__beta_,
+                               nodes__ThinPrismFisheyePose__Mp_,
+                               ThinPrismFisheyePose_num_,
+                               nodes__ThinPrismFisheyePose__w_,
+                               ThinPrismFisheyePose_num_,
+                               ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateMp(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__Mp_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyePrincipalPoint__Mp_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoJtjpDirect() {
@@ -4809,6 +7074,61 @@ void GraphSolver::DoJtjpDirect() {
       nodes__PinholeCalib__w_,
       PinholeCalib_num_,
       pinhole_fixed_point_num_);
+  ThinPrismFisheyeJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye__args__pose__idx_shared_,
+      facs__thin_prism_fisheye__args__pose__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye__args__calib__idx_shared_,
+      facs__thin_prism_fisheye__args__calib__jac_,
+      thin_prism_fisheye_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye__args__point__idx_shared_,
+      facs__thin_prism_fisheye__args__point__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_num_);
+  ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+  ThinPrismFisheyeFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
   SimpleRadialSplitFixedFocalAndExtraJtjnjtrDirect(
       nodes__SimpleRadialPose__p_,
       SimpleRadialPose_num_,
@@ -5061,6 +7381,132 @@ void GraphSolver::DoJtjpDirect() {
       nodes__PinholeFocal__w_,
       PinholeFocal_num_,
       pinhole_split_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
 }
 
 void GraphSolver::DoAlphaFirst() {
@@ -5151,6 +7597,46 @@ void GraphSolver::DoAlphaFirst() {
       solver__alpha_numerator_,
       solver__alpha_denominator_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePrincipalPoint_num_);
 
   AlphaFromNumDenom(solver__alpha_numerator_,
                     solver__alpha_denominator_,
@@ -5217,6 +7703,34 @@ void GraphSolver::DoAlpha() {
       SimpleRadialPrincipalPoint_num_,
       solver__alpha_denominator_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePrincipalPoint_num_);
 
   AlphaFromNumDenom(solver__beta_numerator_,
                     solver__alpha_denominator_,
@@ -5281,6 +7795,32 @@ void GraphSolver::DoUpdateStepFirst() {
       nodes__SimpleRadialPrincipalPoint__step_,
       SimpleRadialPrincipalPoint_num_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateStepFirst(nodes__ThinPrismFisheyeCalib__p_,
+                                       ThinPrismFisheyeCalib_num_,
+                                       solver__alpha_,
+                                       nodes__ThinPrismFisheyeCalib__step_,
+                                       ThinPrismFisheyeCalib_num_,
+                                       ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateStepFirst(nodes__ThinPrismFisheyePose__p_,
+                                      ThinPrismFisheyePose_num_,
+                                      solver__alpha_,
+                                      nodes__ThinPrismFisheyePose__step_,
+                                      ThinPrismFisheyePose_num_,
+                                      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateStepFirst(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateStep() {
@@ -5356,6 +7896,40 @@ void GraphSolver::DoUpdateStep() {
                                        nodes__SimpleRadialPrincipalPoint__step_,
                                        SimpleRadialPrincipalPoint_num_,
                                        SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateStep(nodes__ThinPrismFisheyeCalib__step_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  nodes__ThinPrismFisheyeCalib__p_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  solver__alpha_,
+                                  nodes__ThinPrismFisheyeCalib__step_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateStep(
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateStep(nodes__ThinPrismFisheyePose__step_,
+                                 ThinPrismFisheyePose_num_,
+                                 nodes__ThinPrismFisheyePose__p_,
+                                 ThinPrismFisheyePose_num_,
+                                 solver__alpha_,
+                                 nodes__ThinPrismFisheyePose__step_,
+                                 ThinPrismFisheyePose_num_,
+                                 ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateStep(
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateRFirst() {
@@ -5461,6 +8035,52 @@ void GraphSolver::DoUpdateRFirst() {
       solver__r_kp1_norm2_tot_,
       SimpleRadialPrincipalPoint_num_);
 
+  ThinPrismFisheyeCalibUpdateRFirst(nodes__ThinPrismFisheyeCalib__r_k_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    nodes__ThinPrismFisheyeCalib__w_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    solver__neg_alpha_,
+                                    nodes__ThinPrismFisheyeCalib__r_k_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    solver__r_0_norm2_tot_,
+                                    solver__r_kp1_norm2_tot_,
+                                    ThinPrismFisheyeCalib_num_);
+
+  ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__r_0_norm2_tot_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+
+  ThinPrismFisheyePoseUpdateRFirst(nodes__ThinPrismFisheyePose__r_k_,
+                                   ThinPrismFisheyePose_num_,
+                                   nodes__ThinPrismFisheyePose__w_,
+                                   ThinPrismFisheyePose_num_,
+                                   solver__neg_alpha_,
+                                   nodes__ThinPrismFisheyePose__r_k_,
+                                   ThinPrismFisheyePose_num_,
+                                   solver__r_0_norm2_tot_,
+                                   solver__r_kp1_norm2_tot_,
+                                   ThinPrismFisheyePose_num_);
+
+  ThinPrismFisheyePrincipalPointUpdateRFirst(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__r_0_norm2_tot_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
+
   pcg_r_0_norm2_ = ReadCuMem(solver__r_0_norm2_tot_);
   pcg_r_kp1_norm2_ = ReadCuMem(solver__r_kp1_norm2_tot_);
 }
@@ -5549,6 +8169,44 @@ void GraphSolver::DoUpdateR() {
                                     SimpleRadialPrincipalPoint_num_,
                                     solver__r_kp1_norm2_tot_,
                                     SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateR(nodes__ThinPrismFisheyeCalib__r_k_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__w_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__neg_alpha_,
+                               nodes__ThinPrismFisheyeCalib__r_k_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__r_kp1_norm2_tot_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateR(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateR(nodes__ThinPrismFisheyePose__r_k_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__w_,
+                              ThinPrismFisheyePose_num_,
+                              solver__neg_alpha_,
+                              nodes__ThinPrismFisheyePose__r_k_,
+                              ThinPrismFisheyePose_num_,
+                              solver__r_kp1_norm2_tot_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateR(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
   pcg_r_kp1_norm2_ = ReadCuMem(solver__r_kp1_norm2_tot_);
 }
 
@@ -5618,6 +8276,36 @@ float GraphSolver::DoRetractScore() {
       nodes__SimpleRadialPrincipalPoint__storage_check_,
       SimpleRadialPrincipalPoint_num_max_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibRetract(nodes__ThinPrismFisheyeCalib__storage_current_,
+                               ThinPrismFisheyeCalib_num_max_,
+                               nodes__ThinPrismFisheyeCalib__step_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__storage_check_,
+                               ThinPrismFisheyeCalib_num_max_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraRetract(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseRetract(nodes__ThinPrismFisheyePose__storage_current_,
+                              ThinPrismFisheyePose_num_max_,
+                              nodes__ThinPrismFisheyePose__step_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__storage_check_,
+                              ThinPrismFisheyePose_num_max_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointRetract(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      ThinPrismFisheyePrincipalPoint_num_);
   Zero(solver__res_tot_, solver__res_tot_ + 1);
   SimpleRadialScore(nodes__SimpleRadialPose__storage_check_,
                     SimpleRadialPose_num_max_,
@@ -5736,6 +8424,65 @@ float GraphSolver::DoRetractScore() {
       pinhole_fixed_pose_fixed_point_num_max_,
       solver__res_tot_,
       pinhole_fixed_pose_fixed_point_num_);
+  ThinPrismFisheyeScore(nodes__ThinPrismFisheyePose__storage_check_,
+                        ThinPrismFisheyePose_num_max_,
+                        facs__thin_prism_fisheye__args__pose__idx_shared_,
+                        facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+                        thin_prism_fisheye_num_max_,
+                        nodes__ThinPrismFisheyeCalib__storage_check_,
+                        ThinPrismFisheyeCalib_num_max_,
+                        facs__thin_prism_fisheye__args__calib__idx_shared_,
+                        nodes__Point__storage_check_,
+                        Point_num_max_,
+                        facs__thin_prism_fisheye__args__point__idx_shared_,
+                        facs__thin_prism_fisheye__args__pixel__data_,
+                        thin_prism_fisheye_num_max_,
+                        solver__res_tot_,
+                        thin_prism_fisheye_num_);
+  ThinPrismFisheyeFixedPoseScore(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_pose_num_);
+  ThinPrismFisheyeFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_point_num_);
+  ThinPrismFisheyeFixedPoseFixedPointScore(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
   SimpleRadialSplitFixedFocalAndExtraScore(
       nodes__SimpleRadialPose__storage_check_,
       SimpleRadialPose_num_max_,
@@ -6106,6 +8853,191 @@ float GraphSolver::DoRetractScore() {
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_,
       solver__res_tot_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   return 0.5 * ReadCuMem(solver__res_tot_);
 }
 
@@ -6178,6 +9110,38 @@ void GraphSolver::DoBeta() {
       SimpleRadialPrincipalPoint_num_,
       solver__beta_numerator_,
       SimpleRadialPrincipalPoint_num_);
+
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__z_,
+      ThinPrismFisheyeCalib_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyeCalib_num_);
+
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__z_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__z_,
+      ThinPrismFisheyePose_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyePose_num_);
+
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__z_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyePrincipalPoint_num_);
   BetaFromNumDenom(
       solver__beta_numerator_, solver__alpha_numerator_, solver__beta_);
 }
@@ -6255,6 +9219,39 @@ void GraphSolver::DoUpdateP() {
                                     nodes__SimpleRadialPrincipalPoint__p_,
                                     SimpleRadialPrincipalPoint_num_,
                                     SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateP(nodes__ThinPrismFisheyeCalib__z_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__p_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__beta_,
+                               nodes__ThinPrismFisheyeCalib__p_,
+                               ThinPrismFisheyeCalib_num_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateP(nodes__ThinPrismFisheyeFocalAndExtra__z_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       nodes__ThinPrismFisheyeFocalAndExtra__p_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       solver__beta_,
+                                       nodes__ThinPrismFisheyeFocalAndExtra__p_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateP(nodes__ThinPrismFisheyePose__z_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__p_,
+                              ThinPrismFisheyePose_num_,
+                              solver__beta_,
+                              nodes__ThinPrismFisheyePose__p_,
+                              ThinPrismFisheyePose_num_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateP(
+      nodes__ThinPrismFisheyePrincipalPoint__z_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 float GraphSolver::GetPredDecrease() {
@@ -6343,6 +9340,46 @@ float GraphSolver::GetPredDecrease() {
       SimpleRadialPrincipalPoint_num_,
       solver__pred_decrease_tot_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyeCalib__step_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyeCalib__r_0_,
+      ThinPrismFisheyeCalib_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_0_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePosePredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyePose__step_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyePose__r_0_,
+      ThinPrismFisheyePose_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_0_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
   return 0.5 * ReadCuMem(solver__pred_decrease_tot_);
 }
 
@@ -7019,6 +10056,315 @@ void GraphSolver::GetSimpleRadialPrincipalPointNodesToStackedDevice(
       nodes__SimpleRadialPrincipalPoint__storage_current_,
       data,
       SimpleRadialPrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyeCalib_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyeCalib_num_max_");
+  }
+  ThinPrismFisheyeCalib_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNodesFromStackedHost(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             12 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyeCalibStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNodesFromStackedDevice(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyeCalibNodesToStackedHost(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibCasparToStacked(
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             12 * num * sizeof(float),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyeCalibNodesToStackedDevice(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibCasparToStacked(
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      data,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyeFocalAndExtra_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_max_");
+  }
+  ThinPrismFisheyeFocalAndExtra_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNodesFromStackedHost(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNodesFromStackedDevice(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyeFocalAndExtraNodesToStackedHost(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraCasparToStacked(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             10 * num * sizeof(float),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyeFocalAndExtraNodesToStackedDevice(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraCasparToStacked(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      data,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyePose_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyePose_num_max_");
+  }
+  ThinPrismFisheyePose_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNodesFromStackedHost(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNodesFromStackedDevice(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyePoseNodesToStackedHost(float* const data,
+                                                            const size_t offset,
+                                                            const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseCasparToStacked(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             7 * num * sizeof(float),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyePoseNodesToStackedDevice(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseCasparToStacked(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      data,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyePrincipalPoint_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_max_");
+  }
+  ThinPrismFisheyePrincipalPoint_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNodesFromStackedHost(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNodesFromStackedDevice(
+    const float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyePrincipalPointNodesToStackedHost(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointCasparToStacked(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             2 * num * sizeof(float),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyePrincipalPointNodesToStackedDevice(
+    float* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointCasparToStacked(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      data,
+      ThinPrismFisheyePrincipalPoint_num_max_,
       offset,
       num);
 }
@@ -8465,6 +11811,766 @@ void GraphSolver::SetPinholeFixedPoseFixedPointPointDataFromStackedDevice(
       data,
       facs__pinhole_fixed_pose_fixed_point__args__point__data_,
       pinhole_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeNum(const size_t num) {
+  if (num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  thin_prism_fisheye_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyePoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyePoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__pose__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyeCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__calib__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyePointIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyePointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyePointIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__point__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyeSensorFromRigDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeSensorFromRigDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyePixelDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(marker__scratch_inout_,
+                            facs__thin_prism_fisheye__args__pixel__data_,
+                            thin_prism_fisheye_num_max_,
+                            offset,
+                            num);
+}
+
+void GraphSolver::SetThinPrismFisheyePixelDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  ConstPixelStackedToCaspar(data,
+                            facs__thin_prism_fisheye__args__pixel__data_,
+                            thin_prism_fisheye_num_max_,
+                            offset,
+                            num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  thin_prism_fisheye_fixed_pose_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePointIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePixelDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePixelDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePoseDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePoseDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_fixed_point_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPixelDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPixelDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPointDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPointDataFromStackedDevice(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_fixed_pose_fixed_point_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pose_fixed_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pose_fixed_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedHost(
+    const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
       offset,
       num);
 }
@@ -14034,6 +18140,2930 @@ void GraphSolver::
       offset,
       num);
 }
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraNum(
+    const size_t num) {
+  if (num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPrincipalPointNum(
+    const size_t num) {
+  if (num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_principal_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "fixed_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "point_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "fixed_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "point_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(float),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const float* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
 
 size_t GraphSolver::get_nbytes() {
   size_t offset = 0;
@@ -14066,6 +21096,18 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<SharedIndex>(offset, 1 * simple_radial_num_, 4);
   increment_offset<float>(offset, 8 * simple_radial_num_, 4);
   increment_offset<SharedIndex>(offset, 1 * simple_radial_num_, 4);
@@ -14112,6 +21154,35 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
   increment_offset<float>(offset, 8 * pinhole_fixed_pose_fixed_point_num_, 4);
   increment_offset<float>(offset, 4 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 8 * thin_prism_fisheye_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(offset, 8 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(offset, 4 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 8 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 8 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 4 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<SharedIndex>(
       offset, 1 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<float>(
@@ -14490,18 +21561,266 @@ size_t GraphSolver::get_nbytes() {
       offset,
       4 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
-  at_least =
-      std::max(at_least,
-               offset + std::max({4 * PinholeCalib_num_max_,
-                                  2 * PinholeFocal_num_max_,
-                                  7 * PinholePose_num_max_,
-                                  2 * PinholePrincipalPoint_num_max_,
-                                  3 * Point_num_max_,
-                                  4 * SimpleRadialCalib_num_max_,
-                                  2 * SimpleRadialFocalAndExtra_num_max_,
-                                  7 * SimpleRadialPose_num_max_,
-                                  2 * SimpleRadialPrincipalPoint_num_max_}) *
-                            sizeof(float));
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 8 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 10 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset, 8 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  at_least = std::max(
+      at_least,
+      offset + std::max({4 * PinholeCalib_num_max_,
+                         2 * PinholeFocal_num_max_,
+                         7 * PinholePose_num_max_,
+                         2 * PinholePrincipalPoint_num_max_,
+                         3 * Point_num_max_,
+                         4 * SimpleRadialCalib_num_max_,
+                         2 * SimpleRadialFocalAndExtra_num_max_,
+                         7 * SimpleRadialPose_num_max_,
+                         2 * SimpleRadialPrincipalPoint_num_max_,
+                         12 * ThinPrismFisheyeCalib_num_max_,
+                         10 * ThinPrismFisheyeFocalAndExtra_num_max_,
+                         7 * ThinPrismFisheyePose_num_max_,
+                         2 * ThinPrismFisheyePrincipalPoint_num_max_}) *
+                   sizeof(float));
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 2 * simple_radial_num_, 4);
   increment_offset<float>(offset, 2 * simple_radial_fixed_pose_num_, 4);
@@ -14512,6 +21831,11 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<float>(
       offset, 2 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<float>(
@@ -14575,6 +21899,46 @@ size_t GraphSolver::get_nbytes() {
       offset,
       2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
   increment_offset<float>(offset, 12 * simple_radial_num_, 4);
   increment_offset<float>(offset, 4 * simple_radial_num_, 4);
   increment_offset<float>(offset, 6 * simple_radial_num_, 4);
@@ -14592,6 +21956,15 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 12 * pinhole_fixed_point_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(offset, 12 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 16 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 6 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 16 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 6 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 12 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(offset, 16 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 16 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<float>(
       offset, 12 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<float>(
@@ -14696,6 +22069,77 @@ size_t GraphSolver::get_nbytes() {
       offset,
       12 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
+  increment_offset<float>(
+      offset, 12 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 0 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 6 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 12 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset, 16 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset, 6 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      16 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      12 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      12 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      12 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      16 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      16 *
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      12 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 2 * PinholeFocal_num_, 4);
@@ -14714,23 +22158,13 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 2 * PinholeFocal_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 6 * PinholePose_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 2 * PinholePrincipalPoint_num_, 4);
-  increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 4 * Point_num_, 4);
-  increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 4 * SimpleRadialCalib_num_, 4);
-  increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
-  increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
-  increment_offset<float>(offset, 0 * 0, 4);
-  increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
@@ -14750,6 +22184,40 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * PinholeFocal_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 6 * PinholePose_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * PinholePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 4 * Point_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 4 * SimpleRadialCalib_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<float>(offset, 2 * PinholeFocal_num_, 4);
@@ -14760,6 +22228,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 1);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
@@ -14771,6 +22243,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
@@ -14782,6 +22258,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
@@ -14793,6 +22273,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<float>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 4 * PinholeCalib_num_, 4);
@@ -14813,6 +22297,14 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 16 * SimpleRadialPose_num_, 4);
   increment_offset<float>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<float>(offset, 1 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 66 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<float>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 45 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<float>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 16 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<float>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<float>(offset, 1 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<float>(offset, 0 * 0, 1);
   increment_offset<float>(offset, 0 * 0, 4);
   increment_offset<float>(offset, 2 * simple_radial_num_, 4);
@@ -14824,6 +22316,11 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<float>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<float>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<float>(
       offset, 2 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<float>(
@@ -14886,6 +22383,46 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<float>(
       offset,
       2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<float>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<float>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
       4);
   increment_offset<float>(offset, 0 * 0, 1);
   increment_offset<float>(offset, 1 * 1, 1);

--- a/src/thirdparty/Symforce-Caspar/generated/f32/solver.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f32/solver.h
@@ -54,6 +54,14 @@ class GraphSolver {
    * @param SimpleRadialPose_num_max the maximum number of SimpleRadialPoses
    * @param SimpleRadialPrincipalPoint_num_max the maximum number of
    * SimpleRadialPrincipalPoints
+   * @param ThinPrismFisheyeCalib_num_max the maximum number of
+   * ThinPrismFisheyeCalibs
+   * @param ThinPrismFisheyeFocalAndExtra_num_max the maximum number of
+   * ThinPrismFisheyeFocalAndExtras
+   * @param ThinPrismFisheyePose_num_max the maximum number of
+   * ThinPrismFisheyePoses
+   * @param ThinPrismFisheyePrincipalPoint_num_max the maximum number of
+   * ThinPrismFisheyePrincipalPoints
    * @param simple_radial_num_max the maximum number of simple_radials
    * @param simple_radial_fixed_pose_num_max the maximum number of
    * simple_radial_fixed_poses
@@ -67,6 +75,13 @@ class GraphSolver {
    * pinhole_fixed_points
    * @param pinhole_fixed_pose_fixed_point_num_max the maximum number of
    * pinhole_fixed_pose_fixed_points
+   * @param thin_prism_fisheye_num_max the maximum number of thin_prism_fisheyes
+   * @param thin_prism_fisheye_fixed_pose_num_max the maximum number of
+   * thin_prism_fisheye_fixed_poses
+   * @param thin_prism_fisheye_fixed_point_num_max the maximum number of
+   * thin_prism_fisheye_fixed_points
+   * @param thin_prism_fisheye_fixed_pose_fixed_point_num_max the maximum number
+   * of thin_prism_fisheye_fixed_pose_fixed_points
    * @param simple_radial_split_fixed_focal_and_extra_num_max the maximum number
    * of simple_radial_split_fixed_focal_and_extras
    * @param simple_radial_split_fixed_principal_point_num_max the maximum number
@@ -124,6 +139,42 @@ class GraphSolver {
    * @param pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max
    * the maximum number of
    * pinhole_split_fixed_focal_fixed_principal_point_fixed_points
+   * @param thin_prism_fisheye_split_fixed_focal_and_extra_num_max the maximum
+   * number of thin_prism_fisheye_split_fixed_focal_and_extras
+   * @param thin_prism_fisheye_split_fixed_principal_point_num_max the maximum
+   * number of thin_prism_fisheye_split_fixed_principal_points
+   * @param thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extras
+   * @param thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_points
+   * @param
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_points
+   * @param thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_points
+   * @param thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_principal_point_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_points
    */
   GraphSolver(
       const SolverParams<double>& params,
@@ -136,6 +187,10 @@ class GraphSolver {
       size_t SimpleRadialFocalAndExtra_num_max,
       size_t SimpleRadialPose_num_max,
       size_t SimpleRadialPrincipalPoint_num_max,
+      size_t ThinPrismFisheyeCalib_num_max,
+      size_t ThinPrismFisheyeFocalAndExtra_num_max,
+      size_t ThinPrismFisheyePose_num_max,
+      size_t ThinPrismFisheyePrincipalPoint_num_max,
       size_t simple_radial_num_max,
       size_t simple_radial_fixed_pose_num_max,
       size_t simple_radial_fixed_point_num_max,
@@ -144,6 +199,10 @@ class GraphSolver {
       size_t pinhole_fixed_pose_num_max,
       size_t pinhole_fixed_point_num_max,
       size_t pinhole_fixed_pose_fixed_point_num_max,
+      size_t thin_prism_fisheye_num_max,
+      size_t thin_prism_fisheye_fixed_pose_num_max,
+      size_t thin_prism_fisheye_fixed_point_num_max,
+      size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max,
       size_t simple_radial_split_fixed_focal_and_extra_num_max,
       size_t simple_radial_split_fixed_principal_point_num_max,
       size_t simple_radial_split_fixed_pose_fixed_focal_and_extra_num_max,
@@ -172,6 +231,22 @@ class GraphSolver {
       size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
       size_t
           pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max,
+      size_t thin_prism_fisheye_split_fixed_principal_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max,
+      size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max,
       int device_id = 0);
 
   // This class is managing cuda memory and cannot be copied.
@@ -638,6 +713,200 @@ class GraphSolver {
    * progress and can have performance impacts.
    */
   void SetSimpleRadialPrincipalPointNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeCalib nodes from the stacked
+   * host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeCalibNodesFromStackedHost(const float* const data,
+                                                    size_t offset,
+                                                    size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeCalib nodes from the stacked
+   * device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeCalibNodesFromStackedDevice(const float* const data,
+                                                      size_t offset,
+                                                      size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeCalib nodes into the stacked
+   * output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeCalibNodesToStackedHost(float* const data,
+                                                  size_t offset,
+                                                  size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeCalib nodes into the stacked
+   * output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeCalibNodesToStackedDevice(float* const data,
+                                                    size_t offset,
+                                                    size_t num);
+
+  /**
+   * Set the current number of active nodes of type ThinPrismFisheyeCalib.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeCalibNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeFocalAndExtra nodes from the
+   * stacked host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNodesFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeFocalAndExtra nodes from the
+   * stacked device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNodesFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeFocalAndExtra nodes into the
+   * stacked output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeFocalAndExtraNodesToStackedHost(float* const data,
+                                                          size_t offset,
+                                                          size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeFocalAndExtra nodes into the
+   * stacked output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeFocalAndExtraNodesToStackedDevice(float* const data,
+                                                            size_t offset,
+                                                            size_t num);
+
+  /**
+   * Set the current number of active nodes of type
+   * ThinPrismFisheyeFocalAndExtra.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePose nodes from the stacked
+   * host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePoseNodesFromStackedHost(const float* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePose nodes from the stacked
+   * device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePoseNodesFromStackedDevice(const float* const data,
+                                                     size_t offset,
+                                                     size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePose nodes into the stacked
+   * output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePoseNodesToStackedHost(float* const data,
+                                                 size_t offset,
+                                                 size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePose nodes into the stacked
+   * output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePoseNodesToStackedDevice(float* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the current number of active nodes of type ThinPrismFisheyePose.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyePoseNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePrincipalPoint nodes from the
+   * stacked host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePrincipalPointNodesFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePrincipalPoint nodes from the
+   * stacked device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePrincipalPointNodesFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePrincipalPoint nodes into
+   * the stacked output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePrincipalPointNodesToStackedHost(float* const data,
+                                                           size_t offset,
+                                                           size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePrincipalPoint nodes into
+   * the stacked output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePrincipalPointNodesToStackedDevice(float* const data,
+                                                             size_t offset,
+                                                             size_t num);
+
+  /**
+   * Set the current number of active nodes of type
+   * ThinPrismFisheyePrincipalPoint.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyePrincipalPointNum(size_t num);
 
   /**
    * Set the indices for the pose argument for the SimpleRadial factor from
@@ -1376,6 +1645,372 @@ class GraphSolver {
    * progress and can have performance impacts.
    */
   void SetPinholeFixedPoseFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyePoseIndicesFromHost(const unsigned int* const indices,
+                                              size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyePoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyeCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyeCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyePointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyePointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheye factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheye factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheye factor from stacked
+   * host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyePixelDataFromStackedHost(const float* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheye factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyePixelDataFromStackedDevice(const float* const data,
+                                                     size_t offset,
+                                                     size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheye factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeNum(size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPose
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPoseCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPose
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheyeFixedPose
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPosePointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheyeFixedPose
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPose
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPose
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPose factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPose factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPose factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPose factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPose factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPoseNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheyeFixedPoint
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheyeFixedPoint
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPoint
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPointCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPoint
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the calib argument for the
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from device.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPoseFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointNum(size_t num);
 
   /**
    * Set the indices for the pose argument for the
@@ -4066,6 +4701,1437 @@ class GraphSolver {
    */
   void SetPinholeSplitFixedFocalFixedPrincipalPointFixedPointNum(size_t num);
 
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeSplitFixedFocalAndExtra
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeSplitFixedFocalAndExtra
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedFocalAndExtra factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPrincipalPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointNum(size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const float* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointNum(
+      size_t num);
+
  private:
   SolverParams<float> params_;
   int device_id_;
@@ -4099,6 +6165,14 @@ class GraphSolver {
   size_t SimpleRadialPose_num_max_;
   size_t SimpleRadialPrincipalPoint_num_;
   size_t SimpleRadialPrincipalPoint_num_max_;
+  size_t ThinPrismFisheyeCalib_num_;
+  size_t ThinPrismFisheyeCalib_num_max_;
+  size_t ThinPrismFisheyeFocalAndExtra_num_;
+  size_t ThinPrismFisheyeFocalAndExtra_num_max_;
+  size_t ThinPrismFisheyePose_num_;
+  size_t ThinPrismFisheyePose_num_max_;
+  size_t ThinPrismFisheyePrincipalPoint_num_;
+  size_t ThinPrismFisheyePrincipalPoint_num_max_;
   size_t simple_radial_num_;
   size_t simple_radial_num_max_;
   size_t simple_radial_fixed_pose_num_;
@@ -4115,6 +6189,14 @@ class GraphSolver {
   size_t pinhole_fixed_point_num_max_;
   size_t pinhole_fixed_pose_fixed_point_num_;
   size_t pinhole_fixed_pose_fixed_point_num_max_;
+  size_t thin_prism_fisheye_num_;
+  size_t thin_prism_fisheye_num_max_;
+  size_t thin_prism_fisheye_fixed_pose_num_;
+  size_t thin_prism_fisheye_fixed_pose_num_max_;
+  size_t thin_prism_fisheye_fixed_point_num_;
+  size_t thin_prism_fisheye_fixed_point_num_max_;
+  size_t thin_prism_fisheye_fixed_pose_fixed_point_num_;
+  size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max_;
   size_t simple_radial_split_fixed_focal_and_extra_num_;
   size_t simple_radial_split_fixed_focal_and_extra_num_max_;
   size_t simple_radial_split_fixed_principal_point_num_;
@@ -4166,6 +6248,38 @@ class GraphSolver {
   size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max_;
   size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_;
   size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_num_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_;
 
   size_t get_nbytes();
   float LinearizeFirst();
@@ -4214,6 +6328,18 @@ class GraphSolver {
   float* nodes__SimpleRadialPrincipalPoint__storage_current_;
   float* nodes__SimpleRadialPrincipalPoint__storage_check_;
   float* nodes__SimpleRadialPrincipalPoint__storage_new_best_;
+  float* nodes__ThinPrismFisheyeCalib__storage_current_;
+  float* nodes__ThinPrismFisheyeCalib__storage_check_;
+  float* nodes__ThinPrismFisheyeCalib__storage_new_best_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__storage_current_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__storage_check_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_;
+  float* nodes__ThinPrismFisheyePose__storage_current_;
+  float* nodes__ThinPrismFisheyePose__storage_check_;
+  float* nodes__ThinPrismFisheyePose__storage_new_best_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__storage_current_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__storage_check_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_;
   SharedIndex* facs__simple_radial__args__pose__idx_shared_;
   float* facs__simple_radial__args__sensor_from_rig__data_;
   SharedIndex* facs__simple_radial__args__calib__idx_shared_;
@@ -4256,6 +6382,28 @@ class GraphSolver {
   float* facs__pinhole_fixed_pose_fixed_point__args__pixel__data_;
   float* facs__pinhole_fixed_pose_fixed_point__args__pose__data_;
   float* facs__pinhole_fixed_pose_fixed_point__args__point__data_;
+  SharedIndex* facs__thin_prism_fisheye__args__pose__idx_shared_;
+  float* facs__thin_prism_fisheye__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye__args__calib__idx_shared_;
+  SharedIndex* facs__thin_prism_fisheye__args__point__idx_shared_;
+  float* facs__thin_prism_fisheye__args__pixel__data_;
+  float* facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_;
+  float* facs__thin_prism_fisheye_fixed_pose__args__pixel__data_;
+  float* facs__thin_prism_fisheye_fixed_pose__args__pose__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_;
+  float* facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_;
+  float* facs__thin_prism_fisheye_fixed_point__args__pixel__data_;
+  float* facs__thin_prism_fisheye_fixed_point__args__point__data_;
+  float*
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_;
   SharedIndex*
       facs__simple_radial_split_fixed_focal_and_extra__args__pose__idx_shared_;
   float*
@@ -4506,6 +6654,138 @@ class GraphSolver {
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__principal_point__data_;
   float*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_;
   float* marker__scratch_inout_;
   float* facs__simple_radial__res_;
   float* facs__simple_radial_fixed_pose__res_;
@@ -4515,6 +6795,10 @@ class GraphSolver {
   float* facs__pinhole_fixed_pose__res_;
   float* facs__pinhole_fixed_point__res_;
   float* facs__pinhole_fixed_pose_fixed_point__res_;
+  float* facs__thin_prism_fisheye__res_;
+  float* facs__thin_prism_fisheye_fixed_pose__res_;
+  float* facs__thin_prism_fisheye_fixed_point__res_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__res_;
   float* facs__simple_radial_split_fixed_focal_and_extra__res_;
   float* facs__simple_radial_split_fixed_principal_point__res_;
   float* facs__simple_radial_split_fixed_pose_fixed_focal_and_extra__res_;
@@ -4543,6 +6827,22 @@ class GraphSolver {
   float* facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__res_;
   float*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__res_;
+  float* facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_;
+  float* facs__thin_prism_fisheye_split_fixed_principal_point__res_;
+  float* facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_;
+  float* facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_;
+  float* facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_;
+  float* facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_;
   float* facs__simple_radial__args__pose__jac_;
   float* facs__simple_radial__args__calib__jac_;
   float* facs__simple_radial__args__point__jac_;
@@ -4559,6 +6859,14 @@ class GraphSolver {
   float* facs__pinhole_fixed_point__args__pose__jac_;
   float* facs__pinhole_fixed_point__args__calib__jac_;
   float* facs__pinhole_fixed_pose_fixed_point__args__calib__jac_;
+  float* facs__thin_prism_fisheye__args__pose__jac_;
+  float* facs__thin_prism_fisheye__args__calib__jac_;
+  float* facs__thin_prism_fisheye__args__point__jac_;
+  float* facs__thin_prism_fisheye_fixed_pose__args__calib__jac_;
+  float* facs__thin_prism_fisheye_fixed_pose__args__point__jac_;
+  float* facs__thin_prism_fisheye_fixed_point__args__pose__jac_;
+  float* facs__thin_prism_fisheye_fixed_point__args__calib__jac_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__jac_;
   float* facs__simple_radial_split_fixed_focal_and_extra__args__pose__jac_;
   float*
       facs__simple_radial_split_fixed_focal_and_extra__args__principal_point__jac_;
@@ -4627,6 +6935,44 @@ class GraphSolver {
       facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__args__focal__jac_;
   float*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__pose__jac_;
+  float* facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_;
+  float* facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__jac_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__jac_;
   float* nodes__PinholeCalib__z_;
   float* nodes__PinholeCalib__z_end__;
   float* nodes__PinholeFocal__z_;
@@ -4645,6 +6991,14 @@ class GraphSolver {
   float* nodes__SimpleRadialPose__z_end__;
   float* nodes__SimpleRadialPrincipalPoint__z_;
   float* nodes__SimpleRadialPrincipalPoint__z_end__;
+  float* nodes__ThinPrismFisheyeCalib__z_;
+  float* nodes__ThinPrismFisheyeCalib__z_end__;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__z_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__z_end__;
+  float* nodes__ThinPrismFisheyePose__z_;
+  float* nodes__ThinPrismFisheyePose__z_end__;
+  float* nodes__ThinPrismFisheyePrincipalPoint__z_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__z_end__;
   float* nodes__PinholeCalib__p_;
   float* nodes__PinholeCalib__p_end__;
   float* nodes__PinholeFocal__p_;
@@ -4663,6 +7017,14 @@ class GraphSolver {
   float* nodes__SimpleRadialPose__p_end__;
   float* nodes__SimpleRadialPrincipalPoint__p_;
   float* nodes__SimpleRadialPrincipalPoint__p_end__;
+  float* nodes__ThinPrismFisheyeCalib__p_;
+  float* nodes__ThinPrismFisheyeCalib__p_end__;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__p_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__p_end__;
+  float* nodes__ThinPrismFisheyePose__p_;
+  float* nodes__ThinPrismFisheyePose__p_end__;
+  float* nodes__ThinPrismFisheyePrincipalPoint__p_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__p_end__;
   float* nodes__PinholeCalib__step_;
   float* nodes__PinholeCalib__step_end__;
   float* nodes__PinholeFocal__step_;
@@ -4681,6 +7043,14 @@ class GraphSolver {
   float* nodes__SimpleRadialPose__step_end__;
   float* nodes__SimpleRadialPrincipalPoint__step_;
   float* nodes__SimpleRadialPrincipalPoint__step_end__;
+  float* nodes__ThinPrismFisheyeCalib__step_;
+  float* nodes__ThinPrismFisheyeCalib__step_end__;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__step_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__step_end__;
+  float* nodes__ThinPrismFisheyePose__step_;
+  float* nodes__ThinPrismFisheyePose__step_end__;
+  float* nodes__ThinPrismFisheyePrincipalPoint__step_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__step_end__;
   float* marker__w_start_;
   float* nodes__PinholeCalib__w_;
   float* nodes__PinholeFocal__w_;
@@ -4691,6 +7061,10 @@ class GraphSolver {
   float* nodes__SimpleRadialFocalAndExtra__w_;
   float* nodes__SimpleRadialPose__w_;
   float* nodes__SimpleRadialPrincipalPoint__w_;
+  float* nodes__ThinPrismFisheyeCalib__w_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__w_;
+  float* nodes__ThinPrismFisheyePose__w_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__w_;
   float* marker__w_end_;
   float* marker__r_0_start_;
   float* nodes__PinholeCalib__r_0_;
@@ -4702,6 +7076,10 @@ class GraphSolver {
   float* nodes__SimpleRadialFocalAndExtra__r_0_;
   float* nodes__SimpleRadialPose__r_0_;
   float* nodes__SimpleRadialPrincipalPoint__r_0_;
+  float* nodes__ThinPrismFisheyeCalib__r_0_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__r_0_;
+  float* nodes__ThinPrismFisheyePose__r_0_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__r_0_;
   float* marker__r_0_end_;
   float* marker__r_k_start_;
   float* nodes__PinholeCalib__r_k_;
@@ -4713,6 +7091,10 @@ class GraphSolver {
   float* nodes__SimpleRadialFocalAndExtra__r_k_;
   float* nodes__SimpleRadialPose__r_k_;
   float* nodes__SimpleRadialPrincipalPoint__r_k_;
+  float* nodes__ThinPrismFisheyeCalib__r_k_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__r_k_;
+  float* nodes__ThinPrismFisheyePose__r_k_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__r_k_;
   float* marker__r_k_end_;
   float* marker__Mp_start_;
   float* nodes__PinholeCalib__Mp_;
@@ -4724,6 +7106,10 @@ class GraphSolver {
   float* nodes__SimpleRadialFocalAndExtra__Mp_;
   float* nodes__SimpleRadialPose__Mp_;
   float* nodes__SimpleRadialPrincipalPoint__Mp_;
+  float* nodes__ThinPrismFisheyeCalib__Mp_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__Mp_;
+  float* nodes__ThinPrismFisheyePose__Mp_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__Mp_;
   float* marker__Mp_end_;
   float* marker__precond_start_;
   float* nodes__PinholeCalib__precond_diag_;
@@ -4744,6 +7130,14 @@ class GraphSolver {
   float* nodes__SimpleRadialPose__precond_tril_;
   float* nodes__SimpleRadialPrincipalPoint__precond_diag_;
   float* nodes__SimpleRadialPrincipalPoint__precond_tril_;
+  float* nodes__ThinPrismFisheyeCalib__precond_diag_;
+  float* nodes__ThinPrismFisheyeCalib__precond_tril_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_;
+  float* nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_;
+  float* nodes__ThinPrismFisheyePose__precond_diag_;
+  float* nodes__ThinPrismFisheyePose__precond_tril_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__precond_diag_;
+  float* nodes__ThinPrismFisheyePrincipalPoint__precond_tril_;
   float* marker__precond_end_;
   float* marker__jp_start_;
   float* facs__simple_radial__jp_;
@@ -4754,6 +7148,10 @@ class GraphSolver {
   float* facs__pinhole_fixed_pose__jp_;
   float* facs__pinhole_fixed_point__jp_;
   float* facs__pinhole_fixed_pose_fixed_point__jp_;
+  float* facs__thin_prism_fisheye__jp_;
+  float* facs__thin_prism_fisheye_fixed_pose__jp_;
+  float* facs__thin_prism_fisheye_fixed_point__jp_;
+  float* facs__thin_prism_fisheye_fixed_pose_fixed_point__jp_;
   float* facs__simple_radial_split_fixed_focal_and_extra__jp_;
   float* facs__simple_radial_split_fixed_principal_point__jp_;
   float* facs__simple_radial_split_fixed_pose_fixed_focal_and_extra__jp_;
@@ -4781,6 +7179,22 @@ class GraphSolver {
   float* facs__pinhole_split_fixed_pose_fixed_focal_fixed_point__jp_;
   float* facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__jp_;
   float* facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_focal_and_extra__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_principal_point__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__jp_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__jp_;
+  float* facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__jp_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__jp_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__jp_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__jp_;
+  float*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__jp_;
   float* marker__jp_end_;
   float* solver__current_diag_;
   float* solver__alpha_numerator_;

--- a/src/thirdparty/Symforce-Caspar/generated/f64/CMakeLists.txt
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/CMakeLists.txt
@@ -6,9 +6,11 @@ endif()
 
 project(caspar_library LANGUAGES CXX CUDA)
 
+set(CASPAR_MIN_ARCH 75 CACHE INTERNAL "Minimum CUDA arch required by Caspar")
+
 # SASS for Turing/Ampere/Ada (sm_75–89) + PTX fallback for forward JIT-compatibility. sm_75 minimum required by cooperative_groups::reduce.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 75-virtual)
+  set(CMAKE_CUDA_ARCHITECTURES ${CASPAR_MIN_ARCH} 80-real 86-real 89-real)
 endif()
 
 find_package(CUDAToolkit REQUIRED)

--- a/src/thirdparty/Symforce-Caspar/generated/f64/caspar_mappings.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/caspar_mappings.cu
@@ -1043,6 +1043,478 @@ cudaError_t ConstSimpleRadialSensorFromRigCasparToStacked(
 }
 
 __global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 10];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 10] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+    data[1] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeFocalAndExtraCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 10];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[6] = data[0];
+    stacked_local_ptr[7] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 10];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel<<<num_blocks,
+                                                             block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeFocalAndExtraCasparToStacked_kernel<<<num_blocks,
+                                                             block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePoseStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    out_ptr[0] = data[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePoseCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    data[0] = in_ptr[0];
+    stacked_local_ptr[6] = data[0];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyePoseStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePoseStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyePoseCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePoseCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePrincipalPointStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 2];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 2] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyePrincipalPointCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 2];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 2];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar_kernel<<<num_blocks,
+                                                              block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyePrincipalPointCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyePrincipalPointCasparToStacked_kernel<<<num_blocks,
+                                                              block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeSensorFromRigStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    out_ptr[0] = data[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ConstThinPrismFisheyeSensorFromRigCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    data[0] = in_ptr[0];
+    stacked_local_ptr[6] = data[0];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar_kernel<<<num_blocks,
+                                                             block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ConstThinPrismFisheyeSensorFromRigCasparToStacked_kernel<<<num_blocks,
+                                                             block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
 __launch_bounds__(block_size, 1) void PinholeCalibStackedToCaspar_kernel(
     const double* const __restrict__ stacked_data,
     double* const __restrict__ cas_data,
@@ -1929,6 +2401,502 @@ cudaError_t SimpleRadialPrincipalPointCasparToStacked(
   const int num_blocks = (num_objects + block_size - 1) / block_size;
 
   SimpleRadialPrincipalPointCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeCalibStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 12];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 12 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 12;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 12] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 12;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+    data[1] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[10];
+    data[1] = stacked_local_ptr[11];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 10 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeCalibCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 12];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 12;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[6] = data[0];
+    stacked_local_ptr[7] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 10 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[10] = data[0];
+    stacked_local_ptr[11] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 12 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 12;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 12];
+  }
+}
+
+cudaError_t ThinPrismFisheyeCalibStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeCalibStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyeCalibCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeCalibCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 10];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 10] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+    data[1] = stacked_local_ptr[7];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[8];
+    data[1] = stacked_local_ptr[9];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyeFocalAndExtraCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 10];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 10;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[6] = data[0];
+    stacked_local_ptr[7] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 8 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[8] = data[0];
+    stacked_local_ptr[9] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 10 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 10;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 10];
+  }
+}
+
+cudaError_t ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar_kernel<<<num_blocks,
+                                                        block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyeFocalAndExtraCasparToStacked_kernel<<<num_blocks,
+                                                        block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePoseStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 7] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[2];
+    data[1] = stacked_local_ptr[3];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[4];
+    data[1] = stacked_local_ptr[5];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+    data[0] = stacked_local_ptr[6];
+
+    out_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    out_ptr[0] = data[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePoseCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 7];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 7;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 2 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[2] = data[0];
+    stacked_local_ptr[3] = data[1];
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 4 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[4] = data[0];
+    stacked_local_ptr[5] = data[1];
+    in_ptr = cas_data + 1 * (global_thread_idx + cas_offset) + 6 * cas_stride;
+    data[0] = in_ptr[0];
+    stacked_local_ptr[6] = data[0];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 7 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 7;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 7];
+  }
+}
+
+cudaError_t ThinPrismFisheyePoseStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePoseStackedToCaspar_kernel<<<num_blocks, block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyePoseCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePoseCasparToStacked_kernel<<<num_blocks, block_size>>>(
+      cas_data, stacked_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePrincipalPointStackedToCaspar_kernel(
+    const double* const __restrict__ stacked_data,
+    double* const __restrict__ cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 2];
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data_local[target - (blockIdx.x * blockDim.x) * 2] =
+        stacked_data[target];
+  }
+
+  __syncthreads();
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    double* out_ptr;
+    data[0] = stacked_local_ptr[0];
+    data[1] = stacked_local_ptr[1];
+
+    out_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(out_ptr)[0] =
+        reinterpret_cast<double2*>(data)[0];
+  }
+}
+
+__global__
+__launch_bounds__(block_size, 1) void ThinPrismFisheyePrincipalPointCasparToStacked_kernel(
+    const double* const __restrict__ cas_data,
+    double* const __restrict__ stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const unsigned int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ double stacked_data_local[block_size * 2];
+
+  if (global_thread_idx < num_objects) {
+    double data[4] = {0, 0, 0, 0};
+    double* stacked_local_ptr = stacked_data_local + threadIdx.x * 2;
+    const double* in_ptr;
+    in_ptr = cas_data + 2 * (global_thread_idx + cas_offset) + 0 * cas_stride;
+    reinterpret_cast<double2*>(data)[0] =
+        reinterpret_cast<const double2*>(in_ptr)[0];
+    stacked_local_ptr[0] = data[0];
+    stacked_local_ptr[1] = data[1];
+  }
+
+  __syncthreads();
+
+  for (unsigned int target = (blockIdx.x * blockDim.x) * 2 + threadIdx.x;
+       target < min(num_objects, (blockIdx.x + 1) * blockDim.x) * 2;
+       target += blockDim.x) {
+    stacked_data[target] =
+        stacked_data_local[target - (blockIdx.x * blockDim.x) * 2];
+  }
+}
+
+cudaError_t ThinPrismFisheyePrincipalPointStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePrincipalPointStackedToCaspar_kernel<<<num_blocks,
+                                                         block_size>>>(
+      stacked_data, cas_data, cas_stride, cas_offset, num_objects);
+
+  return cudaGetLastError();
+}
+
+cudaError_t ThinPrismFisheyePrincipalPointCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects) {
+  const int num_blocks = (num_objects + block_size - 1) / block_size;
+
+  ThinPrismFisheyePrincipalPointCasparToStacked_kernel<<<num_blocks,
+                                                         block_size>>>(
       cas_data, stacked_data, cas_stride, cas_offset, num_objects);
 
   return cudaGetLastError();

--- a/src/thirdparty/Symforce-Caspar/generated/f64/caspar_mappings.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/caspar_mappings.h
@@ -136,6 +136,62 @@ cudaError_t ConstSimpleRadialSensorFromRigCasparToStacked(
     const unsigned int cas_offset,
     const unsigned int num_objects);
 
+cudaError_t ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePoseStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePoseCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyePrincipalPointCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ConstThinPrismFisheyeSensorFromRigCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
 cudaError_t PinholeCalibStackedToCaspar(const double* stacked_data,
                                         double* cas_data,
                                         const unsigned int cas_stride,
@@ -244,6 +300,60 @@ cudaError_t SimpleRadialPrincipalPointStackedToCaspar(
     const unsigned int num_objects);
 
 cudaError_t SimpleRadialPrincipalPointCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeCalibStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeCalibCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyeFocalAndExtraCasparToStacked(
+    const double* cas_data,
+    double* stacked_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePoseStackedToCaspar(const double* stacked_data,
+                                                double* cas_data,
+                                                const unsigned int cas_stride,
+                                                const unsigned int cas_offset,
+                                                const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePoseCasparToStacked(const double* cas_data,
+                                                double* stacked_data,
+                                                const unsigned int cas_stride,
+                                                const unsigned int cas_offset,
+                                                const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePrincipalPointStackedToCaspar(
+    const double* stacked_data,
+    double* cas_data,
+    const unsigned int cas_stride,
+    const unsigned int cas_offset,
+    const unsigned int num_objects);
+
+cudaError_t ThinPrismFisheyePrincipalPointCasparToStacked(
     const double* cas_data,
     double* stacked_data,
     const unsigned int cas_stride,

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,145 @@
+#include "kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumeratorKernel(
+        double* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        double* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        double* const ThinPrismFisheyeCalib_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyeCalib_out_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        4 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r0, r2, r1 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        2 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        2 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r4);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        0 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        6 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        6 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        8 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        10 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        10 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    r2 = fma(r3, r4, r2);
+    r2 = fma(r6, r8, r2);
+    r2 = fma(r9, r11, r2);
+    r2 = fma(r13, r15, r2);
+    r2 = fma(r0, r1, r2);
+    r2 = fma(r10, r12, r2);
+    r2 = fma(r5, r7, r2);
+    r2 = fma(r14, r16, r2);
+    r2 = fma(r18, r20, r2);
+    r2 = fma(r17, r19, r2);
+  };
+  SumStore<double>(ThinPrismFisheyeCalib_out_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  SumFlushFinal<double>(
+      ThinPrismFisheyeCalib_out_local, ThinPrismFisheyeCalib_out, 1);
+}
+
+void ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    double* const ThinPrismFisheyeCalib_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks,
+                                                               1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      ThinPrismFisheyeCalib_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    double* const ThinPrismFisheyeCalib_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.cu
@@ -1,0 +1,211 @@
+#include "kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibAlphaNumeratorDenominatorKernel(
+        double* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        double* ThinPrismFisheyeCalib_r_k,
+        unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+        double* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        double* const ThinPrismFisheyeCalib_total_ag,
+        double* const ThinPrismFisheyeCalib_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyeCalib_total_ag_local[1];
+
+  __shared__ double ThinPrismFisheyeCalib_total_ac_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        10 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        10 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fma(r1, r3, r0 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        2 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        2 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        6 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        6 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r21,
+        r22);
+    r3 = fma(r2, r5, r3);
+    r3 = fma(r8, r10, r3);
+    r3 = fma(r12, r14, r3);
+    r3 = fma(r4, r6, r3);
+    r3 = fma(r16, r18, r3);
+    r3 = fma(r7, r9, r3);
+    r3 = fma(r19, r21, r3);
+    r3 = fma(r11, r13, r3);
+    r3 = fma(r15, r17, r3);
+    r3 = fma(r20, r22, r3);
+  };
+  SumStore<double>(ThinPrismFisheyeCalib_total_ag_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        4 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r22);
+    r3 = fma(r11, r3, r12 * r22);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        2 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r22);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        0 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r12,
+        r17);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        6 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r13,
+        r21);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        8 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r9,
+        r18);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        10 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r14);
+    r3 = fma(r4, r22, r3);
+    r3 = fma(r16, r17, r3);
+    r3 = fma(r7, r13, r3);
+    r3 = fma(r19, r9, r3);
+    r3 = fma(r2, r11, r3);
+    r3 = fma(r8, r21, r3);
+    r3 = fma(r15, r12, r3);
+    r3 = fma(r20, r18, r3);
+    r3 = fma(r1, r14, r3);
+    r3 = fma(r0, r6, r3);
+  };
+  SumStore<double>(ThinPrismFisheyeCalib_total_ac_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(
+      ThinPrismFisheyeCalib_total_ag_local, ThinPrismFisheyeCalib_total_ag, 1);
+  SumFlushFinal<double>(
+      ThinPrismFisheyeCalib_total_ac_local, ThinPrismFisheyeCalib_total_ac, 1);
+}
+
+void ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    double* const ThinPrismFisheyeCalib_total_ag,
+    double* const ThinPrismFisheyeCalib_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibAlphaNumeratorDenominatorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      ThinPrismFisheyeCalib_total_ag,
+      ThinPrismFisheyeCalib_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    double* const ThinPrismFisheyeCalib_total_ag,
+    double* const ThinPrismFisheyeCalib_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_normalize.cu
@@ -1,0 +1,899 @@
+#include "kernel_ThinPrismFisheyeCalib_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibNormalizeKernel(double* precond_diag,
+                                         unsigned int precond_diag_num_alloc,
+                                         double* precond_tril,
+                                         unsigned int precond_tril_num_alloc,
+                                         double* njtr,
+                                         unsigned int njtr_num_alloc,
+                                         const double* const diag,
+                                         double* out_normalized,
+                                         unsigned int out_normalized_num_alloc,
+                                         size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 8 * precond_tril_num_alloc, global_thread_idx, r0, r1);
+    r2 = -1.00000000000000000e+00;
+    r3 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 64 * precond_tril_num_alloc, global_thread_idx, r4, r5);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 18 * precond_tril_num_alloc, global_thread_idx, r5, r6);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 20 * precond_tril_num_alloc, global_thread_idx, r6, r7);
+    r7 = r5 * r6;
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 0 * precond_diag_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r10);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r11 = 1.00000000000000000e+00;
+    r11 = r10 + r11;
+    r12 = 1.00000000000000008e-15;
+    r12 = r10 * r12;
+    r9 = fma(r9, r11, r12);
+    r9 = 1.0 / r9;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 42 * precond_tril_num_alloc, global_thread_idx, r10, r13);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 22 * precond_tril_num_alloc, global_thread_idx, r14, r15);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 2 * precond_tril_num_alloc, global_thread_idx, r16, r17);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 0 * precond_tril_num_alloc, global_thread_idx, r16, r18);
+    r16 = r18 * r2;
+    r8 = fma(r8, r11, r12);
+    r8 = 1.0 / r8;
+    r16 = r16 * r8;
+    r14 = fma(r17, r16, r14);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 2 * precond_diag_num_alloc, global_thread_idx, r19, r20);
+    r19 = fma(r19, r11, r12);
+    r19 = fma(r18, r16, r19);
+    r19 = 1.0 / r19;
+    r18 = r14 * r19;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 26 * precond_tril_num_alloc, global_thread_idx, r21, r22);
+    r22 = fma(r0, r16, r22);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 12 * precond_tril_num_alloc, global_thread_idx, r23, r24);
+    r25 = r24 * r5;
+    r25 = fma(r9, r25, r22 * r18);
+    r26 = r17 * r0;
+    r25 = fma(r8, r26, r25);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 30 * precond_tril_num_alloc, global_thread_idx, r27, r28);
+    r29 = r2 * r9;
+    r30 = r23 * r29;
+    r27 = fma(r24, r30, r27);
+    r20 = fma(r20, r11, r12);
+    r20 = fma(r23, r30, r20);
+    r20 = 1.0 / r20;
+    r23 = r27 * r20;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 34 * precond_tril_num_alloc, global_thread_idx, r31, r32);
+    r32 = fma(r5, r30, r32);
+    r25 = fma(r32, r23, r25);
+    r25 = fma(r2, r25, r10);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 44 * precond_tril_num_alloc, global_thread_idx, r10, r26);
+    r33 = r24 * r6;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 36 * precond_tril_num_alloc, global_thread_idx, r34, r35);
+    r35 = fma(r6, r30, r35);
+    r33 = fma(r35, r23, r9 * r33);
+    r33 = fma(r2, r33, r10);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 4 * precond_diag_num_alloc, global_thread_idx, r10, r34);
+    r10 = fma(r10, r11, r12);
+    r36 = r17 * r17;
+    r36 = fma(r8, r36, r14 * r18);
+    r14 = r24 * r24;
+    r36 = fma(r9, r14, r36);
+    r36 = fma(r27, r23, r36);
+    r10 = fma(r2, r36, r10);
+    r10 = 1.0 / r10;
+    r36 = r33 * r10;
+    r7 = fma(r25, r36, r9 * r7);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 56 * precond_tril_num_alloc, global_thread_idx, r27, r14);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 16 * precond_tril_num_alloc, global_thread_idx, r37, r38);
+    r39 = r37 * r5;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 6 * precond_tril_num_alloc, global_thread_idx, r40, r41);
+    r42 = r40 * r0;
+    r42 = fma(r8, r42, r9 * r39);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 40 * precond_tril_num_alloc, global_thread_idx, r39, r43);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 24 * precond_tril_num_alloc, global_thread_idx, r44, r45);
+    r45 = fma(r40, r16, r45);
+    r46 = r24 * r37;
+    r46 = fma(r9, r46, r45 * r18);
+    r47 = r17 * r40;
+    r46 = fma(r8, r47, r46);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 32 * precond_tril_num_alloc, global_thread_idx, r48, r49);
+    r49 = fma(r37, r30, r49);
+    r46 = fma(r49, r23, r46);
+    r46 = fma(r2, r46, r39);
+    r39 = r46 * r25;
+    r42 = fma(r10, r39, r42);
+    r47 = r45 * r22;
+    r42 = fma(r19, r47, r42);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 46 * precond_tril_num_alloc, global_thread_idx, r50, r51);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 4 * precond_tril_num_alloc, global_thread_idx, r52, r53);
+    r15 = fma(r52, r16, r15);
+    r54 = r15 * r45;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 14 * precond_tril_num_alloc, global_thread_idx, r55, r56);
+    r57 = r55 * r37;
+    r57 = fma(r9, r57, r19 * r54);
+    r54 = r52 * r40;
+    r57 = fma(r8, r54, r57);
+    r28 = fma(r55, r30, r28);
+    r58 = r28 * r49;
+    r57 = fma(r20, r58, r57);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 38 * precond_tril_num_alloc, global_thread_idx, r59, r60);
+    r61 = r24 * r55;
+    r61 = fma(r9, r61, r15 * r18);
+    r62 = r17 * r52;
+    r61 = fma(r8, r62, r61);
+    r61 = fma(r28, r23, r61);
+    r61 = fma(r2, r61, r59);
+    r59 = r61 * r46;
+    r57 = fma(r10, r59, r57);
+    r57 = fma(r2, r57, r50);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 48 * precond_tril_num_alloc, global_thread_idx, r50, r59);
+    r58 = r15 * r22;
+    r54 = r55 * r5;
+    r54 = fma(r9, r54, r19 * r58);
+    r58 = r52 * r0;
+    r54 = fma(r8, r58, r54);
+    r62 = r28 * r32;
+    r54 = fma(r20, r62, r54);
+    r63 = r61 * r25;
+    r54 = fma(r10, r63, r54);
+    r54 = fma(r2, r54, r50);
+    r50 = r57 * r54;
+    r34 = fma(r34, r11, r12);
+    r63 = r15 * r15;
+    r62 = r28 * r28;
+    r62 = fma(r20, r62, r19 * r63);
+    r63 = r52 * r52;
+    r58 = r55 * r55;
+    r64 = r61 * r61;
+    r62 = fma(r8, r63, r62);
+    r62 = fma(r9, r58, r62);
+    r62 = fma(r10, r64, r62);
+    r34 = fma(r2, r62, r34);
+    r34 = 1.0 / r34;
+    r42 = fma(r34, r50, r42);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 52 * precond_tril_num_alloc, global_thread_idx, r62, r64);
+    r58 = r56 * r5;
+    r63 = r53 * r0;
+    r63 = fma(r8, r63, r9 * r58);
+    r44 = fma(r53, r16, r44);
+    r58 = r24 * r56;
+    r58 = fma(r9, r58, r44 * r18);
+    r65 = r17 * r53;
+    r58 = fma(r8, r65, r58);
+    r48 = fma(r56, r30, r48);
+    r58 = fma(r48, r23, r58);
+    r58 = fma(r2, r58, r60);
+    r60 = r58 * r25;
+    r63 = fma(r10, r60, r63);
+    r65 = r15 * r44;
+    r66 = r55 * r56;
+    r66 = fma(r9, r66, r19 * r65);
+    r65 = r52 * r53;
+    r66 = fma(r8, r65, r66);
+    r67 = r61 * r58;
+    r66 = fma(r10, r67, r66);
+    r68 = r28 * r48;
+    r66 = fma(r20, r68, r66);
+    r66 = fma(r2, r66, r26);
+    r26 = r66 * r34;
+    r68 = r48 * r32;
+    r63 = fma(r20, r68, r63);
+    r67 = r44 * r22;
+    r63 = fma(r19, r67, r63);
+    r63 = fma(r54, r26, r63);
+    r63 = fma(r2, r63, r64);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 50 * precond_tril_num_alloc, global_thread_idx, r64, r67);
+    r68 = r56 * r37;
+    r60 = r53 * r40;
+    r60 = fma(r8, r60, r9 * r68);
+    r68 = r58 * r46;
+    r60 = fma(r10, r68, r60);
+    r65 = r44 * r45;
+    r60 = fma(r19, r65, r60);
+    r69 = r48 * r49;
+    r60 = fma(r20, r69, r60);
+    r60 = fma(r57, r26, r60);
+    r60 = fma(r2, r60, r67);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 6 * precond_diag_num_alloc, global_thread_idx, r67, r69);
+    r67 = fma(r67, r11, r12);
+    r65 = r44 * r44;
+    r68 = r58 * r58;
+    r68 = fma(r10, r68, r19 * r65);
+    r65 = r53 * r53;
+    r70 = r56 * r56;
+    r71 = r48 * r48;
+    r68 = fma(r8, r65, r68);
+    r68 = fma(r9, r70, r68);
+    r68 = fma(r20, r71, r68);
+    r68 = fma(r66, r26, r68);
+    r67 = fma(r2, r68, r67);
+    r67 = 1.0 / r67;
+    r68 = r60 * r67;
+    r66 = r49 * r32;
+    r42 = fma(r20, r66, r42);
+    r42 = fma(r63, r68, r42);
+    r42 = fma(r2, r42, r14);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 58 * precond_tril_num_alloc, global_thread_idx, r14, r66);
+    r50 = r37 * r6;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 54 * precond_tril_num_alloc, global_thread_idx, r47, r39);
+    r71 = r56 * r6;
+    r71 = fma(r58, r36, r9 * r71);
+    r70 = r55 * r6;
+    r70 = fma(r61, r36, r9 * r70);
+    r65 = r28 * r35;
+    r70 = fma(r20, r65, r70);
+    r70 = fma(r2, r70, r64);
+    r64 = r48 * r35;
+    r71 = fma(r20, r64, r71);
+    r71 = fma(r70, r26, r71);
+    r71 = fma(r2, r71, r39);
+    r50 = fma(r71, r68, r9 * r50);
+    r39 = r57 * r70;
+    r50 = fma(r34, r39, r50);
+    r64 = r49 * r35;
+    r50 = fma(r20, r64, r50);
+    r50 = fma(r46, r36, r50);
+    r50 = fma(r2, r50, r66);
+    r69 = fma(r69, r11, r12);
+    r66 = r57 * r57;
+    r64 = r45 * r45;
+    r64 = fma(r19, r64, r34 * r66);
+    r66 = r40 * r40;
+    r39 = r37 * r37;
+    r65 = r46 * r46;
+    r72 = r49 * r49;
+    r64 = fma(r8, r66, r64);
+    r64 = fma(r9, r39, r64);
+    r64 = fma(r60, r68, r64);
+    r64 = fma(r10, r65, r64);
+    r64 = fma(r20, r72, r64);
+    r69 = fma(r2, r64, r69);
+    r69 = 1.0 / r69;
+    r64 = r50 * r69;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 60 * precond_tril_num_alloc, global_thread_idx, r72, r65);
+    r21 = fma(r41, r16, r21);
+    r60 = r24 * r38;
+    r60 = fma(r9, r60, r21 * r18);
+    r39 = r17 * r41;
+    r60 = fma(r8, r39, r60);
+    r31 = fma(r38, r30, r31);
+    r60 = fma(r31, r23, r60);
+    r60 = fma(r2, r60, r43);
+    r43 = r60 * r46;
+    r39 = r37 * r38;
+    r39 = fma(r9, r39, r10 * r43);
+    r43 = r40 * r41;
+    r39 = fma(r8, r43, r39);
+    r66 = r15 * r21;
+    r73 = r55 * r38;
+    r73 = fma(r9, r73, r19 * r66);
+    r66 = r52 * r41;
+    r73 = fma(r8, r66, r73);
+    r74 = r60 * r61;
+    r73 = fma(r10, r74, r73);
+    r75 = r31 * r28;
+    r73 = fma(r20, r75, r73);
+    r73 = fma(r2, r73, r51);
+    r51 = r73 * r57;
+    r39 = fma(r34, r51, r39);
+    r75 = r31 * r49;
+    r39 = fma(r20, r75, r39);
+    r74 = r21 * r45;
+    r39 = fma(r19, r74, r39);
+    r66 = r56 * r38;
+    r76 = r53 * r41;
+    r76 = fma(r8, r76, r9 * r66);
+    r66 = r60 * r58;
+    r76 = fma(r10, r66, r76);
+    r77 = r31 * r48;
+    r76 = fma(r20, r77, r76);
+    r78 = r21 * r44;
+    r76 = fma(r19, r78, r76);
+    r76 = fma(r73, r26, r76);
+    r76 = fma(r2, r76, r62);
+    r39 = fma(r76, r68, r39);
+    r39 = fma(r2, r39, r27);
+    r27 = r39 * r42;
+    r74 = r38 * r5;
+    r74 = fma(r9, r74, r69 * r27);
+    r27 = r41 * r0;
+    r74 = fma(r8, r27, r74);
+    r75 = r60 * r25;
+    r74 = fma(r10, r75, r74);
+    r51 = r76 * r63;
+    r74 = fma(r67, r51, r74);
+    r43 = r31 * r32;
+    r74 = fma(r20, r43, r74);
+    r62 = r73 * r54;
+    r74 = fma(r34, r62, r74);
+    r78 = r21 * r22;
+    r74 = fma(r19, r78, r74);
+    r74 = fma(r2, r74, r72);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 62 * precond_tril_num_alloc, global_thread_idx, r72, r78);
+    r62 = r38 * r6;
+    r43 = r73 * r70;
+    r43 = fma(r34, r43, r9 * r62);
+    r62 = r76 * r71;
+    r43 = fma(r67, r62, r43);
+    r51 = r31 * r35;
+    r43 = fma(r20, r51, r43);
+    r43 = fma(r60, r36, r43);
+    r43 = fma(r39, r64, r43);
+    r43 = fma(r2, r43, r72);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 8 * precond_diag_num_alloc, global_thread_idx, r72, r51);
+    r72 = fma(r72, r11, r12);
+    r62 = r21 * r21;
+    r75 = r41 * r41;
+    r75 = fma(r8, r75, r19 * r62);
+    r62 = r38 * r38;
+    r27 = r76 * r76;
+    r77 = r73 * r73;
+    r66 = r60 * r60;
+    r79 = r31 * r31;
+    r80 = r39 * r39;
+    r75 = fma(r9, r62, r75);
+    r75 = fma(r67, r27, r75);
+    r75 = fma(r34, r77, r75);
+    r75 = fma(r10, r66, r75);
+    r75 = fma(r20, r79, r75);
+    r75 = fma(r69, r80, r75);
+    r72 = fma(r2, r75, r72);
+    r72 = 1.0 / r72;
+    r75 = r43 * r72;
+    r80 = r70 * r54;
+    r7 = fma(r34, r80, r7);
+    r79 = r35 * r32;
+    r7 = fma(r20, r79, r7);
+    r66 = r71 * r63;
+    r7 = fma(r67, r66, r7);
+    r7 = fma(r42, r64, r7);
+    r7 = fma(r74, r75, r7);
+    r7 = fma(r2, r7, r4);
+    r51 = fma(r51, r11, r12);
+    r4 = r74 * r74;
+    r66 = r22 * r22;
+    r66 = fma(r19, r66, r72 * r4);
+    r4 = r54 * r54;
+    r79 = r0 * r0;
+    r80 = r5 * r5;
+    r77 = r63 * r63;
+    r27 = r32 * r32;
+    r62 = r25 * r25;
+    r81 = r42 * r42;
+    r66 = fma(r34, r4, r66);
+    r66 = fma(r8, r79, r66);
+    r66 = fma(r9, r80, r66);
+    r66 = fma(r67, r77, r66);
+    r66 = fma(r20, r27, r66);
+    r66 = fma(r10, r62, r66);
+    r66 = fma(r69, r81, r66);
+    r51 = fma(r2, r66, r51);
+    r51 = 1.0 / r51;
+    r66 = r7 * r51;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 10 * njtr_num_alloc, global_thread_idx, r81, r62);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 8 * njtr_num_alloc, global_thread_idx, r27, r77);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r80, r79);
+    r4 = r38 * r79;
+    r4 = fma(r29, r4, r27);
+    r27 = r2 * r76;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 6 * njtr_num_alloc, global_thread_idx, r82, r83);
+    r84 = r56 * r79;
+    r84 = fma(r29, r84, r82);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r82, r85);
+    r86 = r55 * r79;
+    r86 = fma(r29, r86, r85);
+    r85 = r2 * r28;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 2 * njtr_num_alloc, global_thread_idx, r87, r88);
+    r88 = fma(r79, r30, r88);
+    r85 = r85 * r88;
+    r86 = fma(r20, r85, r86);
+    r89 = r2 * r15;
+    r87 = fma(r80, r16, r87);
+    r89 = r89 * r87;
+    r86 = fma(r19, r89, r86);
+    r90 = r2 * r61;
+    r91 = r24 * r79;
+    r91 = fma(r29, r91, r82);
+    r82 = r2 * r88;
+    r91 = fma(r23, r82, r91);
+    r92 = r2 * r87;
+    r91 = fma(r18, r92, r91);
+    r93 = r17 * r80;
+    r93 = r93 * r2;
+    r91 = fma(r8, r93, r91);
+    r90 = r90 * r91;
+    r86 = fma(r10, r90, r86);
+    r93 = r52 * r80;
+    r93 = r93 * r2;
+    r86 = fma(r8, r93, r86);
+    r93 = r2 * r86;
+    r84 = fma(r26, r93, r84);
+    r90 = r2 * r48;
+    r90 = r90 * r88;
+    r84 = fma(r20, r90, r84);
+    r89 = r53 * r80;
+    r89 = r89 * r2;
+    r84 = fma(r8, r89, r84);
+    r85 = r2 * r58;
+    r85 = r85 * r91;
+    r84 = fma(r10, r85, r84);
+    r92 = r2 * r44;
+    r92 = r92 * r87;
+    r84 = fma(r19, r92, r84);
+    r27 = r27 * r84;
+    r4 = fma(r67, r27, r4);
+    r92 = r2 * r31;
+    r92 = r92 * r88;
+    r4 = fma(r20, r92, r4);
+    r85 = r2 * r73;
+    r85 = r85 * r86;
+    r4 = fma(r34, r85, r4);
+    r89 = r41 * r80;
+    r89 = r89 * r2;
+    r4 = fma(r8, r89, r4);
+    r90 = r2 * r21;
+    r90 = r90 * r87;
+    r4 = fma(r19, r90, r4);
+    r93 = r2 * r39;
+    r82 = r37 * r79;
+    r82 = fma(r29, r82, r83);
+    r83 = r2 * r91;
+    r83 = r83 * r46;
+    r82 = fma(r10, r83, r82);
+    r94 = r2 * r88;
+    r94 = r94 * r49;
+    r82 = fma(r20, r94, r82);
+    r95 = r40 * r80;
+    r95 = r95 * r2;
+    r82 = fma(r8, r95, r82);
+    r96 = r2 * r87;
+    r96 = r96 * r45;
+    r82 = fma(r19, r96, r82);
+    r97 = r2 * r84;
+    r82 = fma(r68, r97, r82);
+    r98 = r2 * r86;
+    r98 = r98 * r57;
+    r82 = fma(r34, r98, r82);
+    r93 = r93 * r82;
+    r4 = fma(r69, r93, r4);
+    r98 = r2 * r60;
+    r98 = r98 * r91;
+    r4 = fma(r10, r98, r4);
+    r98 = r2 * r4;
+    r98 = fma(r75, r98, r62);
+    r62 = r6 * r79;
+    r98 = fma(r29, r62, r98);
+    r93 = r2 * r86;
+    r93 = r93 * r70;
+    r98 = fma(r34, r93, r98);
+    r90 = r40 * r1;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 28 * precond_tril_num_alloc, global_thread_idx, r89, r85);
+    r89 = fma(r1, r16, r89);
+    r85 = r15 * r89;
+    r92 = r52 * r1;
+    r92 = fma(r8, r92, r19 * r85);
+    r85 = r17 * r1;
+    r85 = fma(r8, r85, r89 * r18);
+    r85 = fma(r2, r85, r13);
+    r13 = r61 * r85;
+    r92 = fma(r10, r13, r92);
+    r92 = fma(r2, r92, r59);
+    r59 = r57 * r92;
+    r59 = fma(r34, r59, r8 * r90);
+    r90 = r53 * r1;
+    r90 = fma(r92, r26, r8 * r90);
+    r13 = r44 * r89;
+    r90 = fma(r19, r13, r90);
+    r27 = r58 * r85;
+    r90 = fma(r10, r27, r90);
+    r90 = fma(r2, r90, r47);
+    r47 = r46 * r85;
+    r59 = fma(r10, r47, r59);
+    r27 = r45 * r89;
+    r59 = fma(r19, r27, r59);
+    r59 = fma(r90, r68, r59);
+    r59 = fma(r2, r59, r14);
+    r14 = r0 * r1;
+    r27 = r59 * r42;
+    r27 = fma(r69, r27, r8 * r14);
+    r14 = r90 * r63;
+    r27 = fma(r67, r14, r27);
+    r47 = r92 * r54;
+    r27 = fma(r34, r47, r27);
+    r13 = r89 * r22;
+    r27 = fma(r19, r13, r27);
+    r97 = r85 * r25;
+    r27 = fma(r10, r97, r27);
+    r96 = r73 * r92;
+    r95 = r60 * r85;
+    r95 = fma(r10, r95, r34 * r96);
+    r96 = r41 * r1;
+    r95 = fma(r8, r96, r95);
+    r94 = r39 * r59;
+    r95 = fma(r69, r94, r95);
+    r83 = r21 * r89;
+    r95 = fma(r19, r83, r95);
+    r99 = r76 * r90;
+    r95 = fma(r67, r99, r95);
+    r95 = fma(r2, r95, r65);
+    r65 = r95 * r74;
+    r27 = fma(r72, r65, r27);
+    r27 = fma(r2, r27, r78);
+    r78 = r27 * r51;
+    r65 = fma(r7, r78, r59 * r64);
+    r97 = r70 * r92;
+    r65 = fma(r34, r97, r65);
+    r13 = r71 * r90;
+    r65 = fma(r67, r13, r65);
+    r65 = fma(r85, r36, r65);
+    r65 = fma(r95, r75, r65);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 10 * precond_diag_num_alloc, global_thread_idx, r13, r97);
+    r13 = fma(r13, r11, r12);
+    r47 = r92 * r92;
+    r14 = r89 * r89;
+    r14 = fma(r19, r14, r34 * r47);
+    r47 = r1 * r1;
+    r99 = r85 * r85;
+    r83 = r95 * r95;
+    r94 = r90 * r90;
+    r96 = r59 * r59;
+    r14 = fma(r8, r47, r14);
+    r14 = fma(r10, r99, r14);
+    r14 = fma(r27, r78, r14);
+    r14 = fma(r72, r83, r14);
+    r14 = fma(r67, r94, r14);
+    r14 = fma(r69, r96, r14);
+    r13 = fma(r2, r14, r13);
+    r13 = 1.0 / r13;
+    r14 = r65 * r13;
+    r96 = r2 * r4;
+    r96 = r96 * r95;
+    r96 = fma(r72, r96, r81);
+    r78 = r2 * r78;
+    r81 = r5 * r79;
+    r81 = fma(r29, r81, r77);
+    r77 = r2 * r4;
+    r77 = r77 * r74;
+    r81 = fma(r72, r77, r81);
+    r94 = r2 * r88;
+    r94 = r94 * r32;
+    r81 = fma(r20, r94, r81);
+    r83 = r2 * r82;
+    r83 = r83 * r42;
+    r81 = fma(r69, r83, r81);
+    r27 = r0 * r80;
+    r27 = r27 * r2;
+    r81 = fma(r8, r27, r81);
+    r99 = r2 * r84;
+    r99 = r99 * r63;
+    r81 = fma(r67, r99, r81);
+    r47 = r2 * r87;
+    r47 = r47 * r22;
+    r81 = fma(r19, r47, r81);
+    r100 = r2 * r91;
+    r100 = r100 * r25;
+    r81 = fma(r10, r100, r81);
+    r101 = r2 * r86;
+    r101 = r101 * r54;
+    r81 = fma(r34, r101, r81);
+    r101 = r2 * r84;
+    r101 = r101 * r90;
+    r96 = fma(r67, r101, r96);
+    r100 = r2 * r87;
+    r100 = r100 * r89;
+    r96 = fma(r19, r100, r96);
+    r47 = r2 * r91;
+    r47 = r47 * r85;
+    r96 = fma(r10, r47, r96);
+    r99 = r2 * r86;
+    r99 = r99 * r92;
+    r96 = fma(r34, r99, r96);
+    r27 = r1 * r80;
+    r27 = r27 * r2;
+    r96 = fma(r8, r27, r96);
+    r83 = r2 * r82;
+    r83 = r83 * r59;
+    r96 = fma(r69, r83, r96);
+    r96 = fma(r81, r78, r96);
+    r83 = r2 * r82;
+    r98 = fma(r64, r83, r98);
+    r27 = r2 * r7;
+    r27 = r27 * r81;
+    r98 = fma(r51, r27, r98);
+    r99 = r2 * r88;
+    r99 = r99 * r35;
+    r98 = fma(r20, r99, r98);
+    r47 = r2 * r84;
+    r47 = r47 * r71;
+    r98 = fma(r67, r47, r98);
+    r100 = r2 * r91;
+    r98 = fma(r36, r100, r98);
+    r98 = fma(r96, r14, r98);
+    r11 = fma(r97, r11, r12);
+    r97 = r71 * r71;
+    r97 = fma(r67, r97, r50 * r64);
+    r50 = r7 * r7;
+    r12 = r6 * r6;
+    r100 = r70 * r70;
+    r47 = r35 * r35;
+    r97 = fma(r51, r50, r97);
+    r97 = fma(r9, r12, r97);
+    r97 = fma(r33, r36, r97);
+    r97 = fma(r34, r100, r97);
+    r97 = fma(r20, r47, r97);
+    r97 = fma(r43, r75, r97);
+    r97 = fma(r65, r14, r97);
+    r11 = fma(r2, r97, r11);
+    r11 = 1.0 / r11;
+    r11 = r98 * r11;
+    r98 = r2 * r11;
+    r81 = fma(r81, r51, r98 * r66);
+    r14 = fma(r11, r14, r96 * r13);
+    r81 = fma(r14, r78, r81);
+    r3 = r3 * r81;
+    r78 = r40 * r2;
+    r13 = r2 * r42;
+    r13 = r13 * r81;
+    r13 = fma(r82, r69, r69 * r13);
+    r96 = r2 * r59;
+    r96 = r96 * r14;
+    r13 = fma(r69, r96, r13);
+    r66 = r2 * r39;
+    r75 = fma(r98, r75, r4 * r72);
+    r97 = r2 * r74;
+    r97 = r97 * r81;
+    r75 = fma(r72, r97, r75);
+    r65 = r2 * r95;
+    r65 = r65 * r14;
+    r75 = fma(r72, r65, r75);
+    r66 = r66 * r75;
+    r13 = fma(r69, r66, r13);
+    r13 = fma(r98, r64, r13);
+    r78 = r78 * r13;
+    r78 = fma(r8, r78, r8 * r3);
+    r3 = r41 * r2;
+    r3 = r3 * r75;
+    r78 = fma(r8, r3, r78);
+    r66 = r53 * r2;
+    r64 = r2 * r63;
+    r64 = r64 * r81;
+    r96 = r2 * r76;
+    r96 = r96 * r75;
+    r96 = fma(r67, r96, r67 * r64);
+    r64 = r2 * r90;
+    r64 = r64 * r14;
+    r96 = fma(r67, r64, r96);
+    r69 = r2 * r13;
+    r96 = fma(r68, r69, r96);
+    r68 = r71 * r67;
+    r96 = fma(r98, r68, r96);
+    r96 = fma(r84, r67, r96);
+    r66 = r66 * r96;
+    r78 = fma(r8, r66, r78);
+    r68 = r2 * r21;
+    r68 = r68 * r75;
+    r69 = r2 * r89;
+    r69 = r69 * r14;
+    r69 = fma(r19, r69, r19 * r68);
+    r68 = r2 * r25;
+    r68 = r68 * r81;
+    r64 = r2 * r58;
+    r64 = r64 * r96;
+    r64 = fma(r10, r64, r10 * r68);
+    r68 = r2 * r46;
+    r68 = r68 * r13;
+    r64 = fma(r10, r68, r64);
+    r65 = r2 * r60;
+    r65 = r65 * r75;
+    r64 = fma(r10, r65, r64);
+    r97 = r2 * r61;
+    r72 = r2 * r92;
+    r72 = r72 * r14;
+    r43 = r2 * r57;
+    r43 = r43 * r13;
+    r43 = fma(r34, r43, r34 * r72);
+    r72 = r2 * r96;
+    r43 = fma(r26, r72, r43);
+    r26 = r2 * r54;
+    r26 = r26 * r81;
+    r43 = fma(r34, r26, r43);
+    r47 = r70 * r34;
+    r43 = fma(r98, r47, r43);
+    r100 = r2 * r73;
+    r100 = r100 * r75;
+    r43 = fma(r34, r100, r43);
+    r43 = fma(r86, r34, r43);
+    r97 = r97 * r43;
+    r64 = fma(r10, r97, r64);
+    r100 = r2 * r85;
+    r100 = r100 * r14;
+    r64 = fma(r10, r100, r64);
+    r64 = fma(r36, r98, r64);
+    r64 = fma(r91, r10, r64);
+    r10 = r2 * r64;
+    r69 = fma(r18, r10, r69);
+    r18 = r2 * r15;
+    r18 = r18 * r43;
+    r69 = fma(r19, r18, r69);
+    r100 = r2 * r45;
+    r100 = r100 * r13;
+    r69 = fma(r19, r100, r69);
+    r97 = r2 * r44;
+    r97 = r97 * r96;
+    r69 = fma(r19, r97, r69);
+    r65 = r2 * r22;
+    r65 = r65 * r81;
+    r69 = fma(r19, r65, r69);
+    r69 = fma(r87, r19, r69);
+    r65 = r17 * r2;
+    r65 = r65 * r64;
+    r78 = fma(r8, r65, r78);
+    r97 = r1 * r2;
+    r97 = r97 * r14;
+    r78 = fma(r8, r97, r78);
+    r100 = r52 * r2;
+    r100 = r100 * r43;
+    r78 = fma(r8, r100, r78);
+    r78 = fma(r69, r16, r78);
+    r78 = fma(r80, r8, r78);
+    r100 = r35 * r20;
+    r97 = r2 * r31;
+    r97 = r97 * r75;
+    r97 = fma(r20, r97, r98 * r100);
+    r100 = r2 * r28;
+    r100 = r100 * r43;
+    r97 = fma(r20, r100, r97);
+    r98 = r2 * r32;
+    r98 = r98 * r81;
+    r97 = fma(r20, r98, r97);
+    r65 = r2 * r64;
+    r97 = fma(r23, r65, r97);
+    r23 = r2 * r49;
+    r23 = r23 * r13;
+    r97 = fma(r20, r23, r97);
+    r8 = r2 * r48;
+    r8 = r8 * r96;
+    r97 = fma(r20, r8, r97);
+    r97 = fma(r88, r20, r97);
+    r8 = r6 * r29;
+    r8 = fma(r11, r8, r97 * r30);
+    r30 = r5 * r81;
+    r8 = fma(r29, r30, r8);
+    r23 = r37 * r13;
+    r8 = fma(r29, r23, r8);
+    r65 = r24 * r64;
+    r8 = fma(r29, r65, r8);
+    r98 = r55 * r43;
+    r8 = fma(r29, r98, r8);
+    r100 = r56 * r96;
+    r8 = fma(r29, r100, r8);
+    r16 = r38 * r75;
+    r8 = fma(r29, r16, r8);
+    r8 = fma(r79, r9, r8);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             0 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r78,
+                                             r8);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             2 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r69,
+                                             r97);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             4 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r64,
+                                             r43);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             6 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r96,
+                                             r13);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             8 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r75,
+                                             r81);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             10 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r14,
+                                             r11);
+  };
+}
+
+void ThinPrismFisheyeCalibNormalize(double* precond_diag,
+                                    unsigned int precond_diag_num_alloc,
+                                    double* precond_tril,
+                                    unsigned int precond_tril_num_alloc,
+                                    double* njtr,
+                                    unsigned int njtr_num_alloc,
+                                    const double* const diag,
+                                    double* out_normalized,
+                                    unsigned int out_normalized_num_alloc,
+                                    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_normalize.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibNormalize(double* precond_diag,
+                                    unsigned int precond_diag_num_alloc,
+                                    double* precond_tril,
+                                    unsigned int precond_tril_num_alloc,
+                                    double* njtr,
+                                    unsigned int njtr_num_alloc,
+                                    const double* const diag,
+                                    double* out_normalized,
+                                    unsigned int out_normalized_num_alloc,
+                                    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.cu
@@ -1,0 +1,222 @@
+#include "kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibPredDecreaseTimesTwoKernel(
+        double* ThinPrismFisheyeCalib_step,
+        unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+        double* ThinPrismFisheyeCalib_precond_diag,
+        unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyeCalib_njtr,
+        unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+        double* const out_ThinPrismFisheyeCalib_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeCalib_pred_dec_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        10 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        10 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        10 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fma(r7, r6, r3);
+    r3 = r0 * r4;
+    r3 = fma(r7, r3, r2);
+    r3 = fma(r0, r3, r1 * r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        6 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r6,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        6 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r8,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        6 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r10,
+        r11);
+    r12 = r2 * r11;
+    r12 = fma(r7, r12, r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        8 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r9,
+        r13);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        8 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r14,
+        r15);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r16,
+        r17);
+    r18 = r9 * r16;
+    r18 = fma(r7, r18, r14);
+    r14 = r13 * r17;
+    r14 = fma(r7, r14, r15);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        2 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r15,
+        r19);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        2 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r20,
+        r21);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        2 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r22,
+        r23);
+    r24 = r19 * r23;
+    r24 = fma(r7, r24, r21);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        4 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r21,
+        r25);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        4 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r26,
+        r27);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r28,
+        r29);
+    r30 = r21 * r28;
+    r30 = fma(r7, r30, r26);
+    r26 = r25 * r29;
+    r26 = fma(r7, r26, r27);
+    r27 = r15 * r22;
+    r27 = fma(r7, r27, r20);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step,
+        0 * ThinPrismFisheyeCalib_step_num_alloc,
+        global_thread_idx,
+        r20,
+        r31);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_njtr,
+        0 * ThinPrismFisheyeCalib_njtr_num_alloc,
+        global_thread_idx,
+        r32,
+        r33);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r34,
+        r35);
+    r36 = r31 * r35;
+    r36 = fma(r7, r36, r33);
+    r33 = r6 * r10;
+    r33 = fma(r7, r33, r8);
+    r8 = r20 * r34;
+    r8 = fma(r7, r8, r32);
+    r3 = fma(r2, r12, r3);
+    r3 = fma(r9, r18, r3);
+    r3 = fma(r13, r14, r3);
+    r3 = fma(r19, r24, r3);
+    r3 = fma(r21, r30, r3);
+    r3 = fma(r25, r26, r3);
+    r3 = fma(r15, r27, r3);
+    r3 = fma(r31, r36, r3);
+    r3 = fma(r6, r33, r3);
+    r3 = fma(r20, r8, r3);
+  };
+  SumStore<double>(out_ThinPrismFisheyeCalib_pred_dec_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(out_ThinPrismFisheyeCalib_pred_dec_local,
+                        out_ThinPrismFisheyeCalib_pred_dec,
+                        1);
+}
+
+void ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+    double* ThinPrismFisheyeCalib_step,
+    unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_njtr,
+    unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_step,
+      ThinPrismFisheyeCalib_step_num_alloc,
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_njtr,
+      ThinPrismFisheyeCalib_njtr_num_alloc,
+      out_ThinPrismFisheyeCalib_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+    double* ThinPrismFisheyeCalib_step,
+    unsigned int ThinPrismFisheyeCalib_step_num_alloc,
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_njtr,
+    unsigned int ThinPrismFisheyeCalib_njtr_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_retract.cu
@@ -1,0 +1,143 @@
+#include "kernel_ThinPrismFisheyeCalib_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibRetractKernel(
+    double* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  double r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyeCalib,
+                                            0 * ThinPrismFisheyeCalib_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        0 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyeCalib,
+                                            2 * ThinPrismFisheyeCalib_num_alloc,
+                                            global_thread_idx,
+                                            r3,
+                                            r2);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 2 * delta_num_alloc, global_thread_idx, r1, r0);
+    r1 = r3 + r1;
+    r0 = r2 + r0;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        2 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyeCalib,
+                                            4 * ThinPrismFisheyeCalib_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        4 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyeCalib,
+                                            6 * ThinPrismFisheyeCalib_num_alloc,
+                                            global_thread_idx,
+                                            r3,
+                                            r2);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 6 * delta_num_alloc, global_thread_idx, r1, r0);
+    r1 = r3 + r1;
+    r0 = r2 + r0;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        6 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyeCalib,
+                                            8 * ThinPrismFisheyeCalib_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 8 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        8 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib,
+        10 * ThinPrismFisheyeCalib_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 10 * delta_num_alloc, global_thread_idx, r1, r0);
+    r1 = r3 + r1;
+    r0 = r2 + r0;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_retracted,
+        10 * out_ThinPrismFisheyeCalib_retracted_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+  };
+}
+
+void ThinPrismFisheyeCalibRetract(
+    double* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib,
+      ThinPrismFisheyeCalib_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyeCalib_retracted,
+      out_ThinPrismFisheyeCalib_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibRetract(
+    double* ThinPrismFisheyeCalib,
+    unsigned int ThinPrismFisheyeCalib_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyeCalib_retracted,
+    unsigned int out_ThinPrismFisheyeCalib_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w.cu
@@ -1,0 +1,195 @@
+#include "kernel_ThinPrismFisheyeCalib_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibStartWKernel(
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        0 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        2 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        2 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        2 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        4 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        6 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        6 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        6 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        8 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        10 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        10 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r2 = r0 * r2;
+    r2 = r2 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        10 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeCalibStartW(
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_p,
+      ThinPrismFisheyeCalib_p_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibStartW(
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w_contribute.cu
@@ -1,0 +1,196 @@
+#include "kernel_ThinPrismFisheyeCalib_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibStartWContributeKernel(
+        double* ThinPrismFisheyeCalib_precond_diag,
+        unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyeCalib_p,
+        unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+        double* out_ThinPrismFisheyeCalib_w,
+        unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        0 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        0 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        2 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        2 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        2 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        4 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        4 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        6 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        6 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        6 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        8 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        8 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_precond_diag,
+        10 * ThinPrismFisheyeCalib_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p,
+        10 * ThinPrismFisheyeCalib_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r2 = r0 * r2;
+    r2 = r2 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        10 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeCalibStartWContribute(
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_precond_diag,
+      ThinPrismFisheyeCalib_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeCalib_p,
+      ThinPrismFisheyeCalib_p_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibStartWContribute(
+    double* ThinPrismFisheyeCalib_precond_diag,
+    unsigned int ThinPrismFisheyeCalib_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeCalib_p,
+    unsigned int ThinPrismFisheyeCalib_p_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_Mp.cu
@@ -1,0 +1,225 @@
+#include "kernel_ThinPrismFisheyeCalib_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdateMpKernel(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        0 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        0 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        2 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        2 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r3 = fma(r3, r4, r5);
+    r2 = fma(r2, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        2 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        4 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r6 = fma(r6, r4, r7);
+    r5 = fma(r5, r4, r8);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        4 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        6 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        6 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    r8 = fma(r8, r4, r9);
+    r7 = fma(r7, r4, r10);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        6 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        8 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r10,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r10 = fma(r10, r4, r11);
+    r9 = fma(r9, r4, r12);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        8 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r10,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_Mp,
+        10 * ThinPrismFisheyeCalib_Mp_num_alloc,
+        global_thread_idx,
+        r12,
+        r11);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        10 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    r12 = fma(r12, r4, r13);
+    r4 = fma(r11, r4, r14);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_Mp_kp1,
+        10 * out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r12,
+        r4);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        0 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        2 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        4 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        6 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        8 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r10,
+        r9);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_w,
+        10 * out_ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r12,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateMp(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_Mp,
+      ThinPrismFisheyeCalib_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyeCalib_Mp_kp1,
+      out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_w,
+      out_ThinPrismFisheyeCalib_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateMp(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_Mp,
+    unsigned int ThinPrismFisheyeCalib_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyeCalib_w,
+    unsigned int out_ThinPrismFisheyeCalib_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_p.cu
@@ -1,0 +1,183 @@
+#include "kernel_ThinPrismFisheyeCalib_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdatePKernel(
+    double* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    double* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        0 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        0 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        0 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        2 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        2 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        2 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        4 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        4 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        4 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        6 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        6 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        6 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        8 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        8 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        8 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_k,
+        10 * ThinPrismFisheyeCalib_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_z,
+        10 * ThinPrismFisheyeCalib_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r4 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_p_kp1,
+        10 * out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateP(
+    double* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    double* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_z,
+      ThinPrismFisheyeCalib_z_num_alloc,
+      ThinPrismFisheyeCalib_p_k,
+      ThinPrismFisheyeCalib_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyeCalib_p_kp1,
+      out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateP(
+    double* ThinPrismFisheyeCalib_z,
+    unsigned int ThinPrismFisheyeCalib_z_num_alloc,
+    double* ThinPrismFisheyeCalib_p_k,
+    unsigned int ThinPrismFisheyeCalib_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeCalib_p_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r.cu
@@ -1,0 +1,207 @@
+#include "kernel_ThinPrismFisheyeCalib_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeCalibUpdateRKernel(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        0 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        0 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        2 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        2 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r5 = fma(r5, r4, r1);
+    r6 = fma(r6, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        2 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        4 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r0);
+    r8 = fma(r8, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        4 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        6 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        6 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    r9 = fma(r9, r4, r1);
+    r10 = fma(r10, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        6 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        8 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r11 = fma(r11, r4, r0);
+    r12 = fma(r12, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        8 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        10 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        10 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    r13 = fma(r13, r4, r1);
+    r4 = fma(r14, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        10 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r4);
+    r2 = fma(r2, r2, r12 * r12);
+    r2 = fma(r9, r9, r2);
+    r2 = fma(r8, r8, r2);
+    r2 = fma(r3, r3, r2);
+    r2 = fma(r11, r11, r2);
+    r2 = fma(r10, r10, r2);
+    r2 = fma(r6, r6, r2);
+    r2 = fma(r5, r5, r2);
+    r2 = fma(r7, r7, r2);
+    r2 = fma(r13, r13, r2);
+    r2 = fma(r4, r4, r2);
+  };
+  SumStore<double>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  SumFlushFinal<double>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyeCalibUpdateR(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeCalib_r_kp1,
+      out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateR(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r_first.cu
@@ -1,0 +1,235 @@
+#include "kernel_ThinPrismFisheyeCalib_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateRFirstKernel(
+        double* ThinPrismFisheyeCalib_r_k,
+        unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+        double* ThinPrismFisheyeCalib_w,
+        unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyeCalib_r_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+        double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeCalib_r_0_norm2_tot_local[1];
+
+  __shared__ double out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        0 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        0 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        0 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        2 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        2 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r5);
+    r8 = fma(r8, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        2 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        4 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        4 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r11 = fma(r11, r4, r9);
+    r12 = fma(r12, r4, r10);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        4 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        6 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        6 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    r15 = fma(r15, r4, r13);
+    r16 = fma(r16, r4, r14);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        6 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        8 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        8 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    r19 = fma(r19, r4, r17);
+    r20 = fma(r20, r4, r18);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        8 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_r_k,
+        10 * ThinPrismFisheyeCalib_r_k_num_alloc,
+        global_thread_idx,
+        r21,
+        r22);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_w,
+        10 * ThinPrismFisheyeCalib_w_num_alloc,
+        global_thread_idx,
+        r23,
+        r24);
+    r23 = fma(r23, r4, r21);
+    r4 = fma(r24, r4, r22);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_r_kp1,
+        10 * out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+        global_thread_idx,
+        r23,
+        r4);
+    r13 = fma(r13, r13, r14 * r14);
+    r13 = fma(r6, r6, r13);
+    r13 = fma(r5, r5, r13);
+    r13 = fma(r1, r1, r13);
+    r13 = fma(r0, r0, r13);
+    r13 = fma(r18, r18, r13);
+    r13 = fma(r17, r17, r13);
+    r13 = fma(r9, r9, r13);
+    r13 = fma(r10, r10, r13);
+    r13 = fma(r22, r22, r13);
+    r13 = fma(r21, r21, r13);
+  };
+  SumStore<double>(out_ThinPrismFisheyeCalib_r_0_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r13);
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r2, r20 * r20);
+    r2 = fma(r15, r15, r2);
+    r2 = fma(r12, r12, r2);
+    r2 = fma(r3, r3, r2);
+    r2 = fma(r19, r19, r2);
+    r2 = fma(r16, r16, r2);
+    r2 = fma(r8, r8, r2);
+    r2 = fma(r7, r7, r2);
+    r2 = fma(r11, r11, r2);
+    r2 = fma(r23, r23, r2);
+    r2 = fma(r4, r4, r2);
+  };
+  SumStore<double>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  SumFlushFinal<double>(out_ThinPrismFisheyeCalib_r_0_norm2_tot_local,
+                        out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+                        1);
+  SumFlushFinal<double>(out_ThinPrismFisheyeCalib_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyeCalibUpdateRFirst(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_r_k,
+      ThinPrismFisheyeCalib_r_k_num_alloc,
+      ThinPrismFisheyeCalib_w,
+      ThinPrismFisheyeCalib_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeCalib_r_kp1,
+      out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+      out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+      out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateRFirst(
+    double* ThinPrismFisheyeCalib_r_k,
+    unsigned int ThinPrismFisheyeCalib_r_k_num_alloc,
+    double* ThinPrismFisheyeCalib_w,
+    unsigned int ThinPrismFisheyeCalib_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeCalib_r_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeCalib_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyeCalib_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step.cu
@@ -1,0 +1,184 @@
+#include "kernel_ThinPrismFisheyeCalib_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateStepKernel(
+        double* ThinPrismFisheyeCalib_step_k,
+        unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+        double* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyeCalib_step_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        0 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        0 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        2 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        2 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        2 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        4 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        4 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        6 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        6 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        6 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        8 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        8 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_step_k,
+        10 * ThinPrismFisheyeCalib_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        10 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r4 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        10 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateStep(
+    double* ThinPrismFisheyeCalib_step_k,
+    unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_step_k,
+      ThinPrismFisheyeCalib_step_k_num_alloc,
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeCalib_step_kp1,
+      out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateStep(
+    double* ThinPrismFisheyeCalib_step_k,
+    unsigned int ThinPrismFisheyeCalib_step_k_num_alloc,
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step_first.cu
@@ -1,0 +1,142 @@
+#include "kernel_ThinPrismFisheyeCalib_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeCalibUpdateStepFirstKernel(
+        double* ThinPrismFisheyeCalib_p_kp1,
+        unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyeCalib_step_kp1,
+        unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        0 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        0 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        2 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r0 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        2 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        4 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        4 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        6 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r0 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        6 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        8 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        8 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeCalib_p_kp1,
+        10 * ThinPrismFisheyeCalib_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r2 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeCalib_step_kp1,
+        10 * out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeCalibUpdateStepFirst(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeCalibUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeCalib_p_kp1,
+      ThinPrismFisheyeCalib_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeCalib_step_kp1,
+      out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeCalib_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeCalibUpdateStepFirst(
+    double* ThinPrismFisheyeCalib_p_kp1,
+    unsigned int ThinPrismFisheyeCalib_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeCalib_step_kp1,
+    unsigned int out_ThinPrismFisheyeCalib_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,132 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumeratorKernel(
+        double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        double* const ThinPrismFisheyeFocalAndExtra_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyeFocalAndExtra_out_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        6 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        6 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r7);
+    r7 = fma(r5, r7, r0 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        2 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        2 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    r7 = fma(r5, r0, r7);
+    r7 = fma(r9, r11, r7);
+    r7 = fma(r10, r12, r7);
+    r7 = fma(r13, r15, r7);
+    r7 = fma(r14, r16, r7);
+    r7 = fma(r2, r8, r7);
+    r7 = fma(r1, r3, r7);
+    r7 = fma(r4, r6, r7);
+  };
+  SumStore<double>(ThinPrismFisheyeFocalAndExtra_out_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r7);
+  SumFlushFinal<double>(ThinPrismFisheyeFocalAndExtra_out_local,
+                        ThinPrismFisheyeFocalAndExtra_out,
+                        1);
+}
+
+void ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    double* const ThinPrismFisheyeFocalAndExtra_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks,
+                                                                       1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    double* const ThinPrismFisheyeFocalAndExtra_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.cu
@@ -1,0 +1,192 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominatorKernel(
+        double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        double* const ThinPrismFisheyeFocalAndExtra_total_ag,
+        double* const ThinPrismFisheyeFocalAndExtra_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyeFocalAndExtra_total_ag_local[1];
+
+  __shared__ double ThinPrismFisheyeFocalAndExtra_total_ac_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r6,
+        r7);
+    r6 = fma(r4, r6, r1 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        2 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        2 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        6 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        6 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    r6 = fma(r8, r10, r6);
+    r6 = fma(r11, r13, r6);
+    r6 = fma(r16, r18, r6);
+    r6 = fma(r5, r7, r6);
+    r6 = fma(r0, r2, r6);
+    r6 = fma(r15, r17, r6);
+    r6 = fma(r12, r14, r6);
+    r6 = fma(r3, r9, r6);
+  };
+  SumStore<double>(ThinPrismFisheyeFocalAndExtra_total_ag_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r6);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        6 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r14,
+        r17);
+    r17 = fma(r16, r17, r3 * r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r16,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        2 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r18);
+    r17 = fma(r4, r16, r17);
+    r17 = fma(r11, r3, r17);
+    r17 = fma(r12, r2, r17);
+    r17 = fma(r0, r7, r17);
+    r17 = fma(r1, r18, r17);
+    r17 = fma(r5, r6, r17);
+    r17 = fma(r8, r9, r17);
+    r17 = fma(r15, r14, r17);
+  };
+  SumStore<double>(ThinPrismFisheyeFocalAndExtra_total_ac_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r17);
+  SumFlushFinal<double>(ThinPrismFisheyeFocalAndExtra_total_ag_local,
+                        ThinPrismFisheyeFocalAndExtra_total_ag,
+                        1);
+  SumFlushFinal<double>(ThinPrismFisheyeFocalAndExtra_total_ac_local,
+                        ThinPrismFisheyeFocalAndExtra_total_ac,
+                        1);
+}
+
+void ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    double* const ThinPrismFisheyeFocalAndExtra_total_ag,
+    double* const ThinPrismFisheyeFocalAndExtra_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominatorKernel<<<n_blocks,
+                                                                 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_total_ag,
+      ThinPrismFisheyeFocalAndExtra_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    double* const ThinPrismFisheyeFocalAndExtra_total_ag,
+    double* const ThinPrismFisheyeFocalAndExtra_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_normalize.cu
@@ -1,0 +1,650 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraNormalizeKernel(
+        double* precond_diag,
+        unsigned int precond_diag_num_alloc,
+        double* precond_tril,
+        unsigned int precond_tril_num_alloc,
+        double* njtr,
+        unsigned int njtr_num_alloc,
+        const double* const diag,
+        double* out_normalized,
+        unsigned int out_normalized_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 2 * precond_tril_num_alloc, global_thread_idx, r0, r1);
+    r2 = -1.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 34 * precond_tril_num_alloc, global_thread_idx, r3, r4);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 16 * precond_tril_num_alloc, global_thread_idx, r5, r6);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 10 * precond_tril_num_alloc, global_thread_idx, r7, r8);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 1.00000000000000008e-15;
+    r10 = r9 * r10;
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 0 * precond_diag_num_alloc, global_thread_idx, r11, r12);
+    r13 = 1.00000000000000000e+00;
+    r13 = r9 + r13;
+    r12 = fma(r12, r13, r10);
+    r12 = 1.0 / r12;
+    r9 = r8 * r12;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 24 * precond_tril_num_alloc, global_thread_idx, r14, r15);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 18 * precond_tril_num_alloc, global_thread_idx, r16, r17);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 0 * precond_tril_num_alloc, global_thread_idx, r18, r19);
+    r18 = r19 * r1;
+    r11 = fma(r11, r13, r10);
+    r11 = 1.0 / r11;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 8 * precond_tril_num_alloc, global_thread_idx, r20, r21);
+    r18 = fma(r21, r9, r11 * r18);
+    r18 = fma(r2, r18, r16);
+    r16 = r21 * r21;
+    r20 = r19 * r19;
+    r20 = fma(r11, r20, r12 * r16);
+    r20 = fma(r2, r20, r10);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 2 * precond_diag_num_alloc, global_thread_idx, r16, r22);
+    r20 = fma(r16, r13, r20);
+    r20 = 1.0 / r20;
+    r16 = r18 * r20;
+    r23 = r19 * r0;
+    r24 = r21 * r7;
+    r24 = fma(r12, r24, r11 * r23);
+    r24 = fma(r2, r24, r6);
+    r6 = fma(r7, r9, r24 * r16);
+    r23 = r0 * r1;
+    r6 = fma(r11, r23, r6);
+    r6 = fma(r2, r6, r14);
+    r14 = r0 * r0;
+    r23 = r7 * r7;
+    r23 = fma(r12, r23, r11 * r14);
+    r14 = r24 * r24;
+    r23 = fma(r20, r14, r23);
+    r23 = fma(r2, r23, r10);
+    r23 = fma(r22, r13, r23);
+    r23 = 1.0 / r23;
+    r22 = r6 * r23;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 28 * precond_tril_num_alloc, global_thread_idx, r14, r25);
+    r26 = r7 * r5;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 22 * precond_tril_num_alloc, global_thread_idx, r27, r28);
+    r29 = r21 * r5;
+    r29 = r29 * r2;
+    r29 = fma(r12, r29, r28);
+    r28 = r24 * r29;
+    r28 = fma(r20, r28, r12 * r26);
+    r28 = fma(r2, r28, r25);
+    r25 = fma(r28, r22, r5 * r9);
+    r25 = fma(r29, r16, r25);
+    r25 = fma(r2, r25, r3);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 32 * precond_tril_num_alloc, global_thread_idx, r3, r26);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 6 * precond_tril_num_alloc, global_thread_idx, r30, r31);
+    r32 = r19 * r31;
+    r33 = r2 * r11;
+    r32 = fma(r33, r32, r27);
+    r27 = r1 * r31;
+    r27 = fma(r11, r27, r32 * r16);
+    r34 = r0 * r31;
+    r35 = r24 * r32;
+    r35 = fma(r20, r35, r11 * r34);
+    r35 = fma(r2, r35, r14);
+    r27 = fma(r35, r22, r27);
+    r27 = fma(r2, r27, r26);
+    r26 = r25 * r27;
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 4 * precond_diag_num_alloc, global_thread_idx, r14, r34);
+    r14 = fma(r14, r13, r10);
+    r36 = r1 * r1;
+    r6 = fma(r6, r22, r11 * r36);
+    r6 = fma(r8, r9, r6);
+    r6 = fma(r18, r16, r6);
+    r14 = fma(r2, r6, r14);
+    r14 = 1.0 / r14;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 40 * precond_tril_num_alloc, global_thread_idx, r6, r18);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 30 * precond_tril_num_alloc, global_thread_idx, r8, r36);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 12 * precond_tril_num_alloc, global_thread_idx, r37, r38);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 4 * precond_tril_num_alloc, global_thread_idx, r39, r40);
+    r41 = r1 * r40;
+    r41 = fma(r11, r41, r38 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 20 * precond_tril_num_alloc, global_thread_idx, r42, r43);
+    r44 = r19 * r40;
+    r45 = r21 * r38;
+    r45 = fma(r12, r45, r11 * r44);
+    r45 = fma(r2, r45, r42);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 26 * precond_tril_num_alloc, global_thread_idx, r42, r44);
+    r46 = r7 * r38;
+    r47 = r0 * r40;
+    r47 = fma(r11, r47, r12 * r46);
+    r46 = r24 * r45;
+    r47 = fma(r20, r46, r47);
+    r47 = fma(r2, r47, r42);
+    r41 = fma(r45, r16, r41);
+    r41 = fma(r47, r22, r41);
+    r41 = fma(r2, r41, r36);
+    r36 = r41 * r14;
+    r42 = r40 * r31;
+    r42 = fma(r11, r42, r27 * r36);
+    r46 = r47 * r35;
+    r42 = fma(r23, r46, r42);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 36 * precond_tril_num_alloc, global_thread_idx, r48, r49);
+    r50 = r39 * r31;
+    r51 = r19 * r39;
+    r52 = r21 * r37;
+    r52 = fma(r12, r52, r11 * r51);
+    r52 = fma(r2, r52, r17);
+    r17 = r52 * r32;
+    r17 = fma(r20, r17, r11 * r50);
+    r50 = r7 * r37;
+    r51 = r0 * r39;
+    r51 = fma(r11, r51, r12 * r50);
+    r50 = r24 * r52;
+    r51 = fma(r20, r50, r51);
+    r51 = fma(r2, r51, r15);
+    r15 = r51 * r35;
+    r17 = fma(r23, r15, r17);
+    r50 = fma(r37, r9, r51 * r22);
+    r53 = r1 * r39;
+    r50 = fma(r11, r53, r50);
+    r50 = fma(r52, r16, r50);
+    r50 = fma(r2, r50, r8);
+    r8 = r50 * r27;
+    r17 = fma(r14, r8, r17);
+    r17 = fma(r2, r17, r49);
+    r49 = r45 * r52;
+    r8 = r37 * r38;
+    r8 = fma(r12, r8, r20 * r49);
+    r49 = r39 * r40;
+    r8 = fma(r11, r49, r8);
+    r15 = r47 * r51;
+    r8 = fma(r23, r15, r8);
+    r8 = fma(r50, r36, r8);
+    r8 = fma(r2, r8, r4);
+    r34 = fma(r34, r13, r10);
+    r4 = r50 * r50;
+    r15 = r52 * r52;
+    r15 = fma(r20, r15, r14 * r4);
+    r4 = r51 * r51;
+    r49 = r39 * r39;
+    r53 = r37 * r37;
+    r15 = fma(r23, r4, r15);
+    r15 = fma(r11, r49, r15);
+    r15 = fma(r12, r53, r15);
+    r34 = fma(r2, r15, r34);
+    r34 = 1.0 / r34;
+    r15 = r8 * r34;
+    r53 = r45 * r32;
+    r42 = fma(r20, r53, r42);
+    r42 = fma(r17, r15, r42);
+    r42 = fma(r2, r42, r6);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 6 * precond_diag_num_alloc, global_thread_idx, r6, r53);
+    r6 = fma(r6, r13, r10);
+    r46 = r47 * r47;
+    r49 = r45 * r45;
+    r49 = fma(r20, r49, r23 * r46);
+    r46 = r40 * r40;
+    r4 = r38 * r38;
+    r49 = fma(r11, r46, r49);
+    r49 = fma(r12, r4, r49);
+    r49 = fma(r8, r15, r49);
+    r49 = fma(r41, r36, r49);
+    r6 = fma(r2, r49, r6);
+    r6 = 1.0 / r6;
+    r49 = r42 * r6;
+    r41 = r38 * r5;
+    r41 = fma(r12, r41, r25 * r36);
+    r8 = r45 * r29;
+    r41 = fma(r20, r8, r41);
+    r4 = r47 * r28;
+    r41 = fma(r23, r4, r41);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 38 * precond_tril_num_alloc, global_thread_idx, r46, r54);
+    r55 = r37 * r5;
+    r56 = r28 * r51;
+    r56 = fma(r23, r56, r12 * r55);
+    r55 = r29 * r52;
+    r56 = fma(r20, r55, r56);
+    r57 = r50 * r25;
+    r56 = fma(r14, r57, r56);
+    r56 = fma(r2, r56, r46);
+    r41 = fma(r56, r15, r41);
+    r41 = fma(r2, r41, r18);
+    r26 = fma(r41, r49, r14 * r26);
+    r18 = r28 * r35;
+    r26 = fma(r23, r18, r26);
+    r4 = r56 * r17;
+    r26 = fma(r34, r4, r26);
+    r8 = r29 * r32;
+    r26 = fma(r20, r8, r26);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 42 * precond_tril_num_alloc, global_thread_idx, r46, r57);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 14 * precond_tril_num_alloc, global_thread_idx, r55, r58);
+    r58 = r7 * r55;
+    r59 = r0 * r30;
+    r59 = fma(r11, r59, r12 * r58);
+    r58 = r19 * r30;
+    r60 = r21 * r55;
+    r60 = fma(r12, r60, r11 * r58);
+    r60 = fma(r2, r60, r43);
+    r43 = r24 * r60;
+    r59 = fma(r20, r43, r59);
+    r59 = fma(r2, r59, r44);
+    r44 = r35 * r59;
+    r43 = r30 * r31;
+    r43 = fma(r11, r43, r23 * r44);
+    r44 = r1 * r30;
+    r44 = fma(r11, r44, r55 * r9);
+    r44 = fma(r60, r16, r44);
+    r44 = fma(r59, r22, r44);
+    r44 = fma(r2, r44, r3);
+    r3 = r38 * r55;
+    r3 = fma(r12, r3, r44 * r36);
+    r58 = r40 * r30;
+    r3 = fma(r11, r58, r3);
+    r61 = r47 * r59;
+    r3 = fma(r23, r61, r3);
+    r62 = r45 * r60;
+    r3 = fma(r20, r62, r3);
+    r63 = r52 * r60;
+    r64 = r50 * r44;
+    r64 = fma(r14, r64, r20 * r63);
+    r63 = r37 * r55;
+    r64 = fma(r12, r63, r64);
+    r65 = r39 * r30;
+    r64 = fma(r11, r65, r64);
+    r66 = r51 * r59;
+    r64 = fma(r23, r66, r64);
+    r64 = fma(r2, r64, r48);
+    r3 = fma(r64, r15, r3);
+    r3 = fma(r2, r3, r54);
+    r54 = r32 * r60;
+    r43 = fma(r20, r54, r43);
+    r62 = r27 * r44;
+    r43 = fma(r14, r62, r43);
+    r61 = r17 * r64;
+    r43 = fma(r34, r61, r43);
+    r43 = fma(r3, r49, r43);
+    r43 = fma(r2, r43, r46);
+    r53 = fma(r53, r13, r10);
+    r46 = r44 * r44;
+    r61 = r60 * r60;
+    r61 = fma(r20, r61, r14 * r46);
+    r46 = r30 * r30;
+    r62 = r55 * r55;
+    r54 = r3 * r3;
+    r58 = r59 * r59;
+    r48 = r64 * r64;
+    r61 = fma(r11, r46, r61);
+    r61 = fma(r12, r62, r61);
+    r61 = fma(r6, r54, r61);
+    r61 = fma(r23, r58, r61);
+    r61 = fma(r34, r48, r61);
+    r53 = fma(r2, r61, r53);
+    r53 = 1.0 / r53;
+    r61 = r43 * r53;
+    r48 = r55 * r5;
+    r58 = r56 * r64;
+    r58 = fma(r34, r58, r12 * r48);
+    r48 = r28 * r59;
+    r58 = fma(r23, r48, r58);
+    r54 = r25 * r44;
+    r58 = fma(r14, r54, r58);
+    r62 = r3 * r41;
+    r58 = fma(r6, r62, r58);
+    r46 = r29 * r60;
+    r58 = fma(r20, r46, r58);
+    r58 = fma(r2, r58, r57);
+    r26 = fma(r58, r61, r26);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 8 * precond_diag_num_alloc, global_thread_idx, r8, r4);
+    r8 = fma(r8, r13, r10);
+    r18 = r35 * r35;
+    r18 = fma(r23, r18, r42 * r49);
+    r42 = r27 * r27;
+    r57 = r32 * r32;
+    r46 = r31 * r31;
+    r62 = r17 * r17;
+    r18 = fma(r43, r61, r18);
+    r18 = fma(r14, r42, r18);
+    r18 = fma(r20, r57, r18);
+    r18 = fma(r11, r46, r18);
+    r18 = fma(r34, r62, r18);
+    r8 = fma(r2, r18, r8);
+    r8 = 1.0 / r8;
+    r18 = r26 * r8;
+    r13 = fma(r4, r13, r10);
+    r4 = r28 * r28;
+    r10 = r56 * r56;
+    r10 = fma(r34, r10, r23 * r4);
+    r4 = r5 * r5;
+    r62 = r41 * r41;
+    r46 = r29 * r29;
+    r57 = r58 * r58;
+    r42 = r25 * r25;
+    r10 = fma(r12, r4, r10);
+    r10 = fma(r26, r18, r10);
+    r10 = fma(r6, r62, r10);
+    r10 = fma(r20, r46, r10);
+    r10 = fma(r53, r57, r10);
+    r10 = fma(r14, r42, r10);
+    r13 = fma(r2, r10, r13);
+    r13 = 1.0 / r13;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 8 * njtr_num_alloc, global_thread_idx, r10, r42);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r57, r46);
+    r62 = r5 * r46;
+    r62 = r62 * r2;
+    r62 = fma(r12, r62, r42);
+    r42 = r2 * r29;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 2 * njtr_num_alloc, global_thread_idx, r26, r4);
+    r43 = r57 * r33;
+    r26 = fma(r19, r43, r26);
+    r54 = r21 * r46;
+    r54 = r54 * r2;
+    r26 = fma(r12, r54, r26);
+    r42 = r42 * r26;
+    r62 = fma(r20, r42, r62);
+    r54 = r2 * r17;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r48, r66);
+    r65 = r37 * r46;
+    r65 = r65 * r2;
+    r65 = fma(r12, r65, r66);
+    r66 = r2 * r52;
+    r66 = r66 * r26;
+    r65 = fma(r20, r66, r65);
+    r63 = r2 * r51;
+    r67 = r7 * r46;
+    r67 = r67 * r2;
+    r67 = fma(r12, r67, r4);
+    r4 = r2 * r24;
+    r4 = r4 * r26;
+    r67 = fma(r20, r4, r67);
+    r67 = fma(r0, r43, r67);
+    r63 = r63 * r67;
+    r65 = fma(r23, r63, r65);
+    r4 = r2 * r50;
+    r68 = r46 * r2;
+    r68 = fma(r9, r68, r48);
+    r48 = r2 * r67;
+    r68 = fma(r22, r48, r68);
+    r69 = r2 * r26;
+    r68 = fma(r16, r69, r68);
+    r68 = fma(r1, r43, r68);
+    r4 = r4 * r68;
+    r65 = fma(r14, r4, r65);
+    r65 = fma(r39, r43, r65);
+    r54 = r54 * r65;
+    r54 = fma(r34, r54, r10);
+    r10 = r2 * r35;
+    r10 = r10 * r67;
+    r54 = fma(r23, r10, r54);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 6 * njtr_num_alloc, global_thread_idx, r4, r63);
+    r66 = r38 * r46;
+    r66 = r66 * r2;
+    r66 = fma(r12, r66, r4);
+    r4 = r2 * r45;
+    r4 = r4 * r26;
+    r66 = fma(r20, r4, r66);
+    r15 = r2 * r15;
+    r69 = r2 * r68;
+    r66 = fma(r36, r69, r66);
+    r48 = r2 * r47;
+    r48 = r48 * r67;
+    r66 = fma(r23, r48, r66);
+    r66 = fma(r65, r15, r66);
+    r66 = fma(r40, r43, r66);
+    r48 = r2 * r66;
+    r54 = fma(r49, r48, r54);
+    r69 = r2 * r27;
+    r69 = r69 * r68;
+    r54 = fma(r14, r69, r54);
+    r4 = r55 * r46;
+    r4 = r4 * r2;
+    r4 = fma(r12, r4, r63);
+    r63 = r2 * r59;
+    r63 = r63 * r67;
+    r4 = fma(r23, r63, r4);
+    r70 = r2 * r3;
+    r70 = r70 * r66;
+    r4 = fma(r6, r70, r4);
+    r71 = r2 * r64;
+    r71 = r71 * r65;
+    r4 = fma(r34, r71, r4);
+    r72 = r2 * r60;
+    r72 = r72 * r26;
+    r4 = fma(r20, r72, r4);
+    r73 = r2 * r44;
+    r73 = r73 * r68;
+    r4 = fma(r14, r73, r4);
+    r4 = fma(r30, r43, r4);
+    r73 = r2 * r4;
+    r54 = fma(r61, r73, r54);
+    r72 = r2 * r32;
+    r72 = r72 * r26;
+    r54 = fma(r20, r72, r54);
+    r54 = fma(r31, r43, r54);
+    r43 = r2 * r56;
+    r43 = r43 * r65;
+    r62 = fma(r34, r43, r62);
+    r72 = r2 * r28;
+    r72 = r72 * r67;
+    r62 = fma(r23, r72, r62);
+    r73 = r2 * r41;
+    r73 = r73 * r66;
+    r62 = fma(r6, r73, r62);
+    r69 = r2 * r58;
+    r69 = r69 * r4;
+    r62 = fma(r53, r69, r62);
+    r48 = r2 * r25;
+    r48 = r48 * r68;
+    r62 = fma(r14, r48, r62);
+    r62 = fma(r54, r18, r62);
+    r62 = r13 * r62;
+    r8 = fma(r54, r8, r62 * r18);
+    r54 = r2 * r8;
+    r54 = fma(r66, r6, r49 * r54);
+    r49 = r41 * r6;
+    r18 = r2 * r62;
+    r54 = fma(r18, r49, r54);
+    r13 = r2 * r3;
+    r48 = r2 * r8;
+    r48 = fma(r61, r48, r4 * r53);
+    r61 = r58 * r53;
+    r48 = fma(r18, r61, r48);
+    r13 = r13 * r48;
+    r54 = fma(r6, r13, r54);
+    r13 = r2 * r54;
+    r49 = r25 * r14;
+    r49 = fma(r18, r49, r36 * r13);
+    r13 = r2 * r27;
+    r13 = r13 * r8;
+    r49 = fma(r14, r13, r49);
+    r36 = r2 * r50;
+    r61 = r2 * r17;
+    r61 = r61 * r8;
+    r69 = r2 * r64;
+    r69 = r69 * r48;
+    r69 = fma(r34, r69, r34 * r61);
+    r61 = r56 * r34;
+    r69 = fma(r18, r61, r69);
+    r69 = fma(r54, r15, r69);
+    r69 = fma(r65, r34, r69);
+    r36 = r36 * r69;
+    r49 = fma(r14, r36, r49);
+    r61 = r2 * r44;
+    r61 = r61 * r48;
+    r49 = fma(r14, r61, r49);
+    r49 = fma(r68, r14, r49);
+    r61 = r1 * r49;
+    r36 = r39 * r69;
+    r36 = fma(r33, r36, r33 * r61);
+    r61 = r40 * r54;
+    r36 = fma(r33, r61, r36);
+    r13 = r2 * r59;
+    r13 = r13 * r48;
+    r65 = r2 * r51;
+    r65 = r65 * r69;
+    r65 = fma(r23, r65, r23 * r13);
+    r13 = r28 * r23;
+    r65 = fma(r18, r13, r65);
+    r15 = r2 * r47;
+    r15 = r15 * r54;
+    r65 = fma(r23, r15, r65);
+    r73 = r2 * r49;
+    r65 = fma(r22, r73, r65);
+    r22 = r2 * r35;
+    r22 = r22 * r8;
+    r65 = fma(r23, r22, r65);
+    r65 = fma(r67, r23, r65);
+    r22 = r0 * r65;
+    r36 = fma(r33, r22, r36);
+    r73 = r30 * r48;
+    r36 = fma(r33, r73, r36);
+    r15 = r2 * r24;
+    r15 = r15 * r65;
+    r15 = fma(r26, r20, r20 * r15);
+    r13 = r2 * r49;
+    r15 = fma(r16, r13, r15);
+    r16 = r2 * r52;
+    r16 = r16 * r69;
+    r15 = fma(r20, r16, r15);
+    r72 = r2 * r60;
+    r72 = r72 * r48;
+    r15 = fma(r20, r72, r15);
+    r43 = r2 * r45;
+    r43 = r43 * r54;
+    r15 = fma(r20, r43, r15);
+    r42 = r2 * r32;
+    r42 = r42 * r8;
+    r15 = fma(r20, r42, r15);
+    r10 = r29 * r20;
+    r15 = fma(r18, r10, r15);
+    r10 = r19 * r15;
+    r36 = fma(r33, r10, r36);
+    r42 = r31 * r8;
+    r36 = fma(r33, r42, r36);
+    r36 = fma(r57, r11, r36);
+    r42 = r37 * r2;
+    r42 = r42 * r69;
+    r42 = fma(r46, r12, r12 * r42);
+    r10 = r55 * r2;
+    r10 = r10 * r48;
+    r42 = fma(r12, r10, r42);
+    r11 = r38 * r2;
+    r11 = r11 * r54;
+    r42 = fma(r12, r11, r42);
+    r57 = r21 * r2;
+    r57 = r57 * r15;
+    r42 = fma(r12, r57, r42);
+    r73 = r5 * r12;
+    r42 = fma(r18, r73, r42);
+    r18 = r7 * r2;
+    r18 = r18 * r65;
+    r42 = fma(r12, r18, r42);
+    r22 = r2 * r49;
+    r42 = fma(r9, r22, r42);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             0 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r36,
+                                             r42);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             2 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r15,
+                                             r65);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             4 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r49,
+                                             r69);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             6 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r54,
+                                             r48);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             8 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r8,
+                                             r62);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraNormalize(
+    double* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    double* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    double* njtr,
+    unsigned int njtr_num_alloc,
+    const double* const diag,
+    double* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_normalize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraNormalize(
+    double* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    double* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    double* njtr,
+    unsigned int njtr_num_alloc,
+    const double* const diag,
+    double* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.cu
@@ -1,0 +1,197 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwoKernel(
+        double* ThinPrismFisheyeFocalAndExtra_step,
+        unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyeFocalAndExtra_njtr,
+        unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        double* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeFocalAndExtra_pred_dec_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        8 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        8 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fma(r7, r6, r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        2 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r3,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        2 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        2 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r13 = r3 * r11;
+    r13 = fma(r7, r13, r9);
+    r13 = fma(r3, r13, r1 * r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        6 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r6,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        6 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r14,
+        r15);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        6 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r16,
+        r17);
+    r18 = r9 * r17;
+    r18 = fma(r7, r18, r15);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        0 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r15,
+        r19);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        0 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r20,
+        r21);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r22,
+        r23);
+    r24 = r15 * r22;
+    r24 = fma(r7, r24, r20);
+    r20 = r0 * r4;
+    r20 = fma(r7, r20, r2);
+    r2 = r6 * r16;
+    r2 = fma(r7, r2, r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step,
+        4 * ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+        global_thread_idx,
+        r14,
+        r25);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_njtr,
+        4 * ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+        global_thread_idx,
+        r26,
+        r27);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r28,
+        r29);
+    r30 = r14 * r28;
+    r30 = fma(r7, r30, r26);
+    r26 = r25 * r29;
+    r26 = fma(r7, r26, r27);
+    r27 = r8 * r12;
+    r27 = fma(r7, r27, r10);
+    r10 = r19 * r23;
+    r10 = fma(r7, r10, r21);
+    r13 = fma(r9, r18, r13);
+    r13 = fma(r15, r24, r13);
+    r13 = fma(r0, r20, r13);
+    r13 = fma(r6, r2, r13);
+    r13 = fma(r14, r30, r13);
+    r13 = fma(r25, r26, r13);
+    r13 = fma(r8, r27, r13);
+    r13 = fma(r19, r10, r13);
+  };
+  SumStore<double>(out_ThinPrismFisheyeFocalAndExtra_pred_dec_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r13);
+  SumFlushFinal<double>(out_ThinPrismFisheyeFocalAndExtra_pred_dec_local,
+                        out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+                        1);
+}
+
+void ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+    double* ThinPrismFisheyeFocalAndExtra_step,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_njtr,
+    unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_step,
+      ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_njtr,
+      ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+    double* ThinPrismFisheyeFocalAndExtra_step,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_njtr,
+    unsigned int ThinPrismFisheyeFocalAndExtra_njtr_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_retract.cu
@@ -1,0 +1,133 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraRetractKernel(
+        double* ThinPrismFisheyeFocalAndExtra,
+        unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+        double* delta,
+        unsigned int delta_num_alloc,
+        double* out_ThinPrismFisheyeFocalAndExtra_retracted,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  double r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra,
+        0 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        0 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra,
+        2 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 2 * delta_num_alloc, global_thread_idx, r1, r0);
+    r1 = r3 + r1;
+    r0 = r2 + r0;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        2 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra,
+        4 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        4 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra,
+        6 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 6 * delta_num_alloc, global_thread_idx, r1, r0);
+    r1 = r3 + r1;
+    r0 = r2 + r0;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        6 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra,
+        8 * ThinPrismFisheyeFocalAndExtra_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 8 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_retracted,
+        8 * out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraRetract(
+    double* ThinPrismFisheyeFocalAndExtra,
+    unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_retracted,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra,
+      ThinPrismFisheyeFocalAndExtra_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_retracted,
+      out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraRetract(
+    double* ThinPrismFisheyeFocalAndExtra,
+    unsigned int ThinPrismFisheyeFocalAndExtra_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_retracted,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w.cu
@@ -1,0 +1,174 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraStartWKernel(
+        double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyeFocalAndExtra_p,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        double* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        0 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        2 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        2 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        2 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        4 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        6 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        6 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        6 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        8 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraStartW(
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_p,
+      ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraStartW(
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.cu
@@ -1,0 +1,174 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraStartWContributeKernel(
+        double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+        unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyeFocalAndExtra_p,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        double* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        0 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        0 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        2 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        2 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        2 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        4 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        4 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        6 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        6 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        6 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_precond_diag,
+        8 * ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p,
+        8 * ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraStartWContribute(
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_precond_diag,
+      ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyeFocalAndExtra_p,
+      ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraStartWContribute(
+    double* ThinPrismFisheyeFocalAndExtra_precond_diag,
+    unsigned int ThinPrismFisheyeFocalAndExtra_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyeFocalAndExtra_p,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.cu
@@ -1,0 +1,200 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateMpKernel(
+        double* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_Mp,
+        unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        const double* const beta,
+        double* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        double* out_ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        0 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        2 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        2 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r3 = fma(r3, r4, r5);
+    r2 = fma(r2, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        4 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r6 = fma(r6, r4, r7);
+    r5 = fma(r5, r4, r8);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        6 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        6 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    r8 = fma(r8, r4, r9);
+    r7 = fma(r7, r4, r10);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_Mp,
+        8 * ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+        global_thread_idx,
+        r10,
+        r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r10 = fma(r10, r4, r11);
+    r4 = fma(r9, r4, r12);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r10,
+        r4);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        0 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        2 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        4 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        6 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r8,
+        r7);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_w,
+        8 * out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r10,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateMp(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_Mp,
+    unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_Mp,
+      ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_w,
+      out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateMp(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_Mp,
+    unsigned int ThinPrismFisheyeFocalAndExtra_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeFocalAndExtra_Mp_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_p.cu
@@ -1,0 +1,164 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdatePKernel(
+        double* ThinPrismFisheyeFocalAndExtra_z,
+        unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_p_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        const double* const beta,
+        double* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        0 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        0 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        2 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        2 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        4 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        4 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        6 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        6 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_k,
+        8 * ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_z,
+        8 * ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fma(r0, r4, r2);
+    r4 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateP(
+    double* ThinPrismFisheyeFocalAndExtra_z,
+    unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_p_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_z,
+      ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_p_k,
+      ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateP(
+    double* ThinPrismFisheyeFocalAndExtra_z,
+    unsigned int ThinPrismFisheyeFocalAndExtra_z_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_p_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r.cu
@@ -1,0 +1,186 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateRKernel(
+        double* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        2 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        2 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r5 = fma(r5, r4, r1);
+    r6 = fma(r6, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r0);
+    r8 = fma(r8, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        6 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        6 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    r9 = fma(r9, r4, r1);
+    r10 = fma(r10, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r11 = fma(r11, r4, r0);
+    r4 = fma(r12, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r4);
+    r10 = fma(r10, r10, r11 * r11);
+    r10 = fma(r2, r2, r10);
+    r10 = fma(r5, r5, r10);
+    r10 = fma(r8, r8, r10);
+    r10 = fma(r6, r6, r10);
+    r10 = fma(r9, r9, r10);
+    r10 = fma(r3, r3, r10);
+    r10 = fma(r7, r7, r10);
+    r10 = fma(r4, r4, r10);
+  };
+  SumStore<double>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r10);
+  SumFlushFinal<double>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateR(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateR(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.cu
@@ -1,0 +1,211 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateRFirstKernel(
+        double* ThinPrismFisheyeFocalAndExtra_r_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_w,
+        unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+        double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local[1];
+
+  __shared__ double out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        0 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        0 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        2 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        2 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r5);
+    r8 = fma(r8, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        4 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        4 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r11 = fma(r11, r4, r9);
+    r12 = fma(r12, r4, r10);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        6 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r13,
+        r14);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        6 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    r15 = fma(r15, r4, r13);
+    r16 = fma(r16, r4, r14);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r15,
+        r16);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_r_k,
+        8 * ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+        global_thread_idx,
+        r17,
+        r18);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_w,
+        8 * ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+        global_thread_idx,
+        r19,
+        r20);
+    r19 = fma(r19, r4, r17);
+    r4 = fma(r20, r4, r18);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+        global_thread_idx,
+        r19,
+        r4);
+    r6 = fma(r6, r6, r0 * r0);
+    r6 = fma(r10, r10, r6);
+    r6 = fma(r17, r17, r6);
+    r6 = fma(r1, r1, r6);
+    r6 = fma(r9, r9, r6);
+    r6 = fma(r14, r14, r6);
+    r6 = fma(r5, r5, r6);
+    r6 = fma(r13, r13, r6);
+    r6 = fma(r18, r18, r6);
+  };
+  SumStore<double>(out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r6);
+  if (global_thread_idx < problem_size) {
+    r16 = fma(r16, r16, r19 * r19);
+    r16 = fma(r2, r2, r16);
+    r16 = fma(r7, r7, r16);
+    r16 = fma(r12, r12, r16);
+    r16 = fma(r8, r8, r16);
+    r16 = fma(r15, r15, r16);
+    r16 = fma(r3, r3, r16);
+    r16 = fma(r11, r11, r16);
+    r16 = fma(r4, r4, r16);
+  };
+  SumStore<double>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r16);
+  SumFlushFinal<double>(out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot_local,
+                        out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+                        1);
+  SumFlushFinal<double>(out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_r_k,
+      ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_w,
+      ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+      out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+      out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+    double* ThinPrismFisheyeFocalAndExtra_r_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_r_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_w,
+    unsigned int ThinPrismFisheyeFocalAndExtra_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_r_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyeFocalAndExtra_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step.cu
@@ -1,0 +1,164 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateStepKernel(
+        double* ThinPrismFisheyeFocalAndExtra_step_k,
+        unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        0 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        2 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        2 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        4 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        6 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        6 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_step_k,
+        8 * ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r2, r4, r0);
+    r4 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateStep(
+    double* ThinPrismFisheyeFocalAndExtra_step_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_step_k,
+      ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateStep(
+    double* ThinPrismFisheyeFocalAndExtra_step_k,
+    unsigned int ThinPrismFisheyeFocalAndExtra_step_k_num_alloc,
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.cu
@@ -1,0 +1,128 @@
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFocalAndExtraUpdateStepFirstKernel(
+        double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+        unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        0 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        0 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        2 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r0 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        2 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        4 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        4 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        6 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r0 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        6 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyeFocalAndExtra_p_kp1,
+        8 * ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    r2 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+        8 * out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFocalAndExtraUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyeFocalAndExtra_p_kp1,
+      ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+      out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+    double* ThinPrismFisheyeFocalAndExtra_p_kp1,
+    unsigned int ThinPrismFisheyeFocalAndExtra_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyeFocalAndExtra_step_kp1,
+    unsigned int out_ThinPrismFisheyeFocalAndExtra_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,101 @@
+#include "kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseAlphaDenominatorOrBetaNumeratorKernel(
+        double* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        double* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        double* const ThinPrismFisheyePose_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyePose_out_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        2 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        2 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fma(r1, r3, r0 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        0 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        4 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r3 = fma(r2, r4, r3);
+    r3 = fma(r1, r0, r3);
+    r3 = fma(r6, r8, r3);
+    r3 = fma(r5, r7, r3);
+  };
+  SumStore<double>(ThinPrismFisheyePose_out_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(
+      ThinPrismFisheyePose_out_local, ThinPrismFisheyePose_out, 1);
+}
+
+void ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    double* const ThinPrismFisheyePose_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumeratorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      ThinPrismFisheyePose_out,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    double* const ThinPrismFisheyePose_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.cu
@@ -1,0 +1,144 @@
+#include "kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseAlphaNumeratorDenominatorKernel(
+        double* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        double* ThinPrismFisheyePose_r_k,
+        unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+        double* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        double* const ThinPrismFisheyePose_total_ag,
+        double* const ThinPrismFisheyePose_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyePose_total_ag_local[1];
+
+  __shared__ double ThinPrismFisheyePose_total_ac_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        4 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r0, r2, r1 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        2 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        2 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        0 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    r2 = fma(r4, r6, r2);
+    r2 = fma(r8, r10, r2);
+    r2 = fma(r3, r5, r2);
+    r2 = fma(r7, r9, r2);
+  };
+  SumStore<double>(ThinPrismFisheyePose_total_ag_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        2 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r9);
+    r9 = fma(r4, r9, r3 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        0 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r4,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        4 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r5);
+    r9 = fma(r8, r2, r9);
+    r9 = fma(r7, r4, r9);
+    r9 = fma(r1, r5, r9);
+    r9 = fma(r0, r3, r9);
+  };
+  SumStore<double>(ThinPrismFisheyePose_total_ac_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r9);
+  SumFlushFinal<double>(
+      ThinPrismFisheyePose_total_ag_local, ThinPrismFisheyePose_total_ag, 1);
+  SumFlushFinal<double>(
+      ThinPrismFisheyePose_total_ac_local, ThinPrismFisheyePose_total_ac, 1);
+}
+
+void ThinPrismFisheyePoseAlphaNumeratorDenominator(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    double* const ThinPrismFisheyePose_total_ag,
+    double* const ThinPrismFisheyePose_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseAlphaNumeratorDenominatorKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      ThinPrismFisheyePose_total_ag,
+      ThinPrismFisheyePose_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseAlphaNumeratorDenominator(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    double* const ThinPrismFisheyePose_total_ag,
+    double* const ThinPrismFisheyePose_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_normalize.cu
@@ -1,0 +1,259 @@
+#include "kernel_ThinPrismFisheyePose_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseNormalizeKernel(double* precond_diag,
+                                        unsigned int precond_diag_num_alloc,
+                                        double* precond_tril,
+                                        unsigned int precond_tril_num_alloc,
+                                        double* njtr,
+                                        unsigned int njtr_num_alloc,
+                                        const double* const diag,
+                                        double* out_normalized,
+                                        unsigned int out_normalized_num_alloc,
+                                        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36;
+
+  if (global_thread_idx < problem_size) {
+    r0 = -1.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 6 * precond_tril_num_alloc, global_thread_idx, r1, r2);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 2 * precond_tril_num_alloc, global_thread_idx, r3, r4);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 0 * precond_tril_num_alloc, global_thread_idx, r5, r6);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 0 * precond_diag_num_alloc, global_thread_idx, r7, r8);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 1.00000000000000000e+00;
+    r10 = r9 + r10;
+    r11 = 1.00000000000000008e-15;
+    r11 = r9 * r11;
+    r7 = fma(r7, r10, r11);
+    r7 = 1.0 / r7;
+    r9 = r0 * r7;
+    r12 = r5 * r9;
+    r2 = fma(r4, r12, r2);
+    r13 = r0 * r2;
+    ReadIdx1<1024, double, double, double>(
+        precond_tril, 14 * precond_tril_num_alloc, global_thread_idx, r14);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 4 * precond_tril_num_alloc, global_thread_idx, r15, r16);
+    r17 = r4 * r15;
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 12 * precond_tril_num_alloc, global_thread_idx, r18, r19);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 10 * precond_tril_num_alloc, global_thread_idx, r20, r21);
+    r22 = r6 * r15;
+    r16 = fma(r6, r12, r16);
+    ReadIdx2<1024, double, double, double2>(
+        precond_tril, 8 * precond_tril_num_alloc, global_thread_idx, r23, r24);
+    r23 = fma(r15, r12, r23);
+    r25 = r16 * r23;
+    r8 = fma(r8, r10, r11);
+    r8 = fma(r5, r12, r8);
+    r8 = 1.0 / r8;
+    r25 = fma(r8, r25, r7 * r22);
+    r25 = fma(r0, r25, r21);
+    r21 = r6 * r3;
+    r1 = fma(r3, r12, r1);
+    r22 = r1 * r8;
+    r21 = fma(r16, r22, r7 * r21);
+    r21 = fma(r0, r21, r24);
+    r24 = r6 * r6;
+    r5 = r16 * r16;
+    r5 = fma(r8, r5, r7 * r24);
+    r5 = fma(r0, r5, r11);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 2 * precond_diag_num_alloc, global_thread_idx, r24, r26);
+    r5 = fma(r24, r10, r5);
+    r5 = 1.0 / r5;
+    r24 = r21 * r5;
+    r27 = r3 * r15;
+    r27 = fma(r7, r27, r25 * r24);
+    r27 = fma(r23, r22, r27);
+    r27 = fma(r0, r27, r19);
+    r19 = r3 * r4;
+    r19 = fma(r2, r22, r7 * r19);
+    r28 = r6 * r4;
+    r29 = r16 * r2;
+    r29 = fma(r8, r29, r7 * r28);
+    r29 = fma(r0, r29, r20);
+    r19 = fma(r29, r24, r19);
+    r19 = fma(r0, r19, r18);
+    r26 = fma(r26, r10, r11);
+    r18 = r3 * r3;
+    r21 = fma(r21, r24, r7 * r18);
+    r21 = fma(r1, r22, r21);
+    r26 = fma(r0, r21, r26);
+    r26 = 1.0 / r26;
+    r21 = r19 * r26;
+    r17 = fma(r27, r21, r7 * r17);
+    r1 = r2 * r23;
+    r17 = fma(r8, r1, r17);
+    r18 = r29 * r25;
+    r17 = fma(r5, r18, r17);
+    r17 = fma(r0, r17, r14);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 4 * precond_diag_num_alloc, global_thread_idx, r14, r18);
+    r14 = fma(r14, r10, r11);
+    r1 = r4 * r4;
+    r1 = fma(r7, r1, r19 * r21);
+    r19 = r29 * r29;
+    r20 = r2 * r2;
+    r1 = fma(r5, r19, r1);
+    r1 = fma(r8, r20, r1);
+    r14 = fma(r0, r1, r14);
+    r14 = 1.0 / r14;
+    r1 = r17 * r14;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 4 * njtr_num_alloc, global_thread_idx, r20, r19);
+    r28 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r30, r31);
+    r31 = fma(r30, r12, r31);
+    r28 = r28 * r31;
+    r28 = fma(r8, r28, r20);
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 2 * njtr_num_alloc, global_thread_idx, r20, r32);
+    r33 = r0 * r31;
+    r33 = fma(r22, r33, r32);
+    r32 = r0 * r16;
+    r32 = r32 * r31;
+    r32 = fma(r8, r32, r20);
+    r20 = r6 * r30;
+    r32 = fma(r9, r20, r32);
+    r20 = r0 * r32;
+    r33 = fma(r24, r20, r33);
+    r34 = r3 * r30;
+    r33 = fma(r9, r34, r33);
+    r34 = r0 * r33;
+    r28 = fma(r21, r34, r28);
+    r20 = r4 * r30;
+    r28 = fma(r9, r20, r28);
+    r35 = r0 * r29;
+    r35 = r35 * r32;
+    r28 = fma(r5, r35, r28);
+    r35 = r0 * r28;
+    r35 = fma(r1, r35, r19);
+    r19 = r0 * r23;
+    r19 = r19 * r31;
+    r35 = fma(r8, r19, r35);
+    r20 = r0 * r27;
+    r20 = r20 * r33;
+    r35 = fma(r26, r20, r35);
+    r34 = r15 * r30;
+    r35 = fma(r9, r34, r35);
+    r36 = r0 * r25;
+    r36 = r36 * r32;
+    r35 = fma(r5, r36, r35);
+    r36 = r15 * r15;
+    r36 = fma(r7, r36, r17 * r1);
+    r17 = r23 * r23;
+    r34 = r27 * r27;
+    r20 = r25 * r25;
+    r36 = fma(r8, r17, r36);
+    r36 = fma(r26, r34, r36);
+    r36 = fma(r5, r20, r36);
+    r36 = fma(r0, r36, r11);
+    r36 = fma(r18, r10, r36);
+    r36 = 1.0 / r36;
+    r36 = r35 * r36;
+    r35 = r0 * r36;
+    r14 = fma(r28, r14, r35 * r1);
+    r13 = r13 * r14;
+    r1 = r27 * r26;
+    r10 = r0 * r14;
+    r10 = fma(r21, r10, r35 * r1);
+    r10 = fma(r33, r26, r10);
+    r1 = r0 * r10;
+    r1 = fma(r22, r1, r8 * r13);
+    r13 = r0 * r16;
+    r22 = r25 * r5;
+    r22 = fma(r35, r22, r32 * r5);
+    r21 = r0 * r10;
+    r22 = fma(r24, r21, r22);
+    r24 = r0 * r29;
+    r24 = r24 * r14;
+    r22 = fma(r5, r24, r22);
+    r13 = r13 * r22;
+    r1 = fma(r8, r13, r1);
+    r24 = r23 * r8;
+    r1 = fma(r35, r24, r1);
+    r1 = fma(r31, r8, r1);
+    r24 = r15 * r9;
+    r12 = fma(r1, r12, r36 * r24);
+    r24 = r6 * r22;
+    r12 = fma(r9, r24, r12);
+    r13 = r4 * r14;
+    r12 = fma(r9, r13, r12);
+    r35 = r3 * r10;
+    r12 = fma(r9, r35, r12);
+    r12 = fma(r30, r7, r12);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             0 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r12,
+                                             r1);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             2 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r22,
+                                             r10);
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             4 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r14,
+                                             r36);
+  };
+}
+
+void ThinPrismFisheyePoseNormalize(double* precond_diag,
+                                   unsigned int precond_diag_num_alloc,
+                                   double* precond_tril,
+                                   unsigned int precond_tril_num_alloc,
+                                   double* njtr,
+                                   unsigned int njtr_num_alloc,
+                                   const double* const diag,
+                                   double* out_normalized,
+                                   unsigned int out_normalized_num_alloc,
+                                   size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_normalize.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseNormalize(double* precond_diag,
+                                   unsigned int precond_diag_num_alloc,
+                                   double* precond_tril,
+                                   unsigned int precond_tril_num_alloc,
+                                   double* njtr,
+                                   unsigned int njtr_num_alloc,
+                                   const double* const diag,
+                                   double* out_normalized,
+                                   unsigned int out_normalized_num_alloc,
+                                   size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_pred_decrease_times_two.cu
@@ -1,0 +1,149 @@
+#include "kernel_ThinPrismFisheyePose_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePosePredDecreaseTimesTwoKernel(
+        double* ThinPrismFisheyePose_step,
+        unsigned int ThinPrismFisheyePose_step_num_alloc,
+        double* ThinPrismFisheyePose_precond_diag,
+        unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyePose_njtr,
+        unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+        double* const out_ThinPrismFisheyePose_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePose_pred_dec_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step,
+        0 * ThinPrismFisheyePose_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_njtr,
+        0 * ThinPrismFisheyePose_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fma(r7, r6, r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step,
+        4 * ThinPrismFisheyePose_step_num_alloc,
+        global_thread_idx,
+        r3,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_njtr,
+        4 * ThinPrismFisheyePose_njtr_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r13 = r8 * r12;
+    r13 = fma(r7, r13, r10);
+    r13 = fma(r8, r13, r1 * r6);
+    r6 = r3 * r11;
+    r6 = fma(r7, r6, r9);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step,
+        2 * ThinPrismFisheyePose_step_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_njtr,
+        2 * ThinPrismFisheyePose_njtr_num_alloc,
+        global_thread_idx,
+        r14,
+        r15);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        2 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r16,
+        r17);
+    r18 = r9 * r16;
+    r18 = fma(r7, r18, r14);
+    r14 = r10 * r17;
+    r14 = fma(r7, r14, r15);
+    r15 = r0 * r4;
+    r15 = fma(r7, r15, r2);
+    r13 = fma(r3, r6, r13);
+    r13 = fma(r9, r18, r13);
+    r13 = fma(r10, r14, r13);
+    r13 = fma(r0, r15, r13);
+  };
+  SumStore<double>(out_ThinPrismFisheyePose_pred_dec_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r13);
+  SumFlushFinal<double>(out_ThinPrismFisheyePose_pred_dec_local,
+                        out_ThinPrismFisheyePose_pred_dec,
+                        1);
+}
+
+void ThinPrismFisheyePosePredDecreaseTimesTwo(
+    double* ThinPrismFisheyePose_step,
+    unsigned int ThinPrismFisheyePose_step_num_alloc,
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_njtr,
+    unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+    double* const out_ThinPrismFisheyePose_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePosePredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_step,
+      ThinPrismFisheyePose_step_num_alloc,
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_njtr,
+      ThinPrismFisheyePose_njtr_num_alloc,
+      out_ThinPrismFisheyePose_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePosePredDecreaseTimesTwo(
+    double* ThinPrismFisheyePose_step,
+    unsigned int ThinPrismFisheyePose_step_num_alloc,
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_njtr,
+    unsigned int ThinPrismFisheyePose_njtr_num_alloc,
+    double* const out_ThinPrismFisheyePose_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_retract.cu
@@ -1,0 +1,139 @@
+#include "kernel_ThinPrismFisheyePose_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseRetractKernel(
+    double* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyePose,
+                                            0 * ThinPrismFisheyePose_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    r2 = 5.00000000000000000e-01;
+    r3 = 1.00000000000000008e-30;
+    ReadIdx2<1024, double, double, double2>(
+        delta, 2 * delta_num_alloc, global_thread_idx, r4, r5);
+    r3 = fma(r4, r4, r3);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r6, r7);
+    r3 = fma(r7, r7, r3);
+    r3 = fma(r6, r6, r3);
+    r8 = sqrt(r3);
+    r8 = r2 * r8;
+    r2 = cos(r8);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyePose,
+                                            2 * ThinPrismFisheyePose_num_alloc,
+                                            global_thread_idx,
+                                            r9,
+                                            r10);
+    r8 = sin(r8);
+    r3 = rsqrt(r3);
+    r3 = r8 * r3;
+    r6 = r6 * r3;
+    r8 = fma(r10, r6, r0 * r2);
+    r11 = r1 * r4;
+    r8 = fma(r3, r11, r8);
+    r12 = r9 * r7;
+    r13 = -1.00000000000000000e+00;
+    r12 = r12 * r13;
+    r8 = fma(r3, r12, r8);
+    r12 = fma(r9, r6, r1 * r2);
+    r11 = r0 * r4;
+    r11 = r11 * r13;
+    r12 = fma(r3, r11, r12);
+    r14 = r10 * r7;
+    r12 = fma(r3, r14, r12);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_retracted,
+        0 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r8,
+        r12);
+    r12 = r9 * r4;
+    r12 = fma(r3, r12, r0 * r6);
+    r8 = r1 * r7;
+    r12 = fma(r3, r8, r12);
+    r12 = fma(r10, r2, r13 * r12);
+    r8 = r1 * r13;
+    r8 = fma(r6, r8, r9 * r2);
+    r2 = r10 * r4;
+    r8 = fma(r3, r2, r8);
+    r6 = r0 * r7;
+    r8 = fma(r3, r6, r8);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_retracted,
+        2 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r8,
+        r12);
+    ReadIdx2<1024, double, double, double2>(ThinPrismFisheyePose,
+                                            4 * ThinPrismFisheyePose_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r8);
+    r5 = r12 + r5;
+    ReadIdx2<1024, double, double, double2>(
+        delta, 4 * delta_num_alloc, global_thread_idx, r12, r6);
+    r12 = r8 + r12;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_retracted,
+        4 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r5,
+        r12);
+    ReadIdx1<1024, double, double, double>(ThinPrismFisheyePose,
+                                           6 * ThinPrismFisheyePose_num_alloc,
+                                           global_thread_idx,
+                                           r12);
+    r6 = r12 + r6;
+    WriteIdx1<1024, double, double, double>(
+        out_ThinPrismFisheyePose_retracted,
+        6 * out_ThinPrismFisheyePose_retracted_num_alloc,
+        global_thread_idx,
+        r6);
+  };
+}
+
+void ThinPrismFisheyePoseRetract(
+    double* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose,
+      ThinPrismFisheyePose_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyePose_retracted,
+      out_ThinPrismFisheyePose_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseRetract(
+    double* ThinPrismFisheyePose,
+    unsigned int ThinPrismFisheyePose_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyePose_retracted,
+    unsigned int out_ThinPrismFisheyePose_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w.cu
@@ -1,0 +1,129 @@
+#include "kernel_ThinPrismFisheyePose_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseStartWKernel(
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        0 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        2 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        2 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        2 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        4 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePoseStartW(
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_p,
+      ThinPrismFisheyePose_p_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseStartW(
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w_contribute.cu
@@ -1,0 +1,130 @@
+#include "kernel_ThinPrismFisheyePose_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseStartWContributeKernel(
+        double* ThinPrismFisheyePose_precond_diag,
+        unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyePose_p,
+        unsigned int ThinPrismFisheyePose_p_num_alloc,
+        double* out_ThinPrismFisheyePose_w,
+        unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        0 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        0 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r1 = r1 * r2;
+    r1 = r1 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        2 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        2 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r4,
+        r3);
+    r1 = r1 * r4;
+    r0 = r0 * r2;
+    r0 = r0 * r3;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        2 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_precond_diag,
+        4 * ThinPrismFisheyePose_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p,
+        4 * ThinPrismFisheyePose_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePoseStartWContribute(
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_precond_diag,
+      ThinPrismFisheyePose_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePose_p,
+      ThinPrismFisheyePose_p_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseStartWContribute(
+    double* ThinPrismFisheyePose_precond_diag,
+    unsigned int ThinPrismFisheyePose_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePose_p,
+    unsigned int ThinPrismFisheyePose_p_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_Mp.cu
@@ -1,0 +1,147 @@
+#include "kernel_ThinPrismFisheyePose_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateMpKernel(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_Mp,
+        0 * ThinPrismFisheyePose_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        0 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_Mp_kp1,
+        0 * out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_Mp,
+        2 * ThinPrismFisheyePose_Mp_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        2 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r3 = fma(r3, r4, r5);
+    r2 = fma(r2, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_Mp_kp1,
+        2 * out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_Mp,
+        4 * ThinPrismFisheyePose_Mp_num_alloc,
+        global_thread_idx,
+        r6,
+        r5);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        4 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r6 = fma(r6, r4, r7);
+    r4 = fma(r5, r4, r8);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_Mp_kp1,
+        4 * out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r6,
+        r4);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        0 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        2 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_w,
+        4 * out_ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r6,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateMp(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_Mp,
+      ThinPrismFisheyePose_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyePose_Mp_kp1,
+      out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyePose_w,
+      out_ThinPrismFisheyePose_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateMp(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_Mp,
+    unsigned int ThinPrismFisheyePose_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePose_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyePose_w,
+    unsigned int out_ThinPrismFisheyePose_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_p.cu
@@ -1,0 +1,123 @@
+#include "kernel_ThinPrismFisheyePose_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdatePKernel(
+    double* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    double* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_k,
+        0 * ThinPrismFisheyePose_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_z,
+        0 * ThinPrismFisheyePose_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r1 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_p_kp1,
+        0 * out_ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_k,
+        2 * ThinPrismFisheyePose_p_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_z,
+        2 * ThinPrismFisheyePose_z_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_p_kp1,
+        2 * out_ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_k,
+        4 * ThinPrismFisheyePose_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_z,
+        4 * ThinPrismFisheyePose_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r0 = fma(r0, r4, r2);
+    r4 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_p_kp1,
+        4 * out_ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateP(
+    double* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    double* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_z,
+      ThinPrismFisheyePose_z_num_alloc,
+      ThinPrismFisheyePose_p_k,
+      ThinPrismFisheyePose_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyePose_p_kp1,
+      out_ThinPrismFisheyePose_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateP(
+    double* ThinPrismFisheyePose_z,
+    unsigned int ThinPrismFisheyePose_z_num_alloc,
+    double* ThinPrismFisheyePose_p_k,
+    unsigned int ThinPrismFisheyePose_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePose_p_kp1,
+    unsigned int out_ThinPrismFisheyePose_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r.cu
@@ -1,0 +1,141 @@
+#include "kernel_ThinPrismFisheyePose_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateRKernel(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePose_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        0 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        0 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        0 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        2 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        2 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    r5 = fma(r5, r4, r1);
+    r6 = fma(r6, r4, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        2 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        4 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        4 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r0);
+    r4 = fma(r8, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        4 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r4);
+    r5 = fma(r5, r5, r4 * r4);
+    r5 = fma(r6, r6, r5);
+    r5 = fma(r2, r2, r5);
+    r5 = fma(r7, r7, r5);
+    r5 = fma(r3, r3, r5);
+  };
+  SumStore<double>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r5);
+  SumFlushFinal<double>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyePoseUpdateR(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePose_r_kp1,
+      out_ThinPrismFisheyePose_r_kp1_num_alloc,
+      out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateR(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r_first.cu
@@ -1,0 +1,162 @@
+#include "kernel_ThinPrismFisheyePose_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseUpdateRFirstKernel(
+        double* ThinPrismFisheyePose_r_k,
+        unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+        double* ThinPrismFisheyePose_w,
+        unsigned int ThinPrismFisheyePose_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyePose_r_kp1,
+        unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+        double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePose_r_0_norm2_tot_local[1];
+
+  __shared__ double out_ThinPrismFisheyePose_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        0 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        0 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        0 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        2 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r5,
+        r6);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        2 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    r7 = fma(r7, r4, r5);
+    r8 = fma(r8, r4, r6);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        2 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r7,
+        r8);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_r_k,
+        4 * ThinPrismFisheyePose_r_k_num_alloc,
+        global_thread_idx,
+        r9,
+        r10);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_w,
+        4 * ThinPrismFisheyePose_w_num_alloc,
+        global_thread_idx,
+        r11,
+        r12);
+    r11 = fma(r11, r4, r9);
+    r4 = fma(r12, r4, r10);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_r_kp1,
+        4 * out_ThinPrismFisheyePose_r_kp1_num_alloc,
+        global_thread_idx,
+        r11,
+        r4);
+    r5 = fma(r5, r5, r1 * r1);
+    r5 = fma(r0, r0, r5);
+    r5 = fma(r6, r6, r5);
+    r5 = fma(r10, r10, r5);
+    r5 = fma(r9, r9, r5);
+  };
+  SumStore<double>(out_ThinPrismFisheyePose_r_0_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r5);
+  if (global_thread_idx < problem_size) {
+    r7 = fma(r7, r7, r4 * r4);
+    r7 = fma(r8, r8, r7);
+    r7 = fma(r2, r2, r7);
+    r7 = fma(r11, r11, r7);
+    r7 = fma(r3, r3, r7);
+  };
+  SumStore<double>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r7);
+  SumFlushFinal<double>(out_ThinPrismFisheyePose_r_0_norm2_tot_local,
+                        out_ThinPrismFisheyePose_r_0_norm2_tot,
+                        1);
+  SumFlushFinal<double>(out_ThinPrismFisheyePose_r_kp1_norm2_tot_local,
+                        out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+                        1);
+}
+
+void ThinPrismFisheyePoseUpdateRFirst(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_r_k,
+      ThinPrismFisheyePose_r_k_num_alloc,
+      ThinPrismFisheyePose_w,
+      ThinPrismFisheyePose_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePose_r_kp1,
+      out_ThinPrismFisheyePose_r_kp1_num_alloc,
+      out_ThinPrismFisheyePose_r_0_norm2_tot,
+      out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateRFirst(
+    double* ThinPrismFisheyePose_r_k,
+    unsigned int ThinPrismFisheyePose_r_k_num_alloc,
+    double* ThinPrismFisheyePose_w,
+    unsigned int ThinPrismFisheyePose_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePose_r_kp1,
+    unsigned int out_ThinPrismFisheyePose_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePose_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyePose_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step.cu
@@ -1,0 +1,123 @@
+#include "kernel_ThinPrismFisheyePose_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyePoseUpdateStepKernel(
+    double* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step_k,
+        0 * ThinPrismFisheyePose_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r3 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        0 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step_k,
+        2 * ThinPrismFisheyePose_step_k_num_alloc,
+        global_thread_idx,
+        r3,
+        r2);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        2 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = fma(r1, r4, r3);
+    r0 = fma(r0, r4, r2);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        2 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_step_k,
+        4 * ThinPrismFisheyePose_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r2, r4, r0);
+    r4 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        4 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateStep(
+    double* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_step_k,
+      ThinPrismFisheyePose_step_k_num_alloc,
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePose_step_kp1,
+      out_ThinPrismFisheyePose_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateStep(
+    double* ThinPrismFisheyePose_step_k,
+    unsigned int ThinPrismFisheyePose_step_k_num_alloc,
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step_first.cu
@@ -1,0 +1,100 @@
+#include "kernel_ThinPrismFisheyePose_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePoseUpdateStepFirstKernel(
+        double* ThinPrismFisheyePose_p_kp1,
+        unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyePose_step_kp1,
+        unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        0 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    r1 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        0 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        2 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    r1 = r1 * r2;
+    r0 = r0 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        2 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r1,
+        r0);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePose_p_kp1,
+        4 * ThinPrismFisheyePose_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    r0 = r0 * r2;
+    r2 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePose_step_kp1,
+        4 * out_ThinPrismFisheyePose_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePoseUpdateStepFirst(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePoseUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePose_p_kp1,
+      ThinPrismFisheyePose_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePose_step_kp1,
+      out_ThinPrismFisheyePose_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePose_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePoseUpdateStepFirst(
+    double* ThinPrismFisheyePose_p_kp1,
+    unsigned int ThinPrismFisheyePose_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePose_step_kp1,
+    unsigned int out_ThinPrismFisheyePose_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.cu
@@ -1,0 +1,75 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumeratorKernel(
+        double* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        double* const ThinPrismFisheyePrincipalPoint_out,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyePrincipalPoint_out_local[1];
+
+  double r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fma(r1, r3, r0 * r2);
+  };
+  SumStore<double>(ThinPrismFisheyePrincipalPoint_out_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(ThinPrismFisheyePrincipalPoint_out_local,
+                        ThinPrismFisheyePrincipalPoint_out,
+                        1);
+}
+
+void ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    double* const ThinPrismFisheyePrincipalPoint_out,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumeratorKernel<<<
+      n_blocks,
+      1024>>>(ThinPrismFisheyePrincipalPoint_p_kp1,
+              ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+              ThinPrismFisheyePrincipalPoint_w,
+              ThinPrismFisheyePrincipalPoint_w_num_alloc,
+              ThinPrismFisheyePrincipalPoint_out,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    double* const ThinPrismFisheyePrincipalPoint_out,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.cu
@@ -1,0 +1,103 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointAlphaNumeratorDenominatorKernel(
+        double* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        double* const ThinPrismFisheyePrincipalPoint_total_ag,
+        double* const ThinPrismFisheyePrincipalPoint_total_ac,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[256];
+
+  __shared__ double ThinPrismFisheyePrincipalPoint_total_ag_local[1];
+
+  __shared__ double ThinPrismFisheyePrincipalPoint_total_ac_local[1];
+
+  double r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r2 = fma(r0, r2, r1 * r3);
+  };
+  SumStore<double>(ThinPrismFisheyePrincipalPoint_total_ag_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    r3 = fma(r1, r3, r0 * r2);
+  };
+  SumStore<double>(ThinPrismFisheyePrincipalPoint_total_ac_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(ThinPrismFisheyePrincipalPoint_total_ag_local,
+                        ThinPrismFisheyePrincipalPoint_total_ag,
+                        1);
+  SumFlushFinal<double>(ThinPrismFisheyePrincipalPoint_total_ac_local,
+                        ThinPrismFisheyePrincipalPoint_total_ac,
+                        1);
+}
+
+void ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    double* const ThinPrismFisheyePrincipalPoint_total_ag,
+    double* const ThinPrismFisheyePrincipalPoint_total_ac,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointAlphaNumeratorDenominatorKernel<<<n_blocks,
+                                                                  1024>>>(
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      ThinPrismFisheyePrincipalPoint_total_ag,
+      ThinPrismFisheyePrincipalPoint_total_ac,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    double* const ThinPrismFisheyePrincipalPoint_total_ag,
+    double* const ThinPrismFisheyePrincipalPoint_total_ac,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_normalize.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_normalize.cu
@@ -1,0 +1,89 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_normalize.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointNormalizeKernel(
+        double* precond_diag,
+        unsigned int precond_diag_num_alloc,
+        double* precond_tril,
+        unsigned int precond_tril_num_alloc,
+        double* njtr,
+        unsigned int njtr_num_alloc,
+        const double* const diag,
+        double* out_normalized,
+        unsigned int out_normalized_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4, r5, r6;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        njtr, 0 * njtr_num_alloc, global_thread_idx, r0, r1);
+    ReadIdx2<1024, double, double, double2>(
+        precond_diag, 0 * precond_diag_num_alloc, global_thread_idx, r2, r3);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r5 = 1.00000000000000000e+00;
+    r5 = r4 + r5;
+    r6 = 1.00000000000000008e-15;
+    r6 = r4 * r6;
+    r2 = fma(r2, r5, r6);
+    r2 = 1.0 / r2;
+    r2 = r0 * r2;
+    r5 = fma(r3, r5, r6);
+    r5 = 1.0 / r5;
+    r5 = r1 * r5;
+    WriteIdx2<1024, double, double, double2>(out_normalized,
+                                             0 * out_normalized_num_alloc,
+                                             global_thread_idx,
+                                             r2,
+                                             r5);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointNormalize(
+    double* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    double* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    double* njtr,
+    unsigned int njtr_num_alloc,
+    const double* const diag,
+    double* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointNormalizeKernel<<<n_blocks, 1024>>>(
+      precond_diag,
+      precond_diag_num_alloc,
+      precond_tril,
+      precond_tril_num_alloc,
+      njtr,
+      njtr_num_alloc,
+      diag,
+      out_normalized,
+      out_normalized_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_normalize.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_normalize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointNormalize(
+    double* precond_diag,
+    unsigned int precond_diag_num_alloc,
+    double* precond_tril,
+    unsigned int precond_tril_num_alloc,
+    double* njtr,
+    unsigned int njtr_num_alloc,
+    const double* const diag,
+    double* out_normalized,
+    unsigned int out_normalized_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.cu
@@ -1,0 +1,100 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointPredDecreaseTimesTwoKernel(
+        double* ThinPrismFisheyePrincipalPoint_step,
+        unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyePrincipalPoint_njtr,
+        unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+        double* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePrincipalPoint_pred_dec_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_step,
+        0 * ThinPrismFisheyePrincipalPoint_step_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_njtr,
+        0 * ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r4,
+        r5);
+    r6 = r1 * r5;
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = fma(r7, r6, r3);
+    r3 = r0 * r4;
+    r3 = fma(r7, r3, r2);
+    r3 = fma(r0, r3, r1 * r6);
+  };
+  SumStore<double>(out_ThinPrismFisheyePrincipalPoint_pred_dec_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r3);
+  SumFlushFinal<double>(out_ThinPrismFisheyePrincipalPoint_pred_dec_local,
+                        out_ThinPrismFisheyePrincipalPoint_pred_dec,
+                        1);
+}
+
+void ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+    double* ThinPrismFisheyePrincipalPoint_step,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_njtr,
+    unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointPredDecreaseTimesTwoKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_step,
+      ThinPrismFisheyePrincipalPoint_step_num_alloc,
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_njtr,
+      ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_pred_dec,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+    double* ThinPrismFisheyePrincipalPoint_step,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_njtr,
+    unsigned int ThinPrismFisheyePrincipalPoint_njtr_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_pred_dec,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_retract.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_retract.cu
@@ -1,0 +1,69 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_retract.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointRetractKernel(
+        double* ThinPrismFisheyePrincipalPoint,
+        unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+        double* delta,
+        unsigned int delta_num_alloc,
+        double* out_ThinPrismFisheyePrincipalPoint_retracted,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  double r0, r1, r2, r3;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint,
+        0 * ThinPrismFisheyePrincipalPoint_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        delta, 0 * delta_num_alloc, global_thread_idx, r2, r3);
+    r2 = r0 + r2;
+    r3 = r1 + r3;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_retracted,
+        0 * out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointRetract(
+    double* ThinPrismFisheyePrincipalPoint,
+    unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_retracted,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointRetractKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint,
+      ThinPrismFisheyePrincipalPoint_num_alloc,
+      delta,
+      delta_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_retracted,
+      out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_retract.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_retract.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointRetract(
+    double* ThinPrismFisheyePrincipalPoint,
+    unsigned int ThinPrismFisheyePrincipalPoint_num_alloc,
+    double* delta,
+    unsigned int delta_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_retracted,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_retracted_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w.cu
@@ -1,0 +1,86 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointStartWKernel(
+        double* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyePrincipalPoint_p,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        double* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p,
+        0 * ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointStartW(
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointStartWKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_p,
+      ThinPrismFisheyePrincipalPoint_p_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointStartW(
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.cu
@@ -1,0 +1,86 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointStartWContributeKernel(
+        double* ThinPrismFisheyePrincipalPoint_precond_diag,
+        unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        const double* const diag,
+        double* ThinPrismFisheyePrincipalPoint_p,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        double* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_precond_diag,
+        0 * ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(diag, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p,
+        0 * ThinPrismFisheyePrincipalPoint_p_num_alloc,
+        global_thread_idx,
+        r3,
+        r4);
+    r0 = r0 * r3;
+    r2 = r1 * r2;
+    r2 = r2 * r4;
+    AddIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointStartWContribute(
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointStartWContributeKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_precond_diag,
+      ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+      diag,
+      ThinPrismFisheyePrincipalPoint_p,
+      ThinPrismFisheyePrincipalPoint_p_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointStartWContribute(
+    double* ThinPrismFisheyePrincipalPoint_precond_diag,
+    unsigned int ThinPrismFisheyePrincipalPoint_precond_diag_num_alloc,
+    const double* const diag,
+    double* ThinPrismFisheyePrincipalPoint_p,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.cu
@@ -1,0 +1,96 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateMpKernel(
+        double* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_Mp,
+        unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+        const double* const beta,
+        double* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+        double* out_ThinPrismFisheyePrincipalPoint_w,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_Mp,
+        0 * ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r4 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_w,
+        0 * out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateMp(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_Mp,
+    unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateMpKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_Mp,
+      ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+      beta,
+      out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+      out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_w,
+      out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateMp(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_Mp,
+    unsigned int ThinPrismFisheyePrincipalPoint_Mp_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePrincipalPoint_Mp_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_Mp_kp1_num_alloc,
+    double* out_ThinPrismFisheyePrincipalPoint_w,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_p.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_p.cu
@@ -1,0 +1,84 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_p.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdatePKernel(
+        double* ThinPrismFisheyePrincipalPoint_z,
+        unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_p_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+        const double* const beta,
+        double* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p_k,
+        0 * ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_z,
+        0 * ThinPrismFisheyePrincipalPoint_z_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(beta, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = fma(r0, r4, r2);
+    r4 = fma(r1, r4, r3);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateP(
+    double* ThinPrismFisheyePrincipalPoint_z,
+    unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_p_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdatePKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_z,
+      ThinPrismFisheyePrincipalPoint_z_num_alloc,
+      ThinPrismFisheyePrincipalPoint_p_k,
+      ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+      beta,
+      out_ThinPrismFisheyePrincipalPoint_p_kp1,
+      out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_p.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_p.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateP(
+    double* ThinPrismFisheyePrincipalPoint_z,
+    unsigned int ThinPrismFisheyePrincipalPoint_z_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_p_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_k_num_alloc,
+    const double* const beta,
+    double* out_ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r.cu
@@ -1,0 +1,99 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateRKernel(
+        double* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r4 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+    r2 = fma(r2, r2, r4 * r4);
+  };
+  SumStore<double>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  SumFlushFinal<double>(
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      1);
+}
+
+void ThinPrismFisheyePrincipalPointUpdateR(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateRKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateR(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.cu
@@ -1,0 +1,115 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateRFirstKernel(
+        double* ThinPrismFisheyePrincipalPoint_r_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_w,
+        unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        const double* const negalpha,
+        double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        double* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+        double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  __shared__ double out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local[1];
+
+  __shared__ double out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local[1];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_r_k,
+        0 * ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_w,
+        0 * ThinPrismFisheyePrincipalPoint_w_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(negalpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r4 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_r_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+    r1 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r1);
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r2, r4 * r4);
+  };
+  SumStore<double>(out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r2);
+  SumFlushFinal<double>(out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot_local,
+                        out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+                        1);
+  SumFlushFinal<double>(
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot_local,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      1);
+}
+
+void ThinPrismFisheyePrincipalPointUpdateRFirst(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateRFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_r_k,
+      ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_w,
+      ThinPrismFisheyePrincipalPoint_w_num_alloc,
+      negalpha,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+      out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+      out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateRFirst(
+    double* ThinPrismFisheyePrincipalPoint_r_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_r_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_w,
+    unsigned int ThinPrismFisheyePrincipalPoint_w_num_alloc,
+    const double* const negalpha,
+    double* out_ThinPrismFisheyePrincipalPoint_r_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_r_kp1_num_alloc,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_0_norm2_tot,
+    double* const out_ThinPrismFisheyePrincipalPoint_r_kp1_norm2_tot,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step.cu
@@ -1,0 +1,84 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateStepKernel(
+        double* ThinPrismFisheyePrincipalPoint_step_k,
+        unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+        double* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2, r3, r4;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_step_k,
+        0 * ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r3);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r2, r4, r0);
+    r4 = fma(r3, r4, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        global_thread_idx,
+        r2,
+        r4);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateStep(
+    double* ThinPrismFisheyePrincipalPoint_step_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateStepKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_step_k,
+      ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateStep(
+    double* ThinPrismFisheyePrincipalPoint_step_k,
+    unsigned int ThinPrismFisheyePrincipalPoint_step_k_num_alloc,
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.cu
@@ -1,0 +1,72 @@
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyePrincipalPointUpdateStepFirstKernel(
+        double* ThinPrismFisheyePrincipalPoint_p_kp1,
+        unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        const double* const alpha,
+        double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[8192];
+
+  double r0, r1, r2;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        ThinPrismFisheyePrincipalPoint_p_kp1,
+        0 * ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r1);
+  };
+  LoadUnique<1, double, double>(alpha, 0, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>((double*)inout_shared, 0, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r0 = r0 * r2;
+    r2 = r1 * r2;
+    WriteIdx2<1024, double, double, double2>(
+        out_ThinPrismFisheyePrincipalPoint_step_kp1,
+        0 * out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+        global_thread_idx,
+        r0,
+        r2);
+  };
+}
+
+void ThinPrismFisheyePrincipalPointUpdateStepFirst(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyePrincipalPointUpdateStepFirstKernel<<<n_blocks, 1024>>>(
+      ThinPrismFisheyePrincipalPoint_p_kp1,
+      ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+      alpha,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1,
+      out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyePrincipalPointUpdateStepFirst(
+    double* ThinPrismFisheyePrincipalPoint_p_kp1,
+    unsigned int ThinPrismFisheyePrincipalPoint_p_kp1_num_alloc,
+    const double* const alpha,
+    double* out_ThinPrismFisheyePrincipalPoint_step_kp1,
+    unsigned int out_ThinPrismFisheyePrincipalPoint_step_kp1_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,334 @@
+#include "kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        double* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                2 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                10 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 14 * calib_jac_num_alloc, global_thread_idx, r6, r7);
+    r5 = fma(r5, r7, r3);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                8 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r3,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 10 * calib_jac_num_alloc, global_thread_idx, r9, r10);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                6 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r11,
+                        r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 6 * calib_jac_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 8 * calib_jac_num_alloc, global_thread_idx, r15, r16);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 12 * calib_jac_num_alloc, global_thread_idx, r17, r18);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                4 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r19,
+                        r20);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 4 * calib_jac_num_alloc, global_thread_idx, r21, r22);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 2 * calib_jac_num_alloc, global_thread_idx, r23, r24);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                0 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r25,
+                        r26);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 0 * calib_jac_num_alloc, global_thread_idx, r27, r28);
+    r5 = fma(r3, r10, r5);
+    r5 = fma(r11, r14, r5);
+    r5 = fma(r12, r16, r5);
+    r5 = fma(r8, r18, r5);
+    r5 = fma(r20, r22, r5);
+    r5 = fma(r19, r24, r5);
+    r5 = fma(r26, r28, r5);
+    r4 = fma(r4, r6, r2);
+    r4 = fma(r8, r17, r4);
+    r4 = fma(r3, r9, r4);
+    r4 = fma(r20, r21, r4);
+    r4 = fma(r12, r15, r4);
+    r4 = fma(r11, r13, r4);
+    r4 = fma(r19, r23, r4);
+    r4 = fma(r25, r27, r4);
+    r25 = fma(r0, r4, r1 * r5);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r19, r11);
+    r12 = fma(r19, r4, r11 * r5);
+    WriteSum2<double, double>((double*)inout_shared, r25, r12);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r12, r25);
+    r20 = fma(r12, r4, r25 * r5);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r3, r8);
+    r2 = fma(r3, r4, r8 * r5);
+    WriteSum2<double, double>((double*)inout_shared, r20, r2);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r2, r20);
+    r26 = fma(r2, r4, r20 * r5);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r29, r30);
+    r4 = fma(r29, r4, r30 * r5);
+    WriteSum2<double, double>((double*)inout_shared, r26, r4);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r4,
+                        r26);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r4, r2, r26 * r29);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r29,
+                        r5);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r31,
+                        r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r29, r12, r2);
+    r2 = fma(r5, r3, r2);
+    r2 = fma(r31, r0, r2);
+    r2 = fma(r32, r19, r2);
+    r27 = r27 * r2;
+    r8 = fma(r5, r8, r26 * r30);
+    r8 = fma(r29, r25, r8);
+    r8 = fma(r31, r1, r8);
+    r8 = fma(r32, r11, r8);
+    r8 = fma(r4, r20, r8);
+    r28 = r28 * r8;
+    WriteSum2<double, double>((double*)inout_shared, r27, r28);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r2, r8);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = fma(r24, r8, r23 * r2);
+    r21 = fma(r21, r2, r22 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r24, r21);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = fma(r13, r2, r14 * r8);
+    r15 = fma(r15, r2, r16 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r13, r15);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = fma(r9, r2, r10 * r8);
+    r17 = fma(r17, r2, r18 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r9, r17);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r6 * r2;
+    r8 = r7 * r8;
+    WriteSum2<double, double>((double*)inout_shared, r2, r8);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac.cu
@@ -1,0 +1,2462 @@
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = r18 * r18;
+    r21 = -2.00000000000000000e+00;
+    r19 = r19 * r21;
+    r22 = 1.00000000000000000e+00;
+    r23 = r15 * r13;
+    r24 = r11 * r17;
+    r25 = r23 + r24;
+    r26 = r14 * r12;
+    r27 = r10 * r16;
+    r25 = r25 + r26;
+    r25 = fma(r20, r27, r25);
+    r28 = r21 * r25;
+    r28 = fma(r25, r28, r22);
+    r29 = r19 + r28;
+    r29 = fma(r8, r29, r6);
+    r6 = 2.00000000000000000e+00;
+    r30 = fma(r11, r16, r14 * r13);
+    r31 = r15 * r12;
+    r30 = fma(r20, r31, r30);
+    r30 = fma(r10, r17, r30);
+    r31 = r6 * r30;
+    r31 = r31 * r25;
+    r32 = r18 * r21;
+    r33 = fma(r15, r17, r14 * r16);
+    r33 = fma(r10, r12, r33);
+    r33 = fma(r20, r33, r11 * r13);
+    r32 = fma(r33, r32, r31);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r34);
+    r35 = r6 * r18;
+    r35 = r35 * r30;
+    r36 = r6 * r25;
+    r36 = fma(r33, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r16 * r12;
+    r38 = r38 * r6;
+    r39 = r17 * r13;
+    r39 = fma(r6, r39, r38);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r40, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r12 * r13;
+    r43 = r16 * r17;
+    r43 = r43 * r6;
+    r42 = fma(r21, r42, r43);
+    r44 = r17 * r17;
+    r44 = r44 * r21;
+    r45 = r22 + r44;
+    r46 = r12 * r12;
+    r46 = r46 * r21;
+    r45 = r45 + r46;
+    r29 = fma(r9, r32, r29);
+    r29 = fma(r34, r36, r29);
+    r29 = fma(r37, r39, r29);
+    r29 = fma(r41, r42, r29);
+    r29 = fma(r40, r45, r29);
+    r36 = r29 * r29;
+    r32 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r47);
+    r48 = r21 * r25;
+    r48 = fma(r33, r48, r35);
+    r48 = fma(r8, r48, r47);
+    r47 = r17 * r13;
+    r47 = fma(r21, r47, r38);
+    r44 = r22 + r44;
+    r38 = r16 * r16;
+    r38 = r38 * r21;
+    r44 = r44 + r38;
+    r35 = r17 * r12;
+    r35 = r35 * r6;
+    r49 = r16 * r13;
+    r49 = fma(r6, r49, r35);
+    r50 = r6 * r18;
+    r50 = r50 * r25;
+    r51 = r6 * r30;
+    r51 = fma(r33, r51, r50);
+    r52 = r30 * r30;
+    r52 = r52 * r21;
+    r28 = r52 + r28;
+    r48 = fma(r40, r47, r48);
+    r48 = fma(r37, r44, r48);
+    r48 = fma(r41, r49, r48);
+    r48 = fma(r9, r51, r48);
+    r48 = fma(r34, r28, r48);
+    r28 = copysign(1.0, r48);
+    r28 = fma(r32, r28, r48);
+    r48 = r28 * r28;
+    r51 = 1.0 / r48;
+    r53 = r6 * r18;
+    r53 = fma(r33, r53, r31);
+    r53 = fma(r8, r53, r7);
+    r7 = r12 * r13;
+    r7 = fma(r6, r7, r43);
+    r46 = r22 + r46;
+    r46 = r46 + r38;
+    r38 = r16 * r13;
+    r38 = fma(r21, r38, r35);
+    r35 = r30 * r21;
+    r35 = fma(r33, r35, r50);
+    r19 = r22 + r19;
+    r19 = r19 + r52;
+    r53 = fma(r40, r7, r53);
+    r53 = fma(r41, r46, r53);
+    r53 = fma(r37, r38, r53);
+    r53 = fma(r34, r35, r53);
+    r53 = fma(r9, r19, r53);
+    r19 = r53 * r53;
+    r19 = fma(r51, r19, r51 * r36);
+    r36 = sqrt(r19);
+    r35 = atan(r36);
+    r37 = r53 * r35;
+    r41 = copysign(1.0, r36);
+    r41 = fma(r32, r41, r36);
+    r32 = r41 * r41;
+    r36 = 1.0 / r32;
+    r40 = r51 * r36;
+    r52 = r37 * r40;
+    r50 = r53 * r52;
+    r43 = r35 * r50;
+    r31 = r29 * r35;
+    r54 = 3.00000000000000000e+00;
+    r55 = r29 * r35;
+    r31 = r31 * r54;
+    r31 = r31 * r40;
+    r31 = fma(r55, r31, r43);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r56, r57);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r58 = r29 * r35;
+    r58 = r58 * r40;
+    r58 = r58 * r55;
+    r43 = r43 + r58;
+    r59 = fma(r56, r43, r5 * r31);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r60, r61);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r62 = r43 * r43;
+    r63 = fma(r61, r62, r60 * r43);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r64, r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r62 * r62;
+    r67 = r43 * r62;
+    r63 = fma(r65, r66, r63);
+    r63 = fma(r64, r67, r63);
+    r68 = 1.0 / r28;
+    r69 = 1.0 / r41;
+    r70 = r68 * r69;
+    r71 = r63 * r70;
+    r72 = r4 * r6;
+    r72 = r72 * r55;
+    r59 = fma(r52, r72, r59);
+    r59 = fma(r55, r71, r59);
+    r59 = fma(r70, r55, r59);
+    r0 = fma(r2, r59, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r72, r73);
+    r0 = fma(r72, r20, r0);
+    r72 = r35 * r54;
+    r72 = fma(r50, r72, r58);
+    r58 = fma(r57, r43, r4 * r72);
+    r74 = r5 * r6;
+    r74 = r74 * r55;
+    r58 = fma(r52, r74, r58);
+    r58 = fma(r37, r71, r58);
+    r58 = fma(r37, r70, r58);
+    r1 = fma(r3, r58, r1);
+    r1 = fma(r73, r20, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r73 = r6 * r29;
+    r74 = r14 * r13;
+    r75 = -5.00000000000000000e-01;
+    r76 = r11 * r16;
+    r76 = fma(r75, r76, r75 * r74);
+    r74 = r10 * r17;
+    r76 = fma(r75, r74, r76);
+    r77 = r15 * r12;
+    r78 = 5.00000000000000000e-01;
+    r76 = fma(r78, r77, r76);
+    r77 = r25 * r76;
+    r74 = r10 * r13;
+    r79 = r15 * r16;
+    r79 = fma(r78, r79, r78 * r74);
+    r74 = r14 * r17;
+    r79 = fma(r75, r74, r79);
+    r80 = r11 * r12;
+    r79 = fma(r78, r80, r79);
+    r80 = r33 * r79;
+    r74 = fma(r6, r80, r6 * r77);
+    r81 = r6 * r30;
+    r82 = fma(r78, r27, r75 * r23);
+    r82 = fma(r75, r24, r82);
+    r82 = fma(r75, r26, r82);
+    r83 = r6 * r18;
+    r84 = r11 * r13;
+    r85 = r14 * r16;
+    r85 = fma(r75, r85, r78 * r84);
+    r84 = r15 * r17;
+    r85 = fma(r75, r84, r85);
+    r86 = r10 * r12;
+    r85 = fma(r75, r86, r85);
+    r83 = r83 * r85;
+    r81 = fma(r82, r81, r83);
+    r74 = r74 + r81;
+    r86 = r6 * r25;
+    r86 = r86 * r85;
+    r84 = r6 * r30;
+    r84 = r84 * r79;
+    r87 = r86 + r84;
+    r88 = r18 * r21;
+    r87 = fma(r76, r88, r87);
+    r89 = r21 * r33;
+    r87 = fma(r82, r89, r87);
+    r87 = fma(r9, r87, r34 * r74);
+    r74 = r25 * r79;
+    r89 = -4.00000000000000000e+00;
+    r74 = r74 * r89;
+    r88 = r18 * r82;
+    r90 = r89 * r88;
+    r91 = r74 + r90;
+    r87 = fma(r8, r91, r87);
+    r73 = r73 * r87;
+    r91 = r6 * r25;
+    r91 = r91 * r82;
+    r92 = r6 * r18;
+    r92 = fma(r79, r92, r91);
+    r79 = r6 * r30;
+    r79 = r79 * r76;
+    r93 = r6 * r33;
+    r93 = r93 * r85;
+    r94 = r79 + r93;
+    r95 = r92 + r94;
+    r80 = fma(r21, r80, r21 * r77);
+    r80 = r80 + r81;
+    r80 = fma(r8, r80, r9 * r95);
+    r95 = r30 * r85;
+    r95 = r95 * r89;
+    r74 = r74 + r95;
+    r80 = fma(r34, r74, r80);
+    r74 = r29 * r29;
+    r48 = r28 * r48;
+    r96 = 1.0 / r48;
+    r97 = r21 * r96;
+    r74 = r74 * r97;
+    r73 = fma(r80, r74, r51 * r73);
+    r98 = r53 * r53;
+    r98 = r98 * r80;
+    r73 = fma(r97, r98, r73);
+    r99 = r6 * r53;
+    r100 = r30 * r21;
+    r101 = r21 * r33;
+    r101 = r101 * r85;
+    r100 = fma(r76, r100, r101);
+    r100 = r100 + r92;
+    r90 = r95 + r90;
+    r90 = fma(r9, r90, r34 * r100);
+    r100 = r6 * r33;
+    r100 = fma(r82, r100, r84);
+    r84 = r6 * r18;
+    r84 = fma(r76, r84, r86);
+    r100 = r100 + r84;
+    r90 = fma(r8, r100, r90);
+    r99 = r99 * r90;
+    r73 = fma(r51, r99, r73);
+    r99 = r54 * r73;
+    r98 = r40 * r55;
+    r100 = rsqrt(r19);
+    r19 = r22 + r19;
+    r19 = 1.0 / r19;
+    r86 = r100 * r19;
+    r95 = r29 * r86;
+    r99 = r99 * r98;
+    r92 = -3.00000000000000000e+00;
+    r92 = r35 * r92;
+    r32 = r41 * r32;
+    r102 = 1.0 / r32;
+    r92 = r92 * r51;
+    r92 = r92 * r100;
+    r92 = r92 * r102;
+    r103 = r73 * r92;
+    r104 = r35 * r74;
+    r103 = fma(r104, r103, r95 * r99);
+    r99 = r35 * r87;
+    r105 = 6.00000000000000000e+00;
+    r99 = r99 * r105;
+    r99 = r99 * r40;
+    r103 = fma(r55, r99, r103);
+    r106 = r35 * r80;
+    r107 = -6.00000000000000000e+00;
+    r106 = r106 * r107;
+    r106 = r106 * r36;
+    r106 = r106 * r96;
+    r108 = r29 * r106;
+    r103 = fma(r55, r108, r103);
+    r109 = r53 * r35;
+    r109 = r109 * r80;
+    r109 = r109 * r36;
+    r109 = r109 * r37;
+    r110 = r86 * r50;
+    r109 = fma(r73, r110, r97 * r109);
+    r111 = r20 * r53;
+    r111 = r111 * r35;
+    r111 = r111 * r73;
+    r111 = r111 * r51;
+    r111 = r111 * r100;
+    r111 = r111 * r102;
+    r109 = fma(r37, r111, r109);
+    r112 = r90 * r52;
+    r113 = r6 * r35;
+    r109 = fma(r113, r112, r109);
+    r103 = r103 + r109;
+    r108 = r73 * r98;
+    r99 = r20 * r29;
+    r99 = r99 * r29;
+    r99 = r99 * r35;
+    r99 = r99 * r35;
+    r99 = r99 * r73;
+    r99 = r99 * r51;
+    r99 = r99 * r100;
+    r99 = fma(r102, r99, r95 * r108);
+    r108 = r113 * r98;
+    r112 = r35 * r36;
+    r112 = r112 * r97;
+    r112 = r104 * r112;
+    r99 = fma(r87, r108, r99);
+    r99 = fma(r80, r112, r99);
+    r109 = r109 + r99;
+    r103 = fma(r56, r109, r5 * r103);
+    r111 = r75 * r73;
+    r111 = r111 * r36;
+    r111 = r111 * r68;
+    r111 = r111 * r100;
+    r114 = r63 * r111;
+    r115 = r4 * r87;
+    r115 = r115 * r52;
+    r103 = fma(r113, r115, r103);
+    r116 = r29 * r35;
+    r103 = fma(r111, r116, r103);
+    r117 = r4 * r73;
+    r118 = r6 * r52;
+    r118 = r118 * r95;
+    r103 = fma(r118, r117, r103);
+    r119 = r4 * r21;
+    r119 = r119 * r73;
+    r119 = r119 * r51;
+    r119 = r119 * r100;
+    r119 = r119 * r102;
+    r119 = r119 * r37;
+    r103 = fma(r55, r119, r103);
+    r120 = r78 * r73;
+    r120 = r120 * r70;
+    r103 = fma(r95, r120, r103);
+    r121 = r4 * r108;
+    r122 = r61 * r6;
+    r122 = r122 * r43;
+    r122 = fma(r109, r122, r60 * r109);
+    r123 = 4.00000000000000000e+00;
+    r65 = r65 * r123;
+    r65 = r65 * r67;
+    r64 = r64 * r54;
+    r64 = r64 * r62;
+    r122 = fma(r109, r65, r122);
+    r122 = fma(r109, r64, r122);
+    r124 = r122 * r70;
+    r103 = fma(r55, r124, r103);
+    r125 = r4 * r80;
+    r126 = r89 * r36;
+    r126 = r126 * r96;
+    r126 = r126 * r37;
+    r126 = r126 * r55;
+    r103 = fma(r126, r125, r103);
+    r127 = r20 * r29;
+    r127 = r127 * r35;
+    r127 = r127 * r80;
+    r127 = r127 * r51;
+    r103 = fma(r69, r127, r103);
+    r128 = r35 * r87;
+    r103 = fma(r70, r128, r103);
+    r129 = r78 * r71;
+    r130 = r95 * r129;
+    r131 = r20 * r29;
+    r131 = r131 * r35;
+    r131 = r131 * r63;
+    r131 = r131 * r80;
+    r131 = r131 * r51;
+    r103 = fma(r69, r131, r103);
+    r132 = r35 * r87;
+    r103 = fma(r71, r132, r103);
+    r103 = fma(r114, r55, r103);
+    r103 = fma(r90, r121, r103);
+    r103 = fma(r73, r130, r103);
+    r132 = r2 * r103;
+    r131 = r53 * r37;
+    r128 = r54 * r73;
+    r128 = fma(r110, r128, r106 * r131);
+    r131 = r53 * r37;
+    r131 = r131 * r92;
+    r127 = r35 * r90;
+    r127 = r127 * r105;
+    r128 = fma(r52, r127, r128);
+    r128 = fma(r73, r131, r128);
+    r128 = r128 + r99;
+    r109 = fma(r57, r109, r4 * r128);
+    r128 = r35 * r90;
+    r109 = fma(r71, r128, r109);
+    r99 = r122 * r37;
+    r109 = fma(r70, r99, r109);
+    r127 = r20 * r80;
+    r127 = r127 * r51;
+    r127 = r127 * r69;
+    r109 = fma(r37, r127, r109);
+    r125 = r5 * r87;
+    r125 = r125 * r52;
+    r109 = fma(r113, r125, r109);
+    r124 = r5 * r73;
+    r109 = fma(r118, r124, r109);
+    r120 = r5 * r21;
+    r120 = r120 * r73;
+    r120 = r120 * r51;
+    r120 = r120 * r100;
+    r120 = r120 * r102;
+    r120 = r120 * r37;
+    r109 = fma(r55, r120, r109);
+    r119 = r53 * r78;
+    r119 = r119 * r73;
+    r119 = r119 * r70;
+    r109 = fma(r86, r119, r109);
+    r117 = r53 * r73;
+    r117 = r117 * r86;
+    r109 = fma(r129, r117, r109);
+    r116 = r5 * r90;
+    r109 = fma(r108, r116, r109);
+    r115 = r5 * r126;
+    r133 = r35 * r90;
+    r109 = fma(r70, r133, r109);
+    r134 = r20 * r63;
+    r134 = r134 * r80;
+    r134 = r134 * r51;
+    r134 = r134 * r69;
+    r109 = fma(r37, r134, r109);
+    r109 = fma(r37, r111, r109);
+    r109 = fma(r80, r115, r109);
+    r109 = fma(r37, r114, r109);
+    r134 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r134);
+    r134 = r21 * r25;
+    r134 = fma(r82, r134, r101);
+    r132 = r6 * r18;
+    r133 = r10 * r13;
+    r114 = r15 * r16;
+    r114 = fma(r75, r114, r75 * r133);
+    r133 = r14 * r17;
+    r114 = fma(r78, r133, r114);
+    r116 = r11 * r12;
+    r114 = fma(r75, r116, r114);
+    r132 = r132 * r114;
+    r116 = r6 * r30;
+    r133 = r14 * r13;
+    r117 = r11 * r16;
+    r117 = fma(r78, r117, r78 * r133);
+    r133 = r10 * r17;
+    r117 = fma(r78, r133, r117);
+    r119 = r15 * r12;
+    r117 = fma(r75, r119, r117);
+    r116 = fma(r117, r116, r132);
+    r134 = r134 + r116;
+    r119 = r6 * r25;
+    r119 = r119 * r117;
+    r133 = r6 * r33;
+    r133 = fma(r114, r133, r119);
+    r133 = r133 + r81;
+    r133 = fma(r9, r133, r8 * r134);
+    r134 = r25 * r85;
+    r134 = r134 * r89;
+    r81 = r30 * r114;
+    r111 = r89 * r81;
+    r120 = r134 + r111;
+    r133 = fma(r34, r120, r133);
+    r93 = r91 + r93;
+    r93 = r93 + r116;
+    r116 = r18 * r89;
+    r116 = r116 * r117;
+    r134 = r134 + r116;
+    r134 = fma(r8, r134, r34 * r93);
+    r93 = r21 * r33;
+    r93 = fma(r21, r88, r117 * r93);
+    r91 = r6 * r30;
+    r91 = r91 * r85;
+    r120 = r6 * r25;
+    r120 = fma(r114, r120, r91);
+    r93 = r93 + r120;
+    r134 = fma(r9, r93, r134);
+    r93 = fma(r134, r108, r133 * r112);
+    r124 = r20 * r29;
+    r125 = r6 * r29;
+    r125 = r125 * r134;
+    r127 = r6 * r53;
+    r119 = r83 + r119;
+    r83 = r30 * r21;
+    r119 = fma(r82, r83, r119);
+    r82 = r21 * r33;
+    r119 = fma(r114, r82, r119);
+    r82 = r6 * r33;
+    r88 = fma(r6, r88, r117 * r82);
+    r88 = r88 + r120;
+    r88 = fma(r8, r88, r34 * r119);
+    r111 = r116 + r111;
+    r88 = fma(r9, r111, r88);
+    r127 = r127 * r88;
+    r127 = fma(r51, r127, r51 * r125);
+    r125 = r53 * r53;
+    r125 = r125 * r133;
+    r127 = fma(r97, r125, r127);
+    r127 = fma(r133, r74, r127);
+    r124 = r124 * r29;
+    r124 = r124 * r35;
+    r124 = r124 * r35;
+    r124 = r124 * r127;
+    r124 = r124 * r51;
+    r124 = r124 * r100;
+    r93 = fma(r102, r124, r93);
+    r125 = r127 * r98;
+    r93 = fma(r95, r125, r93);
+    r125 = r88 * r52;
+    r124 = r20 * r53;
+    r124 = r124 * r35;
+    r124 = r124 * r127;
+    r124 = r124 * r51;
+    r124 = r124 * r100;
+    r124 = r124 * r102;
+    r124 = fma(r37, r124, r113 * r125);
+    r125 = r53 * r35;
+    r125 = r125 * r133;
+    r125 = r125 * r36;
+    r125 = r125 * r37;
+    r124 = fma(r97, r125, r124);
+    r124 = fma(r127, r110, r124);
+    r125 = r93 + r124;
+    r111 = r29 * r29;
+    r111 = r111 * r35;
+    r111 = r111 * r35;
+    r111 = r111 * r107;
+    r111 = r111 * r133;
+    r111 = r111 * r36;
+    r116 = r35 * r105;
+    r116 = r116 * r134;
+    r116 = r116 * r40;
+    r116 = fma(r55, r116, r96 * r111);
+    r111 = r127 * r92;
+    r116 = fma(r104, r111, r116);
+    r119 = r54 * r127;
+    r119 = r119 * r98;
+    r116 = fma(r95, r119, r116);
+    r116 = r116 + r124;
+    r116 = fma(r5, r116, r56 * r125);
+    r124 = r20 * r29;
+    r124 = r124 * r35;
+    r124 = r124 * r133;
+    r124 = r124 * r51;
+    r116 = fma(r69, r124, r116);
+    r119 = r78 * r127;
+    r119 = r119 * r70;
+    r116 = fma(r95, r119, r116);
+    r111 = r35 * r134;
+    r116 = fma(r71, r111, r116);
+    r82 = r61 * r6;
+    r82 = r82 * r43;
+    r82 = fma(r125, r82, r60 * r125);
+    r82 = fma(r125, r65, r82);
+    r82 = fma(r125, r64, r82);
+    r117 = r82 * r70;
+    r116 = fma(r55, r117, r116);
+    r83 = r127 * r118;
+    r99 = r4 * r133;
+    r116 = fma(r126, r99, r116);
+    r128 = r4 * r134;
+    r128 = r128 * r52;
+    r116 = fma(r113, r128, r116);
+    r135 = r4 * r21;
+    r135 = r135 * r127;
+    r135 = r135 * r51;
+    r135 = r135 * r100;
+    r135 = r135 * r102;
+    r135 = r135 * r37;
+    r116 = fma(r55, r135, r116);
+    r136 = r20 * r29;
+    r136 = r136 * r35;
+    r136 = r136 * r63;
+    r136 = r136 * r133;
+    r136 = r136 * r51;
+    r116 = fma(r69, r136, r116);
+    r137 = r35 * r134;
+    r116 = fma(r70, r137, r116);
+    r138 = r29 * r35;
+    r138 = r138 * r63;
+    r138 = r138 * r75;
+    r138 = r138 * r127;
+    r138 = r138 * r36;
+    r138 = r138 * r68;
+    r116 = fma(r100, r138, r116);
+    r139 = r29 * r35;
+    r139 = r139 * r75;
+    r139 = r139 * r127;
+    r139 = r139 * r36;
+    r139 = r139 * r68;
+    r116 = fma(r100, r139, r116);
+    r116 = fma(r88, r121, r116);
+    r116 = fma(r4, r83, r116);
+    r116 = fma(r127, r130, r116);
+    r139 = r2 * r116;
+    r138 = r35 * r105;
+    r138 = r138 * r88;
+    r138 = fma(r127, r131, r52 * r138);
+    r137 = r53 * r35;
+    r137 = r137 * r107;
+    r137 = r137 * r133;
+    r137 = r137 * r36;
+    r137 = r137 * r96;
+    r138 = fma(r37, r137, r138);
+    r136 = r54 * r127;
+    r138 = fma(r110, r136, r138);
+    r138 = r138 + r93;
+    r138 = fma(r4, r138, r57 * r125);
+    r125 = r20 * r63;
+    r125 = r125 * r133;
+    r125 = r125 * r51;
+    r125 = r125 * r69;
+    r138 = fma(r37, r125, r138);
+    r93 = r63 * r75;
+    r93 = r93 * r127;
+    r93 = r93 * r36;
+    r93 = r93 * r68;
+    r93 = r93 * r100;
+    r138 = fma(r37, r93, r138);
+    r136 = r75 * r127;
+    r136 = r136 * r36;
+    r136 = r136 * r68;
+    r136 = r136 * r100;
+    r138 = fma(r37, r136, r138);
+    r137 = r5 * r88;
+    r138 = fma(r108, r137, r138);
+    r135 = r53 * r78;
+    r135 = r135 * r127;
+    r135 = r135 * r70;
+    r138 = fma(r86, r135, r138);
+    r128 = r5 * r134;
+    r128 = r128 * r52;
+    r138 = fma(r113, r128, r138);
+    r99 = r5 * r21;
+    r99 = r99 * r127;
+    r99 = r99 * r51;
+    r99 = r99 * r100;
+    r99 = r99 * r102;
+    r99 = r99 * r37;
+    r138 = fma(r55, r99, r138);
+    r117 = r82 * r37;
+    r138 = fma(r70, r117, r138);
+    r111 = r20 * r133;
+    r111 = r111 * r51;
+    r111 = r111 * r69;
+    r138 = fma(r37, r111, r138);
+    r119 = r53 * r127;
+    r119 = r119 * r86;
+    r138 = fma(r129, r119, r138);
+    r124 = r35 * r88;
+    r138 = fma(r70, r124, r138);
+    r140 = r35 * r88;
+    r138 = fma(r71, r140, r138);
+    r138 = fma(r5, r83, r138);
+    r138 = fma(r133, r115, r138);
+    r140 = r3 * r138;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r139,
+                                             r140);
+    r140 = r53 * r35;
+    r139 = r30 * r89;
+    r27 = fma(r75, r27, r78 * r23);
+    r27 = fma(r78, r24, r27);
+    r27 = fma(r78, r26, r27);
+    r139 = r139 * r27;
+    r77 = r89 * r77;
+    r26 = r139 + r77;
+    r24 = r6 * r18;
+    r24 = r24 * r27;
+    r91 = r91 + r24;
+    r23 = r21 * r25;
+    r91 = fma(r114, r23, r91);
+    r124 = r21 * r33;
+    r91 = fma(r76, r124, r91);
+    r91 = fma(r8, r91, r34 * r26);
+    r26 = r6 * r33;
+    r26 = fma(r6, r81, r27 * r26);
+    r26 = r26 + r84;
+    r91 = fma(r9, r26, r91);
+    r140 = r140 * r91;
+    r140 = r140 * r36;
+    r140 = r140 * r37;
+    r26 = r6 * r53;
+    r124 = r6 * r25;
+    r124 = r124 * r27;
+    r132 = r132 + r124;
+    r132 = r132 + r94;
+    r94 = r21 * r33;
+    r81 = fma(r21, r81, r27 * r94);
+    r81 = r81 + r84;
+    r81 = fma(r34, r81, r8 * r132);
+    r85 = r18 * r85;
+    r85 = r85 * r89;
+    r139 = r139 + r85;
+    r81 = fma(r9, r139, r81);
+    r26 = r26 * r81;
+    r26 = fma(r91, r74, r51 * r26);
+    r139 = r6 * r29;
+    r101 = r79 + r101;
+    r79 = r18 * r21;
+    r101 = fma(r114, r79, r101);
+    r101 = r101 + r124;
+    r77 = r85 + r77;
+    r77 = fma(r8, r77, r9 * r101);
+    r8 = r6 * r33;
+    r8 = fma(r76, r8, r24);
+    r8 = r8 + r120;
+    r77 = fma(r34, r8, r77);
+    r139 = r139 * r77;
+    r26 = fma(r51, r139, r26);
+    r8 = r53 * r53;
+    r8 = r8 * r91;
+    r26 = fma(r97, r8, r26);
+    r140 = fma(r26, r110, r97 * r140);
+    r8 = r81 * r52;
+    r140 = fma(r113, r8, r140);
+    r139 = r20 * r53;
+    r139 = r139 * r35;
+    r139 = r139 * r26;
+    r139 = r139 * r51;
+    r139 = r139 * r100;
+    r139 = r139 * r102;
+    r140 = fma(r37, r139, r140);
+    r139 = r20 * r29;
+    r139 = r139 * r29;
+    r139 = r139 * r35;
+    r139 = r139 * r35;
+    r139 = r139 * r26;
+    r139 = r139 * r51;
+    r139 = r139 * r100;
+    r139 = fma(r77, r108, r102 * r139);
+    r8 = r26 * r98;
+    r139 = fma(r95, r8, r139);
+    r139 = fma(r91, r112, r139);
+    r8 = r140 + r139;
+    r34 = r26 * r92;
+    r120 = r35 * r105;
+    r120 = r120 * r77;
+    r120 = r120 * r40;
+    r120 = fma(r55, r120, r104 * r34);
+    r34 = r29 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r107;
+    r34 = r34 * r91;
+    r34 = r34 * r36;
+    r120 = fma(r96, r34, r120);
+    r24 = r54 * r26;
+    r24 = r24 * r98;
+    r120 = fma(r95, r24, r120);
+    r120 = r120 + r140;
+    r120 = fma(r5, r120, r56 * r8);
+    r140 = r61 * r6;
+    r140 = r140 * r43;
+    r140 = fma(r8, r140, r60 * r8);
+    r140 = fma(r8, r64, r140);
+    r140 = fma(r8, r65, r140);
+    r24 = r140 * r70;
+    r120 = fma(r55, r24, r120);
+    r34 = r78 * r26;
+    r34 = r34 * r70;
+    r120 = fma(r95, r34, r120);
+    r76 = r35 * r77;
+    r120 = fma(r71, r76, r120);
+    r101 = r4 * r26;
+    r120 = fma(r118, r101, r120);
+    r9 = r29 * r35;
+    r9 = r9 * r63;
+    r9 = r9 * r75;
+    r9 = r9 * r26;
+    r9 = r9 * r36;
+    r9 = r9 * r68;
+    r120 = fma(r100, r9, r120);
+    r85 = r20 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r91;
+    r85 = r85 * r51;
+    r120 = fma(r69, r85, r120);
+    r79 = r4 * r77;
+    r79 = r79 * r52;
+    r120 = fma(r113, r79, r120);
+    r124 = r4 * r91;
+    r120 = fma(r126, r124, r120);
+    r114 = r35 * r77;
+    r120 = fma(r70, r114, r120);
+    r89 = r29 * r35;
+    r89 = r89 * r75;
+    r89 = r89 * r26;
+    r89 = r89 * r36;
+    r89 = r89 * r68;
+    r120 = fma(r100, r89, r120);
+    r132 = r20 * r29;
+    r132 = r132 * r35;
+    r132 = r132 * r63;
+    r132 = r132 * r91;
+    r132 = r132 * r51;
+    r120 = fma(r69, r132, r120);
+    r84 = r4 * r21;
+    r84 = r84 * r26;
+    r84 = r84 * r51;
+    r84 = r84 * r100;
+    r84 = r84 * r102;
+    r84 = r84 * r37;
+    r120 = fma(r55, r84, r120);
+    r120 = fma(r81, r121, r120);
+    r120 = fma(r26, r130, r120);
+    r84 = r2 * r120;
+    r132 = r53 * r35;
+    r132 = r132 * r107;
+    r132 = r132 * r91;
+    r132 = r132 * r36;
+    r132 = r132 * r96;
+    r89 = r54 * r26;
+    r89 = fma(r110, r89, r37 * r132);
+    r132 = r35 * r105;
+    r132 = r132 * r81;
+    r89 = fma(r52, r132, r89);
+    r89 = fma(r26, r131, r89);
+    r89 = r89 + r139;
+    r89 = fma(r4, r89, r57 * r8);
+    r8 = r20 * r91;
+    r8 = r8 * r51;
+    r8 = r8 * r69;
+    r89 = fma(r37, r8, r89);
+    r139 = r5 * r81;
+    r89 = fma(r108, r139, r89);
+    r132 = r20 * r63;
+    r132 = r132 * r91;
+    r132 = r132 * r51;
+    r132 = r132 * r69;
+    r89 = fma(r37, r132, r89);
+    r114 = r53 * r78;
+    r114 = r114 * r26;
+    r114 = r114 * r70;
+    r89 = fma(r86, r114, r89);
+    r124 = r35 * r81;
+    r89 = fma(r70, r124, r89);
+    r79 = r5 * r26;
+    r89 = fma(r118, r79, r89);
+    r85 = r63 * r75;
+    r85 = r85 * r26;
+    r85 = r85 * r36;
+    r85 = r85 * r68;
+    r85 = r85 * r100;
+    r89 = fma(r37, r85, r89);
+    r9 = r140 * r37;
+    r89 = fma(r70, r9, r89);
+    r101 = r75 * r26;
+    r101 = r101 * r36;
+    r101 = r101 * r68;
+    r101 = r101 * r100;
+    r89 = fma(r37, r101, r89);
+    r76 = r53 * r26;
+    r76 = r76 * r86;
+    r89 = fma(r129, r76, r89);
+    r34 = r5 * r77;
+    r34 = r34 * r52;
+    r89 = fma(r113, r34, r89);
+    r24 = r35 * r81;
+    r89 = fma(r71, r24, r89);
+    r94 = r5 * r21;
+    r94 = r94 * r26;
+    r94 = r94 * r51;
+    r94 = r94 * r100;
+    r94 = r94 * r102;
+    r94 = r94 * r37;
+    r89 = fma(r55, r94, r89);
+    r89 = fma(r91, r115, r89);
+    r94 = r3 * r89;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r84, r94);
+    r94 = r45 * r35;
+    r94 = r94 * r105;
+    r94 = r94 * r40;
+    r84 = r6 * r7;
+    r84 = r84 * r53;
+    r24 = r47 * r53;
+    r24 = r24 * r53;
+    r24 = fma(r97, r24, r51 * r84);
+    r84 = r6 * r45;
+    r84 = r84 * r29;
+    r24 = fma(r51, r84, r24);
+    r24 = fma(r47, r74, r24);
+    r84 = r24 * r92;
+    r84 = fma(r104, r84, r55 * r94);
+    r94 = r54 * r24;
+    r94 = r94 * r98;
+    r84 = fma(r95, r94, r84);
+    r34 = r47 * r29;
+    r34 = r34 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r107;
+    r34 = r34 * r36;
+    r84 = fma(r96, r34, r84);
+    r76 = r7 * r52;
+    r101 = r20 * r53;
+    r101 = r101 * r35;
+    r101 = r101 * r24;
+    r101 = r101 * r51;
+    r101 = r101 * r100;
+    r101 = r101 * r102;
+    r101 = fma(r37, r101, r113 * r76);
+    r76 = r47 * r53;
+    r76 = r76 * r35;
+    r76 = r76 * r36;
+    r76 = r76 * r37;
+    r101 = fma(r97, r76, r101);
+    r101 = fma(r24, r110, r101);
+    r84 = r84 + r101;
+    r34 = r20 * r29;
+    r34 = r34 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r24;
+    r34 = r34 * r51;
+    r34 = r34 * r100;
+    r34 = fma(r102, r34, r45 * r108);
+    r94 = r24 * r98;
+    r34 = fma(r95, r94, r34);
+    r34 = fma(r47, r112, r34);
+    r101 = r101 + r34;
+    r84 = fma(r56, r101, r5 * r84);
+    r94 = r29 * r35;
+    r94 = r94 * r63;
+    r94 = r94 * r75;
+    r94 = r94 * r24;
+    r94 = r94 * r36;
+    r94 = r94 * r68;
+    r84 = fma(r100, r94, r84);
+    r76 = r78 * r24;
+    r76 = r76 * r70;
+    r84 = fma(r95, r76, r84);
+    r9 = r29 * r35;
+    r9 = r9 * r75;
+    r9 = r9 * r24;
+    r9 = r9 * r36;
+    r9 = r9 * r68;
+    r84 = fma(r100, r9, r84);
+    r85 = r20 * r47;
+    r85 = r85 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r63;
+    r85 = r85 * r51;
+    r84 = fma(r69, r85, r84);
+    r79 = r61 * r6;
+    r79 = r79 * r43;
+    r79 = fma(r101, r79, r60 * r101);
+    r79 = fma(r101, r64, r79);
+    r79 = fma(r101, r65, r79);
+    r124 = r79 * r70;
+    r84 = fma(r55, r124, r84);
+    r114 = r20 * r47;
+    r114 = r114 * r29;
+    r114 = r114 * r35;
+    r114 = r114 * r51;
+    r84 = fma(r69, r114, r84);
+    r132 = r4 * r24;
+    r84 = fma(r118, r132, r84);
+    r139 = r45 * r35;
+    r84 = fma(r71, r139, r84);
+    r8 = r4 * r45;
+    r8 = r8 * r52;
+    r84 = fma(r113, r8, r84);
+    r27 = r45 * r35;
+    r84 = fma(r70, r27, r84);
+    r23 = r4 * r21;
+    r23 = r23 * r24;
+    r23 = r23 * r51;
+    r23 = r23 * r100;
+    r23 = r23 * r102;
+    r23 = r23 * r37;
+    r84 = fma(r55, r23, r84);
+    r119 = r4 * r47;
+    r84 = fma(r126, r119, r84);
+    r84 = fma(r24, r130, r84);
+    r84 = fma(r7, r121, r84);
+    r119 = r2 * r84;
+    r23 = r7 * r35;
+    r23 = r23 * r105;
+    r23 = fma(r24, r131, r52 * r23);
+    r27 = r47 * r53;
+    r27 = r27 * r35;
+    r27 = r27 * r107;
+    r27 = r27 * r36;
+    r27 = r27 * r96;
+    r23 = fma(r37, r27, r23);
+    r8 = r54 * r24;
+    r23 = fma(r110, r8, r23);
+    r23 = r23 + r34;
+    r101 = fma(r57, r101, r4 * r23);
+    r23 = r7 * r35;
+    r101 = fma(r71, r23, r101);
+    r34 = r53 * r78;
+    r34 = r34 * r24;
+    r34 = r34 * r70;
+    r101 = fma(r86, r34, r101);
+    r8 = r7 * r35;
+    r101 = fma(r70, r8, r101);
+    r27 = r20 * r47;
+    r27 = r27 * r51;
+    r27 = r27 * r69;
+    r101 = fma(r37, r27, r101);
+    r139 = r53 * r24;
+    r139 = r139 * r86;
+    r101 = fma(r129, r139, r101);
+    r132 = r20 * r47;
+    r132 = r132 * r63;
+    r132 = r132 * r51;
+    r132 = r132 * r69;
+    r101 = fma(r37, r132, r101);
+    r114 = r5 * r7;
+    r101 = fma(r108, r114, r101);
+    r124 = r63 * r75;
+    r124 = r124 * r24;
+    r124 = r124 * r36;
+    r124 = r124 * r68;
+    r124 = r124 * r100;
+    r101 = fma(r37, r124, r101);
+    r85 = r5 * r24;
+    r101 = fma(r118, r85, r101);
+    r9 = r5 * r45;
+    r9 = r9 * r52;
+    r101 = fma(r113, r9, r101);
+    r76 = r75 * r24;
+    r76 = r76 * r36;
+    r76 = r76 * r68;
+    r76 = r76 * r100;
+    r101 = fma(r37, r76, r101);
+    r94 = r79 * r37;
+    r101 = fma(r70, r94, r101);
+    r111 = r5 * r21;
+    r111 = r111 * r24;
+    r111 = r111 * r51;
+    r111 = r111 * r100;
+    r111 = r111 * r102;
+    r111 = r111 * r37;
+    r101 = fma(r55, r111, r101);
+    r101 = fma(r47, r115, r101);
+    r111 = r3 * r101;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             6 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r119,
+                                             r111);
+    r111 = r53 * r53;
+    r111 = r51 * r111;
+    r119 = r49 * r53;
+    r119 = r119 * r53;
+    r94 = r6 * r46;
+    r94 = r94 * r53;
+    r94 = fma(r51, r94, r97 * r119);
+    r119 = r6 * r42;
+    r119 = r119 * r29;
+    r94 = fma(r51, r119, r94);
+    r94 = fma(r49, r74, r94);
+    r111 = r111 * r36;
+    r111 = r111 * r35;
+    r111 = r111 * r100;
+    r111 = r111 * r19;
+    r111 = r111 * r94;
+    r19 = r49 * r53;
+    r19 = r19 * r35;
+    r19 = r19 * r36;
+    r19 = r19 * r37;
+    r19 = fma(r97, r19, r111);
+    r119 = r46 * r52;
+    r19 = fma(r113, r119, r19);
+    r76 = r20 * r53;
+    r76 = r76 * r35;
+    r76 = r76 * r94;
+    r76 = r76 * r51;
+    r76 = r76 * r100;
+    r76 = r76 * r102;
+    r19 = fma(r37, r76, r19);
+    r76 = r94 * r98;
+    r76 = fma(r49, r112, r95 * r76);
+    r119 = r20 * r29;
+    r119 = r119 * r29;
+    r119 = r119 * r35;
+    r119 = r119 * r35;
+    r119 = r119 * r94;
+    r119 = r119 * r51;
+    r119 = r119 * r100;
+    r76 = fma(r102, r119, r76);
+    r76 = fma(r42, r108, r76);
+    r119 = r19 + r76;
+    r9 = r54 * r94;
+    r9 = r9 * r98;
+    r85 = r49 * r29;
+    r85 = r85 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r35;
+    r85 = r85 * r107;
+    r85 = r85 * r36;
+    r85 = fma(r96, r85, r95 * r9);
+    r9 = r94 * r92;
+    r85 = fma(r104, r9, r85);
+    r124 = r42 * r35;
+    r124 = r124 * r105;
+    r124 = r124 * r40;
+    r85 = fma(r55, r124, r85);
+    r85 = r85 + r19;
+    r85 = fma(r5, r85, r56 * r119);
+    r19 = r4 * r94;
+    r85 = fma(r118, r19, r85);
+    r124 = r42 * r35;
+    r85 = fma(r70, r124, r85);
+    r9 = r20 * r49;
+    r9 = r9 * r29;
+    r9 = r9 * r35;
+    r9 = r9 * r51;
+    r85 = fma(r69, r9, r85);
+    r114 = r4 * r42;
+    r114 = r114 * r52;
+    r85 = fma(r113, r114, r85);
+    r132 = r29 * r35;
+    r132 = r132 * r63;
+    r132 = r132 * r75;
+    r132 = r132 * r94;
+    r132 = r132 * r36;
+    r132 = r132 * r68;
+    r85 = fma(r100, r132, r85);
+    r139 = r20 * r49;
+    r139 = r139 * r29;
+    r139 = r139 * r35;
+    r139 = r139 * r63;
+    r139 = r139 * r51;
+    r85 = fma(r69, r139, r85);
+    r27 = r78 * r94;
+    r27 = r27 * r70;
+    r85 = fma(r95, r27, r85);
+    r8 = r42 * r35;
+    r85 = fma(r71, r8, r85);
+    r34 = r61 * r6;
+    r34 = r34 * r43;
+    r34 = fma(r60, r119, r119 * r34);
+    r34 = fma(r119, r65, r34);
+    r34 = fma(r119, r64, r34);
+    r23 = r34 * r70;
+    r85 = fma(r55, r23, r85);
+    r117 = r29 * r35;
+    r117 = r117 * r75;
+    r117 = r117 * r94;
+    r117 = r117 * r36;
+    r117 = r117 * r68;
+    r85 = fma(r100, r117, r85);
+    r99 = r4 * r21;
+    r99 = r99 * r94;
+    r99 = r99 * r51;
+    r99 = r99 * r100;
+    r99 = r99 * r102;
+    r99 = r99 * r37;
+    r85 = fma(r55, r99, r85);
+    r128 = r4 * r49;
+    r85 = fma(r126, r128, r85);
+    r85 = fma(r94, r130, r85);
+    r85 = fma(r46, r121, r85);
+    r128 = r2 * r85;
+    r99 = r49 * r53;
+    r99 = r99 * r35;
+    r99 = r99 * r107;
+    r99 = r99 * r36;
+    r99 = r99 * r96;
+    r117 = r46 * r35;
+    r117 = r117 * r105;
+    r117 = fma(r52, r117, r37 * r99);
+    r117 = fma(r54, r111, r117);
+    r117 = fma(r94, r131, r117);
+    r117 = r117 + r76;
+    r117 = fma(r4, r117, r57 * r119);
+    r119 = r20 * r49;
+    r119 = r119 * r51;
+    r119 = r119 * r69;
+    r117 = fma(r37, r119, r117);
+    r76 = r20 * r49;
+    r76 = r76 * r63;
+    r76 = r76 * r51;
+    r76 = r76 * r69;
+    r117 = fma(r37, r76, r117);
+    r111 = r5 * r94;
+    r117 = fma(r118, r111, r117);
+    r99 = r53 * r94;
+    r99 = r99 * r86;
+    r117 = fma(r129, r99, r117);
+    r23 = r53 * r78;
+    r23 = r23 * r94;
+    r23 = r23 * r70;
+    r117 = fma(r86, r23, r117);
+    r8 = r5 * r42;
+    r8 = r8 * r52;
+    r117 = fma(r113, r8, r117);
+    r27 = r46 * r35;
+    r117 = fma(r71, r27, r117);
+    r139 = r34 * r37;
+    r117 = fma(r70, r139, r117);
+    r132 = r75 * r94;
+    r132 = r132 * r36;
+    r132 = r132 * r68;
+    r132 = r132 * r100;
+    r117 = fma(r37, r132, r117);
+    r114 = r5 * r46;
+    r117 = fma(r108, r114, r117);
+    r9 = r5 * r21;
+    r9 = r9 * r94;
+    r9 = r9 * r51;
+    r9 = r9 * r100;
+    r9 = r9 * r102;
+    r9 = r9 * r37;
+    r117 = fma(r55, r9, r117);
+    r124 = r46 * r35;
+    r117 = fma(r70, r124, r117);
+    r19 = r63 * r75;
+    r19 = r19 * r94;
+    r19 = r19 * r36;
+    r19 = r19 * r68;
+    r19 = r19 * r100;
+    r117 = fma(r37, r19, r117);
+    r117 = fma(r49, r115, r117);
+    r19 = r3 * r117;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r128, r19);
+    r19 = r20 * r29;
+    r128 = r6 * r38;
+    r128 = r128 * r53;
+    r124 = r44 * r53;
+    r124 = r124 * r53;
+    r124 = fma(r97, r124, r51 * r128);
+    r128 = r6 * r39;
+    r128 = r128 * r29;
+    r124 = fma(r51, r128, r124);
+    r124 = fma(r44, r74, r124);
+    r19 = r19 * r29;
+    r19 = r19 * r35;
+    r19 = r19 * r35;
+    r19 = r19 * r124;
+    r19 = r19 * r51;
+    r19 = r19 * r100;
+    r74 = r124 * r98;
+    r74 = fma(r95, r74, r102 * r19);
+    r74 = fma(r39, r108, r74);
+    r74 = fma(r44, r112, r74);
+    r112 = r44 * r53;
+    r112 = r112 * r35;
+    r112 = r112 * r36;
+    r112 = r112 * r37;
+    r19 = r38 * r52;
+    r19 = fma(r113, r19, r97 * r112);
+    r112 = r20 * r53;
+    r112 = r112 * r35;
+    r112 = r112 * r124;
+    r112 = r112 * r51;
+    r112 = r112 * r100;
+    r112 = r112 * r102;
+    r19 = fma(r37, r112, r19);
+    r19 = fma(r124, r110, r19);
+    r112 = r74 + r19;
+    r97 = r124 * r92;
+    r128 = r54 * r124;
+    r128 = r128 * r98;
+    r128 = fma(r95, r128, r104 * r97);
+    r97 = r39 * r35;
+    r97 = r97 * r105;
+    r97 = r97 * r40;
+    r128 = fma(r55, r97, r128);
+    r40 = r44 * r29;
+    r40 = r40 * r29;
+    r40 = r40 * r35;
+    r40 = r40 * r35;
+    r40 = r40 * r107;
+    r40 = r40 * r36;
+    r128 = fma(r96, r40, r128);
+    r128 = r128 + r19;
+    r128 = fma(r5, r128, r56 * r112);
+    r56 = r61 * r6;
+    r56 = r56 * r43;
+    r60 = fma(r60, r112, r112 * r56);
+    r60 = fma(r112, r64, r60);
+    r60 = fma(r112, r65, r60);
+    r65 = r60 * r70;
+    r128 = fma(r55, r65, r128);
+    r64 = r20 * r44;
+    r64 = r64 * r29;
+    r64 = r64 * r35;
+    r64 = r64 * r63;
+    r64 = r64 * r51;
+    r128 = fma(r69, r64, r128);
+    r56 = r29 * r35;
+    r56 = r56 * r63;
+    r56 = r56 * r75;
+    r56 = r56 * r124;
+    r56 = r56 * r36;
+    r56 = r56 * r68;
+    r128 = fma(r100, r56, r128);
+    r19 = r4 * r21;
+    r19 = r19 * r124;
+    r19 = r19 * r51;
+    r19 = r19 * r100;
+    r19 = r19 * r102;
+    r19 = r19 * r37;
+    r128 = fma(r55, r19, r128);
+    r40 = r4 * r124;
+    r128 = fma(r118, r40, r128);
+    r97 = r4 * r44;
+    r128 = fma(r126, r97, r128);
+    r126 = r78 * r124;
+    r126 = r126 * r70;
+    r128 = fma(r95, r126, r128);
+    r95 = r39 * r35;
+    r128 = fma(r71, r95, r128);
+    r104 = r4 * r39;
+    r104 = r104 * r52;
+    r128 = fma(r113, r104, r128);
+    r9 = r20 * r44;
+    r9 = r9 * r29;
+    r9 = r9 * r35;
+    r9 = r9 * r51;
+    r128 = fma(r69, r9, r128);
+    r114 = r39 * r35;
+    r128 = fma(r70, r114, r128);
+    r132 = r29 * r35;
+    r132 = r132 * r75;
+    r132 = r132 * r124;
+    r132 = r132 * r36;
+    r132 = r132 * r68;
+    r128 = fma(r100, r132, r128);
+    r128 = fma(r38, r121, r128);
+    r128 = fma(r124, r130, r128);
+    r132 = r2 * r128;
+    r130 = r44 * r53;
+    r130 = r130 * r35;
+    r130 = r130 * r107;
+    r130 = r130 * r36;
+    r130 = r130 * r96;
+    r107 = r38 * r35;
+    r107 = r107 * r105;
+    r107 = fma(r52, r107, r37 * r130);
+    r130 = r54 * r124;
+    r107 = fma(r110, r130, r107);
+    r107 = fma(r124, r131, r107);
+    r107 = r107 + r74;
+    r107 = fma(r4, r107, r57 * r112);
+    r112 = r75 * r124;
+    r112 = r112 * r36;
+    r112 = r112 * r68;
+    r112 = r112 * r100;
+    r107 = fma(r37, r112, r107);
+    r57 = r20 * r44;
+    r57 = r57 * r51;
+    r57 = r57 * r69;
+    r107 = fma(r37, r57, r107);
+    r74 = r5 * r38;
+    r107 = fma(r108, r74, r107);
+    r108 = r38 * r35;
+    r107 = fma(r70, r108, r107);
+    r131 = r63 * r75;
+    r131 = r131 * r124;
+    r131 = r131 * r36;
+    r131 = r131 * r68;
+    r131 = r131 * r100;
+    r107 = fma(r37, r131, r107);
+    r68 = r5 * r21;
+    r68 = r68 * r124;
+    r68 = r68 * r51;
+    r68 = r68 * r100;
+    r68 = r68 * r102;
+    r68 = r68 * r37;
+    r107 = fma(r55, r68, r107);
+    r100 = r5 * r124;
+    r107 = fma(r118, r100, r107);
+    r118 = r53 * r124;
+    r118 = r118 * r86;
+    r107 = fma(r129, r118, r107);
+    r129 = r38 * r35;
+    r107 = fma(r71, r129, r107);
+    r71 = r5 * r39;
+    r71 = r71 * r52;
+    r107 = fma(r113, r71, r107);
+    r36 = r53 * r78;
+    r36 = r36 * r124;
+    r36 = r36 * r70;
+    r107 = fma(r86, r36, r107);
+    r86 = r60 * r37;
+    r107 = fma(r70, r86, r107);
+    r130 = r20 * r44;
+    r130 = r130 * r63;
+    r130 = r130 * r51;
+    r130 = r130 * r69;
+    r107 = fma(r37, r130, r107);
+    r107 = fma(r44, r115, r107);
+    r130 = r3 * r107;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r130);
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r132 = r20 * r0;
+    r86 = r2 * r132;
+    r130 = fma(r103, r86, r109 * r130);
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r116, r86, r138 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r130, r36);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r120, r86, r89 * r36);
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r130 = fma(r84, r86, r101 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r36, r130);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r130 = fma(r85, r86, r117 * r130);
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r128, r86, r107 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r130, r36);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r103 * r103;
+    r130 = r2 * r2;
+    r71 = r109 * r109;
+    r129 = r3 * r3;
+    r71 = fma(r129, r71, r130 * r36);
+    r36 = r116 * r116;
+    r118 = r138 * r138;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r89 * r89;
+    r71 = r120 * r120;
+    r71 = fma(r130, r71, r129 * r118);
+    r118 = r101 * r101;
+    r36 = r84 * r84;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r117 * r117;
+    r71 = r85 * r85;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r128 * r128;
+    r118 = r107 * r107;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r103 * r116;
+    r71 = r109 * r138;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r109 * r89;
+    r36 = r103 * r120;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r103 * r84;
+    r71 = r109 * r101;
+    r71 = fma(r129, r71, r130 * r36);
+    r36 = r109 * r117;
+    r118 = r103 * r85;
+    r118 = fma(r130, r118, r129 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r103 * r128;
+    r71 = r109 * r107;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r138 * r89;
+    r36 = r116 * r120;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r138 * r101;
+    r71 = r116 * r84;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r116 * r85;
+    r118 = r138 * r117;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r116 * r128;
+    r71 = r138 * r107;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r89 * r101;
+    r36 = r120 * r84;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r89 * r117;
+    r71 = r120 * r85;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r89 * r107;
+    r118 = r120 * r128;
+    r118 = fma(r130, r118, r129 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r101 * r117;
+    r71 = r84 * r85;
+    r71 = fma(r130, r71, r129 * r118);
+    r118 = r101 * r107;
+    r36 = r84 * r128;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r117 * r107;
+    r71 = r85 * r128;
+    r71 = fma(r130, r71, r129 * r36);
+    WriteSum1<double, double>((double*)inout_shared, r71);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r59,
+                                             r58);
+    r71 = r2 * r43;
+    r71 = r71 * r70;
+    r71 = r71 * r55;
+    r36 = r3 * r43;
+    r36 = r36 * r37;
+    r36 = r36 * r70;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             2 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r71,
+                                             r36);
+    r118 = r2 * r70;
+    r118 = r118 * r55;
+    r118 = r118 * r62;
+    r115 = r3 * r37;
+    r115 = r115 * r70;
+    r115 = r115 * r62;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r118,
+                                             r115);
+    r100 = r3 * r72;
+    r68 = r2 * r6;
+    r68 = r68 * r55;
+    r68 = r68 * r52;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r68,
+                                             r100);
+    r131 = r2 * r31;
+    r108 = r3 * r6;
+    r108 = r108 * r55;
+    r108 = r108 * r52;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r108);
+    r74 = r2 * r70;
+    r74 = r74 * r55;
+    r74 = r74 * r67;
+    r57 = r3 * r37;
+    r57 = r57 * r70;
+    r57 = r57 * r67;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r74,
+                                             r57);
+    r112 = r2 * r70;
+    r112 = r112 * r55;
+    r112 = r112 * r66;
+    r69 = r3 * r37;
+    r69 = r69 * r70;
+    r69 = r69 * r66;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r112,
+                                             r69);
+    r51 = r2 * r43;
+    r110 = r3 * r43;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r51,
+                                             r110);
+    r114 = r20 * r58;
+    r114 = r114 * r1;
+    r9 = r59 * r132;
+    WriteSum2<double, double>((double*)inout_shared, r9, r114);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r20 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r132, r114);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r43 * r70;
+    r114 = r114 * r55;
+    r132 = r3 * r20;
+    r132 = r132 * r43;
+    r132 = r132 * r1;
+    r132 = r132 * r37;
+    r132 = fma(r70, r132, r86 * r114);
+    r114 = r3 * r20;
+    r114 = r114 * r1;
+    r114 = r114 * r37;
+    r114 = r114 * r70;
+    r9 = r70 * r55;
+    r9 = r9 * r62;
+    r9 = fma(r86, r9, r62 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r132, r9);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r20;
+    r9 = r9 * r72;
+    r132 = r2 * r21;
+    r132 = r132 * r0;
+    r132 = r132 * r55;
+    r132 = fma(r52, r132, r1 * r9);
+    r9 = r3 * r21;
+    r9 = r9 * r1;
+    r9 = r9 * r55;
+    r9 = fma(r52, r9, r31 * r86);
+    WriteSum2<double, double>((double*)inout_shared, r132, r9);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r20;
+    r9 = r9 * r1;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    r132 = r70 * r55;
+    r132 = r132 * r67;
+    r132 = fma(r86, r132, r67 * r9);
+    r9 = r3 * r20;
+    r9 = r9 * r1;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    r0 = r70 * r55;
+    r0 = r0 * r66;
+    r0 = fma(r86, r0, r66 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r20;
+    r0 = r0 * r43;
+    r0 = r0 * r1;
+    r86 = r43 * r86;
+    WriteSum2<double, double>((double*)inout_shared, r86, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r59 * r59;
+    r86 = r58 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r0, r86);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r22, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r35 * r62;
+    r22 = r22 * r129;
+    r86 = r29 * r35;
+    r86 = r86 * r62;
+    r86 = r86 * r130;
+    r86 = fma(r98, r86, r50 * r22);
+    r22 = r35 * r129;
+    r22 = r22 * r66;
+    r0 = r29 * r35;
+    r0 = r0 * r130;
+    r0 = r0 * r98;
+    r0 = fma(r66, r0, r50 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r86, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r37 * r130;
+    r22 = r29 * r53;
+    r48 = r28 * r48;
+    r48 = 1.0 / r48;
+    r32 = r41 * r32;
+    r32 = 1.0 / r32;
+    r22 = r22 * r35;
+    r22 = r22 * r35;
+    r22 = r22 * r123;
+    r22 = r22 * r48;
+    r22 = r22 * r32;
+    r22 = r22 * r55;
+    r32 = r72 * r72;
+    r32 = fma(r129, r32, r22 * r86);
+    r86 = r37 * r129;
+    r48 = r31 * r130;
+    r22 = fma(r31, r48, r86 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r32, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r67 * r67;
+    r32 = r35 * r22;
+    r123 = r129 * r50;
+    r41 = r35 * r22;
+    r28 = r29 * r130;
+    r28 = r28 * r98;
+    r41 = fma(r28, r41, r123 * r32);
+    r32 = r43 * r22;
+    r32 = r35 * r32;
+    r1 = r43 * r32;
+    r1 = fma(r28, r1, r123 * r1);
+    WriteSum2<double, double>((double*)inout_shared, r41, r1);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r62 * r130;
+    r132 = r62 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r1, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r132, r59);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r2 * r43;
+    r1 = r1 * r59;
+    r1 = r1 * r70;
+    r1 = r1 * r55;
+    WriteSum2<double, double>((double*)inout_shared, r132, r1);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r2 * r59;
+    r1 = r1 * r70;
+    r1 = r1 * r55;
+    r1 = r1 * r62;
+    r9 = r2 * r6;
+    r9 = r9 * r59;
+    r9 = r9 * r55;
+    r9 = r9 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r1, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r2 * r31;
+    r31 = r31 * r59;
+    r9 = r2 * r59;
+    r9 = r9 * r70;
+    r9 = r9 * r55;
+    r9 = r9 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r31, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r2 * r43;
+    r9 = r9 * r59;
+    r59 = r2 * r59;
+    r59 = r59 * r70;
+    r59 = r59 * r55;
+    r59 = r59 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r59, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r43;
+    r9 = r9 * r58;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    WriteSum2<double, double>((double*)inout_shared, r58, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r72;
+    r9 = r9 * r58;
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r62;
+    WriteSum2<double, double>((double*)inout_shared, r59, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r6;
+    r9 = r9 * r58;
+    r9 = r9 * r55;
+    r9 = r9 * r52;
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r9, r59);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r59, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r3 * r43;
+    r59 = r59 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r59, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r68, r131);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r74, r112);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r51, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r36, r115);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r100, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r57, r69);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r132, r110);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r110 = r35 * r67;
+    r110 = r110 * r129;
+    r69 = r29 * r35;
+    r69 = r69 * r67;
+    r69 = r69 * r130;
+    r69 = fma(r98, r69, r50 * r110);
+    r110 = r70 * r86;
+    r57 = r72 * r110;
+    r108 = r29 * r43;
+    r108 = r108 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r43 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r69, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r43;
+    r108 = r108 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r113;
+    r69 = r55 * r48;
+    r100 = r70 * r69;
+    r108 = fma(r43, r100, r86 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r108, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r70 * r55;
+    r0 = r0 * r62;
+    r0 = r0 * r130;
+    r108 = r35 * r129;
+    r115 = r43 * r66;
+    r108 = r108 * r50;
+    r50 = r29 * r35;
+    r50 = r50 * r130;
+    r50 = r50 * r98;
+    r50 = fma(r115, r50, r115 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r50, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r62 * r110;
+    r108 = r29 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r62;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r62 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r0, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r62;
+    r108 = r108 * r113;
+    r108 = fma(r62, r100, r86 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r108, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r70 * r55;
+    r50 = r50 * r67;
+    r50 = r50 * r130;
+    WriteSum2<double, double>((double*)inout_shared, r41, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r67 * r110;
+    r41 = r6 * r52;
+    r108 = r6 * r72;
+    r108 = r108 * r55;
+    r108 = r108 * r52;
+    r108 = fma(r129, r108, r69 * r41);
+    WriteSum2<double, double>((double*)inout_shared, r50, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r29 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r67;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r67 * r57);
+    r50 = r29 * r96;
+    r50 = r50 * r102;
+    r50 = r50 * r37;
+    r50 = r50 * r55;
+    r50 = r50 * r130;
+    r50 = r50 * r113;
+    r50 = fma(r66, r50, r66 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r108, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r6 * r43;
+    r50 = r50 * r55;
+    r50 = r50 * r52;
+    r50 = r50 * r130;
+    r108 = r43 * r72;
+    r108 = r108 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r50, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r67;
+    r108 = r108 * r113;
+    r108 = fma(r67, r100, r86 * r108);
+    r50 = r53 * r96;
+    r50 = r50 * r102;
+    r50 = r50 * r55;
+    r50 = r50 * r113;
+    r50 = r50 * r66;
+    r100 = fma(r66, r100, r86 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r108, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r43 * r48;
+    r100 = r6 * r43;
+    r100 = r100 * r55;
+    r100 = r100 * r52;
+    r100 = r100 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r48, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = r70 * r55;
+    r100 = r100 * r130;
+    r100 = r100 * r66;
+    r28 = fma(r32, r28, r32 * r123);
+    WriteSum2<double, double>((double*)inout_shared, r28, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r66 * r110;
+    r100 = r70 * r55;
+    r100 = r100 * r130;
+    r100 = r100 * r115;
+    WriteSum2<double, double>((double*)inout_shared, r66, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r110 = r115 * r110;
+    WriteSum2<double, double>((double*)inout_shared, r110, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac_first.cu
@@ -1,0 +1,2473 @@
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = r18 * r18;
+    r21 = -2.00000000000000000e+00;
+    r19 = r19 * r21;
+    r22 = 1.00000000000000000e+00;
+    r23 = r15 * r13;
+    r24 = r11 * r17;
+    r25 = r23 + r24;
+    r26 = r14 * r12;
+    r27 = r10 * r16;
+    r25 = r25 + r26;
+    r25 = fma(r20, r27, r25);
+    r28 = r21 * r25;
+    r28 = fma(r25, r28, r22);
+    r29 = r19 + r28;
+    r29 = fma(r8, r29, r6);
+    r6 = 2.00000000000000000e+00;
+    r30 = fma(r11, r16, r14 * r13);
+    r31 = r15 * r12;
+    r30 = fma(r20, r31, r30);
+    r30 = fma(r10, r17, r30);
+    r31 = r6 * r30;
+    r31 = r31 * r25;
+    r32 = r18 * r21;
+    r33 = fma(r15, r17, r14 * r16);
+    r33 = fma(r10, r12, r33);
+    r33 = fma(r20, r33, r11 * r13);
+    r32 = fma(r33, r32, r31);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r34);
+    r35 = r6 * r18;
+    r35 = r35 * r30;
+    r36 = r6 * r25;
+    r36 = fma(r33, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r16 * r12;
+    r38 = r38 * r6;
+    r39 = r17 * r13;
+    r39 = fma(r6, r39, r38);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r40, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r12 * r13;
+    r43 = r16 * r17;
+    r43 = r43 * r6;
+    r42 = fma(r21, r42, r43);
+    r44 = r17 * r17;
+    r44 = r44 * r21;
+    r45 = r22 + r44;
+    r46 = r12 * r12;
+    r46 = r46 * r21;
+    r45 = r45 + r46;
+    r29 = fma(r9, r32, r29);
+    r29 = fma(r34, r36, r29);
+    r29 = fma(r37, r39, r29);
+    r29 = fma(r41, r42, r29);
+    r29 = fma(r40, r45, r29);
+    r36 = r29 * r29;
+    r32 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r47);
+    r48 = r21 * r25;
+    r48 = fma(r33, r48, r35);
+    r48 = fma(r8, r48, r47);
+    r47 = r17 * r13;
+    r47 = fma(r21, r47, r38);
+    r44 = r22 + r44;
+    r38 = r16 * r16;
+    r38 = r38 * r21;
+    r44 = r44 + r38;
+    r35 = r17 * r12;
+    r35 = r35 * r6;
+    r49 = r16 * r13;
+    r49 = fma(r6, r49, r35);
+    r50 = r6 * r18;
+    r50 = r50 * r25;
+    r51 = r6 * r30;
+    r51 = fma(r33, r51, r50);
+    r52 = r30 * r30;
+    r52 = r52 * r21;
+    r28 = r52 + r28;
+    r48 = fma(r40, r47, r48);
+    r48 = fma(r37, r44, r48);
+    r48 = fma(r41, r49, r48);
+    r48 = fma(r9, r51, r48);
+    r48 = fma(r34, r28, r48);
+    r28 = copysign(1.0, r48);
+    r28 = fma(r32, r28, r48);
+    r48 = r28 * r28;
+    r51 = 1.0 / r48;
+    r53 = r6 * r18;
+    r53 = fma(r33, r53, r31);
+    r53 = fma(r8, r53, r7);
+    r7 = r12 * r13;
+    r7 = fma(r6, r7, r43);
+    r46 = r22 + r46;
+    r46 = r46 + r38;
+    r38 = r16 * r13;
+    r38 = fma(r21, r38, r35);
+    r35 = r30 * r21;
+    r35 = fma(r33, r35, r50);
+    r19 = r22 + r19;
+    r19 = r19 + r52;
+    r53 = fma(r40, r7, r53);
+    r53 = fma(r41, r46, r53);
+    r53 = fma(r37, r38, r53);
+    r53 = fma(r34, r35, r53);
+    r53 = fma(r9, r19, r53);
+    r19 = r53 * r53;
+    r19 = fma(r51, r19, r51 * r36);
+    r36 = sqrt(r19);
+    r35 = atan(r36);
+    r37 = r53 * r35;
+    r41 = copysign(1.0, r36);
+    r41 = fma(r32, r41, r36);
+    r32 = r41 * r41;
+    r36 = 1.0 / r32;
+    r40 = r51 * r36;
+    r52 = r37 * r40;
+    r50 = r53 * r52;
+    r43 = r35 * r50;
+    r31 = r29 * r35;
+    r54 = 3.00000000000000000e+00;
+    r55 = r29 * r35;
+    r31 = r31 * r54;
+    r31 = r31 * r40;
+    r31 = fma(r55, r31, r43);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r56, r57);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r58 = r29 * r35;
+    r58 = r58 * r40;
+    r58 = r58 * r55;
+    r43 = r43 + r58;
+    r59 = fma(r56, r43, r5 * r31);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r60, r61);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r62 = r43 * r43;
+    r63 = fma(r61, r62, r60 * r43);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r64, r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r62 * r62;
+    r67 = r43 * r62;
+    r63 = fma(r65, r66, r63);
+    r63 = fma(r64, r67, r63);
+    r68 = 1.0 / r28;
+    r69 = 1.0 / r41;
+    r70 = r68 * r69;
+    r71 = r63 * r70;
+    r72 = r4 * r6;
+    r72 = r72 * r55;
+    r59 = fma(r52, r72, r59);
+    r59 = fma(r55, r71, r59);
+    r59 = fma(r70, r55, r59);
+    r0 = fma(r2, r59, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r72, r73);
+    r0 = fma(r72, r20, r0);
+    r72 = r35 * r54;
+    r72 = fma(r50, r72, r58);
+    r58 = fma(r57, r43, r4 * r72);
+    r74 = r5 * r6;
+    r74 = r74 * r55;
+    r58 = fma(r52, r74, r58);
+    r58 = fma(r37, r71, r58);
+    r58 = fma(r37, r70, r58);
+    r1 = fma(r3, r58, r1);
+    r1 = fma(r73, r20, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r73 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r73);
+  if (global_thread_idx < problem_size) {
+    r73 = r6 * r29;
+    r74 = r14 * r13;
+    r75 = -5.00000000000000000e-01;
+    r76 = r11 * r16;
+    r76 = fma(r75, r76, r75 * r74);
+    r74 = r10 * r17;
+    r76 = fma(r75, r74, r76);
+    r77 = r15 * r12;
+    r78 = 5.00000000000000000e-01;
+    r76 = fma(r78, r77, r76);
+    r77 = r25 * r76;
+    r74 = r10 * r13;
+    r79 = r15 * r16;
+    r79 = fma(r78, r79, r78 * r74);
+    r74 = r14 * r17;
+    r79 = fma(r75, r74, r79);
+    r80 = r11 * r12;
+    r79 = fma(r78, r80, r79);
+    r80 = r33 * r79;
+    r74 = fma(r6, r80, r6 * r77);
+    r81 = r6 * r30;
+    r82 = fma(r78, r27, r75 * r23);
+    r82 = fma(r75, r24, r82);
+    r82 = fma(r75, r26, r82);
+    r83 = r6 * r18;
+    r84 = r11 * r13;
+    r85 = r14 * r16;
+    r85 = fma(r75, r85, r78 * r84);
+    r84 = r15 * r17;
+    r85 = fma(r75, r84, r85);
+    r86 = r10 * r12;
+    r85 = fma(r75, r86, r85);
+    r83 = r83 * r85;
+    r81 = fma(r82, r81, r83);
+    r74 = r74 + r81;
+    r86 = r6 * r25;
+    r86 = r86 * r85;
+    r84 = r6 * r30;
+    r84 = r84 * r79;
+    r87 = r86 + r84;
+    r88 = r18 * r21;
+    r87 = fma(r76, r88, r87);
+    r89 = r21 * r33;
+    r87 = fma(r82, r89, r87);
+    r87 = fma(r9, r87, r34 * r74);
+    r74 = r25 * r79;
+    r89 = -4.00000000000000000e+00;
+    r74 = r74 * r89;
+    r88 = r18 * r82;
+    r90 = r89 * r88;
+    r91 = r74 + r90;
+    r87 = fma(r8, r91, r87);
+    r73 = r73 * r87;
+    r91 = r6 * r25;
+    r91 = r91 * r82;
+    r92 = r6 * r18;
+    r92 = fma(r79, r92, r91);
+    r79 = r6 * r30;
+    r79 = r79 * r76;
+    r93 = r6 * r33;
+    r93 = r93 * r85;
+    r94 = r79 + r93;
+    r95 = r92 + r94;
+    r80 = fma(r21, r80, r21 * r77);
+    r80 = r80 + r81;
+    r80 = fma(r8, r80, r9 * r95);
+    r95 = r30 * r85;
+    r95 = r95 * r89;
+    r74 = r74 + r95;
+    r80 = fma(r34, r74, r80);
+    r74 = r29 * r29;
+    r48 = r28 * r48;
+    r96 = 1.0 / r48;
+    r97 = r21 * r96;
+    r74 = r74 * r97;
+    r73 = fma(r80, r74, r51 * r73);
+    r98 = r53 * r53;
+    r98 = r98 * r80;
+    r73 = fma(r97, r98, r73);
+    r99 = r6 * r53;
+    r100 = r30 * r21;
+    r101 = r21 * r33;
+    r101 = r101 * r85;
+    r100 = fma(r76, r100, r101);
+    r100 = r100 + r92;
+    r90 = r95 + r90;
+    r90 = fma(r9, r90, r34 * r100);
+    r100 = r6 * r33;
+    r100 = fma(r82, r100, r84);
+    r84 = r6 * r18;
+    r84 = fma(r76, r84, r86);
+    r100 = r100 + r84;
+    r90 = fma(r8, r100, r90);
+    r99 = r99 * r90;
+    r73 = fma(r51, r99, r73);
+    r99 = r54 * r73;
+    r98 = r40 * r55;
+    r100 = rsqrt(r19);
+    r19 = r22 + r19;
+    r19 = 1.0 / r19;
+    r86 = r100 * r19;
+    r95 = r29 * r86;
+    r99 = r99 * r98;
+    r92 = -3.00000000000000000e+00;
+    r92 = r35 * r92;
+    r32 = r41 * r32;
+    r102 = 1.0 / r32;
+    r92 = r92 * r51;
+    r92 = r92 * r100;
+    r92 = r92 * r102;
+    r103 = r73 * r92;
+    r104 = r35 * r74;
+    r103 = fma(r104, r103, r95 * r99);
+    r99 = r35 * r87;
+    r105 = 6.00000000000000000e+00;
+    r99 = r99 * r105;
+    r99 = r99 * r40;
+    r103 = fma(r55, r99, r103);
+    r106 = r35 * r80;
+    r107 = -6.00000000000000000e+00;
+    r106 = r106 * r107;
+    r106 = r106 * r36;
+    r106 = r106 * r96;
+    r108 = r29 * r106;
+    r103 = fma(r55, r108, r103);
+    r109 = r53 * r35;
+    r109 = r109 * r80;
+    r109 = r109 * r36;
+    r109 = r109 * r37;
+    r110 = r86 * r50;
+    r109 = fma(r73, r110, r97 * r109);
+    r111 = r20 * r53;
+    r111 = r111 * r35;
+    r111 = r111 * r73;
+    r111 = r111 * r51;
+    r111 = r111 * r100;
+    r111 = r111 * r102;
+    r109 = fma(r37, r111, r109);
+    r112 = r90 * r52;
+    r113 = r6 * r35;
+    r109 = fma(r113, r112, r109);
+    r103 = r103 + r109;
+    r108 = r73 * r98;
+    r99 = r20 * r29;
+    r99 = r99 * r29;
+    r99 = r99 * r35;
+    r99 = r99 * r35;
+    r99 = r99 * r73;
+    r99 = r99 * r51;
+    r99 = r99 * r100;
+    r99 = fma(r102, r99, r95 * r108);
+    r108 = r113 * r98;
+    r112 = r35 * r36;
+    r112 = r112 * r97;
+    r112 = r104 * r112;
+    r99 = fma(r87, r108, r99);
+    r99 = fma(r80, r112, r99);
+    r109 = r109 + r99;
+    r103 = fma(r56, r109, r5 * r103);
+    r111 = r75 * r73;
+    r111 = r111 * r36;
+    r111 = r111 * r68;
+    r111 = r111 * r100;
+    r114 = r63 * r111;
+    r115 = r4 * r87;
+    r115 = r115 * r52;
+    r103 = fma(r113, r115, r103);
+    r116 = r29 * r35;
+    r103 = fma(r111, r116, r103);
+    r117 = r4 * r73;
+    r118 = r6 * r52;
+    r118 = r118 * r95;
+    r103 = fma(r118, r117, r103);
+    r119 = r4 * r21;
+    r119 = r119 * r73;
+    r119 = r119 * r51;
+    r119 = r119 * r100;
+    r119 = r119 * r102;
+    r119 = r119 * r37;
+    r103 = fma(r55, r119, r103);
+    r120 = r78 * r73;
+    r120 = r120 * r70;
+    r103 = fma(r95, r120, r103);
+    r121 = r4 * r108;
+    r122 = r61 * r6;
+    r122 = r122 * r43;
+    r122 = fma(r109, r122, r60 * r109);
+    r123 = 4.00000000000000000e+00;
+    r65 = r65 * r123;
+    r65 = r65 * r67;
+    r64 = r64 * r54;
+    r64 = r64 * r62;
+    r122 = fma(r109, r65, r122);
+    r122 = fma(r109, r64, r122);
+    r124 = r122 * r70;
+    r103 = fma(r55, r124, r103);
+    r125 = r4 * r80;
+    r126 = r89 * r36;
+    r126 = r126 * r96;
+    r126 = r126 * r37;
+    r126 = r126 * r55;
+    r103 = fma(r126, r125, r103);
+    r127 = r20 * r29;
+    r127 = r127 * r35;
+    r127 = r127 * r80;
+    r127 = r127 * r51;
+    r103 = fma(r69, r127, r103);
+    r128 = r35 * r87;
+    r103 = fma(r70, r128, r103);
+    r129 = r78 * r71;
+    r130 = r95 * r129;
+    r131 = r20 * r29;
+    r131 = r131 * r35;
+    r131 = r131 * r63;
+    r131 = r131 * r80;
+    r131 = r131 * r51;
+    r103 = fma(r69, r131, r103);
+    r132 = r35 * r87;
+    r103 = fma(r71, r132, r103);
+    r103 = fma(r114, r55, r103);
+    r103 = fma(r90, r121, r103);
+    r103 = fma(r73, r130, r103);
+    r132 = r2 * r103;
+    r131 = r53 * r37;
+    r128 = r54 * r73;
+    r128 = fma(r110, r128, r106 * r131);
+    r131 = r53 * r37;
+    r131 = r131 * r92;
+    r127 = r35 * r90;
+    r127 = r127 * r105;
+    r128 = fma(r52, r127, r128);
+    r128 = fma(r73, r131, r128);
+    r128 = r128 + r99;
+    r109 = fma(r57, r109, r4 * r128);
+    r128 = r35 * r90;
+    r109 = fma(r71, r128, r109);
+    r99 = r122 * r37;
+    r109 = fma(r70, r99, r109);
+    r127 = r20 * r80;
+    r127 = r127 * r51;
+    r127 = r127 * r69;
+    r109 = fma(r37, r127, r109);
+    r125 = r5 * r87;
+    r125 = r125 * r52;
+    r109 = fma(r113, r125, r109);
+    r124 = r5 * r73;
+    r109 = fma(r118, r124, r109);
+    r120 = r5 * r21;
+    r120 = r120 * r73;
+    r120 = r120 * r51;
+    r120 = r120 * r100;
+    r120 = r120 * r102;
+    r120 = r120 * r37;
+    r109 = fma(r55, r120, r109);
+    r119 = r53 * r78;
+    r119 = r119 * r73;
+    r119 = r119 * r70;
+    r109 = fma(r86, r119, r109);
+    r117 = r53 * r73;
+    r117 = r117 * r86;
+    r109 = fma(r129, r117, r109);
+    r116 = r5 * r90;
+    r109 = fma(r108, r116, r109);
+    r115 = r5 * r126;
+    r133 = r35 * r90;
+    r109 = fma(r70, r133, r109);
+    r134 = r20 * r63;
+    r134 = r134 * r80;
+    r134 = r134 * r51;
+    r134 = r134 * r69;
+    r109 = fma(r37, r134, r109);
+    r109 = fma(r37, r111, r109);
+    r109 = fma(r80, r115, r109);
+    r109 = fma(r37, r114, r109);
+    r134 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r134);
+    r134 = r53 * r53;
+    r134 = r51 * r134;
+    r132 = r6 * r29;
+    r93 = r91 + r93;
+    r91 = r6 * r18;
+    r133 = r10 * r13;
+    r114 = r15 * r16;
+    r114 = fma(r75, r114, r75 * r133);
+    r133 = r14 * r17;
+    r114 = fma(r78, r133, r114);
+    r116 = r11 * r12;
+    r114 = fma(r75, r116, r114);
+    r91 = r91 * r114;
+    r116 = r6 * r30;
+    r133 = r14 * r13;
+    r117 = r11 * r16;
+    r117 = fma(r78, r117, r78 * r133);
+    r133 = r10 * r17;
+    r117 = fma(r78, r133, r117);
+    r119 = r15 * r12;
+    r117 = fma(r75, r119, r117);
+    r116 = fma(r117, r116, r91);
+    r93 = r93 + r116;
+    r119 = r25 * r85;
+    r119 = r119 * r89;
+    r133 = r18 * r89;
+    r133 = r133 * r117;
+    r111 = r119 + r133;
+    r111 = fma(r8, r111, r34 * r93);
+    r93 = r21 * r33;
+    r93 = fma(r21, r88, r117 * r93);
+    r120 = r6 * r30;
+    r120 = r120 * r85;
+    r124 = r6 * r25;
+    r124 = fma(r114, r124, r120);
+    r93 = r93 + r124;
+    r111 = fma(r9, r93, r111);
+    r132 = r132 * r111;
+    r93 = r6 * r53;
+    r125 = r6 * r25;
+    r125 = r125 * r117;
+    r83 = r83 + r125;
+    r127 = r30 * r21;
+    r83 = fma(r82, r127, r83);
+    r99 = r21 * r33;
+    r83 = fma(r114, r99, r83);
+    r99 = r6 * r33;
+    r88 = fma(r6, r88, r117 * r99);
+    r88 = r88 + r124;
+    r88 = fma(r8, r88, r34 * r83);
+    r83 = r30 * r114;
+    r99 = r89 * r83;
+    r133 = r133 + r99;
+    r88 = fma(r9, r133, r88);
+    r93 = r93 * r88;
+    r93 = fma(r51, r93, r51 * r132);
+    r132 = r53 * r53;
+    r133 = r21 * r25;
+    r133 = fma(r82, r133, r101);
+    r133 = r133 + r116;
+    r116 = r6 * r33;
+    r116 = fma(r114, r116, r125);
+    r116 = r116 + r81;
+    r116 = fma(r9, r116, r8 * r133);
+    r99 = r119 + r99;
+    r116 = fma(r34, r99, r116);
+    r132 = r132 * r116;
+    r93 = fma(r97, r132, r93);
+    r93 = fma(r116, r74, r93);
+    r134 = r134 * r36;
+    r134 = r134 * r35;
+    r134 = r134 * r100;
+    r134 = r134 * r19;
+    r134 = r134 * r93;
+    r19 = r88 * r52;
+    r19 = fma(r113, r19, r134);
+    r132 = r20 * r53;
+    r132 = r132 * r35;
+    r132 = r132 * r93;
+    r132 = r132 * r51;
+    r132 = r132 * r100;
+    r132 = r132 * r102;
+    r19 = fma(r37, r132, r19);
+    r99 = r53 * r35;
+    r99 = r99 * r116;
+    r99 = r99 * r36;
+    r99 = r99 * r37;
+    r19 = fma(r97, r99, r19);
+    r99 = fma(r111, r108, r116 * r112);
+    r132 = r20 * r29;
+    r132 = r132 * r29;
+    r132 = r132 * r35;
+    r132 = r132 * r35;
+    r132 = r132 * r93;
+    r132 = r132 * r51;
+    r132 = r132 * r100;
+    r99 = fma(r102, r132, r99);
+    r119 = r93 * r98;
+    r99 = fma(r95, r119, r99);
+    r119 = r19 + r99;
+    r132 = r29 * r29;
+    r132 = r132 * r35;
+    r132 = r132 * r35;
+    r132 = r132 * r107;
+    r132 = r132 * r116;
+    r132 = r132 * r36;
+    r133 = r35 * r105;
+    r133 = r133 * r111;
+    r133 = r133 * r40;
+    r133 = fma(r55, r133, r96 * r132);
+    r132 = r93 * r92;
+    r133 = fma(r104, r132, r133);
+    r81 = r54 * r93;
+    r81 = r81 * r98;
+    r133 = fma(r95, r81, r133);
+    r133 = r133 + r19;
+    r133 = fma(r5, r133, r56 * r119);
+    r19 = r20 * r29;
+    r19 = r19 * r35;
+    r19 = r19 * r116;
+    r19 = r19 * r51;
+    r133 = fma(r69, r19, r133);
+    r81 = r78 * r93;
+    r81 = r81 * r70;
+    r133 = fma(r95, r81, r133);
+    r132 = r35 * r111;
+    r133 = fma(r71, r132, r133);
+    r125 = r61 * r6;
+    r125 = r125 * r43;
+    r125 = fma(r119, r125, r60 * r119);
+    r125 = fma(r119, r65, r125);
+    r125 = fma(r119, r64, r125);
+    r82 = r125 * r70;
+    r133 = fma(r55, r82, r133);
+    r117 = r4 * r93;
+    r133 = fma(r118, r117, r133);
+    r127 = r4 * r116;
+    r133 = fma(r126, r127, r133);
+    r128 = r4 * r111;
+    r128 = r128 * r52;
+    r133 = fma(r113, r128, r133);
+    r135 = r4 * r21;
+    r135 = r135 * r93;
+    r135 = r135 * r51;
+    r135 = r135 * r100;
+    r135 = r135 * r102;
+    r135 = r135 * r37;
+    r133 = fma(r55, r135, r133);
+    r136 = r20 * r29;
+    r136 = r136 * r35;
+    r136 = r136 * r63;
+    r136 = r136 * r116;
+    r136 = r136 * r51;
+    r133 = fma(r69, r136, r133);
+    r137 = r35 * r111;
+    r133 = fma(r70, r137, r133);
+    r138 = r29 * r35;
+    r138 = r138 * r63;
+    r138 = r138 * r75;
+    r138 = r138 * r93;
+    r138 = r138 * r36;
+    r138 = r138 * r68;
+    r133 = fma(r100, r138, r133);
+    r139 = r29 * r35;
+    r139 = r139 * r75;
+    r139 = r139 * r93;
+    r139 = r139 * r36;
+    r139 = r139 * r68;
+    r133 = fma(r100, r139, r133);
+    r133 = fma(r88, r121, r133);
+    r133 = fma(r93, r130, r133);
+    r139 = r2 * r133;
+    r138 = r35 * r105;
+    r138 = r138 * r88;
+    r138 = fma(r93, r131, r52 * r138);
+    r137 = r53 * r35;
+    r137 = r137 * r107;
+    r137 = r137 * r116;
+    r137 = r137 * r36;
+    r137 = r137 * r96;
+    r138 = fma(r37, r137, r138);
+    r138 = fma(r54, r134, r138);
+    r138 = r138 + r99;
+    r138 = fma(r4, r138, r57 * r119);
+    r119 = r20 * r63;
+    r119 = r119 * r116;
+    r119 = r119 * r51;
+    r119 = r119 * r69;
+    r138 = fma(r37, r119, r138);
+    r99 = r63 * r75;
+    r99 = r99 * r93;
+    r99 = r99 * r36;
+    r99 = r99 * r68;
+    r99 = r99 * r100;
+    r138 = fma(r37, r99, r138);
+    r134 = r75 * r93;
+    r134 = r134 * r36;
+    r134 = r134 * r68;
+    r134 = r134 * r100;
+    r138 = fma(r37, r134, r138);
+    r137 = r5 * r88;
+    r138 = fma(r108, r137, r138);
+    r136 = r5 * r93;
+    r138 = fma(r118, r136, r138);
+    r135 = r53 * r78;
+    r135 = r135 * r93;
+    r135 = r135 * r70;
+    r138 = fma(r86, r135, r138);
+    r128 = r5 * r111;
+    r128 = r128 * r52;
+    r138 = fma(r113, r128, r138);
+    r127 = r5 * r21;
+    r127 = r127 * r93;
+    r127 = r127 * r51;
+    r127 = r127 * r100;
+    r127 = r127 * r102;
+    r127 = r127 * r37;
+    r138 = fma(r55, r127, r138);
+    r117 = r125 * r37;
+    r138 = fma(r70, r117, r138);
+    r82 = r20 * r116;
+    r82 = r82 * r51;
+    r82 = r82 * r69;
+    r138 = fma(r37, r82, r138);
+    r132 = r53 * r93;
+    r132 = r132 * r86;
+    r138 = fma(r129, r132, r138);
+    r81 = r35 * r88;
+    r138 = fma(r70, r81, r138);
+    r19 = r35 * r88;
+    r138 = fma(r71, r19, r138);
+    r138 = fma(r116, r115, r138);
+    r19 = r3 * r138;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 2 * out_pose_jac_num_alloc, global_thread_idx, r139, r19);
+    r19 = r53 * r35;
+    r139 = r30 * r89;
+    r27 = fma(r75, r27, r78 * r23);
+    r27 = fma(r78, r24, r27);
+    r27 = fma(r78, r26, r27);
+    r139 = r139 * r27;
+    r77 = r89 * r77;
+    r26 = r139 + r77;
+    r24 = r6 * r18;
+    r24 = r24 * r27;
+    r120 = r120 + r24;
+    r23 = r21 * r25;
+    r120 = fma(r114, r23, r120);
+    r81 = r21 * r33;
+    r120 = fma(r76, r81, r120);
+    r120 = fma(r8, r120, r34 * r26);
+    r26 = r6 * r33;
+    r26 = fma(r6, r83, r27 * r26);
+    r26 = r26 + r84;
+    r120 = fma(r9, r26, r120);
+    r19 = r19 * r120;
+    r19 = r19 * r36;
+    r19 = r19 * r37;
+    r26 = r6 * r53;
+    r81 = r6 * r25;
+    r81 = r81 * r27;
+    r91 = r91 + r81;
+    r91 = r91 + r94;
+    r94 = r21 * r33;
+    r83 = fma(r21, r83, r27 * r94);
+    r83 = r83 + r84;
+    r83 = fma(r34, r83, r8 * r91);
+    r85 = r18 * r85;
+    r85 = r85 * r89;
+    r139 = r139 + r85;
+    r83 = fma(r9, r139, r83);
+    r26 = r26 * r83;
+    r26 = fma(r120, r74, r51 * r26);
+    r139 = r6 * r29;
+    r101 = r79 + r101;
+    r79 = r18 * r21;
+    r101 = fma(r114, r79, r101);
+    r101 = r101 + r81;
+    r77 = r85 + r77;
+    r77 = fma(r8, r77, r9 * r101);
+    r8 = r6 * r33;
+    r8 = fma(r76, r8, r24);
+    r8 = r8 + r124;
+    r77 = fma(r34, r8, r77);
+    r139 = r139 * r77;
+    r26 = fma(r51, r139, r26);
+    r8 = r53 * r53;
+    r8 = r8 * r120;
+    r26 = fma(r97, r8, r26);
+    r19 = fma(r26, r110, r97 * r19);
+    r8 = r83 * r52;
+    r19 = fma(r113, r8, r19);
+    r139 = r20 * r53;
+    r139 = r139 * r35;
+    r139 = r139 * r26;
+    r139 = r139 * r51;
+    r139 = r139 * r100;
+    r139 = r139 * r102;
+    r19 = fma(r37, r139, r19);
+    r139 = r20 * r29;
+    r139 = r139 * r29;
+    r139 = r139 * r35;
+    r139 = r139 * r35;
+    r139 = r139 * r26;
+    r139 = r139 * r51;
+    r139 = r139 * r100;
+    r139 = fma(r77, r108, r102 * r139);
+    r8 = r26 * r98;
+    r139 = fma(r95, r8, r139);
+    r139 = fma(r120, r112, r139);
+    r8 = r19 + r139;
+    r34 = r26 * r92;
+    r124 = r35 * r105;
+    r124 = r124 * r77;
+    r124 = r124 * r40;
+    r124 = fma(r55, r124, r104 * r34);
+    r34 = r29 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r107;
+    r34 = r34 * r120;
+    r34 = r34 * r36;
+    r124 = fma(r96, r34, r124);
+    r24 = r54 * r26;
+    r24 = r24 * r98;
+    r124 = fma(r95, r24, r124);
+    r124 = r124 + r19;
+    r124 = fma(r5, r124, r56 * r8);
+    r19 = r61 * r6;
+    r19 = r19 * r43;
+    r19 = fma(r8, r19, r60 * r8);
+    r19 = fma(r8, r64, r19);
+    r19 = fma(r8, r65, r19);
+    r24 = r19 * r70;
+    r124 = fma(r55, r24, r124);
+    r34 = r78 * r26;
+    r34 = r34 * r70;
+    r124 = fma(r95, r34, r124);
+    r76 = r35 * r77;
+    r124 = fma(r71, r76, r124);
+    r101 = r4 * r26;
+    r124 = fma(r118, r101, r124);
+    r9 = r29 * r35;
+    r9 = r9 * r63;
+    r9 = r9 * r75;
+    r9 = r9 * r26;
+    r9 = r9 * r36;
+    r9 = r9 * r68;
+    r124 = fma(r100, r9, r124);
+    r85 = r20 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r120;
+    r85 = r85 * r51;
+    r124 = fma(r69, r85, r124);
+    r79 = r4 * r77;
+    r79 = r79 * r52;
+    r124 = fma(r113, r79, r124);
+    r81 = r4 * r120;
+    r124 = fma(r126, r81, r124);
+    r114 = r35 * r77;
+    r124 = fma(r70, r114, r124);
+    r89 = r29 * r35;
+    r89 = r89 * r75;
+    r89 = r89 * r26;
+    r89 = r89 * r36;
+    r89 = r89 * r68;
+    r124 = fma(r100, r89, r124);
+    r91 = r20 * r29;
+    r91 = r91 * r35;
+    r91 = r91 * r63;
+    r91 = r91 * r120;
+    r91 = r91 * r51;
+    r124 = fma(r69, r91, r124);
+    r84 = r4 * r21;
+    r84 = r84 * r26;
+    r84 = r84 * r51;
+    r84 = r84 * r100;
+    r84 = r84 * r102;
+    r84 = r84 * r37;
+    r124 = fma(r55, r84, r124);
+    r124 = fma(r83, r121, r124);
+    r124 = fma(r26, r130, r124);
+    r84 = r2 * r124;
+    r91 = r53 * r35;
+    r91 = r91 * r107;
+    r91 = r91 * r120;
+    r91 = r91 * r36;
+    r91 = r91 * r96;
+    r89 = r54 * r26;
+    r89 = fma(r110, r89, r37 * r91);
+    r91 = r35 * r105;
+    r91 = r91 * r83;
+    r89 = fma(r52, r91, r89);
+    r89 = fma(r26, r131, r89);
+    r89 = r89 + r139;
+    r89 = fma(r4, r89, r57 * r8);
+    r8 = r20 * r120;
+    r8 = r8 * r51;
+    r8 = r8 * r69;
+    r89 = fma(r37, r8, r89);
+    r139 = r5 * r83;
+    r89 = fma(r108, r139, r89);
+    r91 = r20 * r63;
+    r91 = r91 * r120;
+    r91 = r91 * r51;
+    r91 = r91 * r69;
+    r89 = fma(r37, r91, r89);
+    r114 = r53 * r78;
+    r114 = r114 * r26;
+    r114 = r114 * r70;
+    r89 = fma(r86, r114, r89);
+    r81 = r35 * r83;
+    r89 = fma(r70, r81, r89);
+    r79 = r5 * r26;
+    r89 = fma(r118, r79, r89);
+    r85 = r63 * r75;
+    r85 = r85 * r26;
+    r85 = r85 * r36;
+    r85 = r85 * r68;
+    r85 = r85 * r100;
+    r89 = fma(r37, r85, r89);
+    r9 = r19 * r37;
+    r89 = fma(r70, r9, r89);
+    r101 = r75 * r26;
+    r101 = r101 * r36;
+    r101 = r101 * r68;
+    r101 = r101 * r100;
+    r89 = fma(r37, r101, r89);
+    r76 = r53 * r26;
+    r76 = r76 * r86;
+    r89 = fma(r129, r76, r89);
+    r34 = r5 * r77;
+    r34 = r34 * r52;
+    r89 = fma(r113, r34, r89);
+    r24 = r35 * r83;
+    r89 = fma(r71, r24, r89);
+    r94 = r5 * r21;
+    r94 = r94 * r26;
+    r94 = r94 * r51;
+    r94 = r94 * r100;
+    r94 = r94 * r102;
+    r94 = r94 * r37;
+    r89 = fma(r55, r94, r89);
+    r89 = fma(r120, r115, r89);
+    r94 = r3 * r89;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r84, r94);
+    r94 = r45 * r35;
+    r94 = r94 * r105;
+    r94 = r94 * r40;
+    r84 = r6 * r7;
+    r84 = r84 * r53;
+    r24 = r47 * r53;
+    r24 = r24 * r53;
+    r24 = fma(r97, r24, r51 * r84);
+    r84 = r6 * r45;
+    r84 = r84 * r29;
+    r24 = fma(r51, r84, r24);
+    r24 = fma(r47, r74, r24);
+    r84 = r24 * r92;
+    r84 = fma(r104, r84, r55 * r94);
+    r94 = r54 * r24;
+    r94 = r94 * r98;
+    r84 = fma(r95, r94, r84);
+    r34 = r47 * r29;
+    r34 = r34 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r107;
+    r34 = r34 * r36;
+    r84 = fma(r96, r34, r84);
+    r76 = r7 * r52;
+    r101 = r20 * r53;
+    r101 = r101 * r35;
+    r101 = r101 * r24;
+    r101 = r101 * r51;
+    r101 = r101 * r100;
+    r101 = r101 * r102;
+    r101 = fma(r37, r101, r113 * r76);
+    r76 = r47 * r53;
+    r76 = r76 * r35;
+    r76 = r76 * r36;
+    r76 = r76 * r37;
+    r101 = fma(r97, r76, r101);
+    r101 = fma(r24, r110, r101);
+    r84 = r84 + r101;
+    r34 = r20 * r29;
+    r34 = r34 * r29;
+    r34 = r34 * r35;
+    r34 = r34 * r35;
+    r34 = r34 * r24;
+    r34 = r34 * r51;
+    r34 = r34 * r100;
+    r34 = fma(r102, r34, r45 * r108);
+    r94 = r24 * r98;
+    r34 = fma(r95, r94, r34);
+    r34 = fma(r47, r112, r34);
+    r101 = r101 + r34;
+    r84 = fma(r56, r101, r5 * r84);
+    r94 = r29 * r35;
+    r94 = r94 * r63;
+    r94 = r94 * r75;
+    r94 = r94 * r24;
+    r94 = r94 * r36;
+    r94 = r94 * r68;
+    r84 = fma(r100, r94, r84);
+    r76 = r78 * r24;
+    r76 = r76 * r70;
+    r84 = fma(r95, r76, r84);
+    r9 = r29 * r35;
+    r9 = r9 * r75;
+    r9 = r9 * r24;
+    r9 = r9 * r36;
+    r9 = r9 * r68;
+    r84 = fma(r100, r9, r84);
+    r85 = r20 * r47;
+    r85 = r85 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r63;
+    r85 = r85 * r51;
+    r84 = fma(r69, r85, r84);
+    r79 = r61 * r6;
+    r79 = r79 * r43;
+    r79 = fma(r101, r79, r60 * r101);
+    r79 = fma(r101, r64, r79);
+    r79 = fma(r101, r65, r79);
+    r81 = r79 * r70;
+    r84 = fma(r55, r81, r84);
+    r114 = r20 * r47;
+    r114 = r114 * r29;
+    r114 = r114 * r35;
+    r114 = r114 * r51;
+    r84 = fma(r69, r114, r84);
+    r91 = r4 * r24;
+    r84 = fma(r118, r91, r84);
+    r139 = r45 * r35;
+    r84 = fma(r71, r139, r84);
+    r8 = r4 * r45;
+    r8 = r8 * r52;
+    r84 = fma(r113, r8, r84);
+    r27 = r45 * r35;
+    r84 = fma(r70, r27, r84);
+    r23 = r4 * r21;
+    r23 = r23 * r24;
+    r23 = r23 * r51;
+    r23 = r23 * r100;
+    r23 = r23 * r102;
+    r23 = r23 * r37;
+    r84 = fma(r55, r23, r84);
+    r132 = r4 * r47;
+    r84 = fma(r126, r132, r84);
+    r84 = fma(r24, r130, r84);
+    r84 = fma(r7, r121, r84);
+    r132 = r2 * r84;
+    r23 = r7 * r35;
+    r23 = r23 * r105;
+    r23 = fma(r24, r131, r52 * r23);
+    r27 = r47 * r53;
+    r27 = r27 * r35;
+    r27 = r27 * r107;
+    r27 = r27 * r36;
+    r27 = r27 * r96;
+    r23 = fma(r37, r27, r23);
+    r8 = r54 * r24;
+    r23 = fma(r110, r8, r23);
+    r23 = r23 + r34;
+    r101 = fma(r57, r101, r4 * r23);
+    r23 = r7 * r35;
+    r101 = fma(r71, r23, r101);
+    r34 = r53 * r78;
+    r34 = r34 * r24;
+    r34 = r34 * r70;
+    r101 = fma(r86, r34, r101);
+    r8 = r7 * r35;
+    r101 = fma(r70, r8, r101);
+    r27 = r20 * r47;
+    r27 = r27 * r51;
+    r27 = r27 * r69;
+    r101 = fma(r37, r27, r101);
+    r139 = r53 * r24;
+    r139 = r139 * r86;
+    r101 = fma(r129, r139, r101);
+    r91 = r20 * r47;
+    r91 = r91 * r63;
+    r91 = r91 * r51;
+    r91 = r91 * r69;
+    r101 = fma(r37, r91, r101);
+    r114 = r5 * r7;
+    r101 = fma(r108, r114, r101);
+    r81 = r63 * r75;
+    r81 = r81 * r24;
+    r81 = r81 * r36;
+    r81 = r81 * r68;
+    r81 = r81 * r100;
+    r101 = fma(r37, r81, r101);
+    r85 = r5 * r24;
+    r101 = fma(r118, r85, r101);
+    r9 = r5 * r45;
+    r9 = r9 * r52;
+    r101 = fma(r113, r9, r101);
+    r76 = r75 * r24;
+    r76 = r76 * r36;
+    r76 = r76 * r68;
+    r76 = r76 * r100;
+    r101 = fma(r37, r76, r101);
+    r94 = r79 * r37;
+    r101 = fma(r70, r94, r101);
+    r82 = r5 * r21;
+    r82 = r82 * r24;
+    r82 = r82 * r51;
+    r82 = r82 * r100;
+    r82 = r82 * r102;
+    r82 = r82 * r37;
+    r101 = fma(r55, r82, r101);
+    r101 = fma(r47, r115, r101);
+    r82 = r3 * r101;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r132, r82);
+    r82 = r49 * r53;
+    r82 = r82 * r35;
+    r82 = r82 * r36;
+    r82 = r82 * r37;
+    r132 = r46 * r52;
+    r132 = fma(r113, r132, r97 * r82);
+    r82 = r49 * r53;
+    r82 = r82 * r53;
+    r94 = r6 * r46;
+    r94 = r94 * r53;
+    r94 = fma(r51, r94, r97 * r82);
+    r82 = r6 * r42;
+    r82 = r82 * r29;
+    r94 = fma(r51, r82, r94);
+    r94 = fma(r49, r74, r94);
+    r82 = r20 * r53;
+    r82 = r82 * r35;
+    r82 = r82 * r94;
+    r82 = r82 * r51;
+    r82 = r82 * r100;
+    r82 = r82 * r102;
+    r132 = fma(r37, r82, r132);
+    r132 = fma(r94, r110, r132);
+    r82 = r94 * r98;
+    r82 = fma(r49, r112, r95 * r82);
+    r76 = r20 * r29;
+    r76 = r76 * r29;
+    r76 = r76 * r35;
+    r76 = r76 * r35;
+    r76 = r76 * r94;
+    r76 = r76 * r51;
+    r76 = r76 * r100;
+    r82 = fma(r102, r76, r82);
+    r82 = fma(r42, r108, r82);
+    r76 = r132 + r82;
+    r9 = r54 * r94;
+    r9 = r9 * r98;
+    r85 = r49 * r29;
+    r85 = r85 * r29;
+    r85 = r85 * r35;
+    r85 = r85 * r35;
+    r85 = r85 * r107;
+    r85 = r85 * r36;
+    r85 = fma(r96, r85, r95 * r9);
+    r9 = r94 * r92;
+    r85 = fma(r104, r9, r85);
+    r81 = r42 * r35;
+    r81 = r81 * r105;
+    r81 = r81 * r40;
+    r85 = fma(r55, r81, r85);
+    r85 = r85 + r132;
+    r85 = fma(r5, r85, r56 * r76);
+    r132 = r94 * r118;
+    r81 = r42 * r35;
+    r85 = fma(r70, r81, r85);
+    r9 = r20 * r49;
+    r9 = r9 * r29;
+    r9 = r9 * r35;
+    r9 = r9 * r51;
+    r85 = fma(r69, r9, r85);
+    r114 = r4 * r42;
+    r114 = r114 * r52;
+    r85 = fma(r113, r114, r85);
+    r91 = r29 * r35;
+    r91 = r91 * r63;
+    r91 = r91 * r75;
+    r91 = r91 * r94;
+    r91 = r91 * r36;
+    r91 = r91 * r68;
+    r85 = fma(r100, r91, r85);
+    r139 = r20 * r49;
+    r139 = r139 * r29;
+    r139 = r139 * r35;
+    r139 = r139 * r63;
+    r139 = r139 * r51;
+    r85 = fma(r69, r139, r85);
+    r27 = r78 * r94;
+    r27 = r27 * r70;
+    r85 = fma(r95, r27, r85);
+    r8 = r42 * r35;
+    r85 = fma(r71, r8, r85);
+    r34 = r61 * r6;
+    r34 = r34 * r43;
+    r34 = fma(r60, r76, r76 * r34);
+    r34 = fma(r76, r65, r34);
+    r34 = fma(r76, r64, r34);
+    r23 = r34 * r70;
+    r85 = fma(r55, r23, r85);
+    r117 = r29 * r35;
+    r117 = r117 * r75;
+    r117 = r117 * r94;
+    r117 = r117 * r36;
+    r117 = r117 * r68;
+    r85 = fma(r100, r117, r85);
+    r127 = r4 * r21;
+    r127 = r127 * r94;
+    r127 = r127 * r51;
+    r127 = r127 * r100;
+    r127 = r127 * r102;
+    r127 = r127 * r37;
+    r85 = fma(r55, r127, r85);
+    r128 = r4 * r49;
+    r85 = fma(r126, r128, r85);
+    r85 = fma(r4, r132, r85);
+    r85 = fma(r94, r130, r85);
+    r85 = fma(r46, r121, r85);
+    r128 = r2 * r85;
+    r127 = r49 * r53;
+    r127 = r127 * r35;
+    r127 = r127 * r107;
+    r127 = r127 * r36;
+    r127 = r127 * r96;
+    r117 = r46 * r35;
+    r117 = r117 * r105;
+    r117 = fma(r52, r117, r37 * r127);
+    r127 = r54 * r94;
+    r117 = fma(r110, r127, r117);
+    r117 = fma(r94, r131, r117);
+    r117 = r117 + r82;
+    r117 = fma(r4, r117, r57 * r76);
+    r76 = r20 * r49;
+    r76 = r76 * r51;
+    r76 = r76 * r69;
+    r117 = fma(r37, r76, r117);
+    r82 = r20 * r49;
+    r82 = r82 * r63;
+    r82 = r82 * r51;
+    r82 = r82 * r69;
+    r117 = fma(r37, r82, r117);
+    r127 = r53 * r94;
+    r127 = r127 * r86;
+    r117 = fma(r129, r127, r117);
+    r23 = r53 * r78;
+    r23 = r23 * r94;
+    r23 = r23 * r70;
+    r117 = fma(r86, r23, r117);
+    r8 = r5 * r42;
+    r8 = r8 * r52;
+    r117 = fma(r113, r8, r117);
+    r27 = r46 * r35;
+    r117 = fma(r71, r27, r117);
+    r139 = r34 * r37;
+    r117 = fma(r70, r139, r117);
+    r91 = r75 * r94;
+    r91 = r91 * r36;
+    r91 = r91 * r68;
+    r91 = r91 * r100;
+    r117 = fma(r37, r91, r117);
+    r114 = r5 * r46;
+    r117 = fma(r108, r114, r117);
+    r9 = r5 * r21;
+    r9 = r9 * r94;
+    r9 = r9 * r51;
+    r9 = r9 * r100;
+    r9 = r9 * r102;
+    r9 = r9 * r37;
+    r117 = fma(r55, r9, r117);
+    r81 = r46 * r35;
+    r117 = fma(r70, r81, r117);
+    r135 = r63 * r75;
+    r135 = r135 * r94;
+    r135 = r135 * r36;
+    r135 = r135 * r68;
+    r135 = r135 * r100;
+    r117 = fma(r37, r135, r117);
+    r117 = fma(r5, r132, r117);
+    r117 = fma(r49, r115, r117);
+    r135 = r3 * r117;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             8 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r128,
+                                             r135);
+    r135 = r20 * r29;
+    r128 = r6 * r38;
+    r128 = r128 * r53;
+    r81 = r44 * r53;
+    r81 = r81 * r53;
+    r81 = fma(r97, r81, r51 * r128);
+    r128 = r6 * r39;
+    r128 = r128 * r29;
+    r81 = fma(r51, r128, r81);
+    r81 = fma(r44, r74, r81);
+    r135 = r135 * r29;
+    r135 = r135 * r35;
+    r135 = r135 * r35;
+    r135 = r135 * r81;
+    r135 = r135 * r51;
+    r135 = r135 * r100;
+    r74 = r81 * r98;
+    r74 = fma(r95, r74, r102 * r135);
+    r74 = fma(r39, r108, r74);
+    r74 = fma(r44, r112, r74);
+    r112 = r44 * r53;
+    r112 = r112 * r35;
+    r112 = r112 * r36;
+    r112 = r112 * r37;
+    r135 = r38 * r52;
+    r135 = fma(r113, r135, r97 * r112);
+    r112 = r20 * r53;
+    r112 = r112 * r35;
+    r112 = r112 * r81;
+    r112 = r112 * r51;
+    r112 = r112 * r100;
+    r112 = r112 * r102;
+    r135 = fma(r37, r112, r135);
+    r135 = fma(r81, r110, r135);
+    r112 = r74 + r135;
+    r97 = r81 * r92;
+    r128 = r54 * r81;
+    r128 = r128 * r98;
+    r128 = fma(r95, r128, r104 * r97);
+    r97 = r39 * r35;
+    r97 = r97 * r105;
+    r97 = r97 * r40;
+    r128 = fma(r55, r97, r128);
+    r40 = r44 * r29;
+    r40 = r40 * r29;
+    r40 = r40 * r35;
+    r40 = r40 * r35;
+    r40 = r40 * r107;
+    r40 = r40 * r36;
+    r128 = fma(r96, r40, r128);
+    r128 = r128 + r135;
+    r128 = fma(r5, r128, r56 * r112);
+    r56 = r61 * r6;
+    r56 = r56 * r43;
+    r60 = fma(r60, r112, r112 * r56);
+    r60 = fma(r112, r64, r60);
+    r60 = fma(r112, r65, r60);
+    r65 = r60 * r70;
+    r128 = fma(r55, r65, r128);
+    r64 = r20 * r44;
+    r64 = r64 * r29;
+    r64 = r64 * r35;
+    r64 = r64 * r63;
+    r64 = r64 * r51;
+    r128 = fma(r69, r64, r128);
+    r56 = r29 * r35;
+    r56 = r56 * r63;
+    r56 = r56 * r75;
+    r56 = r56 * r81;
+    r56 = r56 * r36;
+    r56 = r56 * r68;
+    r128 = fma(r100, r56, r128);
+    r135 = r4 * r21;
+    r135 = r135 * r81;
+    r135 = r135 * r51;
+    r135 = r135 * r100;
+    r135 = r135 * r102;
+    r135 = r135 * r37;
+    r128 = fma(r55, r135, r128);
+    r40 = r4 * r81;
+    r128 = fma(r118, r40, r128);
+    r97 = r4 * r44;
+    r128 = fma(r126, r97, r128);
+    r126 = r78 * r81;
+    r126 = r126 * r70;
+    r128 = fma(r95, r126, r128);
+    r95 = r39 * r35;
+    r128 = fma(r71, r95, r128);
+    r104 = r4 * r39;
+    r104 = r104 * r52;
+    r128 = fma(r113, r104, r128);
+    r9 = r20 * r44;
+    r9 = r9 * r29;
+    r9 = r9 * r35;
+    r9 = r9 * r51;
+    r128 = fma(r69, r9, r128);
+    r114 = r39 * r35;
+    r128 = fma(r70, r114, r128);
+    r91 = r29 * r35;
+    r91 = r91 * r75;
+    r91 = r91 * r81;
+    r91 = r91 * r36;
+    r91 = r91 * r68;
+    r128 = fma(r100, r91, r128);
+    r128 = fma(r38, r121, r128);
+    r128 = fma(r81, r130, r128);
+    r91 = r2 * r128;
+    r130 = r44 * r53;
+    r130 = r130 * r35;
+    r130 = r130 * r107;
+    r130 = r130 * r36;
+    r130 = r130 * r96;
+    r107 = r38 * r35;
+    r107 = r107 * r105;
+    r107 = fma(r52, r107, r37 * r130);
+    r130 = r54 * r81;
+    r107 = fma(r110, r130, r107);
+    r107 = fma(r81, r131, r107);
+    r107 = r107 + r74;
+    r107 = fma(r4, r107, r57 * r112);
+    r112 = r75 * r81;
+    r112 = r112 * r36;
+    r112 = r112 * r68;
+    r112 = r112 * r100;
+    r107 = fma(r37, r112, r107);
+    r57 = r20 * r44;
+    r57 = r57 * r51;
+    r57 = r57 * r69;
+    r107 = fma(r37, r57, r107);
+    r74 = r5 * r38;
+    r107 = fma(r108, r74, r107);
+    r108 = r38 * r35;
+    r107 = fma(r70, r108, r107);
+    r131 = r63 * r75;
+    r131 = r131 * r81;
+    r131 = r131 * r36;
+    r131 = r131 * r68;
+    r131 = r131 * r100;
+    r107 = fma(r37, r131, r107);
+    r68 = r5 * r21;
+    r68 = r68 * r81;
+    r68 = r68 * r51;
+    r68 = r68 * r100;
+    r68 = r68 * r102;
+    r68 = r68 * r37;
+    r107 = fma(r55, r68, r107);
+    r100 = r5 * r81;
+    r107 = fma(r118, r100, r107);
+    r118 = r53 * r81;
+    r118 = r118 * r86;
+    r107 = fma(r129, r118, r107);
+    r129 = r38 * r35;
+    r107 = fma(r71, r129, r107);
+    r71 = r5 * r39;
+    r71 = r71 * r52;
+    r107 = fma(r113, r71, r107);
+    r36 = r53 * r78;
+    r36 = r36 * r81;
+    r36 = r36 * r70;
+    r107 = fma(r86, r36, r107);
+    r86 = r60 * r37;
+    r107 = fma(r70, r86, r107);
+    r130 = r20 * r44;
+    r130 = r130 * r63;
+    r130 = r130 * r51;
+    r130 = r130 * r69;
+    r107 = fma(r37, r130, r107);
+    r107 = fma(r44, r115, r107);
+    r130 = r3 * r107;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r91,
+                                             r130);
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r91 = r20 * r0;
+    r86 = r2 * r91;
+    r130 = fma(r103, r86, r109 * r130);
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r133, r86, r138 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r130, r36);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r124, r86, r89 * r36);
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r130 = fma(r84, r86, r101 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r36, r130);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r3 * r20;
+    r130 = r130 * r1;
+    r130 = fma(r85, r86, r117 * r130);
+    r36 = r3 * r20;
+    r36 = r36 * r1;
+    r36 = fma(r128, r86, r107 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r130, r36);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r103 * r103;
+    r130 = r2 * r2;
+    r71 = r109 * r109;
+    r129 = r3 * r3;
+    r71 = fma(r129, r71, r130 * r36);
+    r36 = r133 * r133;
+    r118 = r138 * r138;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r89 * r89;
+    r71 = r124 * r124;
+    r71 = fma(r130, r71, r129 * r118);
+    r118 = r101 * r101;
+    r36 = r84 * r84;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r117 * r117;
+    r71 = r85 * r85;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r128 * r128;
+    r118 = r107 * r107;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r103 * r133;
+    r71 = r109 * r138;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r109 * r89;
+    r36 = r103 * r124;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r103 * r84;
+    r71 = r109 * r101;
+    r71 = fma(r129, r71, r130 * r36);
+    r36 = r109 * r117;
+    r118 = r103 * r85;
+    r118 = fma(r130, r118, r129 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r103 * r128;
+    r71 = r109 * r107;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r138 * r89;
+    r36 = r133 * r124;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r138 * r101;
+    r71 = r133 * r84;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r133 * r85;
+    r118 = r138 * r117;
+    r118 = fma(r129, r118, r130 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r133 * r128;
+    r71 = r138 * r107;
+    r71 = fma(r129, r71, r130 * r118);
+    r118 = r89 * r101;
+    r36 = r124 * r84;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r89 * r117;
+    r71 = r124 * r85;
+    r71 = fma(r130, r71, r129 * r36);
+    r36 = r89 * r107;
+    r118 = r124 * r128;
+    r118 = fma(r130, r118, r129 * r36);
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r118 = r101 * r117;
+    r71 = r84 * r85;
+    r71 = fma(r130, r71, r129 * r118);
+    r118 = r101 * r107;
+    r36 = r84 * r128;
+    r36 = fma(r130, r36, r129 * r118);
+    WriteSum2<double, double>((double*)inout_shared, r71, r36);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r117 * r107;
+    r71 = r85 * r128;
+    r71 = fma(r130, r71, r129 * r36);
+    WriteSum1<double, double>((double*)inout_shared, r71);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r59,
+                                             r58);
+    r71 = r2 * r43;
+    r71 = r71 * r70;
+    r71 = r71 * r55;
+    r36 = r3 * r43;
+    r36 = r36 * r37;
+    r36 = r36 * r70;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             2 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r71,
+                                             r36);
+    r118 = r2 * r70;
+    r118 = r118 * r55;
+    r118 = r118 * r62;
+    r115 = r3 * r37;
+    r115 = r115 * r70;
+    r115 = r115 * r62;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r118,
+                                             r115);
+    r100 = r3 * r72;
+    r68 = r2 * r6;
+    r68 = r68 * r55;
+    r68 = r68 * r52;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r68,
+                                             r100);
+    r131 = r2 * r31;
+    r108 = r3 * r6;
+    r108 = r108 * r55;
+    r108 = r108 * r52;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r108);
+    r74 = r2 * r70;
+    r74 = r74 * r55;
+    r74 = r74 * r67;
+    r57 = r3 * r37;
+    r57 = r57 * r70;
+    r57 = r57 * r67;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r74,
+                                             r57);
+    r112 = r2 * r70;
+    r112 = r112 * r55;
+    r112 = r112 * r66;
+    r69 = r3 * r37;
+    r69 = r69 * r70;
+    r69 = r69 * r66;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r112,
+                                             r69);
+    r51 = r2 * r43;
+    r110 = r3 * r43;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r51,
+                                             r110);
+    r114 = r20 * r58;
+    r114 = r114 * r1;
+    r9 = r59 * r91;
+    WriteSum2<double, double>((double*)inout_shared, r9, r114);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r20 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r91, r114);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = r43 * r70;
+    r114 = r114 * r55;
+    r91 = r3 * r20;
+    r91 = r91 * r43;
+    r91 = r91 * r1;
+    r91 = r91 * r37;
+    r91 = fma(r70, r91, r86 * r114);
+    r114 = r3 * r20;
+    r114 = r114 * r1;
+    r114 = r114 * r37;
+    r114 = r114 * r70;
+    r9 = r70 * r55;
+    r9 = r9 * r62;
+    r9 = fma(r86, r9, r62 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r91, r9);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r20;
+    r9 = r9 * r72;
+    r91 = r2 * r21;
+    r91 = r91 * r0;
+    r91 = r91 * r55;
+    r91 = fma(r52, r91, r1 * r9);
+    r9 = r3 * r21;
+    r9 = r9 * r1;
+    r9 = r9 * r55;
+    r9 = fma(r52, r9, r31 * r86);
+    WriteSum2<double, double>((double*)inout_shared, r91, r9);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r20;
+    r9 = r9 * r1;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    r91 = r70 * r55;
+    r91 = r91 * r67;
+    r91 = fma(r86, r91, r67 * r9);
+    r9 = r3 * r20;
+    r9 = r9 * r1;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    r0 = r70 * r55;
+    r0 = r0 * r66;
+    r0 = fma(r86, r0, r66 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r91, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r20;
+    r0 = r0 * r43;
+    r0 = r0 * r1;
+    r86 = r43 * r86;
+    WriteSum2<double, double>((double*)inout_shared, r86, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r59 * r59;
+    r86 = r58 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r0, r86);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r22, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r35 * r62;
+    r22 = r22 * r129;
+    r86 = r29 * r35;
+    r86 = r86 * r62;
+    r86 = r86 * r130;
+    r86 = fma(r98, r86, r50 * r22);
+    r22 = r35 * r129;
+    r22 = r22 * r66;
+    r0 = r29 * r35;
+    r0 = r0 * r130;
+    r0 = r0 * r98;
+    r0 = fma(r66, r0, r50 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r86, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r37 * r130;
+    r22 = r29 * r53;
+    r48 = r28 * r48;
+    r48 = 1.0 / r48;
+    r32 = r41 * r32;
+    r32 = 1.0 / r32;
+    r22 = r22 * r35;
+    r22 = r22 * r35;
+    r22 = r22 * r123;
+    r22 = r22 * r48;
+    r22 = r22 * r32;
+    r22 = r22 * r55;
+    r32 = r72 * r72;
+    r32 = fma(r129, r32, r22 * r86);
+    r86 = r37 * r129;
+    r48 = r31 * r130;
+    r22 = fma(r31, r48, r86 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r32, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r67 * r67;
+    r32 = r35 * r22;
+    r123 = r129 * r50;
+    r41 = r35 * r22;
+    r28 = r29 * r130;
+    r28 = r28 * r98;
+    r41 = fma(r28, r41, r123 * r32);
+    r32 = r43 * r22;
+    r32 = r35 * r32;
+    r1 = r43 * r32;
+    r1 = fma(r28, r1, r123 * r1);
+    WriteSum2<double, double>((double*)inout_shared, r41, r1);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r62 * r130;
+    r91 = r62 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r1, r91);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r91, r59);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r2 * r43;
+    r1 = r1 * r59;
+    r1 = r1 * r70;
+    r1 = r1 * r55;
+    WriteSum2<double, double>((double*)inout_shared, r91, r1);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r2 * r59;
+    r1 = r1 * r70;
+    r1 = r1 * r55;
+    r1 = r1 * r62;
+    r9 = r2 * r6;
+    r9 = r9 * r59;
+    r9 = r9 * r55;
+    r9 = r9 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r1, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r2 * r31;
+    r31 = r31 * r59;
+    r9 = r2 * r59;
+    r9 = r9 * r70;
+    r9 = r9 * r55;
+    r9 = r9 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r31, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r2 * r43;
+    r9 = r9 * r59;
+    r59 = r2 * r59;
+    r59 = r59 * r70;
+    r59 = r59 * r55;
+    r59 = r59 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r59, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r43;
+    r9 = r9 * r58;
+    r9 = r9 * r37;
+    r9 = r9 * r70;
+    WriteSum2<double, double>((double*)inout_shared, r58, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r72;
+    r9 = r9 * r58;
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r62;
+    WriteSum2<double, double>((double*)inout_shared, r59, r9);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r6;
+    r9 = r9 * r58;
+    r9 = r9 * r55;
+    r9 = r9 * r52;
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r9, r59);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r3 * r58;
+    r59 = r59 * r37;
+    r59 = r59 * r70;
+    r59 = r59 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r59, r91);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r3 * r43;
+    r59 = r59 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r59, r91);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r71, r118);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r68, r131);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r74, r112);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r51, r91);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r36, r115);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r100, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r57, r69);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r91, r110);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r110 = r35 * r67;
+    r110 = r110 * r129;
+    r69 = r29 * r35;
+    r69 = r69 * r67;
+    r69 = r69 * r130;
+    r69 = fma(r98, r69, r50 * r110);
+    r110 = r70 * r86;
+    r57 = r72 * r110;
+    r108 = r29 * r43;
+    r108 = r108 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r43 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r69, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r43;
+    r108 = r108 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r113;
+    r69 = r55 * r48;
+    r100 = r70 * r69;
+    r108 = fma(r43, r100, r86 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r108, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r70 * r55;
+    r0 = r0 * r62;
+    r0 = r0 * r130;
+    r108 = r35 * r129;
+    r115 = r43 * r66;
+    r108 = r108 * r50;
+    r50 = r29 * r35;
+    r50 = r50 * r130;
+    r50 = r50 * r98;
+    r50 = fma(r115, r50, r115 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r50, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r62 * r110;
+    r108 = r29 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r62;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r62 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r0, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r62;
+    r108 = r108 * r113;
+    r108 = fma(r62, r100, r86 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r108, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r70 * r55;
+    r50 = r50 * r67;
+    r50 = r50 * r130;
+    WriteSum2<double, double>((double*)inout_shared, r41, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r67 * r110;
+    r41 = r6 * r52;
+    r108 = r6 * r72;
+    r108 = r108 * r55;
+    r108 = r108 * r52;
+    r108 = fma(r129, r108, r69 * r41);
+    WriteSum2<double, double>((double*)inout_shared, r50, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r29 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r37;
+    r108 = r108 * r55;
+    r108 = r108 * r67;
+    r108 = r108 * r130;
+    r108 = fma(r113, r108, r67 * r57);
+    r50 = r29 * r96;
+    r50 = r50 * r102;
+    r50 = r50 * r37;
+    r50 = r50 * r55;
+    r50 = r50 * r130;
+    r50 = r50 * r113;
+    r50 = fma(r66, r50, r66 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r108, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r6 * r43;
+    r50 = r50 * r55;
+    r50 = r50 * r52;
+    r50 = r50 * r130;
+    r108 = r43 * r72;
+    r108 = r108 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r50, r108);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r53 * r96;
+    r108 = r108 * r102;
+    r108 = r108 * r55;
+    r108 = r108 * r67;
+    r108 = r108 * r113;
+    r108 = fma(r67, r100, r86 * r108);
+    r50 = r53 * r96;
+    r50 = r50 * r102;
+    r50 = r50 * r55;
+    r50 = r50 * r113;
+    r50 = r50 * r66;
+    r100 = fma(r66, r100, r86 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r108, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r43 * r48;
+    r100 = r6 * r43;
+    r100 = r100 * r55;
+    r100 = r100 * r52;
+    r100 = r100 * r129;
+    WriteSum2<double, double>((double*)inout_shared, r48, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = r70 * r55;
+    r100 = r100 * r130;
+    r100 = r100 * r66;
+    r28 = fma(r32, r28, r32 * r123);
+    WriteSum2<double, double>((double*)inout_shared, r28, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r66 * r110;
+    r100 = r70 * r55;
+    r100 = r100 * r130;
+    r100 = r100 * r115;
+    WriteSum2<double, double>((double*)inout_shared, r66, r100);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r110 = r115 * r110;
+    WriteSum2<double, double>((double*)inout_shared, r110, r91);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_res_jac_first.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_score.cu
@@ -1,0 +1,346 @@
+#include "kernel_thin_prism_fisheye_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = r27 * r27;
+    r28 = fma(r28, r8, r36 * r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r8 * r8;
+    r8 = r27 * r8;
+    r28 = fma(r7, r44, r28);
+    r28 = fma(r36, r8, r28);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r28 = r28 * r43;
+    r11 = r4 * r19;
+    r11 = r11 * r42;
+    r11 = r11 * r29;
+    r32 = fma(r6, r11, r32);
+    r32 = fma(r42, r28, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r28, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPointScore(double* pose,
+                                     unsigned int pose_num_alloc,
+                                     SharedIndex* pose_indices,
+                                     double* sensor_from_rig,
+                                     unsigned int sensor_from_rig_num_alloc,
+                                     double* calib,
+                                     unsigned int calib_num_alloc,
+                                     SharedIndex* calib_indices,
+                                     double* pixel,
+                                     unsigned int pixel_num_alloc,
+                                     double* point,
+                                     unsigned int point_num_alloc,
+                                     double* const out_rTr,
+                                     size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPointScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_point_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPointScore(double* pose,
+                                     unsigned int pose_num_alloc,
+                                     SharedIndex* pose_indices,
+                                     double* sensor_from_rig,
+                                     unsigned int sensor_from_rig_num_alloc,
+                                     double* calib,
+                                     unsigned int calib_num_alloc,
+                                     SharedIndex* calib_indices,
+                                     double* pixel,
+                                     unsigned int pixel_num_alloc,
+                                     double* point,
+                                     unsigned int point_num_alloc,
+                                     double* const out_rTr,
+                                     size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,58 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirectKernel(
+        double* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        double* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirect(
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointJtjnjtrDirect(
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.cu
@@ -1,0 +1,860 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r24 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r18);
+    r26 = r15 * r16;
+    r26 = r26 * r10;
+    r27 = r11 * r12;
+    r27 = fma(r10, r27, r26);
+    r28 = -2.00000000000000000e+00;
+    r29 = r15 * r15;
+    r29 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r11 * r11;
+    r31 = fma(r28, r31, r30);
+    r32 = r29 + r31;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r33);
+    r34 = r16 * r11;
+    r34 = r34 * r10;
+    r35 = r15 * r12;
+    r35 = fma(r28, r35, r34);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r36);
+    r37 = r10 * r23;
+    r37 = r37 * r22;
+    r38 = r28 * r25;
+    r39 = fma(r19, r38, r37);
+    r40 = r23 * r23;
+    r40 = r28 * r40;
+    r41 = r30 + r40;
+    r42 = r19 * r19;
+    r42 = r28 * r42;
+    r41 = r41 + r42;
+    r24 = fma(r7, r27, r24);
+    r24 = fma(r18, r32, r24);
+    r24 = fma(r33, r35, r24);
+    r24 = fma(r36, r39, r24);
+    r24 = fma(r9, r41, r24);
+    r41 = r22 * r22;
+    r41 = r28 * r41;
+    r39 = r30 + r41;
+    r39 = r39 + r40;
+    r39 = fma(r8, r39, r6);
+    r20 = fma(r23, r38, r20);
+    r6 = r10 * r23;
+    r6 = r6 * r19;
+    r40 = r10 * r22;
+    r40 = fma(r25, r40, r6);
+    r35 = r15 * r11;
+    r35 = r35 * r10;
+    r32 = r16 * r12;
+    r27 = fma(r10, r32, r35);
+    r43 = r11 * r12;
+    r43 = fma(r28, r43, r26);
+    r26 = r16 * r16;
+    r26 = r26 * r28;
+    r31 = r26 + r31;
+    r39 = fma(r9, r20, r39);
+    r39 = fma(r36, r40, r39);
+    r39 = fma(r33, r27, r39);
+    r39 = fma(r18, r43, r39);
+    r39 = fma(r7, r31, r39);
+    r31 = r39 * r39;
+    r43 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r27);
+    r38 = fma(r22, r38, r6);
+    r38 = fma(r8, r38, r27);
+    r32 = fma(r28, r32, r35);
+    r26 = r30 + r26;
+    r26 = r26 + r29;
+    r29 = r15 * r12;
+    r29 = fma(r10, r29, r34);
+    r34 = r10 * r19;
+    r34 = fma(r25, r34, r37);
+    r41 = r30 + r41;
+    r41 = r41 + r42;
+    r38 = fma(r7, r32, r38);
+    r38 = fma(r33, r26, r38);
+    r38 = fma(r18, r29, r38);
+    r38 = fma(r9, r34, r38);
+    r38 = fma(r36, r41, r38);
+    r41 = copysign(1.0, r38);
+    r41 = fma(r43, r41, r38);
+    r38 = r41 * r41;
+    r36 = 1.0 / r38;
+    r34 = r24 * r24;
+    r34 = fma(r36, r34, r36 * r31);
+    r34 = sqrt(r34);
+    r31 = atan(r34);
+    r9 = r24 * r31;
+    r29 = r24 * r9;
+    r18 = copysign(1.0, r34);
+    r18 = fma(r43, r18, r34);
+    r43 = r18 * r18;
+    r34 = 1.0 / r43;
+    r34 = r36 * r34;
+    r36 = r31 * r34;
+    r29 = r29 * r36;
+    r26 = r39 * r39;
+    r33 = 3.00000000000000000e+00;
+    r26 = r26 * r31;
+    r26 = r26 * r33;
+    r26 = fma(r36, r26, r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r39 * r39;
+    r42 = r42 * r31;
+    r42 = r42 * r36;
+    r29 = r29 + r42;
+    r32 = fma(r32, r29, r5 * r26);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r37, r25);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r35 = r29 * r29;
+    r25 = fma(r25, r35, r37 * r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r37, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = r35 * r35;
+    r6 = r29 * r35;
+    r25 = fma(r8, r27, r25);
+    r25 = fma(r37, r6, r25);
+    r37 = 1.0 / r41;
+    r8 = 1.0 / r18;
+    r40 = r37 * r8;
+    r20 = r25 * r40;
+    r44 = r39 * r31;
+    r32 = fma(r44, r20, r32);
+    r45 = r4 * r44;
+    r46 = r10 * r9;
+    r47 = r34 * r46;
+    r32 = fma(r47, r45, r32);
+    r32 = fma(r40, r44, r32);
+    r0 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r45, r20);
+    r0 = fma(r45, r21, r0);
+    r45 = r24 * r33;
+    r45 = r45 * r9;
+    r45 = fma(r36, r45, r42);
+    r7 = fma(r7, r29, r4 * r45);
+    r42 = r25 * r9;
+    r7 = fma(r40, r42, r7);
+    r48 = r5 * r44;
+    r7 = fma(r47, r48, r7);
+    r7 = fma(r9, r40, r7);
+    r1 = fma(r3, r7, r1);
+    r1 = fma(r20, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r20 = r21 * r7;
+    r20 = r20 * r1;
+    r48 = r21 * r0;
+    r42 = r32 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r42, r20);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r21 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r48, r20);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r2 * r44;
+    r42 = r20 * r48;
+    r49 = r40 * r42;
+    r50 = r21 * r29;
+    r51 = r3 * r9;
+    r50 = r50 * r1;
+    r50 = r50 * r40;
+    r50 = fma(r51, r50, r29 * r49);
+    r52 = r21 * r1;
+    r53 = r3 * r24;
+    r53 = r53 * r31;
+    r53 = r53 * r35;
+    r53 = r53 * r37;
+    r53 = r53 * r8;
+    r8 = r35 * r40;
+    r42 = fma(r8, r42, r53 * r52);
+    WriteSum2<double, double>((double*)inout_shared, r50, r42);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r3 * r21;
+    r42 = r42 * r45;
+    r50 = r28 * r0;
+    r50 = r50 * r9;
+    r50 = r50 * r20;
+    r50 = fma(r34, r50, r1 * r42);
+    r42 = r2 * r26;
+    r52 = r28 * r1;
+    r52 = r52 * r44;
+    r52 = r52 * r51;
+    r52 = fma(r34, r52, r48 * r42);
+    WriteSum2<double, double>((double*)inout_shared, r50, r52);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r52 = r21 * r1;
+    r52 = r52 * r6;
+    r52 = r52 * r40;
+    r52 = fma(r6, r49, r51 * r52);
+    r50 = r21 * r1;
+    r50 = r50 * r40;
+    r50 = r50 * r51;
+    r49 = fma(r27, r49, r27 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r52, r49);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r21;
+    r49 = r49 * r29;
+    r49 = r49 * r1;
+    r52 = r2 * r29;
+    r52 = r52 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r52, r49);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r32 * r32;
+    r52 = r7 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r49, r52);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r30, r30);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r3 * r51;
+    r52 = r24 * r30;
+    r49 = r36 * r52;
+    r48 = r39 * r39;
+    r50 = r2 * r2;
+    r48 = r48 * r31;
+    r48 = r48 * r35;
+    r48 = r48 * r36;
+    r48 = fma(r50, r48, r35 * r49);
+    r42 = r27 * r36;
+    r37 = r2 * r20;
+    r54 = r39 * r37;
+    r42 = fma(r54, r42, r27 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r48, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r24 * r9;
+    r55 = r31 * r31;
+    r56 = 4.00000000000000000e+00;
+    r38 = r41 * r38;
+    r41 = r41 * r38;
+    r41 = 1.0 / r41;
+    r43 = r18 * r43;
+    r18 = r18 * r43;
+    r18 = 1.0 / r18;
+    r55 = r55 * r56;
+    r55 = r55 * r41;
+    r55 = r55 * r18;
+    r48 = r48 * r54;
+    r18 = r3 * r3;
+    r41 = r45 * r45;
+    r18 = fma(r41, r18, r55 * r48);
+    r48 = r39 * r44;
+    r48 = r48 * r52;
+    r41 = r26 * r26;
+    r50 = fma(r41, r50, r55 * r48);
+    WriteSum2<double, double>((double*)inout_shared, r18, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r6 * r6;
+    r18 = r36 * r54;
+    r18 = fma(r50, r18, r50 * r49);
+    r41 = r27 * r27;
+    r48 = r36 * r54;
+    r48 = fma(r41, r48, r49 * r41);
+    WriteSum2<double, double>((double*)inout_shared, r18, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r2 * r2;
+    r48 = r48 * r35;
+    r41 = r3 * r3;
+    r41 = r41 * r35;
+    WriteSum2<double, double>((double*)inout_shared, r48, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r41, r32);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r29 * r32;
+    r48 = r48 * r40;
+    r48 = r48 * r20;
+    WriteSum2<double, double>((double*)inout_shared, r41, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r32 * r20;
+    r48 = r48 * r8;
+    r55 = r32 * r20;
+    r55 = r55 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r48, r55);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r2 * r26;
+    r55 = r55 * r32;
+    r48 = r32 * r6;
+    r48 = r48 * r40;
+    r48 = r48 * r20;
+    WriteSum2<double, double>((double*)inout_shared, r55, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r2 * r29;
+    r48 = r48 * r32;
+    r32 = r32 * r40;
+    r32 = r32 * r20;
+    r32 = r32 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r29 * r7;
+    r48 = r48 * r40;
+    r48 = r48 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r7, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r3 * r45;
+    r48 = r48 * r7;
+    r32 = r7 * r53;
+    WriteSum2<double, double>((double*)inout_shared, r32, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r10 * r7;
+    r48 = r48 * r44;
+    r48 = r48 * r51;
+    r48 = r48 * r34;
+    r32 = r7 * r6;
+    r32 = r32 * r40;
+    r32 = r32 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r48, r32);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r7 * r40;
+    r32 = r32 * r51;
+    r32 = r32 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r3 * r29;
+    r32 = r32 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r32, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r29 * r40;
+    r32 = r32 * r20;
+    r7 = r20 * r8;
+    WriteSum2<double, double>((double*)inout_shared, r32, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r2 * r26;
+    r32 = r20 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r32, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r6 * r40;
+    r7 = r7 * r20;
+    r20 = r40 * r20;
+    r20 = r20 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r7, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r2 * r29;
+    WriteSum2<double, double>((double*)inout_shared, r20, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r29 * r40;
+    r20 = r20 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r20, r53);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r3 * r45;
+    r20 = r10 * r44;
+    r20 = r20 * r51;
+    r20 = r20 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r53, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r51;
+    r51 = r40 * r51;
+    r51 = r51 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r20, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r3 * r29;
+    WriteSum2<double, double>((double*)inout_shared, r41, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r6 * r54;
+    r20 = fma(r36, r51, r6 * r49);
+    r53 = r29 * r45;
+    r53 = r53 * r40;
+    r7 = r29 * r54;
+    r38 = 1.0 / r38;
+    r38 = r31 * r38;
+    r43 = 1.0 / r43;
+    r38 = r38 * r43;
+    r7 = r7 * r46;
+    r7 = fma(r38, r7, r30 * r53);
+    WriteSum2<double, double>((double*)inout_shared, r20, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r10 * r44;
+    r7 = r7 * r52;
+    r7 = r7 * r38;
+    r52 = r29 * r26;
+    r52 = r52 * r40;
+    r52 = fma(r37, r52, r29 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r52, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r37 * r8;
+    r52 = r29 * r27;
+    r20 = r36 * r52;
+    r20 = fma(r54, r20, r52 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r20, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r30 * r8;
+    r53 = r45 * r30;
+    r43 = r35 * r54;
+    r43 = r43 * r46;
+    r43 = fma(r38, r43, r8 * r53);
+    WriteSum2<double, double>((double*)inout_shared, r42, r43);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r26 * r37;
+    r43 = fma(r8, r43, r35 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r43, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r37;
+    WriteSum2<double, double>((double*)inout_shared, r18, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r30;
+    r47 = r37 * r47;
+    r18 = r10 * r45;
+    r18 = r18 * r44;
+    r18 = r18 * r34;
+    r18 = fma(r30, r18, r26 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r20, r18);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r18 = r45 * r6;
+    r18 = r18 * r40;
+    r20 = r46 * r38;
+    r20 = fma(r51, r20, r30 * r18);
+    r18 = r45 * r40;
+    r18 = r18 * r27;
+    r51 = r27 * r54;
+    r51 = r51 * r46;
+    r51 = fma(r38, r51, r30 * r18);
+    WriteSum2<double, double>((double*)inout_shared, r20, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r29 * r47;
+    r51 = r3 * r3;
+    r51 = r51 * r29;
+    r51 = r51 * r45;
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r26 * r6;
+    r51 = r51 * r40;
+    r51 = fma(r37, r51, r6 * r7);
+    r47 = r26 * r40;
+    r47 = r47 * r27;
+    r47 = fma(r37, r47, r27 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r51, r47);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r2 * r2;
+    r47 = r47 * r29;
+    r47 = r47 * r26;
+    r51 = r10 * r29;
+    r51 = r51 * r44;
+    r51 = r51 * r34;
+    r51 = r51 * r30;
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r40 * r27;
+    r51 = r51 * r37;
+    r50 = r29 * r50;
+    r47 = r36 * r54;
+    r47 = fma(r50, r47, r49 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r40 * r27;
+    r51 = r51 * r30;
+    r47 = r40 * r37;
+    r47 = r47 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r51, r47);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r40 * r30;
+    r47 = r47 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r47, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointResJacKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.cu
@@ -1,0 +1,874 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r24 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r18);
+    r26 = r15 * r16;
+    r26 = r26 * r10;
+    r27 = r11 * r12;
+    r27 = fma(r10, r27, r26);
+    r28 = -2.00000000000000000e+00;
+    r29 = r15 * r15;
+    r29 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r11 * r11;
+    r31 = fma(r28, r31, r30);
+    r32 = r29 + r31;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r33);
+    r34 = r16 * r11;
+    r34 = r34 * r10;
+    r35 = r15 * r12;
+    r35 = fma(r28, r35, r34);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r36);
+    r37 = r10 * r23;
+    r37 = r37 * r22;
+    r38 = r28 * r25;
+    r39 = fma(r19, r38, r37);
+    r40 = r23 * r23;
+    r40 = r28 * r40;
+    r41 = r30 + r40;
+    r42 = r19 * r19;
+    r42 = r28 * r42;
+    r41 = r41 + r42;
+    r24 = fma(r7, r27, r24);
+    r24 = fma(r18, r32, r24);
+    r24 = fma(r33, r35, r24);
+    r24 = fma(r36, r39, r24);
+    r24 = fma(r9, r41, r24);
+    r41 = r22 * r22;
+    r41 = r28 * r41;
+    r39 = r30 + r41;
+    r39 = r39 + r40;
+    r39 = fma(r8, r39, r6);
+    r20 = fma(r23, r38, r20);
+    r6 = r10 * r23;
+    r6 = r6 * r19;
+    r40 = r10 * r22;
+    r40 = fma(r25, r40, r6);
+    r35 = r15 * r11;
+    r35 = r35 * r10;
+    r32 = r16 * r12;
+    r27 = fma(r10, r32, r35);
+    r43 = r11 * r12;
+    r43 = fma(r28, r43, r26);
+    r26 = r16 * r16;
+    r26 = r26 * r28;
+    r31 = r26 + r31;
+    r39 = fma(r9, r20, r39);
+    r39 = fma(r36, r40, r39);
+    r39 = fma(r33, r27, r39);
+    r39 = fma(r18, r43, r39);
+    r39 = fma(r7, r31, r39);
+    r31 = r39 * r39;
+    r43 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r27);
+    r38 = fma(r22, r38, r6);
+    r38 = fma(r8, r38, r27);
+    r32 = fma(r28, r32, r35);
+    r26 = r30 + r26;
+    r26 = r26 + r29;
+    r29 = r15 * r12;
+    r29 = fma(r10, r29, r34);
+    r34 = r10 * r19;
+    r34 = fma(r25, r34, r37);
+    r41 = r30 + r41;
+    r41 = r41 + r42;
+    r38 = fma(r7, r32, r38);
+    r38 = fma(r33, r26, r38);
+    r38 = fma(r18, r29, r38);
+    r38 = fma(r9, r34, r38);
+    r38 = fma(r36, r41, r38);
+    r41 = copysign(1.0, r38);
+    r41 = fma(r43, r41, r38);
+    r38 = r41 * r41;
+    r36 = 1.0 / r38;
+    r34 = r24 * r24;
+    r34 = fma(r36, r34, r36 * r31);
+    r34 = sqrt(r34);
+    r31 = atan(r34);
+    r9 = r24 * r31;
+    r29 = r24 * r9;
+    r18 = copysign(1.0, r34);
+    r18 = fma(r43, r18, r34);
+    r43 = r18 * r18;
+    r34 = 1.0 / r43;
+    r34 = r36 * r34;
+    r36 = r31 * r34;
+    r29 = r29 * r36;
+    r26 = r39 * r39;
+    r33 = 3.00000000000000000e+00;
+    r26 = r26 * r31;
+    r26 = r26 * r33;
+    r26 = fma(r36, r26, r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r39 * r39;
+    r42 = r42 * r31;
+    r42 = r42 * r36;
+    r29 = r29 + r42;
+    r32 = fma(r32, r29, r5 * r26);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r37, r25);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r35 = r29 * r29;
+    r25 = fma(r25, r35, r37 * r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r37, r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = r35 * r35;
+    r6 = r29 * r35;
+    r25 = fma(r8, r27, r25);
+    r25 = fma(r37, r6, r25);
+    r37 = 1.0 / r41;
+    r8 = 1.0 / r18;
+    r40 = r37 * r8;
+    r20 = r25 * r40;
+    r44 = r39 * r31;
+    r32 = fma(r44, r20, r32);
+    r45 = r4 * r44;
+    r46 = r10 * r9;
+    r47 = r34 * r46;
+    r32 = fma(r47, r45, r32);
+    r32 = fma(r40, r44, r32);
+    r0 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r45, r20);
+    r0 = fma(r45, r21, r0);
+    r45 = r24 * r33;
+    r45 = r45 * r9;
+    r45 = fma(r36, r45, r42);
+    r7 = fma(r7, r29, r4 * r45);
+    r42 = r25 * r9;
+    r7 = fma(r40, r42, r7);
+    r48 = r5 * r44;
+    r7 = fma(r47, r48, r7);
+    r7 = fma(r9, r40, r7);
+    r1 = fma(r3, r7, r1);
+    r1 = fma(r20, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r20 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r20);
+  if (global_thread_idx < problem_size) {
+    r20 = r21 * r7;
+    r20 = r20 * r1;
+    r48 = r21 * r0;
+    r42 = r32 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r42, r20);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r21 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r48, r20);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r2 * r44;
+    r42 = r20 * r48;
+    r49 = r40 * r42;
+    r50 = r21 * r29;
+    r51 = r3 * r9;
+    r50 = r50 * r1;
+    r50 = r50 * r40;
+    r50 = fma(r51, r50, r29 * r49);
+    r52 = r21 * r1;
+    r53 = r3 * r24;
+    r53 = r53 * r31;
+    r53 = r53 * r35;
+    r53 = r53 * r37;
+    r53 = r53 * r8;
+    r8 = r35 * r40;
+    r42 = fma(r8, r42, r53 * r52);
+    WriteSum2<double, double>((double*)inout_shared, r50, r42);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r3 * r21;
+    r42 = r42 * r45;
+    r50 = r28 * r0;
+    r50 = r50 * r9;
+    r50 = r50 * r20;
+    r50 = fma(r34, r50, r1 * r42);
+    r42 = r2 * r26;
+    r52 = r28 * r1;
+    r52 = r52 * r44;
+    r52 = r52 * r51;
+    r52 = fma(r34, r52, r48 * r42);
+    WriteSum2<double, double>((double*)inout_shared, r50, r52);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r52 = r21 * r1;
+    r52 = r52 * r6;
+    r52 = r52 * r40;
+    r52 = fma(r6, r49, r51 * r52);
+    r50 = r21 * r1;
+    r50 = r50 * r40;
+    r50 = r50 * r51;
+    r49 = fma(r27, r49, r27 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r52, r49);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r21;
+    r49 = r49 * r29;
+    r49 = r49 * r1;
+    r52 = r2 * r29;
+    r52 = r52 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r52, r49);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r32 * r32;
+    r52 = r7 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r49, r52);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r30, r30);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r3 * r51;
+    r52 = r24 * r30;
+    r49 = r36 * r52;
+    r48 = r39 * r39;
+    r50 = r2 * r2;
+    r48 = r48 * r31;
+    r48 = r48 * r35;
+    r48 = r48 * r36;
+    r48 = fma(r50, r48, r35 * r49);
+    r42 = r27 * r36;
+    r37 = r2 * r20;
+    r54 = r39 * r37;
+    r42 = fma(r54, r42, r27 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r48, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r24 * r9;
+    r55 = r31 * r31;
+    r56 = 4.00000000000000000e+00;
+    r38 = r41 * r38;
+    r41 = r41 * r38;
+    r41 = 1.0 / r41;
+    r43 = r18 * r43;
+    r18 = r18 * r43;
+    r18 = 1.0 / r18;
+    r55 = r55 * r56;
+    r55 = r55 * r41;
+    r55 = r55 * r18;
+    r48 = r48 * r54;
+    r18 = r3 * r3;
+    r41 = r45 * r45;
+    r18 = fma(r41, r18, r55 * r48);
+    r48 = r39 * r44;
+    r48 = r48 * r52;
+    r41 = r26 * r26;
+    r50 = fma(r41, r50, r55 * r48);
+    WriteSum2<double, double>((double*)inout_shared, r18, r50);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r6 * r6;
+    r18 = r36 * r54;
+    r18 = fma(r50, r18, r50 * r49);
+    r41 = r27 * r27;
+    r48 = r36 * r54;
+    r48 = fma(r41, r48, r49 * r41);
+    WriteSum2<double, double>((double*)inout_shared, r18, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r2 * r2;
+    r48 = r48 * r35;
+    r41 = r3 * r3;
+    r41 = r41 * r35;
+    WriteSum2<double, double>((double*)inout_shared, r48, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r41 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r41, r32);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r29 * r32;
+    r48 = r48 * r40;
+    r48 = r48 * r20;
+    WriteSum2<double, double>((double*)inout_shared, r41, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r32 * r20;
+    r48 = r48 * r8;
+    r55 = r32 * r20;
+    r55 = r55 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r48, r55);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r2 * r26;
+    r55 = r55 * r32;
+    r48 = r32 * r6;
+    r48 = r48 * r40;
+    r48 = r48 * r20;
+    WriteSum2<double, double>((double*)inout_shared, r55, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r2 * r29;
+    r48 = r48 * r32;
+    r32 = r32 * r40;
+    r32 = r32 * r20;
+    r32 = r32 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r29 * r7;
+    r48 = r48 * r40;
+    r48 = r48 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r7, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r3 * r45;
+    r48 = r48 * r7;
+    r32 = r7 * r53;
+    WriteSum2<double, double>((double*)inout_shared, r32, r48);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r48 = r10 * r7;
+    r48 = r48 * r44;
+    r48 = r48 * r51;
+    r48 = r48 * r34;
+    r32 = r7 * r6;
+    r32 = r32 * r40;
+    r32 = r32 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r48, r32);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r7 * r40;
+    r32 = r32 * r51;
+    r32 = r32 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r3 * r29;
+    r32 = r32 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r32, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r32 = r29 * r40;
+    r32 = r32 * r20;
+    r7 = r20 * r8;
+    WriteSum2<double, double>((double*)inout_shared, r32, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r2 * r26;
+    r32 = r20 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r32, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r6 * r40;
+    r7 = r7 * r20;
+    r20 = r40 * r20;
+    r20 = r20 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r7, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r2 * r29;
+    WriteSum2<double, double>((double*)inout_shared, r20, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r29 * r40;
+    r20 = r20 * r51;
+    WriteSum2<double, double>((double*)inout_shared, r20, r53);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r3 * r45;
+    r20 = r10 * r44;
+    r20 = r20 * r51;
+    r20 = r20 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r53, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r51;
+    r51 = r40 * r51;
+    r51 = r51 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r20, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r3 * r29;
+    WriteSum2<double, double>((double*)inout_shared, r41, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r6 * r54;
+    r20 = fma(r36, r51, r6 * r49);
+    r53 = r29 * r45;
+    r53 = r53 * r40;
+    r7 = r29 * r54;
+    r38 = 1.0 / r38;
+    r38 = r31 * r38;
+    r43 = 1.0 / r43;
+    r38 = r38 * r43;
+    r7 = r7 * r46;
+    r7 = fma(r38, r7, r30 * r53);
+    WriteSum2<double, double>((double*)inout_shared, r20, r7);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = r10 * r44;
+    r7 = r7 * r52;
+    r7 = r7 * r38;
+    r52 = r29 * r26;
+    r52 = r52 * r40;
+    r52 = fma(r37, r52, r29 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r52, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r37 * r8;
+    r52 = r29 * r27;
+    r20 = r36 * r52;
+    r20 = fma(r54, r20, r52 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r20, r42);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r30 * r8;
+    r53 = r45 * r30;
+    r43 = r35 * r54;
+    r43 = r43 * r46;
+    r43 = fma(r38, r43, r8 * r53);
+    WriteSum2<double, double>((double*)inout_shared, r42, r43);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r43 = r26 * r37;
+    r43 = fma(r8, r43, r35 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r43, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r37;
+    WriteSum2<double, double>((double*)inout_shared, r18, r20);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r6 * r40;
+    r20 = r20 * r30;
+    r47 = r37 * r47;
+    r18 = r10 * r45;
+    r18 = r18 * r44;
+    r18 = r18 * r34;
+    r18 = fma(r30, r18, r26 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r20, r18);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r18 = r45 * r6;
+    r18 = r18 * r40;
+    r20 = r46 * r38;
+    r20 = fma(r51, r20, r30 * r18);
+    r18 = r45 * r40;
+    r18 = r18 * r27;
+    r51 = r27 * r54;
+    r51 = r51 * r46;
+    r51 = fma(r38, r51, r30 * r18);
+    WriteSum2<double, double>((double*)inout_shared, r20, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r29 * r47;
+    r51 = r3 * r3;
+    r51 = r51 * r29;
+    r51 = r51 * r45;
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r26 * r6;
+    r51 = r51 * r40;
+    r51 = fma(r37, r51, r6 * r7);
+    r47 = r26 * r40;
+    r47 = r47 * r27;
+    r47 = fma(r37, r47, r27 * r7);
+    WriteSum2<double, double>((double*)inout_shared, r51, r47);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r2 * r2;
+    r47 = r47 * r29;
+    r47 = r47 * r26;
+    r51 = r10 * r29;
+    r51 = r51 * r44;
+    r51 = r51 * r34;
+    r51 = r51 * r30;
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r40 * r27;
+    r51 = r51 * r37;
+    r50 = r29 * r50;
+    r47 = r36 * r54;
+    r47 = fma(r50, r47, r49 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r47, r51);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r40 * r27;
+    r51 = r51 * r30;
+    r47 = r40 * r37;
+    r47 = r47 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r51, r47);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r40 * r30;
+    r47 = r47 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r47, r41);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.cu
@@ -1,0 +1,310 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseFixedPointScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = r27 * r27;
+    r28 = fma(r28, r8, r36 * r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r8 * r8;
+    r8 = r27 * r8;
+    r28 = fma(r7, r44, r28);
+    r28 = fma(r36, r8, r28);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r28 = r28 * r43;
+    r13 = r4 * r19;
+    r13 = r13 * r42;
+    r13 = r13 * r29;
+    r32 = fma(r6, r13, r32);
+    r32 = fma(r42, r28, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r28, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseFixedPointScoreKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.cu
@@ -1,0 +1,293 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseJtjnjtrDirectKernel(
+        double* calib_njtr,
+        unsigned int calib_njtr_num_alloc,
+        SharedIndex* calib_njtr_indices,
+        double* calib_jac,
+        unsigned int calib_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 0 * calib_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r3, r4);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r5,
+                        r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r7, r8);
+    r9 = fma(r6, r7, r2 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r10, r11);
+    r9 = fma(r5, r10, r9);
+    r12 = r0 * r9;
+    r6 = fma(r6, r8, r2 * r4);
+    r6 = fma(r5, r11, r6);
+    r5 = r1 * r6;
+    WriteSum2<double, double>((double*)inout_shared, r12, r5);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r9, r6);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 2 * calib_jac_num_alloc, global_thread_idx, r5, r12);
+    r2 = fma(r5, r9, r12 * r6);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 4 * calib_jac_num_alloc, global_thread_idx, r13, r14);
+    r15 = fma(r14, r6, r13 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r2, r15);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 6 * calib_jac_num_alloc, global_thread_idx, r15, r2);
+    r16 = fma(r2, r6, r15 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 8 * calib_jac_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r18, r6, r17 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r16, r19);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 10 * calib_jac_num_alloc, global_thread_idx, r19, r16);
+    r20 = fma(r16, r6, r19 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 12 * calib_jac_num_alloc, global_thread_idx, r21, r22);
+    r23 = fma(r22, r6, r21 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r20, r23);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 14 * calib_jac_num_alloc, global_thread_idx, r23, r20);
+    r9 = r23 * r9;
+    r6 = r20 * r6;
+    WriteSum2<double, double>((double*)inout_shared, r9, r6);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(calib_njtr,
+                                2 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r6,
+                        r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                10 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r24,
+                        r25);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r23 = fma(r24, r23, r6);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                8 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r24,
+                        r6);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                4 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r26,
+                        r27);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                6 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r28,
+                        r29);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                0 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r30,
+                        r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r23 = fma(r6, r21, r23);
+    r23 = fma(r24, r19, r23);
+    r23 = fma(r27, r13, r23);
+    r23 = fma(r29, r17, r23);
+    r23 = fma(r28, r15, r23);
+    r23 = fma(r26, r5, r23);
+    r23 = fma(r30, r0, r23);
+    r20 = fma(r25, r20, r9);
+    r20 = fma(r24, r16, r20);
+    r20 = fma(r28, r2, r20);
+    r20 = fma(r29, r18, r20);
+    r20 = fma(r6, r22, r20);
+    r20 = fma(r27, r14, r20);
+    r20 = fma(r26, r12, r20);
+    r20 = fma(r31, r1, r20);
+    r11 = fma(r11, r20, r10 * r23);
+    r8 = fma(r8, r20, r7 * r23);
+    WriteSum2<double, double>((double*)inout_shared, r11, r8);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = fma(r4, r20, r3 * r23);
+    WriteSum1<double, double>((double*)inout_shared, r20);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+    double* calib_njtr,
+    unsigned int calib_njtr_num_alloc,
+    SharedIndex* calib_njtr_indices,
+    double* calib_jac,
+    unsigned int calib_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac.cu
@@ -1,0 +1,1631 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r16 * r17;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r11, r14, r19);
+    r20 = r10 * r19;
+    r22 = fma(r15, r14, r12 * r17);
+    r23 = r11 * r18;
+    r22 = fma(r21, r23, r22);
+    r22 = fma(r16, r13, r22);
+    r20 = r20 * r22;
+    r23 = -2.00000000000000000e+00;
+    r24 = r15 * r13;
+    r24 = fma(r21, r24, r12 * r18);
+    r24 = fma(r16, r14, r24);
+    r24 = fma(r11, r17, r24);
+    r25 = r23 * r24;
+    r26 = fma(r16, r18, r15 * r17);
+    r26 = fma(r11, r13, r26);
+    r26 = fma(r21, r26, r12 * r14);
+    r25 = fma(r26, r25, r20);
+    r7 = fma(r8, r25, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r14, r27);
+    r28 = r15 * r11;
+    r28 = r28 * r10;
+    r29 = r16 * r12;
+    r30 = fma(r23, r29, r28);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r31);
+    r32 = r15 * r15;
+    r32 = r23 * r32;
+    r33 = 1.00000000000000000e+00;
+    r34 = r16 * r16;
+    r34 = fma(r23, r34, r33);
+    r35 = r32 + r34;
+    r36 = r16 * r11;
+    r36 = r36 * r10;
+    r37 = r15 * r12;
+    r37 = fma(r10, r37, r36);
+    r38 = r10 * r19;
+    r38 = r38 * r24;
+    r39 = r22 * r26;
+    r40 = fma(r10, r39, r38);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r23 * r42;
+    r43 = r33 + r42;
+    r44 = r22 * r22;
+    r44 = r44 * r23;
+    r43 = r43 + r44;
+    r7 = fma(r14, r30, r7);
+    r7 = fma(r31, r35, r7);
+    r7 = fma(r27, r37, r7);
+    r7 = fma(r9, r40, r7);
+    r7 = fma(r41, r43, r7);
+    r37 = copysign(1.0, r7);
+    r37 = fma(r6, r37, r7);
+    r7 = r37 * r37;
+    r35 = 1.0 / r7;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r30,
+                                            r45);
+    r22 = r10 * r22;
+    r22 = r22 * r24;
+    r46 = r10 * r19;
+    r46 = fma(r26, r46, r22);
+    r45 = fma(r8, r46, r45);
+    r47 = r15 * r16;
+    r47 = r47 * r10;
+    r48 = r11 * r12;
+    r48 = fma(r10, r48, r47);
+    r49 = r11 * r11;
+    r49 = r23 * r49;
+    r50 = r33 + r49;
+    r50 = r50 + r32;
+    r32 = r15 * r12;
+    r32 = fma(r23, r32, r36);
+    r39 = fma(r23, r39, r38);
+    r38 = r19 * r19;
+    r38 = r23 * r38;
+    r36 = r33 + r38;
+    r36 = r36 + r44;
+    r45 = fma(r14, r48, r45);
+    r45 = fma(r27, r50, r45);
+    r45 = fma(r31, r32, r45);
+    r45 = fma(r41, r39, r45);
+    r45 = fma(r9, r36, r45);
+    r32 = r45 * r45;
+    r32 = r35 * r32;
+    r42 = r33 + r42;
+    r42 = r42 + r38;
+    r8 = fma(r8, r42, r30);
+    r30 = r19 * r23;
+    r30 = fma(r26, r30, r22);
+    r22 = r10 * r24;
+    r22 = fma(r26, r22, r20);
+    r29 = fma(r10, r29, r28);
+    r28 = r11 * r12;
+    r28 = fma(r23, r28, r47);
+    r34 = r49 + r34;
+    r8 = fma(r9, r30, r8);
+    r8 = fma(r41, r22, r8);
+    r8 = fma(r31, r29, r8);
+    r8 = fma(r27, r28, r8);
+    r8 = fma(r14, r34, r8);
+    r34 = r8 * r8;
+    r14 = r45 * r45;
+    r14 = fma(r35, r14, r35 * r34);
+    r34 = sqrt(r14);
+    r28 = copysign(1.0, r34);
+    r28 = fma(r6, r28, r34);
+    r6 = r28 * r28;
+    r27 = 1.0 / r6;
+    r34 = atan(r34);
+    r29 = r34 * r34;
+    r32 = r32 * r27;
+    r32 = r32 * r29;
+    r29 = r8 * r34;
+    r31 = 3.00000000000000000e+00;
+    r41 = r35 * r27;
+    r9 = r8 * r34;
+    r29 = r29 * r31;
+    r29 = r29 * r41;
+    r29 = fma(r9, r29, r32);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r49, r47);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r20 = r8 * r34;
+    r20 = r20 * r41;
+    r20 = r20 * r9;
+    r26 = r32 + r20;
+    r38 = fma(r49, r26, r5 * r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r50, r48);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r26 * r26;
+    r51 = fma(r48, r44, r50 * r26);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r52, r53);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r54 = r44 * r44;
+    r55 = r26 * r44;
+    r51 = fma(r53, r54, r51);
+    r51 = fma(r52, r55, r51);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r28;
+    r58 = r56 * r57;
+    r59 = r51 * r58;
+    r60 = r4 * r10;
+    r61 = r45 * r34;
+    r62 = r61 * r41;
+    r60 = r60 * r9;
+    r38 = fma(r62, r60, r38);
+    r38 = fma(r9, r59, r38);
+    r38 = fma(r58, r9, r38);
+    r0 = fma(r2, r38, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r60, r63);
+    r0 = fma(r60, r21, r0);
+    r20 = fma(r31, r32, r20);
+    r60 = fma(r47, r26, r4 * r20);
+    r64 = r5 * r10;
+    r64 = r64 * r9;
+    r60 = fma(r62, r64, r60);
+    r60 = fma(r61, r59, r60);
+    r60 = fma(r61, r58, r60);
+    r1 = fma(r3, r60, r1);
+    r1 = fma(r63, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r38,
+                                             r60);
+    r63 = r26 * r58;
+    r64 = r2 * r9;
+    r63 = r63 * r64;
+    r65 = r3 * r26;
+    r65 = r65 * r61;
+    r65 = r65 * r58;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             2 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r63,
+                                             r65);
+    r66 = r58 * r44;
+    r66 = r66 * r64;
+    r67 = r3 * r61;
+    r67 = r67 * r58;
+    r67 = r67 * r44;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r66,
+                                             r67);
+    r68 = r3 * r20;
+    r69 = r10 * r62;
+    r69 = r69 * r64;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r69,
+                                             r68);
+    r70 = r2 * r29;
+    r71 = r3 * r10;
+    r71 = r71 * r9;
+    r71 = r71 * r62;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r70,
+                                             r71);
+    r72 = r58 * r55;
+    r72 = r72 * r64;
+    r73 = r3 * r61;
+    r73 = r73 * r58;
+    r73 = r73 * r55;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r72,
+                                             r73);
+    r74 = r58 * r64;
+    r74 = r74 * r54;
+    r75 = r3 * r61;
+    r75 = r75 * r58;
+    r75 = r75 * r54;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r74,
+                                             r75);
+    r76 = r2 * r26;
+    r77 = r3 * r26;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r76,
+                                             r77);
+    r78 = r21 * r60;
+    r78 = r78 * r1;
+    r79 = r21 * r0;
+    r80 = r38 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r80, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r21 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r79, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r26 * r58;
+    r78 = r78 * r64;
+    r80 = r3 * r21;
+    r80 = r80 * r26;
+    r80 = r80 * r1;
+    r80 = r80 * r61;
+    r80 = fma(r58, r80, r79 * r78);
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r81 = r58 * r44;
+    r81 = r81 * r64;
+    r81 = fma(r79, r81, r44 * r78);
+    WriteSum2<double, double>((double*)inout_shared, r80, r81);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r21;
+    r81 = r81 * r20;
+    r80 = r23 * r0;
+    r80 = r80 * r62;
+    r80 = fma(r64, r80, r1 * r81);
+    r81 = r2 * r79;
+    r78 = r3 * r23;
+    r78 = r78 * r1;
+    r78 = r78 * r9;
+    r78 = fma(r62, r78, r29 * r81);
+    WriteSum2<double, double>((double*)inout_shared, r80, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r80 = r58 * r55;
+    r80 = r80 * r64;
+    r80 = fma(r79, r80, r55 * r78);
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r82 = r58 * r64;
+    r82 = r82 * r54;
+    r82 = fma(r79, r82, r54 * r78);
+    WriteSum2<double, double>((double*)inout_shared, r80, r82);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r3 * r21;
+    r82 = r82 * r26;
+    r82 = r82 * r1;
+    r80 = r26 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r80, r82);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r38 * r38;
+    r80 = r60 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r82, r80);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r33, r33);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r3 * r3;
+    r32 = r80 * r32;
+    r82 = r8 * r34;
+    r78 = r2 * r64;
+    r82 = r82 * r41;
+    r82 = r82 * r44;
+    r82 = fma(r78, r82, r44 * r32);
+    r79 = r8 * r34;
+    r79 = r79 * r41;
+    r79 = r79 * r54;
+    r79 = fma(r78, r79, r54 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r82, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r61 * r78;
+    r83 = r8 * r45;
+    r84 = 4.00000000000000000e+00;
+    r7 = r37 * r7;
+    r37 = r37 * r7;
+    r37 = 1.0 / r37;
+    r6 = r28 * r6;
+    r28 = r28 * r6;
+    r28 = 1.0 / r28;
+    r83 = r83 * r34;
+    r83 = r83 * r34;
+    r83 = r83 * r84;
+    r83 = r83 * r37;
+    r83 = r83 * r28;
+    r28 = r20 * r20;
+    r28 = fma(r80, r28, r83 * r82);
+    r82 = r61 * r80;
+    r37 = r9 * r82;
+    r85 = r2 * r2;
+    r85 = r85 * r29;
+    r85 = fma(r29, r85, r83 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r28, r85);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r55 * r55;
+    r28 = r8 * r34;
+    r28 = r28 * r41;
+    r28 = r28 * r78;
+    r28 = fma(r85, r28, r85 * r32);
+    r37 = r54 * r54;
+    r83 = r8 * r34;
+    r83 = r83 * r41;
+    r83 = r83 * r78;
+    r83 = fma(r37, r83, r32 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r28, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r2 * r2;
+    r83 = r83 * r44;
+    r37 = r44 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r83, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r37, r38);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r26 * r38;
+    r83 = r83 * r58;
+    r83 = r83 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r37, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r38 * r58;
+    r83 = r83 * r44;
+    r83 = r83 * r64;
+    r86 = r10 * r38;
+    r86 = r86 * r62;
+    r86 = r86 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r83, r86);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r2 * r29;
+    r86 = r86 * r38;
+    r83 = r38 * r58;
+    r83 = r83 * r55;
+    r83 = r83 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r86, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r2 * r26;
+    r83 = r83 * r38;
+    r38 = r38 * r58;
+    r38 = r38 * r64;
+    r38 = r38 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r38, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r26;
+    r83 = r83 * r60;
+    r83 = r83 * r61;
+    r83 = r83 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r60, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r20;
+    r83 = r83 * r60;
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r44;
+    WriteSum2<double, double>((double*)inout_shared, r38, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r10;
+    r83 = r83 * r60;
+    r83 = r83 * r9;
+    r83 = r83 * r62;
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r55;
+    WriteSum2<double, double>((double*)inout_shared, r83, r38);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r38, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r38 = r3 * r26;
+    r38 = r38 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r38, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r63, r66);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r69, r70);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r72, r74);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r76, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r65, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r68, r71);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r73, r75);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r37, r77);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r77 = r8 * r34;
+    r77 = r77 * r41;
+    r77 = r77 * r55;
+    r77 = fma(r78, r77, r55 * r32);
+    r75 = r58 * r82;
+    r73 = r20 * r75;
+    r71 = r8 * r26;
+    r7 = 1.0 / r7;
+    r6 = 1.0 / r6;
+    r68 = r10 * r34;
+    r71 = r71 * r7;
+    r71 = r71 * r6;
+    r71 = r71 * r61;
+    r71 = r71 * r68;
+    r71 = fma(r78, r71, r26 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r77, r71);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r45 * r26;
+    r71 = r71 * r7;
+    r71 = r71 * r6;
+    r71 = r71 * r9;
+    r71 = r71 * r68;
+    r77 = r29 * r78;
+    r67 = r58 * r77;
+    r71 = fma(r26, r67, r82 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r71, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r58 * r44;
+    r79 = r79 * r78;
+    r71 = r26 * r54;
+    r65 = r8 * r34;
+    r65 = r65 * r41;
+    r65 = r65 * r78;
+    r65 = fma(r71, r65, r71 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r65, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r44 * r75;
+    r76 = r8 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r61;
+    r76 = r76 * r44;
+    r76 = r76 * r68;
+    r76 = fma(r78, r76, r44 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r79, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r45 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r9;
+    r76 = r76 * r44;
+    r76 = r76 * r68;
+    r76 = fma(r44, r67, r82 * r76);
+    WriteSum2<double, double>((double*)inout_shared, r76, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r58 * r55;
+    r65 = r65 * r78;
+    WriteSum2<double, double>((double*)inout_shared, r28, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r55 * r75;
+    r28 = r10 * r62;
+    r76 = r10 * r20;
+    r76 = r76 * r9;
+    r76 = r76 * r62;
+    r76 = fma(r80, r76, r77 * r28);
+    WriteSum2<double, double>((double*)inout_shared, r65, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r8 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r61;
+    r76 = r76 * r55;
+    r76 = r76 * r68;
+    r76 = fma(r78, r76, r55 * r73);
+    r65 = r8 * r7;
+    r65 = r65 * r6;
+    r65 = r65 * r61;
+    r65 = r65 * r54;
+    r65 = r65 * r68;
+    r65 = fma(r78, r65, r54 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r76, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r10 * r26;
+    r65 = r65 * r62;
+    r65 = r65 * r78;
+    r76 = r26 * r20;
+    r76 = r76 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r65, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r45 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r9;
+    r76 = r76 * r55;
+    r76 = r76 * r68;
+    r76 = fma(r55, r67, r82 * r76);
+    r65 = r45 * r7;
+    r65 = r65 * r6;
+    r65 = r65 * r9;
+    r65 = r65 * r54;
+    r65 = r65 * r68;
+    r67 = fma(r54, r67, r82 * r65);
+    WriteSum2<double, double>((double*)inout_shared, r76, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r2 * r2;
+    r67 = r67 * r26;
+    r67 = r67 * r29;
+    r29 = r10 * r26;
+    r29 = r29 * r9;
+    r29 = r29 * r62;
+    r29 = r29 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r67, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r29 = r58 * r54;
+    r29 = r29 * r78;
+    r85 = r26 * r85;
+    r67 = r8 * r34;
+    r67 = r67 * r41;
+    r67 = r67 * r78;
+    r67 = fma(r85, r67, r32 * r85);
+    WriteSum2<double, double>((double*)inout_shared, r67, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r54 * r75;
+    r29 = r58 * r78;
+    r29 = r29 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r54, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = r71 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r75, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r8 * r8;
+    r75 = r25 * r34;
+    r71 = -6.00000000000000000e+00;
+    r75 = r75 * r71;
+    r75 = r75 * r27;
+    r75 = r75 * r7;
+    r37 = r37 * r34;
+    r29 = r10 * r42;
+    r29 = r29 * r8;
+    r54 = r25 * r45;
+    r67 = r23 * r7;
+    r54 = r54 * r45;
+    r54 = fma(r67, r54, r35 * r29);
+    r29 = r8 * r8;
+    r29 = r29 * r67;
+    r85 = r10 * r46;
+    r85 = r85 * r45;
+    r54 = fma(r35, r85, r54);
+    r54 = fma(r25, r29, r54);
+    r85 = r31 * r54;
+    r32 = rsqrt(r14);
+    r14 = r33 + r14;
+    r14 = 1.0 / r14;
+    r14 = r32 * r14;
+    r33 = r8 * r14;
+    r76 = r41 * r9;
+    r85 = r85 * r33;
+    r85 = fma(r76, r85, r75 * r37);
+    r37 = r42 * r34;
+    r65 = 6.00000000000000000e+00;
+    r37 = r37 * r65;
+    r37 = r37 * r41;
+    r85 = fma(r9, r37, r85);
+    r73 = -3.00000000000000000e+00;
+    r73 = r34 * r73;
+    r73 = r73 * r35;
+    r73 = r73 * r6;
+    r73 = r73 * r32;
+    r28 = r54 * r73;
+    r77 = r34 * r29;
+    r85 = fma(r77, r28, r85);
+    r79 = r25 * r45;
+    r79 = r79 * r34;
+    r79 = r79 * r27;
+    r79 = r79 * r61;
+    r74 = r21 * r45;
+    r74 = r74 * r34;
+    r74 = r74 * r54;
+    r74 = r74 * r35;
+    r74 = r74 * r6;
+    r74 = r74 * r32;
+    r74 = fma(r61, r74, r67 * r79);
+    r79 = r54 * r14;
+    r72 = r45 * r62;
+    r74 = fma(r72, r79, r74);
+    r70 = r46 * r62;
+    r74 = fma(r68, r70, r74);
+    r85 = r85 + r74;
+    r28 = r34 * r27;
+    r28 = r28 * r77;
+    r37 = r54 * r33;
+    r37 = fma(r76, r37, r25 * r28);
+    r70 = r68 * r76;
+    r79 = r21 * r8;
+    r79 = r79 * r8;
+    r79 = r79 * r34;
+    r79 = r79 * r34;
+    r79 = r79 * r54;
+    r79 = r79 * r35;
+    r79 = r79 * r6;
+    r37 = fma(r32, r79, r37);
+    r37 = fma(r42, r70, r37);
+    r74 = r74 + r37;
+    r85 = fma(r49, r74, r5 * r85);
+    r79 = r4 * r25;
+    r69 = -4.00000000000000000e+00;
+    r69 = r69 * r27;
+    r69 = r69 * r7;
+    r69 = r69 * r61;
+    r69 = r69 * r9;
+    r85 = fma(r69, r79, r85);
+    r66 = r48 * r10;
+    r66 = r66 * r26;
+    r66 = fma(r74, r66, r50 * r74);
+    r52 = r52 * r31;
+    r52 = r52 * r44;
+    r84 = r53 * r84;
+    r84 = r84 * r55;
+    r66 = fma(r74, r52, r66);
+    r66 = fma(r74, r84, r66);
+    r53 = r66 * r58;
+    r85 = fma(r9, r53, r85);
+    r63 = r4 * r54;
+    r38 = r10 * r62;
+    r38 = r38 * r33;
+    r85 = fma(r38, r63, r85);
+    r60 = r21 * r25;
+    r60 = r60 * r8;
+    r60 = r60 * r34;
+    r60 = r60 * r51;
+    r60 = r60 * r35;
+    r85 = fma(r57, r60, r85);
+    r83 = r4 * r70;
+    r86 = r42 * r34;
+    r85 = fma(r59, r86, r85);
+    r87 = 5.00000000000000000e-01;
+    r88 = r87 * r54;
+    r88 = r88 * r58;
+    r85 = fma(r33, r88, r85);
+    r89 = r54 * r33;
+    r90 = r87 * r59;
+    r85 = fma(r90, r89, r85);
+    r91 = r21 * r25;
+    r91 = r91 * r8;
+    r91 = r91 * r34;
+    r91 = r91 * r35;
+    r85 = fma(r57, r91, r85);
+    r92 = r4 * r42;
+    r92 = r92 * r62;
+    r85 = fma(r68, r92, r85);
+    r93 = r42 * r34;
+    r85 = fma(r58, r93, r85);
+    r94 = r4 * r23;
+    r94 = r94 * r54;
+    r94 = r94 * r35;
+    r94 = r94 * r6;
+    r94 = r94 * r32;
+    r94 = r94 * r61;
+    r85 = fma(r9, r94, r85);
+    r95 = r8 * r34;
+    r96 = -5.00000000000000000e-01;
+    r97 = r96 * r54;
+    r97 = r97 * r27;
+    r97 = r97 * r56;
+    r97 = r97 * r32;
+    r95 = r95 * r51;
+    r85 = fma(r97, r95, r85);
+    r98 = r8 * r34;
+    r85 = fma(r97, r98, r85);
+    r85 = fma(r46, r83, r85);
+    r98 = r2 * r85;
+    r95 = r45 * r61;
+    r94 = r45 * r54;
+    r94 = r94 * r61;
+    r94 = fma(r73, r94, r75 * r95);
+    r95 = r31 * r54;
+    r95 = r95 * r14;
+    r94 = fma(r72, r95, r94);
+    r75 = r46 * r34;
+    r75 = r75 * r65;
+    r94 = fma(r62, r75, r94);
+    r94 = r94 + r37;
+    r74 = fma(r47, r74, r4 * r94);
+    r94 = r45 * r27;
+    r94 = r94 * r34;
+    r94 = r94 * r56;
+    r94 = r94 * r96;
+    r94 = r94 * r32;
+    r94 = r94 * r54;
+    r37 = r45 * r87;
+    r37 = r37 * r54;
+    r37 = r37 * r58;
+    r74 = fma(r14, r37, r74);
+    r75 = r45 * r14;
+    r75 = r75 * r90;
+    r95 = r5 * r69;
+    r93 = r21 * r25;
+    r93 = r93 * r35;
+    r93 = r93 * r57;
+    r74 = fma(r61, r93, r74);
+    r92 = r5 * r54;
+    r74 = fma(r38, r92, r74);
+    r91 = r21 * r25;
+    r91 = r91 * r51;
+    r91 = r91 * r35;
+    r91 = r91 * r57;
+    r74 = fma(r61, r91, r74);
+    r89 = r46 * r34;
+    r74 = fma(r59, r89, r74);
+    r88 = r5 * r46;
+    r74 = fma(r70, r88, r74);
+    r86 = r66 * r61;
+    r74 = fma(r58, r86, r74);
+    r60 = r46 * r34;
+    r74 = fma(r58, r60, r74);
+    r63 = r5 * r42;
+    r63 = r63 * r62;
+    r74 = fma(r68, r63, r74);
+    r53 = r5 * r23;
+    r53 = r53 * r54;
+    r53 = r53 * r35;
+    r53 = r53 * r6;
+    r53 = r53 * r32;
+    r53 = r53 * r61;
+    r74 = fma(r9, r53, r74);
+    r74 = r74 + r94;
+    r74 = fma(r54, r75, r74);
+    r74 = fma(r25, r95, r74);
+    r74 = fma(r51, r94, r74);
+    r53 = r3 * r74;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r98,
+                                             r53);
+    r53 = r30 * r34;
+    r53 = r53 * r65;
+    r53 = r53 * r41;
+    r98 = r40 * r8;
+    r98 = r98 * r8;
+    r98 = r98 * r34;
+    r98 = r98 * r34;
+    r98 = r98 * r71;
+    r98 = r98 * r27;
+    r98 = fma(r7, r98, r9 * r53);
+    r53 = r10 * r30;
+    r53 = r53 * r8;
+    r53 = fma(r35, r53, r40 * r29);
+    r63 = r10 * r36;
+    r63 = r63 * r45;
+    r53 = fma(r35, r63, r53);
+    r60 = r40 * r45;
+    r60 = r60 * r45;
+    r53 = fma(r67, r60, r53);
+    r60 = r53 * r73;
+    r98 = fma(r77, r60, r98);
+    r63 = r31 * r53;
+    r63 = r63 * r33;
+    r98 = fma(r76, r63, r98);
+    r86 = r40 * r45;
+    r86 = r86 * r34;
+    r86 = r86 * r27;
+    r86 = r86 * r61;
+    r94 = r53 * r14;
+    r94 = fma(r72, r94, r67 * r86);
+    r86 = r36 * r62;
+    r94 = fma(r68, r86, r94);
+    r88 = r21 * r45;
+    r88 = r88 * r34;
+    r88 = r88 * r53;
+    r88 = r88 * r35;
+    r88 = r88 * r6;
+    r88 = r88 * r32;
+    r94 = fma(r61, r88, r94);
+    r98 = r98 + r94;
+    r63 = fma(r40, r28, r30 * r70);
+    r60 = r21 * r8;
+    r60 = r60 * r8;
+    r60 = r60 * r34;
+    r60 = r60 * r34;
+    r60 = r60 * r53;
+    r60 = r60 * r35;
+    r60 = r60 * r6;
+    r63 = fma(r32, r60, r63);
+    r88 = r53 * r33;
+    r63 = fma(r76, r88, r63);
+    r94 = r94 + r63;
+    r98 = fma(r49, r94, r5 * r98);
+    r88 = r87 * r53;
+    r88 = r88 * r58;
+    r98 = fma(r33, r88, r98);
+    r60 = r30 * r34;
+    r98 = fma(r59, r60, r98);
+    r86 = r53 * r38;
+    r89 = r53 * r33;
+    r98 = fma(r90, r89, r98);
+    r91 = r21 * r40;
+    r91 = r91 * r8;
+    r91 = r91 * r34;
+    r91 = r91 * r35;
+    r98 = fma(r57, r91, r98);
+    r92 = r30 * r34;
+    r98 = fma(r58, r92, r98);
+    r93 = r8 * r34;
+    r93 = r93 * r51;
+    r93 = r93 * r96;
+    r93 = r93 * r53;
+    r93 = r93 * r27;
+    r93 = r93 * r56;
+    r98 = fma(r32, r93, r98);
+    r37 = r4 * r23;
+    r37 = r37 * r53;
+    r37 = r37 * r35;
+    r37 = r37 * r6;
+    r37 = r37 * r32;
+    r37 = r37 * r61;
+    r98 = fma(r9, r37, r98);
+    r79 = r48 * r10;
+    r79 = r79 * r26;
+    r79 = fma(r94, r79, r50 * r94);
+    r79 = fma(r94, r52, r79);
+    r79 = fma(r94, r84, r79);
+    r97 = r79 * r58;
+    r98 = fma(r9, r97, r98);
+    r99 = r8 * r34;
+    r99 = r99 * r96;
+    r99 = r99 * r53;
+    r99 = r99 * r27;
+    r99 = r99 * r56;
+    r98 = fma(r32, r99, r98);
+    r100 = r21 * r40;
+    r100 = r100 * r8;
+    r100 = r100 * r34;
+    r100 = r100 * r51;
+    r100 = r100 * r35;
+    r98 = fma(r57, r100, r98);
+    r101 = r4 * r40;
+    r98 = fma(r69, r101, r98);
+    r102 = r4 * r30;
+    r102 = r102 * r62;
+    r98 = fma(r68, r102, r98);
+    r98 = fma(r36, r83, r98);
+    r98 = fma(r4, r86, r98);
+    r102 = r2 * r98;
+    r101 = r40 * r45;
+    r101 = r101 * r34;
+    r101 = r101 * r71;
+    r101 = r101 * r27;
+    r101 = r101 * r7;
+    r100 = r31 * r53;
+    r100 = r100 * r14;
+    r100 = fma(r72, r100, r61 * r101);
+    r101 = r36 * r34;
+    r101 = r101 * r65;
+    r100 = fma(r62, r101, r100);
+    r99 = r45 * r53;
+    r99 = r99 * r61;
+    r100 = fma(r73, r99, r100);
+    r100 = r100 + r63;
+    r94 = fma(r47, r94, r4 * r100);
+    r100 = r21 * r40;
+    r100 = r100 * r35;
+    r100 = r100 * r57;
+    r94 = fma(r61, r100, r94);
+    r63 = r51 * r96;
+    r63 = r63 * r53;
+    r63 = r63 * r27;
+    r63 = r63 * r56;
+    r63 = r63 * r32;
+    r94 = fma(r61, r63, r94);
+    r99 = r5 * r36;
+    r94 = fma(r70, r99, r94);
+    r101 = r45 * r87;
+    r101 = r101 * r53;
+    r101 = r101 * r58;
+    r94 = fma(r14, r101, r94);
+    r97 = r36 * r34;
+    r94 = fma(r59, r97, r94);
+    r37 = r21 * r40;
+    r37 = r37 * r51;
+    r37 = r37 * r35;
+    r37 = r37 * r57;
+    r94 = fma(r61, r37, r94);
+    r93 = r5 * r23;
+    r93 = r93 * r53;
+    r93 = r93 * r35;
+    r93 = r93 * r6;
+    r93 = r93 * r32;
+    r93 = r93 * r61;
+    r94 = fma(r9, r93, r94);
+    r92 = r96 * r53;
+    r92 = r92 * r27;
+    r92 = r92 * r56;
+    r92 = r92 * r32;
+    r94 = fma(r61, r92, r94);
+    r91 = r79 * r61;
+    r94 = fma(r58, r91, r94);
+    r89 = r36 * r34;
+    r94 = fma(r58, r89, r94);
+    r60 = r5 * r30;
+    r60 = r60 * r62;
+    r94 = fma(r68, r60, r94);
+    r94 = fma(r53, r75, r94);
+    r94 = fma(r5, r86, r94);
+    r94 = fma(r40, r95, r94);
+    r60 = r3 * r94;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r102,
+                                             r60);
+    r60 = r43 * r8;
+    r60 = r60 * r8;
+    r60 = r60 * r34;
+    r60 = r60 * r34;
+    r60 = r60 * r71;
+    r60 = r60 * r27;
+    r102 = r10 * r22;
+    r102 = r102 * r8;
+    r89 = r43 * r45;
+    r89 = r89 * r45;
+    r89 = fma(r67, r89, r35 * r102);
+    r102 = r10 * r39;
+    r102 = r102 * r45;
+    r89 = fma(r35, r102, r89);
+    r89 = fma(r43, r29, r89);
+    r102 = r89 * r73;
+    r77 = fma(r77, r102, r7 * r60);
+    r60 = r31 * r89;
+    r60 = r60 * r33;
+    r77 = fma(r76, r60, r77);
+    r29 = r22 * r34;
+    r29 = r29 * r65;
+    r29 = r29 * r41;
+    r77 = fma(r9, r29, r77);
+    r41 = r39 * r62;
+    r91 = r21 * r45;
+    r91 = r91 * r34;
+    r91 = r91 * r89;
+    r91 = r91 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r32;
+    r91 = fma(r61, r91, r68 * r41);
+    r41 = r89 * r14;
+    r91 = fma(r72, r41, r91);
+    r92 = r43 * r45;
+    r92 = r92 * r34;
+    r92 = r92 * r27;
+    r92 = r92 * r61;
+    r91 = fma(r67, r92, r91);
+    r77 = r77 + r91;
+    r29 = r21 * r8;
+    r29 = r29 * r8;
+    r29 = r29 * r34;
+    r29 = r29 * r34;
+    r29 = r29 * r89;
+    r29 = r29 * r35;
+    r29 = r29 * r6;
+    r29 = fma(r32, r29, r43 * r28);
+    r28 = r89 * r33;
+    r29 = fma(r76, r28, r29);
+    r29 = fma(r22, r70, r29);
+    r91 = r91 + r29;
+    r49 = fma(r49, r91, r5 * r77);
+    r77 = r8 * r34;
+    r77 = r77 * r51;
+    r77 = r77 * r96;
+    r77 = r77 * r89;
+    r77 = r77 * r27;
+    r77 = r77 * r56;
+    r49 = fma(r32, r77, r49);
+    r28 = r21 * r43;
+    r28 = r28 * r8;
+    r28 = r28 * r34;
+    r28 = r28 * r35;
+    r49 = fma(r57, r28, r49);
+    r76 = r8 * r34;
+    r76 = r76 * r96;
+    r76 = r76 * r89;
+    r76 = r76 * r27;
+    r76 = r76 * r56;
+    r49 = fma(r32, r76, r49);
+    r60 = r87 * r89;
+    r60 = r60 * r58;
+    r49 = fma(r33, r60, r49);
+    r92 = r4 * r43;
+    r49 = fma(r69, r92, r49);
+    r69 = r4 * r22;
+    r69 = r69 * r62;
+    r49 = fma(r68, r69, r49);
+    r41 = r4 * r89;
+    r49 = fma(r38, r41, r49);
+    r67 = r21 * r43;
+    r67 = r67 * r8;
+    r67 = r67 * r34;
+    r67 = r67 * r51;
+    r67 = r67 * r35;
+    r49 = fma(r57, r67, r49);
+    r93 = r4 * r23;
+    r93 = r93 * r89;
+    r93 = r93 * r35;
+    r93 = r93 * r6;
+    r93 = r93 * r32;
+    r93 = r93 * r61;
+    r49 = fma(r9, r93, r49);
+    r37 = r22 * r34;
+    r49 = fma(r58, r37, r49);
+    r97 = r48 * r10;
+    r97 = r97 * r26;
+    r50 = fma(r50, r91, r91 * r97);
+    r50 = fma(r91, r52, r50);
+    r50 = fma(r91, r84, r50);
+    r84 = r50 * r58;
+    r49 = fma(r9, r84, r49);
+    r52 = r89 * r33;
+    r49 = fma(r90, r52, r49);
+    r90 = r22 * r34;
+    r49 = fma(r59, r90, r49);
+    r49 = fma(r39, r83, r49);
+    r90 = r2 * r49;
+    r52 = r39 * r34;
+    r52 = r52 * r65;
+    r65 = r45 * r61;
+    r65 = fma(r102, r65, r62 * r52);
+    r52 = r31 * r89;
+    r52 = r52 * r14;
+    r65 = fma(r72, r52, r65);
+    r72 = r43 * r45;
+    r72 = r72 * r34;
+    r72 = r72 * r71;
+    r72 = r72 * r27;
+    r72 = r72 * r7;
+    r65 = fma(r61, r72, r65);
+    r65 = r65 + r29;
+    r91 = fma(r47, r91, r4 * r65);
+    r47 = r51 * r96;
+    r47 = r47 * r89;
+    r47 = r47 * r27;
+    r47 = r47 * r56;
+    r47 = r47 * r32;
+    r91 = fma(r61, r47, r91);
+    r65 = r96 * r89;
+    r65 = r65 * r27;
+    r65 = r65 * r56;
+    r65 = r65 * r32;
+    r91 = fma(r61, r65, r91);
+    r56 = r5 * r22;
+    r56 = r56 * r62;
+    r91 = fma(r68, r56, r91);
+    r68 = r5 * r89;
+    r91 = fma(r38, r68, r91);
+    r38 = r21 * r43;
+    r38 = r38 * r51;
+    r38 = r38 * r35;
+    r38 = r38 * r57;
+    r91 = fma(r61, r38, r91);
+    r27 = r50 * r61;
+    r91 = fma(r58, r27, r91);
+    r29 = r5 * r39;
+    r91 = fma(r70, r29, r91);
+    r70 = r5 * r23;
+    r70 = r70 * r89;
+    r70 = r70 * r35;
+    r70 = r70 * r6;
+    r70 = r70 * r32;
+    r70 = r70 * r61;
+    r91 = fma(r9, r70, r91);
+    r32 = r39 * r34;
+    r91 = fma(r58, r32, r91);
+    r6 = r45 * r87;
+    r6 = r6 * r89;
+    r6 = r6 * r58;
+    r91 = fma(r14, r6, r91);
+    r72 = r39 * r34;
+    r91 = fma(r59, r72, r91);
+    r59 = r21 * r43;
+    r59 = r59 * r35;
+    r59 = r59 * r57;
+    r91 = fma(r61, r59, r91);
+    r91 = fma(r43, r95, r91);
+    r91 = fma(r89, r75, r91);
+    r59 = r3 * r91;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r90,
+                                             r59);
+    r59 = r3 * r21;
+    r59 = r59 * r1;
+    r59 = fma(r85, r81, r74 * r59);
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r90 = fma(r98, r81, r94 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r59, r90);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r81 = fma(r49, r81, r91 * r90);
+    WriteSum1<double, double>((double*)inout_shared, r81);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r2 * r2;
+    r90 = r85 * r85;
+    r1 = r74 * r74;
+    r1 = fma(r80, r1, r90 * r81);
+    r90 = r94 * r94;
+    r59 = r98 * r98;
+    r59 = fma(r59, r81, r80 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r1, r59);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r91 * r91;
+    r1 = r49 * r49;
+    r81 = fma(r1, r81, r80 * r59);
+    WriteSum1<double, double>((double*)inout_shared, r81);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r2 * r2;
+    r81 = r81 * r85;
+    r1 = r74 * r94;
+    r1 = fma(r80, r1, r98 * r81);
+    r81 = r74 * r91;
+    r59 = r2 * r2;
+    r59 = r59 * r85;
+    r59 = fma(r49, r59, r80 * r81);
+    WriteSum2<double, double>((double*)inout_shared, r1, r59);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r94 * r91;
+    r1 = r2 * r2;
+    r1 = r1 * r98;
+    r1 = fma(r49, r1, r80 * r59);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeFixedPoseResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseResJacKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.cu
@@ -1,0 +1,1637 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* calib,
+        unsigned int calib_num_alloc,
+        SharedIndex* calib_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_calib_jac,
+        unsigned int out_calib_jac_num_alloc,
+        double* const out_calib_njtr,
+        unsigned int out_calib_njtr_num_alloc,
+        double* const out_calib_precond_diag,
+        unsigned int out_calib_precond_diag_num_alloc,
+        double* const out_calib_precond_tril,
+        unsigned int out_calib_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r16 * r17;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r11, r14, r19);
+    r20 = r10 * r19;
+    r22 = fma(r15, r14, r12 * r17);
+    r23 = r11 * r18;
+    r22 = fma(r21, r23, r22);
+    r22 = fma(r16, r13, r22);
+    r20 = r20 * r22;
+    r23 = -2.00000000000000000e+00;
+    r24 = r15 * r13;
+    r24 = fma(r21, r24, r12 * r18);
+    r24 = fma(r16, r14, r24);
+    r24 = fma(r11, r17, r24);
+    r25 = r23 * r24;
+    r26 = fma(r16, r18, r15 * r17);
+    r26 = fma(r11, r13, r26);
+    r26 = fma(r21, r26, r12 * r14);
+    r25 = fma(r26, r25, r20);
+    r7 = fma(r8, r25, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r14, r27);
+    r28 = r15 * r11;
+    r28 = r28 * r10;
+    r29 = r16 * r12;
+    r30 = fma(r23, r29, r28);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r31);
+    r32 = r15 * r15;
+    r32 = r23 * r32;
+    r33 = 1.00000000000000000e+00;
+    r34 = r16 * r16;
+    r34 = fma(r23, r34, r33);
+    r35 = r32 + r34;
+    r36 = r16 * r11;
+    r36 = r36 * r10;
+    r37 = r15 * r12;
+    r37 = fma(r10, r37, r36);
+    r38 = r10 * r19;
+    r38 = r38 * r24;
+    r39 = r22 * r26;
+    r40 = fma(r10, r39, r38);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r23 * r42;
+    r43 = r33 + r42;
+    r44 = r22 * r22;
+    r44 = r44 * r23;
+    r43 = r43 + r44;
+    r7 = fma(r14, r30, r7);
+    r7 = fma(r31, r35, r7);
+    r7 = fma(r27, r37, r7);
+    r7 = fma(r9, r40, r7);
+    r7 = fma(r41, r43, r7);
+    r37 = copysign(1.0, r7);
+    r37 = fma(r6, r37, r7);
+    r7 = r37 * r37;
+    r35 = 1.0 / r7;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r30,
+                                            r45);
+    r22 = r10 * r22;
+    r22 = r22 * r24;
+    r46 = r10 * r19;
+    r46 = fma(r26, r46, r22);
+    r45 = fma(r8, r46, r45);
+    r47 = r15 * r16;
+    r47 = r47 * r10;
+    r48 = r11 * r12;
+    r48 = fma(r10, r48, r47);
+    r49 = r11 * r11;
+    r49 = r23 * r49;
+    r50 = r33 + r49;
+    r50 = r50 + r32;
+    r32 = r15 * r12;
+    r32 = fma(r23, r32, r36);
+    r39 = fma(r23, r39, r38);
+    r38 = r19 * r19;
+    r38 = r23 * r38;
+    r36 = r33 + r38;
+    r36 = r36 + r44;
+    r45 = fma(r14, r48, r45);
+    r45 = fma(r27, r50, r45);
+    r45 = fma(r31, r32, r45);
+    r45 = fma(r41, r39, r45);
+    r45 = fma(r9, r36, r45);
+    r32 = r45 * r45;
+    r32 = r35 * r32;
+    r42 = r33 + r42;
+    r42 = r42 + r38;
+    r8 = fma(r8, r42, r30);
+    r30 = r19 * r23;
+    r30 = fma(r26, r30, r22);
+    r22 = r10 * r24;
+    r22 = fma(r26, r22, r20);
+    r29 = fma(r10, r29, r28);
+    r28 = r11 * r12;
+    r28 = fma(r23, r28, r47);
+    r34 = r49 + r34;
+    r8 = fma(r9, r30, r8);
+    r8 = fma(r41, r22, r8);
+    r8 = fma(r31, r29, r8);
+    r8 = fma(r27, r28, r8);
+    r8 = fma(r14, r34, r8);
+    r34 = r8 * r8;
+    r14 = r45 * r45;
+    r14 = fma(r35, r14, r35 * r34);
+    r34 = sqrt(r14);
+    r28 = copysign(1.0, r34);
+    r28 = fma(r6, r28, r34);
+    r6 = r28 * r28;
+    r27 = 1.0 / r6;
+    r34 = atan(r34);
+    r29 = r34 * r34;
+    r32 = r32 * r27;
+    r32 = r32 * r29;
+    r29 = r8 * r34;
+    r31 = 3.00000000000000000e+00;
+    r41 = r35 * r27;
+    r9 = r8 * r34;
+    r29 = r29 * r31;
+    r29 = r29 * r41;
+    r29 = fma(r9, r29, r32);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r49, r47);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r20 = r8 * r34;
+    r20 = r20 * r41;
+    r20 = r20 * r9;
+    r26 = r32 + r20;
+    r38 = fma(r49, r26, r5 * r29);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r50, r48);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r26 * r26;
+    r51 = fma(r48, r44, r50 * r26);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r52, r53);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r54 = r44 * r44;
+    r55 = r26 * r44;
+    r51 = fma(r53, r54, r51);
+    r51 = fma(r52, r55, r51);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r28;
+    r58 = r56 * r57;
+    r59 = r51 * r58;
+    r60 = r4 * r10;
+    r61 = r45 * r34;
+    r62 = r61 * r41;
+    r60 = r60 * r9;
+    r38 = fma(r62, r60, r38);
+    r38 = fma(r9, r59, r38);
+    r38 = fma(r58, r9, r38);
+    r0 = fma(r2, r38, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r60, r63);
+    r0 = fma(r60, r21, r0);
+    r20 = fma(r31, r32, r20);
+    r60 = fma(r47, r26, r4 * r20);
+    r64 = r5 * r10;
+    r64 = r64 * r9;
+    r60 = fma(r62, r64, r60);
+    r60 = fma(r61, r59, r60);
+    r60 = fma(r61, r58, r60);
+    r1 = fma(r3, r60, r1);
+    r1 = fma(r63, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r63 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r63);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r38,
+                                             r60);
+    r63 = r26 * r58;
+    r64 = r2 * r9;
+    r63 = r63 * r64;
+    r65 = r3 * r26;
+    r65 = r65 * r61;
+    r65 = r65 * r58;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             2 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r63,
+                                             r65);
+    r66 = r58 * r44;
+    r66 = r66 * r64;
+    r67 = r3 * r61;
+    r67 = r67 * r58;
+    r67 = r67 * r44;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r66,
+                                             r67);
+    r68 = r3 * r20;
+    r69 = r10 * r62;
+    r69 = r69 * r64;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r69,
+                                             r68);
+    r70 = r2 * r29;
+    r71 = r3 * r10;
+    r71 = r71 * r9;
+    r71 = r71 * r62;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r70,
+                                             r71);
+    r72 = r58 * r55;
+    r72 = r72 * r64;
+    r73 = r3 * r61;
+    r73 = r73 * r58;
+    r73 = r73 * r55;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r72,
+                                             r73);
+    r74 = r58 * r64;
+    r74 = r74 * r54;
+    r75 = r3 * r61;
+    r75 = r75 * r58;
+    r75 = r75 * r54;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r74,
+                                             r75);
+    r76 = r2 * r26;
+    r77 = r3 * r26;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r76,
+                                             r77);
+    r78 = r21 * r60;
+    r78 = r78 * r1;
+    r79 = r21 * r0;
+    r80 = r38 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r80, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r21 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r79, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r26 * r58;
+    r78 = r78 * r64;
+    r80 = r3 * r21;
+    r80 = r80 * r26;
+    r80 = r80 * r1;
+    r80 = r80 * r61;
+    r80 = fma(r58, r80, r79 * r78);
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r81 = r58 * r44;
+    r81 = r81 * r64;
+    r81 = fma(r79, r81, r44 * r78);
+    WriteSum2<double, double>((double*)inout_shared, r80, r81);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r21;
+    r81 = r81 * r20;
+    r80 = r23 * r0;
+    r80 = r80 * r62;
+    r80 = fma(r64, r80, r1 * r81);
+    r81 = r2 * r79;
+    r78 = r3 * r23;
+    r78 = r78 * r1;
+    r78 = r78 * r9;
+    r78 = fma(r62, r78, r29 * r81);
+    WriteSum2<double, double>((double*)inout_shared, r80, r78);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r80 = r58 * r55;
+    r80 = r80 * r64;
+    r80 = fma(r79, r80, r55 * r78);
+    r78 = r3 * r21;
+    r78 = r78 * r1;
+    r78 = r78 * r61;
+    r78 = r78 * r58;
+    r82 = r58 * r64;
+    r82 = r82 * r54;
+    r82 = fma(r79, r82, r54 * r78);
+    WriteSum2<double, double>((double*)inout_shared, r80, r82);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r3 * r21;
+    r82 = r82 * r26;
+    r82 = r82 * r1;
+    r80 = r26 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r80, r82);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r38 * r38;
+    r80 = r60 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r82, r80);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r33, r33);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r80 = r3 * r3;
+    r32 = r80 * r32;
+    r82 = r8 * r34;
+    r78 = r2 * r64;
+    r82 = r82 * r41;
+    r82 = r82 * r44;
+    r82 = fma(r78, r82, r44 * r32);
+    r79 = r8 * r34;
+    r79 = r79 * r41;
+    r79 = r79 * r54;
+    r79 = fma(r78, r79, r54 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r82, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r82 = r61 * r78;
+    r83 = r8 * r45;
+    r84 = 4.00000000000000000e+00;
+    r7 = r37 * r7;
+    r37 = r37 * r7;
+    r37 = 1.0 / r37;
+    r6 = r28 * r6;
+    r28 = r28 * r6;
+    r28 = 1.0 / r28;
+    r83 = r83 * r34;
+    r83 = r83 * r34;
+    r83 = r83 * r84;
+    r83 = r83 * r37;
+    r83 = r83 * r28;
+    r28 = r20 * r20;
+    r28 = fma(r80, r28, r83 * r82);
+    r82 = r61 * r80;
+    r37 = r9 * r82;
+    r85 = r2 * r2;
+    r85 = r85 * r29;
+    r85 = fma(r29, r85, r83 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r28, r85);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r55 * r55;
+    r28 = r8 * r34;
+    r28 = r28 * r41;
+    r28 = r28 * r78;
+    r28 = fma(r85, r28, r85 * r32);
+    r37 = r54 * r54;
+    r83 = r8 * r34;
+    r83 = r83 * r41;
+    r83 = r83 * r78;
+    r83 = fma(r37, r83, r32 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r28, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r2 * r2;
+    r83 = r83 * r44;
+    r37 = r44 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r83, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r37, r38);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r26 * r38;
+    r83 = r83 * r58;
+    r83 = r83 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r37, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r38 * r58;
+    r83 = r83 * r44;
+    r83 = r83 * r64;
+    r86 = r10 * r38;
+    r86 = r86 * r62;
+    r86 = r86 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r83, r86);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r2 * r29;
+    r86 = r86 * r38;
+    r83 = r38 * r58;
+    r83 = r83 * r55;
+    r83 = r83 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r86, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r2 * r26;
+    r83 = r83 * r38;
+    r38 = r38 * r58;
+    r38 = r38 * r64;
+    r38 = r38 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r38, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r26;
+    r83 = r83 * r60;
+    r83 = r83 * r61;
+    r83 = r83 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r60, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r20;
+    r83 = r83 * r60;
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r44;
+    WriteSum2<double, double>((double*)inout_shared, r38, r83);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r83 = r3 * r10;
+    r83 = r83 * r60;
+    r83 = r83 * r9;
+    r83 = r83 * r62;
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r55;
+    WriteSum2<double, double>((double*)inout_shared, r83, r38);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r38 = r3 * r60;
+    r38 = r38 * r61;
+    r38 = r38 * r58;
+    r38 = r38 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r38, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r38 = r3 * r26;
+    r38 = r38 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r38, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r63, r66);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r69, r70);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r72, r74);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r76, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r65, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r68, r71);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r73, r75);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r37, r77);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r77 = r8 * r34;
+    r77 = r77 * r41;
+    r77 = r77 * r55;
+    r77 = fma(r78, r77, r55 * r32);
+    r75 = r58 * r82;
+    r73 = r20 * r75;
+    r71 = r8 * r26;
+    r7 = 1.0 / r7;
+    r6 = 1.0 / r6;
+    r68 = r10 * r34;
+    r71 = r71 * r7;
+    r71 = r71 * r6;
+    r71 = r71 * r61;
+    r71 = r71 * r68;
+    r71 = fma(r78, r71, r26 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r77, r71);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r45 * r26;
+    r71 = r71 * r7;
+    r71 = r71 * r6;
+    r71 = r71 * r9;
+    r71 = r71 * r68;
+    r77 = r29 * r78;
+    r67 = r58 * r77;
+    r71 = fma(r26, r67, r82 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r71, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r58 * r44;
+    r79 = r79 * r78;
+    r71 = r26 * r54;
+    r65 = r8 * r34;
+    r65 = r65 * r41;
+    r65 = r65 * r78;
+    r65 = fma(r71, r65, r71 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r65, r79);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r44 * r75;
+    r76 = r8 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r61;
+    r76 = r76 * r44;
+    r76 = r76 * r68;
+    r76 = fma(r78, r76, r44 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r79, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r45 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r9;
+    r76 = r76 * r44;
+    r76 = r76 * r68;
+    r76 = fma(r44, r67, r82 * r76);
+    WriteSum2<double, double>((double*)inout_shared, r76, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r58 * r55;
+    r65 = r65 * r78;
+    WriteSum2<double, double>((double*)inout_shared, r28, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r55 * r75;
+    r28 = r10 * r62;
+    r76 = r10 * r20;
+    r76 = r76 * r9;
+    r76 = r76 * r62;
+    r76 = fma(r80, r76, r77 * r28);
+    WriteSum2<double, double>((double*)inout_shared, r65, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r8 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r61;
+    r76 = r76 * r55;
+    r76 = r76 * r68;
+    r76 = fma(r78, r76, r55 * r73);
+    r65 = r8 * r7;
+    r65 = r65 * r6;
+    r65 = r65 * r61;
+    r65 = r65 * r54;
+    r65 = r65 * r68;
+    r65 = fma(r78, r65, r54 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r76, r65);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r65 = r10 * r26;
+    r65 = r65 * r62;
+    r65 = r65 * r78;
+    r76 = r26 * r20;
+    r76 = r76 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r65, r76);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r76 = r45 * r7;
+    r76 = r76 * r6;
+    r76 = r76 * r9;
+    r76 = r76 * r55;
+    r76 = r76 * r68;
+    r76 = fma(r55, r67, r82 * r76);
+    r65 = r45 * r7;
+    r65 = r65 * r6;
+    r65 = r65 * r9;
+    r65 = r65 * r54;
+    r65 = r65 * r68;
+    r67 = fma(r54, r67, r82 * r65);
+    WriteSum2<double, double>((double*)inout_shared, r76, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r2 * r2;
+    r67 = r67 * r26;
+    r67 = r67 * r29;
+    r29 = r10 * r26;
+    r29 = r29 * r9;
+    r29 = r29 * r62;
+    r29 = r29 * r80;
+    WriteSum2<double, double>((double*)inout_shared, r67, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r29 = r58 * r54;
+    r29 = r29 * r78;
+    r85 = r26 * r85;
+    r67 = r8 * r34;
+    r67 = r67 * r41;
+    r67 = r67 * r78;
+    r67 = fma(r85, r67, r32 * r85);
+    WriteSum2<double, double>((double*)inout_shared, r67, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r54 * r75;
+    r29 = r58 * r78;
+    r29 = r29 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r54, r29);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r75 = r71 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r75, r37);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r25 * r34;
+    r75 = -6.00000000000000000e+00;
+    r37 = r37 * r75;
+    r37 = r37 * r27;
+    r37 = r37 * r7;
+    r71 = r8 * r37;
+    r29 = r10 * r42;
+    r29 = r29 * r8;
+    r54 = r25 * r45;
+    r67 = r23 * r7;
+    r54 = r54 * r45;
+    r54 = fma(r67, r54, r35 * r29);
+    r29 = r8 * r8;
+    r29 = r29 * r67;
+    r85 = r10 * r46;
+    r85 = r85 * r45;
+    r54 = fma(r35, r85, r54);
+    r54 = fma(r25, r29, r54);
+    r85 = r31 * r54;
+    r32 = rsqrt(r14);
+    r14 = r33 + r14;
+    r14 = 1.0 / r14;
+    r14 = r32 * r14;
+    r33 = r8 * r14;
+    r76 = r41 * r9;
+    r85 = r85 * r33;
+    r85 = fma(r76, r85, r9 * r71);
+    r71 = r42 * r34;
+    r65 = 6.00000000000000000e+00;
+    r71 = r71 * r65;
+    r71 = r71 * r41;
+    r85 = fma(r9, r71, r85);
+    r73 = -3.00000000000000000e+00;
+    r73 = r34 * r73;
+    r73 = r73 * r35;
+    r73 = r73 * r6;
+    r73 = r73 * r32;
+    r28 = r54 * r73;
+    r77 = r34 * r29;
+    r85 = fma(r77, r28, r85);
+    r79 = r25 * r45;
+    r79 = r79 * r34;
+    r79 = r79 * r27;
+    r79 = r79 * r61;
+    r74 = r21 * r45;
+    r74 = r74 * r34;
+    r74 = r74 * r54;
+    r74 = r74 * r35;
+    r74 = r74 * r6;
+    r74 = r74 * r32;
+    r74 = fma(r61, r74, r67 * r79);
+    r79 = r54 * r14;
+    r72 = r45 * r62;
+    r74 = fma(r72, r79, r74);
+    r70 = r46 * r62;
+    r74 = fma(r68, r70, r74);
+    r85 = r85 + r74;
+    r28 = r34 * r27;
+    r28 = r28 * r77;
+    r71 = r54 * r33;
+    r71 = fma(r76, r71, r25 * r28);
+    r70 = r68 * r76;
+    r79 = r21 * r8;
+    r79 = r79 * r8;
+    r79 = r79 * r34;
+    r79 = r79 * r34;
+    r79 = r79 * r54;
+    r79 = r79 * r35;
+    r79 = r79 * r6;
+    r71 = fma(r32, r79, r71);
+    r71 = fma(r42, r70, r71);
+    r74 = r74 + r71;
+    r85 = fma(r49, r74, r5 * r85);
+    r79 = r4 * r25;
+    r69 = -4.00000000000000000e+00;
+    r69 = r69 * r27;
+    r69 = r69 * r7;
+    r69 = r69 * r61;
+    r69 = r69 * r9;
+    r85 = fma(r69, r79, r85);
+    r66 = r48 * r10;
+    r66 = r66 * r26;
+    r66 = fma(r74, r66, r50 * r74);
+    r52 = r52 * r31;
+    r52 = r52 * r44;
+    r84 = r53 * r84;
+    r84 = r84 * r55;
+    r66 = fma(r74, r52, r66);
+    r66 = fma(r74, r84, r66);
+    r53 = r66 * r58;
+    r85 = fma(r9, r53, r85);
+    r63 = r4 * r54;
+    r38 = r10 * r62;
+    r38 = r38 * r33;
+    r85 = fma(r38, r63, r85);
+    r60 = r21 * r25;
+    r60 = r60 * r8;
+    r60 = r60 * r34;
+    r60 = r60 * r51;
+    r60 = r60 * r35;
+    r85 = fma(r57, r60, r85);
+    r83 = r4 * r70;
+    r86 = r42 * r34;
+    r85 = fma(r59, r86, r85);
+    r87 = 5.00000000000000000e-01;
+    r88 = r87 * r54;
+    r88 = r88 * r58;
+    r85 = fma(r33, r88, r85);
+    r89 = r54 * r33;
+    r90 = r87 * r59;
+    r85 = fma(r90, r89, r85);
+    r91 = r21 * r25;
+    r91 = r91 * r8;
+    r91 = r91 * r34;
+    r91 = r91 * r35;
+    r85 = fma(r57, r91, r85);
+    r92 = r4 * r42;
+    r92 = r92 * r62;
+    r85 = fma(r68, r92, r85);
+    r93 = r42 * r34;
+    r85 = fma(r58, r93, r85);
+    r94 = r4 * r23;
+    r94 = r94 * r54;
+    r94 = r94 * r35;
+    r94 = r94 * r6;
+    r94 = r94 * r32;
+    r94 = r94 * r61;
+    r85 = fma(r9, r94, r85);
+    r95 = -5.00000000000000000e-01;
+    r96 = r95 * r54;
+    r96 = r96 * r27;
+    r96 = r96 * r56;
+    r96 = r96 * r32;
+    r97 = r51 * r96;
+    r98 = r8 * r34;
+    r85 = fma(r96, r98, r85);
+    r85 = fma(r46, r83, r85);
+    r85 = fma(r97, r9, r85);
+    r98 = r2 * r85;
+    r94 = r45 * r61;
+    r93 = r45 * r54;
+    r93 = r93 * r61;
+    r93 = fma(r73, r93, r37 * r94);
+    r92 = r31 * r54;
+    r92 = r92 * r14;
+    r93 = fma(r72, r92, r93);
+    r91 = r46 * r34;
+    r91 = r91 * r65;
+    r93 = fma(r62, r91, r93);
+    r93 = r93 + r71;
+    r74 = fma(r47, r74, r4 * r93);
+    r93 = r45 * r87;
+    r93 = r93 * r54;
+    r93 = r93 * r58;
+    r74 = fma(r14, r93, r74);
+    r71 = r45 * r14;
+    r71 = r71 * r90;
+    r91 = r5 * r69;
+    r92 = r21 * r25;
+    r92 = r92 * r35;
+    r92 = r92 * r57;
+    r74 = fma(r61, r92, r74);
+    r89 = r5 * r54;
+    r74 = fma(r38, r89, r74);
+    r88 = r21 * r25;
+    r88 = r88 * r51;
+    r88 = r88 * r35;
+    r88 = r88 * r57;
+    r74 = fma(r61, r88, r74);
+    r86 = r46 * r34;
+    r74 = fma(r59, r86, r74);
+    r60 = r5 * r46;
+    r74 = fma(r70, r60, r74);
+    r63 = r66 * r61;
+    r74 = fma(r58, r63, r74);
+    r53 = r46 * r34;
+    r74 = fma(r58, r53, r74);
+    r79 = r5 * r42;
+    r79 = r79 * r62;
+    r74 = fma(r68, r79, r74);
+    r99 = r5 * r23;
+    r99 = r99 * r54;
+    r99 = r99 * r35;
+    r99 = r99 * r6;
+    r99 = r99 * r32;
+    r99 = r99 * r61;
+    r74 = fma(r9, r99, r74);
+    r74 = fma(r54, r71, r74);
+    r74 = fma(r25, r91, r74);
+    r74 = fma(r61, r97, r74);
+    r74 = fma(r61, r96, r74);
+    r99 = r3 * r74;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r98,
+                                             r99);
+    r99 = r30 * r34;
+    r99 = r99 * r65;
+    r99 = r99 * r41;
+    r98 = r40 * r8;
+    r98 = r98 * r8;
+    r98 = r98 * r34;
+    r98 = r98 * r34;
+    r98 = r98 * r75;
+    r98 = r98 * r27;
+    r98 = fma(r7, r98, r9 * r99);
+    r99 = r10 * r30;
+    r99 = r99 * r8;
+    r99 = fma(r35, r99, r40 * r29);
+    r79 = r10 * r36;
+    r79 = r79 * r45;
+    r99 = fma(r35, r79, r99);
+    r53 = r40 * r45;
+    r53 = r53 * r45;
+    r99 = fma(r67, r53, r99);
+    r53 = r99 * r73;
+    r79 = r31 * r99;
+    r79 = r79 * r33;
+    r98 = fma(r76, r79, r98);
+    r63 = r40 * r45;
+    r63 = r63 * r34;
+    r63 = r63 * r27;
+    r63 = r63 * r61;
+    r96 = r99 * r14;
+    r96 = fma(r72, r96, r67 * r63);
+    r63 = r36 * r62;
+    r96 = fma(r68, r63, r96);
+    r97 = r21 * r45;
+    r97 = r97 * r34;
+    r97 = r97 * r99;
+    r97 = r97 * r35;
+    r97 = r97 * r6;
+    r97 = r97 * r32;
+    r96 = fma(r61, r97, r96);
+    r98 = fma(r77, r53, r98);
+    r98 = r98 + r96;
+    r79 = fma(r40, r28, r30 * r70);
+    r97 = r21 * r8;
+    r97 = r97 * r8;
+    r97 = r97 * r34;
+    r97 = r97 * r34;
+    r97 = r97 * r99;
+    r97 = r97 * r35;
+    r97 = r97 * r6;
+    r79 = fma(r32, r97, r79);
+    r63 = r99 * r33;
+    r79 = fma(r76, r63, r79);
+    r96 = r96 + r79;
+    r98 = fma(r49, r96, r5 * r98);
+    r63 = r87 * r99;
+    r63 = r63 * r58;
+    r98 = fma(r33, r63, r98);
+    r97 = r30 * r34;
+    r98 = fma(r59, r97, r98);
+    r60 = r4 * r99;
+    r98 = fma(r38, r60, r98);
+    r86 = r99 * r33;
+    r98 = fma(r90, r86, r98);
+    r88 = r21 * r40;
+    r88 = r88 * r8;
+    r88 = r88 * r34;
+    r88 = r88 * r35;
+    r98 = fma(r57, r88, r98);
+    r89 = r30 * r34;
+    r98 = fma(r58, r89, r98);
+    r92 = r8 * r34;
+    r92 = r92 * r51;
+    r92 = r92 * r95;
+    r92 = r92 * r99;
+    r92 = r92 * r27;
+    r92 = r92 * r56;
+    r98 = fma(r32, r92, r98);
+    r93 = r4 * r23;
+    r93 = r93 * r99;
+    r93 = r93 * r35;
+    r93 = r93 * r6;
+    r93 = r93 * r32;
+    r93 = r93 * r61;
+    r98 = fma(r9, r93, r98);
+    r100 = r48 * r10;
+    r100 = r100 * r26;
+    r100 = fma(r96, r100, r50 * r96);
+    r100 = fma(r96, r52, r100);
+    r100 = fma(r96, r84, r100);
+    r101 = r100 * r58;
+    r98 = fma(r9, r101, r98);
+    r102 = r8 * r34;
+    r102 = r102 * r95;
+    r102 = r102 * r99;
+    r102 = r102 * r27;
+    r102 = r102 * r56;
+    r98 = fma(r32, r102, r98);
+    r103 = r21 * r40;
+    r103 = r103 * r8;
+    r103 = r103 * r34;
+    r103 = r103 * r51;
+    r103 = r103 * r35;
+    r98 = fma(r57, r103, r98);
+    r104 = r4 * r40;
+    r98 = fma(r69, r104, r98);
+    r105 = r4 * r30;
+    r105 = r105 * r62;
+    r98 = fma(r68, r105, r98);
+    r98 = fma(r36, r83, r98);
+    r105 = r2 * r98;
+    r104 = r40 * r45;
+    r104 = r104 * r34;
+    r104 = r104 * r75;
+    r104 = r104 * r27;
+    r104 = r104 * r7;
+    r103 = r31 * r99;
+    r103 = r103 * r14;
+    r103 = fma(r72, r103, r61 * r104);
+    r104 = r36 * r34;
+    r104 = r104 * r65;
+    r103 = fma(r62, r104, r103);
+    r103 = fma(r53, r94, r103);
+    r103 = r103 + r79;
+    r96 = fma(r47, r96, r4 * r103);
+    r103 = r21 * r40;
+    r103 = r103 * r35;
+    r103 = r103 * r57;
+    r96 = fma(r61, r103, r96);
+    r79 = r51 * r95;
+    r79 = r79 * r99;
+    r79 = r79 * r27;
+    r79 = r79 * r56;
+    r79 = r79 * r32;
+    r96 = fma(r61, r79, r96);
+    r94 = r5 * r36;
+    r96 = fma(r70, r94, r96);
+    r53 = r5 * r99;
+    r96 = fma(r38, r53, r96);
+    r104 = r45 * r87;
+    r104 = r104 * r99;
+    r104 = r104 * r58;
+    r96 = fma(r14, r104, r96);
+    r102 = r36 * r34;
+    r96 = fma(r59, r102, r96);
+    r101 = r21 * r40;
+    r101 = r101 * r51;
+    r101 = r101 * r35;
+    r101 = r101 * r57;
+    r96 = fma(r61, r101, r96);
+    r93 = r5 * r23;
+    r93 = r93 * r99;
+    r93 = r93 * r35;
+    r93 = r93 * r6;
+    r93 = r93 * r32;
+    r93 = r93 * r61;
+    r96 = fma(r9, r93, r96);
+    r92 = r95 * r99;
+    r92 = r92 * r27;
+    r92 = r92 * r56;
+    r92 = r92 * r32;
+    r96 = fma(r61, r92, r96);
+    r89 = r100 * r61;
+    r96 = fma(r58, r89, r96);
+    r88 = r36 * r34;
+    r96 = fma(r58, r88, r96);
+    r86 = r5 * r30;
+    r86 = r86 * r62;
+    r96 = fma(r68, r86, r96);
+    r96 = fma(r99, r71, r96);
+    r96 = fma(r40, r91, r96);
+    r86 = r3 * r96;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r105,
+                                             r86);
+    r86 = r43 * r8;
+    r86 = r86 * r8;
+    r86 = r86 * r34;
+    r86 = r86 * r34;
+    r86 = r86 * r75;
+    r86 = r86 * r27;
+    r105 = r10 * r22;
+    r105 = r105 * r8;
+    r88 = r43 * r45;
+    r88 = r88 * r45;
+    r88 = fma(r67, r88, r35 * r105);
+    r105 = r10 * r39;
+    r105 = r105 * r45;
+    r88 = fma(r35, r105, r88);
+    r88 = fma(r43, r29, r88);
+    r105 = r88 * r73;
+    r105 = fma(r77, r105, r7 * r86);
+    r86 = r31 * r88;
+    r86 = r86 * r33;
+    r105 = fma(r76, r86, r105);
+    r77 = r22 * r34;
+    r77 = r77 * r65;
+    r77 = r77 * r41;
+    r105 = fma(r9, r77, r105);
+    r41 = r39 * r62;
+    r29 = r21 * r45;
+    r29 = r29 * r34;
+    r29 = r29 * r88;
+    r29 = r29 * r35;
+    r29 = r29 * r6;
+    r29 = r29 * r32;
+    r29 = fma(r61, r29, r68 * r41);
+    r41 = r88 * r14;
+    r29 = fma(r72, r41, r29);
+    r89 = r43 * r45;
+    r89 = r89 * r34;
+    r89 = r89 * r27;
+    r89 = r89 * r61;
+    r29 = fma(r67, r89, r29);
+    r105 = r105 + r29;
+    r77 = r21 * r8;
+    r77 = r77 * r8;
+    r77 = r77 * r34;
+    r77 = r77 * r34;
+    r77 = r77 * r88;
+    r77 = r77 * r35;
+    r77 = r77 * r6;
+    r77 = fma(r32, r77, r43 * r28);
+    r28 = r88 * r33;
+    r77 = fma(r76, r28, r77);
+    r77 = fma(r22, r70, r77);
+    r29 = r29 + r77;
+    r49 = fma(r49, r29, r5 * r105);
+    r105 = r8 * r34;
+    r105 = r105 * r51;
+    r105 = r105 * r95;
+    r105 = r105 * r88;
+    r105 = r105 * r27;
+    r105 = r105 * r56;
+    r49 = fma(r32, r105, r49);
+    r28 = r21 * r43;
+    r28 = r28 * r8;
+    r28 = r28 * r34;
+    r28 = r28 * r35;
+    r49 = fma(r57, r28, r49);
+    r76 = r8 * r34;
+    r76 = r76 * r95;
+    r76 = r76 * r88;
+    r76 = r76 * r27;
+    r76 = r76 * r56;
+    r49 = fma(r32, r76, r49);
+    r86 = r87 * r88;
+    r86 = r86 * r58;
+    r49 = fma(r33, r86, r49);
+    r89 = r4 * r43;
+    r49 = fma(r69, r89, r49);
+    r69 = r4 * r22;
+    r69 = r69 * r62;
+    r49 = fma(r68, r69, r49);
+    r38 = r88 * r38;
+    r41 = r21 * r43;
+    r41 = r41 * r8;
+    r41 = r41 * r34;
+    r41 = r41 * r51;
+    r41 = r41 * r35;
+    r49 = fma(r57, r41, r49);
+    r67 = r4 * r23;
+    r67 = r67 * r88;
+    r67 = r67 * r35;
+    r67 = r67 * r6;
+    r67 = r67 * r32;
+    r67 = r67 * r61;
+    r49 = fma(r9, r67, r49);
+    r92 = r22 * r34;
+    r49 = fma(r58, r92, r49);
+    r93 = r48 * r10;
+    r93 = r93 * r26;
+    r50 = fma(r50, r29, r29 * r93);
+    r50 = fma(r29, r52, r50);
+    r50 = fma(r29, r84, r50);
+    r84 = r50 * r58;
+    r49 = fma(r9, r84, r49);
+    r52 = r88 * r33;
+    r49 = fma(r90, r52, r49);
+    r90 = r22 * r34;
+    r49 = fma(r59, r90, r49);
+    r49 = fma(r4, r38, r49);
+    r49 = fma(r39, r83, r49);
+    r90 = r2 * r49;
+    r52 = r39 * r34;
+    r52 = r52 * r65;
+    r65 = r45 * r88;
+    r65 = r65 * r61;
+    r65 = fma(r73, r65, r62 * r52);
+    r52 = r31 * r88;
+    r52 = r52 * r14;
+    r65 = fma(r72, r52, r65);
+    r72 = r43 * r45;
+    r72 = r72 * r34;
+    r72 = r72 * r75;
+    r72 = r72 * r27;
+    r72 = r72 * r7;
+    r65 = fma(r61, r72, r65);
+    r65 = r65 + r77;
+    r29 = fma(r47, r29, r4 * r65);
+    r47 = r51 * r95;
+    r47 = r47 * r88;
+    r47 = r47 * r27;
+    r47 = r47 * r56;
+    r47 = r47 * r32;
+    r29 = fma(r61, r47, r29);
+    r65 = r95 * r88;
+    r65 = r65 * r27;
+    r65 = r65 * r56;
+    r65 = r65 * r32;
+    r29 = fma(r61, r65, r29);
+    r56 = r5 * r22;
+    r56 = r56 * r62;
+    r29 = fma(r68, r56, r29);
+    r68 = r21 * r43;
+    r68 = r68 * r51;
+    r68 = r68 * r35;
+    r68 = r68 * r57;
+    r29 = fma(r61, r68, r29);
+    r27 = r50 * r61;
+    r29 = fma(r58, r27, r29);
+    r77 = r5 * r39;
+    r29 = fma(r70, r77, r29);
+    r70 = r5 * r23;
+    r70 = r70 * r88;
+    r70 = r70 * r35;
+    r70 = r70 * r6;
+    r70 = r70 * r32;
+    r70 = r70 * r61;
+    r29 = fma(r9, r70, r29);
+    r32 = r39 * r34;
+    r29 = fma(r58, r32, r29);
+    r6 = r45 * r87;
+    r6 = r6 * r88;
+    r6 = r6 * r58;
+    r29 = fma(r14, r6, r29);
+    r72 = r39 * r34;
+    r29 = fma(r59, r72, r29);
+    r59 = r21 * r43;
+    r59 = r59 * r35;
+    r59 = r59 * r57;
+    r29 = fma(r61, r59, r29);
+    r29 = fma(r43, r91, r29);
+    r29 = fma(r88, r71, r29);
+    r29 = fma(r5, r38, r29);
+    r59 = r3 * r29;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r90,
+                                             r59);
+    r59 = r3 * r21;
+    r59 = r59 * r1;
+    r59 = fma(r85, r81, r74 * r59);
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r90 = fma(r98, r81, r96 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r59, r90);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r81 = fma(r49, r81, r29 * r90);
+    WriteSum1<double, double>((double*)inout_shared, r81);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r2 * r2;
+    r90 = r85 * r85;
+    r1 = r74 * r74;
+    r1 = fma(r80, r1, r90 * r81);
+    r90 = r96 * r96;
+    r59 = r98 * r98;
+    r59 = fma(r59, r81, r80 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r1, r59);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r29 * r29;
+    r1 = r49 * r49;
+    r81 = fma(r1, r81, r80 * r59);
+    WriteSum1<double, double>((double*)inout_shared, r81);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r2 * r2;
+    r81 = r81 * r85;
+    r1 = r74 * r96;
+    r1 = fma(r80, r1, r98 * r81);
+    r81 = r74 * r29;
+    r59 = r2 * r2;
+    r59 = r59 * r85;
+    r59 = fma(r49, r59, r80 * r81);
+    WriteSum2<double, double>((double*)inout_shared, r1, r59);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r59 = r96 * r29;
+    r1 = r2 * r2;
+    r1 = r1 * r98;
+    r1 = fma(r49, r1, r80 * r59);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseResJacFirstKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_score.cu
@@ -1,0 +1,330 @@
+#include "kernel_thin_prism_fisheye_fixed_pose_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeFixedPoseScoreKernel(double* sensor_from_rig,
+                                         unsigned int sensor_from_rig_num_alloc,
+                                         double* calib,
+                                         unsigned int calib_num_alloc,
+                                         SharedIndex* calib_indices,
+                                         double* point,
+                                         unsigned int point_num_alloc,
+                                         SharedIndex* point_indices,
+                                         double* pixel,
+                                         unsigned int pixel_num_alloc,
+                                         double* pose,
+                                         unsigned int pose_num_alloc,
+                                         double* const out_rTr,
+                                         size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = r27 * r27;
+    r28 = fma(r28, r8, r36 * r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r8 * r8;
+    r8 = r27 * r8;
+    r28 = fma(r7, r44, r28);
+    r28 = fma(r36, r8, r28);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r28 = r28 * r43;
+    r13 = r4 * r19;
+    r13 = r13 * r42;
+    r13 = r13 * r29;
+    r32 = fma(r6, r13, r32);
+    r32 = fma(r42, r28, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r28, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeFixedPoseScore(double* sensor_from_rig,
+                                    unsigned int sensor_from_rig_num_alloc,
+                                    double* calib,
+                                    unsigned int calib_num_alloc,
+                                    SharedIndex* calib_indices,
+                                    double* point,
+                                    unsigned int point_num_alloc,
+                                    SharedIndex* point_indices,
+                                    double* pixel,
+                                    unsigned int pixel_num_alloc,
+                                    double* pose,
+                                    unsigned int pose_num_alloc,
+                                    double* const out_rTr,
+                                    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeFixedPoseScoreKernel<<<n_blocks, 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_fixed_pose_score.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeFixedPoseScore(double* sensor_from_rig,
+                                    unsigned int sensor_from_rig_num_alloc,
+                                    double* calib,
+                                    unsigned int calib_num_alloc,
+                                    SharedIndex* calib_indices,
+                                    double* point,
+                                    unsigned int point_num_alloc,
+                                    SharedIndex* point_indices,
+                                    double* pixel,
+                                    unsigned int pixel_num_alloc,
+                                    double* pose,
+                                    unsigned int pose_num_alloc,
+                                    double* const out_rTr,
+                                    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_jtjnjtr_direct.cu
@@ -1,0 +1,416 @@
+#include "kernel_thin_prism_fisheye_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeJtjnjtrDirectKernel(double* pose_njtr,
+                                        unsigned int pose_njtr_num_alloc,
+                                        SharedIndex* pose_njtr_indices,
+                                        double* pose_jac,
+                                        unsigned int pose_jac_num_alloc,
+                                        double* calib_njtr,
+                                        unsigned int calib_njtr_num_alloc,
+                                        SharedIndex* calib_njtr_indices,
+                                        double* calib_jac,
+                                        unsigned int calib_jac_num_alloc,
+                                        double* point_njtr,
+                                        unsigned int point_njtr_num_alloc,
+                                        SharedIndex* point_njtr_indices,
+                                        double* point_jac,
+                                        unsigned int point_jac_num_alloc,
+                                        double* const out_pose_njtr,
+                                        unsigned int out_pose_njtr_num_alloc,
+                                        double* const out_calib_njtr,
+                                        unsigned int out_calib_njtr_num_alloc,
+                                        double* const out_point_njtr,
+                                        unsigned int out_point_njtr_num_alloc,
+                                        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_njtr_indices_loc[1024];
+  calib_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                2 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(calib_njtr,
+                                10 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 14 * calib_jac_num_alloc, global_thread_idx, r6, r7);
+    r4 = fma(r4, r6, r2);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                8 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 12 * calib_jac_num_alloc, global_thread_idx, r9, r10);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 10 * calib_jac_num_alloc, global_thread_idx, r11, r12);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                4 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r13,
+                        r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 4 * calib_jac_num_alloc, global_thread_idx, r15, r16);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                6 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r17,
+                        r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 8 * calib_jac_num_alloc, global_thread_idx, r19, r20);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 6 * calib_jac_num_alloc, global_thread_idx, r21, r22);
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 2 * calib_jac_num_alloc, global_thread_idx, r23, r24);
+  };
+  LoadShared<2, double, double>(calib_njtr,
+                                0 * calib_njtr_num_alloc,
+                                calib_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        calib_njtr_indices_loc[threadIdx.x].target,
+                        r25,
+                        r26);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        calib_jac, 0 * calib_jac_num_alloc, global_thread_idx, r27, r28);
+    r4 = fma(r8, r9, r4);
+    r4 = fma(r2, r11, r4);
+    r4 = fma(r14, r15, r4);
+    r4 = fma(r18, r19, r4);
+    r4 = fma(r17, r21, r4);
+    r4 = fma(r13, r23, r4);
+    r4 = fma(r25, r27, r4);
+  };
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r25);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r29, r30);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r31,
+                        r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r33, r34);
+    r35 = fma(r32, r33, r25 * r29);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r36, r37);
+    r35 = fma(r31, r36, r35);
+    r38 = r4 + r35;
+    r5 = fma(r5, r7, r3);
+    r5 = fma(r2, r12, r5);
+    r5 = fma(r17, r22, r5);
+    r5 = fma(r18, r20, r5);
+    r5 = fma(r8, r10, r5);
+    r5 = fma(r14, r16, r5);
+    r5 = fma(r13, r24, r5);
+    r5 = fma(r26, r28, r5);
+    r32 = fma(r32, r34, r25 * r30);
+    r32 = fma(r31, r37, r32);
+    r31 = r5 + r32;
+    r25 = fma(r1, r31, r0 * r38);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r26, r13);
+    r14 = fma(r13, r31, r26 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r25, r14);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r14, r25);
+    r8 = fma(r25, r31, r14 * r38);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r18, r17);
+    r2 = fma(r17, r31, r18 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r8, r2);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r2, r8);
+    r3 = fma(r8, r31, r2 * r38);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r39, r40);
+    r31 = fma(r40, r31, r39 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r3, r31);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r31,
+                        r3);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r31, r2, r3 * r39);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r39,
+                        r38);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r41,
+                        r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r2 = fma(r39, r14, r2);
+    r2 = fma(r38, r18, r2);
+    r2 = fma(r41, r0, r2);
+    r2 = fma(r42, r26, r2);
+    r35 = r2 + r35;
+    r27 = r27 * r35;
+    r17 = fma(r38, r17, r3 * r40);
+    r17 = fma(r39, r25, r17);
+    r17 = fma(r41, r1, r17);
+    r17 = fma(r42, r13, r17);
+    r17 = fma(r31, r8, r17);
+    r32 = r17 + r32;
+    r28 = r28 * r32;
+    WriteSum2<double, double>((double*)inout_shared, r27, r28);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r35, r32);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = fma(r24, r32, r23 * r35);
+    r15 = fma(r15, r35, r16 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r24, r15);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r21 = fma(r21, r35, r22 * r32);
+    r19 = fma(r19, r35, r20 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r21, r19);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r11 = fma(r11, r35, r12 * r32);
+    r9 = fma(r9, r35, r10 * r32);
+    WriteSum2<double, double>((double*)inout_shared, r11, r9);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r35 = r6 * r35;
+    r32 = r7 * r32;
+    WriteSum2<double, double>((double*)inout_shared, r35, r32);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r4 + r2;
+    r17 = r5 + r17;
+    r37 = fma(r37, r17, r36 * r2);
+    r34 = fma(r34, r17, r33 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r37, r34);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r17 = fma(r30, r17, r29 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r17);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeJtjnjtrDirect(double* pose_njtr,
+                                   unsigned int pose_njtr_num_alloc,
+                                   SharedIndex* pose_njtr_indices,
+                                   double* pose_jac,
+                                   unsigned int pose_jac_num_alloc,
+                                   double* calib_njtr,
+                                   unsigned int calib_njtr_num_alloc,
+                                   SharedIndex* calib_njtr_indices,
+                                   double* calib_jac,
+                                   unsigned int calib_jac_num_alloc,
+                                   double* point_njtr,
+                                   unsigned int point_njtr_num_alloc,
+                                   SharedIndex* point_njtr_indices,
+                                   double* point_jac,
+                                   unsigned int point_jac_num_alloc,
+                                   double* const out_pose_njtr,
+                                   unsigned int out_pose_njtr_num_alloc,
+                                   double* const out_calib_njtr,
+                                   unsigned int out_calib_njtr_num_alloc,
+                                   double* const out_point_njtr,
+                                   unsigned int out_point_njtr_num_alloc,
+                                   size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeJtjnjtrDirectKernel<<<n_blocks, 1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      calib_njtr,
+      calib_njtr_num_alloc,
+      calib_njtr_indices,
+      calib_jac,
+      calib_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_jtjnjtr_direct.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeJtjnjtrDirect(double* pose_njtr,
+                                   unsigned int pose_njtr_num_alloc,
+                                   SharedIndex* pose_njtr_indices,
+                                   double* pose_jac,
+                                   unsigned int pose_jac_num_alloc,
+                                   double* calib_njtr,
+                                   unsigned int calib_njtr_num_alloc,
+                                   SharedIndex* calib_njtr_indices,
+                                   double* calib_jac,
+                                   unsigned int calib_jac_num_alloc,
+                                   double* point_njtr,
+                                   unsigned int point_njtr_num_alloc,
+                                   SharedIndex* point_njtr_indices,
+                                   double* point_jac,
+                                   unsigned int point_jac_num_alloc,
+                                   double* const out_pose_njtr,
+                                   unsigned int out_pose_njtr_num_alloc,
+                                   double* const out_calib_njtr,
+                                   unsigned int out_calib_njtr_num_alloc,
+                                   double* const out_point_njtr,
+                                   unsigned int out_point_njtr_num_alloc,
+                                   size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac.cu
@@ -1,0 +1,2987 @@
+#include "kernel_thin_prism_fisheye_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeResJacKernel(double* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 double* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 double* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 double* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 double* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 double* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 double* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 double* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 double* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 double* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 double* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 double* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 double* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 double* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 double* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 double* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 double* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 double* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150, r151, r152,
+      r153, r154, r155, r156;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = r18 * r18;
+    r21 = -2.00000000000000000e+00;
+    r19 = r19 * r21;
+    r22 = 1.00000000000000000e+00;
+    r23 = r15 * r13;
+    r24 = r11 * r17;
+    r25 = r23 + r24;
+    r26 = r14 * r12;
+    r27 = r10 * r16;
+    r25 = r25 + r26;
+    r25 = fma(r20, r27, r25);
+    r28 = r21 * r25;
+    r28 = fma(r25, r28, r22);
+    r29 = r19 + r28;
+    r6 = fma(r8, r29, r6);
+    r30 = 2.00000000000000000e+00;
+    r31 = fma(r11, r16, r14 * r13);
+    r32 = r15 * r12;
+    r31 = fma(r20, r32, r31);
+    r31 = fma(r10, r17, r31);
+    r32 = r30 * r31;
+    r32 = r32 * r25;
+    r33 = r18 * r21;
+    r34 = fma(r15, r17, r14 * r16);
+    r34 = fma(r10, r12, r34);
+    r34 = fma(r20, r34, r11 * r13);
+    r33 = fma(r34, r33, r32);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r30 * r18;
+    r36 = r36 * r31;
+    r37 = r30 * r25;
+    r37 = fma(r34, r37, r36);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r16 * r12;
+    r39 = r39 * r30;
+    r40 = r17 * r13;
+    r40 = fma(r30, r40, r39);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r41, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r12 * r13;
+    r44 = r16 * r17;
+    r44 = r44 * r30;
+    r43 = fma(r21, r43, r44);
+    r45 = r17 * r17;
+    r45 = r45 * r21;
+    r46 = r22 + r45;
+    r47 = r12 * r12;
+    r47 = r47 * r21;
+    r46 = r46 + r47;
+    r6 = fma(r9, r33, r6);
+    r6 = fma(r35, r37, r6);
+    r6 = fma(r38, r40, r6);
+    r6 = fma(r42, r43, r6);
+    r6 = fma(r41, r46, r6);
+    r48 = r6 * r6;
+    r49 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r50);
+    r51 = r21 * r25;
+    r51 = fma(r34, r51, r36);
+    r50 = fma(r8, r51, r50);
+    r36 = r17 * r13;
+    r36 = fma(r21, r36, r39);
+    r45 = r22 + r45;
+    r39 = r16 * r16;
+    r39 = r39 * r21;
+    r45 = r45 + r39;
+    r52 = r17 * r12;
+    r52 = r52 * r30;
+    r53 = r16 * r13;
+    r53 = fma(r30, r53, r52);
+    r54 = r30 * r18;
+    r54 = r54 * r25;
+    r55 = r30 * r31;
+    r55 = fma(r34, r55, r54);
+    r56 = r31 * r31;
+    r56 = r56 * r21;
+    r28 = r56 + r28;
+    r50 = fma(r41, r36, r50);
+    r50 = fma(r38, r45, r50);
+    r50 = fma(r42, r53, r50);
+    r50 = fma(r9, r55, r50);
+    r50 = fma(r35, r28, r50);
+    r57 = copysign(1.0, r50);
+    r57 = fma(r49, r57, r50);
+    r50 = r57 * r57;
+    r58 = 1.0 / r50;
+    r59 = r30 * r18;
+    r59 = fma(r34, r59, r32);
+    r7 = fma(r8, r59, r7);
+    r32 = r12 * r13;
+    r32 = fma(r30, r32, r44);
+    r47 = r22 + r47;
+    r47 = r47 + r39;
+    r39 = r16 * r13;
+    r39 = fma(r21, r39, r52);
+    r52 = r31 * r21;
+    r52 = fma(r34, r52, r54);
+    r19 = r22 + r19;
+    r19 = r19 + r56;
+    r7 = fma(r41, r32, r7);
+    r7 = fma(r42, r47, r7);
+    r7 = fma(r38, r39, r7);
+    r7 = fma(r35, r52, r7);
+    r7 = fma(r9, r19, r7);
+    r38 = r7 * r7;
+    r38 = fma(r58, r38, r58 * r48);
+    r48 = sqrt(r38);
+    r42 = atan(r48);
+    r41 = r42 * r58;
+    r56 = r42 * r41;
+    r54 = copysign(1.0, r48);
+    r54 = fma(r49, r54, r48);
+    r49 = r54 * r54;
+    r48 = 1.0 / r49;
+    r44 = r7 * r48;
+    r60 = r7 * r44;
+    r61 = r56 * r60;
+    r62 = r6 * r6;
+    r63 = 3.00000000000000000e+00;
+    r62 = r62 * r63;
+    r62 = r62 * r48;
+    r62 = fma(r56, r62, r61);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r64, r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r6 * r6;
+    r66 = r66 * r48;
+    r66 = r66 * r56;
+    r61 = r61 + r66;
+    r67 = fma(r64, r61, r5 * r62);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r68, r69);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r70 = r61 * r61;
+    r71 = fma(r69, r70, r68 * r61);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r72, r73);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r74 = r70 * r70;
+    r75 = r61 * r70;
+    r71 = fma(r73, r74, r71);
+    r71 = fma(r72, r75, r71);
+    r76 = 1.0 / r57;
+    r77 = 1.0 / r54;
+    r78 = r76 * r77;
+    r79 = r42 * r78;
+    r80 = r71 * r79;
+    r81 = r4 * r6;
+    r82 = r30 * r56;
+    r81 = r81 * r44;
+    r67 = fma(r82, r81, r67);
+    r67 = fma(r6, r80, r67);
+    r67 = fma(r6, r79, r67);
+    r0 = fma(r2, r67, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r81, r83);
+    r0 = fma(r81, r20, r0);
+    r81 = r63 * r56;
+    r81 = fma(r60, r81, r66);
+    r66 = fma(r65, r61, r4 * r81);
+    r84 = r7 * r79;
+    r85 = r5 * r6;
+    r85 = r85 * r44;
+    r66 = fma(r82, r85, r66);
+    r66 = r66 + r84;
+    r66 = fma(r7, r80, r66);
+    r1 = fma(r3, r66, r1);
+    r1 = fma(r83, r20, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r83 = r30 * r6;
+    r85 = r14 * r13;
+    r86 = -5.00000000000000000e-01;
+    r87 = r11 * r16;
+    r87 = fma(r86, r87, r86 * r85);
+    r85 = r10 * r17;
+    r87 = fma(r86, r85, r87);
+    r88 = r15 * r12;
+    r89 = 5.00000000000000000e-01;
+    r87 = fma(r89, r88, r87);
+    r88 = r25 * r87;
+    r85 = r10 * r13;
+    r90 = r15 * r16;
+    r90 = fma(r89, r90, r89 * r85);
+    r85 = r14 * r17;
+    r90 = fma(r86, r85, r90);
+    r91 = r11 * r12;
+    r90 = fma(r89, r91, r90);
+    r91 = r34 * r90;
+    r85 = fma(r30, r91, r30 * r88);
+    r92 = r30 * r31;
+    r93 = fma(r89, r27, r86 * r23);
+    r93 = fma(r86, r24, r93);
+    r93 = fma(r86, r26, r93);
+    r94 = r30 * r18;
+    r95 = r11 * r13;
+    r96 = r14 * r16;
+    r96 = fma(r86, r96, r89 * r95);
+    r95 = r15 * r17;
+    r96 = fma(r86, r95, r96);
+    r97 = r10 * r12;
+    r96 = fma(r86, r97, r96);
+    r94 = r94 * r96;
+    r92 = fma(r93, r92, r94);
+    r85 = r85 + r92;
+    r97 = r30 * r25;
+    r97 = r97 * r96;
+    r95 = r30 * r31;
+    r95 = r95 * r90;
+    r98 = r97 + r95;
+    r99 = r18 * r21;
+    r98 = fma(r87, r99, r98);
+    r100 = r21 * r34;
+    r98 = fma(r93, r100, r98);
+    r98 = fma(r9, r98, r35 * r85);
+    r85 = r25 * r90;
+    r100 = -4.00000000000000000e+00;
+    r85 = r85 * r100;
+    r99 = r18 * r93;
+    r101 = r100 * r99;
+    r102 = r85 + r101;
+    r98 = fma(r8, r102, r98);
+    r83 = r83 * r98;
+    r102 = r30 * r25;
+    r102 = r102 * r93;
+    r103 = r30 * r18;
+    r103 = fma(r90, r103, r102);
+    r90 = r30 * r31;
+    r90 = r90 * r87;
+    r104 = r30 * r34;
+    r104 = r104 * r96;
+    r105 = r90 + r104;
+    r106 = r103 + r105;
+    r91 = fma(r21, r91, r21 * r88);
+    r91 = r91 + r92;
+    r91 = fma(r8, r91, r9 * r106);
+    r106 = r31 * r96;
+    r106 = r106 * r100;
+    r85 = r85 + r106;
+    r91 = fma(r35, r85, r91);
+    r50 = r57 * r50;
+    r85 = 1.0 / r50;
+    r107 = r21 * r85;
+    r108 = r91 * r107;
+    r109 = r6 * r6;
+    r108 = fma(r109, r108, r58 * r83);
+    r83 = r7 * r7;
+    r83 = r83 * r91;
+    r108 = fma(r107, r83, r108);
+    r110 = r30 * r7;
+    r111 = r31 * r21;
+    r112 = r21 * r34;
+    r112 = r112 * r96;
+    r111 = fma(r87, r111, r112);
+    r111 = r111 + r103;
+    r101 = r106 + r101;
+    r101 = fma(r9, r101, r35 * r111);
+    r111 = r30 * r34;
+    r111 = fma(r93, r111, r95);
+    r95 = r30 * r18;
+    r95 = fma(r87, r95, r97);
+    r111 = r111 + r95;
+    r101 = fma(r8, r111, r101);
+    r110 = r110 * r101;
+    r108 = fma(r58, r110, r108);
+    r110 = r63 * r108;
+    r83 = rsqrt(r38);
+    r111 = r6 * r83;
+    r38 = r22 + r38;
+    r38 = 1.0 / r38;
+    r97 = r38 * r41;
+    r106 = r6 * r48;
+    r110 = r110 * r111;
+    r110 = r110 * r97;
+    r103 = -3.00000000000000000e+00;
+    r113 = r6 * r103;
+    r49 = r54 * r49;
+    r114 = 1.0 / r49;
+    r115 = r114 * r56;
+    r115 = r115 * r111;
+    r113 = r113 * r108;
+    r113 = fma(r115, r113, r106 * r110);
+    r110 = r6 * r98;
+    r116 = 6.00000000000000000e+00;
+    r110 = r110 * r116;
+    r110 = r110 * r48;
+    r113 = fma(r56, r110, r113);
+    r117 = r6 * r6;
+    r118 = -6.00000000000000000e+00;
+    r119 = r91 * r118;
+    r119 = r119 * r85;
+    r117 = r117 * r42;
+    r117 = r117 * r42;
+    r117 = r117 * r48;
+    r113 = fma(r119, r117, r113);
+    r120 = r91 * r60;
+    r121 = r42 * r42;
+    r122 = r107 * r121;
+    r123 = r83 * r97;
+    r123 = r123 * r60;
+    r120 = fma(r108, r123, r122 * r120);
+    r124 = r20 * r7;
+    r124 = r124 * r7;
+    r124 = r124 * r108;
+    r124 = r124 * r83;
+    r124 = r124 * r114;
+    r120 = fma(r56, r124, r120);
+    r125 = r101 * r44;
+    r120 = fma(r82, r125, r120);
+    r113 = r113 + r120;
+    r117 = r108 * r111;
+    r117 = r117 * r97;
+    r110 = r20 * r6;
+    r110 = r110 * r108;
+    r110 = fma(r115, r110, r106 * r117);
+    r117 = r82 * r106;
+    r125 = r48 * r109;
+    r125 = r125 * r122;
+    r110 = fma(r98, r117, r110);
+    r110 = fma(r91, r125, r110);
+    r120 = r120 + r110;
+    r113 = fma(r64, r120, r5 * r113);
+    r124 = r42 * r86;
+    r124 = r124 * r48;
+    r124 = r124 * r76;
+    r124 = r124 * r111;
+    r126 = r71 * r124;
+    r127 = r4 * r98;
+    r127 = r127 * r44;
+    r113 = fma(r82, r127, r113);
+    r128 = r4 * r108;
+    r129 = r30 * r44;
+    r129 = r129 * r111;
+    r129 = r129 * r97;
+    r113 = fma(r129, r128, r113);
+    r130 = r4 * r108;
+    r131 = r21 * r7;
+    r131 = r131 * r115;
+    r113 = fma(r131, r130, r113);
+    r132 = r89 * r108;
+    r132 = r132 * r38;
+    r132 = r132 * r78;
+    r133 = r4 * r101;
+    r113 = fma(r117, r133, r113);
+    r134 = r69 * r30;
+    r134 = r134 * r61;
+    r134 = fma(r120, r134, r68 * r120);
+    r135 = 4.00000000000000000e+00;
+    r73 = r73 * r135;
+    r73 = r73 * r75;
+    r72 = r72 * r63;
+    r72 = r72 * r70;
+    r134 = fma(r120, r73, r134);
+    r134 = fma(r120, r72, r134);
+    r136 = r6 * r134;
+    r113 = fma(r79, r136, r113);
+    r137 = r4 * r6;
+    r137 = r137 * r42;
+    r137 = r137 * r42;
+    r137 = r137 * r100;
+    r137 = r137 * r85;
+    r137 = r137 * r44;
+    r138 = r20 * r6;
+    r138 = r138 * r91;
+    r138 = r138 * r77;
+    r113 = fma(r41, r138, r113);
+    r139 = r71 * r111;
+    r113 = fma(r132, r139, r113);
+    r140 = r20 * r6;
+    r140 = r140 * r71;
+    r140 = r140 * r91;
+    r140 = r140 * r77;
+    r113 = fma(r41, r140, r113);
+    r113 = fma(r108, r126, r113);
+    r113 = fma(r108, r124, r113);
+    r113 = fma(r111, r132, r113);
+    r113 = fma(r91, r137, r113);
+    r113 = fma(r98, r79, r113);
+    r113 = fma(r98, r80, r113);
+    r140 = r2 * r113;
+    r139 = r60 * r121;
+    r138 = r63 * r108;
+    r138 = fma(r123, r138, r119 * r139);
+    r139 = r7 * r7;
+    r139 = r139 * r103;
+    r139 = r139 * r108;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r138 = fma(r56, r139, r138);
+    r119 = r101 * r116;
+    r119 = r119 * r56;
+    r138 = fma(r44, r119, r138);
+    r138 = r138 + r110;
+    r110 = r7 * r89;
+    r110 = r110 * r76;
+    r110 = r110 * r77;
+    r110 = r110 * r83;
+    r110 = r110 * r108;
+    r110 = r110 * r38;
+    r138 = fma(r4, r138, r110);
+    r119 = r7 * r134;
+    r138 = fma(r79, r119, r138);
+    r139 = r20 * r7;
+    r139 = r139 * r91;
+    r139 = r139 * r77;
+    r138 = fma(r41, r139, r138);
+    r136 = r5 * r98;
+    r136 = r136 * r44;
+    r138 = fma(r82, r136, r138);
+    r133 = r5 * r108;
+    r138 = fma(r129, r133, r138);
+    r132 = r5 * r108;
+    r138 = fma(r131, r132, r138);
+    r130 = r42 * r86;
+    r130 = r130 * r108;
+    r130 = r130 * r76;
+    r130 = r130 * r83;
+    r138 = fma(r44, r130, r138);
+    r128 = r5 * r117;
+    r127 = r5 * r6;
+    r127 = r127 * r42;
+    r127 = r127 * r42;
+    r127 = r127 * r100;
+    r127 = r127 * r91;
+    r127 = r127 * r85;
+    r138 = fma(r44, r127, r138);
+    r141 = r42 * r71;
+    r141 = r141 * r86;
+    r141 = r141 * r108;
+    r141 = r141 * r76;
+    r141 = r141 * r83;
+    r138 = fma(r44, r141, r138);
+    r142 = r20 * r7;
+    r142 = r142 * r71;
+    r142 = r142 * r91;
+    r142 = r142 * r77;
+    r138 = fma(r41, r142, r138);
+    r138 = fma(r65, r120, r138);
+    r138 = fma(r101, r80, r138);
+    r138 = fma(r71, r110, r138);
+    r138 = fma(r101, r128, r138);
+    r138 = fma(r101, r79, r138);
+    r142 = r3 * r138;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r140,
+                                             r142);
+    r142 = r21 * r25;
+    r142 = fma(r93, r142, r112);
+    r140 = r30 * r18;
+    r141 = r10 * r13;
+    r127 = r15 * r16;
+    r127 = fma(r86, r127, r86 * r141);
+    r141 = r14 * r17;
+    r127 = fma(r89, r141, r127);
+    r110 = r11 * r12;
+    r127 = fma(r86, r110, r127);
+    r140 = r140 * r127;
+    r110 = r30 * r31;
+    r141 = r14 * r13;
+    r130 = r11 * r16;
+    r130 = fma(r89, r130, r89 * r141);
+    r141 = r10 * r17;
+    r130 = fma(r89, r141, r130);
+    r132 = r15 * r12;
+    r130 = fma(r86, r132, r130);
+    r110 = fma(r130, r110, r140);
+    r142 = r142 + r110;
+    r132 = r30 * r25;
+    r132 = r132 * r130;
+    r141 = r30 * r34;
+    r141 = fma(r127, r141, r132);
+    r141 = r141 + r92;
+    r141 = fma(r9, r141, r8 * r142);
+    r142 = r25 * r96;
+    r142 = r142 * r100;
+    r92 = r31 * r127;
+    r133 = r100 * r92;
+    r136 = r142 + r133;
+    r141 = fma(r35, r136, r141);
+    r104 = r102 + r104;
+    r104 = r104 + r110;
+    r110 = r18 * r100;
+    r110 = r110 * r130;
+    r142 = r142 + r110;
+    r142 = fma(r8, r142, r35 * r104);
+    r104 = r21 * r34;
+    r104 = fma(r21, r99, r130 * r104);
+    r102 = r30 * r31;
+    r102 = r102 * r96;
+    r136 = r30 * r25;
+    r136 = fma(r127, r136, r102);
+    r104 = r104 + r136;
+    r142 = fma(r9, r104, r142);
+    r104 = fma(r142, r117, r141 * r125);
+    r139 = r20 * r6;
+    r119 = r30 * r6;
+    r119 = r119 * r142;
+    r120 = r30 * r7;
+    r132 = r94 + r132;
+    r94 = r31 * r21;
+    r132 = fma(r93, r94, r132);
+    r93 = r21 * r34;
+    r132 = fma(r127, r93, r132);
+    r93 = r30 * r34;
+    r99 = fma(r30, r99, r130 * r93);
+    r99 = r99 + r136;
+    r99 = fma(r8, r99, r35 * r132);
+    r133 = r110 + r133;
+    r99 = fma(r9, r133, r99);
+    r120 = r120 * r99;
+    r120 = fma(r58, r120, r58 * r119);
+    r119 = r7 * r7;
+    r119 = r119 * r141;
+    r120 = fma(r107, r119, r120);
+    r133 = r141 * r107;
+    r120 = fma(r109, r133, r120);
+    r139 = r139 * r120;
+    r104 = fma(r115, r139, r104);
+    r133 = r120 * r111;
+    r133 = r133 * r97;
+    r104 = fma(r106, r133, r104);
+    r133 = r99 * r44;
+    r139 = r20 * r7;
+    r139 = r139 * r7;
+    r139 = r139 * r120;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r139 = fma(r56, r139, r82 * r133);
+    r133 = r141 * r60;
+    r139 = fma(r122, r133, r139);
+    r139 = fma(r120, r123, r139);
+    r133 = r104 + r139;
+    r119 = r6 * r6;
+    r119 = r119 * r42;
+    r119 = r119 * r42;
+    r119 = r119 * r118;
+    r119 = r119 * r141;
+    r119 = r119 * r48;
+    r110 = r6 * r116;
+    r110 = r110 * r142;
+    r110 = r110 * r48;
+    r110 = fma(r56, r110, r85 * r119);
+    r119 = r6 * r115;
+    r132 = r103 * r120;
+    r110 = fma(r132, r119, r110);
+    r93 = r63 * r120;
+    r93 = r93 * r111;
+    r93 = r93 * r97;
+    r110 = fma(r106, r93, r110);
+    r110 = r110 + r139;
+    r110 = fma(r5, r110, r64 * r133);
+    r139 = r20 * r6;
+    r139 = r139 * r141;
+    r139 = r139 * r77;
+    r110 = fma(r41, r139, r110);
+    r93 = r89 * r120;
+    r93 = r93 * r38;
+    r93 = r93 * r78;
+    r110 = fma(r111, r93, r110);
+    r119 = r69 * r30;
+    r119 = r119 * r61;
+    r119 = fma(r133, r119, r68 * r133);
+    r119 = fma(r133, r73, r119);
+    r119 = fma(r133, r72, r119);
+    r130 = r6 * r119;
+    r110 = fma(r79, r130, r110);
+    r94 = r4 * r99;
+    r110 = fma(r117, r94, r110);
+    r143 = r4 * r120;
+    r110 = fma(r129, r143, r110);
+    r144 = r4 * r142;
+    r144 = r144 * r44;
+    r110 = fma(r82, r144, r110);
+    r145 = r4 * r120;
+    r110 = fma(r131, r145, r110);
+    r146 = r20 * r6;
+    r146 = r146 * r71;
+    r146 = r146 * r141;
+    r146 = r146 * r77;
+    r110 = fma(r41, r146, r110);
+    r147 = r89 * r71;
+    r147 = r147 * r120;
+    r147 = r147 * r38;
+    r147 = r147 * r78;
+    r110 = fma(r111, r147, r110);
+    r110 = fma(r142, r80, r110);
+    r110 = fma(r141, r137, r110);
+    r110 = fma(r142, r79, r110);
+    r110 = fma(r120, r126, r110);
+    r110 = fma(r120, r124, r110);
+    r147 = r2 * r110;
+    r146 = r116 * r99;
+    r146 = r146 * r56;
+    r145 = r7 * r7;
+    r145 = r145 * r83;
+    r145 = r145 * r114;
+    r145 = r145 * r56;
+    r145 = fma(r132, r145, r44 * r146);
+    r146 = r118 * r141;
+    r146 = r146 * r85;
+    r146 = r146 * r60;
+    r145 = fma(r121, r146, r145);
+    r132 = r63 * r120;
+    r145 = fma(r123, r132, r145);
+    r145 = r145 + r104;
+    r145 = fma(r4, r145, r65 * r133);
+    r133 = r20 * r7;
+    r133 = r133 * r71;
+    r133 = r133 * r141;
+    r133 = r133 * r77;
+    r145 = fma(r41, r133, r145);
+    r104 = r42 * r71;
+    r104 = r104 * r86;
+    r104 = r104 * r120;
+    r104 = r104 * r76;
+    r104 = r104 * r83;
+    r145 = fma(r44, r104, r145);
+    r132 = r42 * r86;
+    r132 = r132 * r120;
+    r132 = r132 * r76;
+    r132 = r132 * r83;
+    r145 = fma(r44, r132, r145);
+    r146 = r5 * r120;
+    r145 = fma(r129, r146, r145);
+    r144 = r7 * r89;
+    r144 = r144 * r120;
+    r144 = r144 * r83;
+    r144 = r144 * r38;
+    r145 = fma(r78, r144, r145);
+    r143 = r5 * r6;
+    r143 = r143 * r42;
+    r143 = r143 * r42;
+    r143 = r143 * r100;
+    r143 = r143 * r141;
+    r143 = r143 * r85;
+    r145 = fma(r44, r143, r145);
+    r94 = r5 * r142;
+    r94 = r94 * r44;
+    r145 = fma(r82, r94, r145);
+    r130 = r5 * r120;
+    r145 = fma(r131, r130, r145);
+    r93 = r7 * r119;
+    r145 = fma(r79, r93, r145);
+    r139 = r20 * r7;
+    r139 = r139 * r141;
+    r139 = r139 * r77;
+    r145 = fma(r41, r139, r145);
+    r148 = r7 * r89;
+    r148 = r148 * r71;
+    r148 = r148 * r120;
+    r148 = r148 * r83;
+    r148 = r148 * r38;
+    r145 = fma(r78, r148, r145);
+    r145 = fma(r99, r128, r145);
+    r145 = fma(r99, r79, r145);
+    r145 = fma(r99, r80, r145);
+    r148 = r3 * r145;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r147,
+                                             r148);
+    r148 = r31 * r100;
+    r27 = fma(r86, r27, r89 * r23);
+    r27 = fma(r89, r24, r27);
+    r27 = fma(r89, r26, r27);
+    r148 = r148 * r27;
+    r88 = r100 * r88;
+    r26 = r148 + r88;
+    r24 = r30 * r18;
+    r24 = r24 * r27;
+    r102 = r102 + r24;
+    r23 = r21 * r25;
+    r102 = fma(r127, r23, r102);
+    r147 = r21 * r34;
+    r102 = fma(r87, r147, r102);
+    r102 = fma(r8, r102, r35 * r26);
+    r26 = r30 * r34;
+    r26 = fma(r30, r92, r27 * r26);
+    r26 = r26 + r95;
+    r102 = fma(r9, r26, r102);
+    r26 = r102 * r60;
+    r147 = r30 * r7;
+    r23 = r30 * r25;
+    r23 = r23 * r27;
+    r140 = r140 + r23;
+    r140 = r140 + r105;
+    r105 = r21 * r34;
+    r92 = fma(r21, r92, r27 * r105);
+    r92 = r92 + r95;
+    r92 = fma(r35, r92, r8 * r140);
+    r96 = r18 * r96;
+    r96 = r96 * r100;
+    r148 = r148 + r96;
+    r92 = fma(r9, r148, r92);
+    r147 = r147 * r92;
+    r148 = r102 * r107;
+    r148 = fma(r109, r148, r58 * r147);
+    r147 = r30 * r6;
+    r112 = r90 + r112;
+    r90 = r18 * r21;
+    r112 = fma(r127, r90, r112);
+    r112 = r112 + r23;
+    r88 = r96 + r88;
+    r88 = fma(r8, r88, r9 * r112);
+    r8 = r30 * r34;
+    r8 = fma(r87, r8, r24);
+    r8 = r8 + r136;
+    r88 = fma(r35, r8, r88);
+    r147 = r147 * r88;
+    r148 = fma(r58, r147, r148);
+    r8 = r7 * r7;
+    r8 = r8 * r102;
+    r148 = fma(r107, r8, r148);
+    r26 = fma(r148, r123, r122 * r26);
+    r8 = r92 * r44;
+    r26 = fma(r82, r8, r26);
+    r147 = r20 * r7;
+    r147 = r147 * r7;
+    r147 = r147 * r148;
+    r147 = r147 * r83;
+    r147 = r147 * r114;
+    r26 = fma(r56, r147, r26);
+    r147 = r20 * r6;
+    r147 = r147 * r148;
+    r147 = fma(r88, r117, r115 * r147);
+    r8 = r148 * r111;
+    r8 = r8 * r97;
+    r147 = fma(r106, r8, r147);
+    r147 = fma(r102, r125, r147);
+    r8 = r26 + r147;
+    r35 = r6 * r103;
+    r35 = r35 * r148;
+    r136 = r6 * r116;
+    r136 = r136 * r88;
+    r136 = r136 * r48;
+    r136 = fma(r56, r136, r115 * r35);
+    r35 = r6 * r6;
+    r35 = r35 * r42;
+    r35 = r35 * r42;
+    r35 = r35 * r118;
+    r35 = r35 * r102;
+    r35 = r35 * r48;
+    r136 = fma(r85, r35, r136);
+    r24 = r63 * r148;
+    r24 = r24 * r111;
+    r24 = r24 * r97;
+    r136 = fma(r106, r24, r136);
+    r136 = r136 + r26;
+    r136 = fma(r5, r136, r64 * r8);
+    r26 = r69 * r30;
+    r26 = r26 * r61;
+    r26 = fma(r8, r26, r68 * r8);
+    r26 = fma(r8, r72, r26);
+    r26 = fma(r8, r73, r26);
+    r24 = r6 * r26;
+    r136 = fma(r79, r24, r136);
+    r35 = r4 * r92;
+    r136 = fma(r117, r35, r136);
+    r87 = r89 * r148;
+    r87 = r87 * r38;
+    r87 = r87 * r78;
+    r136 = fma(r111, r87, r136);
+    r112 = r4 * r148;
+    r136 = fma(r129, r112, r136);
+    r9 = r89 * r71;
+    r9 = r9 * r148;
+    r9 = r9 * r38;
+    r9 = r9 * r78;
+    r136 = fma(r111, r9, r136);
+    r96 = r20 * r6;
+    r96 = r96 * r102;
+    r96 = r96 * r77;
+    r136 = fma(r41, r96, r136);
+    r90 = r4 * r88;
+    r90 = r90 * r44;
+    r136 = fma(r82, r90, r136);
+    r23 = r20 * r6;
+    r23 = r23 * r71;
+    r23 = r23 * r102;
+    r23 = r23 * r77;
+    r136 = fma(r41, r23, r136);
+    r127 = r4 * r148;
+    r136 = fma(r131, r127, r136);
+    r136 = fma(r88, r80, r136);
+    r136 = fma(r148, r126, r136);
+    r136 = fma(r102, r137, r136);
+    r136 = fma(r88, r79, r136);
+    r136 = fma(r148, r124, r136);
+    r127 = r2 * r136;
+    r23 = r118 * r102;
+    r23 = r23 * r85;
+    r23 = r23 * r60;
+    r90 = r63 * r148;
+    r90 = fma(r123, r90, r121 * r23);
+    r23 = r116 * r92;
+    r23 = r23 * r56;
+    r90 = fma(r44, r23, r90);
+    r96 = r7 * r7;
+    r96 = r96 * r103;
+    r96 = r96 * r148;
+    r96 = r96 * r83;
+    r96 = r96 * r114;
+    r90 = fma(r56, r96, r90);
+    r90 = r90 + r147;
+    r90 = fma(r4, r90, r65 * r8);
+    r8 = r20 * r7;
+    r8 = r8 * r102;
+    r8 = r8 * r77;
+    r90 = fma(r41, r8, r90);
+    r147 = r20 * r7;
+    r147 = r147 * r71;
+    r147 = r147 * r102;
+    r147 = r147 * r77;
+    r90 = fma(r41, r147, r90);
+    r96 = r7 * r89;
+    r96 = r96 * r148;
+    r96 = r96 * r83;
+    r96 = r96 * r38;
+    r90 = fma(r78, r96, r90);
+    r23 = r5 * r148;
+    r90 = fma(r129, r23, r90);
+    r9 = r42 * r71;
+    r9 = r9 * r86;
+    r9 = r9 * r148;
+    r9 = r9 * r76;
+    r9 = r9 * r83;
+    r90 = fma(r44, r9, r90);
+    r112 = r7 * r26;
+    r90 = fma(r79, r112, r90);
+    r87 = r42 * r86;
+    r87 = r87 * r148;
+    r87 = r87 * r76;
+    r87 = r87 * r83;
+    r90 = fma(r44, r87, r90);
+    r35 = r7 * r89;
+    r35 = r35 * r71;
+    r35 = r35 * r148;
+    r35 = r35 * r83;
+    r35 = r35 * r38;
+    r90 = fma(r78, r35, r90);
+    r24 = r5 * r88;
+    r24 = r24 * r44;
+    r90 = fma(r82, r24, r90);
+    r140 = r5 * r6;
+    r140 = r140 * r42;
+    r140 = r140 * r42;
+    r140 = r140 * r100;
+    r140 = r140 * r102;
+    r140 = r140 * r85;
+    r90 = fma(r44, r140, r90);
+    r95 = r5 * r148;
+    r90 = fma(r131, r95, r90);
+    r90 = fma(r92, r128, r90);
+    r90 = fma(r92, r79, r90);
+    r90 = fma(r92, r80, r90);
+    r95 = r3 * r90;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r127, r95);
+    r95 = r46 * r6;
+    r95 = r95 * r116;
+    r95 = r95 * r48;
+    r127 = r6 * r103;
+    r140 = r30 * r32;
+    r140 = r140 * r7;
+    r24 = r36 * r7;
+    r24 = r24 * r7;
+    r24 = fma(r107, r24, r58 * r140);
+    r140 = r36 * r107;
+    r24 = fma(r109, r140, r24);
+    r35 = r30 * r46;
+    r35 = r35 * r6;
+    r24 = fma(r58, r35, r24);
+    r127 = r127 * r24;
+    r127 = fma(r115, r127, r56 * r95);
+    r95 = r63 * r24;
+    r95 = r95 * r111;
+    r95 = r95 * r97;
+    r127 = fma(r106, r95, r127);
+    r35 = r36 * r6;
+    r35 = r35 * r6;
+    r35 = r35 * r42;
+    r35 = r35 * r42;
+    r35 = r35 * r118;
+    r35 = r35 * r48;
+    r127 = fma(r85, r35, r127);
+    r140 = r32 * r44;
+    r87 = r20 * r7;
+    r87 = r87 * r7;
+    r87 = r87 * r24;
+    r87 = r87 * r83;
+    r87 = r87 * r114;
+    r87 = fma(r56, r87, r82 * r140);
+    r140 = r36 * r60;
+    r87 = fma(r122, r140, r87);
+    r87 = fma(r24, r123, r87);
+    r127 = r127 + r87;
+    r35 = r20 * r6;
+    r35 = r35 * r24;
+    r35 = fma(r115, r35, r46 * r117);
+    r95 = r24 * r111;
+    r95 = r95 * r97;
+    r35 = fma(r106, r95, r35);
+    r35 = fma(r36, r125, r35);
+    r87 = r87 + r35;
+    r127 = fma(r64, r87, r5 * r127);
+    r95 = r89 * r24;
+    r95 = r95 * r38;
+    r95 = r95 * r78;
+    r127 = fma(r111, r95, r127);
+    r140 = r89 * r71;
+    r140 = r140 * r24;
+    r140 = r140 * r38;
+    r140 = r140 * r78;
+    r127 = fma(r111, r140, r127);
+    r112 = r20 * r36;
+    r112 = r112 * r6;
+    r112 = r112 * r71;
+    r112 = r112 * r77;
+    r127 = fma(r41, r112, r127);
+    r9 = r4 * r32;
+    r127 = fma(r117, r9, r127);
+    r23 = r69 * r30;
+    r23 = r23 * r61;
+    r23 = fma(r87, r23, r68 * r87);
+    r23 = fma(r87, r72, r23);
+    r23 = fma(r87, r73, r23);
+    r96 = r6 * r23;
+    r127 = fma(r79, r96, r127);
+    r147 = r20 * r36;
+    r147 = r147 * r6;
+    r147 = r147 * r77;
+    r127 = fma(r41, r147, r127);
+    r8 = r4 * r24;
+    r127 = fma(r129, r8, r127);
+    r105 = r4 * r46;
+    r105 = r105 * r44;
+    r127 = fma(r82, r105, r127);
+    r27 = r4 * r24;
+    r127 = fma(r131, r27, r127);
+    r127 = fma(r24, r126, r127);
+    r127 = fma(r24, r124, r127);
+    r127 = fma(r46, r80, r127);
+    r127 = fma(r46, r79, r127);
+    r127 = fma(r36, r137, r127);
+    r27 = r2 * r127;
+    r105 = r32 * r116;
+    r105 = r105 * r56;
+    r8 = r7 * r7;
+    r8 = r8 * r103;
+    r8 = r8 * r24;
+    r8 = r8 * r83;
+    r8 = r8 * r114;
+    r8 = fma(r56, r8, r44 * r105);
+    r105 = r36 * r118;
+    r105 = r105 * r85;
+    r105 = r105 * r60;
+    r8 = fma(r121, r105, r8);
+    r147 = r63 * r24;
+    r8 = fma(r123, r147, r8);
+    r8 = r8 + r35;
+    r87 = fma(r65, r87, r4 * r8);
+    r8 = r7 * r89;
+    r8 = r8 * r24;
+    r8 = r8 * r83;
+    r8 = r8 * r38;
+    r87 = fma(r78, r8, r87);
+    r35 = r20 * r36;
+    r35 = r35 * r7;
+    r35 = r35 * r77;
+    r87 = fma(r41, r35, r87);
+    r147 = r7 * r89;
+    r147 = r147 * r71;
+    r147 = r147 * r24;
+    r147 = r147 * r83;
+    r147 = r147 * r38;
+    r87 = fma(r78, r147, r87);
+    r105 = r20 * r36;
+    r105 = r105 * r7;
+    r105 = r105 * r71;
+    r105 = r105 * r77;
+    r87 = fma(r41, r105, r87);
+    r96 = r42 * r71;
+    r96 = r96 * r86;
+    r96 = r96 * r24;
+    r96 = r96 * r76;
+    r96 = r96 * r83;
+    r87 = fma(r44, r96, r87);
+    r9 = r5 * r24;
+    r87 = fma(r129, r9, r87);
+    r112 = r5 * r46;
+    r112 = r112 * r44;
+    r87 = fma(r82, r112, r87);
+    r140 = r42 * r86;
+    r140 = r140 * r24;
+    r140 = r140 * r76;
+    r140 = r140 * r83;
+    r87 = fma(r44, r140, r87);
+    r95 = r7 * r23;
+    r87 = fma(r79, r95, r87);
+    r139 = r5 * r24;
+    r87 = fma(r131, r139, r87);
+    r93 = r5 * r36;
+    r93 = r93 * r6;
+    r93 = r93 * r42;
+    r93 = r93 * r42;
+    r93 = r93 * r100;
+    r93 = r93 * r85;
+    r87 = fma(r44, r93, r87);
+    r87 = fma(r32, r80, r87);
+    r87 = fma(r32, r79, r87);
+    r87 = fma(r32, r128, r87);
+    r93 = r3 * r87;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r27, r93);
+    r93 = r53 * r60;
+    r27 = r47 * r44;
+    r27 = fma(r82, r27, r122 * r93);
+    r93 = r53 * r7;
+    r93 = r93 * r7;
+    r139 = r30 * r47;
+    r139 = r139 * r7;
+    r139 = fma(r58, r139, r107 * r93);
+    r93 = r53 * r107;
+    r139 = fma(r109, r93, r139);
+    r95 = r30 * r43;
+    r95 = r95 * r6;
+    r139 = fma(r58, r95, r139);
+    r95 = r20 * r7;
+    r95 = r95 * r7;
+    r95 = r95 * r139;
+    r95 = r95 * r83;
+    r95 = r95 * r114;
+    r27 = fma(r56, r95, r27);
+    r27 = fma(r139, r123, r27);
+    r95 = r139 * r111;
+    r95 = r95 * r97;
+    r95 = fma(r53, r125, r106 * r95);
+    r93 = r20 * r6;
+    r93 = r93 * r139;
+    r95 = fma(r115, r93, r95);
+    r95 = fma(r43, r117, r95);
+    r93 = r27 + r95;
+    r140 = r63 * r139;
+    r140 = r140 * r111;
+    r140 = r140 * r97;
+    r112 = r53 * r6;
+    r112 = r112 * r6;
+    r112 = r112 * r42;
+    r112 = r112 * r42;
+    r112 = r112 * r118;
+    r112 = r112 * r48;
+    r112 = fma(r85, r112, r106 * r140);
+    r140 = r6 * r103;
+    r140 = r140 * r139;
+    r112 = fma(r115, r140, r112);
+    r9 = r43 * r6;
+    r9 = r9 * r116;
+    r9 = r9 * r48;
+    r112 = fma(r56, r9, r112);
+    r112 = r112 + r27;
+    r112 = fma(r5, r112, r64 * r93);
+    r27 = r4 * r139;
+    r112 = fma(r129, r27, r112);
+    r9 = r20 * r53;
+    r9 = r9 * r6;
+    r9 = r9 * r77;
+    r112 = fma(r41, r9, r112);
+    r140 = r4 * r43;
+    r140 = r140 * r44;
+    r112 = fma(r82, r140, r112);
+    r96 = r89 * r71;
+    r96 = r96 * r139;
+    r96 = r96 * r38;
+    r96 = r96 * r78;
+    r112 = fma(r111, r96, r112);
+    r105 = r20 * r53;
+    r105 = r105 * r6;
+    r105 = r105 * r71;
+    r105 = r105 * r77;
+    r112 = fma(r41, r105, r112);
+    r147 = r89 * r139;
+    r147 = r147 * r38;
+    r147 = r147 * r78;
+    r112 = fma(r111, r147, r112);
+    r35 = r4 * r47;
+    r112 = fma(r117, r35, r112);
+    r8 = r69 * r30;
+    r8 = r8 * r61;
+    r8 = fma(r68, r93, r93 * r8);
+    r8 = fma(r93, r73, r8);
+    r8 = fma(r93, r72, r8);
+    r130 = r6 * r8;
+    r112 = fma(r79, r130, r112);
+    r94 = r4 * r139;
+    r112 = fma(r131, r94, r112);
+    r112 = fma(r43, r79, r112);
+    r112 = fma(r139, r126, r112);
+    r112 = fma(r43, r80, r112);
+    r112 = fma(r139, r124, r112);
+    r112 = fma(r53, r137, r112);
+    r94 = r2 * r112;
+    r130 = r53 * r118;
+    r130 = r130 * r85;
+    r130 = r130 * r60;
+    r35 = r47 * r116;
+    r35 = r35 * r56;
+    r35 = fma(r44, r35, r121 * r130);
+    r130 = r63 * r139;
+    r35 = fma(r123, r130, r35);
+    r147 = r7 * r7;
+    r147 = r147 * r103;
+    r147 = r147 * r139;
+    r147 = r147 * r83;
+    r147 = r147 * r114;
+    r35 = fma(r56, r147, r35);
+    r35 = r35 + r95;
+    r35 = fma(r4, r35, r65 * r93);
+    r93 = r20 * r53;
+    r93 = r93 * r7;
+    r93 = r93 * r77;
+    r35 = fma(r41, r93, r35);
+    r95 = r20 * r53;
+    r95 = r95 * r7;
+    r95 = r95 * r71;
+    r95 = r95 * r77;
+    r35 = fma(r41, r95, r35);
+    r147 = r5 * r139;
+    r35 = fma(r129, r147, r35);
+    r130 = r7 * r89;
+    r130 = r130 * r71;
+    r130 = r130 * r139;
+    r130 = r130 * r83;
+    r130 = r130 * r38;
+    r35 = fma(r78, r130, r35);
+    r105 = r7 * r89;
+    r105 = r105 * r139;
+    r105 = r105 * r83;
+    r105 = r105 * r38;
+    r35 = fma(r78, r105, r35);
+    r96 = r5 * r43;
+    r96 = r96 * r44;
+    r35 = fma(r82, r96, r35);
+    r140 = r7 * r8;
+    r35 = fma(r79, r140, r35);
+    r9 = r42 * r86;
+    r9 = r9 * r139;
+    r9 = r9 * r76;
+    r9 = r9 * r83;
+    r35 = fma(r44, r9, r35);
+    r27 = r5 * r139;
+    r35 = fma(r131, r27, r35);
+    r143 = r42 * r71;
+    r143 = r143 * r86;
+    r143 = r143 * r139;
+    r143 = r143 * r76;
+    r143 = r143 * r83;
+    r35 = fma(r44, r143, r35);
+    r144 = r5 * r53;
+    r144 = r144 * r6;
+    r144 = r144 * r42;
+    r144 = r144 * r42;
+    r144 = r144 * r100;
+    r144 = r144 * r85;
+    r35 = fma(r44, r144, r35);
+    r35 = fma(r47, r80, r35);
+    r35 = fma(r47, r128, r35);
+    r35 = fma(r47, r79, r35);
+    r144 = r3 * r35;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r94, r144);
+    r144 = r20 * r6;
+    r94 = r30 * r39;
+    r94 = r94 * r7;
+    r143 = r45 * r7;
+    r143 = r143 * r7;
+    r143 = fma(r107, r143, r58 * r94);
+    r94 = r30 * r40;
+    r94 = r94 * r6;
+    r143 = fma(r58, r94, r143);
+    r27 = r45 * r107;
+    r143 = fma(r109, r27, r143);
+    r144 = r144 * r143;
+    r27 = r143 * r111;
+    r27 = r27 * r97;
+    r27 = fma(r106, r27, r115 * r144);
+    r27 = fma(r40, r117, r27);
+    r27 = fma(r45, r125, r27);
+    r144 = r45 * r60;
+    r94 = r39 * r44;
+    r94 = fma(r82, r94, r122 * r144);
+    r144 = r20 * r7;
+    r144 = r144 * r7;
+    r144 = r144 * r143;
+    r144 = r144 * r83;
+    r144 = r144 * r114;
+    r94 = fma(r56, r144, r94);
+    r94 = fma(r143, r123, r94);
+    r144 = r27 + r94;
+    r9 = r6 * r103;
+    r9 = r9 * r143;
+    r140 = r63 * r143;
+    r140 = r140 * r111;
+    r140 = r140 * r97;
+    r140 = fma(r106, r140, r115 * r9);
+    r9 = r40 * r6;
+    r9 = r9 * r116;
+    r9 = r9 * r48;
+    r140 = fma(r56, r9, r140);
+    r96 = r45 * r6;
+    r96 = r96 * r6;
+    r96 = r96 * r42;
+    r96 = r96 * r42;
+    r96 = r96 * r118;
+    r96 = r96 * r48;
+    r140 = fma(r85, r96, r140);
+    r140 = r140 + r94;
+    r140 = fma(r5, r140, r64 * r144);
+    r94 = r4 * r39;
+    r140 = fma(r117, r94, r140);
+    r96 = r69 * r30;
+    r96 = r96 * r61;
+    r96 = fma(r68, r144, r144 * r96);
+    r96 = fma(r144, r72, r96);
+    r96 = fma(r144, r73, r96);
+    r9 = r6 * r96;
+    r140 = fma(r79, r9, r140);
+    r105 = r20 * r45;
+    r105 = r105 * r6;
+    r105 = r105 * r71;
+    r105 = r105 * r77;
+    r140 = fma(r41, r105, r140);
+    r130 = r143 * r131;
+    r147 = r4 * r143;
+    r140 = fma(r129, r147, r140);
+    r95 = r89 * r143;
+    r95 = r95 * r38;
+    r95 = r95 * r78;
+    r140 = fma(r111, r95, r140);
+    r93 = r4 * r40;
+    r93 = r93 * r44;
+    r140 = fma(r82, r93, r140);
+    r146 = r20 * r45;
+    r146 = r146 * r6;
+    r146 = r146 * r77;
+    r140 = fma(r41, r146, r140);
+    r132 = r89 * r71;
+    r132 = r132 * r143;
+    r132 = r132 * r38;
+    r132 = r132 * r78;
+    r140 = fma(r111, r132, r140);
+    r140 = fma(r143, r126, r140);
+    r140 = fma(r4, r130, r140);
+    r140 = fma(r45, r137, r140);
+    r140 = fma(r40, r80, r140);
+    r140 = fma(r40, r79, r140);
+    r140 = fma(r143, r124, r140);
+    r132 = r2 * r140;
+    r146 = r45 * r118;
+    r146 = r146 * r85;
+    r146 = r146 * r60;
+    r93 = r39 * r116;
+    r93 = r93 * r56;
+    r93 = fma(r44, r93, r121 * r146);
+    r146 = r63 * r143;
+    r93 = fma(r123, r146, r93);
+    r95 = r7 * r7;
+    r95 = r95 * r103;
+    r95 = r95 * r143;
+    r95 = r95 * r83;
+    r95 = r95 * r114;
+    r93 = fma(r56, r95, r93);
+    r93 = r93 + r27;
+    r93 = fma(r4, r93, r65 * r144);
+    r144 = r42 * r86;
+    r144 = r144 * r143;
+    r144 = r144 * r76;
+    r144 = r144 * r83;
+    r93 = fma(r44, r144, r93);
+    r27 = r20 * r45;
+    r27 = r27 * r7;
+    r27 = r27 * r77;
+    r93 = fma(r41, r27, r93);
+    r95 = r42 * r71;
+    r95 = r95 * r86;
+    r95 = r95 * r143;
+    r95 = r95 * r76;
+    r95 = r95 * r83;
+    r93 = fma(r44, r95, r93);
+    r146 = r5 * r143;
+    r93 = fma(r129, r146, r93);
+    r147 = r5 * r45;
+    r147 = r147 * r6;
+    r147 = r147 * r42;
+    r147 = r147 * r42;
+    r147 = r147 * r100;
+    r147 = r147 * r85;
+    r93 = fma(r44, r147, r93);
+    r105 = r7 * r89;
+    r105 = r105 * r71;
+    r105 = r105 * r143;
+    r105 = r105 * r83;
+    r105 = r105 * r38;
+    r93 = fma(r78, r105, r93);
+    r9 = r5 * r40;
+    r9 = r9 * r44;
+    r93 = fma(r82, r9, r93);
+    r94 = r7 * r89;
+    r94 = r94 * r143;
+    r94 = r94 * r83;
+    r94 = r94 * r38;
+    r93 = fma(r78, r94, r93);
+    r104 = r7 * r96;
+    r93 = fma(r79, r104, r93);
+    r133 = r20 * r45;
+    r133 = r133 * r7;
+    r133 = r133 * r71;
+    r133 = r133 * r77;
+    r93 = fma(r41, r133, r93);
+    r93 = fma(r39, r128, r93);
+    r93 = fma(r39, r79, r93);
+    r93 = fma(r5, r130, r93);
+    r93 = fma(r39, r80, r93);
+    r133 = r3 * r93;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r133);
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r132 = r20 * r0;
+    r104 = r2 * r132;
+    r133 = fma(r113, r104, r138 * r133);
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r110, r104, r145 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r133, r94);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r136, r104, r90 * r94);
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r133 = fma(r127, r104, r87 * r133);
+    WriteSum2<double, double>((double*)inout_shared, r94, r133);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r133 = fma(r112, r104, r35 * r133);
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r140, r104, r93 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r133, r94);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r113 * r113;
+    r133 = r2 * r2;
+    r9 = r138 * r138;
+    r105 = r3 * r3;
+    r9 = fma(r105, r9, r133 * r94);
+    r94 = r110 * r110;
+    r147 = r145 * r145;
+    r147 = fma(r105, r147, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r90 * r90;
+    r9 = r136 * r136;
+    r9 = fma(r133, r9, r105 * r147);
+    r147 = r87 * r87;
+    r94 = r127 * r127;
+    r94 = fma(r133, r94, r105 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r9, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r35 * r35;
+    r9 = r112 * r112;
+    r9 = fma(r133, r9, r105 * r94);
+    r94 = r140 * r140;
+    r147 = r93 * r93;
+    r147 = fma(r105, r147, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r113 * r110;
+    r9 = r138 * r145;
+    r9 = fma(r105, r9, r133 * r147);
+    r147 = r138 * r90;
+    r94 = r113 * r136;
+    r94 = fma(r133, r94, r105 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r9, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r113 * r127;
+    r9 = r138 * r87;
+    r9 = fma(r105, r9, r133 * r94);
+    r94 = r138 * r35;
+    r147 = r113 * r112;
+    r147 = fma(r133, r147, r105 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r113 * r140;
+    r9 = r138 * r93;
+    r9 = fma(r105, r9, r133 * r147);
+    r147 = r145 * r90;
+    r94 = r110 * r136;
+    r94 = fma(r133, r94, r105 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r9, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r145 * r87;
+    r9 = r110 * r127;
+    r9 = fma(r133, r9, r105 * r94);
+    r94 = r110 * r112;
+    r147 = r145 * r35;
+    r147 = fma(r105, r147, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r110 * r140;
+    r9 = r145 * r93;
+    r9 = fma(r105, r9, r133 * r147);
+    r147 = r90 * r87;
+    r94 = r136 * r127;
+    r94 = fma(r133, r94, r105 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r9, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r90 * r35;
+    r9 = r136 * r112;
+    r9 = fma(r133, r9, r105 * r94);
+    r94 = r90 * r93;
+    r147 = r136 * r140;
+    r147 = fma(r133, r147, r105 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r87 * r35;
+    r9 = r127 * r112;
+    r9 = fma(r133, r9, r105 * r147);
+    r147 = r87 * r93;
+    r94 = r127 * r140;
+    r94 = fma(r133, r94, r105 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r9, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r35 * r93;
+    r9 = r112 * r140;
+    r9 = fma(r133, r9, r105 * r94);
+    WriteSum1<double, double>((double*)inout_shared, r9);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r67,
+                                             r66);
+    r9 = r2 * r6;
+    r9 = r9 * r61;
+    r9 = r9 * r79;
+    r94 = r3 * r7;
+    r94 = r94 * r61;
+    r94 = r94 * r79;
+    WriteIdx2<1024, double, double, double2>(
+        out_calib_jac, 2 * out_calib_jac_num_alloc, global_thread_idx, r9, r94);
+    r147 = r2 * r6;
+    r147 = r147 * r79;
+    r147 = r147 * r70;
+    r146 = r3 * r7;
+    r146 = r146 * r79;
+    r146 = r146 * r70;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r147,
+                                             r146);
+    r130 = r3 * r81;
+    r95 = r2 * r6;
+    r95 = r95 * r44;
+    r95 = r95 * r82;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r95,
+                                             r130);
+    r27 = r2 * r62;
+    r144 = r3 * r6;
+    r144 = r144 * r44;
+    r144 = r144 * r82;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r27,
+                                             r144);
+    r149 = r2 * r6;
+    r149 = r149 * r79;
+    r149 = r149 * r75;
+    r150 = r3 * r7;
+    r150 = r150 * r79;
+    r150 = r150 * r75;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r149,
+                                             r150);
+    r151 = r2 * r6;
+    r151 = r151 * r79;
+    r151 = r151 * r74;
+    r152 = r3 * r7;
+    r152 = r152 * r79;
+    r152 = r152 * r74;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r151,
+                                             r152);
+    r153 = r2 * r61;
+    r154 = r3 * r61;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r153,
+                                             r154);
+    r155 = r20 * r66;
+    r155 = r155 * r1;
+    r156 = r67 * r132;
+    WriteSum2<double, double>((double*)inout_shared, r156, r155);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r20 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r132, r155);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r6 * r61;
+    r155 = r155 * r79;
+    r132 = r3 * r20;
+    r132 = r132 * r7;
+    r132 = r132 * r61;
+    r132 = r132 * r1;
+    r132 = fma(r79, r132, r104 * r155);
+    r155 = r3 * r20;
+    r155 = r155 * r7;
+    r155 = r155 * r1;
+    r155 = r155 * r79;
+    r156 = r6 * r79;
+    r156 = r156 * r70;
+    r156 = fma(r104, r156, r70 * r155);
+    WriteSum2<double, double>((double*)inout_shared, r132, r156);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r3 * r20;
+    r156 = r156 * r81;
+    r132 = r2 * r21;
+    r132 = r132 * r6;
+    r132 = r132 * r0;
+    r132 = r132 * r56;
+    r132 = fma(r44, r132, r1 * r156);
+    r156 = r3 * r21;
+    r156 = r156 * r6;
+    r156 = r156 * r1;
+    r156 = r156 * r56;
+    r156 = fma(r44, r156, r62 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r132, r156);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r3 * r20;
+    r156 = r156 * r7;
+    r156 = r156 * r1;
+    r156 = r156 * r79;
+    r132 = r6 * r79;
+    r132 = r132 * r75;
+    r132 = fma(r104, r132, r75 * r156);
+    r156 = r3 * r20;
+    r156 = r156 * r7;
+    r156 = r156 * r1;
+    r156 = r156 * r79;
+    r0 = r6 * r79;
+    r0 = r0 * r74;
+    r0 = fma(r104, r0, r74 * r156);
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r20;
+    r0 = r0 * r61;
+    r0 = r0 * r1;
+    r132 = r61 * r104;
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r67 * r67;
+    r132 = r66 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r0, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r22, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r56 * r70;
+    r22 = r22 * r105;
+    r132 = r6 * r56;
+    r132 = r132 * r70;
+    r132 = r132 * r133;
+    r132 = fma(r106, r132, r60 * r22);
+    r22 = r56 * r105;
+    r22 = r22 * r60;
+    r0 = r6 * r56;
+    r0 = r0 * r133;
+    r0 = r0 * r106;
+    r0 = fma(r74, r0, r74 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = r7 * r7;
+    r50 = r57 * r50;
+    r50 = 1.0 / r50;
+    r49 = r54 * r49;
+    r49 = 1.0 / r49;
+    r132 = r132 * r42;
+    r132 = r132 * r42;
+    r132 = r132 * r135;
+    r132 = r132 * r50;
+    r132 = r132 * r49;
+    r132 = r132 * r121;
+    r132 = r132 * r109;
+    r49 = r81 * r105;
+    r50 = fma(r81, r49, r133 * r132);
+    r135 = r62 * r133;
+    r132 = fma(r62, r135, r105 * r132);
+    WriteSum2<double, double>((double*)inout_shared, r50, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = r56 * r105;
+    r50 = r75 * r75;
+    r132 = r132 * r60;
+    r54 = r6 * r56;
+    r54 = r54 * r133;
+    r54 = r54 * r106;
+    r132 = fma(r50, r54, r50 * r132);
+    r57 = r74 * r74;
+    r22 = r56 * r105;
+    r22 = r22 * r60;
+    r57 = fma(r54, r57, r57 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r132, r57);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r70 * r133;
+    r156 = r70 * r105;
+    WriteSum2<double, double>((double*)inout_shared, r57, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r156, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r2 * r6;
+    r57 = r57 * r61;
+    r57 = r57 * r67;
+    r57 = r57 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r156, r57);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r57 = r2 * r6;
+    r57 = r57 * r67;
+    r57 = r57 * r79;
+    r57 = r57 * r70;
+    r155 = r2 * r6;
+    r155 = r155 * r67;
+    r155 = r155 * r44;
+    r155 = r155 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r57, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r2 * r62;
+    r62 = r62 * r67;
+    r155 = r2 * r6;
+    r155 = r155 * r67;
+    r155 = r155 * r79;
+    r155 = r155 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r62, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r2 * r61;
+    r155 = r155 * r67;
+    r62 = r2 * r6;
+    r62 = r62 * r67;
+    r62 = r62 * r79;
+    r62 = r62 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r62, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r7;
+    r155 = r155 * r61;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r66, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r81;
+    r81 = r81 * r66;
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r70;
+    WriteSum2<double, double>((double*)inout_shared, r155, r81);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r6;
+    r81 = r81 * r66;
+    r81 = r81 * r44;
+    r81 = r81 * r82;
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r81, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r155, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r61;
+    r155 = r155 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r155, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r9, r147);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r95, r27);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r149, r151);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r153, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r94, r146);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r130, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r150, r152);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r156, r154);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r56 * r75;
+    r154 = r154 * r105;
+    r152 = r6 * r56;
+    r152 = r152 * r75;
+    r152 = r152 * r133;
+    r152 = fma(r106, r152, r60 * r154);
+    r154 = r49 * r84;
+    r150 = r30 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r61;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r133;
+    r150 = r150 * r121;
+    r150 = fma(r109, r150, r61 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r152, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r30 * r6;
+    r150 = r150 * r7;
+    r150 = r150 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r61;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r105;
+    r152 = r6 * r135;
+    r144 = r79 * r152;
+    r150 = fma(r61, r144, r121 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r150, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r6 * r79;
+    r0 = r0 * r70;
+    r0 = r0 * r133;
+    r150 = r56 * r105;
+    r130 = r61 * r74;
+    r150 = r150 * r60;
+    r150 = fma(r130, r54, r130 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r150, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r7 * r79;
+    r0 = r0 * r70;
+    r0 = r0 * r105;
+    r146 = r30 * r7;
+    r146 = r146 * r42;
+    r146 = r146 * r85;
+    r146 = r146 * r114;
+    r146 = r146 * r70;
+    r146 = r146 * r133;
+    r146 = r146 * r121;
+    r146 = fma(r109, r146, r70 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r0, r146);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r146 = r30 * r6;
+    r146 = r146 * r7;
+    r146 = r146 * r7;
+    r146 = r146 * r42;
+    r146 = r146 * r85;
+    r146 = r146 * r114;
+    r146 = r146 * r70;
+    r146 = r146 * r105;
+    r146 = fma(r70, r144, r121 * r146);
+    WriteSum2<double, double>((double*)inout_shared, r146, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r6 * r79;
+    r150 = r150 * r75;
+    r150 = r150 * r133;
+    WriteSum2<double, double>((double*)inout_shared, r132, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r7 * r79;
+    r150 = r150 * r75;
+    r150 = r150 * r105;
+    r132 = r44 * r82;
+    r146 = r6 * r49;
+    r146 = fma(r132, r146, r152 * r132);
+    WriteSum2<double, double>((double*)inout_shared, r150, r146);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r146 = r30 * r7;
+    r146 = r146 * r42;
+    r146 = r146 * r85;
+    r146 = r146 * r114;
+    r146 = r146 * r75;
+    r146 = r146 * r133;
+    r146 = r146 * r121;
+    r146 = fma(r109, r146, r75 * r154);
+    r150 = r30 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r133;
+    r150 = r150 * r121;
+    r150 = r150 * r74;
+    r150 = fma(r109, r150, r74 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r146, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r6 * r61;
+    r150 = r150 * r44;
+    r150 = r150 * r82;
+    r150 = r150 * r133;
+    r146 = r61 * r49;
+    WriteSum2<double, double>((double*)inout_shared, r150, r146);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r146 = r30 * r6;
+    r146 = r146 * r7;
+    r146 = r146 * r7;
+    r146 = r146 * r42;
+    r146 = r146 * r85;
+    r146 = r146 * r114;
+    r146 = r146 * r75;
+    r146 = r146 * r105;
+    r146 = fma(r75, r144, r121 * r146);
+    r150 = r30 * r6;
+    r150 = r150 * r7;
+    r150 = r150 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r105;
+    r150 = r150 * r121;
+    r144 = fma(r74, r144, r74 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r146, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r135 = r61 * r135;
+    r144 = r6 * r61;
+    r144 = r144 * r44;
+    r144 = r144 * r82;
+    r144 = r144 * r105;
+    WriteSum2<double, double>((double*)inout_shared, r135, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r6 * r79;
+    r144 = r144 * r133;
+    r144 = r144 * r74;
+    r50 = r61 * r50;
+    r54 = fma(r50, r54, r50 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r54, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r7 * r79;
+    r144 = r144 * r105;
+    r144 = r144 * r74;
+    r74 = r6 * r79;
+    r74 = r74 * r133;
+    r74 = r74 * r130;
+    WriteSum2<double, double>((double*)inout_shared, r144, r74);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r105 * r130;
+    r130 = r130 * r84;
+    WriteSum2<double, double>((double*)inout_shared, r130, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r51 * r6;
+    r156 = r156 * r6;
+    r156 = r156 * r42;
+    r156 = r156 * r42;
+    r156 = r156 * r118;
+    r156 = r156 * r48;
+    r130 = r30 * r29;
+    r130 = r130 * r6;
+    r84 = r51 * r7;
+    r84 = r84 * r7;
+    r84 = fma(r107, r84, r58 * r130);
+    r130 = r51 * r107;
+    r84 = fma(r109, r130, r84);
+    r74 = r30 * r59;
+    r74 = r74 * r7;
+    r84 = fma(r58, r74, r84);
+    r74 = r63 * r84;
+    r74 = r74 * r111;
+    r74 = r74 * r97;
+    r74 = fma(r106, r74, r85 * r156);
+    r156 = r29 * r6;
+    r156 = r156 * r116;
+    r156 = r156 * r48;
+    r74 = fma(r56, r156, r74);
+    r130 = r6 * r103;
+    r130 = r130 * r84;
+    r74 = fma(r115, r130, r74);
+    r144 = r51 * r60;
+    r54 = r20 * r7;
+    r54 = r54 * r7;
+    r54 = r54 * r84;
+    r54 = r54 * r83;
+    r54 = r54 * r114;
+    r54 = fma(r56, r54, r122 * r144);
+    r144 = r59 * r44;
+    r54 = fma(r82, r144, r54);
+    r54 = fma(r84, r123, r54);
+    r74 = r74 + r54;
+    r130 = r84 * r111;
+    r130 = r130 * r97;
+    r130 = fma(r106, r130, r51 * r125);
+    r156 = r20 * r6;
+    r156 = r156 * r84;
+    r130 = fma(r115, r156, r130);
+    r130 = fma(r29, r117, r130);
+    r54 = r54 + r130;
+    r74 = fma(r64, r54, r5 * r74);
+    r156 = r69 * r30;
+    r156 = r156 * r61;
+    r156 = fma(r54, r156, r68 * r54);
+    r156 = fma(r54, r72, r156);
+    r156 = fma(r54, r73, r156);
+    r144 = r6 * r156;
+    r74 = fma(r79, r144, r74);
+    r50 = r4 * r84;
+    r74 = fma(r129, r50, r74);
+    r22 = r20 * r51;
+    r22 = r22 * r6;
+    r22 = r22 * r71;
+    r22 = r22 * r77;
+    r74 = fma(r41, r22, r74);
+    r135 = r4 * r59;
+    r74 = fma(r117, r135, r74);
+    r146 = r89 * r84;
+    r146 = r146 * r38;
+    r146 = r146 * r78;
+    r74 = fma(r111, r146, r74);
+    r150 = r89 * r71;
+    r150 = r150 * r84;
+    r150 = r150 * r38;
+    r150 = r150 * r78;
+    r74 = fma(r111, r150, r74);
+    r154 = r20 * r51;
+    r154 = r154 * r6;
+    r154 = r154 * r77;
+    r74 = fma(r41, r154, r74);
+    r132 = r4 * r29;
+    r132 = r132 * r44;
+    r74 = fma(r82, r132, r74);
+    r152 = r4 * r84;
+    r74 = fma(r131, r152, r74);
+    r74 = fma(r51, r137, r74);
+    r74 = fma(r29, r80, r74);
+    r74 = fma(r29, r79, r74);
+    r74 = fma(r84, r126, r74);
+    r74 = fma(r84, r124, r74);
+    r152 = r2 * r74;
+    r132 = r51 * r118;
+    r132 = r132 * r85;
+    r132 = r132 * r60;
+    r154 = r7 * r7;
+    r154 = r154 * r103;
+    r154 = r154 * r84;
+    r154 = r154 * r83;
+    r154 = r154 * r114;
+    r154 = fma(r56, r154, r121 * r132);
+    r132 = r63 * r84;
+    r154 = fma(r123, r132, r154);
+    r150 = r59 * r116;
+    r150 = r150 * r56;
+    r154 = fma(r44, r150, r154);
+    r154 = r154 + r130;
+    r54 = fma(r65, r54, r4 * r154);
+    r154 = r7 * r89;
+    r154 = r154 * r84;
+    r154 = r154 * r83;
+    r154 = r154 * r38;
+    r54 = fma(r78, r154, r54);
+    r130 = r7 * r89;
+    r130 = r130 * r71;
+    r130 = r130 * r84;
+    r130 = r130 * r83;
+    r130 = r130 * r38;
+    r54 = fma(r78, r130, r54);
+    r150 = r5 * r51;
+    r150 = r150 * r6;
+    r150 = r150 * r42;
+    r150 = r150 * r42;
+    r150 = r150 * r100;
+    r150 = r150 * r85;
+    r54 = fma(r44, r150, r54);
+    r132 = r20 * r51;
+    r132 = r132 * r7;
+    r132 = r132 * r77;
+    r54 = fma(r41, r132, r54);
+    r146 = r5 * r84;
+    r54 = fma(r129, r146, r54);
+    r135 = r20 * r51;
+    r135 = r135 * r7;
+    r135 = r135 * r71;
+    r135 = r135 * r77;
+    r54 = fma(r41, r135, r54);
+    r22 = r42 * r71;
+    r22 = r22 * r86;
+    r22 = r22 * r84;
+    r22 = r22 * r76;
+    r22 = r22 * r83;
+    r54 = fma(r44, r22, r54);
+    r50 = r42 * r86;
+    r50 = r50 * r84;
+    r50 = r50 * r76;
+    r50 = r50 * r83;
+    r54 = fma(r44, r50, r54);
+    r144 = r7 * r156;
+    r54 = fma(r79, r144, r54);
+    r0 = r5 * r29;
+    r0 = r0 * r44;
+    r54 = fma(r82, r0, r54);
+    r94 = r5 * r84;
+    r54 = fma(r131, r94, r54);
+    r54 = fma(r59, r80, r54);
+    r54 = fma(r59, r128, r54);
+    r54 = fma(r59, r79, r54);
+    r94 = r3 * r54;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r152,
+                                             r94);
+    r94 = r33 * r6;
+    r94 = r94 * r116;
+    r94 = r94 * r48;
+    r152 = r55 * r6;
+    r152 = r152 * r6;
+    r152 = r152 * r42;
+    r152 = r152 * r42;
+    r152 = r152 * r118;
+    r152 = r152 * r48;
+    r152 = fma(r85, r152, r56 * r94);
+    r94 = r6 * r103;
+    r0 = r55 * r107;
+    r144 = r30 * r33;
+    r144 = r144 * r6;
+    r144 = fma(r58, r144, r109 * r0);
+    r0 = r30 * r19;
+    r0 = r0 * r7;
+    r144 = fma(r58, r0, r144);
+    r50 = r55 * r7;
+    r50 = r50 * r7;
+    r144 = fma(r107, r50, r144);
+    r94 = r94 * r144;
+    r152 = fma(r115, r94, r152);
+    r50 = r63 * r144;
+    r50 = r50 * r111;
+    r50 = r50 * r97;
+    r152 = fma(r106, r50, r152);
+    r0 = r55 * r60;
+    r0 = fma(r144, r123, r122 * r0);
+    r22 = r19 * r44;
+    r0 = fma(r82, r22, r0);
+    r135 = r20 * r7;
+    r135 = r135 * r7;
+    r135 = r135 * r144;
+    r135 = r135 * r83;
+    r135 = r135 * r114;
+    r0 = fma(r56, r135, r0);
+    r152 = r152 + r0;
+    r50 = fma(r55, r125, r33 * r117);
+    r94 = r20 * r6;
+    r94 = r94 * r144;
+    r50 = fma(r115, r94, r50);
+    r135 = r144 * r111;
+    r135 = r135 * r97;
+    r50 = fma(r106, r135, r50);
+    r0 = r0 + r50;
+    r152 = fma(r64, r0, r5 * r152);
+    r135 = r89 * r144;
+    r135 = r135 * r38;
+    r135 = r135 * r78;
+    r152 = fma(r111, r135, r152);
+    r94 = r4 * r19;
+    r152 = fma(r117, r94, r152);
+    r22 = r144 * r129;
+    r146 = r89 * r71;
+    r146 = r146 * r144;
+    r146 = r146 * r38;
+    r146 = r146 * r78;
+    r152 = fma(r111, r146, r152);
+    r132 = r20 * r55;
+    r132 = r132 * r6;
+    r132 = r132 * r77;
+    r152 = fma(r41, r132, r152);
+    r150 = r4 * r144;
+    r152 = fma(r131, r150, r152);
+    r130 = r69 * r30;
+    r130 = r130 * r61;
+    r130 = fma(r0, r130, r68 * r0);
+    r130 = fma(r0, r72, r130);
+    r130 = fma(r0, r73, r130);
+    r154 = r6 * r130;
+    r152 = fma(r79, r154, r152);
+    r153 = r20 * r55;
+    r153 = r153 * r6;
+    r153 = r153 * r71;
+    r153 = r153 * r77;
+    r152 = fma(r41, r153, r152);
+    r151 = r4 * r33;
+    r151 = r151 * r44;
+    r152 = fma(r82, r151, r152);
+    r152 = fma(r33, r80, r152);
+    r152 = fma(r4, r22, r152);
+    r152 = fma(r33, r79, r152);
+    r152 = fma(r144, r126, r152);
+    r152 = fma(r144, r124, r152);
+    r152 = fma(r55, r137, r152);
+    r151 = r2 * r152;
+    r153 = r55 * r118;
+    r153 = r153 * r85;
+    r153 = r153 * r60;
+    r154 = r63 * r144;
+    r154 = fma(r123, r154, r121 * r153);
+    r153 = r19 * r116;
+    r153 = r153 * r56;
+    r154 = fma(r44, r153, r154);
+    r123 = r7 * r7;
+    r123 = r123 * r103;
+    r123 = r123 * r144;
+    r123 = r123 * r83;
+    r123 = r123 * r114;
+    r154 = fma(r56, r123, r154);
+    r154 = r154 + r50;
+    r0 = fma(r65, r0, r4 * r154);
+    r154 = r20 * r55;
+    r154 = r154 * r7;
+    r154 = r154 * r77;
+    r0 = fma(r41, r154, r0);
+    r50 = r42 * r71;
+    r50 = r50 * r86;
+    r50 = r50 * r144;
+    r50 = r50 * r76;
+    r50 = r50 * r83;
+    r0 = fma(r44, r50, r0);
+    r123 = r7 * r89;
+    r123 = r123 * r71;
+    r123 = r123 * r144;
+    r123 = r123 * r83;
+    r123 = r123 * r38;
+    r0 = fma(r78, r123, r0);
+    r153 = r7 * r89;
+    r153 = r153 * r144;
+    r153 = r153 * r83;
+    r153 = r153 * r38;
+    r0 = fma(r78, r153, r0);
+    r150 = r20 * r55;
+    r150 = r150 * r7;
+    r150 = r150 * r71;
+    r150 = r150 * r77;
+    r0 = fma(r41, r150, r0);
+    r132 = r5 * r144;
+    r0 = fma(r131, r132, r0);
+    r146 = r42 * r86;
+    r146 = r146 * r144;
+    r146 = r146 * r76;
+    r146 = r146 * r83;
+    r0 = fma(r44, r146, r0);
+    r94 = r7 * r130;
+    r0 = fma(r79, r94, r0);
+    r135 = r5 * r55;
+    r135 = r135 * r6;
+    r135 = r135 * r42;
+    r135 = r135 * r42;
+    r135 = r135 * r100;
+    r135 = r135 * r85;
+    r0 = fma(r44, r135, r0);
+    r149 = r5 * r33;
+    r149 = r149 * r44;
+    r0 = fma(r82, r149, r0);
+    r0 = fma(r19, r128, r0);
+    r0 = fma(r5, r22, r0);
+    r0 = fma(r19, r80, r0);
+    r0 = fma(r19, r79, r0);
+    r149 = r3 * r0;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r151,
+                                             r149);
+    r149 = r28 * r6;
+    r149 = r149 * r6;
+    r149 = r149 * r42;
+    r149 = r149 * r42;
+    r149 = r149 * r118;
+    r149 = r149 * r48;
+    r151 = r6 * r103;
+    r135 = r30 * r37;
+    r135 = r135 * r6;
+    r94 = r28 * r7;
+    r94 = r94 * r7;
+    r94 = fma(r107, r94, r58 * r135);
+    r135 = r28 * r107;
+    r94 = fma(r109, r135, r94);
+    r109 = r30 * r52;
+    r109 = r109 * r7;
+    r94 = fma(r58, r109, r94);
+    r151 = r151 * r94;
+    r151 = fma(r115, r151, r85 * r149);
+    r149 = r63 * r94;
+    r149 = r149 * r111;
+    r149 = r149 * r97;
+    r151 = fma(r106, r149, r151);
+    r109 = r37 * r6;
+    r109 = r109 * r116;
+    r109 = r109 * r48;
+    r151 = fma(r56, r109, r151);
+    r135 = r7 * r7;
+    r135 = r58 * r135;
+    r135 = r135 * r48;
+    r135 = r135 * r42;
+    r135 = r135 * r83;
+    r135 = r135 * r38;
+    r135 = r135 * r94;
+    r48 = r52 * r44;
+    r48 = fma(r82, r48, r135);
+    r58 = r20 * r7;
+    r58 = r58 * r7;
+    r58 = r58 * r94;
+    r58 = r58 * r83;
+    r58 = r58 * r114;
+    r48 = fma(r56, r58, r48);
+    r146 = r28 * r60;
+    r48 = fma(r122, r146, r48);
+    r151 = r151 + r48;
+    r109 = r20 * r6;
+    r109 = r109 * r94;
+    r109 = fma(r115, r109, r28 * r125);
+    r125 = r94 * r111;
+    r125 = r125 * r97;
+    r109 = fma(r106, r125, r109);
+    r109 = fma(r37, r117, r109);
+    r48 = r48 + r109;
+    r64 = fma(r64, r48, r5 * r151);
+    r151 = r20 * r28;
+    r151 = r151 * r6;
+    r151 = r151 * r77;
+    r64 = fma(r41, r151, r64);
+    r125 = r89 * r94;
+    r125 = r125 * r38;
+    r125 = r125 * r78;
+    r64 = fma(r111, r125, r64);
+    r106 = r4 * r37;
+    r106 = r106 * r44;
+    r64 = fma(r82, r106, r64);
+    r97 = r4 * r94;
+    r64 = fma(r129, r97, r64);
+    r149 = r20 * r28;
+    r149 = r149 * r6;
+    r149 = r149 * r71;
+    r149 = r149 * r77;
+    r64 = fma(r41, r149, r64);
+    r146 = r4 * r52;
+    r64 = fma(r117, r146, r64);
+    r117 = r4 * r94;
+    r64 = fma(r131, r117, r64);
+    r58 = r69 * r30;
+    r58 = r58 * r61;
+    r68 = fma(r68, r48, r48 * r58);
+    r68 = fma(r48, r72, r68);
+    r68 = fma(r48, r73, r68);
+    r73 = r6 * r68;
+    r64 = fma(r79, r73, r64);
+    r72 = r89 * r71;
+    r72 = r72 * r94;
+    r72 = r72 * r38;
+    r72 = r72 * r78;
+    r64 = fma(r111, r72, r64);
+    r64 = fma(r94, r126, r64);
+    r64 = fma(r94, r124, r64);
+    r64 = fma(r28, r137, r64);
+    r64 = fma(r37, r79, r64);
+    r64 = fma(r37, r80, r64);
+    r72 = r2 * r64;
+    r73 = r52 * r116;
+    r73 = r73 * r56;
+    r117 = r7 * r7;
+    r117 = r117 * r103;
+    r117 = r117 * r94;
+    r117 = r117 * r83;
+    r117 = r117 * r114;
+    r117 = fma(r56, r117, r44 * r73);
+    r73 = r28 * r118;
+    r73 = r73 * r85;
+    r73 = r73 * r60;
+    r117 = fma(r121, r73, r117);
+    r117 = fma(r63, r135, r117);
+    r117 = r117 + r109;
+    r48 = fma(r65, r48, r4 * r117);
+    r65 = r42 * r71;
+    r65 = r65 * r86;
+    r65 = r65 * r94;
+    r65 = r65 * r76;
+    r65 = r65 * r83;
+    r48 = fma(r44, r65, r48);
+    r117 = r5 * r28;
+    r117 = r117 * r6;
+    r117 = r117 * r42;
+    r117 = r117 * r42;
+    r117 = r117 * r100;
+    r117 = r117 * r85;
+    r48 = fma(r44, r117, r48);
+    r85 = r42 * r86;
+    r85 = r85 * r94;
+    r85 = r85 * r76;
+    r85 = r85 * r83;
+    r48 = fma(r44, r85, r48);
+    r76 = r7 * r89;
+    r76 = r76 * r71;
+    r76 = r76 * r94;
+    r76 = r76 * r83;
+    r76 = r76 * r38;
+    r48 = fma(r78, r76, r48);
+    r100 = r5 * r37;
+    r100 = r100 * r44;
+    r48 = fma(r82, r100, r48);
+    r82 = r5 * r94;
+    r48 = fma(r129, r82, r48);
+    r129 = r20 * r28;
+    r129 = r129 * r7;
+    r129 = r129 * r71;
+    r129 = r129 * r77;
+    r48 = fma(r41, r129, r48);
+    r109 = r7 * r68;
+    r48 = fma(r79, r109, r48);
+    r73 = r5 * r94;
+    r48 = fma(r131, r73, r48);
+    r131 = r7 * r89;
+    r131 = r131 * r94;
+    r131 = r131 * r83;
+    r131 = r131 * r38;
+    r48 = fma(r78, r131, r48);
+    r78 = r20 * r28;
+    r78 = r78 * r7;
+    r78 = r78 * r77;
+    r48 = fma(r41, r78, r48);
+    r48 = fma(r52, r128, r48);
+    r48 = fma(r52, r79, r48);
+    r48 = fma(r52, r80, r48);
+    r78 = r3 * r48;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r72,
+                                             r78);
+    r78 = r3 * r20;
+    r78 = r78 * r1;
+    r78 = fma(r74, r104, r54 * r78);
+    r72 = r3 * r20;
+    r72 = r72 * r1;
+    r72 = fma(r152, r104, r0 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r78, r72);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r3 * r20;
+    r72 = r72 * r1;
+    r104 = fma(r64, r104, r48 * r72);
+    WriteSum1<double, double>((double*)inout_shared, r104);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r74 * r74;
+    r72 = r54 * r54;
+    r72 = fma(r105, r72, r133 * r104);
+    r104 = r0 * r0;
+    r1 = r152 * r152;
+    r1 = fma(r133, r1, r105 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r72, r1);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r48 * r48;
+    r72 = r64 * r64;
+    r72 = fma(r133, r72, r105 * r1);
+    WriteSum1<double, double>((double*)inout_shared, r72);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r74 * r152;
+    r1 = r54 * r0;
+    r1 = fma(r105, r1, r133 * r72);
+    r72 = r54 * r48;
+    r104 = r74 * r64;
+    r104 = fma(r133, r104, r105 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r1, r104);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r0 * r48;
+    r1 = r152 * r64;
+    r1 = fma(r133, r1, r105 * r104);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeResJac(double* pose,
+                            unsigned int pose_num_alloc,
+                            SharedIndex* pose_indices,
+                            double* sensor_from_rig,
+                            unsigned int sensor_from_rig_num_alloc,
+                            double* calib,
+                            unsigned int calib_num_alloc,
+                            SharedIndex* calib_indices,
+                            double* point,
+                            unsigned int point_num_alloc,
+                            SharedIndex* point_indices,
+                            double* pixel,
+                            unsigned int pixel_num_alloc,
+                            double* out_res,
+                            unsigned int out_res_num_alloc,
+                            double* out_pose_jac,
+                            unsigned int out_pose_jac_num_alloc,
+                            double* const out_pose_njtr,
+                            unsigned int out_pose_njtr_num_alloc,
+                            double* const out_pose_precond_diag,
+                            unsigned int out_pose_precond_diag_num_alloc,
+                            double* const out_pose_precond_tril,
+                            unsigned int out_pose_precond_tril_num_alloc,
+                            double* out_calib_jac,
+                            unsigned int out_calib_jac_num_alloc,
+                            double* const out_calib_njtr,
+                            unsigned int out_calib_njtr_num_alloc,
+                            double* const out_calib_precond_diag,
+                            unsigned int out_calib_precond_diag_num_alloc,
+                            double* const out_calib_precond_tril,
+                            unsigned int out_calib_precond_tril_num_alloc,
+                            double* out_point_jac,
+                            unsigned int out_point_jac_num_alloc,
+                            double* const out_point_njtr,
+                            unsigned int out_point_njtr_num_alloc,
+                            double* const out_point_precond_diag,
+                            unsigned int out_point_precond_diag_num_alloc,
+                            double* const out_point_precond_tril,
+                            unsigned int out_point_precond_tril_num_alloc,
+                            size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeResJac(double* pose,
+                            unsigned int pose_num_alloc,
+                            SharedIndex* pose_indices,
+                            double* sensor_from_rig,
+                            unsigned int sensor_from_rig_num_alloc,
+                            double* calib,
+                            unsigned int calib_num_alloc,
+                            SharedIndex* calib_indices,
+                            double* point,
+                            unsigned int point_num_alloc,
+                            SharedIndex* point_indices,
+                            double* pixel,
+                            unsigned int pixel_num_alloc,
+                            double* out_res,
+                            unsigned int out_res_num_alloc,
+                            double* out_pose_jac,
+                            unsigned int out_pose_jac_num_alloc,
+                            double* const out_pose_njtr,
+                            unsigned int out_pose_njtr_num_alloc,
+                            double* const out_pose_precond_diag,
+                            unsigned int out_pose_precond_diag_num_alloc,
+                            double* const out_pose_precond_tril,
+                            unsigned int out_pose_precond_tril_num_alloc,
+                            double* out_calib_jac,
+                            unsigned int out_calib_jac_num_alloc,
+                            double* const out_calib_njtr,
+                            unsigned int out_calib_njtr_num_alloc,
+                            double* const out_calib_precond_diag,
+                            unsigned int out_calib_precond_diag_num_alloc,
+                            double* const out_calib_precond_tril,
+                            unsigned int out_calib_precond_tril_num_alloc,
+                            double* out_point_jac,
+                            unsigned int out_point_jac_num_alloc,
+                            double* const out_point_njtr,
+                            unsigned int out_point_njtr_num_alloc,
+                            double* const out_point_precond_diag,
+                            unsigned int out_point_precond_diag_num_alloc,
+                            double* const out_point_precond_tril,
+                            unsigned int out_point_precond_tril_num_alloc,
+                            size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac_first.cu
@@ -1,0 +1,3004 @@
+#include "kernel_thin_prism_fisheye_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1) ThinPrismFisheyeResJacFirstKernel(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* calib,
+    unsigned int calib_num_alloc,
+    SharedIndex* calib_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_calib_jac,
+    unsigned int out_calib_jac_num_alloc,
+    double* const out_calib_njtr,
+    unsigned int out_calib_njtr_num_alloc,
+    double* const out_calib_precond_diag,
+    unsigned int out_calib_precond_diag_num_alloc,
+    double* const out_calib_precond_tril,
+    unsigned int out_calib_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148, r149, r150, r151, r152,
+      r153, r154, r155, r156;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = r18 * r18;
+    r21 = -2.00000000000000000e+00;
+    r19 = r19 * r21;
+    r22 = 1.00000000000000000e+00;
+    r23 = r15 * r13;
+    r24 = r11 * r17;
+    r25 = r23 + r24;
+    r26 = r14 * r12;
+    r27 = r10 * r16;
+    r25 = r25 + r26;
+    r25 = fma(r20, r27, r25);
+    r28 = r21 * r25;
+    r28 = fma(r25, r28, r22);
+    r29 = r19 + r28;
+    r6 = fma(r8, r29, r6);
+    r30 = 2.00000000000000000e+00;
+    r31 = fma(r11, r16, r14 * r13);
+    r32 = r15 * r12;
+    r31 = fma(r20, r32, r31);
+    r31 = fma(r10, r17, r31);
+    r32 = r30 * r31;
+    r32 = r32 * r25;
+    r33 = r18 * r21;
+    r34 = fma(r15, r17, r14 * r16);
+    r34 = fma(r10, r12, r34);
+    r34 = fma(r20, r34, r11 * r13);
+    r33 = fma(r34, r33, r32);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r35);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r36 = r30 * r18;
+    r36 = r36 * r31;
+    r37 = r30 * r25;
+    r37 = fma(r34, r37, r36);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r16 * r12;
+    r39 = r39 * r30;
+    r40 = r17 * r13;
+    r40 = fma(r30, r40, r39);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r41, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r12 * r13;
+    r44 = r16 * r17;
+    r44 = r44 * r30;
+    r43 = fma(r21, r43, r44);
+    r45 = r17 * r17;
+    r45 = r45 * r21;
+    r46 = r22 + r45;
+    r47 = r12 * r12;
+    r47 = r47 * r21;
+    r46 = r46 + r47;
+    r6 = fma(r9, r33, r6);
+    r6 = fma(r35, r37, r6);
+    r6 = fma(r38, r40, r6);
+    r6 = fma(r42, r43, r6);
+    r6 = fma(r41, r46, r6);
+    r48 = r6 * r6;
+    r49 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r50);
+    r51 = r21 * r25;
+    r51 = fma(r34, r51, r36);
+    r50 = fma(r8, r51, r50);
+    r36 = r17 * r13;
+    r36 = fma(r21, r36, r39);
+    r45 = r22 + r45;
+    r39 = r16 * r16;
+    r39 = r39 * r21;
+    r45 = r45 + r39;
+    r52 = r17 * r12;
+    r52 = r52 * r30;
+    r53 = r16 * r13;
+    r53 = fma(r30, r53, r52);
+    r54 = r30 * r18;
+    r54 = r54 * r25;
+    r55 = r30 * r31;
+    r55 = fma(r34, r55, r54);
+    r56 = r31 * r31;
+    r56 = r56 * r21;
+    r28 = r56 + r28;
+    r50 = fma(r41, r36, r50);
+    r50 = fma(r38, r45, r50);
+    r50 = fma(r42, r53, r50);
+    r50 = fma(r9, r55, r50);
+    r50 = fma(r35, r28, r50);
+    r57 = copysign(1.0, r50);
+    r57 = fma(r49, r57, r50);
+    r50 = r57 * r57;
+    r58 = 1.0 / r50;
+    r59 = r30 * r18;
+    r59 = fma(r34, r59, r32);
+    r7 = fma(r8, r59, r7);
+    r32 = r12 * r13;
+    r32 = fma(r30, r32, r44);
+    r47 = r22 + r47;
+    r47 = r47 + r39;
+    r39 = r16 * r13;
+    r39 = fma(r21, r39, r52);
+    r52 = r31 * r21;
+    r52 = fma(r34, r52, r54);
+    r19 = r22 + r19;
+    r19 = r19 + r56;
+    r7 = fma(r41, r32, r7);
+    r7 = fma(r42, r47, r7);
+    r7 = fma(r38, r39, r7);
+    r7 = fma(r35, r52, r7);
+    r7 = fma(r9, r19, r7);
+    r38 = r7 * r7;
+    r38 = fma(r58, r38, r58 * r48);
+    r48 = sqrt(r38);
+    r42 = atan(r48);
+    r41 = r42 * r58;
+    r56 = r42 * r41;
+    r54 = copysign(1.0, r48);
+    r54 = fma(r49, r54, r48);
+    r49 = r54 * r54;
+    r48 = 1.0 / r49;
+    r44 = r7 * r48;
+    r60 = r7 * r44;
+    r61 = r56 * r60;
+    r62 = r6 * r6;
+    r63 = 3.00000000000000000e+00;
+    r62 = r62 * r63;
+    r62 = r62 * r48;
+    r62 = fma(r56, r62, r61);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r64, r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r6 * r6;
+    r66 = r66 * r48;
+    r66 = r66 * r56;
+    r61 = r61 + r66;
+    r67 = fma(r64, r61, r5 * r62);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r68, r69);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r70 = r61 * r61;
+    r71 = fma(r69, r70, r68 * r61);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r72, r73);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r74 = r70 * r70;
+    r75 = r61 * r70;
+    r71 = fma(r73, r74, r71);
+    r71 = fma(r72, r75, r71);
+    r76 = 1.0 / r57;
+    r77 = 1.0 / r54;
+    r78 = r76 * r77;
+    r79 = r42 * r78;
+    r80 = r71 * r79;
+    r81 = r4 * r6;
+    r82 = r30 * r56;
+    r81 = r81 * r44;
+    r67 = fma(r82, r81, r67);
+    r67 = fma(r6, r80, r67);
+    r67 = fma(r6, r79, r67);
+    r0 = fma(r2, r67, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r81, r83);
+    r0 = fma(r81, r20, r0);
+    r81 = r63 * r56;
+    r81 = fma(r60, r81, r66);
+    r66 = fma(r65, r61, r4 * r81);
+    r84 = r7 * r79;
+    r85 = r5 * r6;
+    r85 = r85 * r44;
+    r66 = fma(r82, r85, r66);
+    r66 = r66 + r84;
+    r66 = fma(r7, r80, r66);
+    r1 = fma(r3, r66, r1);
+    r1 = fma(r83, r20, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r83 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r83);
+  if (global_thread_idx < problem_size) {
+    r83 = r30 * r6;
+    r85 = r14 * r13;
+    r86 = -5.00000000000000000e-01;
+    r87 = r11 * r16;
+    r87 = fma(r86, r87, r86 * r85);
+    r85 = r10 * r17;
+    r87 = fma(r86, r85, r87);
+    r88 = r15 * r12;
+    r89 = 5.00000000000000000e-01;
+    r87 = fma(r89, r88, r87);
+    r88 = r25 * r87;
+    r85 = r10 * r13;
+    r90 = r15 * r16;
+    r90 = fma(r89, r90, r89 * r85);
+    r85 = r14 * r17;
+    r90 = fma(r86, r85, r90);
+    r91 = r11 * r12;
+    r90 = fma(r89, r91, r90);
+    r91 = r34 * r90;
+    r85 = fma(r30, r91, r30 * r88);
+    r92 = r30 * r31;
+    r93 = fma(r89, r27, r86 * r23);
+    r93 = fma(r86, r24, r93);
+    r93 = fma(r86, r26, r93);
+    r94 = r30 * r18;
+    r95 = r11 * r13;
+    r96 = r14 * r16;
+    r96 = fma(r86, r96, r89 * r95);
+    r95 = r15 * r17;
+    r96 = fma(r86, r95, r96);
+    r97 = r10 * r12;
+    r96 = fma(r86, r97, r96);
+    r94 = r94 * r96;
+    r92 = fma(r93, r92, r94);
+    r85 = r85 + r92;
+    r97 = r30 * r25;
+    r97 = r97 * r96;
+    r95 = r30 * r31;
+    r95 = r95 * r90;
+    r98 = r97 + r95;
+    r99 = r18 * r21;
+    r98 = fma(r87, r99, r98);
+    r100 = r21 * r34;
+    r98 = fma(r93, r100, r98);
+    r98 = fma(r9, r98, r35 * r85);
+    r85 = r25 * r90;
+    r100 = -4.00000000000000000e+00;
+    r85 = r85 * r100;
+    r99 = r18 * r93;
+    r101 = r100 * r99;
+    r102 = r85 + r101;
+    r98 = fma(r8, r102, r98);
+    r83 = r83 * r98;
+    r102 = r30 * r25;
+    r102 = r102 * r93;
+    r103 = r30 * r18;
+    r103 = fma(r90, r103, r102);
+    r90 = r30 * r31;
+    r90 = r90 * r87;
+    r104 = r30 * r34;
+    r104 = r104 * r96;
+    r105 = r90 + r104;
+    r106 = r103 + r105;
+    r91 = fma(r21, r91, r21 * r88);
+    r91 = r91 + r92;
+    r91 = fma(r8, r91, r9 * r106);
+    r106 = r31 * r96;
+    r106 = r106 * r100;
+    r85 = r85 + r106;
+    r91 = fma(r35, r85, r91);
+    r50 = r57 * r50;
+    r85 = 1.0 / r50;
+    r107 = r21 * r85;
+    r108 = r91 * r107;
+    r109 = r6 * r6;
+    r108 = fma(r109, r108, r58 * r83);
+    r83 = r7 * r7;
+    r83 = r83 * r91;
+    r108 = fma(r107, r83, r108);
+    r110 = r30 * r7;
+    r111 = r31 * r21;
+    r112 = r21 * r34;
+    r112 = r112 * r96;
+    r111 = fma(r87, r111, r112);
+    r111 = r111 + r103;
+    r101 = r106 + r101;
+    r101 = fma(r9, r101, r35 * r111);
+    r111 = r30 * r34;
+    r111 = fma(r93, r111, r95);
+    r95 = r30 * r18;
+    r95 = fma(r87, r95, r97);
+    r111 = r111 + r95;
+    r101 = fma(r8, r111, r101);
+    r110 = r110 * r101;
+    r108 = fma(r58, r110, r108);
+    r110 = r63 * r108;
+    r83 = rsqrt(r38);
+    r111 = r6 * r83;
+    r38 = r22 + r38;
+    r38 = 1.0 / r38;
+    r97 = r38 * r41;
+    r106 = r6 * r48;
+    r110 = r110 * r111;
+    r110 = r110 * r97;
+    r103 = -3.00000000000000000e+00;
+    r113 = r6 * r103;
+    r49 = r54 * r49;
+    r114 = 1.0 / r49;
+    r115 = r114 * r56;
+    r115 = r115 * r111;
+    r113 = r113 * r108;
+    r113 = fma(r115, r113, r106 * r110);
+    r110 = r6 * r98;
+    r116 = 6.00000000000000000e+00;
+    r110 = r110 * r116;
+    r110 = r110 * r48;
+    r113 = fma(r56, r110, r113);
+    r117 = r6 * r6;
+    r118 = -6.00000000000000000e+00;
+    r119 = r91 * r118;
+    r119 = r119 * r85;
+    r117 = r117 * r42;
+    r117 = r117 * r42;
+    r117 = r117 * r48;
+    r113 = fma(r119, r117, r113);
+    r120 = r91 * r60;
+    r121 = r42 * r42;
+    r122 = r107 * r121;
+    r123 = r83 * r97;
+    r123 = r123 * r60;
+    r120 = fma(r108, r123, r122 * r120);
+    r124 = r20 * r7;
+    r124 = r124 * r7;
+    r124 = r124 * r108;
+    r124 = r124 * r83;
+    r124 = r124 * r114;
+    r120 = fma(r56, r124, r120);
+    r125 = r101 * r44;
+    r120 = fma(r82, r125, r120);
+    r113 = r113 + r120;
+    r117 = r108 * r111;
+    r117 = r117 * r97;
+    r110 = r20 * r6;
+    r110 = r110 * r108;
+    r110 = fma(r115, r110, r106 * r117);
+    r117 = r82 * r106;
+    r125 = r48 * r109;
+    r125 = r125 * r122;
+    r110 = fma(r98, r117, r110);
+    r110 = fma(r91, r125, r110);
+    r120 = r120 + r110;
+    r113 = fma(r64, r120, r5 * r113);
+    r124 = r42 * r86;
+    r124 = r124 * r48;
+    r124 = r124 * r76;
+    r124 = r124 * r111;
+    r126 = r71 * r124;
+    r127 = r4 * r98;
+    r127 = r127 * r44;
+    r113 = fma(r82, r127, r113);
+    r128 = r4 * r108;
+    r129 = r30 * r44;
+    r129 = r129 * r111;
+    r129 = r129 * r97;
+    r113 = fma(r129, r128, r113);
+    r130 = r4 * r108;
+    r131 = r21 * r7;
+    r131 = r131 * r115;
+    r113 = fma(r131, r130, r113);
+    r132 = r89 * r108;
+    r132 = r132 * r38;
+    r132 = r132 * r78;
+    r133 = r4 * r101;
+    r113 = fma(r117, r133, r113);
+    r134 = r69 * r30;
+    r134 = r134 * r61;
+    r134 = fma(r120, r134, r68 * r120);
+    r135 = 4.00000000000000000e+00;
+    r73 = r73 * r135;
+    r73 = r73 * r75;
+    r72 = r72 * r63;
+    r72 = r72 * r70;
+    r134 = fma(r120, r73, r134);
+    r134 = fma(r120, r72, r134);
+    r136 = r6 * r134;
+    r113 = fma(r79, r136, r113);
+    r137 = r4 * r6;
+    r137 = r137 * r42;
+    r137 = r137 * r42;
+    r137 = r137 * r100;
+    r137 = r137 * r85;
+    r137 = r137 * r44;
+    r138 = r20 * r6;
+    r138 = r138 * r91;
+    r138 = r138 * r77;
+    r113 = fma(r41, r138, r113);
+    r139 = r71 * r111;
+    r113 = fma(r132, r139, r113);
+    r140 = r20 * r6;
+    r140 = r140 * r71;
+    r140 = r140 * r91;
+    r140 = r140 * r77;
+    r113 = fma(r41, r140, r113);
+    r113 = fma(r108, r126, r113);
+    r113 = fma(r108, r124, r113);
+    r113 = fma(r111, r132, r113);
+    r113 = fma(r91, r137, r113);
+    r113 = fma(r98, r79, r113);
+    r113 = fma(r98, r80, r113);
+    r140 = r2 * r113;
+    r139 = r60 * r121;
+    r138 = r63 * r108;
+    r138 = fma(r123, r138, r119 * r139);
+    r139 = r7 * r7;
+    r139 = r139 * r103;
+    r139 = r139 * r108;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r138 = fma(r56, r139, r138);
+    r119 = r101 * r116;
+    r119 = r119 * r56;
+    r138 = fma(r44, r119, r138);
+    r138 = r138 + r110;
+    r110 = r7 * r89;
+    r110 = r110 * r76;
+    r110 = r110 * r77;
+    r110 = r110 * r83;
+    r110 = r110 * r108;
+    r110 = r110 * r38;
+    r138 = fma(r4, r138, r110);
+    r119 = r7 * r134;
+    r138 = fma(r79, r119, r138);
+    r139 = r20 * r7;
+    r139 = r139 * r91;
+    r139 = r139 * r77;
+    r138 = fma(r41, r139, r138);
+    r136 = r5 * r98;
+    r136 = r136 * r44;
+    r138 = fma(r82, r136, r138);
+    r133 = r5 * r108;
+    r138 = fma(r129, r133, r138);
+    r132 = r5 * r108;
+    r138 = fma(r131, r132, r138);
+    r130 = r42 * r86;
+    r130 = r130 * r108;
+    r130 = r130 * r76;
+    r130 = r130 * r83;
+    r138 = fma(r44, r130, r138);
+    r128 = r5 * r117;
+    r127 = r5 * r6;
+    r127 = r127 * r42;
+    r127 = r127 * r42;
+    r127 = r127 * r100;
+    r127 = r127 * r91;
+    r127 = r127 * r85;
+    r138 = fma(r44, r127, r138);
+    r141 = r42 * r71;
+    r141 = r141 * r86;
+    r141 = r141 * r108;
+    r141 = r141 * r76;
+    r141 = r141 * r83;
+    r138 = fma(r44, r141, r138);
+    r142 = r20 * r7;
+    r142 = r142 * r71;
+    r142 = r142 * r91;
+    r142 = r142 * r77;
+    r138 = fma(r41, r142, r138);
+    r138 = fma(r65, r120, r138);
+    r138 = fma(r101, r80, r138);
+    r138 = fma(r71, r110, r138);
+    r138 = fma(r101, r128, r138);
+    r138 = fma(r101, r79, r138);
+    r142 = r3 * r138;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r140,
+                                             r142);
+    r142 = r21 * r25;
+    r142 = fma(r93, r142, r112);
+    r140 = r30 * r18;
+    r141 = r10 * r13;
+    r127 = r15 * r16;
+    r127 = fma(r86, r127, r86 * r141);
+    r141 = r14 * r17;
+    r127 = fma(r89, r141, r127);
+    r110 = r11 * r12;
+    r127 = fma(r86, r110, r127);
+    r140 = r140 * r127;
+    r110 = r30 * r31;
+    r141 = r14 * r13;
+    r130 = r11 * r16;
+    r130 = fma(r89, r130, r89 * r141);
+    r141 = r10 * r17;
+    r130 = fma(r89, r141, r130);
+    r132 = r15 * r12;
+    r130 = fma(r86, r132, r130);
+    r110 = fma(r130, r110, r140);
+    r142 = r142 + r110;
+    r132 = r30 * r25;
+    r132 = r132 * r130;
+    r141 = r30 * r34;
+    r141 = fma(r127, r141, r132);
+    r141 = r141 + r92;
+    r141 = fma(r9, r141, r8 * r142);
+    r142 = r25 * r96;
+    r142 = r142 * r100;
+    r92 = r31 * r127;
+    r133 = r100 * r92;
+    r136 = r142 + r133;
+    r141 = fma(r35, r136, r141);
+    r104 = r102 + r104;
+    r104 = r104 + r110;
+    r110 = r18 * r100;
+    r110 = r110 * r130;
+    r142 = r142 + r110;
+    r142 = fma(r8, r142, r35 * r104);
+    r104 = r21 * r34;
+    r104 = fma(r21, r99, r130 * r104);
+    r102 = r30 * r31;
+    r102 = r102 * r96;
+    r136 = r30 * r25;
+    r136 = fma(r127, r136, r102);
+    r104 = r104 + r136;
+    r142 = fma(r9, r104, r142);
+    r104 = fma(r142, r117, r141 * r125);
+    r139 = r20 * r6;
+    r119 = r30 * r6;
+    r119 = r119 * r142;
+    r120 = r30 * r7;
+    r132 = r94 + r132;
+    r94 = r31 * r21;
+    r132 = fma(r93, r94, r132);
+    r93 = r21 * r34;
+    r132 = fma(r127, r93, r132);
+    r93 = r30 * r34;
+    r99 = fma(r30, r99, r130 * r93);
+    r99 = r99 + r136;
+    r99 = fma(r8, r99, r35 * r132);
+    r133 = r110 + r133;
+    r99 = fma(r9, r133, r99);
+    r120 = r120 * r99;
+    r120 = fma(r58, r120, r58 * r119);
+    r119 = r7 * r7;
+    r119 = r119 * r141;
+    r120 = fma(r107, r119, r120);
+    r133 = r141 * r107;
+    r120 = fma(r109, r133, r120);
+    r139 = r139 * r120;
+    r104 = fma(r115, r139, r104);
+    r133 = r120 * r111;
+    r133 = r133 * r97;
+    r104 = fma(r106, r133, r104);
+    r133 = r99 * r44;
+    r139 = r20 * r7;
+    r139 = r139 * r7;
+    r139 = r139 * r120;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r139 = fma(r56, r139, r82 * r133);
+    r133 = r141 * r60;
+    r139 = fma(r122, r133, r139);
+    r139 = fma(r120, r123, r139);
+    r133 = r104 + r139;
+    r119 = r6 * r6;
+    r119 = r119 * r42;
+    r119 = r119 * r42;
+    r119 = r119 * r118;
+    r119 = r119 * r141;
+    r119 = r119 * r48;
+    r110 = r6 * r116;
+    r110 = r110 * r142;
+    r110 = r110 * r48;
+    r110 = fma(r56, r110, r85 * r119);
+    r119 = r6 * r115;
+    r132 = r103 * r120;
+    r110 = fma(r132, r119, r110);
+    r93 = r63 * r120;
+    r93 = r93 * r111;
+    r93 = r93 * r97;
+    r110 = fma(r106, r93, r110);
+    r110 = r110 + r139;
+    r110 = fma(r5, r110, r64 * r133);
+    r139 = r20 * r6;
+    r139 = r139 * r141;
+    r139 = r139 * r77;
+    r110 = fma(r41, r139, r110);
+    r93 = r89 * r120;
+    r93 = r93 * r38;
+    r93 = r93 * r78;
+    r110 = fma(r111, r93, r110);
+    r119 = r69 * r30;
+    r119 = r119 * r61;
+    r119 = fma(r133, r119, r68 * r133);
+    r119 = fma(r133, r73, r119);
+    r119 = fma(r133, r72, r119);
+    r130 = r6 * r119;
+    r110 = fma(r79, r130, r110);
+    r94 = r4 * r99;
+    r110 = fma(r117, r94, r110);
+    r143 = r4 * r120;
+    r110 = fma(r129, r143, r110);
+    r144 = r4 * r142;
+    r144 = r144 * r44;
+    r110 = fma(r82, r144, r110);
+    r145 = r4 * r120;
+    r110 = fma(r131, r145, r110);
+    r146 = r20 * r6;
+    r146 = r146 * r71;
+    r146 = r146 * r141;
+    r146 = r146 * r77;
+    r110 = fma(r41, r146, r110);
+    r147 = r89 * r71;
+    r147 = r147 * r120;
+    r147 = r147 * r38;
+    r147 = r147 * r78;
+    r110 = fma(r111, r147, r110);
+    r110 = fma(r142, r80, r110);
+    r110 = fma(r141, r137, r110);
+    r110 = fma(r142, r79, r110);
+    r110 = fma(r120, r126, r110);
+    r110 = fma(r120, r124, r110);
+    r147 = r2 * r110;
+    r146 = r116 * r99;
+    r146 = r146 * r56;
+    r145 = r7 * r7;
+    r145 = r145 * r83;
+    r145 = r145 * r114;
+    r145 = r145 * r56;
+    r145 = fma(r132, r145, r44 * r146);
+    r146 = r118 * r141;
+    r146 = r146 * r85;
+    r146 = r146 * r60;
+    r145 = fma(r121, r146, r145);
+    r132 = r63 * r120;
+    r145 = fma(r123, r132, r145);
+    r145 = r145 + r104;
+    r145 = fma(r4, r145, r65 * r133);
+    r133 = r20 * r7;
+    r133 = r133 * r71;
+    r133 = r133 * r141;
+    r133 = r133 * r77;
+    r145 = fma(r41, r133, r145);
+    r104 = r42 * r71;
+    r104 = r104 * r86;
+    r104 = r104 * r120;
+    r104 = r104 * r76;
+    r104 = r104 * r83;
+    r145 = fma(r44, r104, r145);
+    r132 = r42 * r86;
+    r132 = r132 * r120;
+    r132 = r132 * r76;
+    r132 = r132 * r83;
+    r145 = fma(r44, r132, r145);
+    r146 = r5 * r120;
+    r145 = fma(r129, r146, r145);
+    r144 = r7 * r89;
+    r144 = r144 * r120;
+    r144 = r144 * r83;
+    r144 = r144 * r38;
+    r145 = fma(r78, r144, r145);
+    r143 = r5 * r6;
+    r143 = r143 * r42;
+    r143 = r143 * r42;
+    r143 = r143 * r100;
+    r143 = r143 * r141;
+    r143 = r143 * r85;
+    r145 = fma(r44, r143, r145);
+    r94 = r5 * r142;
+    r94 = r94 * r44;
+    r145 = fma(r82, r94, r145);
+    r130 = r5 * r120;
+    r145 = fma(r131, r130, r145);
+    r93 = r7 * r119;
+    r145 = fma(r79, r93, r145);
+    r139 = r20 * r7;
+    r139 = r139 * r141;
+    r139 = r139 * r77;
+    r145 = fma(r41, r139, r145);
+    r148 = r7 * r89;
+    r148 = r148 * r71;
+    r148 = r148 * r120;
+    r148 = r148 * r83;
+    r148 = r148 * r38;
+    r145 = fma(r78, r148, r145);
+    r145 = fma(r99, r128, r145);
+    r145 = fma(r99, r79, r145);
+    r145 = fma(r99, r80, r145);
+    r148 = r3 * r145;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r147,
+                                             r148);
+    r148 = r31 * r100;
+    r27 = fma(r86, r27, r89 * r23);
+    r27 = fma(r89, r24, r27);
+    r27 = fma(r89, r26, r27);
+    r148 = r148 * r27;
+    r88 = r100 * r88;
+    r26 = r148 + r88;
+    r24 = r30 * r18;
+    r24 = r24 * r27;
+    r102 = r102 + r24;
+    r23 = r21 * r25;
+    r102 = fma(r127, r23, r102);
+    r147 = r21 * r34;
+    r102 = fma(r87, r147, r102);
+    r102 = fma(r8, r102, r35 * r26);
+    r26 = r30 * r34;
+    r26 = fma(r30, r92, r27 * r26);
+    r26 = r26 + r95;
+    r102 = fma(r9, r26, r102);
+    r26 = r102 * r60;
+    r147 = r30 * r7;
+    r23 = r30 * r25;
+    r23 = r23 * r27;
+    r140 = r140 + r23;
+    r140 = r140 + r105;
+    r105 = r21 * r34;
+    r92 = fma(r21, r92, r27 * r105);
+    r92 = r92 + r95;
+    r92 = fma(r35, r92, r8 * r140);
+    r96 = r18 * r96;
+    r96 = r96 * r100;
+    r148 = r148 + r96;
+    r92 = fma(r9, r148, r92);
+    r147 = r147 * r92;
+    r148 = r102 * r107;
+    r148 = fma(r109, r148, r58 * r147);
+    r147 = r30 * r6;
+    r112 = r90 + r112;
+    r90 = r18 * r21;
+    r112 = fma(r127, r90, r112);
+    r112 = r112 + r23;
+    r88 = r96 + r88;
+    r88 = fma(r8, r88, r9 * r112);
+    r8 = r30 * r34;
+    r8 = fma(r87, r8, r24);
+    r8 = r8 + r136;
+    r88 = fma(r35, r8, r88);
+    r147 = r147 * r88;
+    r148 = fma(r58, r147, r148);
+    r8 = r7 * r7;
+    r8 = r8 * r102;
+    r148 = fma(r107, r8, r148);
+    r26 = fma(r148, r123, r122 * r26);
+    r8 = r92 * r44;
+    r26 = fma(r82, r8, r26);
+    r147 = r20 * r7;
+    r147 = r147 * r7;
+    r147 = r147 * r148;
+    r147 = r147 * r83;
+    r147 = r147 * r114;
+    r26 = fma(r56, r147, r26);
+    r147 = r20 * r6;
+    r147 = r147 * r148;
+    r147 = fma(r88, r117, r115 * r147);
+    r8 = r148 * r111;
+    r8 = r8 * r97;
+    r147 = fma(r106, r8, r147);
+    r147 = fma(r102, r125, r147);
+    r8 = r26 + r147;
+    r35 = r6 * r103;
+    r35 = r35 * r148;
+    r136 = r6 * r116;
+    r136 = r136 * r88;
+    r136 = r136 * r48;
+    r136 = fma(r56, r136, r115 * r35);
+    r35 = r6 * r6;
+    r35 = r35 * r42;
+    r35 = r35 * r42;
+    r35 = r35 * r118;
+    r35 = r35 * r102;
+    r35 = r35 * r48;
+    r136 = fma(r85, r35, r136);
+    r24 = r63 * r148;
+    r24 = r24 * r111;
+    r24 = r24 * r97;
+    r136 = fma(r106, r24, r136);
+    r136 = r136 + r26;
+    r136 = fma(r5, r136, r64 * r8);
+    r26 = r69 * r30;
+    r26 = r26 * r61;
+    r26 = fma(r8, r26, r68 * r8);
+    r26 = fma(r8, r72, r26);
+    r26 = fma(r8, r73, r26);
+    r24 = r6 * r26;
+    r136 = fma(r79, r24, r136);
+    r35 = r4 * r92;
+    r136 = fma(r117, r35, r136);
+    r87 = r89 * r148;
+    r87 = r87 * r38;
+    r87 = r87 * r78;
+    r136 = fma(r111, r87, r136);
+    r112 = r4 * r148;
+    r136 = fma(r129, r112, r136);
+    r9 = r89 * r71;
+    r9 = r9 * r148;
+    r9 = r9 * r38;
+    r9 = r9 * r78;
+    r136 = fma(r111, r9, r136);
+    r96 = r20 * r6;
+    r96 = r96 * r102;
+    r96 = r96 * r77;
+    r136 = fma(r41, r96, r136);
+    r90 = r4 * r88;
+    r90 = r90 * r44;
+    r136 = fma(r82, r90, r136);
+    r23 = r20 * r6;
+    r23 = r23 * r71;
+    r23 = r23 * r102;
+    r23 = r23 * r77;
+    r136 = fma(r41, r23, r136);
+    r127 = r4 * r148;
+    r136 = fma(r131, r127, r136);
+    r136 = fma(r88, r80, r136);
+    r136 = fma(r148, r126, r136);
+    r136 = fma(r102, r137, r136);
+    r136 = fma(r88, r79, r136);
+    r136 = fma(r148, r124, r136);
+    r127 = r2 * r136;
+    r23 = r118 * r102;
+    r23 = r23 * r85;
+    r23 = r23 * r60;
+    r90 = r63 * r148;
+    r90 = fma(r123, r90, r121 * r23);
+    r23 = r116 * r92;
+    r23 = r23 * r56;
+    r90 = fma(r44, r23, r90);
+    r96 = r7 * r7;
+    r96 = r96 * r103;
+    r96 = r96 * r148;
+    r96 = r96 * r83;
+    r96 = r96 * r114;
+    r90 = fma(r56, r96, r90);
+    r90 = r90 + r147;
+    r90 = fma(r4, r90, r65 * r8);
+    r8 = r20 * r7;
+    r8 = r8 * r102;
+    r8 = r8 * r77;
+    r90 = fma(r41, r8, r90);
+    r147 = r20 * r7;
+    r147 = r147 * r71;
+    r147 = r147 * r102;
+    r147 = r147 * r77;
+    r90 = fma(r41, r147, r90);
+    r96 = r7 * r89;
+    r96 = r96 * r148;
+    r96 = r96 * r83;
+    r96 = r96 * r38;
+    r90 = fma(r78, r96, r90);
+    r23 = r5 * r148;
+    r90 = fma(r129, r23, r90);
+    r9 = r42 * r71;
+    r9 = r9 * r86;
+    r9 = r9 * r148;
+    r9 = r9 * r76;
+    r9 = r9 * r83;
+    r90 = fma(r44, r9, r90);
+    r112 = r7 * r26;
+    r90 = fma(r79, r112, r90);
+    r87 = r42 * r86;
+    r87 = r87 * r148;
+    r87 = r87 * r76;
+    r87 = r87 * r83;
+    r90 = fma(r44, r87, r90);
+    r35 = r7 * r89;
+    r35 = r35 * r71;
+    r35 = r35 * r148;
+    r35 = r35 * r83;
+    r35 = r35 * r38;
+    r90 = fma(r78, r35, r90);
+    r24 = r5 * r88;
+    r24 = r24 * r44;
+    r90 = fma(r82, r24, r90);
+    r140 = r5 * r6;
+    r140 = r140 * r42;
+    r140 = r140 * r42;
+    r140 = r140 * r100;
+    r140 = r140 * r102;
+    r140 = r140 * r85;
+    r90 = fma(r44, r140, r90);
+    r95 = r5 * r148;
+    r90 = fma(r131, r95, r90);
+    r90 = fma(r92, r128, r90);
+    r90 = fma(r92, r79, r90);
+    r90 = fma(r92, r80, r90);
+    r95 = r3 * r90;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r127, r95);
+    r95 = r46 * r6;
+    r95 = r95 * r116;
+    r95 = r95 * r48;
+    r127 = r6 * r103;
+    r140 = r30 * r32;
+    r140 = r140 * r7;
+    r24 = r36 * r7;
+    r24 = r24 * r7;
+    r24 = fma(r107, r24, r58 * r140);
+    r140 = r36 * r107;
+    r24 = fma(r109, r140, r24);
+    r35 = r30 * r46;
+    r35 = r35 * r6;
+    r24 = fma(r58, r35, r24);
+    r127 = r127 * r24;
+    r127 = fma(r115, r127, r56 * r95);
+    r95 = r63 * r24;
+    r95 = r95 * r111;
+    r95 = r95 * r97;
+    r127 = fma(r106, r95, r127);
+    r35 = r36 * r6;
+    r35 = r35 * r6;
+    r35 = r35 * r42;
+    r35 = r35 * r42;
+    r35 = r35 * r118;
+    r35 = r35 * r48;
+    r127 = fma(r85, r35, r127);
+    r140 = r32 * r44;
+    r87 = r20 * r7;
+    r87 = r87 * r7;
+    r87 = r87 * r24;
+    r87 = r87 * r83;
+    r87 = r87 * r114;
+    r87 = fma(r56, r87, r82 * r140);
+    r140 = r36 * r60;
+    r87 = fma(r122, r140, r87);
+    r87 = fma(r24, r123, r87);
+    r127 = r127 + r87;
+    r35 = r20 * r6;
+    r35 = r35 * r24;
+    r35 = fma(r115, r35, r46 * r117);
+    r95 = r24 * r111;
+    r95 = r95 * r97;
+    r35 = fma(r106, r95, r35);
+    r35 = fma(r36, r125, r35);
+    r87 = r87 + r35;
+    r127 = fma(r64, r87, r5 * r127);
+    r95 = r89 * r24;
+    r95 = r95 * r38;
+    r95 = r95 * r78;
+    r127 = fma(r111, r95, r127);
+    r140 = r89 * r71;
+    r140 = r140 * r24;
+    r140 = r140 * r38;
+    r140 = r140 * r78;
+    r127 = fma(r111, r140, r127);
+    r112 = r20 * r36;
+    r112 = r112 * r6;
+    r112 = r112 * r71;
+    r112 = r112 * r77;
+    r127 = fma(r41, r112, r127);
+    r9 = r4 * r32;
+    r127 = fma(r117, r9, r127);
+    r23 = r69 * r30;
+    r23 = r23 * r61;
+    r23 = fma(r87, r23, r68 * r87);
+    r23 = fma(r87, r72, r23);
+    r23 = fma(r87, r73, r23);
+    r96 = r6 * r23;
+    r127 = fma(r79, r96, r127);
+    r147 = r20 * r36;
+    r147 = r147 * r6;
+    r147 = r147 * r77;
+    r127 = fma(r41, r147, r127);
+    r8 = r4 * r24;
+    r127 = fma(r129, r8, r127);
+    r105 = r4 * r46;
+    r105 = r105 * r44;
+    r127 = fma(r82, r105, r127);
+    r27 = r24 * r131;
+    r127 = fma(r24, r126, r127);
+    r127 = fma(r24, r124, r127);
+    r127 = fma(r46, r80, r127);
+    r127 = fma(r46, r79, r127);
+    r127 = fma(r4, r27, r127);
+    r127 = fma(r36, r137, r127);
+    r105 = r2 * r127;
+    r8 = r32 * r116;
+    r8 = r8 * r56;
+    r147 = r7 * r7;
+    r147 = r147 * r103;
+    r147 = r147 * r24;
+    r147 = r147 * r83;
+    r147 = r147 * r114;
+    r147 = fma(r56, r147, r44 * r8);
+    r8 = r36 * r118;
+    r8 = r8 * r85;
+    r8 = r8 * r60;
+    r147 = fma(r121, r8, r147);
+    r96 = r63 * r24;
+    r147 = fma(r123, r96, r147);
+    r147 = r147 + r35;
+    r87 = fma(r65, r87, r4 * r147);
+    r147 = r7 * r89;
+    r147 = r147 * r24;
+    r147 = r147 * r83;
+    r147 = r147 * r38;
+    r87 = fma(r78, r147, r87);
+    r35 = r20 * r36;
+    r35 = r35 * r7;
+    r35 = r35 * r77;
+    r87 = fma(r41, r35, r87);
+    r96 = r7 * r89;
+    r96 = r96 * r71;
+    r96 = r96 * r24;
+    r96 = r96 * r83;
+    r96 = r96 * r38;
+    r87 = fma(r78, r96, r87);
+    r8 = r20 * r36;
+    r8 = r8 * r7;
+    r8 = r8 * r71;
+    r8 = r8 * r77;
+    r87 = fma(r41, r8, r87);
+    r9 = r42 * r71;
+    r9 = r9 * r86;
+    r9 = r9 * r24;
+    r9 = r9 * r76;
+    r9 = r9 * r83;
+    r87 = fma(r44, r9, r87);
+    r112 = r5 * r24;
+    r87 = fma(r129, r112, r87);
+    r140 = r5 * r46;
+    r140 = r140 * r44;
+    r87 = fma(r82, r140, r87);
+    r95 = r42 * r86;
+    r95 = r95 * r24;
+    r95 = r95 * r76;
+    r95 = r95 * r83;
+    r87 = fma(r44, r95, r87);
+    r139 = r7 * r23;
+    r87 = fma(r79, r139, r87);
+    r93 = r5 * r36;
+    r93 = r93 * r6;
+    r93 = r93 * r42;
+    r93 = r93 * r42;
+    r93 = r93 * r100;
+    r93 = r93 * r85;
+    r87 = fma(r44, r93, r87);
+    r87 = fma(r32, r80, r87);
+    r87 = fma(r32, r79, r87);
+    r87 = fma(r32, r128, r87);
+    r87 = fma(r5, r27, r87);
+    r93 = r3 * r87;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r105, r93);
+    r93 = r53 * r60;
+    r105 = r47 * r44;
+    r105 = fma(r82, r105, r122 * r93);
+    r93 = r53 * r7;
+    r93 = r93 * r7;
+    r27 = r30 * r47;
+    r27 = r27 * r7;
+    r27 = fma(r58, r27, r107 * r93);
+    r93 = r53 * r107;
+    r27 = fma(r109, r93, r27);
+    r139 = r30 * r43;
+    r139 = r139 * r6;
+    r27 = fma(r58, r139, r27);
+    r139 = r20 * r7;
+    r139 = r139 * r7;
+    r139 = r139 * r27;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r105 = fma(r56, r139, r105);
+    r105 = fma(r27, r123, r105);
+    r139 = r27 * r111;
+    r139 = r139 * r97;
+    r139 = fma(r53, r125, r106 * r139);
+    r93 = r20 * r6;
+    r93 = r93 * r27;
+    r139 = fma(r115, r93, r139);
+    r139 = fma(r43, r117, r139);
+    r93 = r105 + r139;
+    r95 = r63 * r27;
+    r95 = r95 * r111;
+    r95 = r95 * r97;
+    r140 = r53 * r6;
+    r140 = r140 * r6;
+    r140 = r140 * r42;
+    r140 = r140 * r42;
+    r140 = r140 * r118;
+    r140 = r140 * r48;
+    r140 = fma(r85, r140, r106 * r95);
+    r95 = r6 * r103;
+    r95 = r95 * r27;
+    r140 = fma(r115, r95, r140);
+    r112 = r43 * r6;
+    r112 = r112 * r116;
+    r112 = r112 * r48;
+    r140 = fma(r56, r112, r140);
+    r140 = r140 + r105;
+    r140 = fma(r5, r140, r64 * r93);
+    r105 = r27 * r129;
+    r112 = r20 * r53;
+    r112 = r112 * r6;
+    r112 = r112 * r77;
+    r140 = fma(r41, r112, r140);
+    r95 = r4 * r43;
+    r95 = r95 * r44;
+    r140 = fma(r82, r95, r140);
+    r9 = r89 * r71;
+    r9 = r9 * r27;
+    r9 = r9 * r38;
+    r9 = r9 * r78;
+    r140 = fma(r111, r9, r140);
+    r8 = r20 * r53;
+    r8 = r8 * r6;
+    r8 = r8 * r71;
+    r8 = r8 * r77;
+    r140 = fma(r41, r8, r140);
+    r96 = r89 * r27;
+    r96 = r96 * r38;
+    r96 = r96 * r78;
+    r140 = fma(r111, r96, r140);
+    r35 = r4 * r47;
+    r140 = fma(r117, r35, r140);
+    r147 = r69 * r30;
+    r147 = r147 * r61;
+    r147 = fma(r68, r93, r93 * r147);
+    r147 = fma(r93, r73, r147);
+    r147 = fma(r93, r72, r147);
+    r130 = r6 * r147;
+    r140 = fma(r79, r130, r140);
+    r94 = r4 * r27;
+    r140 = fma(r131, r94, r140);
+    r140 = fma(r4, r105, r140);
+    r140 = fma(r43, r79, r140);
+    r140 = fma(r27, r126, r140);
+    r140 = fma(r43, r80, r140);
+    r140 = fma(r27, r124, r140);
+    r140 = fma(r53, r137, r140);
+    r94 = r2 * r140;
+    r130 = r53 * r118;
+    r130 = r130 * r85;
+    r130 = r130 * r60;
+    r35 = r47 * r116;
+    r35 = r35 * r56;
+    r35 = fma(r44, r35, r121 * r130);
+    r130 = r63 * r27;
+    r35 = fma(r123, r130, r35);
+    r96 = r7 * r7;
+    r96 = r96 * r103;
+    r96 = r96 * r27;
+    r96 = r96 * r83;
+    r96 = r96 * r114;
+    r35 = fma(r56, r96, r35);
+    r35 = r35 + r139;
+    r35 = fma(r4, r35, r65 * r93);
+    r93 = r20 * r53;
+    r93 = r93 * r7;
+    r93 = r93 * r77;
+    r35 = fma(r41, r93, r35);
+    r139 = r20 * r53;
+    r139 = r139 * r7;
+    r139 = r139 * r71;
+    r139 = r139 * r77;
+    r35 = fma(r41, r139, r35);
+    r96 = r7 * r89;
+    r96 = r96 * r71;
+    r96 = r96 * r27;
+    r96 = r96 * r83;
+    r96 = r96 * r38;
+    r35 = fma(r78, r96, r35);
+    r130 = r7 * r89;
+    r130 = r130 * r27;
+    r130 = r130 * r83;
+    r130 = r130 * r38;
+    r35 = fma(r78, r130, r35);
+    r8 = r5 * r43;
+    r8 = r8 * r44;
+    r35 = fma(r82, r8, r35);
+    r9 = r7 * r147;
+    r35 = fma(r79, r9, r35);
+    r95 = r42 * r86;
+    r95 = r95 * r27;
+    r95 = r95 * r76;
+    r95 = r95 * r83;
+    r35 = fma(r44, r95, r35);
+    r112 = r5 * r27;
+    r35 = fma(r131, r112, r35);
+    r143 = r42 * r71;
+    r143 = r143 * r86;
+    r143 = r143 * r27;
+    r143 = r143 * r76;
+    r143 = r143 * r83;
+    r35 = fma(r44, r143, r35);
+    r144 = r5 * r53;
+    r144 = r144 * r6;
+    r144 = r144 * r42;
+    r144 = r144 * r42;
+    r144 = r144 * r100;
+    r144 = r144 * r85;
+    r35 = fma(r44, r144, r35);
+    r35 = fma(r5, r105, r35);
+    r35 = fma(r47, r80, r35);
+    r35 = fma(r47, r128, r35);
+    r35 = fma(r47, r79, r35);
+    r144 = r3 * r35;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r94, r144);
+    r144 = r20 * r6;
+    r94 = r30 * r39;
+    r94 = r94 * r7;
+    r143 = r45 * r7;
+    r143 = r143 * r7;
+    r143 = fma(r107, r143, r58 * r94);
+    r94 = r30 * r40;
+    r94 = r94 * r6;
+    r143 = fma(r58, r94, r143);
+    r112 = r45 * r107;
+    r143 = fma(r109, r112, r143);
+    r144 = r144 * r143;
+    r112 = r143 * r111;
+    r112 = r112 * r97;
+    r112 = fma(r106, r112, r115 * r144);
+    r112 = fma(r40, r117, r112);
+    r112 = fma(r45, r125, r112);
+    r144 = r45 * r60;
+    r94 = r39 * r44;
+    r94 = fma(r82, r94, r122 * r144);
+    r144 = r20 * r7;
+    r144 = r144 * r7;
+    r144 = r144 * r143;
+    r144 = r144 * r83;
+    r144 = r144 * r114;
+    r94 = fma(r56, r144, r94);
+    r94 = fma(r143, r123, r94);
+    r144 = r112 + r94;
+    r95 = r6 * r103;
+    r95 = r95 * r143;
+    r9 = r63 * r143;
+    r9 = r9 * r111;
+    r9 = r9 * r97;
+    r9 = fma(r106, r9, r115 * r95);
+    r95 = r40 * r6;
+    r95 = r95 * r116;
+    r95 = r95 * r48;
+    r9 = fma(r56, r95, r9);
+    r8 = r45 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r42;
+    r8 = r8 * r42;
+    r8 = r8 * r118;
+    r8 = r8 * r48;
+    r9 = fma(r85, r8, r9);
+    r9 = r9 + r94;
+    r9 = fma(r5, r9, r64 * r144);
+    r94 = r4 * r39;
+    r9 = fma(r117, r94, r9);
+    r8 = r69 * r30;
+    r8 = r8 * r61;
+    r8 = fma(r68, r144, r144 * r8);
+    r8 = fma(r144, r72, r8);
+    r8 = fma(r144, r73, r8);
+    r95 = r6 * r8;
+    r9 = fma(r79, r95, r9);
+    r130 = r20 * r45;
+    r130 = r130 * r6;
+    r130 = r130 * r71;
+    r130 = r130 * r77;
+    r9 = fma(r41, r130, r9);
+    r96 = r4 * r143;
+    r9 = fma(r131, r96, r9);
+    r105 = r4 * r143;
+    r9 = fma(r129, r105, r9);
+    r139 = r89 * r143;
+    r139 = r139 * r38;
+    r139 = r139 * r78;
+    r9 = fma(r111, r139, r9);
+    r93 = r4 * r40;
+    r93 = r93 * r44;
+    r9 = fma(r82, r93, r9);
+    r146 = r20 * r45;
+    r146 = r146 * r6;
+    r146 = r146 * r77;
+    r9 = fma(r41, r146, r9);
+    r132 = r89 * r71;
+    r132 = r132 * r143;
+    r132 = r132 * r38;
+    r132 = r132 * r78;
+    r9 = fma(r111, r132, r9);
+    r9 = fma(r143, r126, r9);
+    r9 = fma(r45, r137, r9);
+    r9 = fma(r40, r80, r9);
+    r9 = fma(r40, r79, r9);
+    r9 = fma(r143, r124, r9);
+    r132 = r2 * r9;
+    r146 = r45 * r118;
+    r146 = r146 * r85;
+    r146 = r146 * r60;
+    r93 = r39 * r116;
+    r93 = r93 * r56;
+    r93 = fma(r44, r93, r121 * r146);
+    r146 = r63 * r143;
+    r93 = fma(r123, r146, r93);
+    r139 = r7 * r7;
+    r139 = r139 * r103;
+    r139 = r139 * r143;
+    r139 = r139 * r83;
+    r139 = r139 * r114;
+    r93 = fma(r56, r139, r93);
+    r93 = r93 + r112;
+    r93 = fma(r4, r93, r65 * r144);
+    r144 = r42 * r86;
+    r144 = r144 * r143;
+    r144 = r144 * r76;
+    r144 = r144 * r83;
+    r93 = fma(r44, r144, r93);
+    r112 = r20 * r45;
+    r112 = r112 * r7;
+    r112 = r112 * r77;
+    r93 = fma(r41, r112, r93);
+    r139 = r42 * r71;
+    r139 = r139 * r86;
+    r139 = r139 * r143;
+    r139 = r139 * r76;
+    r139 = r139 * r83;
+    r93 = fma(r44, r139, r93);
+    r146 = r5 * r143;
+    r93 = fma(r131, r146, r93);
+    r105 = r5 * r143;
+    r93 = fma(r129, r105, r93);
+    r96 = r5 * r45;
+    r96 = r96 * r6;
+    r96 = r96 * r42;
+    r96 = r96 * r42;
+    r96 = r96 * r100;
+    r96 = r96 * r85;
+    r93 = fma(r44, r96, r93);
+    r130 = r7 * r89;
+    r130 = r130 * r71;
+    r130 = r130 * r143;
+    r130 = r130 * r83;
+    r130 = r130 * r38;
+    r93 = fma(r78, r130, r93);
+    r95 = r5 * r40;
+    r95 = r95 * r44;
+    r93 = fma(r82, r95, r93);
+    r94 = r7 * r89;
+    r94 = r94 * r143;
+    r94 = r94 * r83;
+    r94 = r94 * r38;
+    r93 = fma(r78, r94, r93);
+    r104 = r7 * r8;
+    r93 = fma(r79, r104, r93);
+    r133 = r20 * r45;
+    r133 = r133 * r7;
+    r133 = r133 * r71;
+    r133 = r133 * r77;
+    r93 = fma(r41, r133, r93);
+    r93 = fma(r39, r128, r93);
+    r93 = fma(r39, r79, r93);
+    r93 = fma(r39, r80, r93);
+    r133 = r3 * r93;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r133);
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r132 = r20 * r0;
+    r104 = r2 * r132;
+    r133 = fma(r113, r104, r138 * r133);
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r110, r104, r145 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r133, r94);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r136, r104, r90 * r94);
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r133 = fma(r127, r104, r87 * r133);
+    WriteSum2<double, double>((double*)inout_shared, r94, r133);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r133 = r3 * r20;
+    r133 = r133 * r1;
+    r133 = fma(r140, r104, r35 * r133);
+    r94 = r3 * r20;
+    r94 = r94 * r1;
+    r94 = fma(r9, r104, r93 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r133, r94);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r113 * r113;
+    r133 = r2 * r2;
+    r95 = r138 * r138;
+    r130 = r3 * r3;
+    r95 = fma(r130, r95, r133 * r94);
+    r94 = r110 * r110;
+    r96 = r145 * r145;
+    r96 = fma(r130, r96, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r90 * r90;
+    r95 = r136 * r136;
+    r95 = fma(r133, r95, r130 * r96);
+    r96 = r87 * r87;
+    r94 = r127 * r127;
+    r94 = fma(r133, r94, r130 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r95, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r35 * r35;
+    r95 = r140 * r140;
+    r95 = fma(r133, r95, r130 * r94);
+    r94 = r9 * r9;
+    r96 = r93 * r93;
+    r96 = fma(r130, r96, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r113 * r110;
+    r95 = r138 * r145;
+    r95 = fma(r130, r95, r133 * r96);
+    r96 = r138 * r90;
+    r94 = r113 * r136;
+    r94 = fma(r133, r94, r130 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r95, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r113 * r127;
+    r95 = r138 * r87;
+    r95 = fma(r130, r95, r133 * r94);
+    r94 = r138 * r35;
+    r96 = r113 * r140;
+    r96 = fma(r133, r96, r130 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r113 * r9;
+    r95 = r138 * r93;
+    r95 = fma(r130, r95, r133 * r96);
+    r96 = r145 * r90;
+    r94 = r110 * r136;
+    r94 = fma(r133, r94, r130 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r95, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r145 * r87;
+    r95 = r110 * r127;
+    r95 = fma(r133, r95, r130 * r94);
+    r94 = r110 * r140;
+    r96 = r145 * r35;
+    r96 = fma(r130, r96, r133 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r110 * r9;
+    r95 = r145 * r93;
+    r95 = fma(r130, r95, r133 * r96);
+    r96 = r90 * r87;
+    r94 = r136 * r127;
+    r94 = fma(r133, r94, r130 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r95, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r90 * r35;
+    r95 = r136 * r140;
+    r95 = fma(r133, r95, r130 * r94);
+    r94 = r90 * r93;
+    r96 = r136 * r9;
+    r96 = fma(r133, r96, r130 * r94);
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r87 * r35;
+    r95 = r127 * r140;
+    r95 = fma(r133, r95, r130 * r96);
+    r96 = r87 * r93;
+    r94 = r127 * r9;
+    r94 = fma(r133, r94, r130 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r95, r94);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r94 = r35 * r93;
+    r95 = r140 * r9;
+    r95 = fma(r133, r95, r130 * r94);
+    WriteSum1<double, double>((double*)inout_shared, r95);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             0 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r67,
+                                             r66);
+    r95 = r2 * r6;
+    r95 = r95 * r61;
+    r95 = r95 * r79;
+    r94 = r3 * r7;
+    r94 = r94 * r61;
+    r94 = r94 * r79;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             2 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r95,
+                                             r94);
+    r96 = r2 * r6;
+    r96 = r96 * r79;
+    r96 = r96 * r70;
+    r105 = r3 * r7;
+    r105 = r105 * r79;
+    r105 = r105 * r70;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             4 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r96,
+                                             r105);
+    r146 = r3 * r81;
+    r139 = r2 * r6;
+    r139 = r139 * r44;
+    r139 = r139 * r82;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             6 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r139,
+                                             r146);
+    r112 = r2 * r62;
+    r144 = r3 * r6;
+    r144 = r144 * r44;
+    r144 = r144 * r82;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             8 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r112,
+                                             r144);
+    r149 = r2 * r6;
+    r149 = r149 * r79;
+    r149 = r149 * r75;
+    r150 = r3 * r7;
+    r150 = r150 * r79;
+    r150 = r150 * r75;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             10 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r149,
+                                             r150);
+    r151 = r2 * r6;
+    r151 = r151 * r79;
+    r151 = r151 * r74;
+    r152 = r3 * r7;
+    r152 = r152 * r79;
+    r152 = r152 * r74;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             12 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r151,
+                                             r152);
+    r153 = r2 * r61;
+    r154 = r3 * r61;
+    WriteIdx2<1024, double, double, double2>(out_calib_jac,
+                                             14 * out_calib_jac_num_alloc,
+                                             global_thread_idx,
+                                             r153,
+                                             r154);
+    r155 = r20 * r66;
+    r155 = r155 * r1;
+    r156 = r67 * r132;
+    WriteSum2<double, double>((double*)inout_shared, r156, r155);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            0 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r20 * r1;
+    WriteSum2<double, double>((double*)inout_shared, r132, r155);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            2 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r6 * r61;
+    r155 = r155 * r79;
+    r132 = r3 * r20;
+    r132 = r132 * r7;
+    r132 = r132 * r61;
+    r132 = r132 * r1;
+    r132 = fma(r79, r132, r104 * r155);
+    r155 = r3 * r20;
+    r155 = r155 * r7;
+    r155 = r155 * r1;
+    r155 = r155 * r79;
+    r156 = r6 * r79;
+    r156 = r156 * r70;
+    r156 = fma(r104, r156, r70 * r155);
+    WriteSum2<double, double>((double*)inout_shared, r132, r156);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            4 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r3 * r20;
+    r156 = r156 * r81;
+    r132 = r2 * r21;
+    r132 = r132 * r6;
+    r132 = r132 * r0;
+    r132 = r132 * r56;
+    r132 = fma(r44, r132, r1 * r156);
+    r156 = r3 * r21;
+    r156 = r156 * r6;
+    r156 = r156 * r1;
+    r156 = r156 * r56;
+    r156 = fma(r44, r156, r62 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r132, r156);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            6 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r3 * r20;
+    r156 = r156 * r7;
+    r156 = r156 * r1;
+    r156 = r156 * r79;
+    r132 = r6 * r79;
+    r132 = r132 * r75;
+    r132 = fma(r104, r132, r75 * r156);
+    r156 = r3 * r20;
+    r156 = r156 * r7;
+    r156 = r156 * r1;
+    r156 = r156 * r79;
+    r0 = r6 * r79;
+    r0 = r0 * r74;
+    r0 = fma(r104, r0, r74 * r156);
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            8 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r20;
+    r0 = r0 * r61;
+    r0 = r0 * r1;
+    r132 = r61 * r104;
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_njtr,
+                            10 * out_calib_njtr_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r67 * r67;
+    r132 = r66 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r0, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            0 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r22, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            2 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r56 * r70;
+    r22 = r22 * r130;
+    r132 = r6 * r56;
+    r132 = r132 * r70;
+    r132 = r132 * r133;
+    r132 = fma(r106, r132, r60 * r22);
+    r22 = r56 * r130;
+    r22 = r22 * r60;
+    r0 = r6 * r56;
+    r0 = r0 * r133;
+    r0 = r0 * r106;
+    r0 = fma(r74, r0, r74 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r132, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            4 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = r7 * r7;
+    r50 = r57 * r50;
+    r50 = 1.0 / r50;
+    r49 = r54 * r49;
+    r49 = 1.0 / r49;
+    r132 = r132 * r42;
+    r132 = r132 * r42;
+    r132 = r132 * r135;
+    r132 = r132 * r50;
+    r132 = r132 * r49;
+    r132 = r132 * r121;
+    r132 = r132 * r109;
+    r49 = r81 * r130;
+    r50 = fma(r81, r49, r133 * r132);
+    r135 = r62 * r133;
+    r132 = fma(r62, r135, r130 * r132);
+    WriteSum2<double, double>((double*)inout_shared, r50, r132);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            6 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r132 = r75 * r75;
+    r132 = r56 * r132;
+    r50 = r130 * r60;
+    r54 = r6 * r133;
+    r54 = r54 * r106;
+    r57 = fma(r132, r54, r132 * r50);
+    r132 = r61 * r132;
+    r22 = r61 * r132;
+    r22 = fma(r54, r22, r50 * r22);
+    WriteSum2<double, double>((double*)inout_shared, r57, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            8 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r70 * r133;
+    r156 = r70 * r130;
+    WriteSum2<double, double>((double*)inout_shared, r22, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_diag,
+                            10 * out_calib_precond_diag_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = 0.00000000000000000e+00;
+    WriteSum2<double, double>((double*)inout_shared, r156, r67);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            0 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r2 * r6;
+    r22 = r22 * r61;
+    r22 = r22 * r67;
+    r22 = r22 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r156, r22);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            2 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = r2 * r6;
+    r22 = r22 * r67;
+    r22 = r22 * r79;
+    r22 = r22 * r70;
+    r155 = r2 * r6;
+    r155 = r155 * r67;
+    r155 = r155 * r44;
+    r155 = r155 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r22, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            4 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r2 * r62;
+    r62 = r62 * r67;
+    r155 = r2 * r6;
+    r155 = r155 * r67;
+    r155 = r155 * r79;
+    r155 = r155 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r62, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            6 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r2 * r61;
+    r155 = r155 * r67;
+    r62 = r2 * r6;
+    r62 = r62 * r67;
+    r62 = r62 * r79;
+    r62 = r62 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r62, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            8 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r7;
+    r155 = r155 * r61;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    WriteSum2<double, double>((double*)inout_shared, r66, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            12 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r81;
+    r81 = r81 * r66;
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r70;
+    WriteSum2<double, double>((double*)inout_shared, r155, r81);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            14 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r81 = r3 * r6;
+    r81 = r81 * r66;
+    r81 = r81 * r44;
+    r81 = r81 * r82;
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r75;
+    WriteSum2<double, double>((double*)inout_shared, r81, r155);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            16 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r7;
+    r155 = r155 * r66;
+    r155 = r155 * r79;
+    r155 = r155 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r155, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            18 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r155 = r3 * r61;
+    r155 = r155 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r155, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            20 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r95, r96);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            22 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r139, r112);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            24 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r149, r151);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            26 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r153, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            28 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r94, r105);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            30 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r146, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            32 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r150, r152);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            34 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r156, r154);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            36 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r154 = r56 * r75;
+    r154 = r154 * r130;
+    r152 = r6 * r56;
+    r152 = r152 * r75;
+    r152 = r152 * r133;
+    r152 = fma(r106, r152, r60 * r154);
+    r154 = r49 * r84;
+    r150 = r30 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r61;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r133;
+    r150 = r150 * r121;
+    r150 = fma(r109, r150, r61 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r152, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            38 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r30 * r6;
+    r150 = r150 * r7;
+    r150 = r150 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r61;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r130;
+    r152 = r6 * r135;
+    r144 = r79 * r152;
+    r150 = fma(r61, r144, r121 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r150, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            40 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r6 * r79;
+    r0 = r0 * r70;
+    r0 = r0 * r133;
+    r150 = r56 * r130;
+    r146 = r61 * r74;
+    r150 = r150 * r60;
+    r105 = r6 * r56;
+    r105 = r105 * r133;
+    r105 = r105 * r106;
+    r105 = fma(r146, r105, r146 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r105, r0);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            42 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r7 * r79;
+    r0 = r0 * r70;
+    r0 = r0 * r130;
+    r150 = r30 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r70;
+    r150 = r150 * r133;
+    r150 = r150 * r121;
+    r150 = fma(r109, r150, r70 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r0, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            44 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r30 * r6;
+    r150 = r150 * r7;
+    r150 = r150 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r70;
+    r150 = r150 * r130;
+    r150 = fma(r70, r144, r121 * r150);
+    WriteSum2<double, double>((double*)inout_shared, r150, r105);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            46 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r6 * r79;
+    r105 = r105 * r75;
+    r105 = r105 * r133;
+    WriteSum2<double, double>((double*)inout_shared, r57, r105);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            48 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r7 * r79;
+    r105 = r105 * r75;
+    r105 = r105 * r130;
+    r57 = r44 * r82;
+    r150 = r6 * r49;
+    r150 = fma(r57, r150, r152 * r57);
+    WriteSum2<double, double>((double*)inout_shared, r105, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            50 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r30 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r75;
+    r150 = r150 * r133;
+    r150 = r150 * r121;
+    r150 = fma(r109, r150, r75 * r154);
+    r105 = r30 * r7;
+    r105 = r105 * r42;
+    r105 = r105 * r85;
+    r105 = r105 * r114;
+    r105 = r105 * r133;
+    r105 = r105 * r121;
+    r105 = r105 * r74;
+    r105 = fma(r109, r105, r74 * r154);
+    WriteSum2<double, double>((double*)inout_shared, r150, r105);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            52 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r6 * r61;
+    r105 = r105 * r44;
+    r105 = r105 * r82;
+    r105 = r105 * r133;
+    r150 = r61 * r49;
+    WriteSum2<double, double>((double*)inout_shared, r105, r150);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            54 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r150 = r30 * r6;
+    r150 = r150 * r7;
+    r150 = r150 * r7;
+    r150 = r150 * r42;
+    r150 = r150 * r85;
+    r150 = r150 * r114;
+    r150 = r150 * r75;
+    r150 = r150 * r130;
+    r150 = fma(r75, r144, r121 * r150);
+    r105 = r30 * r6;
+    r105 = r105 * r7;
+    r105 = r105 * r7;
+    r105 = r105 * r42;
+    r105 = r105 * r85;
+    r105 = r105 * r114;
+    r105 = r105 * r130;
+    r105 = r105 * r121;
+    r144 = fma(r74, r144, r74 * r105);
+    WriteSum2<double, double>((double*)inout_shared, r150, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            56 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r135 = r61 * r135;
+    r144 = r6 * r61;
+    r144 = r144 * r44;
+    r144 = r144 * r82;
+    r144 = r144 * r130;
+    WriteSum2<double, double>((double*)inout_shared, r135, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            58 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r6 * r79;
+    r144 = r144 * r133;
+    r144 = r144 * r74;
+    r54 = fma(r132, r54, r132 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r54, r144);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            60 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r7 * r79;
+    r144 = r144 * r130;
+    r144 = r144 * r74;
+    r74 = r6 * r79;
+    r74 = r74 * r133;
+    r74 = r74 * r146;
+    WriteSum2<double, double>((double*)inout_shared, r144, r74);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            62 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r146 = r130 * r146;
+    r146 = r146 * r84;
+    WriteSum2<double, double>((double*)inout_shared, r146, r156);
+  };
+  FlushSumShared<2, double>(out_calib_precond_tril,
+                            64 * out_calib_precond_tril_num_alloc,
+                            calib_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r156 = r51 * r6;
+    r156 = r156 * r6;
+    r156 = r156 * r42;
+    r156 = r156 * r42;
+    r156 = r156 * r118;
+    r156 = r156 * r48;
+    r146 = r30 * r29;
+    r146 = r146 * r6;
+    r84 = r51 * r7;
+    r84 = r84 * r7;
+    r84 = fma(r107, r84, r58 * r146);
+    r146 = r51 * r107;
+    r84 = fma(r109, r146, r84);
+    r74 = r30 * r59;
+    r74 = r74 * r7;
+    r84 = fma(r58, r74, r84);
+    r74 = r63 * r84;
+    r74 = r74 * r111;
+    r74 = r74 * r97;
+    r74 = fma(r106, r74, r85 * r156);
+    r156 = r29 * r6;
+    r156 = r156 * r116;
+    r156 = r156 * r48;
+    r74 = fma(r56, r156, r74);
+    r146 = r6 * r103;
+    r146 = r146 * r84;
+    r74 = fma(r115, r146, r74);
+    r144 = r51 * r60;
+    r54 = r20 * r7;
+    r54 = r54 * r7;
+    r54 = r54 * r84;
+    r54 = r54 * r83;
+    r54 = r54 * r114;
+    r54 = fma(r56, r54, r122 * r144);
+    r144 = r59 * r44;
+    r54 = fma(r82, r144, r54);
+    r54 = fma(r84, r123, r54);
+    r74 = r74 + r54;
+    r146 = r84 * r111;
+    r146 = r146 * r97;
+    r146 = fma(r106, r146, r51 * r125);
+    r156 = r20 * r6;
+    r156 = r156 * r84;
+    r146 = fma(r115, r156, r146);
+    r146 = fma(r29, r117, r146);
+    r54 = r54 + r146;
+    r74 = fma(r64, r54, r5 * r74);
+    r156 = r69 * r30;
+    r156 = r156 * r61;
+    r156 = fma(r54, r156, r68 * r54);
+    r156 = fma(r54, r72, r156);
+    r156 = fma(r54, r73, r156);
+    r144 = r6 * r156;
+    r74 = fma(r79, r144, r74);
+    r132 = r4 * r84;
+    r74 = fma(r129, r132, r74);
+    r50 = r20 * r51;
+    r50 = r50 * r6;
+    r50 = r50 * r71;
+    r50 = r50 * r77;
+    r74 = fma(r41, r50, r74);
+    r135 = r4 * r59;
+    r74 = fma(r117, r135, r74);
+    r150 = r89 * r84;
+    r150 = r150 * r38;
+    r150 = r150 * r78;
+    r74 = fma(r111, r150, r74);
+    r105 = r89 * r71;
+    r105 = r105 * r84;
+    r105 = r105 * r38;
+    r105 = r105 * r78;
+    r74 = fma(r111, r105, r74);
+    r154 = r20 * r51;
+    r154 = r154 * r6;
+    r154 = r154 * r77;
+    r74 = fma(r41, r154, r74);
+    r57 = r4 * r29;
+    r57 = r57 * r44;
+    r74 = fma(r82, r57, r74);
+    r152 = r4 * r84;
+    r74 = fma(r131, r152, r74);
+    r74 = fma(r51, r137, r74);
+    r74 = fma(r29, r80, r74);
+    r74 = fma(r29, r79, r74);
+    r74 = fma(r84, r126, r74);
+    r74 = fma(r84, r124, r74);
+    r152 = r2 * r74;
+    r57 = r51 * r118;
+    r57 = r57 * r85;
+    r57 = r57 * r60;
+    r154 = r7 * r7;
+    r154 = r154 * r103;
+    r154 = r154 * r84;
+    r154 = r154 * r83;
+    r154 = r154 * r114;
+    r154 = fma(r56, r154, r121 * r57);
+    r57 = r63 * r84;
+    r154 = fma(r123, r57, r154);
+    r105 = r59 * r116;
+    r105 = r105 * r56;
+    r154 = fma(r44, r105, r154);
+    r154 = r154 + r146;
+    r54 = fma(r65, r54, r4 * r154);
+    r154 = r7 * r89;
+    r154 = r154 * r84;
+    r154 = r154 * r83;
+    r154 = r154 * r38;
+    r54 = fma(r78, r154, r54);
+    r146 = r7 * r89;
+    r146 = r146 * r71;
+    r146 = r146 * r84;
+    r146 = r146 * r83;
+    r146 = r146 * r38;
+    r54 = fma(r78, r146, r54);
+    r105 = r5 * r51;
+    r105 = r105 * r6;
+    r105 = r105 * r42;
+    r105 = r105 * r42;
+    r105 = r105 * r100;
+    r105 = r105 * r85;
+    r54 = fma(r44, r105, r54);
+    r57 = r20 * r51;
+    r57 = r57 * r7;
+    r57 = r57 * r77;
+    r54 = fma(r41, r57, r54);
+    r150 = r5 * r84;
+    r54 = fma(r129, r150, r54);
+    r135 = r20 * r51;
+    r135 = r135 * r7;
+    r135 = r135 * r71;
+    r135 = r135 * r77;
+    r54 = fma(r41, r135, r54);
+    r50 = r42 * r71;
+    r50 = r50 * r86;
+    r50 = r50 * r84;
+    r50 = r50 * r76;
+    r50 = r50 * r83;
+    r54 = fma(r44, r50, r54);
+    r132 = r42 * r86;
+    r132 = r132 * r84;
+    r132 = r132 * r76;
+    r132 = r132 * r83;
+    r54 = fma(r44, r132, r54);
+    r144 = r7 * r156;
+    r54 = fma(r79, r144, r54);
+    r0 = r5 * r29;
+    r0 = r0 * r44;
+    r54 = fma(r82, r0, r54);
+    r94 = r5 * r84;
+    r54 = fma(r131, r94, r54);
+    r54 = fma(r59, r80, r54);
+    r54 = fma(r59, r128, r54);
+    r54 = fma(r59, r79, r54);
+    r94 = r3 * r54;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r152,
+                                             r94);
+    r94 = r33 * r6;
+    r94 = r94 * r116;
+    r94 = r94 * r48;
+    r152 = r55 * r6;
+    r152 = r152 * r6;
+    r152 = r152 * r42;
+    r152 = r152 * r42;
+    r152 = r152 * r118;
+    r152 = r152 * r48;
+    r152 = fma(r85, r152, r56 * r94);
+    r94 = r6 * r103;
+    r0 = r55 * r107;
+    r144 = r30 * r33;
+    r144 = r144 * r6;
+    r144 = fma(r58, r144, r109 * r0);
+    r0 = r30 * r19;
+    r0 = r0 * r7;
+    r144 = fma(r58, r0, r144);
+    r132 = r55 * r7;
+    r132 = r132 * r7;
+    r144 = fma(r107, r132, r144);
+    r94 = r94 * r144;
+    r152 = fma(r115, r94, r152);
+    r132 = r63 * r144;
+    r132 = r132 * r111;
+    r132 = r132 * r97;
+    r152 = fma(r106, r132, r152);
+    r0 = r55 * r60;
+    r0 = fma(r144, r123, r122 * r0);
+    r50 = r19 * r44;
+    r0 = fma(r82, r50, r0);
+    r135 = r20 * r7;
+    r135 = r135 * r7;
+    r135 = r135 * r144;
+    r135 = r135 * r83;
+    r135 = r135 * r114;
+    r0 = fma(r56, r135, r0);
+    r152 = r152 + r0;
+    r132 = fma(r55, r125, r33 * r117);
+    r94 = r20 * r6;
+    r94 = r94 * r144;
+    r132 = fma(r115, r94, r132);
+    r135 = r144 * r111;
+    r135 = r135 * r97;
+    r132 = fma(r106, r135, r132);
+    r0 = r0 + r132;
+    r152 = fma(r64, r0, r5 * r152);
+    r135 = r89 * r144;
+    r135 = r135 * r38;
+    r135 = r135 * r78;
+    r152 = fma(r111, r135, r152);
+    r94 = r4 * r19;
+    r152 = fma(r117, r94, r152);
+    r50 = r4 * r144;
+    r152 = fma(r129, r50, r152);
+    r150 = r89 * r71;
+    r150 = r150 * r144;
+    r150 = r150 * r38;
+    r150 = r150 * r78;
+    r152 = fma(r111, r150, r152);
+    r57 = r20 * r55;
+    r57 = r57 * r6;
+    r57 = r57 * r77;
+    r152 = fma(r41, r57, r152);
+    r105 = r4 * r144;
+    r152 = fma(r131, r105, r152);
+    r146 = r69 * r30;
+    r146 = r146 * r61;
+    r146 = fma(r0, r146, r68 * r0);
+    r146 = fma(r0, r72, r146);
+    r146 = fma(r0, r73, r146);
+    r154 = r6 * r146;
+    r152 = fma(r79, r154, r152);
+    r153 = r20 * r55;
+    r153 = r153 * r6;
+    r153 = r153 * r71;
+    r153 = r153 * r77;
+    r152 = fma(r41, r153, r152);
+    r151 = r4 * r33;
+    r151 = r151 * r44;
+    r152 = fma(r82, r151, r152);
+    r152 = fma(r33, r80, r152);
+    r152 = fma(r33, r79, r152);
+    r152 = fma(r144, r126, r152);
+    r152 = fma(r144, r124, r152);
+    r152 = fma(r55, r137, r152);
+    r151 = r2 * r152;
+    r153 = r55 * r118;
+    r153 = r153 * r85;
+    r153 = r153 * r60;
+    r154 = r63 * r144;
+    r154 = fma(r123, r154, r121 * r153);
+    r153 = r19 * r116;
+    r153 = r153 * r56;
+    r154 = fma(r44, r153, r154);
+    r123 = r7 * r7;
+    r123 = r123 * r103;
+    r123 = r123 * r144;
+    r123 = r123 * r83;
+    r123 = r123 * r114;
+    r154 = fma(r56, r123, r154);
+    r154 = r154 + r132;
+    r0 = fma(r65, r0, r4 * r154);
+    r154 = r20 * r55;
+    r154 = r154 * r7;
+    r154 = r154 * r77;
+    r0 = fma(r41, r154, r0);
+    r132 = r42 * r71;
+    r132 = r132 * r86;
+    r132 = r132 * r144;
+    r132 = r132 * r76;
+    r132 = r132 * r83;
+    r0 = fma(r44, r132, r0);
+    r123 = r7 * r89;
+    r123 = r123 * r71;
+    r123 = r123 * r144;
+    r123 = r123 * r83;
+    r123 = r123 * r38;
+    r0 = fma(r78, r123, r0);
+    r153 = r5 * r144;
+    r0 = fma(r129, r153, r0);
+    r105 = r7 * r89;
+    r105 = r105 * r144;
+    r105 = r105 * r83;
+    r105 = r105 * r38;
+    r0 = fma(r78, r105, r0);
+    r57 = r20 * r55;
+    r57 = r57 * r7;
+    r57 = r57 * r71;
+    r57 = r57 * r77;
+    r0 = fma(r41, r57, r0);
+    r150 = r5 * r144;
+    r0 = fma(r131, r150, r0);
+    r50 = r42 * r86;
+    r50 = r50 * r144;
+    r50 = r50 * r76;
+    r50 = r50 * r83;
+    r0 = fma(r44, r50, r0);
+    r94 = r7 * r146;
+    r0 = fma(r79, r94, r0);
+    r135 = r5 * r55;
+    r135 = r135 * r6;
+    r135 = r135 * r42;
+    r135 = r135 * r42;
+    r135 = r135 * r100;
+    r135 = r135 * r85;
+    r0 = fma(r44, r135, r0);
+    r149 = r5 * r33;
+    r149 = r149 * r44;
+    r0 = fma(r82, r149, r0);
+    r0 = fma(r19, r128, r0);
+    r0 = fma(r19, r80, r0);
+    r0 = fma(r19, r79, r0);
+    r149 = r3 * r0;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r151,
+                                             r149);
+    r149 = r28 * r6;
+    r149 = r149 * r6;
+    r149 = r149 * r42;
+    r149 = r149 * r42;
+    r149 = r149 * r118;
+    r149 = r149 * r48;
+    r151 = r6 * r103;
+    r135 = r30 * r37;
+    r135 = r135 * r6;
+    r94 = r28 * r7;
+    r94 = r94 * r7;
+    r94 = fma(r107, r94, r58 * r135);
+    r135 = r28 * r107;
+    r94 = fma(r109, r135, r94);
+    r109 = r30 * r52;
+    r109 = r109 * r7;
+    r94 = fma(r58, r109, r94);
+    r151 = r151 * r94;
+    r151 = fma(r115, r151, r85 * r149);
+    r149 = r63 * r94;
+    r149 = r149 * r111;
+    r149 = r149 * r97;
+    r151 = fma(r106, r149, r151);
+    r109 = r37 * r6;
+    r109 = r109 * r116;
+    r109 = r109 * r48;
+    r151 = fma(r56, r109, r151);
+    r135 = r7 * r7;
+    r135 = r58 * r135;
+    r135 = r135 * r48;
+    r135 = r135 * r42;
+    r135 = r135 * r83;
+    r135 = r135 * r38;
+    r135 = r135 * r94;
+    r48 = r52 * r44;
+    r48 = fma(r82, r48, r135);
+    r58 = r20 * r7;
+    r58 = r58 * r7;
+    r58 = r58 * r94;
+    r58 = r58 * r83;
+    r58 = r58 * r114;
+    r48 = fma(r56, r58, r48);
+    r50 = r28 * r60;
+    r48 = fma(r122, r50, r48);
+    r151 = r151 + r48;
+    r109 = r20 * r6;
+    r109 = r109 * r94;
+    r109 = fma(r115, r109, r28 * r125);
+    r125 = r94 * r111;
+    r125 = r125 * r97;
+    r109 = fma(r106, r125, r109);
+    r109 = fma(r37, r117, r109);
+    r48 = r48 + r109;
+    r64 = fma(r64, r48, r5 * r151);
+    r151 = r20 * r28;
+    r151 = r151 * r6;
+    r151 = r151 * r77;
+    r64 = fma(r41, r151, r64);
+    r125 = r89 * r94;
+    r125 = r125 * r38;
+    r125 = r125 * r78;
+    r64 = fma(r111, r125, r64);
+    r106 = r4 * r37;
+    r106 = r106 * r44;
+    r64 = fma(r82, r106, r64);
+    r97 = r4 * r94;
+    r64 = fma(r129, r97, r64);
+    r149 = r20 * r28;
+    r149 = r149 * r6;
+    r149 = r149 * r71;
+    r149 = r149 * r77;
+    r64 = fma(r41, r149, r64);
+    r50 = r4 * r52;
+    r64 = fma(r117, r50, r64);
+    r117 = r4 * r94;
+    r64 = fma(r131, r117, r64);
+    r58 = r69 * r30;
+    r58 = r58 * r61;
+    r68 = fma(r68, r48, r48 * r58);
+    r68 = fma(r48, r72, r68);
+    r68 = fma(r48, r73, r68);
+    r73 = r6 * r68;
+    r64 = fma(r79, r73, r64);
+    r72 = r89 * r71;
+    r72 = r72 * r94;
+    r72 = r72 * r38;
+    r72 = r72 * r78;
+    r64 = fma(r111, r72, r64);
+    r64 = fma(r94, r126, r64);
+    r64 = fma(r94, r124, r64);
+    r64 = fma(r28, r137, r64);
+    r64 = fma(r37, r79, r64);
+    r64 = fma(r37, r80, r64);
+    r72 = r2 * r64;
+    r73 = r52 * r116;
+    r73 = r73 * r56;
+    r117 = r7 * r7;
+    r117 = r117 * r103;
+    r117 = r117 * r94;
+    r117 = r117 * r83;
+    r117 = r117 * r114;
+    r117 = fma(r56, r117, r44 * r73);
+    r73 = r28 * r118;
+    r73 = r73 * r85;
+    r73 = r73 * r60;
+    r117 = fma(r121, r73, r117);
+    r117 = fma(r63, r135, r117);
+    r117 = r117 + r109;
+    r48 = fma(r65, r48, r4 * r117);
+    r65 = r42 * r71;
+    r65 = r65 * r86;
+    r65 = r65 * r94;
+    r65 = r65 * r76;
+    r65 = r65 * r83;
+    r48 = fma(r44, r65, r48);
+    r117 = r5 * r28;
+    r117 = r117 * r6;
+    r117 = r117 * r42;
+    r117 = r117 * r42;
+    r117 = r117 * r100;
+    r117 = r117 * r85;
+    r48 = fma(r44, r117, r48);
+    r85 = r42 * r86;
+    r85 = r85 * r94;
+    r85 = r85 * r76;
+    r85 = r85 * r83;
+    r48 = fma(r44, r85, r48);
+    r76 = r7 * r89;
+    r76 = r76 * r71;
+    r76 = r76 * r94;
+    r76 = r76 * r83;
+    r76 = r76 * r38;
+    r48 = fma(r78, r76, r48);
+    r100 = r5 * r37;
+    r100 = r100 * r44;
+    r48 = fma(r82, r100, r48);
+    r82 = r5 * r94;
+    r48 = fma(r129, r82, r48);
+    r129 = r20 * r28;
+    r129 = r129 * r7;
+    r129 = r129 * r71;
+    r129 = r129 * r77;
+    r48 = fma(r41, r129, r48);
+    r109 = r7 * r68;
+    r48 = fma(r79, r109, r48);
+    r73 = r5 * r94;
+    r48 = fma(r131, r73, r48);
+    r131 = r7 * r89;
+    r131 = r131 * r94;
+    r131 = r131 * r83;
+    r131 = r131 * r38;
+    r48 = fma(r78, r131, r48);
+    r78 = r20 * r28;
+    r78 = r78 * r7;
+    r78 = r78 * r77;
+    r48 = fma(r41, r78, r48);
+    r48 = fma(r52, r128, r48);
+    r48 = fma(r52, r79, r48);
+    r48 = fma(r52, r80, r48);
+    r78 = r3 * r48;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r72,
+                                             r78);
+    r78 = r3 * r20;
+    r78 = r78 * r1;
+    r78 = fma(r74, r104, r54 * r78);
+    r72 = r3 * r20;
+    r72 = r72 * r1;
+    r72 = fma(r152, r104, r0 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r78, r72);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r3 * r20;
+    r72 = r72 * r1;
+    r104 = fma(r64, r104, r48 * r72);
+    WriteSum1<double, double>((double*)inout_shared, r104);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r74 * r74;
+    r72 = r54 * r54;
+    r72 = fma(r130, r72, r133 * r104);
+    r104 = r0 * r0;
+    r1 = r152 * r152;
+    r1 = fma(r133, r1, r130 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r72, r1);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r48 * r48;
+    r72 = r64 * r64;
+    r72 = fma(r133, r72, r130 * r1);
+    WriteSum1<double, double>((double*)inout_shared, r72);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r74 * r152;
+    r1 = r54 * r0;
+    r1 = fma(r130, r1, r133 * r72);
+    r72 = r54 * r48;
+    r104 = r74 * r64;
+    r104 = fma(r133, r104, r130 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r1, r104);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r0 * r48;
+    r1 = r152 * r64;
+    r1 = fma(r133, r1, r130 * r104);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeResJacFirst(double* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 double* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 double* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 double* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 double* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 double* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 double* const out_rTr,
+                                 double* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 double* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 double* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 double* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 double* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 double* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 double* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 double* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 double* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 double* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 double* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 double* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      calib,
+      calib_num_alloc,
+      calib_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_calib_jac,
+      out_calib_jac_num_alloc,
+      out_calib_njtr,
+      out_calib_njtr_num_alloc,
+      out_calib_precond_diag,
+      out_calib_precond_diag_num_alloc,
+      out_calib_precond_tril,
+      out_calib_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_res_jac_first.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeResJacFirst(double* pose,
+                                 unsigned int pose_num_alloc,
+                                 SharedIndex* pose_indices,
+                                 double* sensor_from_rig,
+                                 unsigned int sensor_from_rig_num_alloc,
+                                 double* calib,
+                                 unsigned int calib_num_alloc,
+                                 SharedIndex* calib_indices,
+                                 double* point,
+                                 unsigned int point_num_alloc,
+                                 SharedIndex* point_indices,
+                                 double* pixel,
+                                 unsigned int pixel_num_alloc,
+                                 double* out_res,
+                                 unsigned int out_res_num_alloc,
+                                 double* const out_rTr,
+                                 double* out_pose_jac,
+                                 unsigned int out_pose_jac_num_alloc,
+                                 double* const out_pose_njtr,
+                                 unsigned int out_pose_njtr_num_alloc,
+                                 double* const out_pose_precond_diag,
+                                 unsigned int out_pose_precond_diag_num_alloc,
+                                 double* const out_pose_precond_tril,
+                                 unsigned int out_pose_precond_tril_num_alloc,
+                                 double* out_calib_jac,
+                                 unsigned int out_calib_jac_num_alloc,
+                                 double* const out_calib_njtr,
+                                 unsigned int out_calib_njtr_num_alloc,
+                                 double* const out_calib_precond_diag,
+                                 unsigned int out_calib_precond_diag_num_alloc,
+                                 double* const out_calib_precond_tril,
+                                 unsigned int out_calib_precond_tril_num_alloc,
+                                 double* out_point_jac,
+                                 unsigned int out_point_jac_num_alloc,
+                                 double* const out_point_njtr,
+                                 unsigned int out_point_njtr_num_alloc,
+                                 double* const out_point_precond_diag,
+                                 unsigned int out_point_precond_diag_num_alloc,
+                                 double* const out_point_precond_tril,
+                                 unsigned int out_point_precond_tril_num_alloc,
+                                 size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_score.cu
@@ -1,0 +1,364 @@
+#include "kernel_thin_prism_fisheye_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeScoreKernel(double* pose,
+                                unsigned int pose_num_alloc,
+                                SharedIndex* pose_indices,
+                                double* sensor_from_rig,
+                                unsigned int sensor_from_rig_num_alloc,
+                                double* calib,
+                                unsigned int calib_num_alloc,
+                                SharedIndex* calib_indices,
+                                double* point,
+                                unsigned int point_num_alloc,
+                                SharedIndex* point_indices,
+                                double* pixel,
+                                unsigned int pixel_num_alloc,
+                                double* const out_rTr,
+                                size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex calib_indices_loc[1024];
+  calib_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? calib_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(
+      calib, 2 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r0, r1);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 0 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r2, r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      calib, 6 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r4, r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 10 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r32, r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+  };
+  LoadShared<2, double, double>(
+      calib, 4 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = r27 * r27;
+    r28 = fma(r28, r8, r36 * r27);
+  };
+  LoadShared<2, double, double>(
+      calib, 8 * calib_num_alloc, calib_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, calib_indices_loc[threadIdx.x].target, r36, r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r44 = r8 * r8;
+    r8 = r27 * r8;
+    r28 = fma(r7, r44, r28);
+    r28 = fma(r36, r8, r28);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r28 = r28 * r43;
+    r11 = r4 * r19;
+    r11 = r11 * r42;
+    r11 = r11 * r29;
+    r32 = fma(r6, r11, r32);
+    r32 = fma(r42, r28, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r28, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeScore(double* pose,
+                           unsigned int pose_num_alloc,
+                           SharedIndex* pose_indices,
+                           double* sensor_from_rig,
+                           unsigned int sensor_from_rig_num_alloc,
+                           double* calib,
+                           unsigned int calib_num_alloc,
+                           SharedIndex* calib_indices,
+                           double* point,
+                           unsigned int point_num_alloc,
+                           SharedIndex* point_indices,
+                           double* pixel,
+                           unsigned int pixel_num_alloc,
+                           double* const out_rTr,
+                           size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeScoreKernel<<<n_blocks, 1024>>>(pose,
+                                                  pose_num_alloc,
+                                                  pose_indices,
+                                                  sensor_from_rig,
+                                                  sensor_from_rig_num_alloc,
+                                                  calib,
+                                                  calib_num_alloc,
+                                                  calib_indices,
+                                                  point,
+                                                  point_num_alloc,
+                                                  point_indices,
+                                                  pixel,
+                                                  pixel_num_alloc,
+                                                  out_rTr,
+                                                  problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_score.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeScore(double* pose,
+                           unsigned int pose_num_alloc,
+                           SharedIndex* pose_indices,
+                           double* sensor_from_rig,
+                           unsigned int sensor_from_rig_num_alloc,
+                           double* calib,
+                           unsigned int calib_num_alloc,
+                           SharedIndex* calib_indices,
+                           double* point,
+                           unsigned int point_num_alloc,
+                           SharedIndex* point_indices,
+                           double* pixel,
+                           unsigned int pixel_num_alloc,
+                           double* const out_rTr,
+                           size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,194 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        double* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(principal_point_njtr,
+                                0 * principal_point_njtr_num_alloc,
+                                principal_point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r4 = fma(r1, r3, r0 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r5, r6);
+    r7 = fma(r6, r3, r5 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r4, r7);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r7, r4);
+    r8 = fma(r4, r3, r7 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r9, r10);
+    r11 = fma(r10, r3, r9 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r8, r11);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r11, r8);
+    r12 = fma(r8, r3, r11 * r2);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r13, r14);
+    r3 = fma(r14, r3, r13 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r12, r3);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r3,
+                        r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r11 = fma(r3, r11, r12 * r13);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r13,
+                        r2);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r15,
+                        r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r11 = fma(r13, r7, r11);
+    r11 = fma(r2, r9, r11);
+    r11 = fma(r15, r0, r11);
+    r11 = fma(r16, r5, r11);
+    r10 = fma(r2, r10, r12 * r14);
+    r10 = fma(r13, r4, r10);
+    r10 = fma(r15, r1, r10);
+    r10 = fma(r16, r6, r10);
+    r10 = fma(r3, r8, r10);
+    WriteSum2<double, double>((double*)inout_shared, r11, r10);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.cu
@@ -1,0 +1,1765 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r28 * r28;
+    r43 = 1.00000000000000008e-15;
+    r47 = r34 * r24;
+    r47 = r47 * r24;
+    r48 = r35 + r47;
+    r48 = r48 + r44;
+    r48 = fma(r8, r48, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r49 = r17 * r13;
+    r49 = r49 * r10;
+    r50 = r18 * r14;
+    r50 = fma(r10, r50, r49);
+    r51 = r13 * r14;
+    r51 = fma(r34, r51, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r48 = fma(r9, r6, r48);
+    r48 = fma(r41, r44, r48);
+    r48 = fma(r38, r50, r48);
+    r48 = fma(r30, r51, r48);
+    r48 = fma(r7, r36, r48);
+    r44 = r48 * r48;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r6);
+    r52 = r34 * r24;
+    r52 = fma(r29, r52, r20);
+    r52 = fma(r8, r52, r6);
+    r6 = r18 * r14;
+    r6 = fma(r34, r6, r49);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r47 = r35 + r47;
+    r47 = r47 + r46;
+    r52 = fma(r7, r6, r52);
+    r52 = fma(r38, r31, r52);
+    r52 = fma(r30, r33, r52);
+    r52 = fma(r9, r39, r52);
+    r52 = fma(r41, r47, r52);
+    r47 = copysign(1.0, r52);
+    r47 = fma(r43, r47, r52);
+    r52 = r47 * r47;
+    r39 = 1.0 / r52;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = copysign(1.0, r44);
+    r38 = fma(r43, r38, r44);
+    r43 = r38 * r38;
+    r7 = 1.0 / r43;
+    r44 = atan(r44);
+    r46 = r44 * r39;
+    r42 = r44 * r46;
+    r45 = r45 * r7;
+    r45 = r45 * r42;
+    r49 = 3.00000000000000000e+00;
+    r20 = r49 * r42;
+    r53 = r48 * r7;
+    r54 = r48 * r53;
+    r20 = fma(r54, r20, r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r55,
+                                            r56);
+    r57 = r42 * r54;
+    r45 = r45 + r57;
+    r20 = fma(r55, r45, r5 * r20);
+    r58 = r4 * r28;
+    r59 = r10 * r42;
+    r58 = r58 * r53;
+    r20 = fma(r59, r58, r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r60,
+                                            r61);
+    r62 = r45 * r45;
+    r63 = fma(r61, r62, r60 * r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r45 * r62;
+    r65 = r65 * r66;
+    r63 = fma(r45, r65, r63);
+    r63 = fma(r64, r66, r63);
+    r66 = 1.0 / r47;
+    r67 = 1.0 / r38;
+    r68 = r66 * r67;
+    r69 = r44 * r68;
+    r70 = r63 * r69;
+    r20 = fma(r48, r70, r20);
+    r20 = fma(r48, r69, r20);
+    r20 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r58);
+    r20 = fma(r0, r21, r20);
+    r0 = r28 * r28;
+    r0 = r0 * r49;
+    r0 = r0 * r7;
+    r0 = fma(r42, r0, r57);
+    r0 = fma(r56, r45, r4 * r0);
+    r57 = r5 * r28;
+    r57 = r57 * r53;
+    r0 = fma(r59, r57, r0);
+    r0 = fma(r28, r70, r0);
+    r0 = fma(r28, r69, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r58, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r20, r0);
+    r58 = r48 * r7;
+    r1 = -5.00000000000000000e-01;
+    r57 = rsqrt(r30);
+    r71 = r10 * r48;
+    r72 = r11 * r14;
+    r73 = r16 * r17;
+    r73 = fma(r1, r73, r1 * r72);
+    r72 = r15 * r18;
+    r73 = fma(r1, r72, r73);
+    r74 = r12 * r13;
+    r75 = 5.00000000000000000e-01;
+    r73 = fma(r75, r74, r73);
+    r74 = r24 * r73;
+    r72 = r15 * r14;
+    r76 = r12 * r17;
+    r76 = fma(r75, r76, r75 * r72);
+    r72 = r11 * r18;
+    r76 = fma(r1, r72, r76);
+    r77 = r16 * r13;
+    r76 = fma(r75, r77, r76);
+    r77 = r29 * r76;
+    r72 = fma(r10, r77, r10 * r74);
+    r78 = r10 * r19;
+    r79 = fma(r75, r26, r1 * r22);
+    r79 = fma(r1, r23, r79);
+    r79 = fma(r1, r25, r79);
+    r80 = r10 * r27;
+    r81 = r16 * r14;
+    r82 = r11 * r17;
+    r82 = fma(r1, r82, r75 * r81);
+    r81 = r12 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r15 * r13;
+    r82 = fma(r1, r83, r82);
+    r80 = r80 * r82;
+    r78 = fma(r79, r78, r80);
+    r72 = r72 + r78;
+    r83 = r10 * r24;
+    r83 = r83 * r82;
+    r81 = r10 * r19;
+    r81 = r81 * r76;
+    r84 = r83 + r81;
+    r85 = r27 * r34;
+    r84 = fma(r73, r85, r84);
+    r86 = r34 * r29;
+    r84 = fma(r79, r86, r84);
+    r84 = fma(r9, r84, r41 * r72);
+    r72 = r24 * r76;
+    r86 = -4.00000000000000000e+00;
+    r72 = r72 * r86;
+    r85 = r27 * r79;
+    r87 = r86 * r85;
+    r88 = r72 + r87;
+    r84 = fma(r8, r88, r84);
+    r71 = r71 * r84;
+    r88 = r48 * r48;
+    r89 = r10 * r24;
+    r89 = r89 * r79;
+    r90 = r10 * r27;
+    r90 = fma(r76, r90, r89);
+    r76 = r10 * r19;
+    r76 = r76 * r73;
+    r91 = r10 * r29;
+    r91 = r91 * r82;
+    r92 = r76 + r91;
+    r93 = r90 + r92;
+    r77 = fma(r34, r77, r34 * r74);
+    r77 = r77 + r78;
+    r77 = fma(r8, r77, r9 * r93);
+    r93 = r19 * r82;
+    r93 = r93 * r86;
+    r72 = r72 + r93;
+    r77 = fma(r41, r72, r77);
+    r52 = r47 * r52;
+    r52 = 1.0 / r52;
+    r47 = r34 * r52;
+    r88 = r88 * r77;
+    r88 = fma(r47, r88, r39 * r71);
+    r71 = r28 * r28;
+    r71 = r71 * r47;
+    r72 = r10 * r28;
+    r94 = r19 * r34;
+    r95 = r34 * r29;
+    r95 = r95 * r82;
+    r94 = fma(r73, r94, r95);
+    r94 = r94 + r90;
+    r87 = r93 + r87;
+    r87 = fma(r9, r87, r41 * r94);
+    r94 = r10 * r29;
+    r94 = fma(r79, r94, r81);
+    r81 = r10 * r27;
+    r81 = fma(r73, r81, r83);
+    r94 = r94 + r81;
+    r87 = fma(r8, r94, r87);
+    r72 = r72 * r87;
+    r88 = fma(r39, r72, r88);
+    r88 = fma(r77, r71, r88);
+    r58 = r58 * r44;
+    r58 = r58 * r66;
+    r58 = r58 * r1;
+    r58 = r58 * r57;
+    r58 = r58 * r88;
+    r72 = r44 * r44;
+    r94 = r7 * r72;
+    r94 = r94 * r71;
+    r83 = r28 * r57;
+    r93 = r88 * r83;
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r90 = r30 * r46;
+    r96 = r28 * r7;
+    r93 = r93 * r90;
+    r93 = fma(r96, r93, r77 * r94);
+    r97 = r21 * r28;
+    r43 = r38 * r43;
+    r43 = 1.0 / r43;
+    r38 = r43 * r42;
+    r38 = r38 * r83;
+    r97 = r97 * r88;
+    r93 = fma(r38, r97, r93);
+    r98 = r59 * r96;
+    r93 = fma(r87, r98, r93);
+    r97 = r88 * r57;
+    r97 = r97 * r90;
+    r99 = r21 * r48;
+    r99 = r99 * r48;
+    r99 = r99 * r88;
+    r99 = r99 * r57;
+    r99 = r99 * r43;
+    r99 = fma(r42, r99, r54 * r97);
+    r97 = r84 * r53;
+    r99 = fma(r59, r97, r99);
+    r100 = r77 * r47;
+    r72 = r54 * r72;
+    r99 = fma(r72, r100, r99);
+    r100 = r93 + r99;
+    r97 = fma(r55, r100, r58);
+    r101 = r49 * r88;
+    r101 = r101 * r57;
+    r101 = r101 * r90;
+    r102 = r48 * r48;
+    r103 = -3.00000000000000000e+00;
+    r102 = r102 * r103;
+    r102 = r102 * r88;
+    r102 = r102 * r57;
+    r102 = r102 * r43;
+    r102 = fma(r42, r102, r54 * r101);
+    r101 = 6.00000000000000000e+00;
+    r104 = r84 * r101;
+    r104 = r104 * r42;
+    r102 = fma(r53, r104, r102);
+    r105 = -6.00000000000000000e+00;
+    r106 = r105 * r52;
+    r106 = r106 * r72;
+    r102 = fma(r77, r106, r102);
+    r102 = r102 + r93;
+    r93 = r84 * r98;
+    r104 = r21 * r48;
+    r104 = r104 * r63;
+    r104 = r104 * r77;
+    r104 = r104 * r67;
+    r97 = fma(r46, r104, r97);
+    r107 = r48 * r75;
+    r107 = r107 * r57;
+    r107 = r107 * r30;
+    r107 = r107 * r68;
+    r108 = r63 * r107;
+    r109 = r4 * r34;
+    r109 = r109 * r48;
+    r109 = r109 * r88;
+    r97 = fma(r38, r109, r97);
+    r110 = r4 * r87;
+    r110 = r110 * r53;
+    r97 = fma(r59, r110, r97);
+    r111 = r4 * r28;
+    r111 = r111 * r44;
+    r111 = r111 * r44;
+    r111 = r111 * r86;
+    r111 = r111 * r52;
+    r111 = r111 * r53;
+    r112 = r4 * r88;
+    r113 = r10 * r53;
+    r113 = r113 * r83;
+    r113 = r113 * r90;
+    r97 = fma(r113, r112, r97);
+    r114 = r61 * r10;
+    r114 = r114 * r45;
+    r114 = fma(r60, r100, r100 * r114);
+    r64 = r64 * r49;
+    r64 = r64 * r62;
+    r62 = 4.00000000000000000e+00;
+    r65 = r62 * r65;
+    r114 = fma(r100, r64, r114);
+    r114 = fma(r100, r65, r114);
+    r62 = r48 * r114;
+    r97 = fma(r69, r62, r97);
+    r115 = r21 * r48;
+    r115 = r115 * r77;
+    r115 = r115 * r67;
+    r97 = fma(r46, r115, r97);
+    r97 = fma(r5, r102, r97);
+    r97 = fma(r4, r93, r97);
+    r97 = fma(r63, r58, r97);
+    r97 = fma(r88, r108, r97);
+    r97 = fma(r84, r70, r97);
+    r97 = fma(r77, r111, r97);
+    r97 = fma(r88, r107, r97);
+    r97 = fma(r84, r69, r97);
+    r115 = r2 * r97;
+    r62 = r28 * r7;
+    r62 = r62 * r44;
+    r62 = r62 * r66;
+    r62 = r62 * r1;
+    r62 = r62 * r57;
+    r62 = r62 * r88;
+    r100 = fma(r56, r100, r62);
+    r112 = r28 * r28;
+    r112 = r112 * r44;
+    r112 = r112 * r44;
+    r112 = r112 * r77;
+    r112 = r112 * r105;
+    r112 = r112 * r7;
+    r110 = r49 * r88;
+    r110 = r110 * r83;
+    r110 = r110 * r90;
+    r110 = fma(r96, r110, r52 * r112);
+    r112 = r28 * r103;
+    r112 = r112 * r88;
+    r110 = fma(r38, r112, r110);
+    r109 = r28 * r87;
+    r109 = r109 * r101;
+    r109 = r109 * r7;
+    r110 = fma(r42, r109, r110);
+    r110 = r110 + r99;
+    r99 = r21 * r28;
+    r99 = r99 * r77;
+    r99 = r99 * r67;
+    r100 = fma(r46, r99, r100);
+    r109 = r5 * r34;
+    r109 = r109 * r48;
+    r109 = r109 * r38;
+    r112 = r75 * r88;
+    r112 = r112 * r30;
+    r112 = r112 * r83;
+    r100 = fma(r68, r112, r100);
+    r104 = r5 * r87;
+    r104 = r104 * r53;
+    r100 = fma(r59, r104, r100);
+    r58 = r5 * r28;
+    r58 = r58 * r44;
+    r58 = r58 * r44;
+    r58 = r58 * r86;
+    r58 = r58 * r77;
+    r58 = r58 * r52;
+    r100 = fma(r53, r58, r100);
+    r102 = r28 * r114;
+    r100 = fma(r69, r102, r100);
+    r116 = r5 * r88;
+    r100 = fma(r113, r116, r100);
+    r117 = r75 * r63;
+    r117 = r117 * r88;
+    r117 = r117 * r30;
+    r117 = r117 * r83;
+    r100 = fma(r68, r117, r100);
+    r118 = r21 * r28;
+    r118 = r118 * r63;
+    r118 = r118 * r77;
+    r118 = r118 * r67;
+    r100 = fma(r46, r118, r100);
+    r100 = fma(r4, r110, r100);
+    r100 = fma(r5, r93, r100);
+    r100 = fma(r63, r62, r100);
+    r100 = fma(r88, r109, r100);
+    r100 = fma(r87, r70, r100);
+    r100 = fma(r87, r69, r100);
+    r118 = r3 * r100;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r115,
+                                             r118);
+    r118 = r34 * r24;
+    r118 = fma(r79, r118, r95);
+    r115 = r10 * r27;
+    r117 = r15 * r14;
+    r116 = r12 * r17;
+    r116 = fma(r1, r116, r1 * r117);
+    r117 = r11 * r18;
+    r116 = fma(r75, r117, r116);
+    r102 = r16 * r13;
+    r116 = fma(r1, r102, r116);
+    r115 = r115 * r116;
+    r102 = r10 * r19;
+    r117 = r11 * r14;
+    r58 = r16 * r17;
+    r58 = fma(r75, r58, r75 * r117);
+    r117 = r15 * r18;
+    r58 = fma(r75, r117, r58);
+    r104 = r12 * r13;
+    r58 = fma(r1, r104, r58);
+    r102 = fma(r58, r102, r115);
+    r118 = r118 + r102;
+    r104 = r10 * r24;
+    r104 = r104 * r58;
+    r117 = r10 * r29;
+    r117 = fma(r116, r117, r104);
+    r117 = r117 + r78;
+    r117 = fma(r9, r117, r8 * r118);
+    r118 = r24 * r82;
+    r118 = r118 * r86;
+    r78 = r19 * r116;
+    r112 = r86 * r78;
+    r62 = r118 + r112;
+    r117 = fma(r41, r62, r117);
+    r91 = r89 + r91;
+    r91 = r91 + r102;
+    r102 = r27 * r86;
+    r102 = r102 * r58;
+    r118 = r118 + r102;
+    r118 = fma(r8, r118, r41 * r91);
+    r91 = r34 * r29;
+    r91 = fma(r34, r85, r58 * r91);
+    r89 = r10 * r19;
+    r89 = r89 * r82;
+    r62 = r10 * r24;
+    r62 = fma(r116, r62, r89);
+    r91 = r91 + r62;
+    r118 = fma(r9, r91, r118);
+    r91 = r101 * r118;
+    r91 = r91 * r42;
+    r91 = fma(r53, r91, r117 * r106);
+    r99 = r48 * r48;
+    r93 = r10 * r48;
+    r93 = r93 * r118;
+    r110 = r10 * r28;
+    r104 = r80 + r104;
+    r80 = r19 * r34;
+    r104 = fma(r79, r80, r104);
+    r79 = r34 * r29;
+    r104 = fma(r116, r79, r104);
+    r79 = r10 * r29;
+    r85 = fma(r10, r85, r58 * r79);
+    r85 = r85 + r62;
+    r85 = fma(r8, r85, r41 * r104);
+    r112 = r102 + r112;
+    r85 = fma(r9, r112, r85);
+    r110 = r110 * r85;
+    r110 = fma(r39, r110, r39 * r93);
+    r93 = r48 * r48;
+    r93 = r93 * r117;
+    r110 = fma(r47, r93, r110);
+    r110 = fma(r117, r71, r110);
+    r93 = r103 * r110;
+    r99 = r99 * r57;
+    r99 = r99 * r43;
+    r99 = r99 * r42;
+    r91 = fma(r93, r99, r91);
+    r112 = r49 * r110;
+    r112 = r112 * r57;
+    r112 = r112 * r90;
+    r91 = fma(r54, r112, r91);
+    r102 = r21 * r28;
+    r102 = r102 * r110;
+    r102 = fma(r38, r102, r85 * r98);
+    r104 = r110 * r83;
+    r104 = r104 * r90;
+    r102 = fma(r96, r104, r102);
+    r102 = fma(r117, r94, r102);
+    r91 = r91 + r102;
+    r112 = r117 * r47;
+    r99 = r118 * r53;
+    r99 = fma(r59, r99, r72 * r112);
+    r112 = r21 * r48;
+    r112 = r112 * r48;
+    r112 = r112 * r110;
+    r112 = r112 * r57;
+    r112 = r112 * r43;
+    r99 = fma(r42, r112, r99);
+    r104 = r110 * r57;
+    r104 = r104 * r90;
+    r99 = fma(r54, r104, r99);
+    r102 = r102 + r99;
+    r91 = fma(r55, r102, r5 * r91);
+    r104 = r21 * r48;
+    r104 = r104 * r117;
+    r104 = r104 * r67;
+    r91 = fma(r46, r104, r91);
+    r112 = r44 * r63;
+    r112 = r112 * r1;
+    r112 = r112 * r110;
+    r112 = r112 * r66;
+    r112 = r112 * r57;
+    r91 = fma(r53, r112, r91);
+    r79 = r61 * r10;
+    r79 = r79 * r45;
+    r79 = fma(r102, r79, r60 * r102);
+    r79 = fma(r102, r65, r79);
+    r79 = fma(r102, r64, r79);
+    r58 = r48 * r79;
+    r91 = fma(r69, r58, r91);
+    r80 = r21 * r48;
+    r80 = r80 * r63;
+    r80 = r80 * r117;
+    r80 = r80 * r67;
+    r91 = fma(r46, r80, r91);
+    r119 = r4 * r110;
+    r91 = fma(r113, r119, r91);
+    r120 = r4 * r34;
+    r120 = r120 * r48;
+    r120 = r120 * r110;
+    r91 = fma(r38, r120, r91);
+    r121 = r4 * r85;
+    r121 = r121 * r53;
+    r91 = fma(r59, r121, r91);
+    r122 = r4 * r118;
+    r91 = fma(r98, r122, r91);
+    r123 = r44 * r1;
+    r123 = r123 * r110;
+    r123 = r123 * r66;
+    r123 = r123 * r57;
+    r91 = fma(r53, r123, r91);
+    r91 = fma(r110, r108, r91);
+    r91 = fma(r110, r107, r91);
+    r91 = fma(r117, r111, r91);
+    r91 = fma(r118, r69, r91);
+    r91 = fma(r118, r70, r91);
+    r123 = r2 * r91;
+    r122 = r28 * r101;
+    r122 = r122 * r85;
+    r122 = r122 * r7;
+    r121 = r28 * r38;
+    r121 = fma(r93, r121, r42 * r122);
+    r122 = r28 * r28;
+    r122 = r122 * r44;
+    r122 = r122 * r44;
+    r122 = r122 * r105;
+    r122 = r122 * r117;
+    r122 = r122 * r7;
+    r121 = fma(r52, r122, r121);
+    r93 = r49 * r110;
+    r93 = r93 * r83;
+    r93 = r93 * r90;
+    r121 = fma(r96, r93, r121);
+    r121 = r121 + r99;
+    r102 = fma(r56, r102, r4 * r121);
+    r121 = r44 * r1;
+    r121 = r121 * r110;
+    r121 = r121 * r7;
+    r121 = r121 * r66;
+    r102 = fma(r83, r121, r102);
+    r99 = r28 * r79;
+    r102 = fma(r69, r99, r102);
+    r93 = r75 * r110;
+    r93 = r93 * r30;
+    r93 = r93 * r83;
+    r102 = fma(r68, r93, r102);
+    r122 = r5 * r28;
+    r122 = r122 * r44;
+    r122 = r122 * r44;
+    r122 = r122 * r86;
+    r122 = r122 * r117;
+    r122 = r122 * r52;
+    r102 = fma(r53, r122, r102);
+    r120 = r5 * r110;
+    r102 = fma(r113, r120, r102);
+    r119 = r21 * r28;
+    r119 = r119 * r63;
+    r119 = r119 * r117;
+    r119 = r119 * r67;
+    r102 = fma(r46, r119, r102);
+    r80 = r44 * r63;
+    r80 = r80 * r1;
+    r80 = r80 * r110;
+    r80 = r80 * r7;
+    r80 = r80 * r66;
+    r102 = fma(r83, r80, r102);
+    r58 = r21 * r28;
+    r58 = r58 * r117;
+    r58 = r58 * r67;
+    r102 = fma(r46, r58, r102);
+    r112 = r5 * r85;
+    r112 = r112 * r53;
+    r102 = fma(r59, r112, r102);
+    r104 = r75 * r63;
+    r104 = r104 * r110;
+    r104 = r104 * r30;
+    r104 = r104 * r83;
+    r102 = fma(r68, r104, r102);
+    r124 = r5 * r118;
+    r102 = fma(r98, r124, r102);
+    r102 = fma(r85, r70, r102);
+    r102 = fma(r110, r109, r102);
+    r102 = fma(r85, r69, r102);
+    r124 = r3 * r102;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r124);
+    r124 = r19 * r86;
+    r26 = fma(r1, r26, r75 * r22);
+    r26 = fma(r75, r23, r26);
+    r26 = fma(r75, r25, r26);
+    r124 = r124 * r26;
+    r74 = r86 * r74;
+    r25 = r124 + r74;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r89 = r89 + r23;
+    r22 = r34 * r24;
+    r89 = fma(r116, r22, r89);
+    r123 = r34 * r29;
+    r89 = fma(r73, r123, r89);
+    r89 = fma(r8, r89, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r78, r26 * r25);
+    r25 = r25 + r81;
+    r89 = fma(r9, r25, r89);
+    r25 = r10 * r28;
+    r123 = r10 * r24;
+    r123 = r123 * r26;
+    r115 = r115 + r123;
+    r115 = r115 + r92;
+    r92 = r34 * r29;
+    r78 = fma(r34, r78, r26 * r92);
+    r78 = r78 + r81;
+    r78 = fma(r41, r78, r8 * r115);
+    r82 = r27 * r82;
+    r82 = r82 * r86;
+    r124 = r124 + r82;
+    r78 = fma(r9, r124, r78);
+    r25 = r25 * r78;
+    r124 = r48 * r48;
+    r124 = r124 * r89;
+    r124 = fma(r47, r124, r39 * r25);
+    r25 = r10 * r48;
+    r95 = r76 + r95;
+    r76 = r27 * r34;
+    r95 = fma(r116, r76, r95);
+    r95 = r95 + r123;
+    r74 = r82 + r74;
+    r74 = fma(r8, r74, r9 * r95);
+    r8 = r10 * r29;
+    r8 = fma(r73, r8, r23);
+    r8 = r8 + r62;
+    r74 = fma(r41, r8, r74);
+    r25 = r25 * r74;
+    r124 = fma(r39, r25, r124);
+    r124 = fma(r89, r71, r124);
+    r25 = r124 * r83;
+    r25 = r25 * r90;
+    r25 = fma(r96, r25, r89 * r94);
+    r8 = r21 * r28;
+    r8 = r8 * r124;
+    r25 = fma(r38, r8, r25);
+    r25 = fma(r78, r98, r25);
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r41 = r74 * r53;
+    r41 = fma(r59, r41, r42 * r8);
+    r8 = r89 * r47;
+    r41 = fma(r72, r8, r41);
+    r62 = r124 * r57;
+    r62 = r62 * r90;
+    r41 = fma(r54, r62, r41);
+    r62 = r25 + r41;
+    r8 = r48 * r48;
+    r8 = r8 * r103;
+    r8 = r8 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r23 = r101 * r74;
+    r23 = r23 * r42;
+    r23 = fma(r53, r23, r42 * r8);
+    r8 = r49 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r90;
+    r23 = fma(r54, r8, r23);
+    r23 = fma(r89, r106, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r55 * r62);
+    r25 = r61 * r10;
+    r25 = r25 * r45;
+    r25 = fma(r62, r25, r60 * r62);
+    r25 = fma(r62, r64, r25);
+    r25 = fma(r62, r65, r25);
+    r8 = r48 * r25;
+    r23 = fma(r69, r8, r23);
+    r73 = r4 * r74;
+    r23 = fma(r98, r73, r23);
+    r95 = r4 * r124;
+    r23 = fma(r113, r95, r23);
+    r9 = r21 * r48;
+    r9 = r9 * r63;
+    r9 = r9 * r89;
+    r9 = r9 * r67;
+    r23 = fma(r46, r9, r23);
+    r82 = r4 * r34;
+    r82 = r82 * r48;
+    r82 = r82 * r124;
+    r23 = fma(r38, r82, r23);
+    r76 = r21 * r48;
+    r76 = r76 * r89;
+    r76 = r76 * r67;
+    r23 = fma(r46, r76, r23);
+    r123 = r44 * r1;
+    r123 = r123 * r124;
+    r123 = r123 * r66;
+    r123 = r123 * r57;
+    r23 = fma(r53, r123, r23);
+    r116 = r4 * r78;
+    r116 = r116 * r53;
+    r23 = fma(r59, r116, r23);
+    r115 = r44 * r63;
+    r115 = r115 * r1;
+    r115 = r115 * r124;
+    r115 = r115 * r66;
+    r115 = r115 * r57;
+    r23 = fma(r53, r115, r23);
+    r23 = fma(r124, r107, r23);
+    r23 = fma(r124, r108, r23);
+    r23 = fma(r74, r70, r23);
+    r23 = fma(r74, r69, r23);
+    r23 = fma(r89, r111, r23);
+    r115 = r2 * r23;
+    r116 = r28 * r28;
+    r116 = r116 * r44;
+    r116 = r116 * r44;
+    r116 = r116 * r105;
+    r116 = r116 * r89;
+    r116 = r116 * r7;
+    r123 = r49 * r124;
+    r123 = r123 * r83;
+    r123 = r123 * r90;
+    r123 = fma(r96, r123, r52 * r116);
+    r116 = r28 * r101;
+    r116 = r116 * r78;
+    r116 = r116 * r7;
+    r123 = fma(r42, r116, r123);
+    r76 = r28 * r103;
+    r76 = r76 * r124;
+    r123 = fma(r38, r76, r123);
+    r123 = r123 + r41;
+    r123 = fma(r4, r123, r56 * r62);
+    r62 = r21 * r28;
+    r62 = r62 * r63;
+    r62 = r62 * r89;
+    r62 = r62 * r67;
+    r123 = fma(r46, r62, r123);
+    r41 = r21 * r28;
+    r41 = r41 * r89;
+    r41 = r41 * r67;
+    r123 = fma(r46, r41, r123);
+    r76 = r5 * r74;
+    r123 = fma(r98, r76, r123);
+    r116 = r44 * r63;
+    r116 = r116 * r1;
+    r116 = r116 * r124;
+    r116 = r116 * r7;
+    r116 = r116 * r66;
+    r123 = fma(r83, r116, r123);
+    r82 = r5 * r124;
+    r123 = fma(r113, r82, r123);
+    r9 = r75 * r124;
+    r9 = r9 * r30;
+    r9 = r9 * r83;
+    r123 = fma(r68, r9, r123);
+    r95 = r28 * r25;
+    r123 = fma(r69, r95, r123);
+    r73 = r44 * r1;
+    r73 = r73 * r124;
+    r73 = r73 * r7;
+    r73 = r73 * r66;
+    r123 = fma(r83, r73, r123);
+    r8 = r75 * r63;
+    r8 = r8 * r124;
+    r8 = r8 * r30;
+    r8 = r8 * r83;
+    r123 = fma(r68, r8, r123);
+    r81 = r5 * r28;
+    r81 = r81 * r44;
+    r81 = r81 * r44;
+    r81 = r81 * r86;
+    r81 = r81 * r89;
+    r81 = r81 * r52;
+    r123 = fma(r53, r81, r123);
+    r92 = r5 * r78;
+    r92 = r92 * r53;
+    r123 = fma(r59, r92, r123);
+    r123 = fma(r78, r70, r123);
+    r123 = fma(r78, r69, r123);
+    r123 = fma(r124, r109, r123);
+    r92 = r3 * r123;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r115, r92);
+    r92 = r36 * r101;
+    r92 = r92 * r42;
+    r115 = r48 * r48;
+    r81 = r10 * r32;
+    r81 = r81 * r28;
+    r81 = fma(r6, r71, r39 * r81);
+    r8 = r6 * r48;
+    r8 = r8 * r48;
+    r81 = fma(r47, r8, r81);
+    r73 = r10 * r36;
+    r73 = r73 * r48;
+    r81 = fma(r39, r73, r81);
+    r115 = r115 * r103;
+    r115 = r115 * r81;
+    r115 = r115 * r57;
+    r115 = r115 * r43;
+    r115 = fma(r42, r115, r53 * r92);
+    r92 = r49 * r81;
+    r92 = r92 * r57;
+    r92 = r92 * r90;
+    r115 = fma(r54, r92, r115);
+    r73 = r21 * r28;
+    r73 = r73 * r81;
+    r73 = fma(r38, r73, r32 * r98);
+    r8 = r81 * r83;
+    r8 = r8 * r90;
+    r73 = fma(r96, r8, r73);
+    r73 = fma(r6, r94, r73);
+    r115 = fma(r6, r106, r115);
+    r115 = r115 + r73;
+    r92 = r36 * r53;
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r81;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r8 = fma(r42, r8, r59 * r92);
+    r92 = r81 * r57;
+    r92 = r92 * r90;
+    r8 = fma(r54, r92, r8);
+    r95 = r6 * r47;
+    r8 = fma(r72, r95, r8);
+    r73 = r73 + r8;
+    r115 = fma(r55, r73, r5 * r115);
+    r95 = r81 * r113;
+    r92 = r44 * r63;
+    r92 = r92 * r1;
+    r92 = r92 * r81;
+    r92 = r92 * r66;
+    r92 = r92 * r57;
+    r115 = fma(r53, r92, r115);
+    r9 = r44 * r1;
+    r9 = r9 * r81;
+    r9 = r9 * r66;
+    r9 = r9 * r57;
+    r115 = fma(r53, r9, r115);
+    r82 = r4 * r34;
+    r82 = r82 * r48;
+    r82 = r82 * r81;
+    r115 = fma(r38, r82, r115);
+    r116 = r61 * r10;
+    r116 = r116 * r45;
+    r116 = fma(r60, r73, r73 * r116);
+    r116 = fma(r73, r65, r116);
+    r116 = fma(r73, r64, r116);
+    r76 = r48 * r116;
+    r115 = fma(r69, r76, r115);
+    r41 = r21 * r6;
+    r41 = r41 * r48;
+    r41 = r41 * r63;
+    r41 = r41 * r67;
+    r115 = fma(r46, r41, r115);
+    r62 = r21 * r6;
+    r62 = r62 * r48;
+    r62 = r62 * r67;
+    r115 = fma(r46, r62, r115);
+    r26 = r4 * r32;
+    r26 = r26 * r53;
+    r115 = fma(r59, r26, r115);
+    r22 = r4 * r36;
+    r115 = fma(r98, r22, r115);
+    r115 = fma(r36, r70, r115);
+    r115 = fma(r81, r108, r115);
+    r115 = fma(r4, r95, r115);
+    r115 = fma(r81, r107, r115);
+    r115 = fma(r6, r111, r115);
+    r115 = fma(r36, r69, r115);
+    r22 = r2 * r115;
+    r26 = r32 * r28;
+    r26 = r26 * r101;
+    r26 = r26 * r7;
+    r62 = r28 * r103;
+    r62 = r62 * r81;
+    r62 = fma(r38, r62, r42 * r26);
+    r26 = r6 * r28;
+    r26 = r26 * r28;
+    r26 = r26 * r44;
+    r26 = r26 * r44;
+    r26 = r26 * r105;
+    r26 = r26 * r7;
+    r62 = fma(r52, r26, r62);
+    r41 = r49 * r81;
+    r41 = r41 * r83;
+    r41 = r41 * r90;
+    r62 = fma(r96, r41, r62);
+    r62 = r62 + r8;
+    r73 = fma(r56, r73, r4 * r62);
+    r62 = r75 * r81;
+    r62 = r62 * r30;
+    r62 = r62 * r83;
+    r73 = fma(r68, r62, r73);
+    r8 = r44 * r63;
+    r8 = r8 * r1;
+    r8 = r8 * r81;
+    r8 = r8 * r7;
+    r8 = r8 * r66;
+    r73 = fma(r83, r8, r73);
+    r41 = r21 * r6;
+    r41 = r41 * r28;
+    r41 = r41 * r63;
+    r41 = r41 * r67;
+    r73 = fma(r46, r41, r73);
+    r26 = r21 * r6;
+    r26 = r26 * r28;
+    r26 = r26 * r67;
+    r73 = fma(r46, r26, r73);
+    r76 = r5 * r6;
+    r76 = r76 * r28;
+    r76 = r76 * r44;
+    r76 = r76 * r44;
+    r76 = r76 * r86;
+    r76 = r76 * r52;
+    r73 = fma(r53, r76, r73);
+    r82 = r28 * r116;
+    r73 = fma(r69, r82, r73);
+    r9 = r75 * r63;
+    r9 = r9 * r81;
+    r9 = r9 * r30;
+    r9 = r9 * r83;
+    r73 = fma(r68, r9, r73);
+    r92 = r5 * r32;
+    r92 = r92 * r53;
+    r73 = fma(r59, r92, r73);
+    r104 = r44 * r1;
+    r104 = r104 * r81;
+    r104 = r104 * r7;
+    r104 = r104 * r66;
+    r73 = fma(r83, r104, r73);
+    r112 = r5 * r36;
+    r73 = fma(r98, r112, r73);
+    r73 = fma(r32, r69, r73);
+    r73 = fma(r5, r95, r73);
+    r73 = fma(r81, r109, r73);
+    r73 = fma(r32, r70, r73);
+    r112 = r3 * r73;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r112);
+    r112 = r10 * r37;
+    r112 = r112 * r28;
+    r112 = fma(r39, r112, r33 * r71);
+    r22 = r33 * r48;
+    r22 = r22 * r48;
+    r112 = fma(r47, r22, r112);
+    r104 = r10 * r51;
+    r104 = r104 * r48;
+    r112 = fma(r39, r104, r112);
+    r104 = r49 * r112;
+    r104 = r104 * r57;
+    r104 = r104 * r90;
+    r104 = fma(r33, r106, r54 * r104);
+    r22 = r48 * r48;
+    r22 = r22 * r103;
+    r22 = r22 * r112;
+    r22 = r22 * r57;
+    r22 = r22 * r43;
+    r104 = fma(r42, r22, r104);
+    r92 = r51 * r101;
+    r92 = r92 * r42;
+    r104 = fma(r53, r92, r104);
+    r9 = fma(r37, r98, r33 * r94);
+    r82 = r112 * r83;
+    r82 = r82 * r90;
+    r9 = fma(r96, r82, r9);
+    r76 = r21 * r28;
+    r76 = r76 * r112;
+    r9 = fma(r38, r76, r9);
+    r104 = r104 + r9;
+    r92 = r112 * r57;
+    r92 = r92 * r90;
+    r22 = r33 * r47;
+    r22 = fma(r72, r22, r54 * r92);
+    r92 = r21 * r48;
+    r92 = r92 * r48;
+    r92 = r92 * r112;
+    r92 = r92 * r57;
+    r92 = r92 * r43;
+    r22 = fma(r42, r92, r22);
+    r76 = r51 * r53;
+    r22 = fma(r59, r76, r22);
+    r9 = r9 + r22;
+    r104 = fma(r55, r9, r5 * r104);
+    r76 = r4 * r37;
+    r76 = r76 * r53;
+    r104 = fma(r59, r76, r104);
+    r92 = r4 * r112;
+    r104 = fma(r113, r92, r104);
+    r82 = r21 * r33;
+    r82 = r82 * r48;
+    r82 = r82 * r67;
+    r104 = fma(r46, r82, r104);
+    r26 = r4 * r34;
+    r26 = r26 * r48;
+    r26 = r26 * r112;
+    r104 = fma(r38, r26, r104);
+    r95 = r44 * r1;
+    r95 = r95 * r112;
+    r95 = r95 * r66;
+    r95 = r95 * r57;
+    r104 = fma(r53, r95, r104);
+    r41 = r61 * r10;
+    r41 = r41 * r45;
+    r41 = fma(r60, r9, r9 * r41);
+    r41 = fma(r9, r64, r41);
+    r41 = fma(r9, r65, r41);
+    r8 = r48 * r41;
+    r104 = fma(r69, r8, r104);
+    r62 = r44 * r63;
+    r62 = r62 * r1;
+    r62 = r62 * r112;
+    r62 = r62 * r66;
+    r62 = r62 * r57;
+    r104 = fma(r53, r62, r104);
+    r58 = r21 * r33;
+    r58 = r58 * r48;
+    r58 = r58 * r63;
+    r58 = r58 * r67;
+    r104 = fma(r46, r58, r104);
+    r80 = r4 * r51;
+    r104 = fma(r98, r80, r104);
+    r104 = fma(r112, r108, r104);
+    r104 = fma(r51, r69, r104);
+    r104 = fma(r33, r111, r104);
+    r104 = fma(r112, r107, r104);
+    r104 = fma(r51, r70, r104);
+    r80 = r2 * r104;
+    r58 = r33 * r28;
+    r58 = r58 * r28;
+    r58 = r58 * r44;
+    r58 = r58 * r44;
+    r58 = r58 * r105;
+    r58 = r58 * r7;
+    r62 = r37 * r28;
+    r62 = r62 * r101;
+    r62 = r62 * r7;
+    r62 = fma(r42, r62, r52 * r58);
+    r58 = r49 * r112;
+    r58 = r58 * r83;
+    r58 = r58 * r90;
+    r62 = fma(r96, r58, r62);
+    r8 = r28 * r103;
+    r8 = r8 * r112;
+    r62 = fma(r38, r8, r62);
+    r62 = r62 + r22;
+    r62 = fma(r4, r62, r56 * r9);
+    r9 = r21 * r33;
+    r9 = r9 * r28;
+    r9 = r9 * r67;
+    r62 = fma(r46, r9, r62);
+    r22 = r5 * r37;
+    r22 = r22 * r53;
+    r62 = fma(r59, r22, r62);
+    r8 = r5 * r112;
+    r62 = fma(r113, r8, r62);
+    r58 = r75 * r112;
+    r58 = r58 * r30;
+    r58 = r58 * r83;
+    r62 = fma(r68, r58, r62);
+    r95 = r28 * r41;
+    r62 = fma(r69, r95, r62);
+    r26 = r44 * r63;
+    r26 = r26 * r1;
+    r26 = r26 * r112;
+    r26 = r26 * r7;
+    r26 = r26 * r66;
+    r62 = fma(r83, r26, r62);
+    r82 = r5 * r33;
+    r82 = r82 * r28;
+    r82 = r82 * r44;
+    r82 = r82 * r44;
+    r82 = r82 * r86;
+    r82 = r82 * r52;
+    r62 = fma(r53, r82, r62);
+    r92 = r44 * r1;
+    r92 = r92 * r112;
+    r92 = r92 * r7;
+    r92 = r92 * r66;
+    r62 = fma(r83, r92, r62);
+    r76 = r75 * r63;
+    r76 = r76 * r112;
+    r76 = r76 * r30;
+    r76 = r76 * r83;
+    r62 = fma(r68, r76, r62);
+    r119 = r21 * r33;
+    r119 = r119 * r28;
+    r119 = r119 * r63;
+    r119 = r119 * r67;
+    r62 = fma(r46, r119, r62);
+    r120 = r5 * r51;
+    r62 = fma(r98, r120, r62);
+    r62 = fma(r37, r70, r62);
+    r62 = fma(r112, r109, r62);
+    r62 = fma(r37, r69, r62);
+    r120 = r3 * r62;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r80, r120);
+    r120 = r48 * r48;
+    r80 = r10 * r40;
+    r80 = r80 * r28;
+    r71 = fma(r31, r71, r39 * r80);
+    r80 = r10 * r50;
+    r80 = r80 * r48;
+    r71 = fma(r39, r80, r71);
+    r39 = r31 * r48;
+    r39 = r39 * r48;
+    r71 = fma(r47, r39, r71);
+    r120 = r120 * r103;
+    r120 = r120 * r71;
+    r120 = r120 * r57;
+    r120 = r120 * r43;
+    r39 = r49 * r71;
+    r39 = r39 * r57;
+    r39 = r39 * r90;
+    r39 = fma(r54, r39, r42 * r120);
+    r120 = r50 * r101;
+    r120 = r120 * r42;
+    r39 = fma(r53, r120, r39);
+    r94 = fma(r40, r98, r31 * r94);
+    r80 = r71 * r83;
+    r80 = r80 * r90;
+    r94 = fma(r96, r80, r94);
+    r119 = r21 * r28;
+    r119 = r119 * r71;
+    r94 = fma(r38, r119, r94);
+    r39 = fma(r31, r106, r39);
+    r39 = r39 + r94;
+    r106 = r21 * r48;
+    r106 = r106 * r48;
+    r106 = r106 * r71;
+    r106 = r106 * r57;
+    r106 = r106 * r43;
+    r43 = r71 * r57;
+    r43 = r43 * r90;
+    r43 = fma(r54, r43, r42 * r106);
+    r106 = r50 * r53;
+    r43 = fma(r59, r106, r43);
+    r54 = r31 * r47;
+    r43 = fma(r72, r54, r43);
+    r94 = r94 + r43;
+    r55 = fma(r55, r94, r5 * r39);
+    r39 = r4 * r50;
+    r55 = fma(r98, r39, r55);
+    r54 = r4 * r40;
+    r54 = r54 * r53;
+    r55 = fma(r59, r54, r55);
+    r106 = r61 * r10;
+    r106 = r106 * r45;
+    r106 = fma(r94, r106, r60 * r94);
+    r106 = fma(r94, r65, r106);
+    r106 = fma(r94, r64, r106);
+    r64 = r48 * r106;
+    r55 = fma(r69, r64, r55);
+    r65 = r4 * r71;
+    r55 = fma(r113, r65, r55);
+    r60 = r21 * r31;
+    r60 = r60 * r48;
+    r60 = r60 * r67;
+    r55 = fma(r46, r60, r55);
+    r45 = r44 * r63;
+    r45 = r45 * r1;
+    r45 = r45 * r71;
+    r45 = r45 * r66;
+    r45 = r45 * r57;
+    r55 = fma(r53, r45, r55);
+    r72 = r4 * r34;
+    r72 = r72 * r48;
+    r72 = r72 * r71;
+    r55 = fma(r38, r72, r55);
+    r120 = r21 * r31;
+    r120 = r120 * r48;
+    r120 = r120 * r63;
+    r120 = r120 * r67;
+    r55 = fma(r46, r120, r55);
+    r119 = r44 * r1;
+    r119 = r119 * r71;
+    r119 = r119 * r66;
+    r119 = r119 * r57;
+    r55 = fma(r53, r119, r55);
+    r55 = fma(r50, r70, r55);
+    r55 = fma(r31, r111, r55);
+    r55 = fma(r71, r108, r55);
+    r55 = fma(r71, r107, r55);
+    r55 = fma(r50, r69, r55);
+    r119 = r2 * r55;
+    r120 = r31 * r28;
+    r120 = r120 * r28;
+    r120 = r120 * r44;
+    r120 = r120 * r44;
+    r120 = r120 * r105;
+    r120 = r120 * r7;
+    r105 = r40 * r28;
+    r105 = r105 * r101;
+    r105 = r105 * r7;
+    r105 = fma(r42, r105, r52 * r120);
+    r120 = r49 * r71;
+    r120 = r120 * r83;
+    r120 = r120 * r90;
+    r105 = fma(r96, r120, r105);
+    r96 = r28 * r103;
+    r96 = r96 * r71;
+    r105 = fma(r38, r96, r105);
+    r105 = r105 + r43;
+    r105 = fma(r4, r105, r56 * r94);
+    r94 = r44 * r1;
+    r94 = r94 * r71;
+    r94 = r94 * r7;
+    r94 = r94 * r66;
+    r105 = fma(r83, r94, r105);
+    r56 = r21 * r31;
+    r56 = r56 * r28;
+    r56 = r56 * r67;
+    r105 = fma(r46, r56, r105);
+    r43 = r5 * r50;
+    r105 = fma(r98, r43, r105);
+    r98 = r21 * r31;
+    r98 = r98 * r28;
+    r98 = r98 * r63;
+    r98 = r98 * r67;
+    r105 = fma(r46, r98, r105);
+    r46 = r75 * r63;
+    r46 = r46 * r71;
+    r46 = r46 * r30;
+    r46 = r46 * r83;
+    r105 = fma(r68, r46, r105);
+    r67 = r5 * r31;
+    r67 = r67 * r28;
+    r67 = r67 * r44;
+    r67 = r67 * r44;
+    r67 = r67 * r86;
+    r67 = r67 * r52;
+    r105 = fma(r53, r67, r105);
+    r52 = r5 * r40;
+    r52 = r52 * r53;
+    r105 = fma(r59, r52, r105);
+    r59 = r44 * r63;
+    r59 = r59 * r1;
+    r59 = r59 * r71;
+    r59 = r59 * r7;
+    r59 = r59 * r66;
+    r105 = fma(r83, r59, r105);
+    r66 = r5 * r71;
+    r105 = fma(r113, r66, r105);
+    r113 = r75 * r71;
+    r113 = r113 * r30;
+    r113 = r113 * r83;
+    r105 = fma(r68, r113, r105);
+    r68 = r28 * r106;
+    r105 = fma(r69, r68, r105);
+    r105 = fma(r40, r69, r105);
+    r105 = fma(r40, r70, r105);
+    r105 = fma(r71, r109, r105);
+    r109 = r3 * r105;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r119,
+                                             r109);
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r20 = r21 * r20;
+    r119 = r2 * r20;
+    r109 = fma(r97, r119, r100 * r109);
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r68 = fma(r91, r119, r102 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r109, r68);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r68 = fma(r23, r119, r123 * r68);
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r109 = fma(r115, r119, r73 * r109);
+    WriteSum2<double, double>((double*)inout_shared, r68, r109);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r109 = fma(r104, r119, r62 * r109);
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r119 = fma(r55, r119, r105 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r109, r119);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r2 * r2;
+    r119 = r97 * r2;
+    r109 = r3 * r3;
+    r68 = r100 * r109;
+    r100 = fma(r100, r68, r97 * r119);
+    r97 = r91 * r91;
+    r113 = r102 * r102;
+    r113 = fma(r109, r113, r2 * r97);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r23 * r23;
+    r100 = r123 * r123;
+    r100 = fma(r109, r100, r2 * r113);
+    r113 = r73 * r73;
+    r97 = r115 * r115;
+    r97 = fma(r2, r97, r109 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r100, r97);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r97 = r104 * r104;
+    r100 = r62 * r62;
+    r100 = fma(r109, r100, r2 * r97);
+    r97 = r105 * r105;
+    r113 = r55 * r55;
+    r113 = fma(r2, r113, r109 * r97);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = fma(r91, r119, r102 * r68);
+    r100 = fma(r123, r68, r23 * r119);
+    WriteSum2<double, double>((double*)inout_shared, r113, r100);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = fma(r73, r68, r115 * r119);
+    r113 = fma(r62, r68, r104 * r119);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r119 = fma(r55, r119, r105 * r68);
+    r68 = r102 * r123;
+    r113 = r91 * r23;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r91 * r115;
+    r119 = r102 * r73;
+    r119 = fma(r109, r119, r2 * r113);
+    r113 = r91 * r104;
+    r68 = r102 * r62;
+    r68 = fma(r109, r68, r2 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r119, r68);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r102 * r105;
+    r119 = r91 * r55;
+    r119 = fma(r2, r119, r109 * r68);
+    r68 = r123 * r73;
+    r113 = r23 * r115;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r23 * r104;
+    r119 = r123 * r62;
+    r119 = fma(r109, r119, r2 * r113);
+    r113 = r123 * r105;
+    r68 = r23 * r55;
+    r68 = fma(r2, r68, r109 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r119, r68);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r115 * r104;
+    r119 = r73 * r62;
+    r119 = fma(r109, r119, r2 * r68);
+    r68 = r73 * r105;
+    r113 = r115 * r55;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r62 * r105;
+    r119 = r104 * r55;
+    r119 = fma(r2, r119, r109 * r113);
+    WriteSum1<double, double>((double*)inout_shared, r119);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r20, r0);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r35, r35);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacKernel<<<n_blocks,
+                                                                  1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.cu
@@ -1,0 +1,1779 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r28 * r28;
+    r43 = 1.00000000000000008e-15;
+    r47 = r34 * r24;
+    r47 = r47 * r24;
+    r48 = r35 + r47;
+    r48 = r48 + r44;
+    r48 = fma(r8, r48, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r49 = r17 * r13;
+    r49 = r49 * r10;
+    r50 = r18 * r14;
+    r50 = fma(r10, r50, r49);
+    r51 = r13 * r14;
+    r51 = fma(r34, r51, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r48 = fma(r9, r6, r48);
+    r48 = fma(r41, r44, r48);
+    r48 = fma(r38, r50, r48);
+    r48 = fma(r30, r51, r48);
+    r48 = fma(r7, r36, r48);
+    r44 = r48 * r48;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r6);
+    r52 = r34 * r24;
+    r52 = fma(r29, r52, r20);
+    r52 = fma(r8, r52, r6);
+    r6 = r18 * r14;
+    r6 = fma(r34, r6, r49);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r47 = r35 + r47;
+    r47 = r47 + r46;
+    r52 = fma(r7, r6, r52);
+    r52 = fma(r38, r31, r52);
+    r52 = fma(r30, r33, r52);
+    r52 = fma(r9, r39, r52);
+    r52 = fma(r41, r47, r52);
+    r47 = copysign(1.0, r52);
+    r47 = fma(r43, r47, r52);
+    r52 = r47 * r47;
+    r39 = 1.0 / r52;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = copysign(1.0, r44);
+    r38 = fma(r43, r38, r44);
+    r43 = r38 * r38;
+    r7 = 1.0 / r43;
+    r44 = atan(r44);
+    r46 = r44 * r39;
+    r42 = r44 * r46;
+    r45 = r45 * r7;
+    r45 = r45 * r42;
+    r49 = 3.00000000000000000e+00;
+    r20 = r49 * r42;
+    r53 = r48 * r7;
+    r54 = r48 * r53;
+    r20 = fma(r54, r20, r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r55,
+                                            r56);
+    r57 = r42 * r54;
+    r45 = r45 + r57;
+    r20 = fma(r55, r45, r5 * r20);
+    r58 = r4 * r28;
+    r59 = r10 * r42;
+    r58 = r58 * r53;
+    r20 = fma(r59, r58, r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r60,
+                                            r61);
+    r62 = r45 * r45;
+    r63 = fma(r61, r62, r60 * r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r45 * r62;
+    r65 = r65 * r66;
+    r63 = fma(r45, r65, r63);
+    r63 = fma(r64, r66, r63);
+    r66 = 1.0 / r47;
+    r67 = 1.0 / r38;
+    r68 = r66 * r67;
+    r69 = r44 * r68;
+    r70 = r63 * r69;
+    r20 = fma(r48, r70, r20);
+    r20 = fma(r48, r69, r20);
+    r20 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r58);
+    r20 = fma(r0, r21, r20);
+    r0 = r28 * r28;
+    r0 = r0 * r49;
+    r0 = r0 * r7;
+    r0 = fma(r42, r0, r57);
+    r0 = fma(r56, r45, r4 * r0);
+    r57 = r5 * r28;
+    r57 = r57 * r53;
+    r0 = fma(r59, r57, r0);
+    r0 = fma(r28, r70, r0);
+    r0 = fma(r28, r69, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r58, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r20, r0);
+    r58 = fma(r0, r0, r20 * r20);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r58);
+  if (global_thread_idx < problem_size) {
+    r58 = r48 * r7;
+    r1 = -5.00000000000000000e-01;
+    r57 = rsqrt(r30);
+    r71 = r10 * r48;
+    r72 = r11 * r14;
+    r73 = r16 * r17;
+    r73 = fma(r1, r73, r1 * r72);
+    r72 = r15 * r18;
+    r73 = fma(r1, r72, r73);
+    r74 = r12 * r13;
+    r75 = 5.00000000000000000e-01;
+    r73 = fma(r75, r74, r73);
+    r74 = r24 * r73;
+    r72 = r15 * r14;
+    r76 = r12 * r17;
+    r76 = fma(r75, r76, r75 * r72);
+    r72 = r11 * r18;
+    r76 = fma(r1, r72, r76);
+    r77 = r16 * r13;
+    r76 = fma(r75, r77, r76);
+    r77 = r29 * r76;
+    r72 = fma(r10, r77, r10 * r74);
+    r78 = r10 * r19;
+    r79 = fma(r75, r26, r1 * r22);
+    r79 = fma(r1, r23, r79);
+    r79 = fma(r1, r25, r79);
+    r80 = r10 * r27;
+    r81 = r16 * r14;
+    r82 = r11 * r17;
+    r82 = fma(r1, r82, r75 * r81);
+    r81 = r12 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r15 * r13;
+    r82 = fma(r1, r83, r82);
+    r80 = r80 * r82;
+    r78 = fma(r79, r78, r80);
+    r72 = r72 + r78;
+    r83 = r10 * r24;
+    r83 = r83 * r82;
+    r81 = r10 * r19;
+    r81 = r81 * r76;
+    r84 = r83 + r81;
+    r85 = r27 * r34;
+    r84 = fma(r73, r85, r84);
+    r86 = r34 * r29;
+    r84 = fma(r79, r86, r84);
+    r84 = fma(r9, r84, r41 * r72);
+    r72 = r24 * r76;
+    r86 = -4.00000000000000000e+00;
+    r72 = r72 * r86;
+    r85 = r27 * r79;
+    r87 = r86 * r85;
+    r88 = r72 + r87;
+    r84 = fma(r8, r88, r84);
+    r71 = r71 * r84;
+    r88 = r48 * r48;
+    r89 = r10 * r24;
+    r89 = r89 * r79;
+    r90 = r10 * r27;
+    r90 = fma(r76, r90, r89);
+    r76 = r10 * r19;
+    r76 = r76 * r73;
+    r91 = r10 * r29;
+    r91 = r91 * r82;
+    r92 = r76 + r91;
+    r93 = r90 + r92;
+    r77 = fma(r34, r77, r34 * r74);
+    r77 = r77 + r78;
+    r77 = fma(r8, r77, r9 * r93);
+    r93 = r19 * r82;
+    r93 = r93 * r86;
+    r72 = r72 + r93;
+    r77 = fma(r41, r72, r77);
+    r52 = r47 * r52;
+    r52 = 1.0 / r52;
+    r47 = r34 * r52;
+    r88 = r88 * r77;
+    r88 = fma(r47, r88, r39 * r71);
+    r71 = r28 * r28;
+    r71 = r71 * r47;
+    r72 = r10 * r28;
+    r94 = r19 * r34;
+    r95 = r34 * r29;
+    r95 = r95 * r82;
+    r94 = fma(r73, r94, r95);
+    r94 = r94 + r90;
+    r87 = r93 + r87;
+    r87 = fma(r9, r87, r41 * r94);
+    r94 = r10 * r29;
+    r94 = fma(r79, r94, r81);
+    r81 = r10 * r27;
+    r81 = fma(r73, r81, r83);
+    r94 = r94 + r81;
+    r87 = fma(r8, r94, r87);
+    r72 = r72 * r87;
+    r88 = fma(r39, r72, r88);
+    r88 = fma(r77, r71, r88);
+    r58 = r58 * r44;
+    r58 = r58 * r66;
+    r58 = r58 * r1;
+    r58 = r58 * r57;
+    r58 = r58 * r88;
+    r72 = r44 * r44;
+    r94 = r7 * r72;
+    r94 = r94 * r71;
+    r83 = r28 * r57;
+    r93 = r88 * r83;
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r90 = r30 * r46;
+    r96 = r28 * r7;
+    r93 = r93 * r90;
+    r93 = fma(r96, r93, r77 * r94);
+    r97 = r21 * r28;
+    r43 = r38 * r43;
+    r43 = 1.0 / r43;
+    r38 = r43 * r42;
+    r38 = r38 * r83;
+    r97 = r97 * r88;
+    r93 = fma(r38, r97, r93);
+    r98 = r59 * r96;
+    r93 = fma(r87, r98, r93);
+    r97 = r88 * r57;
+    r97 = r97 * r90;
+    r99 = r21 * r48;
+    r99 = r99 * r48;
+    r99 = r99 * r88;
+    r99 = r99 * r57;
+    r99 = r99 * r43;
+    r99 = fma(r42, r99, r54 * r97);
+    r97 = r84 * r53;
+    r99 = fma(r59, r97, r99);
+    r100 = r77 * r47;
+    r72 = r54 * r72;
+    r99 = fma(r72, r100, r99);
+    r100 = r93 + r99;
+    r97 = fma(r55, r100, r58);
+    r101 = r49 * r88;
+    r101 = r101 * r57;
+    r101 = r101 * r90;
+    r102 = r48 * r48;
+    r103 = -3.00000000000000000e+00;
+    r102 = r102 * r103;
+    r102 = r102 * r88;
+    r102 = r102 * r57;
+    r102 = r102 * r43;
+    r102 = fma(r42, r102, r54 * r101);
+    r101 = 6.00000000000000000e+00;
+    r104 = r84 * r101;
+    r104 = r104 * r42;
+    r102 = fma(r53, r104, r102);
+    r105 = -6.00000000000000000e+00;
+    r106 = r105 * r52;
+    r106 = r106 * r72;
+    r102 = fma(r77, r106, r102);
+    r102 = r102 + r93;
+    r93 = r84 * r98;
+    r104 = r21 * r48;
+    r104 = r104 * r63;
+    r104 = r104 * r77;
+    r104 = r104 * r67;
+    r97 = fma(r46, r104, r97);
+    r107 = r48 * r75;
+    r107 = r107 * r57;
+    r107 = r107 * r30;
+    r107 = r107 * r68;
+    r108 = r63 * r107;
+    r109 = r4 * r34;
+    r109 = r109 * r48;
+    r109 = r109 * r88;
+    r97 = fma(r38, r109, r97);
+    r110 = r4 * r87;
+    r110 = r110 * r53;
+    r97 = fma(r59, r110, r97);
+    r111 = r4 * r28;
+    r111 = r111 * r44;
+    r111 = r111 * r44;
+    r111 = r111 * r86;
+    r111 = r111 * r52;
+    r111 = r111 * r53;
+    r112 = r4 * r88;
+    r113 = r10 * r53;
+    r113 = r113 * r83;
+    r113 = r113 * r90;
+    r97 = fma(r113, r112, r97);
+    r114 = r61 * r10;
+    r114 = r114 * r45;
+    r114 = fma(r60, r100, r100 * r114);
+    r64 = r64 * r49;
+    r64 = r64 * r62;
+    r62 = 4.00000000000000000e+00;
+    r65 = r62 * r65;
+    r114 = fma(r100, r64, r114);
+    r114 = fma(r100, r65, r114);
+    r62 = r48 * r114;
+    r97 = fma(r69, r62, r97);
+    r115 = r21 * r48;
+    r115 = r115 * r77;
+    r115 = r115 * r67;
+    r97 = fma(r46, r115, r97);
+    r97 = fma(r5, r102, r97);
+    r97 = fma(r4, r93, r97);
+    r97 = fma(r63, r58, r97);
+    r97 = fma(r88, r108, r97);
+    r97 = fma(r84, r70, r97);
+    r97 = fma(r77, r111, r97);
+    r97 = fma(r88, r107, r97);
+    r97 = fma(r84, r69, r97);
+    r115 = r2 * r97;
+    r62 = r28 * r7;
+    r62 = r62 * r44;
+    r62 = r62 * r66;
+    r62 = r62 * r1;
+    r62 = r62 * r57;
+    r62 = r62 * r88;
+    r100 = fma(r56, r100, r62);
+    r112 = r28 * r28;
+    r112 = r112 * r44;
+    r112 = r112 * r44;
+    r112 = r112 * r77;
+    r112 = r112 * r105;
+    r112 = r112 * r7;
+    r110 = r49 * r88;
+    r110 = r110 * r83;
+    r110 = r110 * r90;
+    r110 = fma(r96, r110, r52 * r112);
+    r112 = r28 * r103;
+    r112 = r112 * r88;
+    r110 = fma(r38, r112, r110);
+    r109 = r28 * r87;
+    r109 = r109 * r101;
+    r109 = r109 * r7;
+    r110 = fma(r42, r109, r110);
+    r110 = r110 + r99;
+    r99 = r21 * r28;
+    r99 = r99 * r77;
+    r99 = r99 * r67;
+    r100 = fma(r46, r99, r100);
+    r109 = r5 * r34;
+    r109 = r109 * r48;
+    r109 = r109 * r38;
+    r112 = r75 * r88;
+    r112 = r112 * r30;
+    r112 = r112 * r83;
+    r100 = fma(r68, r112, r100);
+    r104 = r5 * r87;
+    r104 = r104 * r53;
+    r100 = fma(r59, r104, r100);
+    r58 = r5 * r28;
+    r58 = r58 * r44;
+    r58 = r58 * r44;
+    r58 = r58 * r86;
+    r58 = r58 * r77;
+    r58 = r58 * r52;
+    r100 = fma(r53, r58, r100);
+    r102 = r28 * r114;
+    r100 = fma(r69, r102, r100);
+    r116 = r5 * r88;
+    r100 = fma(r113, r116, r100);
+    r117 = r75 * r63;
+    r117 = r117 * r88;
+    r117 = r117 * r30;
+    r117 = r117 * r83;
+    r100 = fma(r68, r117, r100);
+    r118 = r21 * r28;
+    r118 = r118 * r63;
+    r118 = r118 * r77;
+    r118 = r118 * r67;
+    r100 = fma(r46, r118, r100);
+    r100 = fma(r4, r110, r100);
+    r100 = fma(r5, r93, r100);
+    r100 = fma(r63, r62, r100);
+    r100 = fma(r88, r109, r100);
+    r100 = fma(r87, r70, r100);
+    r100 = fma(r87, r69, r100);
+    r118 = r3 * r100;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r115,
+                                             r118);
+    r118 = r34 * r24;
+    r118 = fma(r79, r118, r95);
+    r115 = r10 * r27;
+    r117 = r15 * r14;
+    r116 = r12 * r17;
+    r116 = fma(r1, r116, r1 * r117);
+    r117 = r11 * r18;
+    r116 = fma(r75, r117, r116);
+    r102 = r16 * r13;
+    r116 = fma(r1, r102, r116);
+    r115 = r115 * r116;
+    r102 = r10 * r19;
+    r117 = r11 * r14;
+    r58 = r16 * r17;
+    r58 = fma(r75, r58, r75 * r117);
+    r117 = r15 * r18;
+    r58 = fma(r75, r117, r58);
+    r104 = r12 * r13;
+    r58 = fma(r1, r104, r58);
+    r102 = fma(r58, r102, r115);
+    r118 = r118 + r102;
+    r104 = r10 * r24;
+    r104 = r104 * r58;
+    r117 = r10 * r29;
+    r117 = fma(r116, r117, r104);
+    r117 = r117 + r78;
+    r117 = fma(r9, r117, r8 * r118);
+    r118 = r24 * r82;
+    r118 = r118 * r86;
+    r78 = r19 * r116;
+    r112 = r86 * r78;
+    r62 = r118 + r112;
+    r117 = fma(r41, r62, r117);
+    r91 = r89 + r91;
+    r91 = r91 + r102;
+    r102 = r27 * r86;
+    r102 = r102 * r58;
+    r118 = r118 + r102;
+    r118 = fma(r8, r118, r41 * r91);
+    r91 = r34 * r29;
+    r91 = fma(r34, r85, r58 * r91);
+    r89 = r10 * r19;
+    r89 = r89 * r82;
+    r62 = r10 * r24;
+    r62 = fma(r116, r62, r89);
+    r91 = r91 + r62;
+    r118 = fma(r9, r91, r118);
+    r91 = r101 * r118;
+    r91 = r91 * r42;
+    r91 = fma(r53, r91, r117 * r106);
+    r99 = r48 * r48;
+    r93 = r10 * r48;
+    r93 = r93 * r118;
+    r110 = r10 * r28;
+    r104 = r80 + r104;
+    r80 = r19 * r34;
+    r104 = fma(r79, r80, r104);
+    r79 = r34 * r29;
+    r104 = fma(r116, r79, r104);
+    r79 = r10 * r29;
+    r85 = fma(r10, r85, r58 * r79);
+    r85 = r85 + r62;
+    r85 = fma(r8, r85, r41 * r104);
+    r112 = r102 + r112;
+    r85 = fma(r9, r112, r85);
+    r110 = r110 * r85;
+    r110 = fma(r39, r110, r39 * r93);
+    r93 = r48 * r48;
+    r93 = r93 * r117;
+    r110 = fma(r47, r93, r110);
+    r110 = fma(r117, r71, r110);
+    r93 = r103 * r110;
+    r99 = r99 * r57;
+    r99 = r99 * r43;
+    r99 = r99 * r42;
+    r91 = fma(r93, r99, r91);
+    r112 = r49 * r110;
+    r112 = r112 * r57;
+    r112 = r112 * r90;
+    r91 = fma(r54, r112, r91);
+    r102 = r21 * r28;
+    r102 = r102 * r110;
+    r102 = fma(r38, r102, r85 * r98);
+    r104 = r110 * r83;
+    r104 = r104 * r90;
+    r102 = fma(r96, r104, r102);
+    r102 = fma(r117, r94, r102);
+    r91 = r91 + r102;
+    r112 = r117 * r47;
+    r99 = r118 * r53;
+    r99 = fma(r59, r99, r72 * r112);
+    r112 = r21 * r48;
+    r112 = r112 * r48;
+    r112 = r112 * r110;
+    r112 = r112 * r57;
+    r112 = r112 * r43;
+    r99 = fma(r42, r112, r99);
+    r104 = r110 * r57;
+    r104 = r104 * r90;
+    r99 = fma(r54, r104, r99);
+    r102 = r102 + r99;
+    r91 = fma(r55, r102, r5 * r91);
+    r104 = r21 * r48;
+    r104 = r104 * r117;
+    r104 = r104 * r67;
+    r91 = fma(r46, r104, r91);
+    r112 = r44 * r63;
+    r112 = r112 * r1;
+    r112 = r112 * r110;
+    r112 = r112 * r66;
+    r112 = r112 * r57;
+    r91 = fma(r53, r112, r91);
+    r79 = r61 * r10;
+    r79 = r79 * r45;
+    r79 = fma(r102, r79, r60 * r102);
+    r79 = fma(r102, r65, r79);
+    r79 = fma(r102, r64, r79);
+    r58 = r48 * r79;
+    r91 = fma(r69, r58, r91);
+    r80 = r21 * r48;
+    r80 = r80 * r63;
+    r80 = r80 * r117;
+    r80 = r80 * r67;
+    r91 = fma(r46, r80, r91);
+    r119 = r4 * r110;
+    r91 = fma(r113, r119, r91);
+    r120 = r4 * r34;
+    r120 = r120 * r48;
+    r120 = r120 * r110;
+    r91 = fma(r38, r120, r91);
+    r121 = r4 * r85;
+    r121 = r121 * r53;
+    r91 = fma(r59, r121, r91);
+    r122 = r4 * r118;
+    r91 = fma(r98, r122, r91);
+    r123 = r44 * r1;
+    r123 = r123 * r110;
+    r123 = r123 * r66;
+    r123 = r123 * r57;
+    r91 = fma(r53, r123, r91);
+    r91 = fma(r110, r108, r91);
+    r91 = fma(r110, r107, r91);
+    r91 = fma(r117, r111, r91);
+    r91 = fma(r118, r69, r91);
+    r91 = fma(r118, r70, r91);
+    r123 = r2 * r91;
+    r122 = r28 * r101;
+    r122 = r122 * r85;
+    r122 = r122 * r7;
+    r121 = r28 * r38;
+    r121 = fma(r93, r121, r42 * r122);
+    r122 = r28 * r28;
+    r122 = r122 * r44;
+    r122 = r122 * r44;
+    r122 = r122 * r105;
+    r122 = r122 * r117;
+    r122 = r122 * r7;
+    r121 = fma(r52, r122, r121);
+    r93 = r49 * r110;
+    r93 = r93 * r83;
+    r93 = r93 * r90;
+    r121 = fma(r96, r93, r121);
+    r121 = r121 + r99;
+    r102 = fma(r56, r102, r4 * r121);
+    r121 = r44 * r1;
+    r121 = r121 * r110;
+    r121 = r121 * r7;
+    r121 = r121 * r66;
+    r102 = fma(r83, r121, r102);
+    r99 = r28 * r79;
+    r102 = fma(r69, r99, r102);
+    r93 = r75 * r110;
+    r93 = r93 * r30;
+    r93 = r93 * r83;
+    r102 = fma(r68, r93, r102);
+    r122 = r5 * r28;
+    r122 = r122 * r44;
+    r122 = r122 * r44;
+    r122 = r122 * r86;
+    r122 = r122 * r117;
+    r122 = r122 * r52;
+    r102 = fma(r53, r122, r102);
+    r120 = r5 * r110;
+    r102 = fma(r113, r120, r102);
+    r119 = r21 * r28;
+    r119 = r119 * r63;
+    r119 = r119 * r117;
+    r119 = r119 * r67;
+    r102 = fma(r46, r119, r102);
+    r80 = r44 * r63;
+    r80 = r80 * r1;
+    r80 = r80 * r110;
+    r80 = r80 * r7;
+    r80 = r80 * r66;
+    r102 = fma(r83, r80, r102);
+    r58 = r21 * r28;
+    r58 = r58 * r117;
+    r58 = r58 * r67;
+    r102 = fma(r46, r58, r102);
+    r112 = r5 * r85;
+    r112 = r112 * r53;
+    r102 = fma(r59, r112, r102);
+    r104 = r75 * r63;
+    r104 = r104 * r110;
+    r104 = r104 * r30;
+    r104 = r104 * r83;
+    r102 = fma(r68, r104, r102);
+    r124 = r5 * r118;
+    r102 = fma(r98, r124, r102);
+    r102 = fma(r85, r70, r102);
+    r102 = fma(r110, r109, r102);
+    r102 = fma(r85, r69, r102);
+    r124 = r3 * r102;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r124);
+    r124 = r19 * r86;
+    r26 = fma(r1, r26, r75 * r22);
+    r26 = fma(r75, r23, r26);
+    r26 = fma(r75, r25, r26);
+    r124 = r124 * r26;
+    r74 = r86 * r74;
+    r25 = r124 + r74;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r89 = r89 + r23;
+    r22 = r34 * r24;
+    r89 = fma(r116, r22, r89);
+    r123 = r34 * r29;
+    r89 = fma(r73, r123, r89);
+    r89 = fma(r8, r89, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r78, r26 * r25);
+    r25 = r25 + r81;
+    r89 = fma(r9, r25, r89);
+    r25 = r10 * r28;
+    r123 = r10 * r24;
+    r123 = r123 * r26;
+    r115 = r115 + r123;
+    r115 = r115 + r92;
+    r92 = r34 * r29;
+    r78 = fma(r34, r78, r26 * r92);
+    r78 = r78 + r81;
+    r78 = fma(r41, r78, r8 * r115);
+    r82 = r27 * r82;
+    r82 = r82 * r86;
+    r124 = r124 + r82;
+    r78 = fma(r9, r124, r78);
+    r25 = r25 * r78;
+    r124 = r48 * r48;
+    r124 = r124 * r89;
+    r124 = fma(r47, r124, r39 * r25);
+    r25 = r10 * r48;
+    r95 = r76 + r95;
+    r76 = r27 * r34;
+    r95 = fma(r116, r76, r95);
+    r95 = r95 + r123;
+    r74 = r82 + r74;
+    r74 = fma(r8, r74, r9 * r95);
+    r8 = r10 * r29;
+    r8 = fma(r73, r8, r23);
+    r8 = r8 + r62;
+    r74 = fma(r41, r8, r74);
+    r25 = r25 * r74;
+    r124 = fma(r39, r25, r124);
+    r124 = fma(r89, r71, r124);
+    r25 = r124 * r83;
+    r25 = r25 * r90;
+    r25 = fma(r96, r25, r89 * r94);
+    r8 = r21 * r28;
+    r8 = r8 * r124;
+    r25 = fma(r38, r8, r25);
+    r25 = fma(r78, r98, r25);
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r41 = r74 * r53;
+    r41 = fma(r59, r41, r42 * r8);
+    r8 = r89 * r47;
+    r41 = fma(r72, r8, r41);
+    r62 = r124 * r57;
+    r62 = r62 * r90;
+    r41 = fma(r54, r62, r41);
+    r62 = r25 + r41;
+    r8 = r48 * r48;
+    r8 = r8 * r103;
+    r8 = r8 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r23 = r101 * r74;
+    r23 = r23 * r42;
+    r23 = fma(r53, r23, r42 * r8);
+    r8 = r49 * r124;
+    r8 = r8 * r57;
+    r8 = r8 * r90;
+    r23 = fma(r54, r8, r23);
+    r23 = fma(r89, r106, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r55 * r62);
+    r25 = r61 * r10;
+    r25 = r25 * r45;
+    r25 = fma(r62, r25, r60 * r62);
+    r25 = fma(r62, r64, r25);
+    r25 = fma(r62, r65, r25);
+    r8 = r48 * r25;
+    r23 = fma(r69, r8, r23);
+    r73 = r4 * r74;
+    r23 = fma(r98, r73, r23);
+    r95 = r4 * r124;
+    r23 = fma(r113, r95, r23);
+    r9 = r21 * r48;
+    r9 = r9 * r63;
+    r9 = r9 * r89;
+    r9 = r9 * r67;
+    r23 = fma(r46, r9, r23);
+    r82 = r4 * r34;
+    r82 = r82 * r48;
+    r82 = r82 * r124;
+    r23 = fma(r38, r82, r23);
+    r76 = r21 * r48;
+    r76 = r76 * r89;
+    r76 = r76 * r67;
+    r23 = fma(r46, r76, r23);
+    r123 = r44 * r1;
+    r123 = r123 * r124;
+    r123 = r123 * r66;
+    r123 = r123 * r57;
+    r23 = fma(r53, r123, r23);
+    r116 = r4 * r78;
+    r116 = r116 * r53;
+    r23 = fma(r59, r116, r23);
+    r115 = r44 * r63;
+    r115 = r115 * r1;
+    r115 = r115 * r124;
+    r115 = r115 * r66;
+    r115 = r115 * r57;
+    r23 = fma(r53, r115, r23);
+    r23 = fma(r124, r107, r23);
+    r23 = fma(r124, r108, r23);
+    r23 = fma(r74, r70, r23);
+    r23 = fma(r74, r69, r23);
+    r23 = fma(r89, r111, r23);
+    r115 = r2 * r23;
+    r116 = r28 * r28;
+    r116 = r116 * r44;
+    r116 = r116 * r44;
+    r116 = r116 * r105;
+    r116 = r116 * r89;
+    r116 = r116 * r7;
+    r123 = r49 * r124;
+    r123 = r123 * r83;
+    r123 = r123 * r90;
+    r123 = fma(r96, r123, r52 * r116);
+    r116 = r28 * r101;
+    r116 = r116 * r78;
+    r116 = r116 * r7;
+    r123 = fma(r42, r116, r123);
+    r76 = r28 * r103;
+    r76 = r76 * r124;
+    r123 = fma(r38, r76, r123);
+    r123 = r123 + r41;
+    r123 = fma(r4, r123, r56 * r62);
+    r62 = r21 * r28;
+    r62 = r62 * r63;
+    r62 = r62 * r89;
+    r62 = r62 * r67;
+    r123 = fma(r46, r62, r123);
+    r41 = r21 * r28;
+    r41 = r41 * r89;
+    r41 = r41 * r67;
+    r123 = fma(r46, r41, r123);
+    r76 = r5 * r74;
+    r123 = fma(r98, r76, r123);
+    r116 = r44 * r63;
+    r116 = r116 * r1;
+    r116 = r116 * r124;
+    r116 = r116 * r7;
+    r116 = r116 * r66;
+    r123 = fma(r83, r116, r123);
+    r82 = r5 * r124;
+    r123 = fma(r113, r82, r123);
+    r9 = r75 * r124;
+    r9 = r9 * r30;
+    r9 = r9 * r83;
+    r123 = fma(r68, r9, r123);
+    r95 = r28 * r25;
+    r123 = fma(r69, r95, r123);
+    r73 = r44 * r1;
+    r73 = r73 * r124;
+    r73 = r73 * r7;
+    r73 = r73 * r66;
+    r123 = fma(r83, r73, r123);
+    r8 = r75 * r63;
+    r8 = r8 * r124;
+    r8 = r8 * r30;
+    r8 = r8 * r83;
+    r123 = fma(r68, r8, r123);
+    r81 = r5 * r28;
+    r81 = r81 * r44;
+    r81 = r81 * r44;
+    r81 = r81 * r86;
+    r81 = r81 * r89;
+    r81 = r81 * r52;
+    r123 = fma(r53, r81, r123);
+    r92 = r5 * r78;
+    r92 = r92 * r53;
+    r123 = fma(r59, r92, r123);
+    r123 = fma(r78, r70, r123);
+    r123 = fma(r78, r69, r123);
+    r123 = fma(r124, r109, r123);
+    r92 = r3 * r123;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r115, r92);
+    r92 = r36 * r101;
+    r92 = r92 * r42;
+    r115 = r48 * r48;
+    r81 = r10 * r32;
+    r81 = r81 * r28;
+    r81 = fma(r6, r71, r39 * r81);
+    r8 = r6 * r48;
+    r8 = r8 * r48;
+    r81 = fma(r47, r8, r81);
+    r73 = r10 * r36;
+    r73 = r73 * r48;
+    r81 = fma(r39, r73, r81);
+    r115 = r115 * r103;
+    r115 = r115 * r81;
+    r115 = r115 * r57;
+    r115 = r115 * r43;
+    r115 = fma(r42, r115, r53 * r92);
+    r92 = r49 * r81;
+    r92 = r92 * r57;
+    r92 = r92 * r90;
+    r115 = fma(r54, r92, r115);
+    r73 = r21 * r28;
+    r73 = r73 * r81;
+    r73 = fma(r38, r73, r32 * r98);
+    r8 = r81 * r83;
+    r8 = r8 * r90;
+    r73 = fma(r96, r8, r73);
+    r73 = fma(r6, r94, r73);
+    r115 = fma(r6, r106, r115);
+    r115 = r115 + r73;
+    r92 = r36 * r53;
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r81;
+    r8 = r8 * r57;
+    r8 = r8 * r43;
+    r8 = fma(r42, r8, r59 * r92);
+    r92 = r81 * r57;
+    r92 = r92 * r90;
+    r8 = fma(r54, r92, r8);
+    r95 = r6 * r47;
+    r8 = fma(r72, r95, r8);
+    r73 = r73 + r8;
+    r115 = fma(r55, r73, r5 * r115);
+    r95 = r4 * r81;
+    r115 = fma(r113, r95, r115);
+    r92 = r44 * r63;
+    r92 = r92 * r1;
+    r92 = r92 * r81;
+    r92 = r92 * r66;
+    r92 = r92 * r57;
+    r115 = fma(r53, r92, r115);
+    r9 = r44 * r1;
+    r9 = r9 * r81;
+    r9 = r9 * r66;
+    r9 = r9 * r57;
+    r115 = fma(r53, r9, r115);
+    r82 = r4 * r34;
+    r82 = r82 * r48;
+    r82 = r82 * r81;
+    r115 = fma(r38, r82, r115);
+    r116 = r61 * r10;
+    r116 = r116 * r45;
+    r116 = fma(r60, r73, r73 * r116);
+    r116 = fma(r73, r65, r116);
+    r116 = fma(r73, r64, r116);
+    r76 = r48 * r116;
+    r115 = fma(r69, r76, r115);
+    r41 = r21 * r6;
+    r41 = r41 * r48;
+    r41 = r41 * r63;
+    r41 = r41 * r67;
+    r115 = fma(r46, r41, r115);
+    r62 = r21 * r6;
+    r62 = r62 * r48;
+    r62 = r62 * r67;
+    r115 = fma(r46, r62, r115);
+    r26 = r4 * r32;
+    r26 = r26 * r53;
+    r115 = fma(r59, r26, r115);
+    r22 = r4 * r36;
+    r115 = fma(r98, r22, r115);
+    r115 = fma(r36, r70, r115);
+    r115 = fma(r81, r108, r115);
+    r115 = fma(r81, r107, r115);
+    r115 = fma(r6, r111, r115);
+    r115 = fma(r36, r69, r115);
+    r22 = r2 * r115;
+    r26 = r32 * r28;
+    r26 = r26 * r101;
+    r26 = r26 * r7;
+    r62 = r28 * r103;
+    r62 = r62 * r81;
+    r62 = fma(r38, r62, r42 * r26);
+    r26 = r6 * r28;
+    r26 = r26 * r28;
+    r26 = r26 * r44;
+    r26 = r26 * r44;
+    r26 = r26 * r105;
+    r26 = r26 * r7;
+    r62 = fma(r52, r26, r62);
+    r41 = r49 * r81;
+    r41 = r41 * r83;
+    r41 = r41 * r90;
+    r62 = fma(r96, r41, r62);
+    r62 = r62 + r8;
+    r73 = fma(r56, r73, r4 * r62);
+    r62 = r75 * r81;
+    r62 = r62 * r30;
+    r62 = r62 * r83;
+    r73 = fma(r68, r62, r73);
+    r8 = r44 * r63;
+    r8 = r8 * r1;
+    r8 = r8 * r81;
+    r8 = r8 * r7;
+    r8 = r8 * r66;
+    r73 = fma(r83, r8, r73);
+    r41 = r21 * r6;
+    r41 = r41 * r28;
+    r41 = r41 * r63;
+    r41 = r41 * r67;
+    r73 = fma(r46, r41, r73);
+    r26 = r5 * r81;
+    r73 = fma(r113, r26, r73);
+    r76 = r21 * r6;
+    r76 = r76 * r28;
+    r76 = r76 * r67;
+    r73 = fma(r46, r76, r73);
+    r82 = r5 * r6;
+    r82 = r82 * r28;
+    r82 = r82 * r44;
+    r82 = r82 * r44;
+    r82 = r82 * r86;
+    r82 = r82 * r52;
+    r73 = fma(r53, r82, r73);
+    r9 = r28 * r116;
+    r73 = fma(r69, r9, r73);
+    r92 = r75 * r63;
+    r92 = r92 * r81;
+    r92 = r92 * r30;
+    r92 = r92 * r83;
+    r73 = fma(r68, r92, r73);
+    r95 = r5 * r32;
+    r95 = r95 * r53;
+    r73 = fma(r59, r95, r73);
+    r104 = r44 * r1;
+    r104 = r104 * r81;
+    r104 = r104 * r7;
+    r104 = r104 * r66;
+    r73 = fma(r83, r104, r73);
+    r112 = r5 * r36;
+    r73 = fma(r98, r112, r73);
+    r73 = fma(r32, r69, r73);
+    r73 = fma(r81, r109, r73);
+    r73 = fma(r32, r70, r73);
+    r112 = r3 * r73;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r112);
+    r112 = r10 * r37;
+    r112 = r112 * r28;
+    r112 = fma(r39, r112, r33 * r71);
+    r22 = r33 * r48;
+    r22 = r22 * r48;
+    r112 = fma(r47, r22, r112);
+    r104 = r10 * r51;
+    r104 = r104 * r48;
+    r112 = fma(r39, r104, r112);
+    r104 = r49 * r112;
+    r104 = r104 * r57;
+    r104 = r104 * r90;
+    r104 = fma(r33, r106, r54 * r104);
+    r22 = r48 * r48;
+    r22 = r22 * r103;
+    r22 = r22 * r112;
+    r22 = r22 * r57;
+    r22 = r22 * r43;
+    r104 = fma(r42, r22, r104);
+    r95 = r51 * r101;
+    r95 = r95 * r42;
+    r104 = fma(r53, r95, r104);
+    r92 = fma(r37, r98, r33 * r94);
+    r9 = r112 * r83;
+    r9 = r9 * r90;
+    r92 = fma(r96, r9, r92);
+    r82 = r21 * r28;
+    r82 = r82 * r112;
+    r92 = fma(r38, r82, r92);
+    r104 = r104 + r92;
+    r95 = r112 * r57;
+    r95 = r95 * r90;
+    r22 = r33 * r47;
+    r22 = fma(r72, r22, r54 * r95);
+    r95 = r21 * r48;
+    r95 = r95 * r48;
+    r95 = r95 * r112;
+    r95 = r95 * r57;
+    r95 = r95 * r43;
+    r22 = fma(r42, r95, r22);
+    r82 = r51 * r53;
+    r22 = fma(r59, r82, r22);
+    r92 = r92 + r22;
+    r104 = fma(r55, r92, r5 * r104);
+    r82 = r4 * r37;
+    r82 = r82 * r53;
+    r104 = fma(r59, r82, r104);
+    r95 = r112 * r113;
+    r9 = r21 * r33;
+    r9 = r9 * r48;
+    r9 = r9 * r67;
+    r104 = fma(r46, r9, r104);
+    r76 = r4 * r34;
+    r76 = r76 * r48;
+    r76 = r76 * r112;
+    r104 = fma(r38, r76, r104);
+    r26 = r44 * r1;
+    r26 = r26 * r112;
+    r26 = r26 * r66;
+    r26 = r26 * r57;
+    r104 = fma(r53, r26, r104);
+    r41 = r61 * r10;
+    r41 = r41 * r45;
+    r41 = fma(r60, r92, r92 * r41);
+    r41 = fma(r92, r64, r41);
+    r41 = fma(r92, r65, r41);
+    r8 = r48 * r41;
+    r104 = fma(r69, r8, r104);
+    r62 = r44 * r63;
+    r62 = r62 * r1;
+    r62 = r62 * r112;
+    r62 = r62 * r66;
+    r62 = r62 * r57;
+    r104 = fma(r53, r62, r104);
+    r58 = r21 * r33;
+    r58 = r58 * r48;
+    r58 = r58 * r63;
+    r58 = r58 * r67;
+    r104 = fma(r46, r58, r104);
+    r80 = r4 * r51;
+    r104 = fma(r98, r80, r104);
+    r104 = fma(r4, r95, r104);
+    r104 = fma(r112, r108, r104);
+    r104 = fma(r51, r69, r104);
+    r104 = fma(r33, r111, r104);
+    r104 = fma(r112, r107, r104);
+    r104 = fma(r51, r70, r104);
+    r80 = r2 * r104;
+    r58 = r33 * r28;
+    r58 = r58 * r28;
+    r58 = r58 * r44;
+    r58 = r58 * r44;
+    r58 = r58 * r105;
+    r58 = r58 * r7;
+    r62 = r37 * r28;
+    r62 = r62 * r101;
+    r62 = r62 * r7;
+    r62 = fma(r42, r62, r52 * r58);
+    r58 = r49 * r112;
+    r58 = r58 * r83;
+    r58 = r58 * r90;
+    r62 = fma(r96, r58, r62);
+    r8 = r28 * r103;
+    r8 = r8 * r112;
+    r62 = fma(r38, r8, r62);
+    r62 = r62 + r22;
+    r62 = fma(r4, r62, r56 * r92);
+    r92 = r21 * r33;
+    r92 = r92 * r28;
+    r92 = r92 * r67;
+    r62 = fma(r46, r92, r62);
+    r22 = r5 * r37;
+    r22 = r22 * r53;
+    r62 = fma(r59, r22, r62);
+    r8 = r75 * r112;
+    r8 = r8 * r30;
+    r8 = r8 * r83;
+    r62 = fma(r68, r8, r62);
+    r58 = r28 * r41;
+    r62 = fma(r69, r58, r62);
+    r26 = r44 * r63;
+    r26 = r26 * r1;
+    r26 = r26 * r112;
+    r26 = r26 * r7;
+    r26 = r26 * r66;
+    r62 = fma(r83, r26, r62);
+    r76 = r5 * r33;
+    r76 = r76 * r28;
+    r76 = r76 * r44;
+    r76 = r76 * r44;
+    r76 = r76 * r86;
+    r76 = r76 * r52;
+    r62 = fma(r53, r76, r62);
+    r9 = r44 * r1;
+    r9 = r9 * r112;
+    r9 = r9 * r7;
+    r9 = r9 * r66;
+    r62 = fma(r83, r9, r62);
+    r82 = r75 * r63;
+    r82 = r82 * r112;
+    r82 = r82 * r30;
+    r82 = r82 * r83;
+    r62 = fma(r68, r82, r62);
+    r119 = r21 * r33;
+    r119 = r119 * r28;
+    r119 = r119 * r63;
+    r119 = r119 * r67;
+    r62 = fma(r46, r119, r62);
+    r120 = r5 * r51;
+    r62 = fma(r98, r120, r62);
+    r62 = fma(r37, r70, r62);
+    r62 = fma(r5, r95, r62);
+    r62 = fma(r112, r109, r62);
+    r62 = fma(r37, r69, r62);
+    r120 = r3 * r62;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r80, r120);
+    r120 = r48 * r48;
+    r80 = r10 * r40;
+    r80 = r80 * r28;
+    r71 = fma(r31, r71, r39 * r80);
+    r80 = r10 * r50;
+    r80 = r80 * r48;
+    r71 = fma(r39, r80, r71);
+    r39 = r31 * r48;
+    r39 = r39 * r48;
+    r71 = fma(r47, r39, r71);
+    r120 = r120 * r103;
+    r120 = r120 * r71;
+    r120 = r120 * r57;
+    r120 = r120 * r43;
+    r39 = r49 * r71;
+    r39 = r39 * r57;
+    r39 = r39 * r90;
+    r39 = fma(r54, r39, r42 * r120);
+    r120 = r50 * r101;
+    r120 = r120 * r42;
+    r39 = fma(r53, r120, r39);
+    r94 = fma(r40, r98, r31 * r94);
+    r80 = r71 * r83;
+    r80 = r80 * r90;
+    r94 = fma(r96, r80, r94);
+    r119 = r21 * r28;
+    r119 = r119 * r71;
+    r94 = fma(r38, r119, r94);
+    r39 = fma(r31, r106, r39);
+    r39 = r39 + r94;
+    r106 = r21 * r48;
+    r106 = r106 * r48;
+    r106 = r106 * r71;
+    r106 = r106 * r57;
+    r106 = r106 * r43;
+    r43 = r71 * r57;
+    r43 = r43 * r90;
+    r43 = fma(r54, r43, r42 * r106);
+    r106 = r50 * r53;
+    r43 = fma(r59, r106, r43);
+    r54 = r31 * r47;
+    r43 = fma(r72, r54, r43);
+    r94 = r94 + r43;
+    r55 = fma(r55, r94, r5 * r39);
+    r39 = r4 * r50;
+    r55 = fma(r98, r39, r55);
+    r54 = r4 * r40;
+    r54 = r54 * r53;
+    r55 = fma(r59, r54, r55);
+    r106 = r61 * r10;
+    r106 = r106 * r45;
+    r106 = fma(r94, r106, r60 * r94);
+    r106 = fma(r94, r65, r106);
+    r106 = fma(r94, r64, r106);
+    r64 = r48 * r106;
+    r55 = fma(r69, r64, r55);
+    r65 = r4 * r71;
+    r55 = fma(r113, r65, r55);
+    r60 = r21 * r31;
+    r60 = r60 * r48;
+    r60 = r60 * r67;
+    r55 = fma(r46, r60, r55);
+    r45 = r44 * r63;
+    r45 = r45 * r1;
+    r45 = r45 * r71;
+    r45 = r45 * r66;
+    r45 = r45 * r57;
+    r55 = fma(r53, r45, r55);
+    r72 = r4 * r34;
+    r72 = r72 * r48;
+    r72 = r72 * r71;
+    r55 = fma(r38, r72, r55);
+    r120 = r21 * r31;
+    r120 = r120 * r48;
+    r120 = r120 * r63;
+    r120 = r120 * r67;
+    r55 = fma(r46, r120, r55);
+    r119 = r44 * r1;
+    r119 = r119 * r71;
+    r119 = r119 * r66;
+    r119 = r119 * r57;
+    r55 = fma(r53, r119, r55);
+    r55 = fma(r50, r70, r55);
+    r55 = fma(r31, r111, r55);
+    r55 = fma(r71, r108, r55);
+    r55 = fma(r71, r107, r55);
+    r55 = fma(r50, r69, r55);
+    r119 = r2 * r55;
+    r120 = r31 * r28;
+    r120 = r120 * r28;
+    r120 = r120 * r44;
+    r120 = r120 * r44;
+    r120 = r120 * r105;
+    r120 = r120 * r7;
+    r105 = r40 * r28;
+    r105 = r105 * r101;
+    r105 = r105 * r7;
+    r105 = fma(r42, r105, r52 * r120);
+    r120 = r49 * r71;
+    r120 = r120 * r83;
+    r120 = r120 * r90;
+    r105 = fma(r96, r120, r105);
+    r96 = r28 * r103;
+    r96 = r96 * r71;
+    r105 = fma(r38, r96, r105);
+    r105 = r105 + r43;
+    r105 = fma(r4, r105, r56 * r94);
+    r94 = r44 * r1;
+    r94 = r94 * r71;
+    r94 = r94 * r7;
+    r94 = r94 * r66;
+    r105 = fma(r83, r94, r105);
+    r56 = r21 * r31;
+    r56 = r56 * r28;
+    r56 = r56 * r67;
+    r105 = fma(r46, r56, r105);
+    r43 = r5 * r50;
+    r105 = fma(r98, r43, r105);
+    r98 = r21 * r31;
+    r98 = r98 * r28;
+    r98 = r98 * r63;
+    r98 = r98 * r67;
+    r105 = fma(r46, r98, r105);
+    r46 = r75 * r63;
+    r46 = r46 * r71;
+    r46 = r46 * r30;
+    r46 = r46 * r83;
+    r105 = fma(r68, r46, r105);
+    r67 = r5 * r31;
+    r67 = r67 * r28;
+    r67 = r67 * r44;
+    r67 = r67 * r44;
+    r67 = r67 * r86;
+    r67 = r67 * r52;
+    r105 = fma(r53, r67, r105);
+    r52 = r5 * r40;
+    r52 = r52 * r53;
+    r105 = fma(r59, r52, r105);
+    r59 = r44 * r63;
+    r59 = r59 * r1;
+    r59 = r59 * r71;
+    r59 = r59 * r7;
+    r59 = r59 * r66;
+    r105 = fma(r83, r59, r105);
+    r66 = r5 * r71;
+    r105 = fma(r113, r66, r105);
+    r113 = r75 * r71;
+    r113 = r113 * r30;
+    r113 = r113 * r83;
+    r105 = fma(r68, r113, r105);
+    r68 = r28 * r106;
+    r105 = fma(r69, r68, r105);
+    r105 = fma(r40, r69, r105);
+    r105 = fma(r40, r70, r105);
+    r105 = fma(r71, r109, r105);
+    r109 = r3 * r105;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r119,
+                                             r109);
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r20 = r21 * r20;
+    r119 = r2 * r20;
+    r109 = fma(r97, r119, r100 * r109);
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r68 = fma(r91, r119, r102 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r109, r68);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r68 = fma(r23, r119, r123 * r68);
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r109 = fma(r115, r119, r73 * r109);
+    WriteSum2<double, double>((double*)inout_shared, r68, r109);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = r3 * r21;
+    r109 = r109 * r0;
+    r109 = fma(r104, r119, r62 * r109);
+    r68 = r3 * r21;
+    r68 = r68 * r0;
+    r119 = fma(r55, r119, r105 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r109, r119);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r2 * r2;
+    r119 = r97 * r2;
+    r109 = r3 * r3;
+    r68 = r100 * r109;
+    r100 = fma(r100, r68, r97 * r119);
+    r97 = r91 * r91;
+    r113 = r102 * r102;
+    r113 = fma(r109, r113, r2 * r97);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r23 * r23;
+    r100 = r123 * r123;
+    r100 = fma(r109, r100, r2 * r113);
+    r113 = r73 * r73;
+    r97 = r115 * r115;
+    r97 = fma(r2, r97, r109 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r100, r97);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r97 = r104 * r104;
+    r100 = r62 * r62;
+    r100 = fma(r109, r100, r2 * r97);
+    r97 = r105 * r105;
+    r113 = r55 * r55;
+    r113 = fma(r2, r113, r109 * r97);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = fma(r91, r119, r102 * r68);
+    r100 = fma(r123, r68, r23 * r119);
+    WriteSum2<double, double>((double*)inout_shared, r113, r100);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = fma(r73, r68, r115 * r119);
+    r113 = fma(r62, r68, r104 * r119);
+    WriteSum2<double, double>((double*)inout_shared, r100, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r119 = fma(r55, r119, r105 * r68);
+    r68 = r102 * r123;
+    r113 = r91 * r23;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r91 * r115;
+    r119 = r102 * r73;
+    r119 = fma(r109, r119, r2 * r113);
+    r113 = r91 * r104;
+    r68 = r102 * r62;
+    r68 = fma(r109, r68, r2 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r119, r68);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r102 * r105;
+    r119 = r91 * r55;
+    r119 = fma(r2, r119, r109 * r68);
+    r68 = r123 * r73;
+    r113 = r23 * r115;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r23 * r104;
+    r119 = r123 * r62;
+    r119 = fma(r109, r119, r2 * r113);
+    r113 = r123 * r105;
+    r68 = r23 * r55;
+    r68 = fma(r2, r68, r109 * r113);
+    WriteSum2<double, double>((double*)inout_shared, r119, r68);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r115 * r104;
+    r119 = r73 * r62;
+    r119 = fma(r109, r119, r2 * r68);
+    r68 = r73 * r105;
+    r113 = r115 * r55;
+    r113 = fma(r2, r113, r109 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r119, r113);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r113 = r62 * r105;
+    r119 = r104 * r55;
+    r119 = fma(r2, r119, r109 * r113);
+    WriteSum1<double, double>((double*)inout_shared, r119);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r20, r0);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r35, r35);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirstKernel<<<n_blocks,
+                                                                       1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.cu
@@ -1,0 +1,342 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScoreKernel<<<n_blocks,
+                                                                 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,1673 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r28 * r28;
+    r43 = 1.00000000000000008e-15;
+    r47 = r34 * r24;
+    r47 = r47 * r24;
+    r48 = r35 + r47;
+    r48 = r48 + r44;
+    r48 = fma(r8, r48, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r49 = r17 * r13;
+    r49 = r49 * r10;
+    r50 = r18 * r14;
+    r50 = fma(r10, r50, r49);
+    r51 = r13 * r14;
+    r51 = fma(r34, r51, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r48 = fma(r9, r6, r48);
+    r48 = fma(r41, r44, r48);
+    r48 = fma(r38, r50, r48);
+    r48 = fma(r30, r51, r48);
+    r48 = fma(r7, r36, r48);
+    r44 = r48 * r48;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r6);
+    r52 = r34 * r24;
+    r52 = fma(r29, r52, r20);
+    r52 = fma(r8, r52, r6);
+    r6 = r18 * r14;
+    r6 = fma(r34, r6, r49);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r47 = r35 + r47;
+    r47 = r47 + r46;
+    r52 = fma(r7, r6, r52);
+    r52 = fma(r38, r31, r52);
+    r52 = fma(r30, r33, r52);
+    r52 = fma(r9, r39, r52);
+    r52 = fma(r41, r47, r52);
+    r47 = copysign(1.0, r52);
+    r47 = fma(r43, r47, r52);
+    r52 = r47 * r47;
+    r39 = 1.0 / r52;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = copysign(1.0, r44);
+    r38 = fma(r43, r38, r44);
+    r43 = r38 * r38;
+    r7 = 1.0 / r43;
+    r44 = atan(r44);
+    r46 = r44 * r39;
+    r42 = r44 * r46;
+    r45 = r45 * r7;
+    r45 = r45 * r42;
+    r49 = 3.00000000000000000e+00;
+    r20 = r49 * r42;
+    r53 = r48 * r7;
+    r54 = r48 * r53;
+    r20 = fma(r54, r20, r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r55,
+                                            r56);
+    r57 = r42 * r54;
+    r45 = r45 + r57;
+    r20 = fma(r55, r45, r5 * r20);
+    r58 = r4 * r28;
+    r59 = r10 * r42;
+    r58 = r58 * r53;
+    r20 = fma(r59, r58, r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r60,
+                                            r61);
+    r62 = r45 * r45;
+    r63 = fma(r61, r62, r60 * r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r45 * r62;
+    r65 = r65 * r66;
+    r63 = fma(r45, r65, r63);
+    r63 = fma(r64, r66, r63);
+    r66 = 1.0 / r47;
+    r67 = 1.0 / r38;
+    r68 = r66 * r67;
+    r69 = r44 * r68;
+    r70 = r63 * r69;
+    r20 = fma(r48, r70, r20);
+    r20 = fma(r48, r69, r20);
+    r20 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r58);
+    r20 = fma(r0, r21, r20);
+    r0 = r28 * r28;
+    r0 = r0 * r49;
+    r0 = r0 * r7;
+    r0 = fma(r42, r0, r57);
+    r0 = fma(r56, r45, r4 * r0);
+    r57 = r5 * r28;
+    r57 = r57 * r53;
+    r0 = fma(r59, r57, r0);
+    r0 = fma(r28, r70, r0);
+    r0 = fma(r28, r69, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r58, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r20, r0);
+    r58 = r3 * r21;
+    r1 = r28 * r7;
+    r57 = -5.00000000000000000e-01;
+    r71 = rsqrt(r30);
+    r72 = r10 * r48;
+    r73 = r11 * r14;
+    r74 = r16 * r17;
+    r74 = fma(r57, r74, r57 * r73);
+    r73 = r15 * r18;
+    r74 = fma(r57, r73, r74);
+    r75 = r12 * r13;
+    r76 = 5.00000000000000000e-01;
+    r74 = fma(r76, r75, r74);
+    r75 = r24 * r74;
+    r73 = r15 * r14;
+    r77 = r12 * r17;
+    r77 = fma(r76, r77, r76 * r73);
+    r73 = r11 * r18;
+    r77 = fma(r57, r73, r77);
+    r78 = r16 * r13;
+    r77 = fma(r76, r78, r77);
+    r78 = r29 * r77;
+    r73 = fma(r10, r78, r10 * r75);
+    r79 = r10 * r19;
+    r80 = fma(r76, r26, r57 * r22);
+    r80 = fma(r57, r23, r80);
+    r80 = fma(r57, r25, r80);
+    r81 = r10 * r27;
+    r82 = r16 * r14;
+    r83 = r11 * r17;
+    r83 = fma(r57, r83, r76 * r82);
+    r82 = r12 * r18;
+    r83 = fma(r57, r82, r83);
+    r84 = r15 * r13;
+    r83 = fma(r57, r84, r83);
+    r81 = r81 * r83;
+    r79 = fma(r80, r79, r81);
+    r73 = r73 + r79;
+    r84 = r10 * r24;
+    r84 = r84 * r83;
+    r82 = r10 * r19;
+    r82 = r82 * r77;
+    r85 = r84 + r82;
+    r86 = r27 * r34;
+    r85 = fma(r74, r86, r85);
+    r87 = r34 * r29;
+    r85 = fma(r80, r87, r85);
+    r85 = fma(r9, r85, r41 * r73);
+    r73 = r24 * r77;
+    r87 = -4.00000000000000000e+00;
+    r73 = r73 * r87;
+    r86 = r27 * r80;
+    r88 = r87 * r86;
+    r89 = r73 + r88;
+    r85 = fma(r8, r89, r85);
+    r72 = r72 * r85;
+    r89 = r48 * r48;
+    r90 = r10 * r24;
+    r90 = r90 * r80;
+    r91 = r10 * r27;
+    r91 = fma(r77, r91, r90);
+    r77 = r10 * r19;
+    r77 = r77 * r74;
+    r92 = r10 * r29;
+    r92 = r92 * r83;
+    r93 = r77 + r92;
+    r94 = r91 + r93;
+    r78 = fma(r34, r78, r34 * r75);
+    r78 = r78 + r79;
+    r78 = fma(r8, r78, r9 * r94);
+    r94 = r19 * r83;
+    r94 = r94 * r87;
+    r73 = r73 + r94;
+    r78 = fma(r41, r73, r78);
+    r52 = r47 * r52;
+    r52 = 1.0 / r52;
+    r47 = r34 * r52;
+    r89 = r89 * r78;
+    r89 = fma(r47, r89, r39 * r72);
+    r72 = r28 * r28;
+    r72 = r72 * r47;
+    r73 = r10 * r28;
+    r95 = r19 * r34;
+    r96 = r34 * r29;
+    r96 = r96 * r83;
+    r95 = fma(r74, r95, r96);
+    r95 = r95 + r91;
+    r88 = r94 + r88;
+    r88 = fma(r9, r88, r41 * r95);
+    r95 = r10 * r29;
+    r95 = fma(r80, r95, r82);
+    r82 = r10 * r27;
+    r82 = fma(r74, r82, r84);
+    r95 = r95 + r82;
+    r88 = fma(r8, r95, r88);
+    r73 = r73 * r88;
+    r89 = fma(r39, r73, r89);
+    r89 = fma(r78, r72, r89);
+    r1 = r1 * r44;
+    r1 = r1 * r66;
+    r1 = r1 * r57;
+    r1 = r1 * r71;
+    r1 = r1 * r89;
+    r73 = r44 * r44;
+    r95 = r7 * r73;
+    r95 = r95 * r72;
+    r84 = r28 * r71;
+    r94 = r89 * r84;
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r35 = r30 * r46;
+    r91 = r28 * r7;
+    r94 = r94 * r35;
+    r94 = fma(r91, r94, r78 * r95);
+    r97 = r21 * r28;
+    r43 = r38 * r43;
+    r43 = 1.0 / r43;
+    r38 = r43 * r42;
+    r38 = r38 * r84;
+    r97 = r97 * r89;
+    r94 = fma(r38, r97, r94);
+    r98 = r59 * r91;
+    r94 = fma(r88, r98, r94);
+    r97 = r89 * r71;
+    r97 = r97 * r35;
+    r99 = r21 * r48;
+    r99 = r99 * r48;
+    r99 = r99 * r89;
+    r99 = r99 * r71;
+    r99 = r99 * r43;
+    r99 = fma(r42, r99, r54 * r97);
+    r97 = r85 * r53;
+    r99 = fma(r59, r97, r99);
+    r100 = r78 * r47;
+    r73 = r54 * r73;
+    r99 = fma(r73, r100, r99);
+    r100 = r94 + r99;
+    r97 = fma(r56, r100, r1);
+    r101 = r28 * r28;
+    r102 = -6.00000000000000000e+00;
+    r101 = r101 * r44;
+    r101 = r101 * r44;
+    r101 = r101 * r78;
+    r101 = r101 * r102;
+    r101 = r101 * r7;
+    r103 = r49 * r89;
+    r103 = r103 * r84;
+    r103 = r103 * r35;
+    r103 = fma(r91, r103, r52 * r101);
+    r101 = -3.00000000000000000e+00;
+    r104 = r28 * r101;
+    r104 = r104 * r89;
+    r103 = fma(r38, r104, r103);
+    r105 = r28 * r88;
+    r106 = 6.00000000000000000e+00;
+    r105 = r105 * r106;
+    r105 = r105 * r7;
+    r103 = fma(r42, r105, r103);
+    r103 = r103 + r99;
+    r99 = r85 * r98;
+    r105 = r21 * r28;
+    r105 = r105 * r78;
+    r105 = r105 * r67;
+    r97 = fma(r46, r105, r97);
+    r104 = r5 * r34;
+    r104 = r104 * r48;
+    r104 = r104 * r38;
+    r107 = r76 * r89;
+    r107 = r107 * r30;
+    r107 = r107 * r84;
+    r97 = fma(r68, r107, r97);
+    r108 = r5 * r88;
+    r108 = r108 * r53;
+    r97 = fma(r59, r108, r97);
+    r109 = r5 * r28;
+    r109 = r109 * r44;
+    r109 = r109 * r44;
+    r109 = r109 * r87;
+    r109 = r109 * r78;
+    r109 = r109 * r52;
+    r97 = fma(r53, r109, r97);
+    r110 = r61 * r10;
+    r110 = r110 * r45;
+    r110 = fma(r60, r100, r100 * r110);
+    r64 = r64 * r49;
+    r64 = r64 * r62;
+    r62 = 4.00000000000000000e+00;
+    r65 = r62 * r65;
+    r110 = fma(r100, r64, r110);
+    r110 = fma(r100, r65, r110);
+    r62 = r28 * r110;
+    r97 = fma(r69, r62, r97);
+    r111 = r5 * r89;
+    r112 = r10 * r53;
+    r112 = r112 * r84;
+    r112 = r112 * r35;
+    r97 = fma(r112, r111, r97);
+    r113 = r76 * r63;
+    r113 = r113 * r89;
+    r113 = r113 * r30;
+    r113 = r113 * r84;
+    r97 = fma(r68, r113, r97);
+    r114 = r21 * r28;
+    r114 = r114 * r63;
+    r114 = r114 * r78;
+    r114 = r114 * r67;
+    r97 = fma(r46, r114, r97);
+    r97 = fma(r4, r103, r97);
+    r97 = fma(r5, r99, r97);
+    r97 = fma(r63, r1, r97);
+    r97 = fma(r89, r104, r97);
+    r97 = fma(r88, r70, r97);
+    r97 = fma(r88, r69, r97);
+    r58 = r58 * r0;
+    r114 = r2 * r21;
+    r114 = r114 * r20;
+    r20 = r48 * r7;
+    r20 = r20 * r44;
+    r20 = r20 * r66;
+    r20 = r20 * r57;
+    r20 = r20 * r71;
+    r20 = r20 * r89;
+    r100 = fma(r55, r100, r20);
+    r113 = r49 * r89;
+    r113 = r113 * r71;
+    r113 = r113 * r35;
+    r111 = r48 * r48;
+    r111 = r111 * r101;
+    r111 = r111 * r89;
+    r111 = r111 * r71;
+    r111 = r111 * r43;
+    r111 = fma(r42, r111, r54 * r113);
+    r113 = r85 * r106;
+    r113 = r113 * r42;
+    r111 = fma(r53, r113, r111);
+    r62 = r102 * r52;
+    r62 = r62 * r73;
+    r111 = fma(r78, r62, r111);
+    r111 = r111 + r94;
+    r94 = r21 * r48;
+    r94 = r94 * r63;
+    r94 = r94 * r78;
+    r94 = r94 * r67;
+    r100 = fma(r46, r94, r100);
+    r113 = r48 * r76;
+    r113 = r113 * r71;
+    r113 = r113 * r30;
+    r113 = r113 * r68;
+    r109 = r63 * r113;
+    r108 = r4 * r34;
+    r108 = r108 * r48;
+    r108 = r108 * r89;
+    r100 = fma(r38, r108, r100);
+    r107 = r4 * r88;
+    r107 = r107 * r53;
+    r100 = fma(r59, r107, r100);
+    r1 = r4 * r28;
+    r1 = r1 * r44;
+    r1 = r1 * r44;
+    r1 = r1 * r87;
+    r1 = r1 * r52;
+    r1 = r1 * r53;
+    r105 = r4 * r89;
+    r100 = fma(r112, r105, r100);
+    r103 = r48 * r110;
+    r100 = fma(r69, r103, r100);
+    r115 = r21 * r48;
+    r115 = r115 * r78;
+    r115 = r115 * r67;
+    r100 = fma(r46, r115, r100);
+    r100 = fma(r5, r111, r100);
+    r100 = fma(r4, r99, r100);
+    r100 = fma(r63, r20, r100);
+    r100 = fma(r89, r109, r100);
+    r100 = fma(r85, r70, r100);
+    r100 = fma(r78, r1, r100);
+    r100 = fma(r89, r113, r100);
+    r100 = fma(r85, r69, r100);
+    r58 = fma(r100, r114, r97 * r58);
+    r115 = r3 * r21;
+    r103 = r28 * r106;
+    r105 = r10 * r24;
+    r107 = r11 * r14;
+    r108 = r16 * r17;
+    r108 = fma(r76, r108, r76 * r107);
+    r107 = r15 * r18;
+    r108 = fma(r76, r107, r108);
+    r94 = r12 * r13;
+    r108 = fma(r57, r94, r108);
+    r105 = r105 * r108;
+    r81 = r81 + r105;
+    r94 = r19 * r34;
+    r81 = fma(r80, r94, r81);
+    r107 = r34 * r29;
+    r20 = r15 * r14;
+    r99 = r12 * r17;
+    r99 = fma(r57, r99, r57 * r20);
+    r20 = r11 * r18;
+    r99 = fma(r76, r20, r99);
+    r111 = r16 * r13;
+    r99 = fma(r57, r111, r99);
+    r81 = fma(r99, r107, r81);
+    r107 = r10 * r29;
+    r107 = fma(r10, r86, r108 * r107);
+    r94 = r10 * r19;
+    r94 = r94 * r83;
+    r111 = r10 * r24;
+    r111 = fma(r99, r111, r94);
+    r107 = r107 + r111;
+    r107 = fma(r8, r107, r41 * r81);
+    r81 = r27 * r87;
+    r81 = r81 * r108;
+    r20 = r19 * r99;
+    r116 = r87 * r20;
+    r117 = r81 + r116;
+    r107 = fma(r9, r117, r107);
+    r103 = r103 * r107;
+    r103 = r103 * r7;
+    r117 = r28 * r38;
+    r118 = r10 * r48;
+    r92 = r90 + r92;
+    r90 = r10 * r27;
+    r90 = r90 * r99;
+    r119 = r10 * r19;
+    r119 = fma(r108, r119, r90);
+    r92 = r92 + r119;
+    r120 = r24 * r83;
+    r120 = r120 * r87;
+    r81 = r120 + r81;
+    r81 = fma(r8, r81, r41 * r92);
+    r92 = r34 * r29;
+    r86 = fma(r34, r86, r108 * r92);
+    r86 = r86 + r111;
+    r81 = fma(r9, r86, r81);
+    r118 = r118 * r81;
+    r86 = r10 * r28;
+    r86 = r86 * r107;
+    r86 = fma(r39, r86, r39 * r118);
+    r118 = r34 * r24;
+    r118 = fma(r80, r118, r96);
+    r118 = r118 + r119;
+    r119 = r10 * r29;
+    r119 = fma(r99, r119, r105);
+    r119 = r119 + r79;
+    r119 = fma(r9, r119, r8 * r118);
+    r116 = r120 + r116;
+    r119 = fma(r41, r116, r119);
+    r116 = r48 * r48;
+    r116 = r116 * r119;
+    r86 = fma(r47, r116, r86);
+    r86 = fma(r119, r72, r86);
+    r116 = r101 * r86;
+    r117 = fma(r116, r117, r42 * r103);
+    r103 = r28 * r28;
+    r103 = r103 * r44;
+    r103 = r103 * r44;
+    r103 = r103 * r102;
+    r103 = r103 * r119;
+    r103 = r103 * r7;
+    r117 = fma(r52, r103, r117);
+    r120 = r49 * r86;
+    r120 = r120 * r84;
+    r120 = r120 * r35;
+    r117 = fma(r91, r120, r117);
+    r118 = r119 * r47;
+    r79 = r81 * r53;
+    r79 = fma(r59, r79, r73 * r118);
+    r118 = r21 * r48;
+    r118 = r118 * r48;
+    r118 = r118 * r86;
+    r118 = r118 * r71;
+    r118 = r118 * r43;
+    r79 = fma(r42, r118, r79);
+    r105 = r86 * r71;
+    r105 = r105 * r35;
+    r79 = fma(r54, r105, r79);
+    r117 = r117 + r79;
+    r120 = r21 * r28;
+    r120 = r120 * r86;
+    r120 = fma(r38, r120, r107 * r98);
+    r103 = r86 * r84;
+    r103 = r103 * r35;
+    r120 = fma(r91, r103, r120);
+    r120 = fma(r119, r95, r120);
+    r79 = r79 + r120;
+    r117 = fma(r56, r79, r4 * r117);
+    r103 = r44 * r57;
+    r103 = r103 * r86;
+    r103 = r103 * r7;
+    r103 = r103 * r66;
+    r117 = fma(r84, r103, r117);
+    r105 = r61 * r10;
+    r105 = r105 * r45;
+    r105 = fma(r79, r105, r60 * r79);
+    r105 = fma(r79, r65, r105);
+    r105 = fma(r79, r64, r105);
+    r118 = r28 * r105;
+    r117 = fma(r69, r118, r117);
+    r80 = r76 * r86;
+    r80 = r80 * r30;
+    r80 = r80 * r84;
+    r117 = fma(r68, r80, r117);
+    r92 = r5 * r28;
+    r92 = r92 * r44;
+    r92 = r92 * r44;
+    r92 = r92 * r87;
+    r92 = r92 * r119;
+    r92 = r92 * r52;
+    r117 = fma(r53, r92, r117);
+    r108 = r5 * r86;
+    r117 = fma(r112, r108, r117);
+    r121 = r21 * r28;
+    r121 = r121 * r63;
+    r121 = r121 * r119;
+    r121 = r121 * r67;
+    r117 = fma(r46, r121, r117);
+    r122 = r44 * r63;
+    r122 = r122 * r57;
+    r122 = r122 * r86;
+    r122 = r122 * r7;
+    r122 = r122 * r66;
+    r117 = fma(r84, r122, r117);
+    r123 = r21 * r28;
+    r123 = r123 * r119;
+    r123 = r123 * r67;
+    r117 = fma(r46, r123, r117);
+    r124 = r5 * r107;
+    r124 = r124 * r53;
+    r117 = fma(r59, r124, r117);
+    r125 = r76 * r63;
+    r125 = r125 * r86;
+    r125 = r125 * r30;
+    r125 = r125 * r84;
+    r117 = fma(r68, r125, r117);
+    r126 = r5 * r81;
+    r117 = fma(r98, r126, r117);
+    r117 = fma(r107, r70, r117);
+    r117 = fma(r86, r104, r117);
+    r117 = fma(r107, r69, r117);
+    r115 = r115 * r0;
+    r126 = r106 * r81;
+    r126 = r126 * r42;
+    r126 = fma(r53, r126, r119 * r62);
+    r125 = r48 * r48;
+    r125 = r125 * r71;
+    r125 = r125 * r43;
+    r125 = r125 * r42;
+    r126 = fma(r116, r125, r126);
+    r116 = r49 * r86;
+    r116 = r116 * r71;
+    r116 = r116 * r35;
+    r126 = fma(r54, r116, r126);
+    r126 = r126 + r120;
+    r79 = fma(r55, r79, r5 * r126);
+    r126 = r21 * r48;
+    r126 = r126 * r119;
+    r126 = r126 * r67;
+    r79 = fma(r46, r126, r79);
+    r120 = r44 * r63;
+    r120 = r120 * r57;
+    r120 = r120 * r86;
+    r120 = r120 * r66;
+    r120 = r120 * r71;
+    r79 = fma(r53, r120, r79);
+    r116 = r48 * r105;
+    r79 = fma(r69, r116, r79);
+    r125 = r21 * r48;
+    r125 = r125 * r63;
+    r125 = r125 * r119;
+    r125 = r125 * r67;
+    r79 = fma(r46, r125, r79);
+    r124 = r4 * r86;
+    r79 = fma(r112, r124, r79);
+    r123 = r4 * r34;
+    r123 = r123 * r48;
+    r123 = r123 * r86;
+    r79 = fma(r38, r123, r79);
+    r122 = r4 * r107;
+    r122 = r122 * r53;
+    r79 = fma(r59, r122, r79);
+    r121 = r4 * r81;
+    r79 = fma(r98, r121, r79);
+    r108 = r44 * r57;
+    r108 = r108 * r86;
+    r108 = r108 * r66;
+    r108 = r108 * r71;
+    r79 = fma(r53, r108, r79);
+    r79 = fma(r86, r109, r79);
+    r79 = fma(r86, r113, r79);
+    r79 = fma(r119, r1, r79);
+    r79 = fma(r81, r69, r79);
+    r79 = fma(r81, r70, r79);
+    r115 = fma(r79, r114, r117 * r115);
+    WriteSum2<double, double>((double*)inout_shared, r58, r115);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r115 = r3 * r21;
+    r58 = r19 * r87;
+    r26 = fma(r57, r26, r76 * r22);
+    r26 = fma(r76, r23, r26);
+    r26 = fma(r76, r25, r26);
+    r58 = r58 * r26;
+    r75 = r87 * r75;
+    r25 = r58 + r75;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r94 = r94 + r23;
+    r22 = r34 * r24;
+    r94 = fma(r99, r22, r94);
+    r108 = r34 * r29;
+    r94 = fma(r74, r108, r94);
+    r94 = fma(r8, r94, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r20, r26 * r25);
+    r25 = r25 + r82;
+    r94 = fma(r9, r25, r94);
+    r25 = r10 * r28;
+    r108 = r10 * r24;
+    r108 = r108 * r26;
+    r90 = r90 + r108;
+    r90 = r90 + r93;
+    r93 = r34 * r29;
+    r20 = fma(r34, r20, r26 * r93);
+    r20 = r20 + r82;
+    r20 = fma(r41, r20, r8 * r90);
+    r83 = r27 * r83;
+    r83 = r83 * r87;
+    r58 = r58 + r83;
+    r20 = fma(r9, r58, r20);
+    r25 = r25 * r20;
+    r58 = r48 * r48;
+    r58 = r58 * r94;
+    r58 = fma(r47, r58, r39 * r25);
+    r25 = r10 * r48;
+    r96 = r77 + r96;
+    r77 = r27 * r34;
+    r96 = fma(r99, r77, r96);
+    r96 = r96 + r108;
+    r75 = r83 + r75;
+    r75 = fma(r8, r75, r9 * r96);
+    r8 = r10 * r29;
+    r8 = fma(r74, r8, r23);
+    r8 = r8 + r111;
+    r75 = fma(r41, r8, r75);
+    r25 = r25 * r75;
+    r58 = fma(r39, r25, r58);
+    r58 = fma(r94, r72, r58);
+    r25 = r58 * r84;
+    r25 = r25 * r35;
+    r25 = fma(r91, r25, r94 * r95);
+    r8 = r21 * r28;
+    r8 = r8 * r58;
+    r25 = fma(r38, r8, r25);
+    r25 = fma(r20, r98, r25);
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r58;
+    r8 = r8 * r71;
+    r8 = r8 * r43;
+    r41 = r75 * r53;
+    r41 = fma(r59, r41, r42 * r8);
+    r8 = r94 * r47;
+    r41 = fma(r73, r8, r41);
+    r111 = r58 * r71;
+    r111 = r111 * r35;
+    r41 = fma(r54, r111, r41);
+    r111 = r25 + r41;
+    r8 = r28 * r28;
+    r8 = r8 * r44;
+    r8 = r8 * r44;
+    r8 = r8 * r102;
+    r8 = r8 * r94;
+    r8 = r8 * r7;
+    r23 = r49 * r58;
+    r23 = r23 * r84;
+    r23 = r23 * r35;
+    r23 = fma(r91, r23, r52 * r8);
+    r8 = r28 * r106;
+    r8 = r8 * r20;
+    r8 = r8 * r7;
+    r23 = fma(r42, r8, r23);
+    r74 = r28 * r101;
+    r74 = r74 * r58;
+    r23 = fma(r38, r74, r23);
+    r23 = r23 + r41;
+    r23 = fma(r4, r23, r56 * r111);
+    r41 = r21 * r28;
+    r41 = r41 * r63;
+    r41 = r41 * r94;
+    r41 = r41 * r67;
+    r23 = fma(r46, r41, r23);
+    r74 = r21 * r28;
+    r74 = r74 * r94;
+    r74 = r74 * r67;
+    r23 = fma(r46, r74, r23);
+    r8 = r5 * r75;
+    r23 = fma(r98, r8, r23);
+    r96 = r44 * r63;
+    r96 = r96 * r57;
+    r96 = r96 * r58;
+    r96 = r96 * r7;
+    r96 = r96 * r66;
+    r23 = fma(r84, r96, r23);
+    r9 = r5 * r58;
+    r23 = fma(r112, r9, r23);
+    r83 = r76 * r58;
+    r83 = r83 * r30;
+    r83 = r83 * r84;
+    r23 = fma(r68, r83, r23);
+    r77 = r61 * r10;
+    r77 = r77 * r45;
+    r77 = fma(r111, r77, r60 * r111);
+    r77 = fma(r111, r64, r77);
+    r77 = fma(r111, r65, r77);
+    r108 = r28 * r77;
+    r23 = fma(r69, r108, r23);
+    r99 = r44 * r57;
+    r99 = r99 * r58;
+    r99 = r99 * r7;
+    r99 = r99 * r66;
+    r23 = fma(r84, r99, r23);
+    r90 = r76 * r63;
+    r90 = r90 * r58;
+    r90 = r90 * r30;
+    r90 = r90 * r84;
+    r23 = fma(r68, r90, r23);
+    r82 = r5 * r28;
+    r82 = r82 * r44;
+    r82 = r82 * r44;
+    r82 = r82 * r87;
+    r82 = r82 * r94;
+    r82 = r82 * r52;
+    r23 = fma(r53, r82, r23);
+    r93 = r5 * r20;
+    r93 = r93 * r53;
+    r23 = fma(r59, r93, r23);
+    r23 = fma(r20, r70, r23);
+    r23 = fma(r20, r69, r23);
+    r23 = fma(r58, r104, r23);
+    r115 = r115 * r0;
+    r93 = r48 * r48;
+    r93 = r93 * r101;
+    r93 = r93 * r58;
+    r93 = r93 * r71;
+    r93 = r93 * r43;
+    r82 = r106 * r75;
+    r82 = r82 * r42;
+    r82 = fma(r53, r82, r42 * r93);
+    r93 = r49 * r58;
+    r93 = r93 * r71;
+    r93 = r93 * r35;
+    r82 = fma(r54, r93, r82);
+    r82 = fma(r94, r62, r82);
+    r82 = r82 + r25;
+    r82 = fma(r5, r82, r55 * r111);
+    r111 = r48 * r77;
+    r82 = fma(r69, r111, r82);
+    r25 = r4 * r75;
+    r82 = fma(r98, r25, r82);
+    r93 = r4 * r58;
+    r82 = fma(r112, r93, r82);
+    r90 = r21 * r48;
+    r90 = r90 * r63;
+    r90 = r90 * r94;
+    r90 = r90 * r67;
+    r82 = fma(r46, r90, r82);
+    r99 = r4 * r34;
+    r99 = r99 * r48;
+    r99 = r99 * r58;
+    r82 = fma(r38, r99, r82);
+    r108 = r21 * r48;
+    r108 = r108 * r94;
+    r108 = r108 * r67;
+    r82 = fma(r46, r108, r82);
+    r83 = r44 * r57;
+    r83 = r83 * r58;
+    r83 = r83 * r66;
+    r83 = r83 * r71;
+    r82 = fma(r53, r83, r82);
+    r9 = r4 * r20;
+    r9 = r9 * r53;
+    r82 = fma(r59, r9, r82);
+    r96 = r44 * r63;
+    r96 = r96 * r57;
+    r96 = r96 * r58;
+    r96 = r96 * r66;
+    r96 = r96 * r71;
+    r82 = fma(r53, r96, r82);
+    r82 = fma(r58, r113, r82);
+    r82 = fma(r58, r109, r82);
+    r82 = fma(r75, r70, r82);
+    r82 = fma(r75, r69, r82);
+    r82 = fma(r94, r1, r82);
+    r115 = fma(r82, r114, r23 * r115);
+    r96 = r3 * r21;
+    r9 = r32 * r28;
+    r9 = r9 * r106;
+    r9 = r9 * r7;
+    r83 = r28 * r101;
+    r108 = r10 * r32;
+    r108 = r108 * r28;
+    r108 = fma(r6, r72, r39 * r108);
+    r99 = r6 * r48;
+    r99 = r99 * r48;
+    r108 = fma(r47, r99, r108);
+    r90 = r10 * r36;
+    r90 = r90 * r48;
+    r108 = fma(r39, r90, r108);
+    r83 = r83 * r108;
+    r83 = fma(r38, r83, r42 * r9);
+    r9 = r6 * r28;
+    r9 = r9 * r28;
+    r9 = r9 * r44;
+    r9 = r9 * r44;
+    r9 = r9 * r102;
+    r9 = r9 * r7;
+    r83 = fma(r52, r9, r83);
+    r90 = r49 * r108;
+    r90 = r90 * r84;
+    r90 = r90 * r35;
+    r83 = fma(r91, r90, r83);
+    r99 = r36 * r53;
+    r93 = r21 * r48;
+    r93 = r93 * r48;
+    r93 = r93 * r108;
+    r93 = r93 * r71;
+    r93 = r93 * r43;
+    r93 = fma(r42, r93, r59 * r99);
+    r99 = r108 * r71;
+    r99 = r99 * r35;
+    r93 = fma(r54, r99, r93);
+    r25 = r6 * r47;
+    r93 = fma(r73, r25, r93);
+    r83 = r83 + r93;
+    r90 = r21 * r28;
+    r90 = r90 * r108;
+    r90 = fma(r38, r90, r32 * r98);
+    r9 = r108 * r84;
+    r9 = r9 * r35;
+    r90 = fma(r91, r9, r90);
+    r90 = fma(r6, r95, r90);
+    r93 = r93 + r90;
+    r83 = fma(r56, r93, r4 * r83);
+    r9 = r76 * r108;
+    r9 = r9 * r30;
+    r9 = r9 * r84;
+    r83 = fma(r68, r9, r83);
+    r25 = r44 * r63;
+    r25 = r25 * r57;
+    r25 = r25 * r108;
+    r25 = r25 * r7;
+    r25 = r25 * r66;
+    r83 = fma(r84, r25, r83);
+    r99 = r21 * r6;
+    r99 = r99 * r28;
+    r99 = r99 * r63;
+    r99 = r99 * r67;
+    r83 = fma(r46, r99, r83);
+    r111 = r108 * r112;
+    r8 = r21 * r6;
+    r8 = r8 * r28;
+    r8 = r8 * r67;
+    r83 = fma(r46, r8, r83);
+    r74 = r5 * r6;
+    r74 = r74 * r28;
+    r74 = r74 * r44;
+    r74 = r74 * r44;
+    r74 = r74 * r87;
+    r74 = r74 * r52;
+    r83 = fma(r53, r74, r83);
+    r41 = r61 * r10;
+    r41 = r41 * r45;
+    r41 = fma(r60, r93, r93 * r41);
+    r41 = fma(r93, r65, r41);
+    r41 = fma(r93, r64, r41);
+    r26 = r28 * r41;
+    r83 = fma(r69, r26, r83);
+    r22 = r76 * r63;
+    r22 = r22 * r108;
+    r22 = r22 * r30;
+    r22 = r22 * r84;
+    r83 = fma(r68, r22, r83);
+    r121 = r5 * r32;
+    r121 = r121 * r53;
+    r83 = fma(r59, r121, r83);
+    r122 = r44 * r57;
+    r122 = r122 * r108;
+    r122 = r122 * r7;
+    r122 = r122 * r66;
+    r83 = fma(r84, r122, r83);
+    r123 = r5 * r36;
+    r83 = fma(r98, r123, r83);
+    r83 = fma(r32, r69, r83);
+    r83 = fma(r5, r111, r83);
+    r83 = fma(r108, r104, r83);
+    r83 = fma(r32, r70, r83);
+    r96 = r96 * r0;
+    r123 = r36 * r106;
+    r123 = r123 * r42;
+    r122 = r48 * r48;
+    r122 = r122 * r101;
+    r122 = r122 * r108;
+    r122 = r122 * r71;
+    r122 = r122 * r43;
+    r122 = fma(r42, r122, r53 * r123);
+    r123 = r49 * r108;
+    r123 = r123 * r71;
+    r123 = r123 * r35;
+    r122 = fma(r54, r123, r122);
+    r122 = fma(r6, r62, r122);
+    r122 = r122 + r90;
+    r93 = fma(r55, r93, r5 * r122);
+    r122 = r44 * r63;
+    r122 = r122 * r57;
+    r122 = r122 * r108;
+    r122 = r122 * r66;
+    r122 = r122 * r71;
+    r93 = fma(r53, r122, r93);
+    r90 = r44 * r57;
+    r90 = r90 * r108;
+    r90 = r90 * r66;
+    r90 = r90 * r71;
+    r93 = fma(r53, r90, r93);
+    r123 = r4 * r34;
+    r123 = r123 * r48;
+    r123 = r123 * r108;
+    r93 = fma(r38, r123, r93);
+    r121 = r48 * r41;
+    r93 = fma(r69, r121, r93);
+    r22 = r21 * r6;
+    r22 = r22 * r48;
+    r22 = r22 * r63;
+    r22 = r22 * r67;
+    r93 = fma(r46, r22, r93);
+    r26 = r21 * r6;
+    r26 = r26 * r48;
+    r26 = r26 * r67;
+    r93 = fma(r46, r26, r93);
+    r74 = r4 * r32;
+    r74 = r74 * r53;
+    r93 = fma(r59, r74, r93);
+    r8 = r4 * r36;
+    r93 = fma(r98, r8, r93);
+    r93 = fma(r36, r70, r93);
+    r93 = fma(r108, r109, r93);
+    r93 = fma(r4, r111, r93);
+    r93 = fma(r108, r113, r93);
+    r93 = fma(r6, r1, r93);
+    r93 = fma(r36, r69, r93);
+    r96 = fma(r93, r114, r83 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r115, r96);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r3 * r21;
+    r115 = fma(r37, r98, r33 * r95);
+    r8 = r10 * r37;
+    r8 = r8 * r28;
+    r8 = fma(r39, r8, r33 * r72);
+    r74 = r33 * r48;
+    r74 = r74 * r48;
+    r8 = fma(r47, r74, r8);
+    r26 = r10 * r51;
+    r26 = r26 * r48;
+    r8 = fma(r39, r26, r8);
+    r26 = r8 * r84;
+    r26 = r26 * r35;
+    r115 = fma(r91, r26, r115);
+    r74 = r21 * r28;
+    r74 = r74 * r8;
+    r115 = fma(r38, r74, r115);
+    r74 = r8 * r71;
+    r74 = r74 * r35;
+    r26 = r33 * r47;
+    r26 = fma(r73, r26, r54 * r74);
+    r74 = r21 * r48;
+    r74 = r74 * r48;
+    r74 = r74 * r8;
+    r74 = r74 * r71;
+    r74 = r74 * r43;
+    r26 = fma(r42, r74, r26);
+    r22 = r51 * r53;
+    r26 = fma(r59, r22, r26);
+    r22 = r115 + r26;
+    r74 = r33 * r28;
+    r74 = r74 * r28;
+    r74 = r74 * r44;
+    r74 = r74 * r44;
+    r74 = r74 * r102;
+    r74 = r74 * r7;
+    r121 = r37 * r28;
+    r121 = r121 * r106;
+    r121 = r121 * r7;
+    r121 = fma(r42, r121, r52 * r74);
+    r74 = r49 * r8;
+    r74 = r74 * r84;
+    r74 = r74 * r35;
+    r121 = fma(r91, r74, r121);
+    r123 = r28 * r101;
+    r123 = r123 * r8;
+    r121 = fma(r38, r123, r121);
+    r121 = r121 + r26;
+    r121 = fma(r4, r121, r56 * r22);
+    r26 = r21 * r33;
+    r26 = r26 * r28;
+    r26 = r26 * r67;
+    r121 = fma(r46, r26, r121);
+    r123 = r5 * r37;
+    r123 = r123 * r53;
+    r121 = fma(r59, r123, r121);
+    r74 = r5 * r8;
+    r121 = fma(r112, r74, r121);
+    r90 = r76 * r8;
+    r90 = r90 * r30;
+    r90 = r90 * r84;
+    r121 = fma(r68, r90, r121);
+    r122 = r61 * r10;
+    r122 = r122 * r45;
+    r122 = fma(r60, r22, r22 * r122);
+    r122 = fma(r22, r64, r122);
+    r122 = fma(r22, r65, r122);
+    r111 = r28 * r122;
+    r121 = fma(r69, r111, r121);
+    r99 = r44 * r63;
+    r99 = r99 * r57;
+    r99 = r99 * r8;
+    r99 = r99 * r7;
+    r99 = r99 * r66;
+    r121 = fma(r84, r99, r121);
+    r25 = r5 * r33;
+    r25 = r25 * r28;
+    r25 = r25 * r44;
+    r25 = r25 * r44;
+    r25 = r25 * r87;
+    r25 = r25 * r52;
+    r121 = fma(r53, r25, r121);
+    r9 = r44 * r57;
+    r9 = r9 * r8;
+    r9 = r9 * r7;
+    r9 = r9 * r66;
+    r121 = fma(r84, r9, r121);
+    r124 = r76 * r63;
+    r124 = r124 * r8;
+    r124 = r124 * r30;
+    r124 = r124 * r84;
+    r121 = fma(r68, r124, r121);
+    r125 = r21 * r33;
+    r125 = r125 * r28;
+    r125 = r125 * r63;
+    r125 = r125 * r67;
+    r121 = fma(r46, r125, r121);
+    r116 = r5 * r51;
+    r121 = fma(r98, r116, r121);
+    r121 = fma(r37, r70, r121);
+    r121 = fma(r8, r104, r121);
+    r121 = fma(r37, r69, r121);
+    r96 = r96 * r0;
+    r116 = r49 * r8;
+    r116 = r116 * r71;
+    r116 = r116 * r35;
+    r116 = fma(r33, r62, r54 * r116);
+    r125 = r48 * r48;
+    r125 = r125 * r101;
+    r125 = r125 * r8;
+    r125 = r125 * r71;
+    r125 = r125 * r43;
+    r116 = fma(r42, r125, r116);
+    r124 = r51 * r106;
+    r124 = r124 * r42;
+    r116 = fma(r53, r124, r116);
+    r116 = r116 + r115;
+    r22 = fma(r55, r22, r5 * r116);
+    r116 = r4 * r37;
+    r116 = r116 * r53;
+    r22 = fma(r59, r116, r22);
+    r115 = r4 * r8;
+    r22 = fma(r112, r115, r22);
+    r124 = r21 * r33;
+    r124 = r124 * r48;
+    r124 = r124 * r67;
+    r22 = fma(r46, r124, r22);
+    r125 = r4 * r34;
+    r125 = r125 * r48;
+    r125 = r125 * r8;
+    r22 = fma(r38, r125, r22);
+    r9 = r44 * r57;
+    r9 = r9 * r8;
+    r9 = r9 * r66;
+    r9 = r9 * r71;
+    r22 = fma(r53, r9, r22);
+    r25 = r48 * r122;
+    r22 = fma(r69, r25, r22);
+    r99 = r44 * r63;
+    r99 = r99 * r57;
+    r99 = r99 * r8;
+    r99 = r99 * r66;
+    r99 = r99 * r71;
+    r22 = fma(r53, r99, r22);
+    r111 = r21 * r33;
+    r111 = r111 * r48;
+    r111 = r111 * r63;
+    r111 = r111 * r67;
+    r22 = fma(r46, r111, r22);
+    r90 = r4 * r51;
+    r22 = fma(r98, r90, r22);
+    r22 = fma(r8, r109, r22);
+    r22 = fma(r51, r69, r22);
+    r22 = fma(r33, r1, r22);
+    r22 = fma(r8, r113, r22);
+    r22 = fma(r51, r70, r22);
+    r96 = fma(r22, r114, r121 * r96);
+    r90 = r3 * r21;
+    r95 = fma(r40, r98, r31 * r95);
+    r111 = r10 * r40;
+    r111 = r111 * r28;
+    r72 = fma(r31, r72, r39 * r111);
+    r111 = r10 * r50;
+    r111 = r111 * r48;
+    r72 = fma(r39, r111, r72);
+    r39 = r31 * r48;
+    r39 = r39 * r48;
+    r72 = fma(r47, r39, r72);
+    r39 = r72 * r84;
+    r39 = r39 * r35;
+    r95 = fma(r91, r39, r95);
+    r111 = r21 * r28;
+    r111 = r111 * r72;
+    r95 = fma(r38, r111, r95);
+    r111 = r21 * r48;
+    r111 = r111 * r48;
+    r111 = r111 * r72;
+    r111 = r111 * r71;
+    r111 = r111 * r43;
+    r39 = r72 * r71;
+    r39 = r39 * r35;
+    r39 = fma(r54, r39, r42 * r111);
+    r111 = r50 * r53;
+    r39 = fma(r59, r111, r39);
+    r99 = r31 * r47;
+    r39 = fma(r73, r99, r39);
+    r99 = r95 + r39;
+    r111 = r31 * r28;
+    r111 = r111 * r28;
+    r111 = r111 * r44;
+    r111 = r111 * r44;
+    r111 = r111 * r102;
+    r111 = r111 * r7;
+    r102 = r40 * r28;
+    r102 = r102 * r106;
+    r102 = r102 * r7;
+    r102 = fma(r42, r102, r52 * r111);
+    r111 = r49 * r72;
+    r111 = r111 * r84;
+    r111 = r111 * r35;
+    r102 = fma(r91, r111, r102);
+    r91 = r28 * r101;
+    r91 = r91 * r72;
+    r102 = fma(r38, r91, r102);
+    r102 = r102 + r39;
+    r102 = fma(r4, r102, r56 * r99);
+    r56 = r44 * r57;
+    r56 = r56 * r72;
+    r56 = r56 * r7;
+    r56 = r56 * r66;
+    r102 = fma(r84, r56, r102);
+    r39 = r21 * r31;
+    r39 = r39 * r28;
+    r39 = r39 * r67;
+    r102 = fma(r46, r39, r102);
+    r91 = r5 * r50;
+    r102 = fma(r98, r91, r102);
+    r111 = r21 * r31;
+    r111 = r111 * r28;
+    r111 = r111 * r63;
+    r111 = r111 * r67;
+    r102 = fma(r46, r111, r102);
+    r73 = r76 * r63;
+    r73 = r73 * r72;
+    r73 = r73 * r30;
+    r73 = r73 * r84;
+    r102 = fma(r68, r73, r102);
+    r25 = r5 * r31;
+    r25 = r25 * r28;
+    r25 = r25 * r44;
+    r25 = r25 * r44;
+    r25 = r25 * r87;
+    r25 = r25 * r52;
+    r102 = fma(r53, r25, r102);
+    r52 = r5 * r40;
+    r52 = r52 * r53;
+    r102 = fma(r59, r52, r102);
+    r87 = r44 * r63;
+    r87 = r87 * r57;
+    r87 = r87 * r72;
+    r87 = r87 * r7;
+    r87 = r87 * r66;
+    r102 = fma(r84, r87, r102);
+    r7 = r5 * r72;
+    r102 = fma(r112, r7, r102);
+    r9 = r76 * r72;
+    r9 = r9 * r30;
+    r9 = r9 * r84;
+    r102 = fma(r68, r9, r102);
+    r68 = r61 * r10;
+    r68 = r68 * r45;
+    r68 = fma(r99, r68, r60 * r99);
+    r68 = fma(r99, r65, r68);
+    r68 = fma(r99, r64, r68);
+    r64 = r28 * r68;
+    r102 = fma(r69, r64, r102);
+    r102 = fma(r40, r69, r102);
+    r102 = fma(r40, r70, r102);
+    r102 = fma(r72, r104, r102);
+    r90 = r90 * r0;
+    r0 = r48 * r48;
+    r0 = r0 * r101;
+    r0 = r0 * r72;
+    r0 = r0 * r71;
+    r0 = r0 * r43;
+    r43 = r49 * r72;
+    r43 = r43 * r71;
+    r43 = r43 * r35;
+    r43 = fma(r54, r43, r42 * r0);
+    r0 = r50 * r106;
+    r0 = r0 * r42;
+    r43 = fma(r53, r0, r43);
+    r43 = fma(r31, r62, r43);
+    r43 = r43 + r95;
+    r99 = fma(r55, r99, r5 * r43);
+    r55 = r4 * r50;
+    r99 = fma(r98, r55, r99);
+    r98 = r4 * r40;
+    r98 = r98 * r53;
+    r99 = fma(r59, r98, r99);
+    r59 = r48 * r68;
+    r99 = fma(r69, r59, r99);
+    r43 = r4 * r72;
+    r99 = fma(r112, r43, r99);
+    r112 = r21 * r31;
+    r112 = r112 * r48;
+    r112 = r112 * r67;
+    r99 = fma(r46, r112, r99);
+    r95 = r44 * r63;
+    r95 = r95 * r57;
+    r95 = r95 * r72;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r99 = fma(r53, r95, r99);
+    r62 = r4 * r34;
+    r62 = r62 * r48;
+    r62 = r62 * r72;
+    r99 = fma(r38, r62, r99);
+    r0 = r21 * r31;
+    r0 = r0 * r48;
+    r0 = r0 * r63;
+    r0 = r0 * r67;
+    r99 = fma(r46, r0, r99);
+    r46 = r44 * r57;
+    r46 = r46 * r72;
+    r46 = r46 * r66;
+    r46 = r46 * r71;
+    r99 = fma(r53, r46, r99);
+    r99 = fma(r50, r70, r99);
+    r99 = fma(r31, r1, r99);
+    r99 = fma(r72, r109, r99);
+    r99 = fma(r72, r113, r99);
+    r99 = fma(r50, r69, r99);
+    r114 = fma(r99, r114, r102 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r96, r114);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r2 * r2;
+    r114 = r100 * r2;
+    r96 = r3 * r3;
+    r90 = r97 * r96;
+    r97 = fma(r97, r90, r100 * r114);
+    r100 = r79 * r79;
+    r46 = r117 * r117;
+    r46 = fma(r96, r46, r2 * r100);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r82 * r82;
+    r97 = r23 * r23;
+    r97 = fma(r96, r97, r2 * r46);
+    r46 = r83 * r83;
+    r100 = r93 * r93;
+    r100 = fma(r2, r100, r96 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r97, r100);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = r22 * r22;
+    r97 = r121 * r121;
+    r97 = fma(r96, r97, r2 * r100);
+    r100 = r102 * r102;
+    r46 = r99 * r99;
+    r46 = fma(r2, r46, r96 * r100);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = fma(r79, r114, r117 * r90);
+    r97 = fma(r23, r90, r82 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r46, r97);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r97 = fma(r83, r90, r93 * r114);
+    r46 = fma(r121, r90, r22 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = fma(r99, r114, r102 * r90);
+    r90 = r117 * r23;
+    r46 = r79 * r82;
+    r46 = fma(r2, r46, r96 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r79 * r93;
+    r114 = r117 * r83;
+    r114 = fma(r96, r114, r2 * r46);
+    r46 = r79 * r22;
+    r90 = r117 * r121;
+    r90 = fma(r96, r90, r2 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r114, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r117 * r102;
+    r114 = r79 * r99;
+    r114 = fma(r2, r114, r96 * r90);
+    r90 = r23 * r83;
+    r46 = r82 * r93;
+    r46 = fma(r2, r46, r96 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r82 * r22;
+    r114 = r23 * r121;
+    r114 = fma(r96, r114, r2 * r46);
+    r46 = r23 * r102;
+    r90 = r82 * r99;
+    r90 = fma(r2, r90, r96 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r114, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r93 * r22;
+    r114 = r83 * r121;
+    r114 = fma(r96, r114, r2 * r90);
+    r90 = r83 * r102;
+    r46 = r93 * r99;
+    r46 = fma(r2, r46, r96 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r121 * r102;
+    r114 = r22 * r99;
+    r114 = fma(r2, r114, r96 * r46);
+    WriteSum1<double, double>((double*)inout_shared, r114);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,1687 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r28 * r28;
+    r43 = 1.00000000000000008e-15;
+    r47 = r34 * r24;
+    r47 = r47 * r24;
+    r48 = r35 + r47;
+    r48 = r48 + r44;
+    r48 = fma(r8, r48, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r49 = r17 * r13;
+    r49 = r49 * r10;
+    r50 = r18 * r14;
+    r50 = fma(r10, r50, r49);
+    r51 = r13 * r14;
+    r51 = fma(r34, r51, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r48 = fma(r9, r6, r48);
+    r48 = fma(r41, r44, r48);
+    r48 = fma(r38, r50, r48);
+    r48 = fma(r30, r51, r48);
+    r48 = fma(r7, r36, r48);
+    r44 = r48 * r48;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r6);
+    r52 = r34 * r24;
+    r52 = fma(r29, r52, r20);
+    r52 = fma(r8, r52, r6);
+    r6 = r18 * r14;
+    r6 = fma(r34, r6, r49);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r47 = r35 + r47;
+    r47 = r47 + r46;
+    r52 = fma(r7, r6, r52);
+    r52 = fma(r38, r31, r52);
+    r52 = fma(r30, r33, r52);
+    r52 = fma(r9, r39, r52);
+    r52 = fma(r41, r47, r52);
+    r47 = copysign(1.0, r52);
+    r47 = fma(r43, r47, r52);
+    r52 = r47 * r47;
+    r39 = 1.0 / r52;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = copysign(1.0, r44);
+    r38 = fma(r43, r38, r44);
+    r43 = r38 * r38;
+    r7 = 1.0 / r43;
+    r44 = atan(r44);
+    r46 = r44 * r39;
+    r42 = r44 * r46;
+    r45 = r45 * r7;
+    r45 = r45 * r42;
+    r49 = 3.00000000000000000e+00;
+    r20 = r49 * r42;
+    r53 = r48 * r7;
+    r54 = r48 * r53;
+    r20 = fma(r54, r20, r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r55,
+                                            r56);
+    r57 = r42 * r54;
+    r45 = r45 + r57;
+    r20 = fma(r55, r45, r5 * r20);
+    r58 = r4 * r28;
+    r59 = r10 * r42;
+    r58 = r58 * r53;
+    r20 = fma(r59, r58, r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r60,
+                                            r61);
+    r62 = r45 * r45;
+    r63 = fma(r61, r62, r60 * r45);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r45 * r62;
+    r65 = r65 * r66;
+    r63 = fma(r45, r65, r63);
+    r63 = fma(r64, r66, r63);
+    r66 = 1.0 / r47;
+    r67 = 1.0 / r38;
+    r68 = r66 * r67;
+    r69 = r44 * r68;
+    r70 = r63 * r69;
+    r20 = fma(r48, r70, r20);
+    r20 = fma(r48, r69, r20);
+    r20 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r58);
+    r20 = fma(r0, r21, r20);
+    r0 = r28 * r28;
+    r0 = r0 * r49;
+    r0 = r0 * r7;
+    r0 = fma(r42, r0, r57);
+    r0 = fma(r56, r45, r4 * r0);
+    r57 = r5 * r28;
+    r57 = r57 * r53;
+    r0 = fma(r59, r57, r0);
+    r0 = fma(r28, r70, r0);
+    r0 = fma(r28, r69, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r58, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r20, r0);
+    r58 = fma(r0, r0, r20 * r20);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r58);
+  if (global_thread_idx < problem_size) {
+    r58 = r3 * r21;
+    r1 = r28 * r7;
+    r57 = -5.00000000000000000e-01;
+    r71 = rsqrt(r30);
+    r72 = r10 * r48;
+    r73 = r11 * r14;
+    r74 = r16 * r17;
+    r74 = fma(r57, r74, r57 * r73);
+    r73 = r15 * r18;
+    r74 = fma(r57, r73, r74);
+    r75 = r12 * r13;
+    r76 = 5.00000000000000000e-01;
+    r74 = fma(r76, r75, r74);
+    r75 = r24 * r74;
+    r73 = r15 * r14;
+    r77 = r12 * r17;
+    r77 = fma(r76, r77, r76 * r73);
+    r73 = r11 * r18;
+    r77 = fma(r57, r73, r77);
+    r78 = r16 * r13;
+    r77 = fma(r76, r78, r77);
+    r78 = r29 * r77;
+    r73 = fma(r10, r78, r10 * r75);
+    r79 = r10 * r19;
+    r80 = fma(r76, r26, r57 * r22);
+    r80 = fma(r57, r23, r80);
+    r80 = fma(r57, r25, r80);
+    r81 = r10 * r27;
+    r82 = r16 * r14;
+    r83 = r11 * r17;
+    r83 = fma(r57, r83, r76 * r82);
+    r82 = r12 * r18;
+    r83 = fma(r57, r82, r83);
+    r84 = r15 * r13;
+    r83 = fma(r57, r84, r83);
+    r81 = r81 * r83;
+    r79 = fma(r80, r79, r81);
+    r73 = r73 + r79;
+    r84 = r10 * r24;
+    r84 = r84 * r83;
+    r82 = r10 * r19;
+    r82 = r82 * r77;
+    r85 = r84 + r82;
+    r86 = r27 * r34;
+    r85 = fma(r74, r86, r85);
+    r87 = r34 * r29;
+    r85 = fma(r80, r87, r85);
+    r85 = fma(r9, r85, r41 * r73);
+    r73 = r24 * r77;
+    r87 = -4.00000000000000000e+00;
+    r73 = r73 * r87;
+    r86 = r27 * r80;
+    r88 = r87 * r86;
+    r89 = r73 + r88;
+    r85 = fma(r8, r89, r85);
+    r72 = r72 * r85;
+    r89 = r48 * r48;
+    r90 = r10 * r24;
+    r90 = r90 * r80;
+    r91 = r10 * r27;
+    r91 = fma(r77, r91, r90);
+    r77 = r10 * r19;
+    r77 = r77 * r74;
+    r92 = r10 * r29;
+    r92 = r92 * r83;
+    r93 = r77 + r92;
+    r94 = r91 + r93;
+    r78 = fma(r34, r78, r34 * r75);
+    r78 = r78 + r79;
+    r78 = fma(r8, r78, r9 * r94);
+    r94 = r19 * r83;
+    r94 = r94 * r87;
+    r73 = r73 + r94;
+    r78 = fma(r41, r73, r78);
+    r52 = r47 * r52;
+    r52 = 1.0 / r52;
+    r47 = r34 * r52;
+    r89 = r89 * r78;
+    r89 = fma(r47, r89, r39 * r72);
+    r72 = r28 * r28;
+    r72 = r72 * r47;
+    r73 = r10 * r28;
+    r95 = r19 * r34;
+    r96 = r34 * r29;
+    r96 = r96 * r83;
+    r95 = fma(r74, r95, r96);
+    r95 = r95 + r91;
+    r88 = r94 + r88;
+    r88 = fma(r9, r88, r41 * r95);
+    r95 = r10 * r29;
+    r95 = fma(r80, r95, r82);
+    r82 = r10 * r27;
+    r82 = fma(r74, r82, r84);
+    r95 = r95 + r82;
+    r88 = fma(r8, r95, r88);
+    r73 = r73 * r88;
+    r89 = fma(r39, r73, r89);
+    r89 = fma(r78, r72, r89);
+    r1 = r1 * r44;
+    r1 = r1 * r66;
+    r1 = r1 * r57;
+    r1 = r1 * r71;
+    r1 = r1 * r89;
+    r73 = r44 * r44;
+    r95 = r7 * r73;
+    r95 = r95 * r72;
+    r84 = r28 * r71;
+    r94 = r89 * r84;
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r35 = r30 * r46;
+    r91 = r28 * r7;
+    r94 = r94 * r35;
+    r94 = fma(r91, r94, r78 * r95);
+    r97 = r21 * r28;
+    r43 = r38 * r43;
+    r43 = 1.0 / r43;
+    r38 = r43 * r42;
+    r38 = r38 * r84;
+    r97 = r97 * r89;
+    r94 = fma(r38, r97, r94);
+    r98 = r59 * r91;
+    r94 = fma(r88, r98, r94);
+    r97 = r89 * r71;
+    r97 = r97 * r35;
+    r99 = r21 * r48;
+    r99 = r99 * r48;
+    r99 = r99 * r89;
+    r99 = r99 * r71;
+    r99 = r99 * r43;
+    r99 = fma(r42, r99, r54 * r97);
+    r97 = r85 * r53;
+    r99 = fma(r59, r97, r99);
+    r100 = r78 * r47;
+    r73 = r54 * r73;
+    r99 = fma(r73, r100, r99);
+    r100 = r94 + r99;
+    r97 = fma(r56, r100, r1);
+    r101 = r28 * r28;
+    r102 = -6.00000000000000000e+00;
+    r101 = r101 * r44;
+    r101 = r101 * r44;
+    r101 = r101 * r78;
+    r101 = r101 * r102;
+    r101 = r101 * r7;
+    r103 = r49 * r89;
+    r103 = r103 * r84;
+    r103 = r103 * r35;
+    r103 = fma(r91, r103, r52 * r101);
+    r101 = -3.00000000000000000e+00;
+    r104 = r28 * r101;
+    r104 = r104 * r89;
+    r103 = fma(r38, r104, r103);
+    r105 = r28 * r88;
+    r106 = 6.00000000000000000e+00;
+    r105 = r105 * r106;
+    r105 = r105 * r7;
+    r103 = fma(r42, r105, r103);
+    r103 = r103 + r99;
+    r99 = r85 * r98;
+    r105 = r21 * r28;
+    r105 = r105 * r78;
+    r105 = r105 * r67;
+    r97 = fma(r46, r105, r97);
+    r104 = r5 * r34;
+    r104 = r104 * r48;
+    r104 = r104 * r38;
+    r107 = r76 * r89;
+    r107 = r107 * r30;
+    r107 = r107 * r84;
+    r97 = fma(r68, r107, r97);
+    r108 = r5 * r88;
+    r108 = r108 * r53;
+    r97 = fma(r59, r108, r97);
+    r109 = r5 * r28;
+    r109 = r109 * r44;
+    r109 = r109 * r44;
+    r109 = r109 * r87;
+    r109 = r109 * r78;
+    r109 = r109 * r52;
+    r97 = fma(r53, r109, r97);
+    r110 = r61 * r10;
+    r110 = r110 * r45;
+    r110 = fma(r60, r100, r100 * r110);
+    r64 = r64 * r49;
+    r64 = r64 * r62;
+    r62 = 4.00000000000000000e+00;
+    r65 = r62 * r65;
+    r110 = fma(r100, r64, r110);
+    r110 = fma(r100, r65, r110);
+    r62 = r28 * r110;
+    r97 = fma(r69, r62, r97);
+    r111 = r5 * r89;
+    r112 = r10 * r53;
+    r112 = r112 * r84;
+    r112 = r112 * r35;
+    r97 = fma(r112, r111, r97);
+    r113 = r76 * r63;
+    r113 = r113 * r89;
+    r113 = r113 * r30;
+    r113 = r113 * r84;
+    r97 = fma(r68, r113, r97);
+    r114 = r21 * r28;
+    r114 = r114 * r63;
+    r114 = r114 * r78;
+    r114 = r114 * r67;
+    r97 = fma(r46, r114, r97);
+    r97 = fma(r4, r103, r97);
+    r97 = fma(r5, r99, r97);
+    r97 = fma(r63, r1, r97);
+    r97 = fma(r89, r104, r97);
+    r97 = fma(r88, r70, r97);
+    r97 = fma(r88, r69, r97);
+    r58 = r58 * r0;
+    r114 = r2 * r21;
+    r114 = r114 * r20;
+    r20 = r48 * r7;
+    r20 = r20 * r44;
+    r20 = r20 * r66;
+    r20 = r20 * r57;
+    r20 = r20 * r71;
+    r20 = r20 * r89;
+    r100 = fma(r55, r100, r20);
+    r113 = r49 * r89;
+    r113 = r113 * r71;
+    r113 = r113 * r35;
+    r111 = r48 * r48;
+    r111 = r111 * r101;
+    r111 = r111 * r89;
+    r111 = r111 * r71;
+    r111 = r111 * r43;
+    r111 = fma(r42, r111, r54 * r113);
+    r113 = r85 * r106;
+    r113 = r113 * r42;
+    r111 = fma(r53, r113, r111);
+    r62 = r102 * r52;
+    r62 = r62 * r73;
+    r111 = fma(r78, r62, r111);
+    r111 = r111 + r94;
+    r94 = r21 * r48;
+    r94 = r94 * r63;
+    r94 = r94 * r78;
+    r94 = r94 * r67;
+    r100 = fma(r46, r94, r100);
+    r113 = r48 * r76;
+    r113 = r113 * r71;
+    r113 = r113 * r30;
+    r113 = r113 * r68;
+    r109 = r63 * r113;
+    r108 = r4 * r34;
+    r108 = r108 * r48;
+    r108 = r108 * r89;
+    r100 = fma(r38, r108, r100);
+    r107 = r4 * r88;
+    r107 = r107 * r53;
+    r100 = fma(r59, r107, r100);
+    r1 = r4 * r28;
+    r1 = r1 * r44;
+    r1 = r1 * r44;
+    r1 = r1 * r87;
+    r1 = r1 * r52;
+    r1 = r1 * r53;
+    r105 = r4 * r89;
+    r100 = fma(r112, r105, r100);
+    r103 = r48 * r110;
+    r100 = fma(r69, r103, r100);
+    r115 = r21 * r48;
+    r115 = r115 * r78;
+    r115 = r115 * r67;
+    r100 = fma(r46, r115, r100);
+    r100 = fma(r5, r111, r100);
+    r100 = fma(r4, r99, r100);
+    r100 = fma(r63, r20, r100);
+    r100 = fma(r89, r109, r100);
+    r100 = fma(r85, r70, r100);
+    r100 = fma(r78, r1, r100);
+    r100 = fma(r89, r113, r100);
+    r100 = fma(r85, r69, r100);
+    r58 = fma(r100, r114, r97 * r58);
+    r115 = r3 * r21;
+    r103 = r28 * r106;
+    r105 = r10 * r24;
+    r107 = r11 * r14;
+    r108 = r16 * r17;
+    r108 = fma(r76, r108, r76 * r107);
+    r107 = r15 * r18;
+    r108 = fma(r76, r107, r108);
+    r94 = r12 * r13;
+    r108 = fma(r57, r94, r108);
+    r105 = r105 * r108;
+    r81 = r81 + r105;
+    r94 = r19 * r34;
+    r81 = fma(r80, r94, r81);
+    r107 = r34 * r29;
+    r20 = r15 * r14;
+    r99 = r12 * r17;
+    r99 = fma(r57, r99, r57 * r20);
+    r20 = r11 * r18;
+    r99 = fma(r76, r20, r99);
+    r111 = r16 * r13;
+    r99 = fma(r57, r111, r99);
+    r81 = fma(r99, r107, r81);
+    r107 = r10 * r29;
+    r107 = fma(r10, r86, r108 * r107);
+    r94 = r10 * r19;
+    r94 = r94 * r83;
+    r111 = r10 * r24;
+    r111 = fma(r99, r111, r94);
+    r107 = r107 + r111;
+    r107 = fma(r8, r107, r41 * r81);
+    r81 = r27 * r87;
+    r81 = r81 * r108;
+    r20 = r19 * r99;
+    r116 = r87 * r20;
+    r117 = r81 + r116;
+    r107 = fma(r9, r117, r107);
+    r103 = r103 * r107;
+    r103 = r103 * r7;
+    r117 = r28 * r38;
+    r118 = r10 * r48;
+    r92 = r90 + r92;
+    r90 = r10 * r27;
+    r90 = r90 * r99;
+    r119 = r10 * r19;
+    r119 = fma(r108, r119, r90);
+    r92 = r92 + r119;
+    r120 = r24 * r83;
+    r120 = r120 * r87;
+    r81 = r120 + r81;
+    r81 = fma(r8, r81, r41 * r92);
+    r92 = r34 * r29;
+    r86 = fma(r34, r86, r108 * r92);
+    r86 = r86 + r111;
+    r81 = fma(r9, r86, r81);
+    r118 = r118 * r81;
+    r86 = r10 * r28;
+    r86 = r86 * r107;
+    r86 = fma(r39, r86, r39 * r118);
+    r118 = r34 * r24;
+    r118 = fma(r80, r118, r96);
+    r118 = r118 + r119;
+    r119 = r10 * r29;
+    r119 = fma(r99, r119, r105);
+    r119 = r119 + r79;
+    r119 = fma(r9, r119, r8 * r118);
+    r116 = r120 + r116;
+    r119 = fma(r41, r116, r119);
+    r116 = r48 * r48;
+    r116 = r116 * r119;
+    r86 = fma(r47, r116, r86);
+    r86 = fma(r119, r72, r86);
+    r116 = r101 * r86;
+    r117 = fma(r116, r117, r42 * r103);
+    r103 = r28 * r28;
+    r103 = r103 * r44;
+    r103 = r103 * r44;
+    r103 = r103 * r102;
+    r103 = r103 * r119;
+    r103 = r103 * r7;
+    r117 = fma(r52, r103, r117);
+    r120 = r49 * r86;
+    r120 = r120 * r84;
+    r120 = r120 * r35;
+    r117 = fma(r91, r120, r117);
+    r118 = r119 * r47;
+    r79 = r81 * r53;
+    r79 = fma(r59, r79, r73 * r118);
+    r118 = r21 * r48;
+    r118 = r118 * r48;
+    r118 = r118 * r86;
+    r118 = r118 * r71;
+    r118 = r118 * r43;
+    r79 = fma(r42, r118, r79);
+    r105 = r86 * r71;
+    r105 = r105 * r35;
+    r79 = fma(r54, r105, r79);
+    r117 = r117 + r79;
+    r120 = r21 * r28;
+    r120 = r120 * r86;
+    r120 = fma(r38, r120, r107 * r98);
+    r103 = r86 * r84;
+    r103 = r103 * r35;
+    r120 = fma(r91, r103, r120);
+    r120 = fma(r119, r95, r120);
+    r79 = r79 + r120;
+    r117 = fma(r56, r79, r4 * r117);
+    r103 = r44 * r57;
+    r103 = r103 * r86;
+    r103 = r103 * r7;
+    r103 = r103 * r66;
+    r117 = fma(r84, r103, r117);
+    r105 = r61 * r10;
+    r105 = r105 * r45;
+    r105 = fma(r79, r105, r60 * r79);
+    r105 = fma(r79, r65, r105);
+    r105 = fma(r79, r64, r105);
+    r118 = r28 * r105;
+    r117 = fma(r69, r118, r117);
+    r80 = r76 * r86;
+    r80 = r80 * r30;
+    r80 = r80 * r84;
+    r117 = fma(r68, r80, r117);
+    r92 = r5 * r28;
+    r92 = r92 * r44;
+    r92 = r92 * r44;
+    r92 = r92 * r87;
+    r92 = r92 * r119;
+    r92 = r92 * r52;
+    r117 = fma(r53, r92, r117);
+    r108 = r5 * r86;
+    r117 = fma(r112, r108, r117);
+    r121 = r21 * r28;
+    r121 = r121 * r63;
+    r121 = r121 * r119;
+    r121 = r121 * r67;
+    r117 = fma(r46, r121, r117);
+    r122 = r44 * r63;
+    r122 = r122 * r57;
+    r122 = r122 * r86;
+    r122 = r122 * r7;
+    r122 = r122 * r66;
+    r117 = fma(r84, r122, r117);
+    r123 = r21 * r28;
+    r123 = r123 * r119;
+    r123 = r123 * r67;
+    r117 = fma(r46, r123, r117);
+    r124 = r5 * r107;
+    r124 = r124 * r53;
+    r117 = fma(r59, r124, r117);
+    r125 = r76 * r63;
+    r125 = r125 * r86;
+    r125 = r125 * r30;
+    r125 = r125 * r84;
+    r117 = fma(r68, r125, r117);
+    r126 = r5 * r81;
+    r117 = fma(r98, r126, r117);
+    r117 = fma(r107, r70, r117);
+    r117 = fma(r86, r104, r117);
+    r117 = fma(r107, r69, r117);
+    r115 = r115 * r0;
+    r126 = r106 * r81;
+    r126 = r126 * r42;
+    r126 = fma(r53, r126, r119 * r62);
+    r125 = r48 * r48;
+    r125 = r125 * r71;
+    r125 = r125 * r43;
+    r125 = r125 * r42;
+    r126 = fma(r116, r125, r126);
+    r116 = r49 * r86;
+    r116 = r116 * r71;
+    r116 = r116 * r35;
+    r126 = fma(r54, r116, r126);
+    r126 = r126 + r120;
+    r79 = fma(r55, r79, r5 * r126);
+    r126 = r21 * r48;
+    r126 = r126 * r119;
+    r126 = r126 * r67;
+    r79 = fma(r46, r126, r79);
+    r120 = r44 * r63;
+    r120 = r120 * r57;
+    r120 = r120 * r86;
+    r120 = r120 * r66;
+    r120 = r120 * r71;
+    r79 = fma(r53, r120, r79);
+    r116 = r48 * r105;
+    r79 = fma(r69, r116, r79);
+    r125 = r21 * r48;
+    r125 = r125 * r63;
+    r125 = r125 * r119;
+    r125 = r125 * r67;
+    r79 = fma(r46, r125, r79);
+    r124 = r4 * r86;
+    r79 = fma(r112, r124, r79);
+    r123 = r4 * r34;
+    r123 = r123 * r48;
+    r123 = r123 * r86;
+    r79 = fma(r38, r123, r79);
+    r122 = r4 * r107;
+    r122 = r122 * r53;
+    r79 = fma(r59, r122, r79);
+    r121 = r4 * r81;
+    r79 = fma(r98, r121, r79);
+    r108 = r44 * r57;
+    r108 = r108 * r86;
+    r108 = r108 * r66;
+    r108 = r108 * r71;
+    r79 = fma(r53, r108, r79);
+    r79 = fma(r86, r109, r79);
+    r79 = fma(r86, r113, r79);
+    r79 = fma(r119, r1, r79);
+    r79 = fma(r81, r69, r79);
+    r79 = fma(r81, r70, r79);
+    r115 = fma(r79, r114, r117 * r115);
+    WriteSum2<double, double>((double*)inout_shared, r58, r115);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r115 = r3 * r21;
+    r58 = r19 * r87;
+    r26 = fma(r57, r26, r76 * r22);
+    r26 = fma(r76, r23, r26);
+    r26 = fma(r76, r25, r26);
+    r58 = r58 * r26;
+    r75 = r87 * r75;
+    r25 = r58 + r75;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r94 = r94 + r23;
+    r22 = r34 * r24;
+    r94 = fma(r99, r22, r94);
+    r108 = r34 * r29;
+    r94 = fma(r74, r108, r94);
+    r94 = fma(r8, r94, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r20, r26 * r25);
+    r25 = r25 + r82;
+    r94 = fma(r9, r25, r94);
+    r25 = r10 * r28;
+    r108 = r10 * r24;
+    r108 = r108 * r26;
+    r90 = r90 + r108;
+    r90 = r90 + r93;
+    r93 = r34 * r29;
+    r20 = fma(r34, r20, r26 * r93);
+    r20 = r20 + r82;
+    r20 = fma(r41, r20, r8 * r90);
+    r83 = r27 * r83;
+    r83 = r83 * r87;
+    r58 = r58 + r83;
+    r20 = fma(r9, r58, r20);
+    r25 = r25 * r20;
+    r58 = r48 * r48;
+    r58 = r58 * r94;
+    r58 = fma(r47, r58, r39 * r25);
+    r25 = r10 * r48;
+    r96 = r77 + r96;
+    r77 = r27 * r34;
+    r96 = fma(r99, r77, r96);
+    r96 = r96 + r108;
+    r75 = r83 + r75;
+    r75 = fma(r8, r75, r9 * r96);
+    r8 = r10 * r29;
+    r8 = fma(r74, r8, r23);
+    r8 = r8 + r111;
+    r75 = fma(r41, r8, r75);
+    r25 = r25 * r75;
+    r58 = fma(r39, r25, r58);
+    r58 = fma(r94, r72, r58);
+    r25 = r58 * r84;
+    r25 = r25 * r35;
+    r25 = fma(r91, r25, r94 * r95);
+    r8 = r21 * r28;
+    r8 = r8 * r58;
+    r25 = fma(r38, r8, r25);
+    r25 = fma(r20, r98, r25);
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r58;
+    r8 = r8 * r71;
+    r8 = r8 * r43;
+    r41 = r75 * r53;
+    r41 = fma(r59, r41, r42 * r8);
+    r8 = r94 * r47;
+    r41 = fma(r73, r8, r41);
+    r111 = r58 * r71;
+    r111 = r111 * r35;
+    r41 = fma(r54, r111, r41);
+    r111 = r25 + r41;
+    r8 = r28 * r28;
+    r8 = r8 * r44;
+    r8 = r8 * r44;
+    r8 = r8 * r102;
+    r8 = r8 * r94;
+    r8 = r8 * r7;
+    r23 = r49 * r58;
+    r23 = r23 * r84;
+    r23 = r23 * r35;
+    r23 = fma(r91, r23, r52 * r8);
+    r8 = r28 * r106;
+    r8 = r8 * r20;
+    r8 = r8 * r7;
+    r23 = fma(r42, r8, r23);
+    r74 = r28 * r101;
+    r74 = r74 * r58;
+    r23 = fma(r38, r74, r23);
+    r23 = r23 + r41;
+    r23 = fma(r4, r23, r56 * r111);
+    r41 = r21 * r28;
+    r41 = r41 * r63;
+    r41 = r41 * r94;
+    r41 = r41 * r67;
+    r23 = fma(r46, r41, r23);
+    r74 = r21 * r28;
+    r74 = r74 * r94;
+    r74 = r74 * r67;
+    r23 = fma(r46, r74, r23);
+    r8 = r5 * r75;
+    r23 = fma(r98, r8, r23);
+    r96 = r44 * r63;
+    r96 = r96 * r57;
+    r96 = r96 * r58;
+    r96 = r96 * r7;
+    r96 = r96 * r66;
+    r23 = fma(r84, r96, r23);
+    r9 = r5 * r58;
+    r23 = fma(r112, r9, r23);
+    r83 = r76 * r58;
+    r83 = r83 * r30;
+    r83 = r83 * r84;
+    r23 = fma(r68, r83, r23);
+    r77 = r61 * r10;
+    r77 = r77 * r45;
+    r77 = fma(r111, r77, r60 * r111);
+    r77 = fma(r111, r64, r77);
+    r77 = fma(r111, r65, r77);
+    r108 = r28 * r77;
+    r23 = fma(r69, r108, r23);
+    r99 = r44 * r57;
+    r99 = r99 * r58;
+    r99 = r99 * r7;
+    r99 = r99 * r66;
+    r23 = fma(r84, r99, r23);
+    r90 = r76 * r63;
+    r90 = r90 * r58;
+    r90 = r90 * r30;
+    r90 = r90 * r84;
+    r23 = fma(r68, r90, r23);
+    r82 = r5 * r28;
+    r82 = r82 * r44;
+    r82 = r82 * r44;
+    r82 = r82 * r87;
+    r82 = r82 * r94;
+    r82 = r82 * r52;
+    r23 = fma(r53, r82, r23);
+    r93 = r5 * r20;
+    r93 = r93 * r53;
+    r23 = fma(r59, r93, r23);
+    r23 = fma(r20, r70, r23);
+    r23 = fma(r20, r69, r23);
+    r23 = fma(r58, r104, r23);
+    r115 = r115 * r0;
+    r93 = r48 * r48;
+    r93 = r93 * r101;
+    r93 = r93 * r58;
+    r93 = r93 * r71;
+    r93 = r93 * r43;
+    r82 = r106 * r75;
+    r82 = r82 * r42;
+    r82 = fma(r53, r82, r42 * r93);
+    r93 = r49 * r58;
+    r93 = r93 * r71;
+    r93 = r93 * r35;
+    r82 = fma(r54, r93, r82);
+    r82 = fma(r94, r62, r82);
+    r82 = r82 + r25;
+    r82 = fma(r5, r82, r55 * r111);
+    r111 = r48 * r77;
+    r82 = fma(r69, r111, r82);
+    r25 = r4 * r75;
+    r82 = fma(r98, r25, r82);
+    r93 = r4 * r58;
+    r82 = fma(r112, r93, r82);
+    r90 = r21 * r48;
+    r90 = r90 * r63;
+    r90 = r90 * r94;
+    r90 = r90 * r67;
+    r82 = fma(r46, r90, r82);
+    r99 = r4 * r34;
+    r99 = r99 * r48;
+    r99 = r99 * r58;
+    r82 = fma(r38, r99, r82);
+    r108 = r21 * r48;
+    r108 = r108 * r94;
+    r108 = r108 * r67;
+    r82 = fma(r46, r108, r82);
+    r83 = r44 * r57;
+    r83 = r83 * r58;
+    r83 = r83 * r66;
+    r83 = r83 * r71;
+    r82 = fma(r53, r83, r82);
+    r9 = r4 * r20;
+    r9 = r9 * r53;
+    r82 = fma(r59, r9, r82);
+    r96 = r44 * r63;
+    r96 = r96 * r57;
+    r96 = r96 * r58;
+    r96 = r96 * r66;
+    r96 = r96 * r71;
+    r82 = fma(r53, r96, r82);
+    r82 = fma(r58, r113, r82);
+    r82 = fma(r58, r109, r82);
+    r82 = fma(r75, r70, r82);
+    r82 = fma(r75, r69, r82);
+    r82 = fma(r94, r1, r82);
+    r115 = fma(r82, r114, r23 * r115);
+    r96 = r3 * r21;
+    r9 = r32 * r28;
+    r9 = r9 * r106;
+    r9 = r9 * r7;
+    r83 = r28 * r101;
+    r108 = r10 * r32;
+    r108 = r108 * r28;
+    r108 = fma(r6, r72, r39 * r108);
+    r99 = r6 * r48;
+    r99 = r99 * r48;
+    r108 = fma(r47, r99, r108);
+    r90 = r10 * r36;
+    r90 = r90 * r48;
+    r108 = fma(r39, r90, r108);
+    r83 = r83 * r108;
+    r83 = fma(r38, r83, r42 * r9);
+    r9 = r6 * r28;
+    r9 = r9 * r28;
+    r9 = r9 * r44;
+    r9 = r9 * r44;
+    r9 = r9 * r102;
+    r9 = r9 * r7;
+    r83 = fma(r52, r9, r83);
+    r90 = r49 * r108;
+    r90 = r90 * r84;
+    r90 = r90 * r35;
+    r83 = fma(r91, r90, r83);
+    r99 = r36 * r53;
+    r93 = r21 * r48;
+    r93 = r93 * r48;
+    r93 = r93 * r108;
+    r93 = r93 * r71;
+    r93 = r93 * r43;
+    r93 = fma(r42, r93, r59 * r99);
+    r99 = r108 * r71;
+    r99 = r99 * r35;
+    r93 = fma(r54, r99, r93);
+    r25 = r6 * r47;
+    r93 = fma(r73, r25, r93);
+    r83 = r83 + r93;
+    r90 = r21 * r28;
+    r90 = r90 * r108;
+    r90 = fma(r38, r90, r32 * r98);
+    r9 = r108 * r84;
+    r9 = r9 * r35;
+    r90 = fma(r91, r9, r90);
+    r90 = fma(r6, r95, r90);
+    r93 = r93 + r90;
+    r83 = fma(r56, r93, r4 * r83);
+    r9 = r76 * r108;
+    r9 = r9 * r30;
+    r9 = r9 * r84;
+    r83 = fma(r68, r9, r83);
+    r25 = r44 * r63;
+    r25 = r25 * r57;
+    r25 = r25 * r108;
+    r25 = r25 * r7;
+    r25 = r25 * r66;
+    r83 = fma(r84, r25, r83);
+    r99 = r21 * r6;
+    r99 = r99 * r28;
+    r99 = r99 * r63;
+    r99 = r99 * r67;
+    r83 = fma(r46, r99, r83);
+    r111 = r5 * r108;
+    r83 = fma(r112, r111, r83);
+    r8 = r21 * r6;
+    r8 = r8 * r28;
+    r8 = r8 * r67;
+    r83 = fma(r46, r8, r83);
+    r74 = r5 * r6;
+    r74 = r74 * r28;
+    r74 = r74 * r44;
+    r74 = r74 * r44;
+    r74 = r74 * r87;
+    r74 = r74 * r52;
+    r83 = fma(r53, r74, r83);
+    r41 = r61 * r10;
+    r41 = r41 * r45;
+    r41 = fma(r60, r93, r93 * r41);
+    r41 = fma(r93, r65, r41);
+    r41 = fma(r93, r64, r41);
+    r26 = r28 * r41;
+    r83 = fma(r69, r26, r83);
+    r22 = r76 * r63;
+    r22 = r22 * r108;
+    r22 = r22 * r30;
+    r22 = r22 * r84;
+    r83 = fma(r68, r22, r83);
+    r121 = r5 * r32;
+    r121 = r121 * r53;
+    r83 = fma(r59, r121, r83);
+    r122 = r44 * r57;
+    r122 = r122 * r108;
+    r122 = r122 * r7;
+    r122 = r122 * r66;
+    r83 = fma(r84, r122, r83);
+    r123 = r5 * r36;
+    r83 = fma(r98, r123, r83);
+    r83 = fma(r32, r69, r83);
+    r83 = fma(r108, r104, r83);
+    r83 = fma(r32, r70, r83);
+    r96 = r96 * r0;
+    r123 = r36 * r106;
+    r123 = r123 * r42;
+    r122 = r48 * r48;
+    r122 = r122 * r101;
+    r122 = r122 * r108;
+    r122 = r122 * r71;
+    r122 = r122 * r43;
+    r122 = fma(r42, r122, r53 * r123);
+    r123 = r49 * r108;
+    r123 = r123 * r71;
+    r123 = r123 * r35;
+    r122 = fma(r54, r123, r122);
+    r122 = fma(r6, r62, r122);
+    r122 = r122 + r90;
+    r93 = fma(r55, r93, r5 * r122);
+    r122 = r4 * r108;
+    r93 = fma(r112, r122, r93);
+    r90 = r44 * r63;
+    r90 = r90 * r57;
+    r90 = r90 * r108;
+    r90 = r90 * r66;
+    r90 = r90 * r71;
+    r93 = fma(r53, r90, r93);
+    r123 = r44 * r57;
+    r123 = r123 * r108;
+    r123 = r123 * r66;
+    r123 = r123 * r71;
+    r93 = fma(r53, r123, r93);
+    r121 = r4 * r34;
+    r121 = r121 * r48;
+    r121 = r121 * r108;
+    r93 = fma(r38, r121, r93);
+    r22 = r48 * r41;
+    r93 = fma(r69, r22, r93);
+    r26 = r21 * r6;
+    r26 = r26 * r48;
+    r26 = r26 * r63;
+    r26 = r26 * r67;
+    r93 = fma(r46, r26, r93);
+    r74 = r21 * r6;
+    r74 = r74 * r48;
+    r74 = r74 * r67;
+    r93 = fma(r46, r74, r93);
+    r8 = r4 * r32;
+    r8 = r8 * r53;
+    r93 = fma(r59, r8, r93);
+    r111 = r4 * r36;
+    r93 = fma(r98, r111, r93);
+    r93 = fma(r36, r70, r93);
+    r93 = fma(r108, r109, r93);
+    r93 = fma(r108, r113, r93);
+    r93 = fma(r6, r1, r93);
+    r93 = fma(r36, r69, r93);
+    r96 = fma(r93, r114, r83 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r115, r96);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r3 * r21;
+    r115 = fma(r37, r98, r33 * r95);
+    r111 = r10 * r37;
+    r111 = r111 * r28;
+    r111 = fma(r39, r111, r33 * r72);
+    r8 = r33 * r48;
+    r8 = r8 * r48;
+    r111 = fma(r47, r8, r111);
+    r74 = r10 * r51;
+    r74 = r74 * r48;
+    r111 = fma(r39, r74, r111);
+    r74 = r111 * r84;
+    r74 = r74 * r35;
+    r115 = fma(r91, r74, r115);
+    r8 = r21 * r28;
+    r8 = r8 * r111;
+    r115 = fma(r38, r8, r115);
+    r8 = r111 * r71;
+    r8 = r8 * r35;
+    r74 = r33 * r47;
+    r74 = fma(r73, r74, r54 * r8);
+    r8 = r21 * r48;
+    r8 = r8 * r48;
+    r8 = r8 * r111;
+    r8 = r8 * r71;
+    r8 = r8 * r43;
+    r74 = fma(r42, r8, r74);
+    r26 = r51 * r53;
+    r74 = fma(r59, r26, r74);
+    r26 = r115 + r74;
+    r8 = r33 * r28;
+    r8 = r8 * r28;
+    r8 = r8 * r44;
+    r8 = r8 * r44;
+    r8 = r8 * r102;
+    r8 = r8 * r7;
+    r22 = r37 * r28;
+    r22 = r22 * r106;
+    r22 = r22 * r7;
+    r22 = fma(r42, r22, r52 * r8);
+    r8 = r49 * r111;
+    r8 = r8 * r84;
+    r8 = r8 * r35;
+    r22 = fma(r91, r8, r22);
+    r121 = r28 * r101;
+    r121 = r121 * r111;
+    r22 = fma(r38, r121, r22);
+    r22 = r22 + r74;
+    r22 = fma(r4, r22, r56 * r26);
+    r74 = r21 * r33;
+    r74 = r74 * r28;
+    r74 = r74 * r67;
+    r22 = fma(r46, r74, r22);
+    r121 = r5 * r37;
+    r121 = r121 * r53;
+    r22 = fma(r59, r121, r22);
+    r8 = r111 * r112;
+    r123 = r76 * r111;
+    r123 = r123 * r30;
+    r123 = r123 * r84;
+    r22 = fma(r68, r123, r22);
+    r90 = r61 * r10;
+    r90 = r90 * r45;
+    r90 = fma(r60, r26, r26 * r90);
+    r90 = fma(r26, r64, r90);
+    r90 = fma(r26, r65, r90);
+    r122 = r28 * r90;
+    r22 = fma(r69, r122, r22);
+    r99 = r44 * r63;
+    r99 = r99 * r57;
+    r99 = r99 * r111;
+    r99 = r99 * r7;
+    r99 = r99 * r66;
+    r22 = fma(r84, r99, r22);
+    r25 = r5 * r33;
+    r25 = r25 * r28;
+    r25 = r25 * r44;
+    r25 = r25 * r44;
+    r25 = r25 * r87;
+    r25 = r25 * r52;
+    r22 = fma(r53, r25, r22);
+    r9 = r44 * r57;
+    r9 = r9 * r111;
+    r9 = r9 * r7;
+    r9 = r9 * r66;
+    r22 = fma(r84, r9, r22);
+    r124 = r76 * r63;
+    r124 = r124 * r111;
+    r124 = r124 * r30;
+    r124 = r124 * r84;
+    r22 = fma(r68, r124, r22);
+    r125 = r21 * r33;
+    r125 = r125 * r28;
+    r125 = r125 * r63;
+    r125 = r125 * r67;
+    r22 = fma(r46, r125, r22);
+    r116 = r5 * r51;
+    r22 = fma(r98, r116, r22);
+    r22 = fma(r37, r70, r22);
+    r22 = fma(r5, r8, r22);
+    r22 = fma(r111, r104, r22);
+    r22 = fma(r37, r69, r22);
+    r96 = r96 * r0;
+    r116 = r49 * r111;
+    r116 = r116 * r71;
+    r116 = r116 * r35;
+    r116 = fma(r33, r62, r54 * r116);
+    r125 = r48 * r48;
+    r125 = r125 * r101;
+    r125 = r125 * r111;
+    r125 = r125 * r71;
+    r125 = r125 * r43;
+    r116 = fma(r42, r125, r116);
+    r124 = r51 * r106;
+    r124 = r124 * r42;
+    r116 = fma(r53, r124, r116);
+    r116 = r116 + r115;
+    r26 = fma(r55, r26, r5 * r116);
+    r116 = r4 * r37;
+    r116 = r116 * r53;
+    r26 = fma(r59, r116, r26);
+    r115 = r21 * r33;
+    r115 = r115 * r48;
+    r115 = r115 * r67;
+    r26 = fma(r46, r115, r26);
+    r124 = r4 * r34;
+    r124 = r124 * r48;
+    r124 = r124 * r111;
+    r26 = fma(r38, r124, r26);
+    r125 = r44 * r57;
+    r125 = r125 * r111;
+    r125 = r125 * r66;
+    r125 = r125 * r71;
+    r26 = fma(r53, r125, r26);
+    r9 = r48 * r90;
+    r26 = fma(r69, r9, r26);
+    r25 = r44 * r63;
+    r25 = r25 * r57;
+    r25 = r25 * r111;
+    r25 = r25 * r66;
+    r25 = r25 * r71;
+    r26 = fma(r53, r25, r26);
+    r99 = r21 * r33;
+    r99 = r99 * r48;
+    r99 = r99 * r63;
+    r99 = r99 * r67;
+    r26 = fma(r46, r99, r26);
+    r122 = r4 * r51;
+    r26 = fma(r98, r122, r26);
+    r26 = fma(r4, r8, r26);
+    r26 = fma(r111, r109, r26);
+    r26 = fma(r51, r69, r26);
+    r26 = fma(r33, r1, r26);
+    r26 = fma(r111, r113, r26);
+    r26 = fma(r51, r70, r26);
+    r96 = fma(r26, r114, r22 * r96);
+    r122 = r3 * r21;
+    r95 = fma(r40, r98, r31 * r95);
+    r99 = r10 * r40;
+    r99 = r99 * r28;
+    r72 = fma(r31, r72, r39 * r99);
+    r99 = r10 * r50;
+    r99 = r99 * r48;
+    r72 = fma(r39, r99, r72);
+    r39 = r31 * r48;
+    r39 = r39 * r48;
+    r72 = fma(r47, r39, r72);
+    r39 = r72 * r84;
+    r39 = r39 * r35;
+    r95 = fma(r91, r39, r95);
+    r99 = r21 * r28;
+    r99 = r99 * r72;
+    r95 = fma(r38, r99, r95);
+    r99 = r21 * r48;
+    r99 = r99 * r48;
+    r99 = r99 * r72;
+    r99 = r99 * r71;
+    r99 = r99 * r43;
+    r39 = r72 * r71;
+    r39 = r39 * r35;
+    r39 = fma(r54, r39, r42 * r99);
+    r99 = r50 * r53;
+    r39 = fma(r59, r99, r39);
+    r25 = r31 * r47;
+    r39 = fma(r73, r25, r39);
+    r25 = r95 + r39;
+    r99 = r31 * r28;
+    r99 = r99 * r28;
+    r99 = r99 * r44;
+    r99 = r99 * r44;
+    r99 = r99 * r102;
+    r99 = r99 * r7;
+    r102 = r40 * r28;
+    r102 = r102 * r106;
+    r102 = r102 * r7;
+    r102 = fma(r42, r102, r52 * r99);
+    r99 = r49 * r72;
+    r99 = r99 * r84;
+    r99 = r99 * r35;
+    r102 = fma(r91, r99, r102);
+    r91 = r28 * r101;
+    r91 = r91 * r72;
+    r102 = fma(r38, r91, r102);
+    r102 = r102 + r39;
+    r102 = fma(r4, r102, r56 * r25);
+    r56 = r44 * r57;
+    r56 = r56 * r72;
+    r56 = r56 * r7;
+    r56 = r56 * r66;
+    r102 = fma(r84, r56, r102);
+    r39 = r21 * r31;
+    r39 = r39 * r28;
+    r39 = r39 * r67;
+    r102 = fma(r46, r39, r102);
+    r91 = r5 * r50;
+    r102 = fma(r98, r91, r102);
+    r99 = r21 * r31;
+    r99 = r99 * r28;
+    r99 = r99 * r63;
+    r99 = r99 * r67;
+    r102 = fma(r46, r99, r102);
+    r73 = r76 * r63;
+    r73 = r73 * r72;
+    r73 = r73 * r30;
+    r73 = r73 * r84;
+    r102 = fma(r68, r73, r102);
+    r9 = r5 * r31;
+    r9 = r9 * r28;
+    r9 = r9 * r44;
+    r9 = r9 * r44;
+    r9 = r9 * r87;
+    r9 = r9 * r52;
+    r102 = fma(r53, r9, r102);
+    r52 = r5 * r40;
+    r52 = r52 * r53;
+    r102 = fma(r59, r52, r102);
+    r87 = r44 * r63;
+    r87 = r87 * r57;
+    r87 = r87 * r72;
+    r87 = r87 * r7;
+    r87 = r87 * r66;
+    r102 = fma(r84, r87, r102);
+    r7 = r5 * r72;
+    r102 = fma(r112, r7, r102);
+    r125 = r76 * r72;
+    r125 = r125 * r30;
+    r125 = r125 * r84;
+    r102 = fma(r68, r125, r102);
+    r68 = r61 * r10;
+    r68 = r68 * r45;
+    r68 = fma(r25, r68, r60 * r25);
+    r68 = fma(r25, r65, r68);
+    r68 = fma(r25, r64, r68);
+    r64 = r28 * r68;
+    r102 = fma(r69, r64, r102);
+    r102 = fma(r40, r69, r102);
+    r102 = fma(r40, r70, r102);
+    r102 = fma(r72, r104, r102);
+    r122 = r122 * r0;
+    r0 = r48 * r48;
+    r0 = r0 * r101;
+    r0 = r0 * r72;
+    r0 = r0 * r71;
+    r0 = r0 * r43;
+    r43 = r49 * r72;
+    r43 = r43 * r71;
+    r43 = r43 * r35;
+    r43 = fma(r54, r43, r42 * r0);
+    r0 = r50 * r106;
+    r0 = r0 * r42;
+    r43 = fma(r53, r0, r43);
+    r43 = fma(r31, r62, r43);
+    r43 = r43 + r95;
+    r25 = fma(r55, r25, r5 * r43);
+    r55 = r4 * r50;
+    r25 = fma(r98, r55, r25);
+    r98 = r4 * r40;
+    r98 = r98 * r53;
+    r25 = fma(r59, r98, r25);
+    r59 = r48 * r68;
+    r25 = fma(r69, r59, r25);
+    r43 = r4 * r72;
+    r25 = fma(r112, r43, r25);
+    r112 = r21 * r31;
+    r112 = r112 * r48;
+    r112 = r112 * r67;
+    r25 = fma(r46, r112, r25);
+    r95 = r44 * r63;
+    r95 = r95 * r57;
+    r95 = r95 * r72;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r25 = fma(r53, r95, r25);
+    r62 = r4 * r34;
+    r62 = r62 * r48;
+    r62 = r62 * r72;
+    r25 = fma(r38, r62, r25);
+    r0 = r21 * r31;
+    r0 = r0 * r48;
+    r0 = r0 * r63;
+    r0 = r0 * r67;
+    r25 = fma(r46, r0, r25);
+    r46 = r44 * r57;
+    r46 = r46 * r72;
+    r46 = r46 * r66;
+    r46 = r46 * r71;
+    r25 = fma(r53, r46, r25);
+    r25 = fma(r50, r70, r25);
+    r25 = fma(r31, r1, r25);
+    r25 = fma(r72, r109, r25);
+    r25 = fma(r72, r113, r25);
+    r25 = fma(r50, r69, r25);
+    r114 = fma(r25, r114, r102 * r122);
+    WriteSum2<double, double>((double*)inout_shared, r96, r114);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r2 * r2;
+    r114 = r100 * r2;
+    r96 = r3 * r3;
+    r122 = r97 * r96;
+    r97 = fma(r97, r122, r100 * r114);
+    r100 = r79 * r79;
+    r46 = r117 * r117;
+    r46 = fma(r96, r46, r2 * r100);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r82 * r82;
+    r97 = r23 * r23;
+    r97 = fma(r96, r97, r2 * r46);
+    r46 = r83 * r83;
+    r100 = r93 * r93;
+    r100 = fma(r2, r100, r96 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r97, r100);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r100 = r26 * r26;
+    r97 = r22 * r22;
+    r97 = fma(r96, r97, r2 * r100);
+    r100 = r102 * r102;
+    r46 = r25 * r25;
+    r46 = fma(r2, r46, r96 * r100);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = fma(r79, r114, r117 * r122);
+    r97 = fma(r23, r122, r82 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r46, r97);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r97 = fma(r83, r122, r93 * r114);
+    r46 = fma(r22, r122, r26 * r114);
+    WriteSum2<double, double>((double*)inout_shared, r97, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r114 = fma(r25, r114, r102 * r122);
+    r122 = r117 * r23;
+    r46 = r79 * r82;
+    r46 = fma(r2, r46, r96 * r122);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r79 * r93;
+    r114 = r117 * r83;
+    r114 = fma(r96, r114, r2 * r46);
+    r46 = r79 * r26;
+    r122 = r117 * r22;
+    r122 = fma(r96, r122, r2 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r114, r122);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r122 = r117 * r102;
+    r114 = r79 * r25;
+    r114 = fma(r2, r114, r96 * r122);
+    r122 = r23 * r83;
+    r46 = r82 * r93;
+    r46 = fma(r2, r46, r96 * r122);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r82 * r26;
+    r114 = r23 * r22;
+    r114 = fma(r96, r114, r2 * r46);
+    r46 = r23 * r102;
+    r122 = r82 * r25;
+    r122 = fma(r2, r122, r96 * r46);
+    WriteSum2<double, double>((double*)inout_shared, r114, r122);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r122 = r93 * r26;
+    r114 = r83 * r22;
+    r114 = fma(r96, r114, r2 * r122);
+    r122 = r83 * r102;
+    r46 = r93 * r25;
+    r46 = fma(r2, r46, r96 * r122);
+    WriteSum2<double, double>((double*)inout_shared, r114, r46);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r22 * r102;
+    r114 = r26 * r25;
+    r114 = fma(r2, r114, r96 * r46);
+    WriteSum1<double, double>((double*)inout_shared, r114);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,328 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,225 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r3, r4);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r5,
+                        r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r7, r8);
+    r9 = fma(r6, r7, r2 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r10, r11);
+    r9 = fma(r5, r10, r9);
+    r6 = fma(r6, r8, r2 * r4);
+    r6 = fma(r5, r11, r6);
+    r5 = fma(r1, r6, r0 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r2, r12);
+    r13 = fma(r12, r6, r2 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r5, r13);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r13, r5);
+    r14 = fma(r5, r6, r13 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r15, r16);
+    r17 = fma(r16, r6, r15 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r14, r17);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r17, r14);
+    r18 = fma(r14, r6, r17 * r9);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r19, r20);
+    r9 = fma(r19, r9, r20 * r6);
+    WriteSum2<double, double>((double*)inout_shared, r18, r9);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r9,
+                        r18);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r6,
+                        r21);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = fma(r21, r16, r18 * r20);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r20,
+                        r22);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r16 = fma(r6, r5, r16);
+    r16 = fma(r20, r1, r16);
+    r16 = fma(r22, r12, r16);
+    r16 = fma(r9, r14, r16);
+    r17 = fma(r9, r17, r18 * r19);
+    r17 = fma(r6, r13, r17);
+    r17 = fma(r21, r15, r17);
+    r17 = fma(r20, r0, r17);
+    r17 = fma(r22, r2, r17);
+    r10 = fma(r10, r17, r11 * r16);
+    r7 = fma(r7, r17, r8 * r16);
+    WriteSum2<double, double>((double*)inout_shared, r10, r7);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r17 = fma(r3, r17, r4 * r16);
+    WriteSum1<double, double>((double*)inout_shared, r17);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
@@ -1,0 +1,2312 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r61 = fma(r64, r48, r5 * r61);
+    r67 = r4 * r7;
+    r68 = r10 * r59;
+    r67 = r67 * r62;
+    r61 = fma(r68, r67, r61);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r69,
+                                            r70);
+    r71 = r48 * r48;
+    r72 = fma(r70, r71, r69 * r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r73,
+                                            r74);
+    r75 = r48 * r71;
+    r74 = r74 * r75;
+    r72 = fma(r48, r74, r72);
+    r72 = fma(r73, r75, r72);
+    r75 = 1.0 / r31;
+    r76 = 1.0 / r47;
+    r77 = r75 * r76;
+    r78 = r56 * r77;
+    r79 = r72 * r78;
+    r61 = fma(r6, r79, r61);
+    r61 = fma(r6, r78, r61);
+    r61 = fma(r2, r61, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r67);
+    r61 = fma(r0, r21, r61);
+    r0 = r7 * r7;
+    r0 = r0 * r60;
+    r0 = r0 * r43;
+    r0 = fma(r59, r0, r66);
+    r0 = fma(r65, r48, r4 * r0);
+    r66 = r5 * r7;
+    r66 = r66 * r62;
+    r0 = fma(r68, r66, r0);
+    r0 = fma(r7, r79, r0);
+    r0 = fma(r7, r78, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r67, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r61, r0);
+    r67 = r6 * r43;
+    r1 = -5.00000000000000000e-01;
+    r66 = rsqrt(r30);
+    r80 = r10 * r6;
+    r81 = r11 * r14;
+    r82 = r16 * r17;
+    r82 = fma(r1, r82, r1 * r81);
+    r81 = r15 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r12 * r13;
+    r84 = 5.00000000000000000e-01;
+    r82 = fma(r84, r83, r82);
+    r83 = r24 * r82;
+    r81 = r15 * r14;
+    r85 = r12 * r17;
+    r85 = fma(r84, r85, r84 * r81);
+    r81 = r11 * r18;
+    r85 = fma(r1, r81, r85);
+    r86 = r16 * r13;
+    r85 = fma(r84, r86, r85);
+    r86 = r29 * r85;
+    r81 = fma(r10, r86, r10 * r83);
+    r87 = r10 * r19;
+    r88 = fma(r84, r26, r1 * r22);
+    r88 = fma(r1, r23, r88);
+    r88 = fma(r1, r25, r88);
+    r89 = r10 * r27;
+    r90 = r16 * r14;
+    r91 = r11 * r17;
+    r91 = fma(r1, r91, r84 * r90);
+    r90 = r12 * r18;
+    r91 = fma(r1, r90, r91);
+    r92 = r15 * r13;
+    r91 = fma(r1, r92, r91);
+    r89 = r89 * r91;
+    r87 = fma(r88, r87, r89);
+    r81 = r81 + r87;
+    r92 = r10 * r24;
+    r92 = r92 * r91;
+    r90 = r10 * r19;
+    r90 = r90 * r85;
+    r93 = r92 + r90;
+    r94 = r27 * r35;
+    r93 = fma(r82, r94, r93);
+    r95 = r35 * r29;
+    r93 = fma(r88, r95, r93);
+    r93 = fma(r9, r93, r42 * r81);
+    r81 = r24 * r85;
+    r95 = -4.00000000000000000e+00;
+    r81 = r81 * r95;
+    r94 = r27 * r88;
+    r96 = r95 * r94;
+    r97 = r81 + r96;
+    r93 = fma(r8, r97, r93);
+    r80 = r80 * r93;
+    r97 = r6 * r6;
+    r98 = r10 * r24;
+    r98 = r98 * r88;
+    r99 = r10 * r27;
+    r99 = fma(r85, r99, r98);
+    r85 = r10 * r19;
+    r85 = r85 * r82;
+    r100 = r10 * r29;
+    r100 = r100 * r91;
+    r101 = r85 + r100;
+    r102 = r99 + r101;
+    r86 = fma(r35, r86, r35 * r83);
+    r86 = r86 + r87;
+    r86 = fma(r8, r86, r9 * r102);
+    r102 = r19 * r91;
+    r102 = r102 * r95;
+    r81 = r81 + r102;
+    r86 = fma(r42, r81, r86);
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r31 = r35 * r57;
+    r97 = r97 * r86;
+    r97 = fma(r31, r97, r39 * r80);
+    r80 = r7 * r7;
+    r80 = r80 * r31;
+    r81 = r10 * r7;
+    r103 = r19 * r35;
+    r104 = r35 * r29;
+    r104 = r104 * r91;
+    r103 = fma(r82, r103, r104);
+    r103 = r103 + r99;
+    r96 = r102 + r96;
+    r96 = fma(r9, r96, r42 * r103);
+    r103 = r10 * r29;
+    r103 = fma(r88, r103, r90);
+    r90 = r10 * r27;
+    r90 = fma(r82, r90, r92);
+    r103 = r103 + r90;
+    r96 = fma(r8, r103, r96);
+    r81 = r81 * r96;
+    r97 = fma(r39, r81, r97);
+    r97 = fma(r86, r80, r97);
+    r67 = r67 * r56;
+    r67 = r67 * r75;
+    r67 = r67 * r1;
+    r67 = r67 * r66;
+    r67 = r67 * r97;
+    r81 = r56 * r56;
+    r103 = r43 * r81;
+    r103 = r103 * r80;
+    r92 = r7 * r66;
+    r102 = r97 * r92;
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r36 = r30 * r53;
+    r99 = r7 * r43;
+    r102 = r102 * r36;
+    r102 = fma(r99, r102, r86 * r103);
+    r105 = r21 * r7;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r47 = r49 * r59;
+    r47 = r47 * r92;
+    r105 = r105 * r97;
+    r102 = fma(r47, r105, r102);
+    r106 = r68 * r99;
+    r102 = fma(r96, r106, r102);
+    r105 = r97 * r66;
+    r105 = r105 * r36;
+    r107 = r21 * r6;
+    r107 = r107 * r6;
+    r107 = r107 * r97;
+    r107 = r107 * r66;
+    r107 = r107 * r49;
+    r107 = fma(r59, r107, r63 * r105);
+    r105 = r93 * r62;
+    r107 = fma(r68, r105, r107);
+    r108 = r86 * r31;
+    r81 = r63 * r81;
+    r107 = fma(r81, r108, r107);
+    r108 = r102 + r107;
+    r105 = fma(r64, r108, r67);
+    r109 = r60 * r97;
+    r109 = r109 * r66;
+    r109 = r109 * r36;
+    r110 = r6 * r6;
+    r111 = -3.00000000000000000e+00;
+    r110 = r110 * r111;
+    r110 = r110 * r97;
+    r110 = r110 * r66;
+    r110 = r110 * r49;
+    r110 = fma(r59, r110, r63 * r109);
+    r109 = 6.00000000000000000e+00;
+    r112 = r93 * r109;
+    r112 = r112 * r59;
+    r110 = fma(r62, r112, r110);
+    r113 = -6.00000000000000000e+00;
+    r114 = r113 * r57;
+    r114 = r114 * r81;
+    r110 = fma(r86, r114, r110);
+    r110 = r110 + r102;
+    r102 = r93 * r106;
+    r112 = r21 * r6;
+    r112 = r112 * r72;
+    r112 = r112 * r86;
+    r112 = r112 * r76;
+    r105 = fma(r53, r112, r105);
+    r115 = r6 * r84;
+    r115 = r115 * r66;
+    r115 = r115 * r30;
+    r115 = r115 * r77;
+    r116 = r72 * r115;
+    r117 = r4 * r35;
+    r117 = r117 * r6;
+    r117 = r117 * r97;
+    r105 = fma(r47, r117, r105);
+    r118 = r4 * r96;
+    r118 = r118 * r62;
+    r105 = fma(r68, r118, r105);
+    r119 = r4 * r7;
+    r119 = r119 * r56;
+    r119 = r119 * r56;
+    r119 = r119 * r95;
+    r119 = r119 * r57;
+    r119 = r119 * r62;
+    r120 = r4 * r97;
+    r121 = r10 * r62;
+    r121 = r121 * r92;
+    r121 = r121 * r36;
+    r105 = fma(r121, r120, r105);
+    r122 = r70 * r10;
+    r122 = r122 * r48;
+    r122 = fma(r69, r108, r108 * r122);
+    r73 = r73 * r60;
+    r73 = r73 * r71;
+    r71 = 4.00000000000000000e+00;
+    r74 = r71 * r74;
+    r122 = fma(r108, r73, r122);
+    r122 = fma(r108, r74, r122);
+    r71 = r6 * r122;
+    r105 = fma(r78, r71, r105);
+    r123 = r21 * r6;
+    r123 = r123 * r86;
+    r123 = r123 * r76;
+    r105 = fma(r53, r123, r105);
+    r105 = fma(r5, r110, r105);
+    r105 = fma(r4, r102, r105);
+    r105 = fma(r72, r67, r105);
+    r105 = fma(r97, r116, r105);
+    r105 = fma(r93, r79, r105);
+    r105 = fma(r86, r119, r105);
+    r105 = fma(r97, r115, r105);
+    r105 = fma(r93, r78, r105);
+    r123 = r2 * r105;
+    r71 = r7 * r43;
+    r71 = r71 * r56;
+    r71 = r71 * r75;
+    r71 = r71 * r1;
+    r71 = r71 * r66;
+    r71 = r71 * r97;
+    r108 = fma(r65, r108, r71);
+    r120 = r7 * r7;
+    r120 = r120 * r56;
+    r120 = r120 * r56;
+    r120 = r120 * r86;
+    r120 = r120 * r113;
+    r120 = r120 * r43;
+    r118 = r60 * r97;
+    r118 = r118 * r92;
+    r118 = r118 * r36;
+    r118 = fma(r99, r118, r57 * r120);
+    r120 = r7 * r111;
+    r120 = r120 * r97;
+    r118 = fma(r47, r120, r118);
+    r117 = r7 * r96;
+    r117 = r117 * r109;
+    r117 = r117 * r43;
+    r118 = fma(r59, r117, r118);
+    r118 = r118 + r107;
+    r107 = r21 * r7;
+    r107 = r107 * r86;
+    r107 = r107 * r76;
+    r108 = fma(r53, r107, r108);
+    r117 = r5 * r35;
+    r117 = r117 * r6;
+    r117 = r117 * r47;
+    r120 = r84 * r97;
+    r120 = r120 * r30;
+    r120 = r120 * r92;
+    r108 = fma(r77, r120, r108);
+    r112 = r5 * r96;
+    r112 = r112 * r62;
+    r108 = fma(r68, r112, r108);
+    r67 = r5 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r86;
+    r67 = r67 * r57;
+    r108 = fma(r62, r67, r108);
+    r110 = r7 * r122;
+    r108 = fma(r78, r110, r108);
+    r124 = r5 * r97;
+    r108 = fma(r121, r124, r108);
+    r125 = r84 * r72;
+    r125 = r125 * r97;
+    r125 = r125 * r30;
+    r125 = r125 * r92;
+    r108 = fma(r77, r125, r108);
+    r126 = r21 * r7;
+    r126 = r126 * r72;
+    r126 = r126 * r86;
+    r126 = r126 * r76;
+    r108 = fma(r53, r126, r108);
+    r108 = fma(r4, r118, r108);
+    r108 = fma(r5, r102, r108);
+    r108 = fma(r72, r71, r108);
+    r108 = fma(r97, r117, r108);
+    r108 = fma(r96, r79, r108);
+    r108 = fma(r96, r78, r108);
+    r126 = r3 * r108;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r126);
+    r126 = r35 * r24;
+    r126 = fma(r88, r126, r104);
+    r123 = r10 * r27;
+    r125 = r15 * r14;
+    r124 = r12 * r17;
+    r124 = fma(r1, r124, r1 * r125);
+    r125 = r11 * r18;
+    r124 = fma(r84, r125, r124);
+    r110 = r16 * r13;
+    r124 = fma(r1, r110, r124);
+    r123 = r123 * r124;
+    r110 = r10 * r19;
+    r125 = r11 * r14;
+    r67 = r16 * r17;
+    r67 = fma(r84, r67, r84 * r125);
+    r125 = r15 * r18;
+    r67 = fma(r84, r125, r67);
+    r112 = r12 * r13;
+    r67 = fma(r1, r112, r67);
+    r110 = fma(r67, r110, r123);
+    r126 = r126 + r110;
+    r112 = r10 * r24;
+    r112 = r112 * r67;
+    r125 = r10 * r29;
+    r125 = fma(r124, r125, r112);
+    r125 = r125 + r87;
+    r125 = fma(r9, r125, r8 * r126);
+    r126 = r24 * r91;
+    r126 = r126 * r95;
+    r87 = r19 * r124;
+    r120 = r95 * r87;
+    r71 = r126 + r120;
+    r125 = fma(r42, r71, r125);
+    r100 = r98 + r100;
+    r100 = r100 + r110;
+    r110 = r27 * r95;
+    r110 = r110 * r67;
+    r126 = r126 + r110;
+    r126 = fma(r8, r126, r42 * r100);
+    r100 = r35 * r29;
+    r100 = fma(r35, r94, r67 * r100);
+    r98 = r10 * r19;
+    r98 = r98 * r91;
+    r71 = r10 * r24;
+    r71 = fma(r124, r71, r98);
+    r100 = r100 + r71;
+    r126 = fma(r9, r100, r126);
+    r100 = r109 * r126;
+    r100 = r100 * r59;
+    r100 = fma(r62, r100, r125 * r114);
+    r107 = r6 * r6;
+    r102 = r10 * r6;
+    r102 = r102 * r126;
+    r118 = r10 * r7;
+    r112 = r89 + r112;
+    r89 = r19 * r35;
+    r112 = fma(r88, r89, r112);
+    r88 = r35 * r29;
+    r112 = fma(r124, r88, r112);
+    r88 = r10 * r29;
+    r94 = fma(r10, r94, r67 * r88);
+    r94 = r94 + r71;
+    r94 = fma(r8, r94, r42 * r112);
+    r120 = r110 + r120;
+    r94 = fma(r9, r120, r94);
+    r118 = r118 * r94;
+    r118 = fma(r39, r118, r39 * r102);
+    r102 = r6 * r6;
+    r102 = r102 * r125;
+    r118 = fma(r31, r102, r118);
+    r118 = fma(r125, r80, r118);
+    r102 = r111 * r118;
+    r107 = r107 * r66;
+    r107 = r107 * r49;
+    r107 = r107 * r59;
+    r100 = fma(r102, r107, r100);
+    r120 = r60 * r118;
+    r120 = r120 * r66;
+    r120 = r120 * r36;
+    r100 = fma(r63, r120, r100);
+    r110 = r21 * r7;
+    r110 = r110 * r118;
+    r110 = fma(r47, r110, r94 * r106);
+    r112 = r118 * r92;
+    r112 = r112 * r36;
+    r110 = fma(r99, r112, r110);
+    r110 = fma(r125, r103, r110);
+    r100 = r100 + r110;
+    r120 = r125 * r31;
+    r107 = r126 * r62;
+    r107 = fma(r68, r107, r81 * r120);
+    r120 = r21 * r6;
+    r120 = r120 * r6;
+    r120 = r120 * r118;
+    r120 = r120 * r66;
+    r120 = r120 * r49;
+    r107 = fma(r59, r120, r107);
+    r112 = r118 * r66;
+    r112 = r112 * r36;
+    r107 = fma(r63, r112, r107);
+    r110 = r110 + r107;
+    r100 = fma(r64, r110, r5 * r100);
+    r112 = r21 * r6;
+    r112 = r112 * r125;
+    r112 = r112 * r76;
+    r100 = fma(r53, r112, r100);
+    r120 = r56 * r72;
+    r120 = r120 * r1;
+    r120 = r120 * r118;
+    r120 = r120 * r75;
+    r120 = r120 * r66;
+    r100 = fma(r62, r120, r100);
+    r88 = r70 * r10;
+    r88 = r88 * r48;
+    r88 = fma(r110, r88, r69 * r110);
+    r88 = fma(r110, r74, r88);
+    r88 = fma(r110, r73, r88);
+    r67 = r6 * r88;
+    r100 = fma(r78, r67, r100);
+    r89 = r21 * r6;
+    r89 = r89 * r72;
+    r89 = r89 * r125;
+    r89 = r89 * r76;
+    r100 = fma(r53, r89, r100);
+    r127 = r4 * r118;
+    r100 = fma(r121, r127, r100);
+    r128 = r4 * r35;
+    r128 = r128 * r6;
+    r128 = r128 * r118;
+    r100 = fma(r47, r128, r100);
+    r129 = r4 * r94;
+    r129 = r129 * r62;
+    r100 = fma(r68, r129, r100);
+    r130 = r4 * r126;
+    r100 = fma(r106, r130, r100);
+    r131 = r56 * r1;
+    r131 = r131 * r118;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r100 = fma(r62, r131, r100);
+    r100 = fma(r118, r116, r100);
+    r100 = fma(r118, r115, r100);
+    r100 = fma(r125, r119, r100);
+    r100 = fma(r126, r78, r100);
+    r100 = fma(r126, r79, r100);
+    r131 = r2 * r100;
+    r130 = r7 * r109;
+    r130 = r130 * r94;
+    r130 = r130 * r43;
+    r129 = r7 * r47;
+    r129 = fma(r102, r129, r59 * r130);
+    r130 = r7 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r113;
+    r130 = r130 * r125;
+    r130 = r130 * r43;
+    r129 = fma(r57, r130, r129);
+    r102 = r60 * r118;
+    r102 = r102 * r92;
+    r102 = r102 * r36;
+    r129 = fma(r99, r102, r129);
+    r129 = r129 + r107;
+    r110 = fma(r65, r110, r4 * r129);
+    r129 = r56 * r1;
+    r129 = r129 * r118;
+    r129 = r129 * r43;
+    r129 = r129 * r75;
+    r110 = fma(r92, r129, r110);
+    r107 = r7 * r88;
+    r110 = fma(r78, r107, r110);
+    r102 = r84 * r118;
+    r102 = r102 * r30;
+    r102 = r102 * r92;
+    r110 = fma(r77, r102, r110);
+    r130 = r5 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r95;
+    r130 = r130 * r125;
+    r130 = r130 * r57;
+    r110 = fma(r62, r130, r110);
+    r128 = r5 * r118;
+    r110 = fma(r121, r128, r110);
+    r127 = r21 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r125;
+    r127 = r127 * r76;
+    r110 = fma(r53, r127, r110);
+    r89 = r56 * r72;
+    r89 = r89 * r1;
+    r89 = r89 * r118;
+    r89 = r89 * r43;
+    r89 = r89 * r75;
+    r110 = fma(r92, r89, r110);
+    r67 = r21 * r7;
+    r67 = r67 * r125;
+    r67 = r67 * r76;
+    r110 = fma(r53, r67, r110);
+    r120 = r5 * r94;
+    r120 = r120 * r62;
+    r110 = fma(r68, r120, r110);
+    r112 = r84 * r72;
+    r112 = r112 * r118;
+    r112 = r112 * r30;
+    r112 = r112 * r92;
+    r110 = fma(r77, r112, r110);
+    r132 = r5 * r126;
+    r110 = fma(r106, r132, r110);
+    r110 = fma(r94, r79, r110);
+    r110 = fma(r118, r117, r110);
+    r110 = fma(r94, r78, r110);
+    r132 = r3 * r110;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r132);
+    r132 = r19 * r95;
+    r26 = fma(r1, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r132 = r132 * r26;
+    r83 = r95 * r83;
+    r25 = r132 + r83;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r98 = r98 + r23;
+    r22 = r35 * r24;
+    r98 = fma(r124, r22, r98);
+    r131 = r35 * r29;
+    r98 = fma(r82, r131, r98);
+    r98 = fma(r8, r98, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r87, r26 * r25);
+    r25 = r25 + r90;
+    r98 = fma(r9, r25, r98);
+    r25 = r10 * r7;
+    r131 = r10 * r24;
+    r131 = r131 * r26;
+    r123 = r123 + r131;
+    r123 = r123 + r101;
+    r101 = r35 * r29;
+    r87 = fma(r35, r87, r26 * r101);
+    r87 = r87 + r90;
+    r87 = fma(r42, r87, r8 * r123);
+    r91 = r27 * r91;
+    r91 = r91 * r95;
+    r132 = r132 + r91;
+    r87 = fma(r9, r132, r87);
+    r25 = r25 * r87;
+    r132 = r6 * r6;
+    r132 = r132 * r98;
+    r132 = fma(r31, r132, r39 * r25);
+    r25 = r10 * r6;
+    r104 = r85 + r104;
+    r85 = r27 * r35;
+    r104 = fma(r124, r85, r104);
+    r104 = r104 + r131;
+    r83 = r91 + r83;
+    r83 = fma(r8, r83, r9 * r104);
+    r8 = r10 * r29;
+    r8 = fma(r82, r8, r23);
+    r8 = r8 + r71;
+    r83 = fma(r42, r8, r83);
+    r25 = r25 * r83;
+    r132 = fma(r39, r25, r132);
+    r132 = fma(r98, r80, r132);
+    r25 = r132 * r92;
+    r25 = r25 * r36;
+    r25 = fma(r99, r25, r98 * r103);
+    r8 = r21 * r7;
+    r8 = r8 * r132;
+    r25 = fma(r47, r8, r25);
+    r25 = fma(r87, r106, r25);
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r42 = r83 * r62;
+    r42 = fma(r68, r42, r59 * r8);
+    r8 = r98 * r31;
+    r42 = fma(r81, r8, r42);
+    r71 = r132 * r66;
+    r71 = r71 * r36;
+    r42 = fma(r63, r71, r42);
+    r71 = r25 + r42;
+    r8 = r6 * r6;
+    r8 = r8 * r111;
+    r8 = r8 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r23 = r109 * r83;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r8);
+    r8 = r60 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r36;
+    r23 = fma(r63, r8, r23);
+    r23 = fma(r98, r114, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r64 * r71);
+    r25 = r70 * r10;
+    r25 = r25 * r48;
+    r25 = fma(r71, r25, r69 * r71);
+    r25 = fma(r71, r73, r25);
+    r25 = fma(r71, r74, r25);
+    r8 = r6 * r25;
+    r23 = fma(r78, r8, r23);
+    r82 = r4 * r83;
+    r23 = fma(r106, r82, r23);
+    r104 = r4 * r132;
+    r23 = fma(r121, r104, r23);
+    r9 = r21 * r6;
+    r9 = r9 * r72;
+    r9 = r9 * r98;
+    r9 = r9 * r76;
+    r23 = fma(r53, r9, r23);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r132;
+    r23 = fma(r47, r91, r23);
+    r85 = r21 * r6;
+    r85 = r85 * r98;
+    r85 = r85 * r76;
+    r23 = fma(r53, r85, r23);
+    r131 = r56 * r1;
+    r131 = r131 * r132;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r23 = fma(r62, r131, r23);
+    r124 = r4 * r87;
+    r124 = r124 * r62;
+    r23 = fma(r68, r124, r23);
+    r123 = r56 * r72;
+    r123 = r123 * r1;
+    r123 = r123 * r132;
+    r123 = r123 * r75;
+    r123 = r123 * r66;
+    r23 = fma(r62, r123, r23);
+    r23 = fma(r132, r115, r23);
+    r23 = fma(r132, r116, r23);
+    r23 = fma(r83, r79, r23);
+    r23 = fma(r83, r78, r23);
+    r23 = fma(r98, r119, r23);
+    r123 = r2 * r23;
+    r124 = r7 * r7;
+    r124 = r124 * r56;
+    r124 = r124 * r56;
+    r124 = r124 * r113;
+    r124 = r124 * r98;
+    r124 = r124 * r43;
+    r131 = r60 * r132;
+    r131 = r131 * r92;
+    r131 = r131 * r36;
+    r131 = fma(r99, r131, r57 * r124);
+    r124 = r7 * r109;
+    r124 = r124 * r87;
+    r124 = r124 * r43;
+    r131 = fma(r59, r124, r131);
+    r85 = r7 * r111;
+    r85 = r85 * r132;
+    r131 = fma(r47, r85, r131);
+    r131 = r131 + r42;
+    r131 = fma(r4, r131, r65 * r71);
+    r71 = r21 * r7;
+    r71 = r71 * r72;
+    r71 = r71 * r98;
+    r71 = r71 * r76;
+    r131 = fma(r53, r71, r131);
+    r42 = r21 * r7;
+    r42 = r42 * r98;
+    r42 = r42 * r76;
+    r131 = fma(r53, r42, r131);
+    r85 = r5 * r83;
+    r131 = fma(r106, r85, r131);
+    r124 = r56 * r72;
+    r124 = r124 * r1;
+    r124 = r124 * r132;
+    r124 = r124 * r43;
+    r124 = r124 * r75;
+    r131 = fma(r92, r124, r131);
+    r91 = r5 * r132;
+    r131 = fma(r121, r91, r131);
+    r9 = r84 * r132;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r131 = fma(r77, r9, r131);
+    r104 = r7 * r25;
+    r131 = fma(r78, r104, r131);
+    r82 = r56 * r1;
+    r82 = r82 * r132;
+    r82 = r82 * r43;
+    r82 = r82 * r75;
+    r131 = fma(r92, r82, r131);
+    r8 = r84 * r72;
+    r8 = r8 * r132;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r131 = fma(r77, r8, r131);
+    r90 = r5 * r7;
+    r90 = r90 * r56;
+    r90 = r90 * r56;
+    r90 = r90 * r95;
+    r90 = r90 * r98;
+    r90 = r90 * r57;
+    r131 = fma(r62, r90, r131);
+    r101 = r5 * r87;
+    r101 = r101 * r62;
+    r131 = fma(r68, r101, r131);
+    r131 = fma(r87, r79, r131);
+    r131 = fma(r87, r78, r131);
+    r131 = fma(r132, r117, r131);
+    r101 = r3 * r131;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r101);
+    r101 = r37 * r109;
+    r101 = r101 * r59;
+    r123 = r6 * r6;
+    r90 = r10 * r33;
+    r90 = r90 * r7;
+    r90 = fma(r20, r80, r39 * r90);
+    r8 = r20 * r6;
+    r8 = r8 * r6;
+    r90 = fma(r31, r8, r90);
+    r82 = r10 * r37;
+    r82 = r82 * r6;
+    r90 = fma(r39, r82, r90);
+    r123 = r123 * r111;
+    r123 = r123 * r90;
+    r123 = r123 * r66;
+    r123 = r123 * r49;
+    r123 = fma(r59, r123, r62 * r101);
+    r101 = r60 * r90;
+    r101 = r101 * r66;
+    r101 = r101 * r36;
+    r123 = fma(r63, r101, r123);
+    r82 = r21 * r7;
+    r82 = r82 * r90;
+    r82 = fma(r47, r82, r33 * r106);
+    r8 = r90 * r92;
+    r8 = r8 * r36;
+    r82 = fma(r99, r8, r82);
+    r82 = fma(r20, r103, r82);
+    r123 = fma(r20, r114, r123);
+    r123 = r123 + r82;
+    r101 = r37 * r62;
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r90;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r8 = fma(r59, r8, r68 * r101);
+    r101 = r90 * r66;
+    r101 = r101 * r36;
+    r8 = fma(r63, r101, r8);
+    r104 = r20 * r31;
+    r8 = fma(r81, r104, r8);
+    r82 = r82 + r8;
+    r123 = fma(r64, r82, r5 * r123);
+    r104 = r4 * r90;
+    r123 = fma(r121, r104, r123);
+    r101 = r56 * r72;
+    r101 = r101 * r1;
+    r101 = r101 * r90;
+    r101 = r101 * r75;
+    r101 = r101 * r66;
+    r123 = fma(r62, r101, r123);
+    r9 = r56 * r1;
+    r9 = r9 * r90;
+    r9 = r9 * r75;
+    r9 = r9 * r66;
+    r123 = fma(r62, r9, r123);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r90;
+    r123 = fma(r47, r91, r123);
+    r124 = r70 * r10;
+    r124 = r124 * r48;
+    r124 = fma(r69, r82, r82 * r124);
+    r124 = fma(r82, r74, r124);
+    r124 = fma(r82, r73, r124);
+    r85 = r6 * r124;
+    r123 = fma(r78, r85, r123);
+    r42 = r21 * r20;
+    r42 = r42 * r6;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r123 = fma(r53, r42, r123);
+    r71 = r21 * r20;
+    r71 = r71 * r6;
+    r71 = r71 * r76;
+    r123 = fma(r53, r71, r123);
+    r26 = r4 * r33;
+    r26 = r26 * r62;
+    r123 = fma(r68, r26, r123);
+    r22 = r4 * r37;
+    r123 = fma(r106, r22, r123);
+    r123 = fma(r37, r79, r123);
+    r123 = fma(r90, r116, r123);
+    r123 = fma(r90, r115, r123);
+    r123 = fma(r20, r119, r123);
+    r123 = fma(r37, r78, r123);
+    r22 = r2 * r123;
+    r26 = r33 * r7;
+    r26 = r26 * r109;
+    r26 = r26 * r43;
+    r71 = r7 * r111;
+    r71 = r71 * r90;
+    r71 = fma(r47, r71, r59 * r26);
+    r26 = r20 * r7;
+    r26 = r26 * r7;
+    r26 = r26 * r56;
+    r26 = r26 * r56;
+    r26 = r26 * r113;
+    r26 = r26 * r43;
+    r71 = fma(r57, r26, r71);
+    r42 = r60 * r90;
+    r42 = r42 * r92;
+    r42 = r42 * r36;
+    r71 = fma(r99, r42, r71);
+    r71 = r71 + r8;
+    r82 = fma(r65, r82, r4 * r71);
+    r71 = r84 * r90;
+    r71 = r71 * r30;
+    r71 = r71 * r92;
+    r82 = fma(r77, r71, r82);
+    r8 = r56 * r72;
+    r8 = r8 * r1;
+    r8 = r8 * r90;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r82 = fma(r92, r8, r82);
+    r42 = r21 * r20;
+    r42 = r42 * r7;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r82 = fma(r53, r42, r82);
+    r26 = r5 * r90;
+    r82 = fma(r121, r26, r82);
+    r85 = r21 * r20;
+    r85 = r85 * r7;
+    r85 = r85 * r76;
+    r82 = fma(r53, r85, r82);
+    r91 = r5 * r20;
+    r91 = r91 * r7;
+    r91 = r91 * r56;
+    r91 = r91 * r56;
+    r91 = r91 * r95;
+    r91 = r91 * r57;
+    r82 = fma(r62, r91, r82);
+    r9 = r7 * r124;
+    r82 = fma(r78, r9, r82);
+    r101 = r84 * r72;
+    r101 = r101 * r90;
+    r101 = r101 * r30;
+    r101 = r101 * r92;
+    r82 = fma(r77, r101, r82);
+    r104 = r5 * r33;
+    r104 = r104 * r62;
+    r82 = fma(r68, r104, r82);
+    r112 = r56 * r1;
+    r112 = r112 * r90;
+    r112 = r112 * r43;
+    r112 = r112 * r75;
+    r82 = fma(r92, r112, r82);
+    r120 = r5 * r37;
+    r82 = fma(r106, r120, r82);
+    r82 = fma(r33, r78, r82);
+    r82 = fma(r90, r117, r82);
+    r82 = fma(r33, r79, r82);
+    r120 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r120);
+    r120 = r10 * r38;
+    r120 = r120 * r7;
+    r120 = fma(r39, r120, r34 * r80);
+    r22 = r34 * r6;
+    r22 = r22 * r6;
+    r120 = fma(r31, r22, r120);
+    r112 = r10 * r55;
+    r112 = r112 * r6;
+    r120 = fma(r39, r112, r120);
+    r112 = r60 * r120;
+    r112 = r112 * r66;
+    r112 = r112 * r36;
+    r112 = fma(r34, r114, r63 * r112);
+    r22 = r6 * r6;
+    r22 = r22 * r111;
+    r22 = r22 * r120;
+    r22 = r22 * r66;
+    r22 = r22 * r49;
+    r112 = fma(r59, r22, r112);
+    r104 = r55 * r109;
+    r104 = r104 * r59;
+    r112 = fma(r62, r104, r112);
+    r101 = fma(r38, r106, r34 * r103);
+    r9 = r120 * r92;
+    r9 = r9 * r36;
+    r101 = fma(r99, r9, r101);
+    r91 = r21 * r7;
+    r91 = r91 * r120;
+    r101 = fma(r47, r91, r101);
+    r112 = r112 + r101;
+    r104 = r120 * r66;
+    r104 = r104 * r36;
+    r22 = r34 * r31;
+    r22 = fma(r81, r22, r63 * r104);
+    r104 = r21 * r6;
+    r104 = r104 * r6;
+    r104 = r104 * r120;
+    r104 = r104 * r66;
+    r104 = r104 * r49;
+    r22 = fma(r59, r104, r22);
+    r91 = r55 * r62;
+    r22 = fma(r68, r91, r22);
+    r101 = r101 + r22;
+    r112 = fma(r64, r101, r5 * r112);
+    r91 = r4 * r38;
+    r91 = r91 * r62;
+    r112 = fma(r68, r91, r112);
+    r104 = r4 * r120;
+    r112 = fma(r121, r104, r112);
+    r9 = r21 * r34;
+    r9 = r9 * r6;
+    r9 = r9 * r76;
+    r112 = fma(r53, r9, r112);
+    r85 = r4 * r35;
+    r85 = r85 * r6;
+    r85 = r85 * r120;
+    r112 = fma(r47, r85, r112);
+    r26 = r56 * r1;
+    r26 = r26 * r120;
+    r26 = r26 * r75;
+    r26 = r26 * r66;
+    r112 = fma(r62, r26, r112);
+    r42 = r70 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r69, r101, r101 * r42);
+    r42 = fma(r101, r73, r42);
+    r42 = fma(r101, r74, r42);
+    r8 = r6 * r42;
+    r112 = fma(r78, r8, r112);
+    r71 = r56 * r72;
+    r71 = r71 * r1;
+    r71 = r71 * r120;
+    r71 = r71 * r75;
+    r71 = r71 * r66;
+    r112 = fma(r62, r71, r112);
+    r67 = r21 * r34;
+    r67 = r67 * r6;
+    r67 = r67 * r72;
+    r67 = r67 * r76;
+    r112 = fma(r53, r67, r112);
+    r89 = r4 * r55;
+    r112 = fma(r106, r89, r112);
+    r112 = fma(r120, r116, r112);
+    r112 = fma(r55, r78, r112);
+    r112 = fma(r34, r119, r112);
+    r112 = fma(r120, r115, r112);
+    r112 = fma(r55, r79, r112);
+    r89 = r2 * r112;
+    r67 = r34 * r7;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r113;
+    r67 = r67 * r43;
+    r71 = r38 * r7;
+    r71 = r71 * r109;
+    r71 = r71 * r43;
+    r71 = fma(r59, r71, r57 * r67);
+    r67 = r60 * r120;
+    r67 = r67 * r92;
+    r67 = r67 * r36;
+    r71 = fma(r99, r67, r71);
+    r8 = r7 * r111;
+    r8 = r8 * r120;
+    r71 = fma(r47, r8, r71);
+    r71 = r71 + r22;
+    r71 = fma(r4, r71, r65 * r101);
+    r101 = r21 * r34;
+    r101 = r101 * r7;
+    r101 = r101 * r76;
+    r71 = fma(r53, r101, r71);
+    r22 = r5 * r38;
+    r22 = r22 * r62;
+    r71 = fma(r68, r22, r71);
+    r8 = r5 * r120;
+    r71 = fma(r121, r8, r71);
+    r67 = r84 * r120;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r71 = fma(r77, r67, r71);
+    r26 = r7 * r42;
+    r71 = fma(r78, r26, r71);
+    r85 = r56 * r72;
+    r85 = r85 * r1;
+    r85 = r85 * r120;
+    r85 = r85 * r43;
+    r85 = r85 * r75;
+    r71 = fma(r92, r85, r71);
+    r9 = r5 * r34;
+    r9 = r9 * r7;
+    r9 = r9 * r56;
+    r9 = r9 * r56;
+    r9 = r9 * r95;
+    r9 = r9 * r57;
+    r71 = fma(r62, r9, r71);
+    r104 = r56 * r1;
+    r104 = r104 * r120;
+    r104 = r104 * r43;
+    r104 = r104 * r75;
+    r71 = fma(r92, r104, r71);
+    r91 = r84 * r72;
+    r91 = r91 * r120;
+    r91 = r91 * r30;
+    r91 = r91 * r92;
+    r71 = fma(r77, r91, r71);
+    r127 = r21 * r34;
+    r127 = r127 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r76;
+    r71 = fma(r53, r127, r71);
+    r128 = r5 * r55;
+    r71 = fma(r106, r128, r71);
+    r71 = fma(r38, r79, r71);
+    r71 = fma(r120, r117, r71);
+    r71 = fma(r38, r78, r71);
+    r128 = r3 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r89, r128);
+    r128 = r6 * r6;
+    r89 = r10 * r41;
+    r89 = r89 * r7;
+    r89 = fma(r32, r80, r39 * r89);
+    r127 = r10 * r54;
+    r127 = r127 * r6;
+    r89 = fma(r39, r127, r89);
+    r91 = r32 * r6;
+    r91 = r91 * r6;
+    r89 = fma(r31, r91, r89);
+    r128 = r128 * r111;
+    r128 = r128 * r89;
+    r128 = r128 * r66;
+    r128 = r128 * r49;
+    r91 = r60 * r89;
+    r91 = r91 * r66;
+    r91 = r91 * r36;
+    r91 = fma(r63, r91, r59 * r128);
+    r128 = r54 * r109;
+    r128 = r128 * r59;
+    r91 = fma(r62, r128, r91);
+    r127 = fma(r41, r106, r32 * r103);
+    r104 = r89 * r92;
+    r104 = r104 * r36;
+    r127 = fma(r99, r104, r127);
+    r9 = r21 * r7;
+    r9 = r9 * r89;
+    r127 = fma(r47, r9, r127);
+    r91 = fma(r32, r114, r91);
+    r91 = r91 + r127;
+    r128 = r21 * r6;
+    r128 = r128 * r6;
+    r128 = r128 * r89;
+    r128 = r128 * r66;
+    r128 = r128 * r49;
+    r9 = r89 * r66;
+    r9 = r9 * r36;
+    r9 = fma(r63, r9, r59 * r128);
+    r128 = r54 * r62;
+    r9 = fma(r68, r128, r9);
+    r104 = r32 * r31;
+    r9 = fma(r81, r104, r9);
+    r127 = r127 + r9;
+    r91 = fma(r64, r127, r5 * r91);
+    r104 = r4 * r54;
+    r91 = fma(r106, r104, r91);
+    r128 = r4 * r41;
+    r128 = r128 * r62;
+    r91 = fma(r68, r128, r91);
+    r85 = r70 * r10;
+    r85 = r85 * r48;
+    r85 = fma(r127, r85, r69 * r127);
+    r85 = fma(r127, r74, r85);
+    r85 = fma(r127, r73, r85);
+    r26 = r6 * r85;
+    r91 = fma(r78, r26, r91);
+    r67 = r4 * r89;
+    r91 = fma(r121, r67, r91);
+    r8 = r21 * r32;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r91 = fma(r53, r8, r91);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r89;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r91 = fma(r62, r22, r91);
+    r101 = r4 * r35;
+    r101 = r101 * r6;
+    r101 = r101 * r89;
+    r91 = fma(r47, r101, r91);
+    r130 = r21 * r32;
+    r130 = r130 * r6;
+    r130 = r130 * r72;
+    r130 = r130 * r76;
+    r91 = fma(r53, r130, r91);
+    r102 = r56 * r1;
+    r102 = r102 * r89;
+    r102 = r102 * r75;
+    r102 = r102 * r66;
+    r91 = fma(r62, r102, r91);
+    r91 = fma(r54, r79, r91);
+    r91 = fma(r32, r119, r91);
+    r91 = fma(r89, r116, r91);
+    r91 = fma(r89, r115, r91);
+    r91 = fma(r54, r78, r91);
+    r102 = r2 * r91;
+    r130 = r32 * r7;
+    r130 = r130 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r113;
+    r130 = r130 * r43;
+    r101 = r41 * r7;
+    r101 = r101 * r109;
+    r101 = r101 * r43;
+    r101 = fma(r59, r101, r57 * r130);
+    r130 = r60 * r89;
+    r130 = r130 * r92;
+    r130 = r130 * r36;
+    r101 = fma(r99, r130, r101);
+    r22 = r7 * r111;
+    r22 = r22 * r89;
+    r101 = fma(r47, r22, r101);
+    r101 = r101 + r9;
+    r101 = fma(r4, r101, r65 * r127);
+    r127 = r56 * r1;
+    r127 = r127 * r89;
+    r127 = r127 * r43;
+    r127 = r127 * r75;
+    r101 = fma(r92, r127, r101);
+    r9 = r21 * r32;
+    r9 = r9 * r7;
+    r9 = r9 * r76;
+    r101 = fma(r53, r9, r101);
+    r22 = r5 * r54;
+    r101 = fma(r106, r22, r101);
+    r130 = r21 * r32;
+    r130 = r130 * r7;
+    r130 = r130 * r72;
+    r130 = r130 * r76;
+    r101 = fma(r53, r130, r101);
+    r8 = r84 * r72;
+    r8 = r8 * r89;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r101 = fma(r77, r8, r101);
+    r67 = r5 * r32;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r57;
+    r101 = fma(r62, r67, r101);
+    r26 = r5 * r41;
+    r26 = r26 * r62;
+    r101 = fma(r68, r26, r101);
+    r128 = r56 * r72;
+    r128 = r128 * r1;
+    r128 = r128 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r75;
+    r101 = fma(r92, r128, r101);
+    r104 = r5 * r89;
+    r101 = fma(r121, r104, r101);
+    r107 = r84 * r89;
+    r107 = r107 * r30;
+    r107 = r107 * r92;
+    r101 = fma(r77, r107, r101);
+    r129 = r7 * r85;
+    r101 = fma(r78, r129, r101);
+    r101 = fma(r41, r78, r101);
+    r101 = fma(r41, r79, r101);
+    r101 = fma(r89, r117, r101);
+    r129 = r3 * r101;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r102,
+                                             r129);
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r102 = r2 * r21;
+    r102 = r102 * r61;
+    r129 = fma(r105, r102, r108 * r129);
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r100, r102, r110 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r129, r61);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r23, r102, r131 * r61);
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r129 = fma(r123, r102, r82 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r61, r129);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r129 = fma(r112, r102, r71 * r129);
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r91, r102, r101 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r129, r61);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r2 * r2;
+    r129 = r105 * r61;
+    r107 = r3 * r3;
+    r104 = r108 * r107;
+    r108 = fma(r108, r104, r105 * r129);
+    r105 = r100 * r100;
+    r128 = r110 * r110;
+    r128 = fma(r107, r128, r61 * r105);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r23 * r23;
+    r108 = r131 * r131;
+    r108 = fma(r107, r108, r61 * r128);
+    r128 = r82 * r82;
+    r105 = r123 * r123;
+    r105 = fma(r61, r105, r107 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r108, r105);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r112 * r112;
+    r108 = r71 * r71;
+    r108 = fma(r107, r108, r61 * r105);
+    r105 = r101 * r101;
+    r128 = r91 * r91;
+    r128 = fma(r61, r128, r107 * r105);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = fma(r100, r129, r110 * r104);
+    r108 = fma(r131, r104, r23 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r128, r108);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = fma(r82, r104, r123 * r129);
+    r128 = fma(r71, r104, r112 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = fma(r91, r129, r101 * r104);
+    r104 = r110 * r131;
+    r128 = r100 * r23;
+    r128 = fma(r61, r128, r107 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r100 * r123;
+    r129 = r110 * r82;
+    r129 = fma(r107, r129, r61 * r128);
+    r128 = r100 * r112;
+    r104 = r110 * r71;
+    r104 = fma(r107, r104, r61 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r129, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r110 * r101;
+    r129 = r100 * r91;
+    r129 = fma(r61, r129, r107 * r104);
+    r104 = r131 * r82;
+    r128 = r23 * r123;
+    r128 = fma(r61, r128, r107 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r23 * r112;
+    r129 = r131 * r71;
+    r129 = fma(r107, r129, r61 * r128);
+    r128 = r131 * r101;
+    r104 = r23 * r91;
+    r104 = fma(r61, r104, r107 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r129, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r123 * r112;
+    r129 = r82 * r71;
+    r129 = fma(r107, r129, r61 * r104);
+    r104 = r82 * r101;
+    r128 = r123 * r91;
+    r128 = fma(r61, r128, r107 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r71 * r101;
+    r129 = r112 * r91;
+    r129 = fma(r61, r129, r107 * r128);
+    WriteSum1<double, double>((double*)inout_shared, r129);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r21 * r7;
+    r128 = r10 * r51;
+    r128 = r128 * r6;
+    r128 = fma(r58, r80, r39 * r128);
+    r104 = r58 * r6;
+    r104 = r104 * r6;
+    r128 = fma(r31, r104, r128);
+    r108 = r10 * r28;
+    r108 = r108 * r7;
+    r128 = fma(r39, r108, r128);
+    r129 = r129 * r128;
+    r129 = fma(r47, r129, r58 * r103);
+    r108 = r128 * r92;
+    r108 = r108 * r36;
+    r129 = fma(r99, r108, r129);
+    r129 = fma(r28, r106, r129);
+    r108 = r58 * r31;
+    r104 = r128 * r66;
+    r104 = r104 * r36;
+    r104 = fma(r63, r104, r81 * r108);
+    r108 = r51 * r62;
+    r104 = fma(r68, r108, r104);
+    r105 = r21 * r6;
+    r105 = r105 * r6;
+    r105 = r105 * r128;
+    r105 = r105 * r66;
+    r105 = r105 * r49;
+    r104 = fma(r59, r105, r104);
+    r105 = r129 + r104;
+    r108 = r60 * r128;
+    r108 = r108 * r66;
+    r108 = r108 * r36;
+    r108 = fma(r63, r108, r58 * r114);
+    r26 = r51 * r109;
+    r26 = r26 * r59;
+    r108 = fma(r62, r26, r108);
+    r67 = r6 * r6;
+    r67 = r67 * r111;
+    r67 = r67 * r128;
+    r67 = r67 * r66;
+    r67 = r67 * r49;
+    r108 = fma(r59, r67, r108);
+    r108 = r108 + r129;
+    r108 = fma(r5, r108, r64 * r105);
+    r129 = r21 * r58;
+    r129 = r129 * r6;
+    r129 = r129 * r72;
+    r129 = r129 * r76;
+    r108 = fma(r53, r129, r108);
+    r67 = r128 * r121;
+    r26 = r4 * r35;
+    r26 = r26 * r6;
+    r26 = r26 * r128;
+    r108 = fma(r47, r26, r108);
+    r8 = r4 * r51;
+    r108 = fma(r106, r8, r108);
+    r130 = r21 * r58;
+    r130 = r130 * r6;
+    r130 = r130 * r76;
+    r108 = fma(r53, r130, r108);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r128;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r108 = fma(r62, r22, r108);
+    r9 = r70 * r10;
+    r9 = r9 * r48;
+    r9 = fma(r69, r105, r105 * r9);
+    r9 = fma(r105, r74, r9);
+    r9 = fma(r105, r73, r9);
+    r127 = r6 * r9;
+    r108 = fma(r78, r127, r108);
+    r133 = r4 * r28;
+    r133 = r133 * r62;
+    r108 = fma(r68, r133, r108);
+    r134 = r56 * r1;
+    r134 = r134 * r128;
+    r134 = r134 * r75;
+    r134 = r134 * r66;
+    r108 = fma(r62, r134, r108);
+    r108 = fma(r128, r116, r108);
+    r108 = fma(r4, r67, r108);
+    r108 = fma(r128, r115, r108);
+    r108 = fma(r51, r78, r108);
+    r108 = fma(r58, r119, r108);
+    r108 = fma(r51, r79, r108);
+    r134 = r2 * r108;
+    r133 = r58 * r7;
+    r133 = r133 * r7;
+    r133 = r133 * r56;
+    r133 = r133 * r56;
+    r133 = r133 * r113;
+    r133 = r133 * r43;
+    r127 = r7 * r111;
+    r127 = r127 * r128;
+    r127 = fma(r47, r127, r57 * r133);
+    r133 = r60 * r128;
+    r133 = r133 * r92;
+    r133 = r133 * r36;
+    r127 = fma(r99, r133, r127);
+    r22 = r28 * r7;
+    r22 = r22 * r109;
+    r22 = r22 * r43;
+    r127 = fma(r59, r22, r127);
+    r127 = r127 + r104;
+    r127 = fma(r4, r127, r65 * r105);
+    r105 = r7 * r9;
+    r127 = fma(r78, r105, r127);
+    r104 = r84 * r128;
+    r104 = r104 * r30;
+    r104 = r104 * r92;
+    r127 = fma(r77, r104, r127);
+    r22 = r21 * r58;
+    r22 = r22 * r7;
+    r22 = r22 * r76;
+    r127 = fma(r53, r22, r127);
+    r133 = r5 * r51;
+    r127 = fma(r106, r133, r127);
+    r130 = r56 * r1;
+    r130 = r130 * r128;
+    r130 = r130 * r43;
+    r130 = r130 * r75;
+    r127 = fma(r92, r130, r127);
+    r8 = r84 * r72;
+    r8 = r8 * r128;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r127 = fma(r77, r8, r127);
+    r26 = r56 * r72;
+    r26 = r26 * r1;
+    r26 = r26 * r128;
+    r26 = r26 * r43;
+    r26 = r26 * r75;
+    r127 = fma(r92, r26, r127);
+    r129 = r21 * r58;
+    r129 = r129 * r7;
+    r129 = r129 * r72;
+    r129 = r129 * r76;
+    r127 = fma(r53, r129, r127);
+    r135 = r5 * r58;
+    r135 = r135 * r7;
+    r135 = r135 * r56;
+    r135 = r135 * r56;
+    r135 = r135 * r95;
+    r135 = r135 * r57;
+    r127 = fma(r62, r135, r127);
+    r136 = r5 * r28;
+    r136 = r136 * r62;
+    r127 = fma(r68, r136, r127);
+    r127 = fma(r28, r79, r127);
+    r127 = fma(r5, r67, r127);
+    r127 = fma(r128, r117, r127);
+    r127 = fma(r28, r78, r127);
+    r136 = r3 * r127;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r134,
+                                             r136);
+    r136 = r45 * r109;
+    r136 = r136 * r59;
+    r136 = fma(r40, r114, r62 * r136);
+    r134 = r6 * r6;
+    r135 = r40 * r6;
+    r135 = r135 * r6;
+    r129 = r10 * r45;
+    r129 = r129 * r6;
+    r129 = fma(r39, r129, r31 * r135);
+    r135 = r10 * r46;
+    r135 = r135 * r7;
+    r129 = fma(r39, r135, r129);
+    r129 = fma(r40, r80, r129);
+    r134 = r134 * r111;
+    r134 = r134 * r129;
+    r134 = r134 * r66;
+    r134 = r134 * r49;
+    r136 = fma(r59, r134, r136);
+    r135 = r60 * r129;
+    r135 = r135 * r66;
+    r135 = r135 * r36;
+    r136 = fma(r63, r135, r136);
+    r26 = r129 * r92;
+    r26 = r26 * r36;
+    r26 = fma(r99, r26, r40 * r103);
+    r8 = r21 * r7;
+    r8 = r8 * r129;
+    r26 = fma(r47, r8, r26);
+    r26 = fma(r46, r106, r26);
+    r136 = r136 + r26;
+    r135 = r45 * r62;
+    r134 = r40 * r31;
+    r134 = fma(r81, r134, r68 * r135);
+    r135 = r21 * r6;
+    r135 = r135 * r6;
+    r135 = r135 * r129;
+    r135 = r135 * r66;
+    r135 = r135 * r49;
+    r134 = fma(r59, r135, r134);
+    r8 = r129 * r66;
+    r8 = r8 * r36;
+    r134 = fma(r63, r8, r134);
+    r26 = r26 + r134;
+    r136 = fma(r64, r26, r5 * r136);
+    r8 = r21 * r40;
+    r8 = r8 * r6;
+    r8 = r8 * r72;
+    r8 = r8 * r76;
+    r136 = fma(r53, r8, r136);
+    r135 = r70 * r10;
+    r135 = r135 * r48;
+    r135 = fma(r26, r135, r69 * r26);
+    r135 = fma(r26, r73, r135);
+    r135 = fma(r26, r74, r135);
+    r130 = r6 * r135;
+    r136 = fma(r78, r130, r136);
+    r133 = r21 * r40;
+    r133 = r133 * r6;
+    r133 = r133 * r76;
+    r136 = fma(r53, r133, r136);
+    r67 = r4 * r46;
+    r67 = r67 * r62;
+    r136 = fma(r68, r67, r136);
+    r22 = r4 * r45;
+    r136 = fma(r106, r22, r136);
+    r104 = r56 * r1;
+    r104 = r104 * r129;
+    r104 = r104 * r75;
+    r104 = r104 * r66;
+    r136 = fma(r62, r104, r136);
+    r105 = r4 * r129;
+    r136 = fma(r121, r105, r136);
+    r137 = r4 * r35;
+    r137 = r137 * r6;
+    r137 = r137 * r129;
+    r136 = fma(r47, r137, r136);
+    r138 = r56 * r72;
+    r138 = r138 * r1;
+    r138 = r138 * r129;
+    r138 = r138 * r75;
+    r138 = r138 * r66;
+    r136 = fma(r62, r138, r136);
+    r136 = fma(r45, r79, r136);
+    r136 = fma(r129, r115, r136);
+    r136 = fma(r129, r116, r136);
+    r136 = fma(r45, r78, r136);
+    r136 = fma(r40, r119, r136);
+    r138 = r2 * r136;
+    r137 = r40 * r7;
+    r137 = r137 * r7;
+    r137 = r137 * r56;
+    r137 = r137 * r56;
+    r137 = r137 * r113;
+    r137 = r137 * r43;
+    r105 = r60 * r129;
+    r105 = r105 * r92;
+    r105 = r105 * r36;
+    r105 = fma(r99, r105, r57 * r137);
+    r137 = r46 * r7;
+    r137 = r137 * r109;
+    r137 = r137 * r43;
+    r105 = fma(r59, r137, r105);
+    r104 = r7 * r111;
+    r104 = r104 * r129;
+    r105 = fma(r47, r104, r105);
+    r105 = r105 + r134;
+    r26 = fma(r65, r26, r4 * r105);
+    r105 = r21 * r40;
+    r105 = r105 * r7;
+    r105 = r105 * r76;
+    r26 = fma(r53, r105, r26);
+    r134 = r21 * r40;
+    r134 = r134 * r7;
+    r134 = r134 * r72;
+    r134 = r134 * r76;
+    r26 = fma(r53, r134, r26);
+    r104 = r84 * r129;
+    r104 = r104 * r30;
+    r104 = r104 * r92;
+    r26 = fma(r77, r104, r26);
+    r137 = r5 * r46;
+    r137 = r137 * r62;
+    r26 = fma(r68, r137, r26);
+    r22 = r56 * r1;
+    r22 = r22 * r129;
+    r22 = r22 * r43;
+    r22 = r22 * r75;
+    r26 = fma(r92, r22, r26);
+    r67 = r5 * r45;
+    r26 = fma(r106, r67, r26);
+    r133 = r5 * r129;
+    r26 = fma(r121, r133, r26);
+    r130 = r5 * r40;
+    r130 = r130 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r95;
+    r130 = r130 * r57;
+    r26 = fma(r62, r130, r26);
+    r8 = r84 * r72;
+    r8 = r8 * r129;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r26 = fma(r77, r8, r26);
+    r139 = r7 * r135;
+    r26 = fma(r78, r139, r26);
+    r140 = r56 * r72;
+    r140 = r140 * r1;
+    r140 = r140 * r129;
+    r140 = r140 * r43;
+    r140 = r140 * r75;
+    r26 = fma(r92, r140, r26);
+    r26 = fma(r46, r79, r26);
+    r26 = fma(r129, r117, r26);
+    r26 = fma(r46, r78, r26);
+    r140 = r3 * r26;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r140);
+    r140 = r6 * r6;
+    r138 = r10 * r52;
+    r138 = r138 * r6;
+    r80 = fma(r50, r80, r39 * r138);
+    r138 = r50 * r6;
+    r138 = r138 * r6;
+    r80 = fma(r31, r138, r80);
+    r139 = r10 * r44;
+    r139 = r139 * r7;
+    r80 = fma(r39, r139, r80);
+    r140 = r140 * r111;
+    r140 = r140 * r80;
+    r140 = r140 * r66;
+    r140 = r140 * r49;
+    r140 = fma(r59, r140, r50 * r114);
+    r114 = r60 * r80;
+    r114 = r114 * r66;
+    r114 = r114 * r36;
+    r140 = fma(r63, r114, r140);
+    r139 = r52 * r109;
+    r139 = r139 * r59;
+    r140 = fma(r62, r139, r140);
+    r138 = r21 * r7;
+    r138 = r138 * r80;
+    r138 = fma(r47, r138, r44 * r106);
+    r39 = r80 * r92;
+    r39 = r39 * r36;
+    r138 = fma(r99, r39, r138);
+    r138 = fma(r50, r103, r138);
+    r140 = r140 + r138;
+    r139 = r50 * r31;
+    r114 = r21 * r6;
+    r114 = r114 * r6;
+    r114 = r114 * r80;
+    r114 = r114 * r66;
+    r114 = r114 * r49;
+    r114 = fma(r59, r114, r81 * r139);
+    r139 = r80 * r66;
+    r139 = r139 * r36;
+    r114 = fma(r63, r139, r114);
+    r63 = r52 * r62;
+    r114 = fma(r68, r63, r114);
+    r138 = r138 + r114;
+    r64 = fma(r64, r138, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r76;
+    r64 = fma(r53, r140, r64);
+    r63 = r4 * r44;
+    r63 = r63 * r62;
+    r64 = fma(r68, r63, r64);
+    r139 = r4 * r35;
+    r139 = r139 * r6;
+    r139 = r139 * r80;
+    r64 = fma(r47, r139, r64);
+    r81 = r56 * r1;
+    r81 = r81 * r80;
+    r81 = r81 * r75;
+    r81 = r81 * r66;
+    r64 = fma(r62, r81, r64);
+    r49 = r4 * r80;
+    r64 = fma(r121, r49, r64);
+    r103 = r4 * r52;
+    r64 = fma(r106, r103, r64);
+    r39 = r56 * r72;
+    r39 = r39 * r1;
+    r39 = r39 * r80;
+    r39 = r39 * r75;
+    r39 = r39 * r66;
+    r64 = fma(r62, r39, r64);
+    r8 = r21 * r50;
+    r8 = r8 * r6;
+    r8 = r8 * r72;
+    r8 = r8 * r76;
+    r64 = fma(r53, r8, r64);
+    r130 = r70 * r10;
+    r130 = r130 * r48;
+    r130 = fma(r138, r130, r69 * r138);
+    r130 = fma(r138, r74, r130);
+    r130 = fma(r138, r73, r130);
+    r73 = r6 * r130;
+    r64 = fma(r78, r73, r64);
+    r64 = fma(r52, r79, r64);
+    r64 = fma(r80, r115, r64);
+    r64 = fma(r80, r116, r64);
+    r64 = fma(r50, r119, r64);
+    r64 = fma(r52, r78, r64);
+    r2 = r2 * r64;
+    r73 = r44 * r7;
+    r73 = r73 * r109;
+    r73 = r73 * r43;
+    r8 = r7 * r111;
+    r8 = r8 * r80;
+    r8 = fma(r47, r8, r59 * r73);
+    r73 = r60 * r80;
+    r73 = r73 * r92;
+    r73 = r73 * r36;
+    r8 = fma(r99, r73, r8);
+    r99 = r50 * r7;
+    r99 = r99 * r7;
+    r99 = r99 * r56;
+    r99 = r99 * r56;
+    r99 = r99 * r113;
+    r99 = r99 * r43;
+    r8 = fma(r57, r99, r8);
+    r8 = r8 + r114;
+    r8 = fma(r4, r8, r65 * r138);
+    r138 = r5 * r44;
+    r138 = r138 * r62;
+    r8 = fma(r68, r138, r8);
+    r68 = r56 * r1;
+    r68 = r68 * r80;
+    r68 = r68 * r43;
+    r68 = r68 * r75;
+    r8 = fma(r92, r68, r8);
+    r65 = r5 * r80;
+    r8 = fma(r121, r65, r8);
+    r121 = r56 * r72;
+    r121 = r121 * r1;
+    r121 = r121 * r80;
+    r121 = r121 * r43;
+    r121 = r121 * r75;
+    r8 = fma(r92, r121, r8);
+    r75 = r84 * r72;
+    r75 = r75 * r80;
+    r75 = r75 * r30;
+    r75 = r75 * r92;
+    r8 = fma(r77, r75, r8);
+    r43 = r21 * r50;
+    r43 = r43 * r7;
+    r43 = r43 * r72;
+    r43 = r43 * r76;
+    r8 = fma(r53, r43, r8);
+    r114 = r5 * r50;
+    r114 = r114 * r7;
+    r114 = r114 * r56;
+    r114 = r114 * r56;
+    r114 = r114 * r95;
+    r114 = r114 * r57;
+    r8 = fma(r62, r114, r8);
+    r57 = r5 * r52;
+    r8 = fma(r106, r57, r8);
+    r106 = r7 * r130;
+    r8 = fma(r78, r106, r8);
+    r95 = r84 * r80;
+    r95 = r95 * r30;
+    r95 = r95 * r92;
+    r8 = fma(r77, r95, r8);
+    r77 = r21 * r50;
+    r77 = r77 * r7;
+    r77 = r77 * r76;
+    r8 = fma(r53, r77, r8);
+    r8 = fma(r80, r117, r8);
+    r8 = fma(r44, r79, r8);
+    r8 = fma(r44, r78, r8);
+    r77 = r3 * r8;
+    WriteIdx2<1024, double, double, double2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r2, r77);
+    r77 = r3 * r21;
+    r77 = r77 * r0;
+    r77 = fma(r108, r102, r127 * r77);
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r2 = fma(r136, r102, r26 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r77, r2);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r102 = fma(r64, r102, r8 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r102);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r127 * r127;
+    r2 = r108 * r108;
+    r2 = fma(r61, r2, r107 * r102);
+    r102 = r26 * r26;
+    r0 = r136 * r136;
+    r0 = fma(r61, r0, r107 * r102);
+    WriteSum2<double, double>((double*)inout_shared, r2, r0);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r8 * r8;
+    r2 = r64 * r64;
+    r2 = fma(r61, r2, r107 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r2);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r127 * r26;
+    r0 = r108 * r136;
+    r0 = fma(r61, r0, r107 * r2);
+    r2 = r127 * r8;
+    r102 = r108 * r64;
+    r102 = fma(r61, r102, r107 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r0, r102);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r26 * r8;
+    r0 = r136 * r64;
+    r0 = fma(r61, r0, r107 * r102);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_point_jac,
+              out_point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,2326 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r61 = fma(r64, r48, r5 * r61);
+    r67 = r4 * r7;
+    r68 = r10 * r59;
+    r67 = r67 * r62;
+    r61 = fma(r68, r67, r61);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r69,
+                                            r70);
+    r71 = r48 * r48;
+    r72 = fma(r70, r71, r69 * r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r73,
+                                            r74);
+    r75 = r48 * r71;
+    r74 = r74 * r75;
+    r72 = fma(r48, r74, r72);
+    r72 = fma(r73, r75, r72);
+    r75 = 1.0 / r31;
+    r76 = 1.0 / r47;
+    r77 = r75 * r76;
+    r78 = r56 * r77;
+    r79 = r72 * r78;
+    r61 = fma(r6, r79, r61);
+    r61 = fma(r6, r78, r61);
+    r61 = fma(r2, r61, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r67);
+    r61 = fma(r0, r21, r61);
+    r0 = r7 * r7;
+    r0 = r0 * r60;
+    r0 = r0 * r43;
+    r0 = fma(r59, r0, r66);
+    r0 = fma(r65, r48, r4 * r0);
+    r66 = r5 * r7;
+    r66 = r66 * r62;
+    r0 = fma(r68, r66, r0);
+    r0 = fma(r7, r79, r0);
+    r0 = fma(r7, r78, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r67, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r61, r0);
+    r67 = fma(r0, r0, r61 * r61);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r67);
+  if (global_thread_idx < problem_size) {
+    r67 = r6 * r43;
+    r1 = -5.00000000000000000e-01;
+    r66 = rsqrt(r30);
+    r80 = r10 * r6;
+    r81 = r11 * r14;
+    r82 = r16 * r17;
+    r82 = fma(r1, r82, r1 * r81);
+    r81 = r15 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r12 * r13;
+    r84 = 5.00000000000000000e-01;
+    r82 = fma(r84, r83, r82);
+    r83 = r24 * r82;
+    r81 = r15 * r14;
+    r85 = r12 * r17;
+    r85 = fma(r84, r85, r84 * r81);
+    r81 = r11 * r18;
+    r85 = fma(r1, r81, r85);
+    r86 = r16 * r13;
+    r85 = fma(r84, r86, r85);
+    r86 = r29 * r85;
+    r81 = fma(r10, r86, r10 * r83);
+    r87 = r10 * r19;
+    r88 = fma(r84, r26, r1 * r22);
+    r88 = fma(r1, r23, r88);
+    r88 = fma(r1, r25, r88);
+    r89 = r10 * r27;
+    r90 = r16 * r14;
+    r91 = r11 * r17;
+    r91 = fma(r1, r91, r84 * r90);
+    r90 = r12 * r18;
+    r91 = fma(r1, r90, r91);
+    r92 = r15 * r13;
+    r91 = fma(r1, r92, r91);
+    r89 = r89 * r91;
+    r87 = fma(r88, r87, r89);
+    r81 = r81 + r87;
+    r92 = r10 * r24;
+    r92 = r92 * r91;
+    r90 = r10 * r19;
+    r90 = r90 * r85;
+    r93 = r92 + r90;
+    r94 = r27 * r35;
+    r93 = fma(r82, r94, r93);
+    r95 = r35 * r29;
+    r93 = fma(r88, r95, r93);
+    r93 = fma(r9, r93, r42 * r81);
+    r81 = r24 * r85;
+    r95 = -4.00000000000000000e+00;
+    r81 = r81 * r95;
+    r94 = r27 * r88;
+    r96 = r95 * r94;
+    r97 = r81 + r96;
+    r93 = fma(r8, r97, r93);
+    r80 = r80 * r93;
+    r97 = r6 * r6;
+    r98 = r10 * r24;
+    r98 = r98 * r88;
+    r99 = r10 * r27;
+    r99 = fma(r85, r99, r98);
+    r85 = r10 * r19;
+    r85 = r85 * r82;
+    r100 = r10 * r29;
+    r100 = r100 * r91;
+    r101 = r85 + r100;
+    r102 = r99 + r101;
+    r86 = fma(r35, r86, r35 * r83);
+    r86 = r86 + r87;
+    r86 = fma(r8, r86, r9 * r102);
+    r102 = r19 * r91;
+    r102 = r102 * r95;
+    r81 = r81 + r102;
+    r86 = fma(r42, r81, r86);
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r31 = r35 * r57;
+    r97 = r97 * r86;
+    r97 = fma(r31, r97, r39 * r80);
+    r80 = r7 * r7;
+    r80 = r80 * r31;
+    r81 = r10 * r7;
+    r103 = r19 * r35;
+    r104 = r35 * r29;
+    r104 = r104 * r91;
+    r103 = fma(r82, r103, r104);
+    r103 = r103 + r99;
+    r96 = r102 + r96;
+    r96 = fma(r9, r96, r42 * r103);
+    r103 = r10 * r29;
+    r103 = fma(r88, r103, r90);
+    r90 = r10 * r27;
+    r90 = fma(r82, r90, r92);
+    r103 = r103 + r90;
+    r96 = fma(r8, r103, r96);
+    r81 = r81 * r96;
+    r97 = fma(r39, r81, r97);
+    r97 = fma(r86, r80, r97);
+    r67 = r67 * r56;
+    r67 = r67 * r75;
+    r67 = r67 * r1;
+    r67 = r67 * r66;
+    r67 = r67 * r97;
+    r81 = r56 * r56;
+    r103 = r43 * r81;
+    r103 = r103 * r80;
+    r92 = r7 * r66;
+    r102 = r97 * r92;
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r36 = r30 * r53;
+    r99 = r7 * r43;
+    r102 = r102 * r36;
+    r102 = fma(r99, r102, r86 * r103);
+    r105 = r21 * r7;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r47 = r49 * r59;
+    r47 = r47 * r92;
+    r105 = r105 * r97;
+    r102 = fma(r47, r105, r102);
+    r106 = r68 * r99;
+    r102 = fma(r96, r106, r102);
+    r105 = r97 * r66;
+    r105 = r105 * r36;
+    r107 = r21 * r6;
+    r107 = r107 * r6;
+    r107 = r107 * r97;
+    r107 = r107 * r66;
+    r107 = r107 * r49;
+    r107 = fma(r59, r107, r63 * r105);
+    r105 = r93 * r62;
+    r107 = fma(r68, r105, r107);
+    r108 = r86 * r31;
+    r81 = r63 * r81;
+    r107 = fma(r81, r108, r107);
+    r108 = r102 + r107;
+    r105 = fma(r64, r108, r67);
+    r109 = r60 * r97;
+    r109 = r109 * r66;
+    r109 = r109 * r36;
+    r110 = r6 * r6;
+    r111 = -3.00000000000000000e+00;
+    r110 = r110 * r111;
+    r110 = r110 * r97;
+    r110 = r110 * r66;
+    r110 = r110 * r49;
+    r110 = fma(r59, r110, r63 * r109);
+    r109 = 6.00000000000000000e+00;
+    r112 = r93 * r109;
+    r112 = r112 * r59;
+    r110 = fma(r62, r112, r110);
+    r113 = -6.00000000000000000e+00;
+    r114 = r113 * r57;
+    r114 = r114 * r81;
+    r110 = fma(r86, r114, r110);
+    r110 = r110 + r102;
+    r102 = r4 * r93;
+    r105 = fma(r106, r102, r105);
+    r112 = r21 * r6;
+    r112 = r112 * r72;
+    r112 = r112 * r86;
+    r112 = r112 * r76;
+    r105 = fma(r53, r112, r105);
+    r115 = r6 * r84;
+    r115 = r115 * r66;
+    r115 = r115 * r30;
+    r115 = r115 * r77;
+    r116 = r72 * r115;
+    r117 = r4 * r35;
+    r117 = r117 * r6;
+    r117 = r117 * r97;
+    r105 = fma(r47, r117, r105);
+    r118 = r4 * r96;
+    r118 = r118 * r62;
+    r105 = fma(r68, r118, r105);
+    r119 = r4 * r7;
+    r119 = r119 * r56;
+    r119 = r119 * r56;
+    r119 = r119 * r95;
+    r119 = r119 * r57;
+    r119 = r119 * r62;
+    r120 = r4 * r97;
+    r121 = r10 * r62;
+    r121 = r121 * r92;
+    r121 = r121 * r36;
+    r105 = fma(r121, r120, r105);
+    r122 = r70 * r10;
+    r122 = r122 * r48;
+    r122 = fma(r69, r108, r108 * r122);
+    r73 = r73 * r60;
+    r73 = r73 * r71;
+    r71 = 4.00000000000000000e+00;
+    r74 = r71 * r74;
+    r122 = fma(r108, r73, r122);
+    r122 = fma(r108, r74, r122);
+    r71 = r6 * r122;
+    r105 = fma(r78, r71, r105);
+    r123 = r21 * r6;
+    r123 = r123 * r86;
+    r123 = r123 * r76;
+    r105 = fma(r53, r123, r105);
+    r105 = fma(r5, r110, r105);
+    r105 = fma(r72, r67, r105);
+    r105 = fma(r97, r116, r105);
+    r105 = fma(r93, r79, r105);
+    r105 = fma(r86, r119, r105);
+    r105 = fma(r97, r115, r105);
+    r105 = fma(r93, r78, r105);
+    r123 = r2 * r105;
+    r71 = r7 * r43;
+    r71 = r71 * r56;
+    r71 = r71 * r75;
+    r71 = r71 * r1;
+    r71 = r71 * r66;
+    r71 = r71 * r97;
+    r108 = fma(r65, r108, r71);
+    r120 = r7 * r7;
+    r120 = r120 * r56;
+    r120 = r120 * r56;
+    r120 = r120 * r86;
+    r120 = r120 * r113;
+    r120 = r120 * r43;
+    r118 = r60 * r97;
+    r118 = r118 * r92;
+    r118 = r118 * r36;
+    r118 = fma(r99, r118, r57 * r120);
+    r120 = r7 * r111;
+    r120 = r120 * r97;
+    r118 = fma(r47, r120, r118);
+    r117 = r7 * r96;
+    r117 = r117 * r109;
+    r117 = r117 * r43;
+    r118 = fma(r59, r117, r118);
+    r118 = r118 + r107;
+    r107 = r5 * r93;
+    r108 = fma(r106, r107, r108);
+    r117 = r21 * r7;
+    r117 = r117 * r86;
+    r117 = r117 * r76;
+    r108 = fma(r53, r117, r108);
+    r120 = r5 * r35;
+    r120 = r120 * r6;
+    r120 = r120 * r47;
+    r112 = r84 * r97;
+    r112 = r112 * r30;
+    r112 = r112 * r92;
+    r108 = fma(r77, r112, r108);
+    r67 = r5 * r96;
+    r67 = r67 * r62;
+    r108 = fma(r68, r67, r108);
+    r102 = r5 * r7;
+    r102 = r102 * r56;
+    r102 = r102 * r56;
+    r102 = r102 * r95;
+    r102 = r102 * r86;
+    r102 = r102 * r57;
+    r108 = fma(r62, r102, r108);
+    r110 = r7 * r122;
+    r108 = fma(r78, r110, r108);
+    r124 = r5 * r97;
+    r108 = fma(r121, r124, r108);
+    r125 = r84 * r72;
+    r125 = r125 * r97;
+    r125 = r125 * r30;
+    r125 = r125 * r92;
+    r108 = fma(r77, r125, r108);
+    r126 = r21 * r7;
+    r126 = r126 * r72;
+    r126 = r126 * r86;
+    r126 = r126 * r76;
+    r108 = fma(r53, r126, r108);
+    r108 = fma(r4, r118, r108);
+    r108 = fma(r72, r71, r108);
+    r108 = fma(r97, r120, r108);
+    r108 = fma(r96, r79, r108);
+    r108 = fma(r96, r78, r108);
+    r126 = r3 * r108;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r126);
+    r126 = r35 * r24;
+    r126 = fma(r88, r126, r104);
+    r123 = r10 * r27;
+    r125 = r15 * r14;
+    r124 = r12 * r17;
+    r124 = fma(r1, r124, r1 * r125);
+    r125 = r11 * r18;
+    r124 = fma(r84, r125, r124);
+    r110 = r16 * r13;
+    r124 = fma(r1, r110, r124);
+    r123 = r123 * r124;
+    r110 = r10 * r19;
+    r125 = r11 * r14;
+    r102 = r16 * r17;
+    r102 = fma(r84, r102, r84 * r125);
+    r125 = r15 * r18;
+    r102 = fma(r84, r125, r102);
+    r67 = r12 * r13;
+    r102 = fma(r1, r67, r102);
+    r110 = fma(r102, r110, r123);
+    r126 = r126 + r110;
+    r67 = r10 * r24;
+    r67 = r67 * r102;
+    r125 = r10 * r29;
+    r125 = fma(r124, r125, r67);
+    r125 = r125 + r87;
+    r125 = fma(r9, r125, r8 * r126);
+    r126 = r24 * r91;
+    r126 = r126 * r95;
+    r87 = r19 * r124;
+    r112 = r95 * r87;
+    r71 = r126 + r112;
+    r125 = fma(r42, r71, r125);
+    r100 = r98 + r100;
+    r100 = r100 + r110;
+    r110 = r27 * r95;
+    r110 = r110 * r102;
+    r126 = r126 + r110;
+    r126 = fma(r8, r126, r42 * r100);
+    r100 = r35 * r29;
+    r100 = fma(r35, r94, r102 * r100);
+    r98 = r10 * r19;
+    r98 = r98 * r91;
+    r71 = r10 * r24;
+    r71 = fma(r124, r71, r98);
+    r100 = r100 + r71;
+    r126 = fma(r9, r100, r126);
+    r100 = r109 * r126;
+    r100 = r100 * r59;
+    r100 = fma(r62, r100, r125 * r114);
+    r117 = r6 * r6;
+    r107 = r10 * r6;
+    r107 = r107 * r126;
+    r118 = r10 * r7;
+    r67 = r89 + r67;
+    r89 = r19 * r35;
+    r67 = fma(r88, r89, r67);
+    r88 = r35 * r29;
+    r67 = fma(r124, r88, r67);
+    r88 = r10 * r29;
+    r94 = fma(r10, r94, r102 * r88);
+    r94 = r94 + r71;
+    r94 = fma(r8, r94, r42 * r67);
+    r112 = r110 + r112;
+    r94 = fma(r9, r112, r94);
+    r118 = r118 * r94;
+    r118 = fma(r39, r118, r39 * r107);
+    r107 = r6 * r6;
+    r107 = r107 * r125;
+    r118 = fma(r31, r107, r118);
+    r118 = fma(r125, r80, r118);
+    r107 = r111 * r118;
+    r117 = r117 * r66;
+    r117 = r117 * r49;
+    r117 = r117 * r59;
+    r100 = fma(r107, r117, r100);
+    r112 = r60 * r118;
+    r112 = r112 * r66;
+    r112 = r112 * r36;
+    r100 = fma(r63, r112, r100);
+    r110 = r21 * r7;
+    r110 = r110 * r118;
+    r110 = fma(r47, r110, r94 * r106);
+    r67 = r118 * r92;
+    r67 = r67 * r36;
+    r110 = fma(r99, r67, r110);
+    r110 = fma(r125, r103, r110);
+    r100 = r100 + r110;
+    r112 = r125 * r31;
+    r117 = r126 * r62;
+    r117 = fma(r68, r117, r81 * r112);
+    r112 = r21 * r6;
+    r112 = r112 * r6;
+    r112 = r112 * r118;
+    r112 = r112 * r66;
+    r112 = r112 * r49;
+    r117 = fma(r59, r112, r117);
+    r67 = r118 * r66;
+    r67 = r67 * r36;
+    r117 = fma(r63, r67, r117);
+    r110 = r110 + r117;
+    r100 = fma(r64, r110, r5 * r100);
+    r67 = r21 * r6;
+    r67 = r67 * r125;
+    r67 = r67 * r76;
+    r100 = fma(r53, r67, r100);
+    r112 = r56 * r72;
+    r112 = r112 * r1;
+    r112 = r112 * r118;
+    r112 = r112 * r75;
+    r112 = r112 * r66;
+    r100 = fma(r62, r112, r100);
+    r88 = r70 * r10;
+    r88 = r88 * r48;
+    r88 = fma(r110, r88, r69 * r110);
+    r88 = fma(r110, r74, r88);
+    r88 = fma(r110, r73, r88);
+    r102 = r6 * r88;
+    r100 = fma(r78, r102, r100);
+    r89 = r21 * r6;
+    r89 = r89 * r72;
+    r89 = r89 * r125;
+    r89 = r89 * r76;
+    r100 = fma(r53, r89, r100);
+    r127 = r4 * r118;
+    r100 = fma(r121, r127, r100);
+    r128 = r4 * r35;
+    r128 = r128 * r6;
+    r128 = r128 * r118;
+    r100 = fma(r47, r128, r100);
+    r129 = r4 * r94;
+    r129 = r129 * r62;
+    r100 = fma(r68, r129, r100);
+    r130 = r4 * r126;
+    r100 = fma(r106, r130, r100);
+    r131 = r56 * r1;
+    r131 = r131 * r118;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r100 = fma(r62, r131, r100);
+    r100 = fma(r118, r116, r100);
+    r100 = fma(r118, r115, r100);
+    r100 = fma(r125, r119, r100);
+    r100 = fma(r126, r78, r100);
+    r100 = fma(r126, r79, r100);
+    r131 = r2 * r100;
+    r130 = r7 * r109;
+    r130 = r130 * r94;
+    r130 = r130 * r43;
+    r129 = r7 * r47;
+    r129 = fma(r107, r129, r59 * r130);
+    r130 = r7 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r113;
+    r130 = r130 * r125;
+    r130 = r130 * r43;
+    r129 = fma(r57, r130, r129);
+    r107 = r60 * r118;
+    r107 = r107 * r92;
+    r107 = r107 * r36;
+    r129 = fma(r99, r107, r129);
+    r129 = r129 + r117;
+    r110 = fma(r65, r110, r4 * r129);
+    r129 = r56 * r1;
+    r129 = r129 * r118;
+    r129 = r129 * r43;
+    r129 = r129 * r75;
+    r110 = fma(r92, r129, r110);
+    r117 = r7 * r88;
+    r110 = fma(r78, r117, r110);
+    r107 = r84 * r118;
+    r107 = r107 * r30;
+    r107 = r107 * r92;
+    r110 = fma(r77, r107, r110);
+    r130 = r5 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r95;
+    r130 = r130 * r125;
+    r130 = r130 * r57;
+    r110 = fma(r62, r130, r110);
+    r128 = r5 * r118;
+    r110 = fma(r121, r128, r110);
+    r127 = r21 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r125;
+    r127 = r127 * r76;
+    r110 = fma(r53, r127, r110);
+    r89 = r56 * r72;
+    r89 = r89 * r1;
+    r89 = r89 * r118;
+    r89 = r89 * r43;
+    r89 = r89 * r75;
+    r110 = fma(r92, r89, r110);
+    r102 = r21 * r7;
+    r102 = r102 * r125;
+    r102 = r102 * r76;
+    r110 = fma(r53, r102, r110);
+    r112 = r5 * r94;
+    r112 = r112 * r62;
+    r110 = fma(r68, r112, r110);
+    r67 = r84 * r72;
+    r67 = r67 * r118;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r110 = fma(r77, r67, r110);
+    r132 = r5 * r126;
+    r110 = fma(r106, r132, r110);
+    r110 = fma(r94, r79, r110);
+    r110 = fma(r118, r120, r110);
+    r110 = fma(r94, r78, r110);
+    r132 = r3 * r110;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r132);
+    r132 = r19 * r95;
+    r26 = fma(r1, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r132 = r132 * r26;
+    r83 = r95 * r83;
+    r25 = r132 + r83;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r98 = r98 + r23;
+    r22 = r35 * r24;
+    r98 = fma(r124, r22, r98);
+    r131 = r35 * r29;
+    r98 = fma(r82, r131, r98);
+    r98 = fma(r8, r98, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r87, r26 * r25);
+    r25 = r25 + r90;
+    r98 = fma(r9, r25, r98);
+    r25 = r10 * r7;
+    r131 = r10 * r24;
+    r131 = r131 * r26;
+    r123 = r123 + r131;
+    r123 = r123 + r101;
+    r101 = r35 * r29;
+    r87 = fma(r35, r87, r26 * r101);
+    r87 = r87 + r90;
+    r87 = fma(r42, r87, r8 * r123);
+    r91 = r27 * r91;
+    r91 = r91 * r95;
+    r132 = r132 + r91;
+    r87 = fma(r9, r132, r87);
+    r25 = r25 * r87;
+    r132 = r6 * r6;
+    r132 = r132 * r98;
+    r132 = fma(r31, r132, r39 * r25);
+    r25 = r10 * r6;
+    r104 = r85 + r104;
+    r85 = r27 * r35;
+    r104 = fma(r124, r85, r104);
+    r104 = r104 + r131;
+    r83 = r91 + r83;
+    r83 = fma(r8, r83, r9 * r104);
+    r8 = r10 * r29;
+    r8 = fma(r82, r8, r23);
+    r8 = r8 + r71;
+    r83 = fma(r42, r8, r83);
+    r25 = r25 * r83;
+    r132 = fma(r39, r25, r132);
+    r132 = fma(r98, r80, r132);
+    r25 = r132 * r92;
+    r25 = r25 * r36;
+    r25 = fma(r99, r25, r98 * r103);
+    r8 = r21 * r7;
+    r8 = r8 * r132;
+    r25 = fma(r47, r8, r25);
+    r25 = fma(r87, r106, r25);
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r42 = r83 * r62;
+    r42 = fma(r68, r42, r59 * r8);
+    r8 = r98 * r31;
+    r42 = fma(r81, r8, r42);
+    r71 = r132 * r66;
+    r71 = r71 * r36;
+    r42 = fma(r63, r71, r42);
+    r71 = r25 + r42;
+    r8 = r6 * r6;
+    r8 = r8 * r111;
+    r8 = r8 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r23 = r109 * r83;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r8);
+    r8 = r60 * r132;
+    r8 = r8 * r66;
+    r8 = r8 * r36;
+    r23 = fma(r63, r8, r23);
+    r23 = fma(r98, r114, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r64 * r71);
+    r25 = r70 * r10;
+    r25 = r25 * r48;
+    r25 = fma(r71, r25, r69 * r71);
+    r25 = fma(r71, r73, r25);
+    r25 = fma(r71, r74, r25);
+    r8 = r6 * r25;
+    r23 = fma(r78, r8, r23);
+    r82 = r4 * r83;
+    r23 = fma(r106, r82, r23);
+    r104 = r4 * r132;
+    r23 = fma(r121, r104, r23);
+    r9 = r21 * r6;
+    r9 = r9 * r72;
+    r9 = r9 * r98;
+    r9 = r9 * r76;
+    r23 = fma(r53, r9, r23);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r132;
+    r23 = fma(r47, r91, r23);
+    r85 = r21 * r6;
+    r85 = r85 * r98;
+    r85 = r85 * r76;
+    r23 = fma(r53, r85, r23);
+    r131 = r56 * r1;
+    r131 = r131 * r132;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r23 = fma(r62, r131, r23);
+    r124 = r4 * r87;
+    r124 = r124 * r62;
+    r23 = fma(r68, r124, r23);
+    r123 = r56 * r72;
+    r123 = r123 * r1;
+    r123 = r123 * r132;
+    r123 = r123 * r75;
+    r123 = r123 * r66;
+    r23 = fma(r62, r123, r23);
+    r23 = fma(r132, r115, r23);
+    r23 = fma(r132, r116, r23);
+    r23 = fma(r83, r79, r23);
+    r23 = fma(r83, r78, r23);
+    r23 = fma(r98, r119, r23);
+    r123 = r2 * r23;
+    r124 = r7 * r7;
+    r124 = r124 * r56;
+    r124 = r124 * r56;
+    r124 = r124 * r113;
+    r124 = r124 * r98;
+    r124 = r124 * r43;
+    r131 = r60 * r132;
+    r131 = r131 * r92;
+    r131 = r131 * r36;
+    r131 = fma(r99, r131, r57 * r124);
+    r124 = r7 * r109;
+    r124 = r124 * r87;
+    r124 = r124 * r43;
+    r131 = fma(r59, r124, r131);
+    r85 = r7 * r111;
+    r85 = r85 * r132;
+    r131 = fma(r47, r85, r131);
+    r131 = r131 + r42;
+    r131 = fma(r4, r131, r65 * r71);
+    r71 = r21 * r7;
+    r71 = r71 * r72;
+    r71 = r71 * r98;
+    r71 = r71 * r76;
+    r131 = fma(r53, r71, r131);
+    r42 = r21 * r7;
+    r42 = r42 * r98;
+    r42 = r42 * r76;
+    r131 = fma(r53, r42, r131);
+    r85 = r5 * r83;
+    r131 = fma(r106, r85, r131);
+    r124 = r56 * r72;
+    r124 = r124 * r1;
+    r124 = r124 * r132;
+    r124 = r124 * r43;
+    r124 = r124 * r75;
+    r131 = fma(r92, r124, r131);
+    r91 = r5 * r132;
+    r131 = fma(r121, r91, r131);
+    r9 = r84 * r132;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r131 = fma(r77, r9, r131);
+    r104 = r7 * r25;
+    r131 = fma(r78, r104, r131);
+    r82 = r56 * r1;
+    r82 = r82 * r132;
+    r82 = r82 * r43;
+    r82 = r82 * r75;
+    r131 = fma(r92, r82, r131);
+    r8 = r84 * r72;
+    r8 = r8 * r132;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r131 = fma(r77, r8, r131);
+    r90 = r5 * r7;
+    r90 = r90 * r56;
+    r90 = r90 * r56;
+    r90 = r90 * r95;
+    r90 = r90 * r98;
+    r90 = r90 * r57;
+    r131 = fma(r62, r90, r131);
+    r101 = r5 * r87;
+    r101 = r101 * r62;
+    r131 = fma(r68, r101, r131);
+    r131 = fma(r87, r79, r131);
+    r131 = fma(r87, r78, r131);
+    r131 = fma(r132, r120, r131);
+    r101 = r3 * r131;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r123,
+                                             r101);
+    r101 = r37 * r109;
+    r101 = r101 * r59;
+    r123 = r6 * r6;
+    r90 = r10 * r33;
+    r90 = r90 * r7;
+    r90 = fma(r20, r80, r39 * r90);
+    r8 = r20 * r6;
+    r8 = r8 * r6;
+    r90 = fma(r31, r8, r90);
+    r82 = r10 * r37;
+    r82 = r82 * r6;
+    r90 = fma(r39, r82, r90);
+    r123 = r123 * r111;
+    r123 = r123 * r90;
+    r123 = r123 * r66;
+    r123 = r123 * r49;
+    r123 = fma(r59, r123, r62 * r101);
+    r101 = r60 * r90;
+    r101 = r101 * r66;
+    r101 = r101 * r36;
+    r123 = fma(r63, r101, r123);
+    r82 = r21 * r7;
+    r82 = r82 * r90;
+    r82 = fma(r47, r82, r33 * r106);
+    r8 = r90 * r92;
+    r8 = r8 * r36;
+    r82 = fma(r99, r8, r82);
+    r82 = fma(r20, r103, r82);
+    r123 = fma(r20, r114, r123);
+    r123 = r123 + r82;
+    r101 = r37 * r62;
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r90;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r8 = fma(r59, r8, r68 * r101);
+    r101 = r90 * r66;
+    r101 = r101 * r36;
+    r8 = fma(r63, r101, r8);
+    r104 = r20 * r31;
+    r8 = fma(r81, r104, r8);
+    r82 = r82 + r8;
+    r123 = fma(r64, r82, r5 * r123);
+    r104 = r4 * r90;
+    r123 = fma(r121, r104, r123);
+    r101 = r56 * r72;
+    r101 = r101 * r1;
+    r101 = r101 * r90;
+    r101 = r101 * r75;
+    r101 = r101 * r66;
+    r123 = fma(r62, r101, r123);
+    r9 = r56 * r1;
+    r9 = r9 * r90;
+    r9 = r9 * r75;
+    r9 = r9 * r66;
+    r123 = fma(r62, r9, r123);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r90;
+    r123 = fma(r47, r91, r123);
+    r124 = r70 * r10;
+    r124 = r124 * r48;
+    r124 = fma(r69, r82, r82 * r124);
+    r124 = fma(r82, r74, r124);
+    r124 = fma(r82, r73, r124);
+    r85 = r6 * r124;
+    r123 = fma(r78, r85, r123);
+    r42 = r21 * r20;
+    r42 = r42 * r6;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r123 = fma(r53, r42, r123);
+    r71 = r21 * r20;
+    r71 = r71 * r6;
+    r71 = r71 * r76;
+    r123 = fma(r53, r71, r123);
+    r26 = r4 * r33;
+    r26 = r26 * r62;
+    r123 = fma(r68, r26, r123);
+    r22 = r4 * r37;
+    r123 = fma(r106, r22, r123);
+    r123 = fma(r37, r79, r123);
+    r123 = fma(r90, r116, r123);
+    r123 = fma(r90, r115, r123);
+    r123 = fma(r20, r119, r123);
+    r123 = fma(r37, r78, r123);
+    r22 = r2 * r123;
+    r26 = r33 * r7;
+    r26 = r26 * r109;
+    r26 = r26 * r43;
+    r71 = r7 * r111;
+    r71 = r71 * r90;
+    r71 = fma(r47, r71, r59 * r26);
+    r26 = r20 * r7;
+    r26 = r26 * r7;
+    r26 = r26 * r56;
+    r26 = r26 * r56;
+    r26 = r26 * r113;
+    r26 = r26 * r43;
+    r71 = fma(r57, r26, r71);
+    r42 = r60 * r90;
+    r42 = r42 * r92;
+    r42 = r42 * r36;
+    r71 = fma(r99, r42, r71);
+    r71 = r71 + r8;
+    r82 = fma(r65, r82, r4 * r71);
+    r71 = r84 * r90;
+    r71 = r71 * r30;
+    r71 = r71 * r92;
+    r82 = fma(r77, r71, r82);
+    r8 = r56 * r72;
+    r8 = r8 * r1;
+    r8 = r8 * r90;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r82 = fma(r92, r8, r82);
+    r42 = r21 * r20;
+    r42 = r42 * r7;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r82 = fma(r53, r42, r82);
+    r26 = r5 * r90;
+    r82 = fma(r121, r26, r82);
+    r85 = r21 * r20;
+    r85 = r85 * r7;
+    r85 = r85 * r76;
+    r82 = fma(r53, r85, r82);
+    r91 = r5 * r20;
+    r91 = r91 * r7;
+    r91 = r91 * r56;
+    r91 = r91 * r56;
+    r91 = r91 * r95;
+    r91 = r91 * r57;
+    r82 = fma(r62, r91, r82);
+    r9 = r7 * r124;
+    r82 = fma(r78, r9, r82);
+    r101 = r84 * r72;
+    r101 = r101 * r90;
+    r101 = r101 * r30;
+    r101 = r101 * r92;
+    r82 = fma(r77, r101, r82);
+    r104 = r5 * r33;
+    r104 = r104 * r62;
+    r82 = fma(r68, r104, r82);
+    r67 = r56 * r1;
+    r67 = r67 * r90;
+    r67 = r67 * r43;
+    r67 = r67 * r75;
+    r82 = fma(r92, r67, r82);
+    r112 = r5 * r37;
+    r82 = fma(r106, r112, r82);
+    r82 = fma(r33, r78, r82);
+    r82 = fma(r90, r120, r82);
+    r82 = fma(r33, r79, r82);
+    r112 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r112);
+    r112 = r10 * r38;
+    r112 = r112 * r7;
+    r112 = fma(r39, r112, r34 * r80);
+    r22 = r34 * r6;
+    r22 = r22 * r6;
+    r112 = fma(r31, r22, r112);
+    r67 = r10 * r55;
+    r67 = r67 * r6;
+    r112 = fma(r39, r67, r112);
+    r67 = r60 * r112;
+    r67 = r67 * r66;
+    r67 = r67 * r36;
+    r67 = fma(r34, r114, r63 * r67);
+    r22 = r6 * r6;
+    r22 = r22 * r111;
+    r22 = r22 * r112;
+    r22 = r22 * r66;
+    r22 = r22 * r49;
+    r67 = fma(r59, r22, r67);
+    r104 = r55 * r109;
+    r104 = r104 * r59;
+    r67 = fma(r62, r104, r67);
+    r101 = fma(r38, r106, r34 * r103);
+    r9 = r112 * r92;
+    r9 = r9 * r36;
+    r101 = fma(r99, r9, r101);
+    r91 = r21 * r7;
+    r91 = r91 * r112;
+    r101 = fma(r47, r91, r101);
+    r67 = r67 + r101;
+    r104 = r112 * r66;
+    r104 = r104 * r36;
+    r22 = r34 * r31;
+    r22 = fma(r81, r22, r63 * r104);
+    r104 = r21 * r6;
+    r104 = r104 * r6;
+    r104 = r104 * r112;
+    r104 = r104 * r66;
+    r104 = r104 * r49;
+    r22 = fma(r59, r104, r22);
+    r91 = r55 * r62;
+    r22 = fma(r68, r91, r22);
+    r101 = r101 + r22;
+    r67 = fma(r64, r101, r5 * r67);
+    r91 = r4 * r38;
+    r91 = r91 * r62;
+    r67 = fma(r68, r91, r67);
+    r104 = r112 * r121;
+    r9 = r21 * r34;
+    r9 = r9 * r6;
+    r9 = r9 * r76;
+    r67 = fma(r53, r9, r67);
+    r85 = r4 * r35;
+    r85 = r85 * r6;
+    r85 = r85 * r112;
+    r67 = fma(r47, r85, r67);
+    r26 = r56 * r1;
+    r26 = r26 * r112;
+    r26 = r26 * r75;
+    r26 = r26 * r66;
+    r67 = fma(r62, r26, r67);
+    r42 = r70 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r69, r101, r101 * r42);
+    r42 = fma(r101, r73, r42);
+    r42 = fma(r101, r74, r42);
+    r8 = r6 * r42;
+    r67 = fma(r78, r8, r67);
+    r71 = r56 * r72;
+    r71 = r71 * r1;
+    r71 = r71 * r112;
+    r71 = r71 * r75;
+    r71 = r71 * r66;
+    r67 = fma(r62, r71, r67);
+    r102 = r21 * r34;
+    r102 = r102 * r6;
+    r102 = r102 * r72;
+    r102 = r102 * r76;
+    r67 = fma(r53, r102, r67);
+    r89 = r4 * r55;
+    r67 = fma(r106, r89, r67);
+    r67 = fma(r4, r104, r67);
+    r67 = fma(r112, r116, r67);
+    r67 = fma(r55, r78, r67);
+    r67 = fma(r34, r119, r67);
+    r67 = fma(r112, r115, r67);
+    r67 = fma(r55, r79, r67);
+    r89 = r2 * r67;
+    r102 = r34 * r7;
+    r102 = r102 * r7;
+    r102 = r102 * r56;
+    r102 = r102 * r56;
+    r102 = r102 * r113;
+    r102 = r102 * r43;
+    r71 = r38 * r7;
+    r71 = r71 * r109;
+    r71 = r71 * r43;
+    r71 = fma(r59, r71, r57 * r102);
+    r102 = r60 * r112;
+    r102 = r102 * r92;
+    r102 = r102 * r36;
+    r71 = fma(r99, r102, r71);
+    r8 = r7 * r111;
+    r8 = r8 * r112;
+    r71 = fma(r47, r8, r71);
+    r71 = r71 + r22;
+    r71 = fma(r4, r71, r65 * r101);
+    r101 = r21 * r34;
+    r101 = r101 * r7;
+    r101 = r101 * r76;
+    r71 = fma(r53, r101, r71);
+    r22 = r5 * r38;
+    r22 = r22 * r62;
+    r71 = fma(r68, r22, r71);
+    r8 = r84 * r112;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r71 = fma(r77, r8, r71);
+    r102 = r7 * r42;
+    r71 = fma(r78, r102, r71);
+    r26 = r56 * r72;
+    r26 = r26 * r1;
+    r26 = r26 * r112;
+    r26 = r26 * r43;
+    r26 = r26 * r75;
+    r71 = fma(r92, r26, r71);
+    r85 = r5 * r34;
+    r85 = r85 * r7;
+    r85 = r85 * r56;
+    r85 = r85 * r56;
+    r85 = r85 * r95;
+    r85 = r85 * r57;
+    r71 = fma(r62, r85, r71);
+    r9 = r56 * r1;
+    r9 = r9 * r112;
+    r9 = r9 * r43;
+    r9 = r9 * r75;
+    r71 = fma(r92, r9, r71);
+    r91 = r84 * r72;
+    r91 = r91 * r112;
+    r91 = r91 * r30;
+    r91 = r91 * r92;
+    r71 = fma(r77, r91, r71);
+    r127 = r21 * r34;
+    r127 = r127 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r76;
+    r71 = fma(r53, r127, r71);
+    r128 = r5 * r55;
+    r71 = fma(r106, r128, r71);
+    r71 = fma(r38, r79, r71);
+    r71 = fma(r5, r104, r71);
+    r71 = fma(r112, r120, r71);
+    r71 = fma(r38, r78, r71);
+    r128 = r3 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r89, r128);
+    r128 = r6 * r6;
+    r89 = r10 * r41;
+    r89 = r89 * r7;
+    r89 = fma(r32, r80, r39 * r89);
+    r127 = r10 * r54;
+    r127 = r127 * r6;
+    r89 = fma(r39, r127, r89);
+    r91 = r32 * r6;
+    r91 = r91 * r6;
+    r89 = fma(r31, r91, r89);
+    r128 = r128 * r111;
+    r128 = r128 * r89;
+    r128 = r128 * r66;
+    r128 = r128 * r49;
+    r91 = r60 * r89;
+    r91 = r91 * r66;
+    r91 = r91 * r36;
+    r91 = fma(r63, r91, r59 * r128);
+    r128 = r54 * r109;
+    r128 = r128 * r59;
+    r91 = fma(r62, r128, r91);
+    r127 = fma(r41, r106, r32 * r103);
+    r9 = r89 * r92;
+    r9 = r9 * r36;
+    r127 = fma(r99, r9, r127);
+    r85 = r21 * r7;
+    r85 = r85 * r89;
+    r127 = fma(r47, r85, r127);
+    r91 = fma(r32, r114, r91);
+    r91 = r91 + r127;
+    r128 = r21 * r6;
+    r128 = r128 * r6;
+    r128 = r128 * r89;
+    r128 = r128 * r66;
+    r128 = r128 * r49;
+    r85 = r89 * r66;
+    r85 = r85 * r36;
+    r85 = fma(r63, r85, r59 * r128);
+    r128 = r54 * r62;
+    r85 = fma(r68, r128, r85);
+    r9 = r32 * r31;
+    r85 = fma(r81, r9, r85);
+    r127 = r127 + r85;
+    r91 = fma(r64, r127, r5 * r91);
+    r9 = r4 * r54;
+    r91 = fma(r106, r9, r91);
+    r128 = r4 * r41;
+    r128 = r128 * r62;
+    r91 = fma(r68, r128, r91);
+    r26 = r70 * r10;
+    r26 = r26 * r48;
+    r26 = fma(r127, r26, r69 * r127);
+    r26 = fma(r127, r74, r26);
+    r26 = fma(r127, r73, r26);
+    r102 = r6 * r26;
+    r91 = fma(r78, r102, r91);
+    r8 = r4 * r89;
+    r91 = fma(r121, r8, r91);
+    r104 = r21 * r32;
+    r104 = r104 * r6;
+    r104 = r104 * r76;
+    r91 = fma(r53, r104, r91);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r89;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r91 = fma(r62, r22, r91);
+    r101 = r4 * r35;
+    r101 = r101 * r6;
+    r101 = r101 * r89;
+    r91 = fma(r47, r101, r91);
+    r130 = r21 * r32;
+    r130 = r130 * r6;
+    r130 = r130 * r72;
+    r130 = r130 * r76;
+    r91 = fma(r53, r130, r91);
+    r107 = r56 * r1;
+    r107 = r107 * r89;
+    r107 = r107 * r75;
+    r107 = r107 * r66;
+    r91 = fma(r62, r107, r91);
+    r91 = fma(r54, r79, r91);
+    r91 = fma(r32, r119, r91);
+    r91 = fma(r89, r116, r91);
+    r91 = fma(r89, r115, r91);
+    r91 = fma(r54, r78, r91);
+    r107 = r2 * r91;
+    r130 = r32 * r7;
+    r130 = r130 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r113;
+    r130 = r130 * r43;
+    r101 = r41 * r7;
+    r101 = r101 * r109;
+    r101 = r101 * r43;
+    r101 = fma(r59, r101, r57 * r130);
+    r130 = r60 * r89;
+    r130 = r130 * r92;
+    r130 = r130 * r36;
+    r101 = fma(r99, r130, r101);
+    r22 = r7 * r111;
+    r22 = r22 * r89;
+    r101 = fma(r47, r22, r101);
+    r101 = r101 + r85;
+    r101 = fma(r4, r101, r65 * r127);
+    r127 = r56 * r1;
+    r127 = r127 * r89;
+    r127 = r127 * r43;
+    r127 = r127 * r75;
+    r101 = fma(r92, r127, r101);
+    r85 = r21 * r32;
+    r85 = r85 * r7;
+    r85 = r85 * r76;
+    r101 = fma(r53, r85, r101);
+    r22 = r5 * r54;
+    r101 = fma(r106, r22, r101);
+    r130 = r21 * r32;
+    r130 = r130 * r7;
+    r130 = r130 * r72;
+    r130 = r130 * r76;
+    r101 = fma(r53, r130, r101);
+    r104 = r84 * r72;
+    r104 = r104 * r89;
+    r104 = r104 * r30;
+    r104 = r104 * r92;
+    r101 = fma(r77, r104, r101);
+    r8 = r5 * r32;
+    r8 = r8 * r7;
+    r8 = r8 * r56;
+    r8 = r8 * r56;
+    r8 = r8 * r95;
+    r8 = r8 * r57;
+    r101 = fma(r62, r8, r101);
+    r102 = r5 * r41;
+    r102 = r102 * r62;
+    r101 = fma(r68, r102, r101);
+    r128 = r56 * r72;
+    r128 = r128 * r1;
+    r128 = r128 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r75;
+    r101 = fma(r92, r128, r101);
+    r9 = r5 * r89;
+    r101 = fma(r121, r9, r101);
+    r117 = r84 * r89;
+    r117 = r117 * r30;
+    r117 = r117 * r92;
+    r101 = fma(r77, r117, r101);
+    r129 = r7 * r26;
+    r101 = fma(r78, r129, r101);
+    r101 = fma(r41, r78, r101);
+    r101 = fma(r41, r79, r101);
+    r101 = fma(r89, r120, r101);
+    r129 = r3 * r101;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r107,
+                                             r129);
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r107 = r2 * r21;
+    r107 = r107 * r61;
+    r129 = fma(r105, r107, r108 * r129);
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r100, r107, r110 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r129, r61);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r23, r107, r131 * r61);
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r129 = fma(r123, r107, r82 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r61, r129);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r3 * r21;
+    r129 = r129 * r0;
+    r129 = fma(r67, r107, r71 * r129);
+    r61 = r3 * r21;
+    r61 = r61 * r0;
+    r61 = fma(r91, r107, r101 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r129, r61);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r2 * r2;
+    r129 = r105 * r61;
+    r117 = r3 * r3;
+    r9 = r108 * r117;
+    r108 = fma(r108, r9, r105 * r129);
+    r105 = r100 * r100;
+    r128 = r110 * r110;
+    r128 = fma(r117, r128, r61 * r105);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r23 * r23;
+    r108 = r131 * r131;
+    r108 = fma(r117, r108, r61 * r128);
+    r128 = r82 * r82;
+    r105 = r123 * r123;
+    r105 = fma(r61, r105, r117 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r108, r105);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r105 = r67 * r67;
+    r108 = r71 * r71;
+    r108 = fma(r117, r108, r61 * r105);
+    r105 = r101 * r101;
+    r128 = r91 * r91;
+    r128 = fma(r61, r128, r117 * r105);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = fma(r100, r129, r110 * r9);
+    r108 = fma(r131, r9, r23 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r128, r108);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = fma(r82, r9, r123 * r129);
+    r128 = fma(r71, r9, r67 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r108, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = fma(r91, r129, r101 * r9);
+    r9 = r110 * r131;
+    r128 = r100 * r23;
+    r128 = fma(r61, r128, r117 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r100 * r123;
+    r129 = r110 * r82;
+    r129 = fma(r117, r129, r61 * r128);
+    r128 = r100 * r67;
+    r9 = r110 * r71;
+    r9 = fma(r117, r9, r61 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r129, r9);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r110 * r101;
+    r129 = r100 * r91;
+    r129 = fma(r61, r129, r117 * r9);
+    r9 = r131 * r82;
+    r128 = r23 * r123;
+    r128 = fma(r61, r128, r117 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r23 * r67;
+    r129 = r131 * r71;
+    r129 = fma(r117, r129, r61 * r128);
+    r128 = r131 * r101;
+    r9 = r23 * r91;
+    r9 = fma(r61, r9, r117 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r129, r9);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r123 * r67;
+    r129 = r82 * r71;
+    r129 = fma(r117, r129, r61 * r9);
+    r9 = r82 * r101;
+    r128 = r123 * r91;
+    r128 = fma(r61, r128, r117 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r129, r128);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r71 * r101;
+    r129 = r67 * r91;
+    r129 = fma(r61, r129, r117 * r128);
+    WriteSum1<double, double>((double*)inout_shared, r129);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r21 * r7;
+    r128 = r10 * r51;
+    r128 = r128 * r6;
+    r128 = fma(r58, r80, r39 * r128);
+    r9 = r58 * r6;
+    r9 = r9 * r6;
+    r128 = fma(r31, r9, r128);
+    r108 = r10 * r28;
+    r108 = r108 * r7;
+    r128 = fma(r39, r108, r128);
+    r129 = r129 * r128;
+    r129 = fma(r47, r129, r58 * r103);
+    r108 = r128 * r92;
+    r108 = r108 * r36;
+    r129 = fma(r99, r108, r129);
+    r129 = fma(r28, r106, r129);
+    r108 = r58 * r31;
+    r9 = r128 * r66;
+    r9 = r9 * r36;
+    r9 = fma(r63, r9, r81 * r108);
+    r108 = r51 * r62;
+    r9 = fma(r68, r108, r9);
+    r105 = r21 * r6;
+    r105 = r105 * r6;
+    r105 = r105 * r128;
+    r105 = r105 * r66;
+    r105 = r105 * r49;
+    r9 = fma(r59, r105, r9);
+    r105 = r129 + r9;
+    r108 = r60 * r128;
+    r108 = r108 * r66;
+    r108 = r108 * r36;
+    r108 = fma(r63, r108, r58 * r114);
+    r102 = r51 * r109;
+    r102 = r102 * r59;
+    r108 = fma(r62, r102, r108);
+    r8 = r6 * r6;
+    r8 = r8 * r111;
+    r8 = r8 * r128;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r108 = fma(r59, r8, r108);
+    r108 = r108 + r129;
+    r108 = fma(r5, r108, r64 * r105);
+    r129 = r21 * r58;
+    r129 = r129 * r6;
+    r129 = r129 * r72;
+    r129 = r129 * r76;
+    r108 = fma(r53, r129, r108);
+    r8 = r4 * r128;
+    r108 = fma(r121, r8, r108);
+    r102 = r4 * r35;
+    r102 = r102 * r6;
+    r102 = r102 * r128;
+    r108 = fma(r47, r102, r108);
+    r104 = r4 * r51;
+    r108 = fma(r106, r104, r108);
+    r130 = r21 * r58;
+    r130 = r130 * r6;
+    r130 = r130 * r76;
+    r108 = fma(r53, r130, r108);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r128;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r108 = fma(r62, r22, r108);
+    r85 = r70 * r10;
+    r85 = r85 * r48;
+    r85 = fma(r69, r105, r105 * r85);
+    r85 = fma(r105, r74, r85);
+    r85 = fma(r105, r73, r85);
+    r127 = r6 * r85;
+    r108 = fma(r78, r127, r108);
+    r133 = r4 * r28;
+    r133 = r133 * r62;
+    r108 = fma(r68, r133, r108);
+    r134 = r56 * r1;
+    r134 = r134 * r128;
+    r134 = r134 * r75;
+    r134 = r134 * r66;
+    r108 = fma(r62, r134, r108);
+    r108 = fma(r128, r116, r108);
+    r108 = fma(r128, r115, r108);
+    r108 = fma(r51, r78, r108);
+    r108 = fma(r58, r119, r108);
+    r108 = fma(r51, r79, r108);
+    r134 = r2 * r108;
+    r133 = r58 * r7;
+    r133 = r133 * r7;
+    r133 = r133 * r56;
+    r133 = r133 * r56;
+    r133 = r133 * r113;
+    r133 = r133 * r43;
+    r127 = r7 * r111;
+    r127 = r127 * r128;
+    r127 = fma(r47, r127, r57 * r133);
+    r133 = r60 * r128;
+    r133 = r133 * r92;
+    r133 = r133 * r36;
+    r127 = fma(r99, r133, r127);
+    r22 = r28 * r7;
+    r22 = r22 * r109;
+    r22 = r22 * r43;
+    r127 = fma(r59, r22, r127);
+    r127 = r127 + r9;
+    r127 = fma(r4, r127, r65 * r105);
+    r105 = r7 * r85;
+    r127 = fma(r78, r105, r127);
+    r9 = r84 * r128;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r127 = fma(r77, r9, r127);
+    r22 = r21 * r58;
+    r22 = r22 * r7;
+    r22 = r22 * r76;
+    r127 = fma(r53, r22, r127);
+    r133 = r5 * r128;
+    r127 = fma(r121, r133, r127);
+    r130 = r5 * r51;
+    r127 = fma(r106, r130, r127);
+    r104 = r56 * r1;
+    r104 = r104 * r128;
+    r104 = r104 * r43;
+    r104 = r104 * r75;
+    r127 = fma(r92, r104, r127);
+    r102 = r84 * r72;
+    r102 = r102 * r128;
+    r102 = r102 * r30;
+    r102 = r102 * r92;
+    r127 = fma(r77, r102, r127);
+    r8 = r56 * r72;
+    r8 = r8 * r1;
+    r8 = r8 * r128;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r127 = fma(r92, r8, r127);
+    r129 = r21 * r58;
+    r129 = r129 * r7;
+    r129 = r129 * r72;
+    r129 = r129 * r76;
+    r127 = fma(r53, r129, r127);
+    r135 = r5 * r58;
+    r135 = r135 * r7;
+    r135 = r135 * r56;
+    r135 = r135 * r56;
+    r135 = r135 * r95;
+    r135 = r135 * r57;
+    r127 = fma(r62, r135, r127);
+    r136 = r5 * r28;
+    r136 = r136 * r62;
+    r127 = fma(r68, r136, r127);
+    r127 = fma(r28, r79, r127);
+    r127 = fma(r128, r120, r127);
+    r127 = fma(r28, r78, r127);
+    r136 = r3 * r127;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r134,
+                                             r136);
+    r136 = r45 * r109;
+    r136 = r136 * r59;
+    r136 = fma(r40, r114, r62 * r136);
+    r134 = r6 * r6;
+    r135 = r40 * r6;
+    r135 = r135 * r6;
+    r129 = r10 * r45;
+    r129 = r129 * r6;
+    r129 = fma(r39, r129, r31 * r135);
+    r135 = r10 * r46;
+    r135 = r135 * r7;
+    r129 = fma(r39, r135, r129);
+    r129 = fma(r40, r80, r129);
+    r134 = r134 * r111;
+    r134 = r134 * r129;
+    r134 = r134 * r66;
+    r134 = r134 * r49;
+    r136 = fma(r59, r134, r136);
+    r135 = r60 * r129;
+    r135 = r135 * r66;
+    r135 = r135 * r36;
+    r136 = fma(r63, r135, r136);
+    r8 = r129 * r92;
+    r8 = r8 * r36;
+    r8 = fma(r99, r8, r40 * r103);
+    r102 = r21 * r7;
+    r102 = r102 * r129;
+    r8 = fma(r47, r102, r8);
+    r8 = fma(r46, r106, r8);
+    r136 = r136 + r8;
+    r135 = r45 * r62;
+    r134 = r40 * r31;
+    r134 = fma(r81, r134, r68 * r135);
+    r135 = r21 * r6;
+    r135 = r135 * r6;
+    r135 = r135 * r129;
+    r135 = r135 * r66;
+    r135 = r135 * r49;
+    r134 = fma(r59, r135, r134);
+    r102 = r129 * r66;
+    r102 = r102 * r36;
+    r134 = fma(r63, r102, r134);
+    r8 = r8 + r134;
+    r136 = fma(r64, r8, r5 * r136);
+    r102 = r21 * r40;
+    r102 = r102 * r6;
+    r102 = r102 * r72;
+    r102 = r102 * r76;
+    r136 = fma(r53, r102, r136);
+    r135 = r70 * r10;
+    r135 = r135 * r48;
+    r135 = fma(r8, r135, r69 * r8);
+    r135 = fma(r8, r73, r135);
+    r135 = fma(r8, r74, r135);
+    r104 = r6 * r135;
+    r136 = fma(r78, r104, r136);
+    r130 = r21 * r40;
+    r130 = r130 * r6;
+    r130 = r130 * r76;
+    r136 = fma(r53, r130, r136);
+    r133 = r4 * r46;
+    r133 = r133 * r62;
+    r136 = fma(r68, r133, r136);
+    r22 = r4 * r45;
+    r136 = fma(r106, r22, r136);
+    r9 = r56 * r1;
+    r9 = r9 * r129;
+    r9 = r9 * r75;
+    r9 = r9 * r66;
+    r136 = fma(r62, r9, r136);
+    r105 = r4 * r129;
+    r136 = fma(r121, r105, r136);
+    r137 = r4 * r35;
+    r137 = r137 * r6;
+    r137 = r137 * r129;
+    r136 = fma(r47, r137, r136);
+    r138 = r56 * r72;
+    r138 = r138 * r1;
+    r138 = r138 * r129;
+    r138 = r138 * r75;
+    r138 = r138 * r66;
+    r136 = fma(r62, r138, r136);
+    r136 = fma(r45, r79, r136);
+    r136 = fma(r129, r115, r136);
+    r136 = fma(r129, r116, r136);
+    r136 = fma(r45, r78, r136);
+    r136 = fma(r40, r119, r136);
+    r138 = r2 * r136;
+    r137 = r40 * r7;
+    r137 = r137 * r7;
+    r137 = r137 * r56;
+    r137 = r137 * r56;
+    r137 = r137 * r113;
+    r137 = r137 * r43;
+    r105 = r60 * r129;
+    r105 = r105 * r92;
+    r105 = r105 * r36;
+    r105 = fma(r99, r105, r57 * r137);
+    r137 = r46 * r7;
+    r137 = r137 * r109;
+    r137 = r137 * r43;
+    r105 = fma(r59, r137, r105);
+    r9 = r7 * r111;
+    r9 = r9 * r129;
+    r105 = fma(r47, r9, r105);
+    r105 = r105 + r134;
+    r8 = fma(r65, r8, r4 * r105);
+    r105 = r21 * r40;
+    r105 = r105 * r7;
+    r105 = r105 * r76;
+    r8 = fma(r53, r105, r8);
+    r134 = r21 * r40;
+    r134 = r134 * r7;
+    r134 = r134 * r72;
+    r134 = r134 * r76;
+    r8 = fma(r53, r134, r8);
+    r9 = r84 * r129;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r8 = fma(r77, r9, r8);
+    r137 = r5 * r46;
+    r137 = r137 * r62;
+    r8 = fma(r68, r137, r8);
+    r22 = r56 * r1;
+    r22 = r22 * r129;
+    r22 = r22 * r43;
+    r22 = r22 * r75;
+    r8 = fma(r92, r22, r8);
+    r133 = r5 * r45;
+    r8 = fma(r106, r133, r8);
+    r130 = r5 * r129;
+    r8 = fma(r121, r130, r8);
+    r104 = r5 * r40;
+    r104 = r104 * r7;
+    r104 = r104 * r56;
+    r104 = r104 * r56;
+    r104 = r104 * r95;
+    r104 = r104 * r57;
+    r8 = fma(r62, r104, r8);
+    r102 = r84 * r72;
+    r102 = r102 * r129;
+    r102 = r102 * r30;
+    r102 = r102 * r92;
+    r8 = fma(r77, r102, r8);
+    r139 = r7 * r135;
+    r8 = fma(r78, r139, r8);
+    r140 = r56 * r72;
+    r140 = r140 * r1;
+    r140 = r140 * r129;
+    r140 = r140 * r43;
+    r140 = r140 * r75;
+    r8 = fma(r92, r140, r8);
+    r8 = fma(r46, r79, r8);
+    r8 = fma(r129, r120, r8);
+    r8 = fma(r46, r78, r8);
+    r140 = r3 * r8;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r140);
+    r140 = r6 * r6;
+    r138 = r10 * r52;
+    r138 = r138 * r6;
+    r80 = fma(r50, r80, r39 * r138);
+    r138 = r50 * r6;
+    r138 = r138 * r6;
+    r80 = fma(r31, r138, r80);
+    r139 = r10 * r44;
+    r139 = r139 * r7;
+    r80 = fma(r39, r139, r80);
+    r140 = r140 * r111;
+    r140 = r140 * r80;
+    r140 = r140 * r66;
+    r140 = r140 * r49;
+    r140 = fma(r59, r140, r50 * r114);
+    r114 = r60 * r80;
+    r114 = r114 * r66;
+    r114 = r114 * r36;
+    r140 = fma(r63, r114, r140);
+    r139 = r52 * r109;
+    r139 = r139 * r59;
+    r140 = fma(r62, r139, r140);
+    r138 = r21 * r7;
+    r138 = r138 * r80;
+    r138 = fma(r47, r138, r44 * r106);
+    r39 = r80 * r92;
+    r39 = r39 * r36;
+    r138 = fma(r99, r39, r138);
+    r138 = fma(r50, r103, r138);
+    r140 = r140 + r138;
+    r139 = r50 * r31;
+    r114 = r21 * r6;
+    r114 = r114 * r6;
+    r114 = r114 * r80;
+    r114 = r114 * r66;
+    r114 = r114 * r49;
+    r114 = fma(r59, r114, r81 * r139);
+    r139 = r80 * r66;
+    r139 = r139 * r36;
+    r114 = fma(r63, r139, r114);
+    r63 = r52 * r62;
+    r114 = fma(r68, r63, r114);
+    r138 = r138 + r114;
+    r64 = fma(r64, r138, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r76;
+    r64 = fma(r53, r140, r64);
+    r63 = r4 * r44;
+    r63 = r63 * r62;
+    r64 = fma(r68, r63, r64);
+    r139 = r4 * r35;
+    r139 = r139 * r6;
+    r139 = r139 * r80;
+    r64 = fma(r47, r139, r64);
+    r81 = r56 * r1;
+    r81 = r81 * r80;
+    r81 = r81 * r75;
+    r81 = r81 * r66;
+    r64 = fma(r62, r81, r64);
+    r49 = r4 * r80;
+    r64 = fma(r121, r49, r64);
+    r106 = r52 * r106;
+    r103 = r56 * r72;
+    r103 = r103 * r1;
+    r103 = r103 * r80;
+    r103 = r103 * r75;
+    r103 = r103 * r66;
+    r64 = fma(r62, r103, r64);
+    r39 = r21 * r50;
+    r39 = r39 * r6;
+    r39 = r39 * r72;
+    r39 = r39 * r76;
+    r64 = fma(r53, r39, r64);
+    r102 = r70 * r10;
+    r102 = r102 * r48;
+    r102 = fma(r138, r102, r69 * r138);
+    r102 = fma(r138, r74, r102);
+    r102 = fma(r138, r73, r102);
+    r73 = r6 * r102;
+    r64 = fma(r78, r73, r64);
+    r64 = fma(r52, r79, r64);
+    r64 = fma(r80, r115, r64);
+    r64 = fma(r80, r116, r64);
+    r64 = fma(r50, r119, r64);
+    r64 = fma(r52, r78, r64);
+    r64 = fma(r4, r106, r64);
+    r2 = r2 * r64;
+    r73 = r44 * r7;
+    r73 = r73 * r109;
+    r73 = r73 * r43;
+    r39 = r7 * r111;
+    r39 = r39 * r80;
+    r39 = fma(r47, r39, r59 * r73);
+    r73 = r60 * r80;
+    r73 = r73 * r92;
+    r73 = r73 * r36;
+    r39 = fma(r99, r73, r39);
+    r99 = r50 * r7;
+    r99 = r99 * r7;
+    r99 = r99 * r56;
+    r99 = r99 * r56;
+    r99 = r99 * r113;
+    r99 = r99 * r43;
+    r39 = fma(r57, r99, r39);
+    r39 = r39 + r114;
+    r39 = fma(r4, r39, r65 * r138);
+    r138 = r5 * r44;
+    r138 = r138 * r62;
+    r39 = fma(r68, r138, r39);
+    r68 = r56 * r1;
+    r68 = r68 * r80;
+    r68 = r68 * r43;
+    r68 = r68 * r75;
+    r39 = fma(r92, r68, r39);
+    r65 = r5 * r80;
+    r39 = fma(r121, r65, r39);
+    r121 = r56 * r72;
+    r121 = r121 * r1;
+    r121 = r121 * r80;
+    r121 = r121 * r43;
+    r121 = r121 * r75;
+    r39 = fma(r92, r121, r39);
+    r75 = r84 * r72;
+    r75 = r75 * r80;
+    r75 = r75 * r30;
+    r75 = r75 * r92;
+    r39 = fma(r77, r75, r39);
+    r43 = r21 * r50;
+    r43 = r43 * r7;
+    r43 = r43 * r72;
+    r43 = r43 * r76;
+    r39 = fma(r53, r43, r39);
+    r114 = r5 * r50;
+    r114 = r114 * r7;
+    r114 = r114 * r56;
+    r114 = r114 * r56;
+    r114 = r114 * r95;
+    r114 = r114 * r57;
+    r39 = fma(r62, r114, r39);
+    r57 = r7 * r102;
+    r39 = fma(r78, r57, r39);
+    r95 = r84 * r80;
+    r95 = r95 * r30;
+    r95 = r95 * r92;
+    r39 = fma(r77, r95, r39);
+    r77 = r21 * r50;
+    r77 = r77 * r7;
+    r77 = r77 * r76;
+    r39 = fma(r53, r77, r39);
+    r39 = fma(r80, r120, r39);
+    r39 = fma(r44, r79, r39);
+    r39 = fma(r5, r106, r39);
+    r39 = fma(r44, r78, r39);
+    r77 = r3 * r39;
+    WriteIdx2<1024, double, double, double2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r2, r77);
+    r77 = r3 * r21;
+    r77 = r77 * r0;
+    r77 = fma(r108, r107, r127 * r77);
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r2 = fma(r136, r107, r8 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r77, r2);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r107 = fma(r64, r107, r39 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r107);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r107 = r127 * r127;
+    r2 = r108 * r108;
+    r2 = fma(r61, r2, r117 * r107);
+    r107 = r8 * r8;
+    r0 = r136 * r136;
+    r0 = fma(r61, r0, r117 * r107);
+    WriteSum2<double, double>((double*)inout_shared, r2, r0);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r39 * r39;
+    r2 = r64 * r64;
+    r2 = fma(r61, r2, r117 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r2);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r127 * r8;
+    r0 = r108 * r136;
+    r0 = fma(r61, r0, r117 * r2);
+    r2 = r127 * r39;
+    r107 = r108 * r64;
+    r107 = fma(r61, r107, r117 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r0, r107);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r107 = r8 * r39;
+    r0 = r136 * r64;
+    r0 = fma(r61, r0, r117 * r107);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_point_jac,
+              out_point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.cu
@@ -1,0 +1,349 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScoreKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.cu
@@ -1,0 +1,276 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        double* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(principal_point_njtr,
+                                0 * principal_point_njtr_num_alloc,
+                                principal_point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r5, r6);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r7,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r9, r10);
+    r11 = fma(r8, r9, r4 * r5);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r12, r13);
+    r11 = fma(r7, r12, r11);
+    r14 = r2 + r11;
+    r8 = fma(r8, r10, r4 * r6);
+    r8 = fma(r7, r13, r8);
+    r7 = r3 + r8;
+    r4 = fma(r1, r7, r0 * r14);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r15, r16);
+    r17 = fma(r16, r7, r15 * r14);
+    WriteSum2<double, double>((double*)inout_shared, r4, r17);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r17, r4);
+    r18 = fma(r4, r7, r17 * r14);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r19, r20);
+    r21 = fma(r20, r7, r19 * r14);
+    WriteSum2<double, double>((double*)inout_shared, r18, r21);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r21, r18);
+    r22 = fma(r18, r7, r21 * r14);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r23, r24);
+    r7 = fma(r24, r7, r23 * r14);
+    WriteSum2<double, double>((double*)inout_shared, r22, r7);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r7,
+                        r22);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r21 = fma(r7, r21, r22 * r23);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r23,
+                        r14);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r25,
+                        r26);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r21 = fma(r23, r17, r21);
+    r21 = fma(r14, r19, r21);
+    r21 = fma(r25, r0, r21);
+    r21 = fma(r26, r15, r21);
+    r11 = r21 + r11;
+    r20 = fma(r14, r20, r22 * r24);
+    r20 = fma(r23, r4, r20);
+    r20 = fma(r25, r1, r20);
+    r20 = fma(r26, r16, r20);
+    r20 = fma(r7, r18, r20);
+    r8 = r20 + r8;
+    WriteSum2<double, double>((double*)inout_shared, r11, r8);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r21 = r2 + r21;
+    r20 = r3 + r20;
+    r13 = fma(r13, r20, r12 * r21);
+    r10 = fma(r10, r20, r9 * r21);
+    WriteSum2<double, double>((double*)inout_shared, r13, r10);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = fma(r6, r20, r5 * r21);
+    WriteSum1<double, double>((double*)inout_shared, r20);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirectKernel<<<n_blocks,
+                                                               1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      principal_point_njtr,
+      principal_point_njtr_num_alloc,
+      principal_point_njtr_indices,
+      principal_point_jac,
+      principal_point_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.cu
@@ -1,0 +1,2363 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r61 = fma(r64, r48, r5 * r61);
+    r67 = r4 * r7;
+    r68 = r10 * r59;
+    r67 = r67 * r62;
+    r61 = fma(r68, r67, r61);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r69,
+                                            r70);
+    r71 = r48 * r48;
+    r72 = fma(r70, r71, r69 * r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r73,
+                                            r74);
+    r75 = r48 * r71;
+    r74 = r74 * r75;
+    r72 = fma(r48, r74, r72);
+    r72 = fma(r73, r75, r72);
+    r75 = 1.0 / r31;
+    r76 = 1.0 / r47;
+    r77 = r75 * r76;
+    r78 = r56 * r77;
+    r79 = r72 * r78;
+    r61 = fma(r6, r79, r61);
+    r61 = fma(r6, r78, r61);
+    r61 = fma(r2, r61, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r67);
+    r61 = fma(r0, r21, r61);
+    r0 = r7 * r7;
+    r0 = r0 * r60;
+    r0 = r0 * r43;
+    r0 = fma(r59, r0, r66);
+    r0 = fma(r65, r48, r4 * r0);
+    r66 = r5 * r7;
+    r66 = r66 * r62;
+    r0 = fma(r68, r66, r0);
+    r0 = fma(r7, r79, r0);
+    r0 = fma(r7, r78, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r67, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r61, r0);
+    r67 = r6 * r43;
+    r1 = -5.00000000000000000e-01;
+    r66 = rsqrt(r30);
+    r80 = r10 * r6;
+    r81 = r11 * r14;
+    r82 = r16 * r17;
+    r82 = fma(r1, r82, r1 * r81);
+    r81 = r15 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r12 * r13;
+    r84 = 5.00000000000000000e-01;
+    r82 = fma(r84, r83, r82);
+    r83 = r24 * r82;
+    r81 = r15 * r14;
+    r85 = r12 * r17;
+    r85 = fma(r84, r85, r84 * r81);
+    r81 = r11 * r18;
+    r85 = fma(r1, r81, r85);
+    r86 = r16 * r13;
+    r85 = fma(r84, r86, r85);
+    r86 = r29 * r85;
+    r81 = fma(r10, r86, r10 * r83);
+    r87 = r10 * r19;
+    r88 = fma(r84, r26, r1 * r22);
+    r88 = fma(r1, r23, r88);
+    r88 = fma(r1, r25, r88);
+    r89 = r10 * r27;
+    r90 = r16 * r14;
+    r91 = r11 * r17;
+    r91 = fma(r1, r91, r84 * r90);
+    r90 = r12 * r18;
+    r91 = fma(r1, r90, r91);
+    r92 = r15 * r13;
+    r91 = fma(r1, r92, r91);
+    r89 = r89 * r91;
+    r87 = fma(r88, r87, r89);
+    r81 = r81 + r87;
+    r92 = r10 * r24;
+    r92 = r92 * r91;
+    r90 = r10 * r19;
+    r90 = r90 * r85;
+    r93 = r92 + r90;
+    r94 = r27 * r35;
+    r93 = fma(r82, r94, r93);
+    r95 = r35 * r29;
+    r93 = fma(r88, r95, r93);
+    r93 = fma(r9, r93, r42 * r81);
+    r81 = r24 * r85;
+    r95 = -4.00000000000000000e+00;
+    r81 = r81 * r95;
+    r94 = r27 * r88;
+    r96 = r95 * r94;
+    r97 = r81 + r96;
+    r93 = fma(r8, r97, r93);
+    r80 = r80 * r93;
+    r97 = r6 * r6;
+    r98 = r10 * r24;
+    r98 = r98 * r88;
+    r99 = r10 * r27;
+    r99 = fma(r85, r99, r98);
+    r85 = r10 * r19;
+    r85 = r85 * r82;
+    r100 = r10 * r29;
+    r100 = r100 * r91;
+    r101 = r85 + r100;
+    r102 = r99 + r101;
+    r86 = fma(r35, r86, r35 * r83);
+    r86 = r86 + r87;
+    r86 = fma(r8, r86, r9 * r102);
+    r102 = r19 * r91;
+    r102 = r102 * r95;
+    r81 = r81 + r102;
+    r86 = fma(r42, r81, r86);
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r31 = r35 * r57;
+    r97 = r97 * r86;
+    r97 = fma(r31, r97, r39 * r80);
+    r80 = r7 * r7;
+    r80 = r80 * r31;
+    r81 = r10 * r7;
+    r103 = r19 * r35;
+    r104 = r35 * r29;
+    r104 = r104 * r91;
+    r103 = fma(r82, r103, r104);
+    r103 = r103 + r99;
+    r96 = r102 + r96;
+    r96 = fma(r9, r96, r42 * r103);
+    r103 = r10 * r29;
+    r103 = fma(r88, r103, r90);
+    r90 = r10 * r27;
+    r90 = fma(r82, r90, r92);
+    r103 = r103 + r90;
+    r96 = fma(r8, r103, r96);
+    r81 = r81 * r96;
+    r97 = fma(r39, r81, r97);
+    r97 = fma(r86, r80, r97);
+    r67 = r67 * r56;
+    r67 = r67 * r75;
+    r67 = r67 * r1;
+    r67 = r67 * r66;
+    r67 = r67 * r97;
+    r81 = r56 * r56;
+    r103 = r43 * r81;
+    r103 = r103 * r80;
+    r92 = r7 * r66;
+    r102 = r97 * r92;
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r99 = r30 * r53;
+    r105 = r7 * r43;
+    r102 = r102 * r99;
+    r102 = fma(r105, r102, r86 * r103);
+    r106 = r21 * r7;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r47 = r49 * r59;
+    r47 = r47 * r92;
+    r106 = r106 * r97;
+    r102 = fma(r47, r106, r102);
+    r107 = r68 * r105;
+    r102 = fma(r96, r107, r102);
+    r106 = r97 * r66;
+    r106 = r106 * r99;
+    r108 = r21 * r6;
+    r108 = r108 * r6;
+    r108 = r108 * r97;
+    r108 = r108 * r66;
+    r108 = r108 * r49;
+    r108 = fma(r59, r108, r63 * r106);
+    r106 = r93 * r62;
+    r108 = fma(r68, r106, r108);
+    r109 = r86 * r31;
+    r81 = r63 * r81;
+    r108 = fma(r81, r109, r108);
+    r109 = r102 + r108;
+    r106 = fma(r64, r109, r67);
+    r110 = r60 * r97;
+    r110 = r110 * r66;
+    r110 = r110 * r99;
+    r111 = r6 * r6;
+    r112 = -3.00000000000000000e+00;
+    r111 = r111 * r112;
+    r111 = r111 * r97;
+    r111 = r111 * r66;
+    r111 = r111 * r49;
+    r111 = fma(r59, r111, r63 * r110);
+    r110 = 6.00000000000000000e+00;
+    r113 = r93 * r110;
+    r113 = r113 * r59;
+    r111 = fma(r62, r113, r111);
+    r114 = -6.00000000000000000e+00;
+    r115 = r114 * r57;
+    r115 = r115 * r81;
+    r111 = fma(r86, r115, r111);
+    r111 = r111 + r102;
+    r102 = r93 * r107;
+    r113 = r21 * r6;
+    r113 = r113 * r72;
+    r113 = r113 * r86;
+    r113 = r113 * r76;
+    r106 = fma(r53, r113, r106);
+    r116 = r6 * r84;
+    r116 = r116 * r66;
+    r116 = r116 * r30;
+    r116 = r116 * r77;
+    r117 = r72 * r116;
+    r118 = r4 * r35;
+    r118 = r118 * r6;
+    r118 = r118 * r97;
+    r106 = fma(r47, r118, r106);
+    r119 = r4 * r96;
+    r119 = r119 * r62;
+    r106 = fma(r68, r119, r106);
+    r120 = r4 * r7;
+    r120 = r120 * r56;
+    r120 = r120 * r56;
+    r120 = r120 * r95;
+    r120 = r120 * r57;
+    r120 = r120 * r62;
+    r121 = r4 * r97;
+    r122 = r10 * r62;
+    r122 = r122 * r92;
+    r122 = r122 * r99;
+    r106 = fma(r122, r121, r106);
+    r123 = r70 * r10;
+    r123 = r123 * r48;
+    r123 = fma(r69, r109, r109 * r123);
+    r73 = r73 * r60;
+    r73 = r73 * r71;
+    r71 = 4.00000000000000000e+00;
+    r74 = r71 * r74;
+    r123 = fma(r109, r73, r123);
+    r123 = fma(r109, r74, r123);
+    r71 = r6 * r123;
+    r106 = fma(r78, r71, r106);
+    r124 = r21 * r6;
+    r124 = r124 * r86;
+    r124 = r124 * r76;
+    r106 = fma(r53, r124, r106);
+    r106 = fma(r5, r111, r106);
+    r106 = fma(r4, r102, r106);
+    r106 = fma(r72, r67, r106);
+    r106 = fma(r97, r117, r106);
+    r106 = fma(r93, r79, r106);
+    r106 = fma(r86, r120, r106);
+    r106 = fma(r97, r116, r106);
+    r106 = fma(r93, r78, r106);
+    r124 = r2 * r106;
+    r71 = r7 * r43;
+    r71 = r71 * r56;
+    r71 = r71 * r75;
+    r71 = r71 * r1;
+    r71 = r71 * r66;
+    r71 = r71 * r97;
+    r109 = fma(r65, r109, r71);
+    r121 = r7 * r7;
+    r121 = r121 * r56;
+    r121 = r121 * r56;
+    r121 = r121 * r86;
+    r121 = r121 * r114;
+    r121 = r121 * r43;
+    r119 = r60 * r97;
+    r119 = r119 * r92;
+    r119 = r119 * r99;
+    r119 = fma(r105, r119, r57 * r121);
+    r121 = r7 * r112;
+    r121 = r121 * r97;
+    r119 = fma(r47, r121, r119);
+    r118 = r7 * r96;
+    r118 = r118 * r110;
+    r118 = r118 * r43;
+    r119 = fma(r59, r118, r119);
+    r119 = r119 + r108;
+    r108 = r21 * r7;
+    r108 = r108 * r86;
+    r108 = r108 * r76;
+    r109 = fma(r53, r108, r109);
+    r118 = r5 * r35;
+    r118 = r118 * r6;
+    r118 = r118 * r47;
+    r121 = r84 * r97;
+    r121 = r121 * r30;
+    r121 = r121 * r92;
+    r109 = fma(r77, r121, r109);
+    r113 = r5 * r96;
+    r113 = r113 * r62;
+    r109 = fma(r68, r113, r109);
+    r67 = r5 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r86;
+    r67 = r67 * r57;
+    r109 = fma(r62, r67, r109);
+    r111 = r7 * r123;
+    r109 = fma(r78, r111, r109);
+    r125 = r5 * r97;
+    r109 = fma(r122, r125, r109);
+    r126 = r84 * r72;
+    r126 = r126 * r97;
+    r126 = r126 * r30;
+    r126 = r126 * r92;
+    r109 = fma(r77, r126, r109);
+    r127 = r21 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r86;
+    r127 = r127 * r76;
+    r109 = fma(r53, r127, r109);
+    r109 = fma(r4, r119, r109);
+    r109 = fma(r5, r102, r109);
+    r109 = fma(r72, r71, r109);
+    r109 = fma(r97, r118, r109);
+    r109 = fma(r96, r79, r109);
+    r109 = fma(r96, r78, r109);
+    r127 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r124,
+                                             r127);
+    r127 = r35 * r24;
+    r127 = fma(r88, r127, r104);
+    r124 = r10 * r27;
+    r126 = r15 * r14;
+    r125 = r12 * r17;
+    r125 = fma(r1, r125, r1 * r126);
+    r126 = r11 * r18;
+    r125 = fma(r84, r126, r125);
+    r111 = r16 * r13;
+    r125 = fma(r1, r111, r125);
+    r124 = r124 * r125;
+    r111 = r10 * r19;
+    r126 = r11 * r14;
+    r67 = r16 * r17;
+    r67 = fma(r84, r67, r84 * r126);
+    r126 = r15 * r18;
+    r67 = fma(r84, r126, r67);
+    r113 = r12 * r13;
+    r67 = fma(r1, r113, r67);
+    r111 = fma(r67, r111, r124);
+    r127 = r127 + r111;
+    r113 = r10 * r24;
+    r113 = r113 * r67;
+    r126 = r10 * r29;
+    r126 = fma(r125, r126, r113);
+    r126 = r126 + r87;
+    r126 = fma(r9, r126, r8 * r127);
+    r127 = r24 * r91;
+    r127 = r127 * r95;
+    r87 = r19 * r125;
+    r121 = r95 * r87;
+    r71 = r127 + r121;
+    r126 = fma(r42, r71, r126);
+    r100 = r98 + r100;
+    r100 = r100 + r111;
+    r111 = r27 * r95;
+    r111 = r111 * r67;
+    r127 = r127 + r111;
+    r127 = fma(r8, r127, r42 * r100);
+    r100 = r35 * r29;
+    r100 = fma(r35, r94, r67 * r100);
+    r98 = r10 * r19;
+    r98 = r98 * r91;
+    r71 = r10 * r24;
+    r71 = fma(r125, r71, r98);
+    r100 = r100 + r71;
+    r127 = fma(r9, r100, r127);
+    r100 = r110 * r127;
+    r100 = r100 * r59;
+    r100 = fma(r62, r100, r126 * r115);
+    r108 = r6 * r6;
+    r102 = r10 * r6;
+    r102 = r102 * r127;
+    r119 = r10 * r7;
+    r113 = r89 + r113;
+    r89 = r19 * r35;
+    r113 = fma(r88, r89, r113);
+    r88 = r35 * r29;
+    r113 = fma(r125, r88, r113);
+    r88 = r10 * r29;
+    r94 = fma(r10, r94, r67 * r88);
+    r94 = r94 + r71;
+    r94 = fma(r8, r94, r42 * r113);
+    r121 = r111 + r121;
+    r94 = fma(r9, r121, r94);
+    r119 = r119 * r94;
+    r119 = fma(r39, r119, r39 * r102);
+    r102 = r6 * r6;
+    r102 = r102 * r126;
+    r119 = fma(r31, r102, r119);
+    r119 = fma(r126, r80, r119);
+    r102 = r112 * r119;
+    r108 = r108 * r66;
+    r108 = r108 * r49;
+    r108 = r108 * r59;
+    r100 = fma(r102, r108, r100);
+    r121 = r60 * r119;
+    r121 = r121 * r66;
+    r121 = r121 * r99;
+    r100 = fma(r63, r121, r100);
+    r111 = r21 * r7;
+    r111 = r111 * r119;
+    r111 = fma(r47, r111, r94 * r107);
+    r113 = r119 * r92;
+    r113 = r113 * r99;
+    r111 = fma(r105, r113, r111);
+    r111 = fma(r126, r103, r111);
+    r100 = r100 + r111;
+    r121 = r126 * r31;
+    r108 = r127 * r62;
+    r108 = fma(r68, r108, r81 * r121);
+    r121 = r21 * r6;
+    r121 = r121 * r6;
+    r121 = r121 * r119;
+    r121 = r121 * r66;
+    r121 = r121 * r49;
+    r108 = fma(r59, r121, r108);
+    r113 = r119 * r66;
+    r113 = r113 * r99;
+    r108 = fma(r63, r113, r108);
+    r111 = r111 + r108;
+    r100 = fma(r64, r111, r5 * r100);
+    r113 = r21 * r6;
+    r113 = r113 * r126;
+    r113 = r113 * r76;
+    r100 = fma(r53, r113, r100);
+    r121 = r56 * r72;
+    r121 = r121 * r1;
+    r121 = r121 * r119;
+    r121 = r121 * r75;
+    r121 = r121 * r66;
+    r100 = fma(r62, r121, r100);
+    r88 = r70 * r10;
+    r88 = r88 * r48;
+    r88 = fma(r111, r88, r69 * r111);
+    r88 = fma(r111, r74, r88);
+    r88 = fma(r111, r73, r88);
+    r67 = r6 * r88;
+    r100 = fma(r78, r67, r100);
+    r89 = r21 * r6;
+    r89 = r89 * r72;
+    r89 = r89 * r126;
+    r89 = r89 * r76;
+    r100 = fma(r53, r89, r100);
+    r128 = r4 * r119;
+    r100 = fma(r122, r128, r100);
+    r129 = r4 * r35;
+    r129 = r129 * r6;
+    r129 = r129 * r119;
+    r100 = fma(r47, r129, r100);
+    r130 = r4 * r94;
+    r130 = r130 * r62;
+    r100 = fma(r68, r130, r100);
+    r131 = r4 * r127;
+    r100 = fma(r107, r131, r100);
+    r132 = r56 * r1;
+    r132 = r132 * r119;
+    r132 = r132 * r75;
+    r132 = r132 * r66;
+    r100 = fma(r62, r132, r100);
+    r100 = fma(r119, r117, r100);
+    r100 = fma(r119, r116, r100);
+    r100 = fma(r126, r120, r100);
+    r100 = fma(r127, r78, r100);
+    r100 = fma(r127, r79, r100);
+    r132 = r2 * r100;
+    r131 = r7 * r110;
+    r131 = r131 * r94;
+    r131 = r131 * r43;
+    r130 = r7 * r47;
+    r130 = fma(r102, r130, r59 * r131);
+    r131 = r7 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r114;
+    r131 = r131 * r126;
+    r131 = r131 * r43;
+    r130 = fma(r57, r131, r130);
+    r102 = r60 * r119;
+    r102 = r102 * r92;
+    r102 = r102 * r99;
+    r130 = fma(r105, r102, r130);
+    r130 = r130 + r108;
+    r111 = fma(r65, r111, r4 * r130);
+    r130 = r56 * r1;
+    r130 = r130 * r119;
+    r130 = r130 * r43;
+    r130 = r130 * r75;
+    r111 = fma(r92, r130, r111);
+    r108 = r7 * r88;
+    r111 = fma(r78, r108, r111);
+    r102 = r84 * r119;
+    r102 = r102 * r30;
+    r102 = r102 * r92;
+    r111 = fma(r77, r102, r111);
+    r131 = r5 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r95;
+    r131 = r131 * r126;
+    r131 = r131 * r57;
+    r111 = fma(r62, r131, r111);
+    r129 = r5 * r119;
+    r111 = fma(r122, r129, r111);
+    r128 = r21 * r7;
+    r128 = r128 * r72;
+    r128 = r128 * r126;
+    r128 = r128 * r76;
+    r111 = fma(r53, r128, r111);
+    r89 = r56 * r72;
+    r89 = r89 * r1;
+    r89 = r89 * r119;
+    r89 = r89 * r43;
+    r89 = r89 * r75;
+    r111 = fma(r92, r89, r111);
+    r67 = r21 * r7;
+    r67 = r67 * r126;
+    r67 = r67 * r76;
+    r111 = fma(r53, r67, r111);
+    r121 = r5 * r94;
+    r121 = r121 * r62;
+    r111 = fma(r68, r121, r111);
+    r113 = r84 * r72;
+    r113 = r113 * r119;
+    r113 = r113 * r30;
+    r113 = r113 * r92;
+    r111 = fma(r77, r113, r111);
+    r133 = r5 * r127;
+    r111 = fma(r107, r133, r111);
+    r111 = fma(r94, r79, r111);
+    r111 = fma(r119, r118, r111);
+    r111 = fma(r94, r78, r111);
+    r133 = r3 * r111;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r133);
+    r133 = r19 * r95;
+    r26 = fma(r1, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r133 = r133 * r26;
+    r83 = r95 * r83;
+    r25 = r133 + r83;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r98 = r98 + r23;
+    r22 = r35 * r24;
+    r98 = fma(r125, r22, r98);
+    r132 = r35 * r29;
+    r98 = fma(r82, r132, r98);
+    r98 = fma(r8, r98, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r87, r26 * r25);
+    r25 = r25 + r90;
+    r98 = fma(r9, r25, r98);
+    r25 = r10 * r7;
+    r132 = r10 * r24;
+    r132 = r132 * r26;
+    r124 = r124 + r132;
+    r124 = r124 + r101;
+    r101 = r35 * r29;
+    r87 = fma(r35, r87, r26 * r101);
+    r87 = r87 + r90;
+    r87 = fma(r42, r87, r8 * r124);
+    r91 = r27 * r91;
+    r91 = r91 * r95;
+    r133 = r133 + r91;
+    r87 = fma(r9, r133, r87);
+    r25 = r25 * r87;
+    r133 = r6 * r6;
+    r133 = r133 * r98;
+    r133 = fma(r31, r133, r39 * r25);
+    r25 = r10 * r6;
+    r104 = r85 + r104;
+    r85 = r27 * r35;
+    r104 = fma(r125, r85, r104);
+    r104 = r104 + r132;
+    r83 = r91 + r83;
+    r83 = fma(r8, r83, r9 * r104);
+    r8 = r10 * r29;
+    r8 = fma(r82, r8, r23);
+    r8 = r8 + r71;
+    r83 = fma(r42, r8, r83);
+    r25 = r25 * r83;
+    r133 = fma(r39, r25, r133);
+    r133 = fma(r98, r80, r133);
+    r25 = r133 * r92;
+    r25 = r25 * r99;
+    r25 = fma(r105, r25, r98 * r103);
+    r8 = r21 * r7;
+    r8 = r8 * r133;
+    r25 = fma(r47, r8, r25);
+    r25 = fma(r87, r107, r25);
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r42 = r83 * r62;
+    r42 = fma(r68, r42, r59 * r8);
+    r8 = r98 * r31;
+    r42 = fma(r81, r8, r42);
+    r71 = r133 * r66;
+    r71 = r71 * r99;
+    r42 = fma(r63, r71, r42);
+    r71 = r25 + r42;
+    r8 = r6 * r6;
+    r8 = r8 * r112;
+    r8 = r8 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r23 = r110 * r83;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r8);
+    r8 = r60 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r99;
+    r23 = fma(r63, r8, r23);
+    r23 = fma(r98, r115, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r64 * r71);
+    r25 = r70 * r10;
+    r25 = r25 * r48;
+    r25 = fma(r71, r25, r69 * r71);
+    r25 = fma(r71, r73, r25);
+    r25 = fma(r71, r74, r25);
+    r8 = r6 * r25;
+    r23 = fma(r78, r8, r23);
+    r82 = r4 * r83;
+    r23 = fma(r107, r82, r23);
+    r104 = r4 * r133;
+    r23 = fma(r122, r104, r23);
+    r9 = r21 * r6;
+    r9 = r9 * r72;
+    r9 = r9 * r98;
+    r9 = r9 * r76;
+    r23 = fma(r53, r9, r23);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r133;
+    r23 = fma(r47, r91, r23);
+    r85 = r21 * r6;
+    r85 = r85 * r98;
+    r85 = r85 * r76;
+    r23 = fma(r53, r85, r23);
+    r132 = r56 * r1;
+    r132 = r132 * r133;
+    r132 = r132 * r75;
+    r132 = r132 * r66;
+    r23 = fma(r62, r132, r23);
+    r125 = r4 * r87;
+    r125 = r125 * r62;
+    r23 = fma(r68, r125, r23);
+    r124 = r56 * r72;
+    r124 = r124 * r1;
+    r124 = r124 * r133;
+    r124 = r124 * r75;
+    r124 = r124 * r66;
+    r23 = fma(r62, r124, r23);
+    r23 = fma(r133, r116, r23);
+    r23 = fma(r133, r117, r23);
+    r23 = fma(r83, r79, r23);
+    r23 = fma(r83, r78, r23);
+    r23 = fma(r98, r120, r23);
+    r124 = r2 * r23;
+    r125 = r7 * r7;
+    r125 = r125 * r56;
+    r125 = r125 * r56;
+    r125 = r125 * r114;
+    r125 = r125 * r98;
+    r125 = r125 * r43;
+    r132 = r60 * r133;
+    r132 = r132 * r92;
+    r132 = r132 * r99;
+    r132 = fma(r105, r132, r57 * r125);
+    r125 = r7 * r110;
+    r125 = r125 * r87;
+    r125 = r125 * r43;
+    r132 = fma(r59, r125, r132);
+    r85 = r7 * r112;
+    r85 = r85 * r133;
+    r132 = fma(r47, r85, r132);
+    r132 = r132 + r42;
+    r132 = fma(r4, r132, r65 * r71);
+    r71 = r21 * r7;
+    r71 = r71 * r72;
+    r71 = r71 * r98;
+    r71 = r71 * r76;
+    r132 = fma(r53, r71, r132);
+    r42 = r21 * r7;
+    r42 = r42 * r98;
+    r42 = r42 * r76;
+    r132 = fma(r53, r42, r132);
+    r85 = r5 * r83;
+    r132 = fma(r107, r85, r132);
+    r125 = r56 * r72;
+    r125 = r125 * r1;
+    r125 = r125 * r133;
+    r125 = r125 * r43;
+    r125 = r125 * r75;
+    r132 = fma(r92, r125, r132);
+    r91 = r5 * r133;
+    r132 = fma(r122, r91, r132);
+    r9 = r84 * r133;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r132 = fma(r77, r9, r132);
+    r104 = r7 * r25;
+    r132 = fma(r78, r104, r132);
+    r82 = r56 * r1;
+    r82 = r82 * r133;
+    r82 = r82 * r43;
+    r82 = r82 * r75;
+    r132 = fma(r92, r82, r132);
+    r8 = r84 * r72;
+    r8 = r8 * r133;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r132 = fma(r77, r8, r132);
+    r90 = r5 * r7;
+    r90 = r90 * r56;
+    r90 = r90 * r56;
+    r90 = r90 * r95;
+    r90 = r90 * r98;
+    r90 = r90 * r57;
+    r132 = fma(r62, r90, r132);
+    r101 = r5 * r87;
+    r101 = r101 * r62;
+    r132 = fma(r68, r101, r132);
+    r132 = fma(r87, r79, r132);
+    r132 = fma(r87, r78, r132);
+    r132 = fma(r133, r118, r132);
+    r101 = r3 * r132;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r124,
+                                             r101);
+    r101 = r37 * r110;
+    r101 = r101 * r59;
+    r124 = r6 * r6;
+    r90 = r10 * r33;
+    r90 = r90 * r7;
+    r90 = fma(r20, r80, r39 * r90);
+    r8 = r20 * r6;
+    r8 = r8 * r6;
+    r90 = fma(r31, r8, r90);
+    r82 = r10 * r37;
+    r82 = r82 * r6;
+    r90 = fma(r39, r82, r90);
+    r124 = r124 * r112;
+    r124 = r124 * r90;
+    r124 = r124 * r66;
+    r124 = r124 * r49;
+    r124 = fma(r59, r124, r62 * r101);
+    r101 = r60 * r90;
+    r101 = r101 * r66;
+    r101 = r101 * r99;
+    r124 = fma(r63, r101, r124);
+    r82 = r21 * r7;
+    r82 = r82 * r90;
+    r82 = fma(r47, r82, r33 * r107);
+    r8 = r90 * r92;
+    r8 = r8 * r99;
+    r82 = fma(r105, r8, r82);
+    r82 = fma(r20, r103, r82);
+    r124 = fma(r20, r115, r124);
+    r124 = r124 + r82;
+    r101 = r37 * r62;
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r90;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r8 = fma(r59, r8, r68 * r101);
+    r101 = r90 * r66;
+    r101 = r101 * r99;
+    r8 = fma(r63, r101, r8);
+    r104 = r20 * r31;
+    r8 = fma(r81, r104, r8);
+    r82 = r82 + r8;
+    r124 = fma(r64, r82, r5 * r124);
+    r104 = r90 * r122;
+    r101 = r56 * r72;
+    r101 = r101 * r1;
+    r101 = r101 * r90;
+    r101 = r101 * r75;
+    r101 = r101 * r66;
+    r124 = fma(r62, r101, r124);
+    r9 = r56 * r1;
+    r9 = r9 * r90;
+    r9 = r9 * r75;
+    r9 = r9 * r66;
+    r124 = fma(r62, r9, r124);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r90;
+    r124 = fma(r47, r91, r124);
+    r125 = r70 * r10;
+    r125 = r125 * r48;
+    r125 = fma(r69, r82, r82 * r125);
+    r125 = fma(r82, r74, r125);
+    r125 = fma(r82, r73, r125);
+    r85 = r6 * r125;
+    r124 = fma(r78, r85, r124);
+    r42 = r21 * r20;
+    r42 = r42 * r6;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r124 = fma(r53, r42, r124);
+    r71 = r21 * r20;
+    r71 = r71 * r6;
+    r71 = r71 * r76;
+    r124 = fma(r53, r71, r124);
+    r26 = r4 * r33;
+    r26 = r26 * r62;
+    r124 = fma(r68, r26, r124);
+    r22 = r4 * r37;
+    r124 = fma(r107, r22, r124);
+    r124 = fma(r37, r79, r124);
+    r124 = fma(r90, r117, r124);
+    r124 = fma(r4, r104, r124);
+    r124 = fma(r90, r116, r124);
+    r124 = fma(r20, r120, r124);
+    r124 = fma(r37, r78, r124);
+    r22 = r2 * r124;
+    r26 = r33 * r7;
+    r26 = r26 * r110;
+    r26 = r26 * r43;
+    r71 = r7 * r112;
+    r71 = r71 * r90;
+    r71 = fma(r47, r71, r59 * r26);
+    r26 = r20 * r7;
+    r26 = r26 * r7;
+    r26 = r26 * r56;
+    r26 = r26 * r56;
+    r26 = r26 * r114;
+    r26 = r26 * r43;
+    r71 = fma(r57, r26, r71);
+    r42 = r60 * r90;
+    r42 = r42 * r92;
+    r42 = r42 * r99;
+    r71 = fma(r105, r42, r71);
+    r71 = r71 + r8;
+    r82 = fma(r65, r82, r4 * r71);
+    r71 = r84 * r90;
+    r71 = r71 * r30;
+    r71 = r71 * r92;
+    r82 = fma(r77, r71, r82);
+    r8 = r56 * r72;
+    r8 = r8 * r1;
+    r8 = r8 * r90;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r82 = fma(r92, r8, r82);
+    r42 = r21 * r20;
+    r42 = r42 * r7;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r82 = fma(r53, r42, r82);
+    r26 = r21 * r20;
+    r26 = r26 * r7;
+    r26 = r26 * r76;
+    r82 = fma(r53, r26, r82);
+    r85 = r5 * r20;
+    r85 = r85 * r7;
+    r85 = r85 * r56;
+    r85 = r85 * r56;
+    r85 = r85 * r95;
+    r85 = r85 * r57;
+    r82 = fma(r62, r85, r82);
+    r91 = r7 * r125;
+    r82 = fma(r78, r91, r82);
+    r9 = r84 * r72;
+    r9 = r9 * r90;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r82 = fma(r77, r9, r82);
+    r101 = r5 * r33;
+    r101 = r101 * r62;
+    r82 = fma(r68, r101, r82);
+    r113 = r56 * r1;
+    r113 = r113 * r90;
+    r113 = r113 * r43;
+    r113 = r113 * r75;
+    r82 = fma(r92, r113, r82);
+    r121 = r5 * r37;
+    r82 = fma(r107, r121, r82);
+    r82 = fma(r33, r78, r82);
+    r82 = fma(r5, r104, r82);
+    r82 = fma(r90, r118, r82);
+    r82 = fma(r33, r79, r82);
+    r121 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r121);
+    r121 = r10 * r38;
+    r121 = r121 * r7;
+    r121 = fma(r39, r121, r34 * r80);
+    r22 = r34 * r6;
+    r22 = r22 * r6;
+    r121 = fma(r31, r22, r121);
+    r113 = r10 * r55;
+    r113 = r113 * r6;
+    r121 = fma(r39, r113, r121);
+    r113 = r60 * r121;
+    r113 = r113 * r66;
+    r113 = r113 * r99;
+    r113 = fma(r34, r115, r63 * r113);
+    r22 = r6 * r6;
+    r22 = r22 * r112;
+    r22 = r22 * r121;
+    r22 = r22 * r66;
+    r22 = r22 * r49;
+    r113 = fma(r59, r22, r113);
+    r101 = r55 * r110;
+    r101 = r101 * r59;
+    r113 = fma(r62, r101, r113);
+    r9 = fma(r38, r107, r34 * r103);
+    r91 = r121 * r92;
+    r91 = r91 * r99;
+    r9 = fma(r105, r91, r9);
+    r85 = r21 * r7;
+    r85 = r85 * r121;
+    r9 = fma(r47, r85, r9);
+    r113 = r113 + r9;
+    r101 = r121 * r66;
+    r101 = r101 * r99;
+    r22 = r34 * r31;
+    r22 = fma(r81, r22, r63 * r101);
+    r101 = r21 * r6;
+    r101 = r101 * r6;
+    r101 = r101 * r121;
+    r101 = r101 * r66;
+    r101 = r101 * r49;
+    r22 = fma(r59, r101, r22);
+    r85 = r55 * r62;
+    r22 = fma(r68, r85, r22);
+    r9 = r9 + r22;
+    r113 = fma(r64, r9, r5 * r113);
+    r85 = r4 * r38;
+    r85 = r85 * r62;
+    r113 = fma(r68, r85, r113);
+    r101 = r4 * r121;
+    r113 = fma(r122, r101, r113);
+    r91 = r21 * r34;
+    r91 = r91 * r6;
+    r91 = r91 * r76;
+    r113 = fma(r53, r91, r113);
+    r26 = r4 * r35;
+    r26 = r26 * r6;
+    r26 = r26 * r121;
+    r113 = fma(r47, r26, r113);
+    r104 = r56 * r1;
+    r104 = r104 * r121;
+    r104 = r104 * r75;
+    r104 = r104 * r66;
+    r113 = fma(r62, r104, r113);
+    r42 = r70 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r69, r9, r9 * r42);
+    r42 = fma(r9, r73, r42);
+    r42 = fma(r9, r74, r42);
+    r8 = r6 * r42;
+    r113 = fma(r78, r8, r113);
+    r71 = r56 * r72;
+    r71 = r71 * r1;
+    r71 = r71 * r121;
+    r71 = r71 * r75;
+    r71 = r71 * r66;
+    r113 = fma(r62, r71, r113);
+    r67 = r21 * r34;
+    r67 = r67 * r6;
+    r67 = r67 * r72;
+    r67 = r67 * r76;
+    r113 = fma(r53, r67, r113);
+    r89 = r4 * r55;
+    r113 = fma(r107, r89, r113);
+    r113 = fma(r121, r117, r113);
+    r113 = fma(r55, r78, r113);
+    r113 = fma(r34, r120, r113);
+    r113 = fma(r121, r116, r113);
+    r113 = fma(r55, r79, r113);
+    r89 = r2 * r113;
+    r67 = r34 * r7;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r114;
+    r67 = r67 * r43;
+    r71 = r38 * r7;
+    r71 = r71 * r110;
+    r71 = r71 * r43;
+    r71 = fma(r59, r71, r57 * r67);
+    r67 = r60 * r121;
+    r67 = r67 * r92;
+    r67 = r67 * r99;
+    r71 = fma(r105, r67, r71);
+    r8 = r7 * r112;
+    r8 = r8 * r121;
+    r71 = fma(r47, r8, r71);
+    r71 = r71 + r22;
+    r71 = fma(r4, r71, r65 * r9);
+    r9 = r21 * r34;
+    r9 = r9 * r7;
+    r9 = r9 * r76;
+    r71 = fma(r53, r9, r71);
+    r22 = r5 * r38;
+    r22 = r22 * r62;
+    r71 = fma(r68, r22, r71);
+    r8 = r5 * r121;
+    r71 = fma(r122, r8, r71);
+    r67 = r84 * r121;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r71 = fma(r77, r67, r71);
+    r104 = r7 * r42;
+    r71 = fma(r78, r104, r71);
+    r26 = r56 * r72;
+    r26 = r26 * r1;
+    r26 = r26 * r121;
+    r26 = r26 * r43;
+    r26 = r26 * r75;
+    r71 = fma(r92, r26, r71);
+    r91 = r5 * r34;
+    r91 = r91 * r7;
+    r91 = r91 * r56;
+    r91 = r91 * r56;
+    r91 = r91 * r95;
+    r91 = r91 * r57;
+    r71 = fma(r62, r91, r71);
+    r101 = r56 * r1;
+    r101 = r101 * r121;
+    r101 = r101 * r43;
+    r101 = r101 * r75;
+    r71 = fma(r92, r101, r71);
+    r85 = r84 * r72;
+    r85 = r85 * r121;
+    r85 = r85 * r30;
+    r85 = r85 * r92;
+    r71 = fma(r77, r85, r71);
+    r128 = r21 * r34;
+    r128 = r128 * r7;
+    r128 = r128 * r72;
+    r128 = r128 * r76;
+    r71 = fma(r53, r128, r71);
+    r129 = r5 * r55;
+    r71 = fma(r107, r129, r71);
+    r71 = fma(r38, r79, r71);
+    r71 = fma(r121, r118, r71);
+    r71 = fma(r38, r78, r71);
+    r129 = r3 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r89, r129);
+    r129 = r6 * r6;
+    r89 = r10 * r41;
+    r89 = r89 * r7;
+    r89 = fma(r32, r80, r39 * r89);
+    r128 = r10 * r54;
+    r128 = r128 * r6;
+    r89 = fma(r39, r128, r89);
+    r85 = r32 * r6;
+    r85 = r85 * r6;
+    r89 = fma(r31, r85, r89);
+    r129 = r129 * r112;
+    r129 = r129 * r89;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r85 = r60 * r89;
+    r85 = r85 * r66;
+    r85 = r85 * r99;
+    r85 = fma(r63, r85, r59 * r129);
+    r129 = r54 * r110;
+    r129 = r129 * r59;
+    r85 = fma(r62, r129, r85);
+    r128 = fma(r41, r107, r32 * r103);
+    r101 = r89 * r92;
+    r101 = r101 * r99;
+    r128 = fma(r105, r101, r128);
+    r91 = r21 * r7;
+    r91 = r91 * r89;
+    r128 = fma(r47, r91, r128);
+    r85 = fma(r32, r115, r85);
+    r85 = r85 + r128;
+    r129 = r21 * r6;
+    r129 = r129 * r6;
+    r129 = r129 * r89;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r91 = r89 * r66;
+    r91 = r91 * r99;
+    r91 = fma(r63, r91, r59 * r129);
+    r129 = r54 * r62;
+    r91 = fma(r68, r129, r91);
+    r101 = r32 * r31;
+    r91 = fma(r81, r101, r91);
+    r128 = r128 + r91;
+    r85 = fma(r64, r128, r5 * r85);
+    r101 = r4 * r54;
+    r85 = fma(r107, r101, r85);
+    r129 = r4 * r41;
+    r129 = r129 * r62;
+    r85 = fma(r68, r129, r85);
+    r26 = r70 * r10;
+    r26 = r26 * r48;
+    r26 = fma(r128, r26, r69 * r128);
+    r26 = fma(r128, r74, r26);
+    r26 = fma(r128, r73, r26);
+    r104 = r6 * r26;
+    r85 = fma(r78, r104, r85);
+    r67 = r4 * r89;
+    r85 = fma(r122, r67, r85);
+    r8 = r21 * r32;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r85 = fma(r53, r8, r85);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r89;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r85 = fma(r62, r22, r85);
+    r9 = r4 * r35;
+    r9 = r9 * r6;
+    r9 = r9 * r89;
+    r85 = fma(r47, r9, r85);
+    r131 = r21 * r32;
+    r131 = r131 * r6;
+    r131 = r131 * r72;
+    r131 = r131 * r76;
+    r85 = fma(r53, r131, r85);
+    r102 = r56 * r1;
+    r102 = r102 * r89;
+    r102 = r102 * r75;
+    r102 = r102 * r66;
+    r85 = fma(r62, r102, r85);
+    r85 = fma(r54, r79, r85);
+    r85 = fma(r32, r120, r85);
+    r85 = fma(r89, r117, r85);
+    r85 = fma(r89, r116, r85);
+    r85 = fma(r54, r78, r85);
+    r102 = r2 * r85;
+    r131 = r32 * r7;
+    r131 = r131 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r114;
+    r131 = r131 * r43;
+    r9 = r41 * r7;
+    r9 = r9 * r110;
+    r9 = r9 * r43;
+    r9 = fma(r59, r9, r57 * r131);
+    r131 = r60 * r89;
+    r131 = r131 * r92;
+    r131 = r131 * r99;
+    r9 = fma(r105, r131, r9);
+    r22 = r7 * r112;
+    r22 = r22 * r89;
+    r9 = fma(r47, r22, r9);
+    r9 = r9 + r91;
+    r9 = fma(r4, r9, r65 * r128);
+    r128 = r56 * r1;
+    r128 = r128 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r75;
+    r9 = fma(r92, r128, r9);
+    r91 = r21 * r32;
+    r91 = r91 * r7;
+    r91 = r91 * r76;
+    r9 = fma(r53, r91, r9);
+    r22 = r5 * r54;
+    r9 = fma(r107, r22, r9);
+    r131 = r21 * r32;
+    r131 = r131 * r7;
+    r131 = r131 * r72;
+    r131 = r131 * r76;
+    r9 = fma(r53, r131, r9);
+    r8 = r84 * r72;
+    r8 = r8 * r89;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r9 = fma(r77, r8, r9);
+    r67 = r5 * r32;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r57;
+    r9 = fma(r62, r67, r9);
+    r104 = r5 * r41;
+    r104 = r104 * r62;
+    r9 = fma(r68, r104, r9);
+    r129 = r56 * r72;
+    r129 = r129 * r1;
+    r129 = r129 * r89;
+    r129 = r129 * r43;
+    r129 = r129 * r75;
+    r9 = fma(r92, r129, r9);
+    r101 = r5 * r89;
+    r9 = fma(r122, r101, r9);
+    r108 = r84 * r89;
+    r108 = r108 * r30;
+    r108 = r108 * r92;
+    r9 = fma(r77, r108, r9);
+    r130 = r7 * r26;
+    r9 = fma(r78, r130, r9);
+    r9 = fma(r41, r78, r9);
+    r9 = fma(r41, r79, r9);
+    r9 = fma(r89, r118, r9);
+    r130 = r3 * r9;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r102,
+                                             r130);
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r61 = r21 * r61;
+    r102 = r2 * r61;
+    r130 = fma(r106, r102, r109 * r130);
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r100, r102, r111 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r130, r108);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r23, r102, r132 * r108);
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r130 = fma(r124, r102, r82 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r108, r130);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r130 = fma(r113, r102, r71 * r130);
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r85, r102, r9 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r130, r108);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r2 * r2;
+    r130 = r106 * r108;
+    r101 = r3 * r3;
+    r129 = r109 * r101;
+    r109 = fma(r109, r129, r106 * r130);
+    r106 = r100 * r100;
+    r104 = r111 * r111;
+    r104 = fma(r101, r104, r108 * r106);
+    WriteSum2<double, double>((double*)inout_shared, r109, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r23 * r23;
+    r109 = r132 * r132;
+    r109 = fma(r101, r109, r108 * r104);
+    r104 = r82 * r82;
+    r106 = r124 * r124;
+    r106 = fma(r108, r106, r101 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r109, r106);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r106 = r113 * r113;
+    r109 = r71 * r71;
+    r109 = fma(r101, r109, r108 * r106);
+    r106 = r9 * r9;
+    r104 = r85 * r85;
+    r104 = fma(r108, r104, r101 * r106);
+    WriteSum2<double, double>((double*)inout_shared, r109, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = fma(r100, r130, r111 * r129);
+    r109 = fma(r132, r129, r23 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r104, r109);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = fma(r82, r129, r124 * r130);
+    r104 = fma(r71, r129, r113 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r109, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = fma(r85, r130, r9 * r129);
+    r129 = r111 * r132;
+    r104 = r100 * r23;
+    r104 = fma(r108, r104, r101 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r100 * r124;
+    r130 = r111 * r82;
+    r130 = fma(r101, r130, r108 * r104);
+    r104 = r100 * r113;
+    r129 = r111 * r71;
+    r129 = fma(r101, r129, r108 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r130, r129);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r111 * r9;
+    r130 = r100 * r85;
+    r130 = fma(r108, r130, r101 * r129);
+    r129 = r132 * r82;
+    r104 = r23 * r124;
+    r104 = fma(r108, r104, r101 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r23 * r113;
+    r130 = r132 * r71;
+    r130 = fma(r101, r130, r108 * r104);
+    r104 = r132 * r9;
+    r129 = r23 * r85;
+    r129 = fma(r108, r129, r101 * r104);
+    WriteSum2<double, double>((double*)inout_shared, r130, r129);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r124 * r113;
+    r130 = r82 * r71;
+    r130 = fma(r101, r130, r108 * r129);
+    r129 = r82 * r9;
+    r104 = r124 * r85;
+    r104 = fma(r108, r104, r101 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r104);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r104 = r71 * r9;
+    r130 = r113 * r85;
+    r130 = fma(r108, r130, r101 * r104);
+    WriteSum1<double, double>((double*)inout_shared, r130);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r61, r130);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r36, r36);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r7;
+    r130 = r10 * r51;
+    r130 = r130 * r6;
+    r130 = fma(r58, r80, r39 * r130);
+    r61 = r58 * r6;
+    r61 = r61 * r6;
+    r130 = fma(r31, r61, r130);
+    r104 = r10 * r28;
+    r104 = r104 * r7;
+    r130 = fma(r39, r104, r130);
+    r36 = r36 * r130;
+    r36 = fma(r47, r36, r58 * r103);
+    r104 = r130 * r92;
+    r104 = r104 * r99;
+    r36 = fma(r105, r104, r36);
+    r36 = fma(r28, r107, r36);
+    r104 = r58 * r31;
+    r61 = r130 * r66;
+    r61 = r61 * r99;
+    r61 = fma(r63, r61, r81 * r104);
+    r104 = r51 * r62;
+    r61 = fma(r68, r104, r61);
+    r129 = r21 * r6;
+    r129 = r129 * r6;
+    r129 = r129 * r130;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r61 = fma(r59, r129, r61);
+    r129 = r36 + r61;
+    r104 = r60 * r130;
+    r104 = r104 * r66;
+    r104 = r104 * r99;
+    r104 = fma(r63, r104, r58 * r115);
+    r109 = r51 * r110;
+    r109 = r109 * r59;
+    r104 = fma(r62, r109, r104);
+    r106 = r6 * r6;
+    r106 = r106 * r112;
+    r106 = r106 * r130;
+    r106 = r106 * r66;
+    r106 = r106 * r49;
+    r104 = fma(r59, r106, r104);
+    r104 = r104 + r36;
+    r104 = fma(r5, r104, r64 * r129);
+    r36 = r21 * r58;
+    r36 = r36 * r6;
+    r36 = r36 * r72;
+    r36 = r36 * r76;
+    r104 = fma(r53, r36, r104);
+    r106 = r4 * r130;
+    r104 = fma(r122, r106, r104);
+    r109 = r4 * r35;
+    r109 = r109 * r6;
+    r109 = r109 * r130;
+    r104 = fma(r47, r109, r104);
+    r67 = r4 * r51;
+    r104 = fma(r107, r67, r104);
+    r8 = r21 * r58;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r104 = fma(r53, r8, r104);
+    r131 = r56 * r72;
+    r131 = r131 * r1;
+    r131 = r131 * r130;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r104 = fma(r62, r131, r104);
+    r22 = r70 * r10;
+    r22 = r22 * r48;
+    r22 = fma(r69, r129, r129 * r22);
+    r22 = fma(r129, r74, r22);
+    r22 = fma(r129, r73, r22);
+    r91 = r6 * r22;
+    r104 = fma(r78, r91, r104);
+    r128 = r4 * r28;
+    r128 = r128 * r62;
+    r104 = fma(r68, r128, r104);
+    r134 = r56 * r1;
+    r134 = r134 * r130;
+    r134 = r134 * r75;
+    r134 = r134 * r66;
+    r104 = fma(r62, r134, r104);
+    r104 = fma(r130, r117, r104);
+    r104 = fma(r130, r116, r104);
+    r104 = fma(r51, r78, r104);
+    r104 = fma(r58, r120, r104);
+    r104 = fma(r51, r79, r104);
+    r134 = r2 * r104;
+    r128 = r58 * r7;
+    r128 = r128 * r7;
+    r128 = r128 * r56;
+    r128 = r128 * r56;
+    r128 = r128 * r114;
+    r128 = r128 * r43;
+    r91 = r7 * r112;
+    r91 = r91 * r130;
+    r91 = fma(r47, r91, r57 * r128);
+    r128 = r60 * r130;
+    r128 = r128 * r92;
+    r128 = r128 * r99;
+    r91 = fma(r105, r128, r91);
+    r131 = r28 * r7;
+    r131 = r131 * r110;
+    r131 = r131 * r43;
+    r91 = fma(r59, r131, r91);
+    r91 = r91 + r61;
+    r91 = fma(r4, r91, r65 * r129);
+    r129 = r7 * r22;
+    r91 = fma(r78, r129, r91);
+    r61 = r84 * r130;
+    r61 = r61 * r30;
+    r61 = r61 * r92;
+    r91 = fma(r77, r61, r91);
+    r131 = r21 * r58;
+    r131 = r131 * r7;
+    r131 = r131 * r76;
+    r91 = fma(r53, r131, r91);
+    r128 = r5 * r130;
+    r91 = fma(r122, r128, r91);
+    r8 = r5 * r51;
+    r91 = fma(r107, r8, r91);
+    r67 = r56 * r1;
+    r67 = r67 * r130;
+    r67 = r67 * r43;
+    r67 = r67 * r75;
+    r91 = fma(r92, r67, r91);
+    r109 = r84 * r72;
+    r109 = r109 * r130;
+    r109 = r109 * r30;
+    r109 = r109 * r92;
+    r91 = fma(r77, r109, r91);
+    r106 = r56 * r72;
+    r106 = r106 * r1;
+    r106 = r106 * r130;
+    r106 = r106 * r43;
+    r106 = r106 * r75;
+    r91 = fma(r92, r106, r91);
+    r36 = r21 * r58;
+    r36 = r36 * r7;
+    r36 = r36 * r72;
+    r36 = r36 * r76;
+    r91 = fma(r53, r36, r91);
+    r135 = r5 * r58;
+    r135 = r135 * r7;
+    r135 = r135 * r56;
+    r135 = r135 * r56;
+    r135 = r135 * r95;
+    r135 = r135 * r57;
+    r91 = fma(r62, r135, r91);
+    r136 = r5 * r28;
+    r136 = r136 * r62;
+    r91 = fma(r68, r136, r91);
+    r91 = fma(r28, r79, r91);
+    r91 = fma(r130, r118, r91);
+    r91 = fma(r28, r78, r91);
+    r136 = r3 * r91;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r134,
+                                             r136);
+    r136 = r45 * r110;
+    r136 = r136 * r59;
+    r136 = fma(r40, r115, r62 * r136);
+    r134 = r6 * r6;
+    r135 = r40 * r6;
+    r135 = r135 * r6;
+    r36 = r10 * r45;
+    r36 = r36 * r6;
+    r36 = fma(r39, r36, r31 * r135);
+    r135 = r10 * r46;
+    r135 = r135 * r7;
+    r36 = fma(r39, r135, r36);
+    r36 = fma(r40, r80, r36);
+    r134 = r134 * r112;
+    r134 = r134 * r36;
+    r134 = r134 * r66;
+    r134 = r134 * r49;
+    r136 = fma(r59, r134, r136);
+    r135 = r60 * r36;
+    r135 = r135 * r66;
+    r135 = r135 * r99;
+    r136 = fma(r63, r135, r136);
+    r106 = r36 * r92;
+    r106 = r106 * r99;
+    r106 = fma(r105, r106, r40 * r103);
+    r109 = r21 * r7;
+    r109 = r109 * r36;
+    r106 = fma(r47, r109, r106);
+    r106 = fma(r46, r107, r106);
+    r136 = r136 + r106;
+    r135 = r45 * r62;
+    r134 = r40 * r31;
+    r134 = fma(r81, r134, r68 * r135);
+    r135 = r21 * r6;
+    r135 = r135 * r6;
+    r135 = r135 * r36;
+    r135 = r135 * r66;
+    r135 = r135 * r49;
+    r134 = fma(r59, r135, r134);
+    r109 = r36 * r66;
+    r109 = r109 * r99;
+    r134 = fma(r63, r109, r134);
+    r106 = r106 + r134;
+    r136 = fma(r64, r106, r5 * r136);
+    r109 = r21 * r40;
+    r109 = r109 * r6;
+    r109 = r109 * r72;
+    r109 = r109 * r76;
+    r136 = fma(r53, r109, r136);
+    r135 = r70 * r10;
+    r135 = r135 * r48;
+    r135 = fma(r106, r135, r69 * r106);
+    r135 = fma(r106, r73, r135);
+    r135 = fma(r106, r74, r135);
+    r67 = r6 * r135;
+    r136 = fma(r78, r67, r136);
+    r8 = r21 * r40;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r136 = fma(r53, r8, r136);
+    r128 = r4 * r46;
+    r128 = r128 * r62;
+    r136 = fma(r68, r128, r136);
+    r131 = r4 * r45;
+    r136 = fma(r107, r131, r136);
+    r61 = r56 * r1;
+    r61 = r61 * r36;
+    r61 = r61 * r75;
+    r61 = r61 * r66;
+    r136 = fma(r62, r61, r136);
+    r129 = r4 * r36;
+    r136 = fma(r122, r129, r136);
+    r137 = r4 * r35;
+    r137 = r137 * r6;
+    r137 = r137 * r36;
+    r136 = fma(r47, r137, r136);
+    r138 = r56 * r72;
+    r138 = r138 * r1;
+    r138 = r138 * r36;
+    r138 = r138 * r75;
+    r138 = r138 * r66;
+    r136 = fma(r62, r138, r136);
+    r136 = fma(r45, r79, r136);
+    r136 = fma(r36, r116, r136);
+    r136 = fma(r36, r117, r136);
+    r136 = fma(r45, r78, r136);
+    r136 = fma(r40, r120, r136);
+    r138 = r2 * r136;
+    r137 = r40 * r7;
+    r137 = r137 * r7;
+    r137 = r137 * r56;
+    r137 = r137 * r56;
+    r137 = r137 * r114;
+    r137 = r137 * r43;
+    r129 = r60 * r36;
+    r129 = r129 * r92;
+    r129 = r129 * r99;
+    r129 = fma(r105, r129, r57 * r137);
+    r137 = r46 * r7;
+    r137 = r137 * r110;
+    r137 = r137 * r43;
+    r129 = fma(r59, r137, r129);
+    r61 = r7 * r112;
+    r61 = r61 * r36;
+    r129 = fma(r47, r61, r129);
+    r129 = r129 + r134;
+    r106 = fma(r65, r106, r4 * r129);
+    r129 = r21 * r40;
+    r129 = r129 * r7;
+    r129 = r129 * r76;
+    r106 = fma(r53, r129, r106);
+    r134 = r21 * r40;
+    r134 = r134 * r7;
+    r134 = r134 * r72;
+    r134 = r134 * r76;
+    r106 = fma(r53, r134, r106);
+    r61 = r84 * r36;
+    r61 = r61 * r30;
+    r61 = r61 * r92;
+    r106 = fma(r77, r61, r106);
+    r137 = r5 * r46;
+    r137 = r137 * r62;
+    r106 = fma(r68, r137, r106);
+    r131 = r56 * r1;
+    r131 = r131 * r36;
+    r131 = r131 * r43;
+    r131 = r131 * r75;
+    r106 = fma(r92, r131, r106);
+    r128 = r5 * r45;
+    r106 = fma(r107, r128, r106);
+    r8 = r5 * r36;
+    r106 = fma(r122, r8, r106);
+    r67 = r5 * r40;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r57;
+    r106 = fma(r62, r67, r106);
+    r109 = r84 * r72;
+    r109 = r109 * r36;
+    r109 = r109 * r30;
+    r109 = r109 * r92;
+    r106 = fma(r77, r109, r106);
+    r139 = r7 * r135;
+    r106 = fma(r78, r139, r106);
+    r140 = r56 * r72;
+    r140 = r140 * r1;
+    r140 = r140 * r36;
+    r140 = r140 * r43;
+    r140 = r140 * r75;
+    r106 = fma(r92, r140, r106);
+    r106 = fma(r46, r79, r106);
+    r106 = fma(r36, r118, r106);
+    r106 = fma(r46, r78, r106);
+    r140 = r3 * r106;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r140);
+    r140 = r6 * r6;
+    r138 = r10 * r52;
+    r138 = r138 * r6;
+    r80 = fma(r50, r80, r39 * r138);
+    r138 = r50 * r6;
+    r138 = r138 * r6;
+    r80 = fma(r31, r138, r80);
+    r139 = r10 * r44;
+    r139 = r139 * r7;
+    r80 = fma(r39, r139, r80);
+    r140 = r140 * r112;
+    r140 = r140 * r80;
+    r140 = r140 * r66;
+    r140 = r140 * r49;
+    r140 = fma(r59, r140, r50 * r115);
+    r115 = r60 * r80;
+    r115 = r115 * r66;
+    r115 = r115 * r99;
+    r140 = fma(r63, r115, r140);
+    r139 = r52 * r110;
+    r139 = r139 * r59;
+    r140 = fma(r62, r139, r140);
+    r138 = r21 * r7;
+    r138 = r138 * r80;
+    r138 = fma(r47, r138, r44 * r107);
+    r39 = r80 * r92;
+    r39 = r39 * r99;
+    r138 = fma(r105, r39, r138);
+    r138 = fma(r50, r103, r138);
+    r140 = r140 + r138;
+    r139 = r50 * r31;
+    r115 = r21 * r6;
+    r115 = r115 * r6;
+    r115 = r115 * r80;
+    r115 = r115 * r66;
+    r115 = r115 * r49;
+    r115 = fma(r59, r115, r81 * r139);
+    r139 = r80 * r66;
+    r139 = r139 * r99;
+    r115 = fma(r63, r139, r115);
+    r63 = r52 * r62;
+    r115 = fma(r68, r63, r115);
+    r138 = r138 + r115;
+    r64 = fma(r64, r138, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r76;
+    r64 = fma(r53, r140, r64);
+    r63 = r4 * r44;
+    r63 = r63 * r62;
+    r64 = fma(r68, r63, r64);
+    r139 = r4 * r35;
+    r139 = r139 * r6;
+    r139 = r139 * r80;
+    r64 = fma(r47, r139, r64);
+    r81 = r56 * r1;
+    r81 = r81 * r80;
+    r81 = r81 * r75;
+    r81 = r81 * r66;
+    r64 = fma(r62, r81, r64);
+    r49 = r4 * r80;
+    r64 = fma(r122, r49, r64);
+    r103 = r4 * r52;
+    r64 = fma(r107, r103, r64);
+    r39 = r56 * r72;
+    r39 = r39 * r1;
+    r39 = r39 * r80;
+    r39 = r39 * r75;
+    r39 = r39 * r66;
+    r64 = fma(r62, r39, r64);
+    r109 = r21 * r50;
+    r109 = r109 * r6;
+    r109 = r109 * r72;
+    r109 = r109 * r76;
+    r64 = fma(r53, r109, r64);
+    r67 = r70 * r10;
+    r67 = r67 * r48;
+    r67 = fma(r138, r67, r69 * r138);
+    r67 = fma(r138, r74, r67);
+    r67 = fma(r138, r73, r67);
+    r73 = r6 * r67;
+    r64 = fma(r78, r73, r64);
+    r64 = fma(r52, r79, r64);
+    r64 = fma(r80, r116, r64);
+    r64 = fma(r80, r117, r64);
+    r64 = fma(r50, r120, r64);
+    r64 = fma(r52, r78, r64);
+    r2 = r2 * r64;
+    r73 = r44 * r7;
+    r73 = r73 * r110;
+    r73 = r73 * r43;
+    r109 = r7 * r112;
+    r109 = r109 * r80;
+    r109 = fma(r47, r109, r59 * r73);
+    r73 = r60 * r80;
+    r73 = r73 * r92;
+    r73 = r73 * r99;
+    r109 = fma(r105, r73, r109);
+    r105 = r50 * r7;
+    r105 = r105 * r7;
+    r105 = r105 * r56;
+    r105 = r105 * r56;
+    r105 = r105 * r114;
+    r105 = r105 * r43;
+    r109 = fma(r57, r105, r109);
+    r109 = r109 + r115;
+    r109 = fma(r4, r109, r65 * r138);
+    r138 = r5 * r44;
+    r138 = r138 * r62;
+    r109 = fma(r68, r138, r109);
+    r68 = r56 * r1;
+    r68 = r68 * r80;
+    r68 = r68 * r43;
+    r68 = r68 * r75;
+    r109 = fma(r92, r68, r109);
+    r65 = r5 * r80;
+    r109 = fma(r122, r65, r109);
+    r122 = r56 * r72;
+    r122 = r122 * r1;
+    r122 = r122 * r80;
+    r122 = r122 * r43;
+    r122 = r122 * r75;
+    r109 = fma(r92, r122, r109);
+    r75 = r84 * r72;
+    r75 = r75 * r80;
+    r75 = r75 * r30;
+    r75 = r75 * r92;
+    r109 = fma(r77, r75, r109);
+    r43 = r21 * r50;
+    r43 = r43 * r7;
+    r43 = r43 * r72;
+    r43 = r43 * r76;
+    r109 = fma(r53, r43, r109);
+    r115 = r5 * r50;
+    r115 = r115 * r7;
+    r115 = r115 * r56;
+    r115 = r115 * r56;
+    r115 = r115 * r95;
+    r115 = r115 * r57;
+    r109 = fma(r62, r115, r109);
+    r57 = r5 * r52;
+    r109 = fma(r107, r57, r109);
+    r107 = r7 * r67;
+    r109 = fma(r78, r107, r109);
+    r95 = r84 * r80;
+    r95 = r95 * r30;
+    r95 = r95 * r92;
+    r109 = fma(r77, r95, r109);
+    r77 = r21 * r50;
+    r77 = r77 * r7;
+    r77 = r77 * r76;
+    r109 = fma(r53, r77, r109);
+    r109 = fma(r80, r118, r109);
+    r109 = fma(r44, r79, r109);
+    r109 = fma(r44, r78, r109);
+    r77 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r2, r77);
+    r77 = r3 * r21;
+    r77 = r77 * r0;
+    r77 = fma(r104, r102, r91 * r77);
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r2 = fma(r136, r102, r106 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r77, r2);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r102 = fma(r64, r102, r109 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r102);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r91 * r91;
+    r2 = r104 * r104;
+    r2 = fma(r108, r2, r101 * r102);
+    r102 = r106 * r106;
+    r0 = r136 * r136;
+    r0 = fma(r108, r0, r101 * r102);
+    WriteSum2<double, double>((double*)inout_shared, r2, r0);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r109 * r109;
+    r2 = r64 * r64;
+    r2 = fma(r108, r2, r101 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r2);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r91 * r106;
+    r0 = r104 * r136;
+    r0 = fma(r108, r0, r101 * r2);
+    r2 = r91 * r109;
+    r102 = r104 * r64;
+    r102 = fma(r108, r102, r101 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r0, r102);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r106 * r109;
+    r0 = r136 * r64;
+    r0 = fma(r108, r0, r101 * r102);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.cu
@@ -1,0 +1,2377 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r64,
+                                            r65);
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r61 = fma(r64, r48, r5 * r61);
+    r67 = r4 * r7;
+    r68 = r10 * r59;
+    r67 = r67 * r62;
+    r61 = fma(r68, r67, r61);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r69,
+                                            r70);
+    r71 = r48 * r48;
+    r72 = fma(r70, r71, r69 * r48);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r73,
+                                            r74);
+    r75 = r48 * r71;
+    r74 = r74 * r75;
+    r72 = fma(r48, r74, r72);
+    r72 = fma(r73, r75, r72);
+    r75 = 1.0 / r31;
+    r76 = 1.0 / r47;
+    r77 = r75 * r76;
+    r78 = r56 * r77;
+    r79 = r72 * r78;
+    r61 = fma(r6, r79, r61);
+    r61 = fma(r6, r78, r61);
+    r61 = fma(r2, r61, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r67);
+    r61 = fma(r0, r21, r61);
+    r0 = r7 * r7;
+    r0 = r0 * r60;
+    r0 = r0 * r43;
+    r0 = fma(r59, r0, r66);
+    r0 = fma(r65, r48, r4 * r0);
+    r66 = r5 * r7;
+    r66 = r66 * r62;
+    r0 = fma(r68, r66, r0);
+    r0 = fma(r7, r79, r0);
+    r0 = fma(r7, r78, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r67, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r61, r0);
+    r67 = fma(r0, r0, r61 * r61);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r67);
+  if (global_thread_idx < problem_size) {
+    r67 = r6 * r43;
+    r1 = -5.00000000000000000e-01;
+    r66 = rsqrt(r30);
+    r80 = r10 * r6;
+    r81 = r11 * r14;
+    r82 = r16 * r17;
+    r82 = fma(r1, r82, r1 * r81);
+    r81 = r15 * r18;
+    r82 = fma(r1, r81, r82);
+    r83 = r12 * r13;
+    r84 = 5.00000000000000000e-01;
+    r82 = fma(r84, r83, r82);
+    r83 = r24 * r82;
+    r81 = r15 * r14;
+    r85 = r12 * r17;
+    r85 = fma(r84, r85, r84 * r81);
+    r81 = r11 * r18;
+    r85 = fma(r1, r81, r85);
+    r86 = r16 * r13;
+    r85 = fma(r84, r86, r85);
+    r86 = r29 * r85;
+    r81 = fma(r10, r86, r10 * r83);
+    r87 = r10 * r19;
+    r88 = fma(r84, r26, r1 * r22);
+    r88 = fma(r1, r23, r88);
+    r88 = fma(r1, r25, r88);
+    r89 = r10 * r27;
+    r90 = r16 * r14;
+    r91 = r11 * r17;
+    r91 = fma(r1, r91, r84 * r90);
+    r90 = r12 * r18;
+    r91 = fma(r1, r90, r91);
+    r92 = r15 * r13;
+    r91 = fma(r1, r92, r91);
+    r89 = r89 * r91;
+    r87 = fma(r88, r87, r89);
+    r81 = r81 + r87;
+    r92 = r10 * r24;
+    r92 = r92 * r91;
+    r90 = r10 * r19;
+    r90 = r90 * r85;
+    r93 = r92 + r90;
+    r94 = r27 * r35;
+    r93 = fma(r82, r94, r93);
+    r95 = r35 * r29;
+    r93 = fma(r88, r95, r93);
+    r93 = fma(r9, r93, r42 * r81);
+    r81 = r24 * r85;
+    r95 = -4.00000000000000000e+00;
+    r81 = r81 * r95;
+    r94 = r27 * r88;
+    r96 = r95 * r94;
+    r97 = r81 + r96;
+    r93 = fma(r8, r97, r93);
+    r80 = r80 * r93;
+    r97 = r6 * r6;
+    r98 = r10 * r24;
+    r98 = r98 * r88;
+    r99 = r10 * r27;
+    r99 = fma(r85, r99, r98);
+    r85 = r10 * r19;
+    r85 = r85 * r82;
+    r100 = r10 * r29;
+    r100 = r100 * r91;
+    r101 = r85 + r100;
+    r102 = r99 + r101;
+    r86 = fma(r35, r86, r35 * r83);
+    r86 = r86 + r87;
+    r86 = fma(r8, r86, r9 * r102);
+    r102 = r19 * r91;
+    r102 = r102 * r95;
+    r81 = r81 + r102;
+    r86 = fma(r42, r81, r86);
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r31 = r35 * r57;
+    r97 = r97 * r86;
+    r97 = fma(r31, r97, r39 * r80);
+    r80 = r7 * r7;
+    r80 = r80 * r31;
+    r81 = r10 * r7;
+    r103 = r19 * r35;
+    r104 = r35 * r29;
+    r104 = r104 * r91;
+    r103 = fma(r82, r103, r104);
+    r103 = r103 + r99;
+    r96 = r102 + r96;
+    r96 = fma(r9, r96, r42 * r103);
+    r103 = r10 * r29;
+    r103 = fma(r88, r103, r90);
+    r90 = r10 * r27;
+    r90 = fma(r82, r90, r92);
+    r103 = r103 + r90;
+    r96 = fma(r8, r103, r96);
+    r81 = r81 * r96;
+    r97 = fma(r39, r81, r97);
+    r97 = fma(r86, r80, r97);
+    r67 = r67 * r56;
+    r67 = r67 * r75;
+    r67 = r67 * r1;
+    r67 = r67 * r66;
+    r67 = r67 * r97;
+    r81 = r56 * r56;
+    r103 = r43 * r81;
+    r103 = r103 * r80;
+    r92 = r7 * r66;
+    r102 = r97 * r92;
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r99 = r30 * r53;
+    r105 = r7 * r43;
+    r102 = r102 * r99;
+    r102 = fma(r105, r102, r86 * r103);
+    r106 = r21 * r7;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r47 = r49 * r59;
+    r47 = r47 * r92;
+    r106 = r106 * r97;
+    r102 = fma(r47, r106, r102);
+    r107 = r68 * r105;
+    r102 = fma(r96, r107, r102);
+    r106 = r97 * r66;
+    r106 = r106 * r99;
+    r108 = r21 * r6;
+    r108 = r108 * r6;
+    r108 = r108 * r97;
+    r108 = r108 * r66;
+    r108 = r108 * r49;
+    r108 = fma(r59, r108, r63 * r106);
+    r106 = r93 * r62;
+    r108 = fma(r68, r106, r108);
+    r109 = r86 * r31;
+    r81 = r63 * r81;
+    r108 = fma(r81, r109, r108);
+    r109 = r102 + r108;
+    r106 = fma(r64, r109, r67);
+    r110 = r60 * r97;
+    r110 = r110 * r66;
+    r110 = r110 * r99;
+    r111 = r6 * r6;
+    r112 = -3.00000000000000000e+00;
+    r111 = r111 * r112;
+    r111 = r111 * r97;
+    r111 = r111 * r66;
+    r111 = r111 * r49;
+    r111 = fma(r59, r111, r63 * r110);
+    r110 = 6.00000000000000000e+00;
+    r113 = r93 * r110;
+    r113 = r113 * r59;
+    r111 = fma(r62, r113, r111);
+    r114 = -6.00000000000000000e+00;
+    r115 = r114 * r57;
+    r115 = r115 * r81;
+    r111 = fma(r86, r115, r111);
+    r111 = r111 + r102;
+    r102 = r93 * r107;
+    r113 = r21 * r6;
+    r113 = r113 * r72;
+    r113 = r113 * r86;
+    r113 = r113 * r76;
+    r106 = fma(r53, r113, r106);
+    r116 = r6 * r84;
+    r116 = r116 * r66;
+    r116 = r116 * r30;
+    r116 = r116 * r77;
+    r117 = r72 * r116;
+    r118 = r4 * r35;
+    r118 = r118 * r6;
+    r118 = r118 * r97;
+    r106 = fma(r47, r118, r106);
+    r119 = r4 * r96;
+    r119 = r119 * r62;
+    r106 = fma(r68, r119, r106);
+    r120 = r4 * r7;
+    r120 = r120 * r56;
+    r120 = r120 * r56;
+    r120 = r120 * r95;
+    r120 = r120 * r57;
+    r120 = r120 * r62;
+    r121 = r4 * r97;
+    r122 = r10 * r62;
+    r122 = r122 * r92;
+    r122 = r122 * r99;
+    r106 = fma(r122, r121, r106);
+    r123 = r70 * r10;
+    r123 = r123 * r48;
+    r123 = fma(r69, r109, r109 * r123);
+    r73 = r73 * r60;
+    r73 = r73 * r71;
+    r71 = 4.00000000000000000e+00;
+    r74 = r71 * r74;
+    r123 = fma(r109, r73, r123);
+    r123 = fma(r109, r74, r123);
+    r71 = r6 * r123;
+    r106 = fma(r78, r71, r106);
+    r124 = r21 * r6;
+    r124 = r124 * r86;
+    r124 = r124 * r76;
+    r106 = fma(r53, r124, r106);
+    r106 = fma(r5, r111, r106);
+    r106 = fma(r4, r102, r106);
+    r106 = fma(r72, r67, r106);
+    r106 = fma(r97, r117, r106);
+    r106 = fma(r93, r79, r106);
+    r106 = fma(r86, r120, r106);
+    r106 = fma(r97, r116, r106);
+    r106 = fma(r93, r78, r106);
+    r124 = r2 * r106;
+    r71 = r7 * r43;
+    r71 = r71 * r56;
+    r71 = r71 * r75;
+    r71 = r71 * r1;
+    r71 = r71 * r66;
+    r71 = r71 * r97;
+    r109 = fma(r65, r109, r71);
+    r121 = r7 * r7;
+    r121 = r121 * r56;
+    r121 = r121 * r56;
+    r121 = r121 * r86;
+    r121 = r121 * r114;
+    r121 = r121 * r43;
+    r119 = r60 * r97;
+    r119 = r119 * r92;
+    r119 = r119 * r99;
+    r119 = fma(r105, r119, r57 * r121);
+    r121 = r7 * r112;
+    r121 = r121 * r97;
+    r119 = fma(r47, r121, r119);
+    r118 = r7 * r96;
+    r118 = r118 * r110;
+    r118 = r118 * r43;
+    r119 = fma(r59, r118, r119);
+    r119 = r119 + r108;
+    r108 = r21 * r7;
+    r108 = r108 * r86;
+    r108 = r108 * r76;
+    r109 = fma(r53, r108, r109);
+    r118 = r5 * r35;
+    r118 = r118 * r6;
+    r118 = r118 * r47;
+    r121 = r84 * r97;
+    r121 = r121 * r30;
+    r121 = r121 * r92;
+    r109 = fma(r77, r121, r109);
+    r113 = r5 * r96;
+    r113 = r113 * r62;
+    r109 = fma(r68, r113, r109);
+    r67 = r5 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r86;
+    r67 = r67 * r57;
+    r109 = fma(r62, r67, r109);
+    r111 = r7 * r123;
+    r109 = fma(r78, r111, r109);
+    r125 = r5 * r97;
+    r109 = fma(r122, r125, r109);
+    r126 = r84 * r72;
+    r126 = r126 * r97;
+    r126 = r126 * r30;
+    r126 = r126 * r92;
+    r109 = fma(r77, r126, r109);
+    r127 = r21 * r7;
+    r127 = r127 * r72;
+    r127 = r127 * r86;
+    r127 = r127 * r76;
+    r109 = fma(r53, r127, r109);
+    r109 = fma(r4, r119, r109);
+    r109 = fma(r5, r102, r109);
+    r109 = fma(r72, r71, r109);
+    r109 = fma(r97, r118, r109);
+    r109 = fma(r96, r79, r109);
+    r109 = fma(r96, r78, r109);
+    r127 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r124,
+                                             r127);
+    r127 = r35 * r24;
+    r127 = fma(r88, r127, r104);
+    r124 = r10 * r27;
+    r126 = r15 * r14;
+    r125 = r12 * r17;
+    r125 = fma(r1, r125, r1 * r126);
+    r126 = r11 * r18;
+    r125 = fma(r84, r126, r125);
+    r111 = r16 * r13;
+    r125 = fma(r1, r111, r125);
+    r124 = r124 * r125;
+    r111 = r10 * r19;
+    r126 = r11 * r14;
+    r67 = r16 * r17;
+    r67 = fma(r84, r67, r84 * r126);
+    r126 = r15 * r18;
+    r67 = fma(r84, r126, r67);
+    r113 = r12 * r13;
+    r67 = fma(r1, r113, r67);
+    r111 = fma(r67, r111, r124);
+    r127 = r127 + r111;
+    r113 = r10 * r24;
+    r113 = r113 * r67;
+    r126 = r10 * r29;
+    r126 = fma(r125, r126, r113);
+    r126 = r126 + r87;
+    r126 = fma(r9, r126, r8 * r127);
+    r127 = r24 * r91;
+    r127 = r127 * r95;
+    r87 = r19 * r125;
+    r121 = r95 * r87;
+    r71 = r127 + r121;
+    r126 = fma(r42, r71, r126);
+    r100 = r98 + r100;
+    r100 = r100 + r111;
+    r111 = r27 * r95;
+    r111 = r111 * r67;
+    r127 = r127 + r111;
+    r127 = fma(r8, r127, r42 * r100);
+    r100 = r35 * r29;
+    r100 = fma(r35, r94, r67 * r100);
+    r98 = r10 * r19;
+    r98 = r98 * r91;
+    r71 = r10 * r24;
+    r71 = fma(r125, r71, r98);
+    r100 = r100 + r71;
+    r127 = fma(r9, r100, r127);
+    r100 = r110 * r127;
+    r100 = r100 * r59;
+    r100 = fma(r62, r100, r126 * r115);
+    r108 = r6 * r6;
+    r102 = r10 * r6;
+    r102 = r102 * r127;
+    r119 = r10 * r7;
+    r113 = r89 + r113;
+    r89 = r19 * r35;
+    r113 = fma(r88, r89, r113);
+    r88 = r35 * r29;
+    r113 = fma(r125, r88, r113);
+    r88 = r10 * r29;
+    r94 = fma(r10, r94, r67 * r88);
+    r94 = r94 + r71;
+    r94 = fma(r8, r94, r42 * r113);
+    r121 = r111 + r121;
+    r94 = fma(r9, r121, r94);
+    r119 = r119 * r94;
+    r119 = fma(r39, r119, r39 * r102);
+    r102 = r6 * r6;
+    r102 = r102 * r126;
+    r119 = fma(r31, r102, r119);
+    r119 = fma(r126, r80, r119);
+    r102 = r112 * r119;
+    r108 = r108 * r66;
+    r108 = r108 * r49;
+    r108 = r108 * r59;
+    r100 = fma(r102, r108, r100);
+    r121 = r60 * r119;
+    r121 = r121 * r66;
+    r121 = r121 * r99;
+    r100 = fma(r63, r121, r100);
+    r111 = r21 * r7;
+    r111 = r111 * r119;
+    r111 = fma(r47, r111, r94 * r107);
+    r113 = r119 * r92;
+    r113 = r113 * r99;
+    r111 = fma(r105, r113, r111);
+    r111 = fma(r126, r103, r111);
+    r100 = r100 + r111;
+    r121 = r126 * r31;
+    r108 = r127 * r62;
+    r108 = fma(r68, r108, r81 * r121);
+    r121 = r21 * r6;
+    r121 = r121 * r6;
+    r121 = r121 * r119;
+    r121 = r121 * r66;
+    r121 = r121 * r49;
+    r108 = fma(r59, r121, r108);
+    r113 = r119 * r66;
+    r113 = r113 * r99;
+    r108 = fma(r63, r113, r108);
+    r111 = r111 + r108;
+    r100 = fma(r64, r111, r5 * r100);
+    r113 = r21 * r6;
+    r113 = r113 * r126;
+    r113 = r113 * r76;
+    r100 = fma(r53, r113, r100);
+    r121 = r56 * r72;
+    r121 = r121 * r1;
+    r121 = r121 * r119;
+    r121 = r121 * r75;
+    r121 = r121 * r66;
+    r100 = fma(r62, r121, r100);
+    r88 = r70 * r10;
+    r88 = r88 * r48;
+    r88 = fma(r111, r88, r69 * r111);
+    r88 = fma(r111, r74, r88);
+    r88 = fma(r111, r73, r88);
+    r67 = r6 * r88;
+    r100 = fma(r78, r67, r100);
+    r89 = r21 * r6;
+    r89 = r89 * r72;
+    r89 = r89 * r126;
+    r89 = r89 * r76;
+    r100 = fma(r53, r89, r100);
+    r128 = r4 * r119;
+    r100 = fma(r122, r128, r100);
+    r129 = r4 * r35;
+    r129 = r129 * r6;
+    r129 = r129 * r119;
+    r100 = fma(r47, r129, r100);
+    r130 = r4 * r94;
+    r130 = r130 * r62;
+    r100 = fma(r68, r130, r100);
+    r131 = r4 * r127;
+    r100 = fma(r107, r131, r100);
+    r132 = r56 * r1;
+    r132 = r132 * r119;
+    r132 = r132 * r75;
+    r132 = r132 * r66;
+    r100 = fma(r62, r132, r100);
+    r100 = fma(r119, r117, r100);
+    r100 = fma(r119, r116, r100);
+    r100 = fma(r126, r120, r100);
+    r100 = fma(r127, r78, r100);
+    r100 = fma(r127, r79, r100);
+    r132 = r2 * r100;
+    r131 = r7 * r110;
+    r131 = r131 * r94;
+    r131 = r131 * r43;
+    r130 = r7 * r47;
+    r130 = fma(r102, r130, r59 * r131);
+    r131 = r7 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r114;
+    r131 = r131 * r126;
+    r131 = r131 * r43;
+    r130 = fma(r57, r131, r130);
+    r102 = r60 * r119;
+    r102 = r102 * r92;
+    r102 = r102 * r99;
+    r130 = fma(r105, r102, r130);
+    r130 = r130 + r108;
+    r111 = fma(r65, r111, r4 * r130);
+    r130 = r56 * r1;
+    r130 = r130 * r119;
+    r130 = r130 * r43;
+    r130 = r130 * r75;
+    r111 = fma(r92, r130, r111);
+    r108 = r7 * r88;
+    r111 = fma(r78, r108, r111);
+    r102 = r84 * r119;
+    r102 = r102 * r30;
+    r102 = r102 * r92;
+    r111 = fma(r77, r102, r111);
+    r131 = r5 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r95;
+    r131 = r131 * r126;
+    r131 = r131 * r57;
+    r111 = fma(r62, r131, r111);
+    r129 = r5 * r119;
+    r111 = fma(r122, r129, r111);
+    r128 = r21 * r7;
+    r128 = r128 * r72;
+    r128 = r128 * r126;
+    r128 = r128 * r76;
+    r111 = fma(r53, r128, r111);
+    r89 = r56 * r72;
+    r89 = r89 * r1;
+    r89 = r89 * r119;
+    r89 = r89 * r43;
+    r89 = r89 * r75;
+    r111 = fma(r92, r89, r111);
+    r67 = r21 * r7;
+    r67 = r67 * r126;
+    r67 = r67 * r76;
+    r111 = fma(r53, r67, r111);
+    r121 = r5 * r94;
+    r121 = r121 * r62;
+    r111 = fma(r68, r121, r111);
+    r113 = r84 * r72;
+    r113 = r113 * r119;
+    r113 = r113 * r30;
+    r113 = r113 * r92;
+    r111 = fma(r77, r113, r111);
+    r133 = r5 * r127;
+    r111 = fma(r107, r133, r111);
+    r111 = fma(r94, r79, r111);
+    r111 = fma(r119, r118, r111);
+    r111 = fma(r94, r78, r111);
+    r133 = r3 * r111;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r132,
+                                             r133);
+    r133 = r19 * r95;
+    r26 = fma(r1, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r133 = r133 * r26;
+    r83 = r95 * r83;
+    r25 = r133 + r83;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r98 = r98 + r23;
+    r22 = r35 * r24;
+    r98 = fma(r125, r22, r98);
+    r132 = r35 * r29;
+    r98 = fma(r82, r132, r98);
+    r98 = fma(r8, r98, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r87, r26 * r25);
+    r25 = r25 + r90;
+    r98 = fma(r9, r25, r98);
+    r25 = r10 * r7;
+    r132 = r10 * r24;
+    r132 = r132 * r26;
+    r124 = r124 + r132;
+    r124 = r124 + r101;
+    r101 = r35 * r29;
+    r87 = fma(r35, r87, r26 * r101);
+    r87 = r87 + r90;
+    r87 = fma(r42, r87, r8 * r124);
+    r91 = r27 * r91;
+    r91 = r91 * r95;
+    r133 = r133 + r91;
+    r87 = fma(r9, r133, r87);
+    r25 = r25 * r87;
+    r133 = r6 * r6;
+    r133 = r133 * r98;
+    r133 = fma(r31, r133, r39 * r25);
+    r25 = r10 * r6;
+    r104 = r85 + r104;
+    r85 = r27 * r35;
+    r104 = fma(r125, r85, r104);
+    r104 = r104 + r132;
+    r83 = r91 + r83;
+    r83 = fma(r8, r83, r9 * r104);
+    r8 = r10 * r29;
+    r8 = fma(r82, r8, r23);
+    r8 = r8 + r71;
+    r83 = fma(r42, r8, r83);
+    r25 = r25 * r83;
+    r133 = fma(r39, r25, r133);
+    r133 = fma(r98, r80, r133);
+    r25 = r133 * r92;
+    r25 = r25 * r99;
+    r25 = fma(r105, r25, r98 * r103);
+    r8 = r21 * r7;
+    r8 = r8 * r133;
+    r25 = fma(r47, r8, r25);
+    r25 = fma(r87, r107, r25);
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r42 = r83 * r62;
+    r42 = fma(r68, r42, r59 * r8);
+    r8 = r98 * r31;
+    r42 = fma(r81, r8, r42);
+    r71 = r133 * r66;
+    r71 = r71 * r99;
+    r42 = fma(r63, r71, r42);
+    r71 = r25 + r42;
+    r8 = r6 * r6;
+    r8 = r8 * r112;
+    r8 = r8 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r23 = r110 * r83;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r8);
+    r8 = r60 * r133;
+    r8 = r8 * r66;
+    r8 = r8 * r99;
+    r23 = fma(r63, r8, r23);
+    r23 = fma(r98, r115, r23);
+    r23 = r23 + r25;
+    r23 = fma(r5, r23, r64 * r71);
+    r25 = r70 * r10;
+    r25 = r25 * r48;
+    r25 = fma(r71, r25, r69 * r71);
+    r25 = fma(r71, r73, r25);
+    r25 = fma(r71, r74, r25);
+    r8 = r6 * r25;
+    r23 = fma(r78, r8, r23);
+    r82 = r4 * r83;
+    r23 = fma(r107, r82, r23);
+    r104 = r4 * r133;
+    r23 = fma(r122, r104, r23);
+    r9 = r21 * r6;
+    r9 = r9 * r72;
+    r9 = r9 * r98;
+    r9 = r9 * r76;
+    r23 = fma(r53, r9, r23);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r133;
+    r23 = fma(r47, r91, r23);
+    r85 = r21 * r6;
+    r85 = r85 * r98;
+    r85 = r85 * r76;
+    r23 = fma(r53, r85, r23);
+    r132 = r56 * r1;
+    r132 = r132 * r133;
+    r132 = r132 * r75;
+    r132 = r132 * r66;
+    r23 = fma(r62, r132, r23);
+    r125 = r4 * r87;
+    r125 = r125 * r62;
+    r23 = fma(r68, r125, r23);
+    r124 = r56 * r72;
+    r124 = r124 * r1;
+    r124 = r124 * r133;
+    r124 = r124 * r75;
+    r124 = r124 * r66;
+    r23 = fma(r62, r124, r23);
+    r23 = fma(r133, r116, r23);
+    r23 = fma(r133, r117, r23);
+    r23 = fma(r83, r79, r23);
+    r23 = fma(r83, r78, r23);
+    r23 = fma(r98, r120, r23);
+    r124 = r2 * r23;
+    r125 = r7 * r7;
+    r125 = r125 * r56;
+    r125 = r125 * r56;
+    r125 = r125 * r114;
+    r125 = r125 * r98;
+    r125 = r125 * r43;
+    r132 = r60 * r133;
+    r132 = r132 * r92;
+    r132 = r132 * r99;
+    r132 = fma(r105, r132, r57 * r125);
+    r125 = r7 * r110;
+    r125 = r125 * r87;
+    r125 = r125 * r43;
+    r132 = fma(r59, r125, r132);
+    r85 = r7 * r112;
+    r85 = r85 * r133;
+    r132 = fma(r47, r85, r132);
+    r132 = r132 + r42;
+    r132 = fma(r4, r132, r65 * r71);
+    r71 = r21 * r7;
+    r71 = r71 * r72;
+    r71 = r71 * r98;
+    r71 = r71 * r76;
+    r132 = fma(r53, r71, r132);
+    r42 = r21 * r7;
+    r42 = r42 * r98;
+    r42 = r42 * r76;
+    r132 = fma(r53, r42, r132);
+    r85 = r5 * r83;
+    r132 = fma(r107, r85, r132);
+    r125 = r56 * r72;
+    r125 = r125 * r1;
+    r125 = r125 * r133;
+    r125 = r125 * r43;
+    r125 = r125 * r75;
+    r132 = fma(r92, r125, r132);
+    r91 = r5 * r133;
+    r132 = fma(r122, r91, r132);
+    r9 = r84 * r133;
+    r9 = r9 * r30;
+    r9 = r9 * r92;
+    r132 = fma(r77, r9, r132);
+    r104 = r7 * r25;
+    r132 = fma(r78, r104, r132);
+    r82 = r56 * r1;
+    r82 = r82 * r133;
+    r82 = r82 * r43;
+    r82 = r82 * r75;
+    r132 = fma(r92, r82, r132);
+    r8 = r84 * r72;
+    r8 = r8 * r133;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r132 = fma(r77, r8, r132);
+    r90 = r5 * r7;
+    r90 = r90 * r56;
+    r90 = r90 * r56;
+    r90 = r90 * r95;
+    r90 = r90 * r98;
+    r90 = r90 * r57;
+    r132 = fma(r62, r90, r132);
+    r101 = r5 * r87;
+    r101 = r101 * r62;
+    r132 = fma(r68, r101, r132);
+    r132 = fma(r87, r79, r132);
+    r132 = fma(r87, r78, r132);
+    r132 = fma(r133, r118, r132);
+    r101 = r3 * r132;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r124,
+                                             r101);
+    r101 = r37 * r110;
+    r101 = r101 * r59;
+    r124 = r6 * r6;
+    r90 = r10 * r33;
+    r90 = r90 * r7;
+    r90 = fma(r20, r80, r39 * r90);
+    r8 = r20 * r6;
+    r8 = r8 * r6;
+    r90 = fma(r31, r8, r90);
+    r82 = r10 * r37;
+    r82 = r82 * r6;
+    r90 = fma(r39, r82, r90);
+    r124 = r124 * r112;
+    r124 = r124 * r90;
+    r124 = r124 * r66;
+    r124 = r124 * r49;
+    r124 = fma(r59, r124, r62 * r101);
+    r101 = r60 * r90;
+    r101 = r101 * r66;
+    r101 = r101 * r99;
+    r124 = fma(r63, r101, r124);
+    r82 = r21 * r7;
+    r82 = r82 * r90;
+    r82 = fma(r47, r82, r33 * r107);
+    r8 = r90 * r92;
+    r8 = r8 * r99;
+    r82 = fma(r105, r8, r82);
+    r82 = fma(r20, r103, r82);
+    r124 = fma(r20, r115, r124);
+    r124 = r124 + r82;
+    r101 = r37 * r62;
+    r8 = r21 * r6;
+    r8 = r8 * r6;
+    r8 = r8 * r90;
+    r8 = r8 * r66;
+    r8 = r8 * r49;
+    r8 = fma(r59, r8, r68 * r101);
+    r101 = r90 * r66;
+    r101 = r101 * r99;
+    r8 = fma(r63, r101, r8);
+    r104 = r20 * r31;
+    r8 = fma(r81, r104, r8);
+    r82 = r82 + r8;
+    r124 = fma(r64, r82, r5 * r124);
+    r104 = r4 * r90;
+    r124 = fma(r122, r104, r124);
+    r101 = r56 * r72;
+    r101 = r101 * r1;
+    r101 = r101 * r90;
+    r101 = r101 * r75;
+    r101 = r101 * r66;
+    r124 = fma(r62, r101, r124);
+    r9 = r56 * r1;
+    r9 = r9 * r90;
+    r9 = r9 * r75;
+    r9 = r9 * r66;
+    r124 = fma(r62, r9, r124);
+    r91 = r4 * r35;
+    r91 = r91 * r6;
+    r91 = r91 * r90;
+    r124 = fma(r47, r91, r124);
+    r125 = r70 * r10;
+    r125 = r125 * r48;
+    r125 = fma(r69, r82, r82 * r125);
+    r125 = fma(r82, r74, r125);
+    r125 = fma(r82, r73, r125);
+    r85 = r6 * r125;
+    r124 = fma(r78, r85, r124);
+    r42 = r21 * r20;
+    r42 = r42 * r6;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r124 = fma(r53, r42, r124);
+    r71 = r21 * r20;
+    r71 = r71 * r6;
+    r71 = r71 * r76;
+    r124 = fma(r53, r71, r124);
+    r26 = r4 * r33;
+    r26 = r26 * r62;
+    r124 = fma(r68, r26, r124);
+    r22 = r4 * r37;
+    r124 = fma(r107, r22, r124);
+    r124 = fma(r37, r79, r124);
+    r124 = fma(r90, r117, r124);
+    r124 = fma(r90, r116, r124);
+    r124 = fma(r20, r120, r124);
+    r124 = fma(r37, r78, r124);
+    r22 = r2 * r124;
+    r26 = r33 * r7;
+    r26 = r26 * r110;
+    r26 = r26 * r43;
+    r71 = r7 * r112;
+    r71 = r71 * r90;
+    r71 = fma(r47, r71, r59 * r26);
+    r26 = r20 * r7;
+    r26 = r26 * r7;
+    r26 = r26 * r56;
+    r26 = r26 * r56;
+    r26 = r26 * r114;
+    r26 = r26 * r43;
+    r71 = fma(r57, r26, r71);
+    r42 = r60 * r90;
+    r42 = r42 * r92;
+    r42 = r42 * r99;
+    r71 = fma(r105, r42, r71);
+    r71 = r71 + r8;
+    r82 = fma(r65, r82, r4 * r71);
+    r71 = r84 * r90;
+    r71 = r71 * r30;
+    r71 = r71 * r92;
+    r82 = fma(r77, r71, r82);
+    r8 = r56 * r72;
+    r8 = r8 * r1;
+    r8 = r8 * r90;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r82 = fma(r92, r8, r82);
+    r42 = r21 * r20;
+    r42 = r42 * r7;
+    r42 = r42 * r72;
+    r42 = r42 * r76;
+    r82 = fma(r53, r42, r82);
+    r26 = r5 * r90;
+    r82 = fma(r122, r26, r82);
+    r85 = r21 * r20;
+    r85 = r85 * r7;
+    r85 = r85 * r76;
+    r82 = fma(r53, r85, r82);
+    r91 = r5 * r20;
+    r91 = r91 * r7;
+    r91 = r91 * r56;
+    r91 = r91 * r56;
+    r91 = r91 * r95;
+    r91 = r91 * r57;
+    r82 = fma(r62, r91, r82);
+    r9 = r7 * r125;
+    r82 = fma(r78, r9, r82);
+    r101 = r84 * r72;
+    r101 = r101 * r90;
+    r101 = r101 * r30;
+    r101 = r101 * r92;
+    r82 = fma(r77, r101, r82);
+    r104 = r5 * r33;
+    r104 = r104 * r62;
+    r82 = fma(r68, r104, r82);
+    r113 = r56 * r1;
+    r113 = r113 * r90;
+    r113 = r113 * r43;
+    r113 = r113 * r75;
+    r82 = fma(r92, r113, r82);
+    r121 = r5 * r37;
+    r82 = fma(r107, r121, r82);
+    r82 = fma(r33, r78, r82);
+    r82 = fma(r90, r118, r82);
+    r82 = fma(r33, r79, r82);
+    r121 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r22, r121);
+    r121 = r10 * r38;
+    r121 = r121 * r7;
+    r121 = fma(r39, r121, r34 * r80);
+    r22 = r34 * r6;
+    r22 = r22 * r6;
+    r121 = fma(r31, r22, r121);
+    r113 = r10 * r55;
+    r113 = r113 * r6;
+    r121 = fma(r39, r113, r121);
+    r113 = r60 * r121;
+    r113 = r113 * r66;
+    r113 = r113 * r99;
+    r113 = fma(r34, r115, r63 * r113);
+    r22 = r6 * r6;
+    r22 = r22 * r112;
+    r22 = r22 * r121;
+    r22 = r22 * r66;
+    r22 = r22 * r49;
+    r113 = fma(r59, r22, r113);
+    r104 = r55 * r110;
+    r104 = r104 * r59;
+    r113 = fma(r62, r104, r113);
+    r101 = fma(r38, r107, r34 * r103);
+    r9 = r121 * r92;
+    r9 = r9 * r99;
+    r101 = fma(r105, r9, r101);
+    r91 = r21 * r7;
+    r91 = r91 * r121;
+    r101 = fma(r47, r91, r101);
+    r113 = r113 + r101;
+    r104 = r121 * r66;
+    r104 = r104 * r99;
+    r22 = r34 * r31;
+    r22 = fma(r81, r22, r63 * r104);
+    r104 = r21 * r6;
+    r104 = r104 * r6;
+    r104 = r104 * r121;
+    r104 = r104 * r66;
+    r104 = r104 * r49;
+    r22 = fma(r59, r104, r22);
+    r91 = r55 * r62;
+    r22 = fma(r68, r91, r22);
+    r101 = r101 + r22;
+    r113 = fma(r64, r101, r5 * r113);
+    r91 = r4 * r38;
+    r91 = r91 * r62;
+    r113 = fma(r68, r91, r113);
+    r104 = r4 * r121;
+    r113 = fma(r122, r104, r113);
+    r9 = r21 * r34;
+    r9 = r9 * r6;
+    r9 = r9 * r76;
+    r113 = fma(r53, r9, r113);
+    r85 = r4 * r35;
+    r85 = r85 * r6;
+    r85 = r85 * r121;
+    r113 = fma(r47, r85, r113);
+    r26 = r56 * r1;
+    r26 = r26 * r121;
+    r26 = r26 * r75;
+    r26 = r26 * r66;
+    r113 = fma(r62, r26, r113);
+    r42 = r70 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r69, r101, r101 * r42);
+    r42 = fma(r101, r73, r42);
+    r42 = fma(r101, r74, r42);
+    r8 = r6 * r42;
+    r113 = fma(r78, r8, r113);
+    r71 = r56 * r72;
+    r71 = r71 * r1;
+    r71 = r71 * r121;
+    r71 = r71 * r75;
+    r71 = r71 * r66;
+    r113 = fma(r62, r71, r113);
+    r67 = r21 * r34;
+    r67 = r67 * r6;
+    r67 = r67 * r72;
+    r67 = r67 * r76;
+    r113 = fma(r53, r67, r113);
+    r89 = r4 * r55;
+    r113 = fma(r107, r89, r113);
+    r113 = fma(r121, r117, r113);
+    r113 = fma(r55, r78, r113);
+    r113 = fma(r34, r120, r113);
+    r113 = fma(r121, r116, r113);
+    r113 = fma(r55, r79, r113);
+    r89 = r2 * r113;
+    r67 = r34 * r7;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r114;
+    r67 = r67 * r43;
+    r71 = r38 * r7;
+    r71 = r71 * r110;
+    r71 = r71 * r43;
+    r71 = fma(r59, r71, r57 * r67);
+    r67 = r60 * r121;
+    r67 = r67 * r92;
+    r67 = r67 * r99;
+    r71 = fma(r105, r67, r71);
+    r8 = r7 * r112;
+    r8 = r8 * r121;
+    r71 = fma(r47, r8, r71);
+    r71 = r71 + r22;
+    r71 = fma(r4, r71, r65 * r101);
+    r101 = r21 * r34;
+    r101 = r101 * r7;
+    r101 = r101 * r76;
+    r71 = fma(r53, r101, r71);
+    r22 = r5 * r38;
+    r22 = r22 * r62;
+    r71 = fma(r68, r22, r71);
+    r8 = r5 * r121;
+    r71 = fma(r122, r8, r71);
+    r67 = r84 * r121;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r71 = fma(r77, r67, r71);
+    r26 = r7 * r42;
+    r71 = fma(r78, r26, r71);
+    r85 = r56 * r72;
+    r85 = r85 * r1;
+    r85 = r85 * r121;
+    r85 = r85 * r43;
+    r85 = r85 * r75;
+    r71 = fma(r92, r85, r71);
+    r9 = r5 * r34;
+    r9 = r9 * r7;
+    r9 = r9 * r56;
+    r9 = r9 * r56;
+    r9 = r9 * r95;
+    r9 = r9 * r57;
+    r71 = fma(r62, r9, r71);
+    r104 = r56 * r1;
+    r104 = r104 * r121;
+    r104 = r104 * r43;
+    r104 = r104 * r75;
+    r71 = fma(r92, r104, r71);
+    r91 = r84 * r72;
+    r91 = r91 * r121;
+    r91 = r91 * r30;
+    r91 = r91 * r92;
+    r71 = fma(r77, r91, r71);
+    r128 = r21 * r34;
+    r128 = r128 * r7;
+    r128 = r128 * r72;
+    r128 = r128 * r76;
+    r71 = fma(r53, r128, r71);
+    r129 = r5 * r55;
+    r71 = fma(r107, r129, r71);
+    r71 = fma(r38, r79, r71);
+    r71 = fma(r121, r118, r71);
+    r71 = fma(r38, r78, r71);
+    r129 = r3 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r89, r129);
+    r129 = r6 * r6;
+    r89 = r10 * r41;
+    r89 = r89 * r7;
+    r89 = fma(r32, r80, r39 * r89);
+    r128 = r10 * r54;
+    r128 = r128 * r6;
+    r89 = fma(r39, r128, r89);
+    r91 = r32 * r6;
+    r91 = r91 * r6;
+    r89 = fma(r31, r91, r89);
+    r129 = r129 * r112;
+    r129 = r129 * r89;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r91 = r60 * r89;
+    r91 = r91 * r66;
+    r91 = r91 * r99;
+    r91 = fma(r63, r91, r59 * r129);
+    r129 = r54 * r110;
+    r129 = r129 * r59;
+    r91 = fma(r62, r129, r91);
+    r128 = fma(r41, r107, r32 * r103);
+    r104 = r89 * r92;
+    r104 = r104 * r99;
+    r128 = fma(r105, r104, r128);
+    r9 = r21 * r7;
+    r9 = r9 * r89;
+    r128 = fma(r47, r9, r128);
+    r91 = fma(r32, r115, r91);
+    r91 = r91 + r128;
+    r129 = r21 * r6;
+    r129 = r129 * r6;
+    r129 = r129 * r89;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r9 = r89 * r66;
+    r9 = r9 * r99;
+    r9 = fma(r63, r9, r59 * r129);
+    r129 = r54 * r62;
+    r9 = fma(r68, r129, r9);
+    r104 = r32 * r31;
+    r9 = fma(r81, r104, r9);
+    r128 = r128 + r9;
+    r91 = fma(r64, r128, r5 * r91);
+    r104 = r4 * r54;
+    r91 = fma(r107, r104, r91);
+    r129 = r4 * r41;
+    r129 = r129 * r62;
+    r91 = fma(r68, r129, r91);
+    r85 = r70 * r10;
+    r85 = r85 * r48;
+    r85 = fma(r128, r85, r69 * r128);
+    r85 = fma(r128, r74, r85);
+    r85 = fma(r128, r73, r85);
+    r26 = r6 * r85;
+    r91 = fma(r78, r26, r91);
+    r67 = r4 * r89;
+    r91 = fma(r122, r67, r91);
+    r8 = r21 * r32;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r91 = fma(r53, r8, r91);
+    r22 = r56 * r72;
+    r22 = r22 * r1;
+    r22 = r22 * r89;
+    r22 = r22 * r75;
+    r22 = r22 * r66;
+    r91 = fma(r62, r22, r91);
+    r101 = r4 * r35;
+    r101 = r101 * r6;
+    r101 = r101 * r89;
+    r91 = fma(r47, r101, r91);
+    r131 = r21 * r32;
+    r131 = r131 * r6;
+    r131 = r131 * r72;
+    r131 = r131 * r76;
+    r91 = fma(r53, r131, r91);
+    r102 = r56 * r1;
+    r102 = r102 * r89;
+    r102 = r102 * r75;
+    r102 = r102 * r66;
+    r91 = fma(r62, r102, r91);
+    r91 = fma(r54, r79, r91);
+    r91 = fma(r32, r120, r91);
+    r91 = fma(r89, r117, r91);
+    r91 = fma(r89, r116, r91);
+    r91 = fma(r54, r78, r91);
+    r102 = r2 * r91;
+    r131 = r32 * r7;
+    r131 = r131 * r7;
+    r131 = r131 * r56;
+    r131 = r131 * r56;
+    r131 = r131 * r114;
+    r131 = r131 * r43;
+    r101 = r41 * r7;
+    r101 = r101 * r110;
+    r101 = r101 * r43;
+    r101 = fma(r59, r101, r57 * r131);
+    r131 = r60 * r89;
+    r131 = r131 * r92;
+    r131 = r131 * r99;
+    r101 = fma(r105, r131, r101);
+    r22 = r7 * r112;
+    r22 = r22 * r89;
+    r101 = fma(r47, r22, r101);
+    r101 = r101 + r9;
+    r101 = fma(r4, r101, r65 * r128);
+    r128 = r56 * r1;
+    r128 = r128 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r75;
+    r101 = fma(r92, r128, r101);
+    r9 = r21 * r32;
+    r9 = r9 * r7;
+    r9 = r9 * r76;
+    r101 = fma(r53, r9, r101);
+    r22 = r5 * r54;
+    r101 = fma(r107, r22, r101);
+    r131 = r21 * r32;
+    r131 = r131 * r7;
+    r131 = r131 * r72;
+    r131 = r131 * r76;
+    r101 = fma(r53, r131, r101);
+    r8 = r84 * r72;
+    r8 = r8 * r89;
+    r8 = r8 * r30;
+    r8 = r8 * r92;
+    r101 = fma(r77, r8, r101);
+    r67 = r5 * r32;
+    r67 = r67 * r7;
+    r67 = r67 * r56;
+    r67 = r67 * r56;
+    r67 = r67 * r95;
+    r67 = r67 * r57;
+    r101 = fma(r62, r67, r101);
+    r26 = r5 * r41;
+    r26 = r26 * r62;
+    r101 = fma(r68, r26, r101);
+    r129 = r56 * r72;
+    r129 = r129 * r1;
+    r129 = r129 * r89;
+    r129 = r129 * r43;
+    r129 = r129 * r75;
+    r101 = fma(r92, r129, r101);
+    r104 = r5 * r89;
+    r101 = fma(r122, r104, r101);
+    r108 = r84 * r89;
+    r108 = r108 * r30;
+    r108 = r108 * r92;
+    r101 = fma(r77, r108, r101);
+    r130 = r7 * r85;
+    r101 = fma(r78, r130, r101);
+    r101 = fma(r41, r78, r101);
+    r101 = fma(r41, r79, r101);
+    r101 = fma(r89, r118, r101);
+    r130 = r3 * r101;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r102,
+                                             r130);
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r61 = r21 * r61;
+    r102 = r2 * r61;
+    r130 = fma(r106, r102, r109 * r130);
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r100, r102, r111 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r130, r108);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r23, r102, r132 * r108);
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r130 = fma(r124, r102, r82 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r108, r130);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r3 * r21;
+    r130 = r130 * r0;
+    r130 = fma(r113, r102, r71 * r130);
+    r108 = r3 * r21;
+    r108 = r108 * r0;
+    r108 = fma(r91, r102, r101 * r108);
+    WriteSum2<double, double>((double*)inout_shared, r130, r108);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r108 = r2 * r2;
+    r130 = r106 * r108;
+    r104 = r3 * r3;
+    r129 = r109 * r104;
+    r109 = fma(r109, r129, r106 * r130);
+    r106 = r100 * r100;
+    r26 = r111 * r111;
+    r26 = fma(r104, r26, r108 * r106);
+    WriteSum2<double, double>((double*)inout_shared, r109, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r26 = r23 * r23;
+    r109 = r132 * r132;
+    r109 = fma(r104, r109, r108 * r26);
+    r26 = r82 * r82;
+    r106 = r124 * r124;
+    r106 = fma(r108, r106, r104 * r26);
+    WriteSum2<double, double>((double*)inout_shared, r109, r106);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r106 = r113 * r113;
+    r109 = r71 * r71;
+    r109 = fma(r104, r109, r108 * r106);
+    r106 = r101 * r101;
+    r26 = r91 * r91;
+    r26 = fma(r108, r26, r104 * r106);
+    WriteSum2<double, double>((double*)inout_shared, r109, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r26 = fma(r100, r130, r111 * r129);
+    r109 = fma(r132, r129, r23 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r26, r109);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r109 = fma(r82, r129, r124 * r130);
+    r26 = fma(r71, r129, r113 * r130);
+    WriteSum2<double, double>((double*)inout_shared, r109, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = fma(r91, r130, r101 * r129);
+    r129 = r111 * r132;
+    r26 = r100 * r23;
+    r26 = fma(r108, r26, r104 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r26 = r100 * r124;
+    r130 = r111 * r82;
+    r130 = fma(r104, r130, r108 * r26);
+    r26 = r100 * r113;
+    r129 = r111 * r71;
+    r129 = fma(r104, r129, r108 * r26);
+    WriteSum2<double, double>((double*)inout_shared, r130, r129);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r111 * r101;
+    r130 = r100 * r91;
+    r130 = fma(r108, r130, r104 * r129);
+    r129 = r132 * r82;
+    r26 = r23 * r124;
+    r26 = fma(r108, r26, r104 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r26 = r23 * r113;
+    r130 = r132 * r71;
+    r130 = fma(r104, r130, r108 * r26);
+    r26 = r132 * r101;
+    r129 = r23 * r91;
+    r129 = fma(r108, r129, r104 * r26);
+    WriteSum2<double, double>((double*)inout_shared, r130, r129);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r129 = r124 * r113;
+    r130 = r82 * r71;
+    r130 = fma(r104, r130, r108 * r129);
+    r129 = r82 * r101;
+    r26 = r124 * r91;
+    r26 = fma(r108, r26, r104 * r129);
+    WriteSum2<double, double>((double*)inout_shared, r130, r26);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r26 = r71 * r101;
+    r130 = r113 * r91;
+    r130 = fma(r108, r130, r104 * r26);
+    WriteSum1<double, double>((double*)inout_shared, r130);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r130 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r61, r130);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r36, r36);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r36 = r21 * r7;
+    r130 = r10 * r51;
+    r130 = r130 * r6;
+    r130 = fma(r58, r80, r39 * r130);
+    r61 = r58 * r6;
+    r61 = r61 * r6;
+    r130 = fma(r31, r61, r130);
+    r26 = r10 * r28;
+    r26 = r26 * r7;
+    r130 = fma(r39, r26, r130);
+    r36 = r36 * r130;
+    r36 = fma(r47, r36, r58 * r103);
+    r26 = r130 * r92;
+    r26 = r26 * r99;
+    r36 = fma(r105, r26, r36);
+    r36 = fma(r28, r107, r36);
+    r26 = r58 * r31;
+    r61 = r130 * r66;
+    r61 = r61 * r99;
+    r61 = fma(r63, r61, r81 * r26);
+    r26 = r51 * r62;
+    r61 = fma(r68, r26, r61);
+    r129 = r21 * r6;
+    r129 = r129 * r6;
+    r129 = r129 * r130;
+    r129 = r129 * r66;
+    r129 = r129 * r49;
+    r61 = fma(r59, r129, r61);
+    r129 = r36 + r61;
+    r26 = r60 * r130;
+    r26 = r26 * r66;
+    r26 = r26 * r99;
+    r26 = fma(r63, r26, r58 * r115);
+    r109 = r51 * r110;
+    r109 = r109 * r59;
+    r26 = fma(r62, r109, r26);
+    r106 = r6 * r6;
+    r106 = r106 * r112;
+    r106 = r106 * r130;
+    r106 = r106 * r66;
+    r106 = r106 * r49;
+    r26 = fma(r59, r106, r26);
+    r26 = r26 + r36;
+    r26 = fma(r5, r26, r64 * r129);
+    r36 = r21 * r58;
+    r36 = r36 * r6;
+    r36 = r36 * r72;
+    r36 = r36 * r76;
+    r26 = fma(r53, r36, r26);
+    r106 = r130 * r122;
+    r109 = r4 * r35;
+    r109 = r109 * r6;
+    r109 = r109 * r130;
+    r26 = fma(r47, r109, r26);
+    r67 = r4 * r51;
+    r26 = fma(r107, r67, r26);
+    r8 = r21 * r58;
+    r8 = r8 * r6;
+    r8 = r8 * r76;
+    r26 = fma(r53, r8, r26);
+    r131 = r56 * r72;
+    r131 = r131 * r1;
+    r131 = r131 * r130;
+    r131 = r131 * r75;
+    r131 = r131 * r66;
+    r26 = fma(r62, r131, r26);
+    r22 = r70 * r10;
+    r22 = r22 * r48;
+    r22 = fma(r69, r129, r129 * r22);
+    r22 = fma(r129, r74, r22);
+    r22 = fma(r129, r73, r22);
+    r9 = r6 * r22;
+    r26 = fma(r78, r9, r26);
+    r128 = r4 * r28;
+    r128 = r128 * r62;
+    r26 = fma(r68, r128, r26);
+    r134 = r56 * r1;
+    r134 = r134 * r130;
+    r134 = r134 * r75;
+    r134 = r134 * r66;
+    r26 = fma(r62, r134, r26);
+    r26 = fma(r130, r117, r26);
+    r26 = fma(r4, r106, r26);
+    r26 = fma(r130, r116, r26);
+    r26 = fma(r51, r78, r26);
+    r26 = fma(r58, r120, r26);
+    r26 = fma(r51, r79, r26);
+    r134 = r2 * r26;
+    r128 = r58 * r7;
+    r128 = r128 * r7;
+    r128 = r128 * r56;
+    r128 = r128 * r56;
+    r128 = r128 * r114;
+    r128 = r128 * r43;
+    r9 = r7 * r112;
+    r9 = r9 * r130;
+    r9 = fma(r47, r9, r57 * r128);
+    r128 = r60 * r130;
+    r128 = r128 * r92;
+    r128 = r128 * r99;
+    r9 = fma(r105, r128, r9);
+    r131 = r28 * r7;
+    r131 = r131 * r110;
+    r131 = r131 * r43;
+    r9 = fma(r59, r131, r9);
+    r9 = r9 + r61;
+    r9 = fma(r4, r9, r65 * r129);
+    r129 = r7 * r22;
+    r9 = fma(r78, r129, r9);
+    r61 = r84 * r130;
+    r61 = r61 * r30;
+    r61 = r61 * r92;
+    r9 = fma(r77, r61, r9);
+    r131 = r21 * r58;
+    r131 = r131 * r7;
+    r131 = r131 * r76;
+    r9 = fma(r53, r131, r9);
+    r128 = r5 * r51;
+    r9 = fma(r107, r128, r9);
+    r8 = r56 * r1;
+    r8 = r8 * r130;
+    r8 = r8 * r43;
+    r8 = r8 * r75;
+    r9 = fma(r92, r8, r9);
+    r67 = r84 * r72;
+    r67 = r67 * r130;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r9 = fma(r77, r67, r9);
+    r109 = r56 * r72;
+    r109 = r109 * r1;
+    r109 = r109 * r130;
+    r109 = r109 * r43;
+    r109 = r109 * r75;
+    r9 = fma(r92, r109, r9);
+    r36 = r21 * r58;
+    r36 = r36 * r7;
+    r36 = r36 * r72;
+    r36 = r36 * r76;
+    r9 = fma(r53, r36, r9);
+    r135 = r5 * r58;
+    r135 = r135 * r7;
+    r135 = r135 * r56;
+    r135 = r135 * r56;
+    r135 = r135 * r95;
+    r135 = r135 * r57;
+    r9 = fma(r62, r135, r9);
+    r136 = r5 * r28;
+    r136 = r136 * r62;
+    r9 = fma(r68, r136, r9);
+    r9 = fma(r28, r79, r9);
+    r9 = fma(r5, r106, r9);
+    r9 = fma(r130, r118, r9);
+    r9 = fma(r28, r78, r9);
+    r136 = r3 * r9;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r134,
+                                             r136);
+    r136 = r45 * r110;
+    r136 = r136 * r59;
+    r136 = fma(r40, r115, r62 * r136);
+    r134 = r6 * r6;
+    r135 = r40 * r6;
+    r135 = r135 * r6;
+    r36 = r10 * r45;
+    r36 = r36 * r6;
+    r36 = fma(r39, r36, r31 * r135);
+    r135 = r10 * r46;
+    r135 = r135 * r7;
+    r36 = fma(r39, r135, r36);
+    r36 = fma(r40, r80, r36);
+    r134 = r134 * r112;
+    r134 = r134 * r36;
+    r134 = r134 * r66;
+    r134 = r134 * r49;
+    r136 = fma(r59, r134, r136);
+    r135 = r60 * r36;
+    r135 = r135 * r66;
+    r135 = r135 * r99;
+    r136 = fma(r63, r135, r136);
+    r109 = r36 * r92;
+    r109 = r109 * r99;
+    r109 = fma(r105, r109, r40 * r103);
+    r67 = r21 * r7;
+    r67 = r67 * r36;
+    r109 = fma(r47, r67, r109);
+    r109 = fma(r46, r107, r109);
+    r136 = r136 + r109;
+    r135 = r45 * r62;
+    r134 = r40 * r31;
+    r134 = fma(r81, r134, r68 * r135);
+    r135 = r21 * r6;
+    r135 = r135 * r6;
+    r135 = r135 * r36;
+    r135 = r135 * r66;
+    r135 = r135 * r49;
+    r134 = fma(r59, r135, r134);
+    r67 = r36 * r66;
+    r67 = r67 * r99;
+    r134 = fma(r63, r67, r134);
+    r109 = r109 + r134;
+    r136 = fma(r64, r109, r5 * r136);
+    r67 = r21 * r40;
+    r67 = r67 * r6;
+    r67 = r67 * r72;
+    r67 = r67 * r76;
+    r136 = fma(r53, r67, r136);
+    r135 = r70 * r10;
+    r135 = r135 * r48;
+    r135 = fma(r109, r135, r69 * r109);
+    r135 = fma(r109, r73, r135);
+    r135 = fma(r109, r74, r135);
+    r8 = r6 * r135;
+    r136 = fma(r78, r8, r136);
+    r128 = r21 * r40;
+    r128 = r128 * r6;
+    r128 = r128 * r76;
+    r136 = fma(r53, r128, r136);
+    r106 = r4 * r46;
+    r106 = r106 * r62;
+    r136 = fma(r68, r106, r136);
+    r131 = r4 * r45;
+    r136 = fma(r107, r131, r136);
+    r61 = r56 * r1;
+    r61 = r61 * r36;
+    r61 = r61 * r75;
+    r61 = r61 * r66;
+    r136 = fma(r62, r61, r136);
+    r129 = r4 * r36;
+    r136 = fma(r122, r129, r136);
+    r137 = r4 * r35;
+    r137 = r137 * r6;
+    r137 = r137 * r36;
+    r136 = fma(r47, r137, r136);
+    r138 = r56 * r72;
+    r138 = r138 * r1;
+    r138 = r138 * r36;
+    r138 = r138 * r75;
+    r138 = r138 * r66;
+    r136 = fma(r62, r138, r136);
+    r136 = fma(r45, r79, r136);
+    r136 = fma(r36, r116, r136);
+    r136 = fma(r36, r117, r136);
+    r136 = fma(r45, r78, r136);
+    r136 = fma(r40, r120, r136);
+    r138 = r2 * r136;
+    r137 = r40 * r7;
+    r137 = r137 * r7;
+    r137 = r137 * r56;
+    r137 = r137 * r56;
+    r137 = r137 * r114;
+    r137 = r137 * r43;
+    r129 = r60 * r36;
+    r129 = r129 * r92;
+    r129 = r129 * r99;
+    r129 = fma(r105, r129, r57 * r137);
+    r137 = r46 * r7;
+    r137 = r137 * r110;
+    r137 = r137 * r43;
+    r129 = fma(r59, r137, r129);
+    r61 = r7 * r112;
+    r61 = r61 * r36;
+    r129 = fma(r47, r61, r129);
+    r129 = r129 + r134;
+    r109 = fma(r65, r109, r4 * r129);
+    r129 = r21 * r40;
+    r129 = r129 * r7;
+    r129 = r129 * r76;
+    r109 = fma(r53, r129, r109);
+    r134 = r21 * r40;
+    r134 = r134 * r7;
+    r134 = r134 * r72;
+    r134 = r134 * r76;
+    r109 = fma(r53, r134, r109);
+    r61 = r84 * r36;
+    r61 = r61 * r30;
+    r61 = r61 * r92;
+    r109 = fma(r77, r61, r109);
+    r137 = r5 * r46;
+    r137 = r137 * r62;
+    r109 = fma(r68, r137, r109);
+    r131 = r56 * r1;
+    r131 = r131 * r36;
+    r131 = r131 * r43;
+    r131 = r131 * r75;
+    r109 = fma(r92, r131, r109);
+    r106 = r5 * r45;
+    r109 = fma(r107, r106, r109);
+    r128 = r5 * r36;
+    r109 = fma(r122, r128, r109);
+    r8 = r5 * r40;
+    r8 = r8 * r7;
+    r8 = r8 * r56;
+    r8 = r8 * r56;
+    r8 = r8 * r95;
+    r8 = r8 * r57;
+    r109 = fma(r62, r8, r109);
+    r67 = r84 * r72;
+    r67 = r67 * r36;
+    r67 = r67 * r30;
+    r67 = r67 * r92;
+    r109 = fma(r77, r67, r109);
+    r139 = r7 * r135;
+    r109 = fma(r78, r139, r109);
+    r140 = r56 * r72;
+    r140 = r140 * r1;
+    r140 = r140 * r36;
+    r140 = r140 * r43;
+    r140 = r140 * r75;
+    r109 = fma(r92, r140, r109);
+    r109 = fma(r46, r79, r109);
+    r109 = fma(r36, r118, r109);
+    r109 = fma(r46, r78, r109);
+    r140 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r140);
+    r140 = r6 * r6;
+    r138 = r10 * r52;
+    r138 = r138 * r6;
+    r80 = fma(r50, r80, r39 * r138);
+    r138 = r50 * r6;
+    r138 = r138 * r6;
+    r80 = fma(r31, r138, r80);
+    r139 = r10 * r44;
+    r139 = r139 * r7;
+    r80 = fma(r39, r139, r80);
+    r140 = r140 * r112;
+    r140 = r140 * r80;
+    r140 = r140 * r66;
+    r140 = r140 * r49;
+    r140 = fma(r59, r140, r50 * r115);
+    r115 = r60 * r80;
+    r115 = r115 * r66;
+    r115 = r115 * r99;
+    r140 = fma(r63, r115, r140);
+    r139 = r52 * r110;
+    r139 = r139 * r59;
+    r140 = fma(r62, r139, r140);
+    r138 = r21 * r7;
+    r138 = r138 * r80;
+    r138 = fma(r47, r138, r44 * r107);
+    r39 = r80 * r92;
+    r39 = r39 * r99;
+    r138 = fma(r105, r39, r138);
+    r138 = fma(r50, r103, r138);
+    r140 = r140 + r138;
+    r139 = r50 * r31;
+    r115 = r21 * r6;
+    r115 = r115 * r6;
+    r115 = r115 * r80;
+    r115 = r115 * r66;
+    r115 = r115 * r49;
+    r115 = fma(r59, r115, r81 * r139);
+    r139 = r80 * r66;
+    r139 = r139 * r99;
+    r115 = fma(r63, r139, r115);
+    r63 = r52 * r62;
+    r115 = fma(r68, r63, r115);
+    r138 = r138 + r115;
+    r64 = fma(r64, r138, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r76;
+    r64 = fma(r53, r140, r64);
+    r63 = r4 * r44;
+    r63 = r63 * r62;
+    r64 = fma(r68, r63, r64);
+    r139 = r4 * r35;
+    r139 = r139 * r6;
+    r139 = r139 * r80;
+    r64 = fma(r47, r139, r64);
+    r81 = r56 * r1;
+    r81 = r81 * r80;
+    r81 = r81 * r75;
+    r81 = r81 * r66;
+    r64 = fma(r62, r81, r64);
+    r49 = r4 * r80;
+    r64 = fma(r122, r49, r64);
+    r103 = r4 * r52;
+    r64 = fma(r107, r103, r64);
+    r39 = r56 * r72;
+    r39 = r39 * r1;
+    r39 = r39 * r80;
+    r39 = r39 * r75;
+    r39 = r39 * r66;
+    r64 = fma(r62, r39, r64);
+    r67 = r21 * r50;
+    r67 = r67 * r6;
+    r67 = r67 * r72;
+    r67 = r67 * r76;
+    r64 = fma(r53, r67, r64);
+    r8 = r70 * r10;
+    r8 = r8 * r48;
+    r8 = fma(r138, r8, r69 * r138);
+    r8 = fma(r138, r74, r8);
+    r8 = fma(r138, r73, r8);
+    r73 = r6 * r8;
+    r64 = fma(r78, r73, r64);
+    r64 = fma(r52, r79, r64);
+    r64 = fma(r80, r116, r64);
+    r64 = fma(r80, r117, r64);
+    r64 = fma(r50, r120, r64);
+    r64 = fma(r52, r78, r64);
+    r2 = r2 * r64;
+    r73 = r44 * r7;
+    r73 = r73 * r110;
+    r73 = r73 * r43;
+    r67 = r7 * r112;
+    r67 = r67 * r80;
+    r67 = fma(r47, r67, r59 * r73);
+    r73 = r60 * r80;
+    r73 = r73 * r92;
+    r73 = r73 * r99;
+    r67 = fma(r105, r73, r67);
+    r105 = r50 * r7;
+    r105 = r105 * r7;
+    r105 = r105 * r56;
+    r105 = r105 * r56;
+    r105 = r105 * r114;
+    r105 = r105 * r43;
+    r67 = fma(r57, r105, r67);
+    r67 = r67 + r115;
+    r67 = fma(r4, r67, r65 * r138);
+    r138 = r5 * r44;
+    r138 = r138 * r62;
+    r67 = fma(r68, r138, r67);
+    r68 = r56 * r1;
+    r68 = r68 * r80;
+    r68 = r68 * r43;
+    r68 = r68 * r75;
+    r67 = fma(r92, r68, r67);
+    r65 = r5 * r80;
+    r67 = fma(r122, r65, r67);
+    r122 = r56 * r72;
+    r122 = r122 * r1;
+    r122 = r122 * r80;
+    r122 = r122 * r43;
+    r122 = r122 * r75;
+    r67 = fma(r92, r122, r67);
+    r75 = r84 * r72;
+    r75 = r75 * r80;
+    r75 = r75 * r30;
+    r75 = r75 * r92;
+    r67 = fma(r77, r75, r67);
+    r43 = r21 * r50;
+    r43 = r43 * r7;
+    r43 = r43 * r72;
+    r43 = r43 * r76;
+    r67 = fma(r53, r43, r67);
+    r115 = r5 * r50;
+    r115 = r115 * r7;
+    r115 = r115 * r56;
+    r115 = r115 * r56;
+    r115 = r115 * r95;
+    r115 = r115 * r57;
+    r67 = fma(r62, r115, r67);
+    r57 = r5 * r52;
+    r67 = fma(r107, r57, r67);
+    r107 = r7 * r8;
+    r67 = fma(r78, r107, r67);
+    r95 = r84 * r80;
+    r95 = r95 * r30;
+    r95 = r95 * r92;
+    r67 = fma(r77, r95, r67);
+    r77 = r21 * r50;
+    r77 = r77 * r7;
+    r77 = r77 * r76;
+    r67 = fma(r53, r77, r67);
+    r67 = fma(r80, r118, r67);
+    r67 = fma(r44, r79, r67);
+    r67 = fma(r44, r78, r67);
+    r77 = r3 * r67;
+    WriteIdx2<1024, double, double, double2>(
+        out_point_jac, 4 * out_point_jac_num_alloc, global_thread_idx, r2, r77);
+    r77 = r3 * r21;
+    r77 = r77 * r0;
+    r77 = fma(r26, r102, r9 * r77);
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r2 = fma(r136, r102, r109 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r77, r2);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r3 * r21;
+    r2 = r2 * r0;
+    r102 = fma(r64, r102, r67 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r102);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r9 * r9;
+    r2 = r26 * r26;
+    r2 = fma(r108, r2, r104 * r102);
+    r102 = r109 * r109;
+    r0 = r136 * r136;
+    r0 = fma(r108, r0, r104 * r102);
+    WriteSum2<double, double>((double*)inout_shared, r2, r0);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r67 * r67;
+    r2 = r64 * r64;
+    r2 = fma(r108, r2, r104 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r2);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r2 = r9 * r109;
+    r0 = r26 * r136;
+    r0 = fma(r108, r0, r104 * r2);
+    r2 = r9 * r67;
+    r102 = r26 * r64;
+    r102 = fma(r108, r102, r104 * r2);
+    WriteSum2<double, double>((double*)inout_shared, r0, r102);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r102 = r109 * r67;
+    r0 = r136 * r64;
+    r0 = fma(r108, r0, r104 * r102);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.cu
@@ -1,0 +1,361 @@
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedFocalAndExtraScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedFocalAndExtraScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirectKernel(
+        double* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        double* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointJtjnjtrDirect(
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.cu
@@ -1,0 +1,333 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r21 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r21, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r32, r27);
+    r32 = r20 * r32;
+    r27 = r20 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r27);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r33, r33);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_principal_point_precond_diag,
+              out_principal_point_precond_diag_num_alloc,
+              out_principal_point_precond_tril,
+              out_principal_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.cu
@@ -1,0 +1,347 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r21 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r21, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r32, r27);
+    r0 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r0);
+  if (global_thread_idx < problem_size) {
+    r32 = r20 * r32;
+    r27 = r20 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r32, r27);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r33, r33);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_principal_point_precond_diag,
+              out_principal_point_precond_diag_num_alloc,
+              out_principal_point_precond_tril,
+              out_principal_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.cu
@@ -1,0 +1,305 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              principal_point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel(
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.cu
@@ -1,0 +1,905 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r7 * r7;
+    r33 = 1.00000000000000008e-15;
+    r28 = r22 * r22;
+    r28 = r29 * r28;
+    r44 = r31 + r28;
+    r44 = r44 + r41;
+    r6 = fma(r8, r44, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r45 = r15 * r11;
+    r45 = r45 * r10;
+    r46 = r16 * r12;
+    r47 = fma(r10, r46, r45);
+    r48 = r11 * r12;
+    r48 = fma(r29, r48, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r47, r6);
+    r6 = fma(r26, r48, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r48);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r48);
+    r46 = fma(r29, r46, r45);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r28 = r31 + r28;
+    r28 = r28 + r43;
+    r8 = fma(r18, r46, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r28, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r33, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = copysign(1.0, r32);
+    r26 = fma(r33, r26, r32);
+    r33 = r26 * r26;
+    r27 = 1.0 / r33;
+    r32 = atan(r32);
+    r34 = r32 * r9;
+    r46 = r32 * r34;
+    r36 = r36 * r27;
+    r36 = r36 * r46;
+    r18 = 3.00000000000000000e+00;
+    r43 = r18 * r46;
+    r38 = r6 * r27;
+    r35 = r6 * r38;
+    r43 = fma(r35, r43, r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r45,
+                                            r48);
+    r20 = r46 * r35;
+    r36 = r36 + r20;
+    r43 = fma(r45, r36, r5 * r43);
+    r25 = r4 * r7;
+    r49 = r10 * r46;
+    r25 = r25 * r38;
+    r43 = fma(r49, r25, r43);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r50,
+                                            r51);
+    r52 = r36 * r36;
+    r53 = fma(r51, r52, r50 * r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r54,
+                                            r55);
+    r56 = r36 * r52;
+    r55 = r55 * r56;
+    r53 = fma(r36, r55, r53);
+    r53 = fma(r54, r56, r53);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r26;
+    r58 = r56 * r57;
+    r59 = r32 * r58;
+    r60 = r53 * r59;
+    r43 = fma(r6, r60, r43);
+    r43 = fma(r6, r59, r43);
+    r43 = fma(r2, r43, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r25);
+    r43 = fma(r0, r21, r43);
+    r0 = r7 * r7;
+    r0 = r0 * r18;
+    r0 = r0 * r27;
+    r0 = fma(r46, r0, r20);
+    r0 = fma(r48, r36, r4 * r0);
+    r20 = r5 * r7;
+    r20 = r20 * r38;
+    r0 = fma(r49, r20, r0);
+    r0 = fma(r7, r60, r0);
+    r0 = fma(r7, r59, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r25, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r43, r0);
+    r25 = r3 * r21;
+    r1 = r32 * r32;
+    r20 = r27 * r1;
+    r61 = r7 * r7;
+    r8 = r37 * r8;
+    r8 = 1.0 / r8;
+    r37 = r29 * r8;
+    r61 = r61 * r37;
+    r20 = r20 * r61;
+    r62 = r21 * r7;
+    r63 = r10 * r44;
+    r63 = r63 * r6;
+    r63 = fma(r47, r61, r9 * r63);
+    r64 = r47 * r6;
+    r64 = r64 * r6;
+    r63 = fma(r37, r64, r63);
+    r65 = r10 * r24;
+    r65 = r65 * r7;
+    r63 = fma(r9, r65, r63);
+    r33 = r26 * r33;
+    r33 = 1.0 / r33;
+    r26 = r33 * r46;
+    r65 = rsqrt(r30);
+    r64 = r7 * r65;
+    r26 = r26 * r64;
+    r62 = r62 * r63;
+    r62 = fma(r26, r62, r47 * r20);
+    r66 = r63 * r64;
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r31 = r30 * r34;
+    r67 = r7 * r27;
+    r66 = r66 * r31;
+    r62 = fma(r67, r66, r62);
+    r68 = r49 * r67;
+    r62 = fma(r24, r68, r62);
+    r66 = r47 * r37;
+    r1 = r35 * r1;
+    r69 = r63 * r65;
+    r69 = r69 * r31;
+    r69 = fma(r35, r69, r1 * r66);
+    r66 = r44 * r38;
+    r69 = fma(r49, r66, r69);
+    r70 = r21 * r6;
+    r70 = r70 * r6;
+    r70 = r70 * r63;
+    r70 = r70 * r65;
+    r70 = r70 * r33;
+    r69 = fma(r46, r70, r69);
+    r70 = r62 + r69;
+    r66 = r47 * r7;
+    r71 = -6.00000000000000000e+00;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r71;
+    r66 = r66 * r27;
+    r72 = -3.00000000000000000e+00;
+    r73 = r7 * r72;
+    r73 = r73 * r63;
+    r73 = fma(r26, r73, r8 * r66);
+    r66 = r18 * r63;
+    r66 = r66 * r64;
+    r66 = r66 * r31;
+    r73 = fma(r67, r66, r73);
+    r74 = r24 * r7;
+    r75 = 6.00000000000000000e+00;
+    r74 = r74 * r75;
+    r74 = r74 * r27;
+    r73 = fma(r46, r74, r73);
+    r73 = r73 + r69;
+    r73 = fma(r4, r73, r48 * r70);
+    r69 = r7 * r27;
+    r74 = -5.00000000000000000e-01;
+    r69 = r69 * r32;
+    r69 = r69 * r56;
+    r69 = r69 * r74;
+    r69 = r69 * r65;
+    r69 = r69 * r63;
+    r66 = r51 * r10;
+    r66 = r66 * r36;
+    r66 = fma(r50, r70, r70 * r66);
+    r76 = 4.00000000000000000e+00;
+    r55 = r76 * r55;
+    r54 = r54 * r18;
+    r54 = r54 * r52;
+    r66 = fma(r70, r55, r66);
+    r66 = fma(r70, r54, r66);
+    r52 = r7 * r66;
+    r73 = fma(r59, r52, r73);
+    r76 = 5.00000000000000000e-01;
+    r77 = r76 * r63;
+    r77 = r77 * r30;
+    r77 = r77 * r64;
+    r73 = fma(r58, r77, r73);
+    r78 = r21 * r47;
+    r78 = r78 * r57;
+    r78 = r78 * r34;
+    r79 = r5 * r63;
+    r80 = r10 * r38;
+    r80 = r80 * r64;
+    r80 = r80 * r31;
+    r73 = fma(r80, r79, r73);
+    r81 = r5 * r29;
+    r81 = r81 * r6;
+    r81 = r81 * r63;
+    r73 = fma(r26, r81, r73);
+    r82 = r5 * r44;
+    r73 = fma(r68, r82, r73);
+    r83 = r76 * r53;
+    r83 = r83 * r63;
+    r83 = r83 * r30;
+    r83 = r83 * r64;
+    r73 = fma(r58, r83, r73);
+    r84 = r7 * r53;
+    r73 = fma(r78, r84, r73);
+    r85 = r5 * r7;
+    r86 = -4.00000000000000000e+00;
+    r85 = r85 * r32;
+    r85 = r85 * r32;
+    r85 = r85 * r86;
+    r85 = r85 * r8;
+    r85 = r85 * r38;
+    r87 = r5 * r24;
+    r87 = r87 * r38;
+    r73 = fma(r49, r87, r73);
+    r73 = r73 + r69;
+    r73 = fma(r24, r60, r73);
+    r73 = fma(r7, r78, r73);
+    r73 = fma(r24, r59, r73);
+    r73 = fma(r53, r69, r73);
+    r73 = fma(r47, r85, r73);
+    r25 = r25 * r0;
+    r87 = r2 * r21;
+    r84 = r71 * r8;
+    r84 = r84 * r1;
+    r69 = r18 * r63;
+    r69 = r69 * r65;
+    r69 = r69 * r31;
+    r69 = fma(r35, r69, r47 * r84);
+    r83 = r44 * r75;
+    r83 = r83 * r46;
+    r69 = fma(r38, r83, r69);
+    r82 = r6 * r6;
+    r82 = r82 * r72;
+    r82 = r82 * r63;
+    r82 = r82 * r65;
+    r82 = r82 * r33;
+    r69 = fma(r46, r82, r69);
+    r69 = r69 + r62;
+    r69 = fma(r5, r69, r45 * r70);
+    r70 = r6 * r76;
+    r70 = r70 * r65;
+    r70 = r70 * r30;
+    r70 = r70 * r58;
+    r62 = r53 * r70;
+    r82 = r6 * r53;
+    r69 = fma(r78, r82, r69);
+    r83 = r4 * r63;
+    r69 = fma(r80, r83, r69);
+    r81 = r4 * r29;
+    r81 = r81 * r6;
+    r81 = r81 * r63;
+    r69 = fma(r26, r81, r69);
+    r79 = r4 * r68;
+    r77 = r53 * r65;
+    r52 = r32 * r74;
+    r52 = r52 * r63;
+    r52 = r52 * r56;
+    r77 = r77 * r38;
+    r69 = fma(r52, r77, r69);
+    r88 = r6 * r66;
+    r69 = fma(r59, r88, r69);
+    r89 = r4 * r47;
+    r89 = r89 * r7;
+    r89 = r89 * r32;
+    r89 = r89 * r32;
+    r89 = r89 * r86;
+    r89 = r89 * r8;
+    r69 = fma(r38, r89, r69);
+    r90 = r4 * r24;
+    r90 = r90 * r38;
+    r69 = fma(r49, r90, r69);
+    r91 = r65 * r38;
+    r69 = fma(r52, r91, r69);
+    r69 = fma(r63, r62, r69);
+    r69 = fma(r63, r70, r69);
+    r69 = fma(r44, r79, r69);
+    r69 = fma(r6, r78, r69);
+    r69 = fma(r44, r59, r69);
+    r69 = fma(r44, r60, r69);
+    r87 = r87 * r43;
+    r87 = fma(r69, r87, r73 * r25);
+    r25 = r2 * r21;
+    r91 = r41 * r75;
+    r91 = r91 * r46;
+    r91 = fma(r39, r84, r38 * r91);
+    r90 = r6 * r6;
+    r89 = r39 * r6;
+    r89 = r89 * r6;
+    r88 = r10 * r41;
+    r88 = r88 * r6;
+    r88 = fma(r9, r88, r37 * r89);
+    r89 = r10 * r42;
+    r89 = r89 * r7;
+    r88 = fma(r9, r89, r88);
+    r88 = fma(r39, r61, r88);
+    r89 = r72 * r88;
+    r90 = r90 * r65;
+    r90 = r90 * r33;
+    r90 = r90 * r46;
+    r91 = fma(r89, r90, r91);
+    r77 = r18 * r88;
+    r77 = r77 * r65;
+    r77 = r77 * r31;
+    r91 = fma(r35, r77, r91);
+    r78 = r88 * r64;
+    r78 = r78 * r31;
+    r78 = fma(r67, r78, r39 * r20);
+    r81 = r21 * r7;
+    r81 = r81 * r88;
+    r78 = fma(r26, r81, r78);
+    r78 = fma(r42, r68, r78);
+    r91 = r91 + r78;
+    r77 = r41 * r38;
+    r90 = r39 * r37;
+    r90 = fma(r1, r90, r49 * r77);
+    r77 = r21 * r6;
+    r77 = r77 * r6;
+    r77 = r77 * r88;
+    r77 = r77 * r65;
+    r77 = r77 * r33;
+    r90 = fma(r46, r77, r90);
+    r81 = r88 * r65;
+    r81 = r81 * r31;
+    r90 = fma(r35, r81, r90);
+    r78 = r78 + r90;
+    r91 = fma(r45, r78, r5 * r91);
+    r81 = r21 * r39;
+    r81 = r81 * r6;
+    r81 = r81 * r53;
+    r81 = r81 * r57;
+    r91 = fma(r34, r81, r91);
+    r77 = r51 * r10;
+    r77 = r77 * r36;
+    r77 = fma(r78, r77, r50 * r78);
+    r77 = fma(r78, r54, r77);
+    r77 = fma(r78, r55, r77);
+    r83 = r6 * r77;
+    r91 = fma(r59, r83, r91);
+    r82 = r21 * r39;
+    r82 = r82 * r6;
+    r82 = r82 * r57;
+    r91 = fma(r34, r82, r91);
+    r52 = r4 * r42;
+    r52 = r52 * r38;
+    r91 = fma(r49, r52, r91);
+    r92 = r32 * r74;
+    r92 = r92 * r88;
+    r92 = r92 * r56;
+    r92 = r92 * r65;
+    r91 = fma(r38, r92, r91);
+    r93 = r4 * r88;
+    r91 = fma(r80, r93, r91);
+    r94 = r4 * r29;
+    r94 = r94 * r6;
+    r94 = r94 * r88;
+    r91 = fma(r26, r94, r91);
+    r95 = r4 * r39;
+    r95 = r95 * r7;
+    r95 = r95 * r32;
+    r95 = r95 * r32;
+    r95 = r95 * r86;
+    r95 = r95 * r8;
+    r91 = fma(r38, r95, r91);
+    r96 = r32 * r53;
+    r96 = r96 * r74;
+    r96 = r96 * r88;
+    r96 = r96 * r56;
+    r96 = r96 * r65;
+    r91 = fma(r38, r96, r91);
+    r91 = fma(r41, r60, r91);
+    r91 = fma(r88, r70, r91);
+    r91 = fma(r88, r62, r91);
+    r91 = fma(r41, r59, r91);
+    r91 = fma(r41, r79, r91);
+    r25 = r25 * r43;
+    r96 = r3 * r21;
+    r95 = r39 * r7;
+    r95 = r95 * r7;
+    r95 = r95 * r32;
+    r95 = r95 * r32;
+    r95 = r95 * r71;
+    r95 = r95 * r27;
+    r94 = r18 * r88;
+    r94 = r94 * r64;
+    r94 = r94 * r31;
+    r94 = fma(r67, r94, r8 * r95);
+    r95 = r42 * r7;
+    r95 = r95 * r75;
+    r95 = r95 * r27;
+    r94 = fma(r46, r95, r94);
+    r93 = r7 * r26;
+    r94 = fma(r89, r93, r94);
+    r94 = r94 + r90;
+    r78 = fma(r48, r78, r4 * r94);
+    r94 = r21 * r39;
+    r94 = r94 * r7;
+    r94 = r94 * r57;
+    r78 = fma(r34, r94, r78);
+    r90 = r21 * r39;
+    r90 = r90 * r7;
+    r90 = r90 * r53;
+    r90 = r90 * r57;
+    r78 = fma(r34, r90, r78);
+    r93 = r76 * r88;
+    r93 = r93 * r30;
+    r93 = r93 * r64;
+    r78 = fma(r58, r93, r78);
+    r95 = r5 * r42;
+    r95 = r95 * r38;
+    r78 = fma(r49, r95, r78);
+    r89 = r32 * r74;
+    r89 = r89 * r88;
+    r89 = r89 * r27;
+    r89 = r89 * r56;
+    r78 = fma(r64, r89, r78);
+    r92 = r5 * r41;
+    r78 = fma(r68, r92, r78);
+    r52 = r5 * r88;
+    r78 = fma(r80, r52, r78);
+    r82 = r5 * r29;
+    r82 = r82 * r6;
+    r82 = r82 * r88;
+    r78 = fma(r26, r82, r78);
+    r83 = r76 * r53;
+    r83 = r83 * r88;
+    r83 = r83 * r30;
+    r83 = r83 * r64;
+    r78 = fma(r58, r83, r78);
+    r81 = r7 * r77;
+    r78 = fma(r59, r81, r78);
+    r97 = r32 * r53;
+    r97 = r97 * r74;
+    r97 = r97 * r88;
+    r97 = r97 * r27;
+    r97 = r97 * r56;
+    r78 = fma(r64, r97, r78);
+    r78 = fma(r42, r60, r78);
+    r78 = fma(r39, r85, r78);
+    r78 = fma(r42, r59, r78);
+    r96 = r96 * r0;
+    r96 = fma(r78, r96, r91 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r87, r96);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r3 * r21;
+    r87 = r21 * r7;
+    r25 = r10 * r19;
+    r25 = r25 * r6;
+    r61 = fma(r28, r61, r9 * r25);
+    r25 = r28 * r6;
+    r25 = r25 * r6;
+    r61 = fma(r37, r25, r61);
+    r97 = r10 * r40;
+    r97 = r97 * r7;
+    r61 = fma(r9, r97, r61);
+    r97 = r61 * r26;
+    r87 = fma(r97, r87, r40 * r68);
+    r25 = r61 * r64;
+    r25 = r25 * r31;
+    r87 = fma(r67, r25, r87);
+    r87 = fma(r28, r20, r87);
+    r20 = r28 * r37;
+    r25 = r21 * r6;
+    r25 = r25 * r6;
+    r25 = r25 * r61;
+    r25 = r25 * r65;
+    r25 = r25 * r33;
+    r25 = fma(r46, r25, r1 * r20);
+    r20 = r61 * r65;
+    r20 = r20 * r31;
+    r25 = fma(r35, r20, r25);
+    r1 = r19 * r38;
+    r25 = fma(r49, r1, r25);
+    r1 = r87 + r25;
+    r20 = r40 * r7;
+    r20 = r20 * r75;
+    r20 = r20 * r27;
+    r9 = r7 * r72;
+    r9 = fma(r97, r9, r46 * r20);
+    r20 = r18 * r61;
+    r20 = r20 * r64;
+    r20 = r20 * r31;
+    r9 = fma(r67, r20, r9);
+    r67 = r28 * r7;
+    r67 = r67 * r7;
+    r67 = r67 * r32;
+    r67 = r67 * r32;
+    r67 = r67 * r71;
+    r67 = r67 * r27;
+    r9 = fma(r8, r67, r9);
+    r9 = r9 + r25;
+    r9 = fma(r4, r9, r48 * r1);
+    r48 = r5 * r40;
+    r48 = r48 * r38;
+    r9 = fma(r49, r48, r9);
+    r25 = r29 * r6;
+    r25 = r25 * r97;
+    r97 = r32 * r74;
+    r97 = r97 * r61;
+    r97 = r97 * r27;
+    r97 = r97 * r56;
+    r9 = fma(r64, r97, r9);
+    r67 = r5 * r61;
+    r9 = fma(r80, r67, r9);
+    r20 = r32 * r53;
+    r20 = r20 * r74;
+    r20 = r20 * r61;
+    r20 = r20 * r27;
+    r20 = r20 * r56;
+    r9 = fma(r64, r20, r9);
+    r27 = r76 * r53;
+    r27 = r27 * r61;
+    r27 = r27 * r30;
+    r27 = r27 * r64;
+    r9 = fma(r58, r27, r9);
+    r71 = r21 * r28;
+    r71 = r71 * r7;
+    r71 = r71 * r53;
+    r71 = r71 * r57;
+    r9 = fma(r34, r71, r9);
+    r81 = r5 * r19;
+    r9 = fma(r68, r81, r9);
+    r68 = r51 * r10;
+    r68 = r68 * r36;
+    r68 = fma(r1, r68, r50 * r1);
+    r68 = fma(r1, r55, r68);
+    r68 = fma(r1, r54, r68);
+    r54 = r7 * r68;
+    r9 = fma(r59, r54, r9);
+    r55 = r76 * r61;
+    r55 = r55 * r30;
+    r55 = r55 * r64;
+    r9 = fma(r58, r55, r9);
+    r58 = r21 * r28;
+    r58 = r58 * r7;
+    r58 = r58 * r57;
+    r9 = fma(r34, r58, r9);
+    r9 = fma(r5, r25, r9);
+    r9 = fma(r28, r85, r9);
+    r9 = fma(r40, r60, r9);
+    r9 = fma(r40, r59, r9);
+    r96 = r96 * r0;
+    r0 = r2 * r21;
+    r58 = r6 * r6;
+    r58 = r58 * r72;
+    r58 = r58 * r61;
+    r58 = r58 * r65;
+    r58 = r58 * r33;
+    r58 = fma(r46, r58, r28 * r84);
+    r84 = r18 * r61;
+    r84 = r84 * r65;
+    r84 = r84 * r31;
+    r58 = fma(r35, r84, r58);
+    r35 = r19 * r75;
+    r35 = r35 * r46;
+    r58 = fma(r38, r35, r58);
+    r58 = r58 + r87;
+    r1 = fma(r45, r1, r5 * r58);
+    r45 = r21 * r28;
+    r45 = r45 * r6;
+    r45 = r45 * r57;
+    r1 = fma(r34, r45, r1);
+    r58 = r4 * r40;
+    r58 = r58 * r38;
+    r1 = fma(r49, r58, r1);
+    r49 = r32 * r74;
+    r49 = r49 * r61;
+    r49 = r49 * r56;
+    r49 = r49 * r65;
+    r1 = fma(r38, r49, r1);
+    r87 = r4 * r61;
+    r1 = fma(r80, r87, r1);
+    r80 = r4 * r28;
+    r80 = r80 * r7;
+    r80 = r80 * r32;
+    r80 = r80 * r32;
+    r80 = r80 * r86;
+    r80 = r80 * r8;
+    r1 = fma(r38, r80, r1);
+    r8 = r32 * r53;
+    r8 = r8 * r74;
+    r8 = r8 * r61;
+    r8 = r8 * r56;
+    r8 = r8 * r65;
+    r1 = fma(r38, r8, r1);
+    r56 = r21 * r28;
+    r56 = r56 * r6;
+    r56 = r56 * r53;
+    r56 = r56 * r57;
+    r1 = fma(r34, r56, r1);
+    r34 = r6 * r68;
+    r1 = fma(r59, r34, r1);
+    r1 = fma(r19, r60, r1);
+    r1 = fma(r4, r25, r1);
+    r1 = fma(r61, r70, r1);
+    r1 = fma(r61, r62, r1);
+    r1 = fma(r19, r59, r1);
+    r1 = fma(r19, r79, r1);
+    r0 = r0 * r43;
+    r0 = fma(r1, r0, r9 * r96);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r3;
+    r96 = r73 * r0;
+    r43 = r2 * r2;
+    r34 = r69 * r69;
+    r34 = fma(r43, r34, r73 * r96);
+    r73 = r78 * r78;
+    r56 = r91 * r91;
+    r56 = fma(r43, r56, r0 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r34, r56);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r9 * r9;
+    r34 = r1 * r43;
+    r1 = fma(r1, r34, r0 * r56);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r69 * r91;
+    r1 = fma(r43, r1, r78 * r96);
+    r96 = fma(r69, r34, r9 * r96);
+    WriteSum2<double, double>((double*)inout_shared, r1, r96);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r78 * r9;
+    r34 = fma(r91, r34, r0 * r96);
+    WriteSum1<double, double>((double*)inout_shared, r34);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,919 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r7 * r7;
+    r33 = 1.00000000000000008e-15;
+    r28 = r22 * r22;
+    r28 = r29 * r28;
+    r44 = r31 + r28;
+    r44 = r44 + r41;
+    r6 = fma(r8, r44, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r45 = r15 * r11;
+    r45 = r45 * r10;
+    r46 = r16 * r12;
+    r47 = fma(r10, r46, r45);
+    r48 = r11 * r12;
+    r48 = fma(r29, r48, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r47, r6);
+    r6 = fma(r26, r48, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r48);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r48);
+    r46 = fma(r29, r46, r45);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r28 = r31 + r28;
+    r28 = r28 + r43;
+    r8 = fma(r18, r46, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r28, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r33, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = copysign(1.0, r32);
+    r26 = fma(r33, r26, r32);
+    r33 = r26 * r26;
+    r27 = 1.0 / r33;
+    r32 = atan(r32);
+    r34 = r32 * r9;
+    r46 = r32 * r34;
+    r36 = r36 * r27;
+    r36 = r36 * r46;
+    r18 = 3.00000000000000000e+00;
+    r43 = r18 * r46;
+    r38 = r6 * r27;
+    r35 = r6 * r38;
+    r43 = fma(r35, r43, r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r45,
+                                            r48);
+    r20 = r46 * r35;
+    r36 = r36 + r20;
+    r43 = fma(r45, r36, r5 * r43);
+    r25 = r4 * r7;
+    r49 = r10 * r46;
+    r25 = r25 * r38;
+    r43 = fma(r49, r25, r43);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r50,
+                                            r51);
+    r52 = r36 * r36;
+    r53 = fma(r51, r52, r50 * r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r54,
+                                            r55);
+    r56 = r36 * r52;
+    r55 = r55 * r56;
+    r53 = fma(r36, r55, r53);
+    r53 = fma(r54, r56, r53);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r26;
+    r58 = r56 * r57;
+    r59 = r32 * r58;
+    r60 = r53 * r59;
+    r43 = fma(r6, r60, r43);
+    r43 = fma(r6, r59, r43);
+    r43 = fma(r2, r43, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r25);
+    r43 = fma(r0, r21, r43);
+    r0 = r7 * r7;
+    r0 = r0 * r18;
+    r0 = r0 * r27;
+    r0 = fma(r46, r0, r20);
+    r0 = fma(r48, r36, r4 * r0);
+    r20 = r5 * r7;
+    r20 = r20 * r38;
+    r0 = fma(r49, r20, r0);
+    r0 = fma(r7, r60, r0);
+    r0 = fma(r7, r59, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r25, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r43, r0);
+    r25 = fma(r0, r0, r43 * r43);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r25);
+  if (global_thread_idx < problem_size) {
+    r25 = r3 * r21;
+    r1 = r32 * r32;
+    r20 = r27 * r1;
+    r61 = r7 * r7;
+    r8 = r37 * r8;
+    r8 = 1.0 / r8;
+    r37 = r29 * r8;
+    r61 = r61 * r37;
+    r20 = r20 * r61;
+    r62 = r21 * r7;
+    r63 = r10 * r44;
+    r63 = r63 * r6;
+    r63 = fma(r47, r61, r9 * r63);
+    r64 = r47 * r6;
+    r64 = r64 * r6;
+    r63 = fma(r37, r64, r63);
+    r65 = r10 * r24;
+    r65 = r65 * r7;
+    r63 = fma(r9, r65, r63);
+    r33 = r26 * r33;
+    r33 = 1.0 / r33;
+    r26 = r33 * r46;
+    r65 = rsqrt(r30);
+    r64 = r7 * r65;
+    r26 = r26 * r64;
+    r62 = r62 * r63;
+    r62 = fma(r26, r62, r47 * r20);
+    r66 = r63 * r64;
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r31 = r30 * r34;
+    r67 = r7 * r27;
+    r66 = r66 * r31;
+    r62 = fma(r67, r66, r62);
+    r68 = r49 * r67;
+    r62 = fma(r24, r68, r62);
+    r66 = r47 * r37;
+    r1 = r35 * r1;
+    r69 = r63 * r65;
+    r69 = r69 * r31;
+    r69 = fma(r35, r69, r1 * r66);
+    r66 = r44 * r38;
+    r69 = fma(r49, r66, r69);
+    r70 = r21 * r6;
+    r70 = r70 * r6;
+    r70 = r70 * r63;
+    r70 = r70 * r65;
+    r70 = r70 * r33;
+    r69 = fma(r46, r70, r69);
+    r70 = r62 + r69;
+    r66 = r47 * r7;
+    r71 = -6.00000000000000000e+00;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r71;
+    r66 = r66 * r27;
+    r72 = -3.00000000000000000e+00;
+    r73 = r7 * r72;
+    r73 = r73 * r63;
+    r73 = fma(r26, r73, r8 * r66);
+    r66 = r18 * r63;
+    r66 = r66 * r64;
+    r66 = r66 * r31;
+    r73 = fma(r67, r66, r73);
+    r74 = r24 * r7;
+    r75 = 6.00000000000000000e+00;
+    r74 = r74 * r75;
+    r74 = r74 * r27;
+    r73 = fma(r46, r74, r73);
+    r73 = r73 + r69;
+    r73 = fma(r4, r73, r48 * r70);
+    r69 = r51 * r10;
+    r69 = r69 * r36;
+    r69 = fma(r50, r70, r70 * r69);
+    r74 = 4.00000000000000000e+00;
+    r55 = r74 * r55;
+    r54 = r54 * r18;
+    r54 = r54 * r52;
+    r69 = fma(r70, r55, r69);
+    r69 = fma(r70, r54, r69);
+    r52 = r7 * r69;
+    r73 = fma(r59, r52, r73);
+    r74 = 5.00000000000000000e-01;
+    r66 = r74 * r63;
+    r66 = r66 * r30;
+    r66 = r66 * r64;
+    r73 = fma(r58, r66, r73);
+    r76 = r21 * r47;
+    r76 = r76 * r57;
+    r76 = r76 * r34;
+    r77 = r5 * r63;
+    r78 = r10 * r38;
+    r78 = r78 * r64;
+    r78 = r78 * r31;
+    r73 = fma(r78, r77, r73);
+    r79 = r5 * r29;
+    r79 = r79 * r6;
+    r79 = r79 * r63;
+    r73 = fma(r26, r79, r73);
+    r80 = r5 * r44;
+    r73 = fma(r68, r80, r73);
+    r81 = r27 * r64;
+    r82 = -5.00000000000000000e-01;
+    r83 = r32 * r82;
+    r83 = r83 * r63;
+    r83 = r83 * r56;
+    r73 = fma(r83, r81, r73);
+    r84 = r74 * r53;
+    r84 = r84 * r63;
+    r84 = r84 * r30;
+    r84 = r84 * r64;
+    r73 = fma(r58, r84, r73);
+    r85 = r53 * r27;
+    r85 = r85 * r64;
+    r73 = fma(r83, r85, r73);
+    r83 = r7 * r53;
+    r73 = fma(r76, r83, r73);
+    r86 = r5 * r7;
+    r87 = -4.00000000000000000e+00;
+    r86 = r86 * r32;
+    r86 = r86 * r32;
+    r86 = r86 * r87;
+    r86 = r86 * r8;
+    r86 = r86 * r38;
+    r88 = r5 * r24;
+    r88 = r88 * r38;
+    r73 = fma(r49, r88, r73);
+    r73 = fma(r24, r60, r73);
+    r73 = fma(r7, r76, r73);
+    r73 = fma(r24, r59, r73);
+    r73 = fma(r47, r86, r73);
+    r25 = r25 * r0;
+    r88 = r2 * r21;
+    r83 = r71 * r8;
+    r83 = r83 * r1;
+    r85 = r18 * r63;
+    r85 = r85 * r65;
+    r85 = r85 * r31;
+    r85 = fma(r35, r85, r47 * r83);
+    r84 = r44 * r75;
+    r84 = r84 * r46;
+    r85 = fma(r38, r84, r85);
+    r81 = r6 * r6;
+    r81 = r81 * r72;
+    r81 = r81 * r63;
+    r81 = r81 * r65;
+    r81 = r81 * r33;
+    r85 = fma(r46, r81, r85);
+    r85 = r85 + r62;
+    r85 = fma(r5, r85, r45 * r70);
+    r70 = r6 * r27;
+    r70 = r70 * r32;
+    r70 = r70 * r56;
+    r70 = r70 * r82;
+    r70 = r70 * r65;
+    r70 = r70 * r63;
+    r62 = r6 * r74;
+    r62 = r62 * r65;
+    r62 = r62 * r30;
+    r62 = r62 * r58;
+    r81 = r53 * r62;
+    r84 = r6 * r53;
+    r85 = fma(r76, r84, r85);
+    r80 = r4 * r63;
+    r85 = fma(r78, r80, r85);
+    r79 = r4 * r29;
+    r79 = r79 * r6;
+    r79 = r79 * r63;
+    r85 = fma(r26, r79, r85);
+    r77 = r4 * r68;
+    r66 = r6 * r69;
+    r85 = fma(r59, r66, r85);
+    r52 = r4 * r47;
+    r52 = r52 * r7;
+    r52 = r52 * r32;
+    r52 = r52 * r32;
+    r52 = r52 * r87;
+    r52 = r52 * r8;
+    r85 = fma(r38, r52, r85);
+    r89 = r4 * r24;
+    r89 = r89 * r38;
+    r85 = fma(r49, r89, r85);
+    r85 = r85 + r70;
+    r85 = fma(r63, r81, r85);
+    r85 = fma(r63, r62, r85);
+    r85 = fma(r44, r77, r85);
+    r85 = fma(r6, r76, r85);
+    r85 = fma(r53, r70, r85);
+    r85 = fma(r44, r59, r85);
+    r85 = fma(r44, r60, r85);
+    r88 = r88 * r43;
+    r88 = fma(r85, r88, r73 * r25);
+    r25 = r2 * r21;
+    r89 = r41 * r75;
+    r89 = r89 * r46;
+    r89 = fma(r39, r83, r38 * r89);
+    r52 = r6 * r6;
+    r66 = r39 * r6;
+    r66 = r66 * r6;
+    r70 = r10 * r41;
+    r70 = r70 * r6;
+    r70 = fma(r9, r70, r37 * r66);
+    r66 = r10 * r42;
+    r66 = r66 * r7;
+    r70 = fma(r9, r66, r70);
+    r70 = fma(r39, r61, r70);
+    r66 = r72 * r70;
+    r52 = r52 * r65;
+    r52 = r52 * r33;
+    r52 = r52 * r46;
+    r89 = fma(r66, r52, r89);
+    r76 = r18 * r70;
+    r76 = r76 * r65;
+    r76 = r76 * r31;
+    r89 = fma(r35, r76, r89);
+    r79 = r70 * r64;
+    r79 = r79 * r31;
+    r79 = fma(r67, r79, r39 * r20);
+    r80 = r21 * r7;
+    r80 = r80 * r70;
+    r79 = fma(r26, r80, r79);
+    r79 = fma(r42, r68, r79);
+    r89 = r89 + r79;
+    r76 = r41 * r38;
+    r52 = r39 * r37;
+    r52 = fma(r1, r52, r49 * r76);
+    r76 = r21 * r6;
+    r76 = r76 * r6;
+    r76 = r76 * r70;
+    r76 = r76 * r65;
+    r76 = r76 * r33;
+    r52 = fma(r46, r76, r52);
+    r80 = r70 * r65;
+    r80 = r80 * r31;
+    r52 = fma(r35, r80, r52);
+    r79 = r79 + r52;
+    r89 = fma(r45, r79, r5 * r89);
+    r80 = r21 * r39;
+    r80 = r80 * r6;
+    r80 = r80 * r53;
+    r80 = r80 * r57;
+    r89 = fma(r34, r80, r89);
+    r76 = r51 * r10;
+    r76 = r76 * r36;
+    r76 = fma(r79, r76, r50 * r79);
+    r76 = fma(r79, r54, r76);
+    r76 = fma(r79, r55, r76);
+    r84 = r6 * r76;
+    r89 = fma(r59, r84, r89);
+    r90 = r21 * r39;
+    r90 = r90 * r6;
+    r90 = r90 * r57;
+    r89 = fma(r34, r90, r89);
+    r91 = r4 * r42;
+    r91 = r91 * r38;
+    r89 = fma(r49, r91, r89);
+    r92 = r32 * r82;
+    r92 = r92 * r70;
+    r92 = r92 * r56;
+    r92 = r92 * r65;
+    r89 = fma(r38, r92, r89);
+    r93 = r4 * r70;
+    r89 = fma(r78, r93, r89);
+    r94 = r4 * r29;
+    r94 = r94 * r6;
+    r94 = r94 * r70;
+    r89 = fma(r26, r94, r89);
+    r95 = r4 * r39;
+    r95 = r95 * r7;
+    r95 = r95 * r32;
+    r95 = r95 * r32;
+    r95 = r95 * r87;
+    r95 = r95 * r8;
+    r89 = fma(r38, r95, r89);
+    r96 = r32 * r53;
+    r96 = r96 * r82;
+    r96 = r96 * r70;
+    r96 = r96 * r56;
+    r96 = r96 * r65;
+    r89 = fma(r38, r96, r89);
+    r89 = fma(r41, r60, r89);
+    r89 = fma(r70, r62, r89);
+    r89 = fma(r70, r81, r89);
+    r89 = fma(r41, r59, r89);
+    r89 = fma(r41, r77, r89);
+    r25 = r25 * r43;
+    r96 = r3 * r21;
+    r95 = r39 * r7;
+    r95 = r95 * r7;
+    r95 = r95 * r32;
+    r95 = r95 * r32;
+    r95 = r95 * r71;
+    r95 = r95 * r27;
+    r94 = r18 * r70;
+    r94 = r94 * r64;
+    r94 = r94 * r31;
+    r94 = fma(r67, r94, r8 * r95);
+    r95 = r42 * r7;
+    r95 = r95 * r75;
+    r95 = r95 * r27;
+    r94 = fma(r46, r95, r94);
+    r93 = r7 * r26;
+    r94 = fma(r66, r93, r94);
+    r94 = r94 + r52;
+    r79 = fma(r48, r79, r4 * r94);
+    r94 = r21 * r39;
+    r94 = r94 * r7;
+    r94 = r94 * r57;
+    r79 = fma(r34, r94, r79);
+    r52 = r21 * r39;
+    r52 = r52 * r7;
+    r52 = r52 * r53;
+    r52 = r52 * r57;
+    r79 = fma(r34, r52, r79);
+    r93 = r74 * r70;
+    r93 = r93 * r30;
+    r93 = r93 * r64;
+    r79 = fma(r58, r93, r79);
+    r95 = r5 * r42;
+    r95 = r95 * r38;
+    r79 = fma(r49, r95, r79);
+    r66 = r32 * r82;
+    r66 = r66 * r70;
+    r66 = r66 * r27;
+    r66 = r66 * r56;
+    r79 = fma(r64, r66, r79);
+    r92 = r5 * r41;
+    r79 = fma(r68, r92, r79);
+    r91 = r5 * r70;
+    r79 = fma(r78, r91, r79);
+    r90 = r5 * r29;
+    r90 = r90 * r6;
+    r90 = r90 * r70;
+    r79 = fma(r26, r90, r79);
+    r84 = r74 * r53;
+    r84 = r84 * r70;
+    r84 = r84 * r30;
+    r84 = r84 * r64;
+    r79 = fma(r58, r84, r79);
+    r80 = r7 * r76;
+    r79 = fma(r59, r80, r79);
+    r97 = r32 * r53;
+    r97 = r97 * r82;
+    r97 = r97 * r70;
+    r97 = r97 * r27;
+    r97 = r97 * r56;
+    r79 = fma(r64, r97, r79);
+    r79 = fma(r42, r60, r79);
+    r79 = fma(r39, r86, r79);
+    r79 = fma(r42, r59, r79);
+    r96 = r96 * r0;
+    r96 = fma(r79, r96, r89 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r88, r96);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r96 = r3 * r21;
+    r88 = r21 * r7;
+    r25 = r10 * r19;
+    r25 = r25 * r6;
+    r61 = fma(r28, r61, r9 * r25);
+    r25 = r28 * r6;
+    r25 = r25 * r6;
+    r61 = fma(r37, r25, r61);
+    r97 = r10 * r40;
+    r97 = r97 * r7;
+    r61 = fma(r9, r97, r61);
+    r97 = r61 * r26;
+    r88 = fma(r97, r88, r40 * r68);
+    r25 = r61 * r64;
+    r25 = r25 * r31;
+    r88 = fma(r67, r25, r88);
+    r88 = fma(r28, r20, r88);
+    r20 = r28 * r37;
+    r25 = r21 * r6;
+    r25 = r25 * r6;
+    r25 = r25 * r61;
+    r25 = r25 * r65;
+    r25 = r25 * r33;
+    r25 = fma(r46, r25, r1 * r20);
+    r20 = r61 * r65;
+    r20 = r20 * r31;
+    r25 = fma(r35, r20, r25);
+    r1 = r19 * r38;
+    r25 = fma(r49, r1, r25);
+    r1 = r88 + r25;
+    r20 = r40 * r7;
+    r20 = r20 * r75;
+    r20 = r20 * r27;
+    r9 = r7 * r72;
+    r9 = fma(r97, r9, r46 * r20);
+    r20 = r18 * r61;
+    r20 = r20 * r64;
+    r20 = r20 * r31;
+    r9 = fma(r67, r20, r9);
+    r67 = r28 * r7;
+    r67 = r67 * r7;
+    r67 = r67 * r32;
+    r67 = r67 * r32;
+    r67 = r67 * r71;
+    r67 = r67 * r27;
+    r9 = fma(r8, r67, r9);
+    r9 = r9 + r25;
+    r9 = fma(r4, r9, r48 * r1);
+    r48 = r5 * r40;
+    r48 = r48 * r38;
+    r9 = fma(r49, r48, r9);
+    r25 = r29 * r6;
+    r25 = r25 * r97;
+    r97 = r32 * r82;
+    r97 = r97 * r61;
+    r97 = r97 * r27;
+    r97 = r97 * r56;
+    r9 = fma(r64, r97, r9);
+    r67 = r5 * r61;
+    r9 = fma(r78, r67, r9);
+    r20 = r32 * r53;
+    r20 = r20 * r82;
+    r20 = r20 * r61;
+    r20 = r20 * r27;
+    r20 = r20 * r56;
+    r9 = fma(r64, r20, r9);
+    r71 = r74 * r53;
+    r71 = r71 * r61;
+    r71 = r71 * r30;
+    r71 = r71 * r64;
+    r9 = fma(r58, r71, r9);
+    r80 = r21 * r28;
+    r80 = r80 * r7;
+    r80 = r80 * r53;
+    r80 = r80 * r57;
+    r9 = fma(r34, r80, r9);
+    r84 = r5 * r19;
+    r9 = fma(r68, r84, r9);
+    r68 = r51 * r10;
+    r68 = r68 * r36;
+    r68 = fma(r1, r68, r50 * r1);
+    r68 = fma(r1, r55, r68);
+    r68 = fma(r1, r54, r68);
+    r54 = r7 * r68;
+    r9 = fma(r59, r54, r9);
+    r55 = r74 * r61;
+    r55 = r55 * r30;
+    r55 = r55 * r64;
+    r9 = fma(r58, r55, r9);
+    r58 = r21 * r28;
+    r58 = r58 * r7;
+    r58 = r58 * r57;
+    r9 = fma(r34, r58, r9);
+    r9 = fma(r5, r25, r9);
+    r9 = fma(r28, r86, r9);
+    r9 = fma(r40, r60, r9);
+    r9 = fma(r40, r59, r9);
+    r96 = r96 * r0;
+    r0 = r2 * r21;
+    r58 = r6 * r6;
+    r58 = r58 * r72;
+    r58 = r58 * r61;
+    r58 = r58 * r65;
+    r58 = r58 * r33;
+    r58 = fma(r46, r58, r28 * r83);
+    r83 = r18 * r61;
+    r83 = r83 * r65;
+    r83 = r83 * r31;
+    r58 = fma(r35, r83, r58);
+    r35 = r19 * r75;
+    r35 = r35 * r46;
+    r58 = fma(r38, r35, r58);
+    r58 = r58 + r88;
+    r1 = fma(r45, r1, r5 * r58);
+    r45 = r21 * r28;
+    r45 = r45 * r6;
+    r45 = r45 * r57;
+    r1 = fma(r34, r45, r1);
+    r58 = r4 * r40;
+    r58 = r58 * r38;
+    r1 = fma(r49, r58, r1);
+    r49 = r32 * r82;
+    r49 = r49 * r61;
+    r49 = r49 * r56;
+    r49 = r49 * r65;
+    r1 = fma(r38, r49, r1);
+    r88 = r4 * r61;
+    r1 = fma(r78, r88, r1);
+    r78 = r4 * r28;
+    r78 = r78 * r7;
+    r78 = r78 * r32;
+    r78 = r78 * r32;
+    r78 = r78 * r87;
+    r78 = r78 * r8;
+    r1 = fma(r38, r78, r1);
+    r8 = r32 * r53;
+    r8 = r8 * r82;
+    r8 = r8 * r61;
+    r8 = r8 * r56;
+    r8 = r8 * r65;
+    r1 = fma(r38, r8, r1);
+    r56 = r21 * r28;
+    r56 = r56 * r6;
+    r56 = r56 * r53;
+    r56 = r56 * r57;
+    r1 = fma(r34, r56, r1);
+    r34 = r6 * r68;
+    r1 = fma(r59, r34, r1);
+    r1 = fma(r19, r60, r1);
+    r1 = fma(r4, r25, r1);
+    r1 = fma(r61, r62, r1);
+    r1 = fma(r61, r81, r1);
+    r1 = fma(r19, r59, r1);
+    r1 = fma(r19, r77, r1);
+    r0 = r0 * r43;
+    r0 = fma(r1, r0, r9 * r96);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r73 * r73;
+    r96 = r3 * r3;
+    r43 = r2 * r2;
+    r34 = r85 * r85;
+    r34 = fma(r43, r34, r96 * r0);
+    r0 = r79 * r79;
+    r56 = r89 * r89;
+    r56 = fma(r43, r56, r96 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r34, r56);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r9 * r96;
+    r34 = r1 * r43;
+    r1 = fma(r1, r34, r9 * r56);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r73 * r79;
+    r9 = r85 * r89;
+    r9 = fma(r43, r9, r96 * r1);
+    r1 = fma(r85, r34, r73 * r56);
+    WriteSum2<double, double>((double*)inout_shared, r9, r1);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = fma(r89, r34, r79 * r56);
+    WriteSum1<double, double>((double*)inout_shared, r34);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              out_point_precond_diag,
+              out_point_precond_diag_num_alloc,
+              out_point_precond_tril,
+              out_point_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.cu
@@ -1,0 +1,314 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              point,
+              point_num_alloc,
+              point_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.cu
@@ -1,0 +1,155 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirectKernel(
+        double* principal_point_njtr,
+        unsigned int principal_point_njtr_num_alloc,
+        SharedIndex* principal_point_njtr_indices,
+        double* principal_point_jac,
+        unsigned int principal_point_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_njtr_indices_loc[1024];
+  principal_point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r0);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r1, r2);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r3,
+                        r4);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r5, r6);
+    r7 = fma(r4, r5, r0 * r1);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r8, r9);
+    r7 = fma(r3, r8, r7);
+    r4 = fma(r4, r6, r0 * r2);
+    r4 = fma(r3, r9, r4);
+    WriteSum2<double, double>((double*)inout_shared, r7, r4);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(principal_point_njtr,
+                                0 * principal_point_njtr_num_alloc,
+                                principal_point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_njtr_indices_loc[threadIdx.x].target,
+                        r4,
+                        r7);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r8 = fma(r4, r8, r7 * r9);
+    r5 = fma(r4, r5, r7 * r6);
+    WriteSum2<double, double>((double*)inout_shared, r8, r5);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = fma(r4, r1, r7 * r2);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(principal_point_njtr,
+              principal_point_njtr_num_alloc,
+              principal_point_njtr_indices,
+              principal_point_jac,
+              principal_point_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_principal_point_njtr,
+              out_principal_point_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+    double* principal_point_njtr,
+    unsigned int principal_point_njtr_num_alloc,
+    SharedIndex* principal_point_njtr_indices,
+    double* principal_point_jac,
+    unsigned int principal_point_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.cu
@@ -1,0 +1,985 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r7 * r7;
+    r33 = 1.00000000000000008e-15;
+    r28 = r22 * r22;
+    r28 = r29 * r28;
+    r44 = r31 + r28;
+    r44 = r44 + r41;
+    r6 = fma(r8, r44, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r45 = r15 * r11;
+    r45 = r45 * r10;
+    r46 = r16 * r12;
+    r47 = fma(r10, r46, r45);
+    r48 = r11 * r12;
+    r48 = fma(r29, r48, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r47, r6);
+    r6 = fma(r26, r48, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r48);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r48);
+    r46 = fma(r29, r46, r45);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r28 = r31 + r28;
+    r28 = r28 + r43;
+    r8 = fma(r18, r46, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r28, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r33, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = copysign(1.0, r32);
+    r26 = fma(r33, r26, r32);
+    r33 = r26 * r26;
+    r27 = 1.0 / r33;
+    r32 = atan(r32);
+    r34 = r32 * r9;
+    r46 = r32 * r34;
+    r36 = r36 * r27;
+    r36 = r36 * r46;
+    r18 = 3.00000000000000000e+00;
+    r43 = r18 * r46;
+    r38 = r6 * r27;
+    r35 = r6 * r38;
+    r43 = fma(r35, r43, r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r45,
+                                            r48);
+    r20 = r46 * r35;
+    r36 = r36 + r20;
+    r43 = fma(r45, r36, r5 * r43);
+    r25 = r4 * r7;
+    r49 = r10 * r46;
+    r25 = r25 * r38;
+    r43 = fma(r49, r25, r43);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r50,
+                                            r51);
+    r52 = r36 * r36;
+    r53 = fma(r51, r52, r50 * r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r54,
+                                            r55);
+    r56 = r36 * r52;
+    r55 = r55 * r56;
+    r53 = fma(r36, r55, r53);
+    r53 = fma(r54, r56, r53);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r26;
+    r58 = r56 * r57;
+    r59 = r32 * r58;
+    r60 = r53 * r59;
+    r43 = fma(r6, r60, r43);
+    r43 = fma(r6, r59, r43);
+    r43 = fma(r2, r43, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r25);
+    r43 = fma(r0, r21, r43);
+    r0 = r7 * r7;
+    r0 = r0 * r18;
+    r0 = r0 * r27;
+    r0 = fma(r46, r0, r20);
+    r0 = fma(r48, r36, r4 * r0);
+    r20 = r5 * r7;
+    r20 = r20 * r38;
+    r0 = fma(r49, r20, r0);
+    r0 = fma(r7, r60, r0);
+    r0 = fma(r7, r59, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r25, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r43, r0);
+    r25 = r21 * r43;
+    r1 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r25, r1);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r31, r31);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r32 * r32;
+    r25 = r27 * r1;
+    r20 = r7 * r7;
+    r8 = r37 * r8;
+    r8 = 1.0 / r8;
+    r37 = r29 * r8;
+    r20 = r20 * r37;
+    r25 = r25 * r20;
+    r61 = r21 * r7;
+    r62 = r10 * r44;
+    r62 = r62 * r6;
+    r62 = fma(r47, r20, r9 * r62);
+    r63 = r47 * r6;
+    r63 = r63 * r6;
+    r62 = fma(r37, r63, r62);
+    r64 = r10 * r24;
+    r64 = r64 * r7;
+    r62 = fma(r9, r64, r62);
+    r33 = r26 * r33;
+    r33 = 1.0 / r33;
+    r26 = r33 * r46;
+    r64 = rsqrt(r30);
+    r63 = r7 * r64;
+    r26 = r26 * r63;
+    r61 = r61 * r62;
+    r61 = fma(r26, r61, r47 * r25);
+    r65 = r62 * r63;
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r31 = r30 * r34;
+    r66 = r7 * r27;
+    r65 = r65 * r31;
+    r61 = fma(r66, r65, r61);
+    r67 = r49 * r66;
+    r61 = fma(r24, r67, r61);
+    r65 = r47 * r37;
+    r1 = r35 * r1;
+    r68 = r62 * r64;
+    r68 = r68 * r31;
+    r68 = fma(r35, r68, r1 * r65);
+    r65 = r44 * r38;
+    r68 = fma(r49, r65, r68);
+    r69 = r21 * r6;
+    r69 = r69 * r6;
+    r69 = r69 * r62;
+    r69 = r69 * r64;
+    r69 = r69 * r33;
+    r68 = fma(r46, r69, r68);
+    r69 = r61 + r68;
+    r65 = -6.00000000000000000e+00;
+    r70 = r65 * r8;
+    r70 = r70 * r1;
+    r71 = r18 * r62;
+    r71 = r71 * r64;
+    r71 = r71 * r31;
+    r71 = fma(r35, r71, r47 * r70);
+    r72 = 6.00000000000000000e+00;
+    r73 = r44 * r72;
+    r73 = r73 * r46;
+    r71 = fma(r38, r73, r71);
+    r74 = r6 * r6;
+    r75 = -3.00000000000000000e+00;
+    r74 = r74 * r75;
+    r74 = r74 * r62;
+    r74 = r74 * r64;
+    r74 = r74 * r33;
+    r71 = fma(r46, r74, r71);
+    r71 = r71 + r61;
+    r71 = fma(r5, r71, r45 * r69);
+    r61 = r6 * r27;
+    r74 = -5.00000000000000000e-01;
+    r61 = r61 * r32;
+    r61 = r61 * r56;
+    r61 = r61 * r74;
+    r61 = r61 * r64;
+    r61 = r61 * r62;
+    r73 = 5.00000000000000000e-01;
+    r76 = r6 * r73;
+    r76 = r76 * r30;
+    r76 = r76 * r64;
+    r76 = r76 * r58;
+    r77 = r53 * r76;
+    r78 = r6 * r53;
+    r79 = r21 * r47;
+    r79 = r79 * r57;
+    r79 = r79 * r34;
+    r71 = fma(r79, r78, r71);
+    r80 = r4 * r62;
+    r81 = r10 * r38;
+    r81 = r81 * r63;
+    r81 = r81 * r31;
+    r71 = fma(r81, r80, r71);
+    r82 = r4 * r29;
+    r82 = r82 * r6;
+    r82 = r82 * r62;
+    r71 = fma(r26, r82, r71);
+    r83 = r4 * r44;
+    r71 = fma(r67, r83, r71);
+    r84 = r51 * r10;
+    r84 = r84 * r36;
+    r84 = fma(r50, r69, r69 * r84);
+    r85 = 4.00000000000000000e+00;
+    r55 = r85 * r55;
+    r54 = r54 * r18;
+    r54 = r54 * r52;
+    r84 = fma(r69, r55, r84);
+    r84 = fma(r69, r54, r84);
+    r52 = r6 * r84;
+    r71 = fma(r59, r52, r71);
+    r85 = r4 * r7;
+    r86 = -4.00000000000000000e+00;
+    r85 = r85 * r32;
+    r85 = r85 * r32;
+    r85 = r85 * r86;
+    r85 = r85 * r8;
+    r85 = r85 * r38;
+    r87 = r4 * r24;
+    r87 = r87 * r38;
+    r71 = fma(r49, r87, r71);
+    r71 = r71 + r61;
+    r71 = fma(r62, r77, r71);
+    r71 = fma(r62, r76, r71);
+    r71 = fma(r6, r79, r71);
+    r71 = fma(r53, r61, r71);
+    r71 = fma(r44, r59, r71);
+    r71 = fma(r47, r85, r71);
+    r71 = fma(r44, r60, r71);
+    r87 = r2 * r71;
+    r52 = r47 * r7;
+    r52 = r52 * r7;
+    r52 = r52 * r32;
+    r52 = r52 * r32;
+    r52 = r52 * r65;
+    r52 = r52 * r27;
+    r61 = r7 * r75;
+    r61 = r61 * r62;
+    r61 = fma(r26, r61, r8 * r52);
+    r52 = r18 * r62;
+    r52 = r52 * r63;
+    r52 = r52 * r31;
+    r61 = fma(r66, r52, r61);
+    r83 = r24 * r7;
+    r83 = r83 * r72;
+    r83 = r83 * r27;
+    r61 = fma(r46, r83, r61);
+    r61 = r61 + r68;
+    r61 = fma(r4, r61, r48 * r69);
+    r69 = r7 * r84;
+    r61 = fma(r59, r69, r61);
+    r68 = r73 * r62;
+    r68 = r68 * r30;
+    r68 = r68 * r63;
+    r61 = fma(r58, r68, r61);
+    r83 = r5 * r62;
+    r61 = fma(r81, r83, r61);
+    r52 = r5 * r29;
+    r52 = r52 * r6;
+    r52 = r52 * r62;
+    r61 = fma(r26, r52, r61);
+    r82 = r5 * r67;
+    r80 = r27 * r63;
+    r78 = r32 * r74;
+    r78 = r78 * r62;
+    r78 = r78 * r56;
+    r61 = fma(r78, r80, r61);
+    r88 = r73 * r53;
+    r88 = r88 * r62;
+    r88 = r88 * r30;
+    r88 = r88 * r63;
+    r61 = fma(r58, r88, r61);
+    r89 = r53 * r27;
+    r89 = r89 * r63;
+    r61 = fma(r78, r89, r61);
+    r78 = r7 * r53;
+    r61 = fma(r79, r78, r61);
+    r90 = r5 * r47;
+    r90 = r90 * r7;
+    r90 = r90 * r32;
+    r90 = r90 * r32;
+    r90 = r90 * r86;
+    r90 = r90 * r8;
+    r61 = fma(r38, r90, r61);
+    r91 = r5 * r24;
+    r91 = r91 * r38;
+    r61 = fma(r49, r91, r61);
+    r61 = fma(r24, r60, r61);
+    r61 = fma(r7, r79, r61);
+    r61 = fma(r44, r82, r61);
+    r61 = fma(r24, r59, r61);
+    r91 = r3 * r61;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r87,
+                                             r91);
+    r91 = r41 * r72;
+    r91 = r91 * r46;
+    r91 = fma(r39, r70, r38 * r91);
+    r87 = r6 * r6;
+    r90 = r39 * r6;
+    r90 = r90 * r6;
+    r78 = r10 * r41;
+    r78 = r78 * r6;
+    r78 = fma(r9, r78, r37 * r90);
+    r90 = r10 * r42;
+    r90 = r90 * r7;
+    r78 = fma(r9, r90, r78);
+    r78 = fma(r39, r20, r78);
+    r90 = r75 * r78;
+    r87 = r87 * r64;
+    r87 = r87 * r33;
+    r87 = r87 * r46;
+    r91 = fma(r90, r87, r91);
+    r89 = r18 * r78;
+    r89 = r89 * r64;
+    r89 = r89 * r31;
+    r91 = fma(r35, r89, r91);
+    r88 = r78 * r63;
+    r88 = r88 * r31;
+    r88 = fma(r66, r88, r39 * r25);
+    r80 = r21 * r7;
+    r80 = r80 * r78;
+    r88 = fma(r26, r80, r88);
+    r88 = fma(r42, r67, r88);
+    r91 = r91 + r88;
+    r89 = r41 * r38;
+    r87 = r39 * r37;
+    r87 = fma(r1, r87, r49 * r89);
+    r89 = r21 * r6;
+    r89 = r89 * r6;
+    r89 = r89 * r78;
+    r89 = r89 * r64;
+    r89 = r89 * r33;
+    r87 = fma(r46, r89, r87);
+    r80 = r78 * r64;
+    r80 = r80 * r31;
+    r87 = fma(r35, r80, r87);
+    r88 = r88 + r87;
+    r91 = fma(r45, r88, r5 * r91);
+    r80 = r21 * r39;
+    r80 = r80 * r6;
+    r80 = r80 * r53;
+    r80 = r80 * r57;
+    r91 = fma(r34, r80, r91);
+    r89 = r51 * r10;
+    r89 = r89 * r36;
+    r89 = fma(r88, r89, r50 * r88);
+    r89 = fma(r88, r54, r89);
+    r89 = fma(r88, r55, r89);
+    r52 = r6 * r89;
+    r91 = fma(r59, r52, r91);
+    r83 = r21 * r39;
+    r83 = r83 * r6;
+    r83 = r83 * r57;
+    r91 = fma(r34, r83, r91);
+    r79 = r4 * r42;
+    r79 = r79 * r38;
+    r91 = fma(r49, r79, r91);
+    r68 = r4 * r41;
+    r91 = fma(r67, r68, r91);
+    r69 = r32 * r74;
+    r69 = r69 * r78;
+    r69 = r69 * r56;
+    r69 = r69 * r64;
+    r91 = fma(r38, r69, r91);
+    r92 = r4 * r78;
+    r91 = fma(r81, r92, r91);
+    r93 = r4 * r29;
+    r93 = r93 * r6;
+    r93 = r93 * r78;
+    r91 = fma(r26, r93, r91);
+    r94 = r32 * r53;
+    r94 = r94 * r74;
+    r94 = r94 * r78;
+    r94 = r94 * r56;
+    r94 = r94 * r64;
+    r91 = fma(r38, r94, r91);
+    r91 = fma(r41, r60, r91);
+    r91 = fma(r78, r76, r91);
+    r91 = fma(r78, r77, r91);
+    r91 = fma(r41, r59, r91);
+    r91 = fma(r39, r85, r91);
+    r94 = r2 * r91;
+    r93 = r39 * r7;
+    r93 = r93 * r7;
+    r93 = r93 * r32;
+    r93 = r93 * r32;
+    r93 = r93 * r65;
+    r93 = r93 * r27;
+    r92 = r18 * r78;
+    r92 = r92 * r63;
+    r92 = r92 * r31;
+    r92 = fma(r66, r92, r8 * r93);
+    r93 = r42 * r7;
+    r93 = r93 * r72;
+    r93 = r93 * r27;
+    r92 = fma(r46, r93, r92);
+    r69 = r7 * r26;
+    r92 = fma(r90, r69, r92);
+    r92 = r92 + r87;
+    r88 = fma(r48, r88, r4 * r92);
+    r92 = r21 * r39;
+    r92 = r92 * r7;
+    r92 = r92 * r57;
+    r88 = fma(r34, r92, r88);
+    r87 = r21 * r39;
+    r87 = r87 * r7;
+    r87 = r87 * r53;
+    r87 = r87 * r57;
+    r88 = fma(r34, r87, r88);
+    r69 = r73 * r78;
+    r69 = r69 * r30;
+    r69 = r69 * r63;
+    r88 = fma(r58, r69, r88);
+    r93 = r5 * r42;
+    r93 = r93 * r38;
+    r88 = fma(r49, r93, r88);
+    r90 = r32 * r74;
+    r90 = r90 * r78;
+    r90 = r90 * r27;
+    r90 = r90 * r56;
+    r88 = fma(r63, r90, r88);
+    r68 = r5 * r78;
+    r88 = fma(r81, r68, r88);
+    r79 = r5 * r29;
+    r79 = r79 * r6;
+    r79 = r79 * r78;
+    r88 = fma(r26, r79, r88);
+    r83 = r5 * r39;
+    r83 = r83 * r7;
+    r83 = r83 * r32;
+    r83 = r83 * r32;
+    r83 = r83 * r86;
+    r83 = r83 * r8;
+    r88 = fma(r38, r83, r88);
+    r52 = r73 * r53;
+    r52 = r52 * r78;
+    r52 = r52 * r30;
+    r52 = r52 * r63;
+    r88 = fma(r58, r52, r88);
+    r80 = r7 * r89;
+    r88 = fma(r59, r80, r88);
+    r95 = r32 * r53;
+    r95 = r95 * r74;
+    r95 = r95 * r78;
+    r95 = r95 * r27;
+    r95 = r95 * r56;
+    r88 = fma(r63, r95, r88);
+    r88 = fma(r42, r60, r88);
+    r88 = fma(r41, r82, r88);
+    r88 = fma(r42, r59, r88);
+    r95 = r3 * r88;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r94,
+                                             r95);
+    r95 = r6 * r6;
+    r94 = r10 * r19;
+    r94 = r94 * r6;
+    r20 = fma(r28, r20, r9 * r94);
+    r94 = r28 * r6;
+    r94 = r94 * r6;
+    r20 = fma(r37, r94, r20);
+    r80 = r10 * r40;
+    r80 = r80 * r7;
+    r20 = fma(r9, r80, r20);
+    r95 = r95 * r75;
+    r95 = r95 * r20;
+    r95 = r95 * r64;
+    r95 = r95 * r33;
+    r95 = fma(r46, r95, r28 * r70);
+    r70 = r18 * r20;
+    r70 = r70 * r64;
+    r70 = r70 * r31;
+    r95 = fma(r35, r70, r95);
+    r80 = r19 * r72;
+    r80 = r80 * r46;
+    r95 = fma(r38, r80, r95);
+    r94 = r21 * r7;
+    r9 = r20 * r26;
+    r94 = fma(r9, r94, r40 * r67);
+    r52 = r20 * r63;
+    r52 = r52 * r31;
+    r94 = fma(r66, r52, r94);
+    r94 = fma(r28, r25, r94);
+    r95 = r95 + r94;
+    r80 = r28 * r37;
+    r70 = r21 * r6;
+    r70 = r70 * r6;
+    r70 = r70 * r20;
+    r70 = r70 * r64;
+    r70 = r70 * r33;
+    r70 = fma(r46, r70, r1 * r80);
+    r80 = r20 * r64;
+    r80 = r80 * r31;
+    r70 = fma(r35, r80, r70);
+    r35 = r19 * r38;
+    r70 = fma(r49, r35, r70);
+    r94 = r94 + r70;
+    r45 = fma(r45, r94, r5 * r95);
+    r95 = r21 * r28;
+    r95 = r95 * r6;
+    r95 = r95 * r57;
+    r45 = fma(r34, r95, r45);
+    r35 = r4 * r40;
+    r35 = r35 * r38;
+    r45 = fma(r49, r35, r45);
+    r80 = r29 * r6;
+    r80 = r80 * r9;
+    r1 = r32 * r74;
+    r1 = r1 * r20;
+    r1 = r1 * r56;
+    r1 = r1 * r64;
+    r45 = fma(r38, r1, r45);
+    r33 = r4 * r20;
+    r45 = fma(r81, r33, r45);
+    r25 = r4 * r19;
+    r45 = fma(r67, r25, r45);
+    r67 = r32 * r53;
+    r67 = r67 * r74;
+    r67 = r67 * r20;
+    r67 = r67 * r56;
+    r67 = r67 * r64;
+    r45 = fma(r38, r67, r45);
+    r52 = r21 * r28;
+    r52 = r52 * r6;
+    r52 = r52 * r53;
+    r52 = r52 * r57;
+    r45 = fma(r34, r52, r45);
+    r83 = r51 * r10;
+    r83 = r83 * r36;
+    r83 = fma(r94, r83, r50 * r94);
+    r83 = fma(r94, r55, r83);
+    r83 = fma(r94, r54, r83);
+    r54 = r6 * r83;
+    r45 = fma(r59, r54, r45);
+    r45 = fma(r19, r60, r45);
+    r45 = fma(r4, r80, r45);
+    r45 = fma(r20, r76, r45);
+    r45 = fma(r20, r77, r45);
+    r45 = fma(r28, r85, r45);
+    r45 = fma(r19, r59, r45);
+    r54 = r2 * r45;
+    r52 = r40 * r7;
+    r52 = r52 * r72;
+    r52 = r52 * r27;
+    r67 = r7 * r75;
+    r67 = fma(r9, r67, r46 * r52);
+    r52 = r18 * r20;
+    r52 = r52 * r63;
+    r52 = r52 * r31;
+    r67 = fma(r66, r52, r67);
+    r66 = r28 * r7;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r65;
+    r66 = r66 * r27;
+    r67 = fma(r8, r66, r67);
+    r67 = r67 + r70;
+    r67 = fma(r4, r67, r48 * r94);
+    r94 = r5 * r40;
+    r94 = r94 * r38;
+    r67 = fma(r49, r94, r67);
+    r49 = r32 * r74;
+    r49 = r49 * r20;
+    r49 = r49 * r27;
+    r49 = r49 * r56;
+    r67 = fma(r63, r49, r67);
+    r48 = r5 * r20;
+    r67 = fma(r81, r48, r67);
+    r81 = r32 * r53;
+    r81 = r81 * r74;
+    r81 = r81 * r20;
+    r81 = r81 * r27;
+    r81 = r81 * r56;
+    r67 = fma(r63, r81, r67);
+    r56 = r73 * r53;
+    r56 = r56 * r20;
+    r56 = r56 * r30;
+    r56 = r56 * r63;
+    r67 = fma(r58, r56, r67);
+    r70 = r21 * r28;
+    r70 = r70 * r7;
+    r70 = r70 * r53;
+    r70 = r70 * r57;
+    r67 = fma(r34, r70, r67);
+    r66 = r5 * r28;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r86;
+    r66 = r66 * r8;
+    r67 = fma(r38, r66, r67);
+    r8 = r7 * r83;
+    r67 = fma(r59, r8, r67);
+    r86 = r73 * r20;
+    r86 = r86 * r30;
+    r86 = r86 * r63;
+    r67 = fma(r58, r86, r67);
+    r58 = r21 * r28;
+    r58 = r58 * r7;
+    r58 = r58 * r57;
+    r67 = fma(r34, r58, r67);
+    r67 = fma(r5, r80, r67);
+    r67 = fma(r40, r60, r67);
+    r67 = fma(r19, r82, r67);
+    r67 = fma(r40, r59, r67);
+    r58 = r3 * r67;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r54,
+                                             r58);
+    r58 = r3 * r21;
+    r58 = r58 * r0;
+    r54 = r2 * r21;
+    r54 = r54 * r43;
+    r54 = fma(r71, r54, r61 * r58);
+    r58 = r2 * r21;
+    r58 = r58 * r43;
+    r86 = r3 * r21;
+    r86 = r86 * r0;
+    r86 = fma(r88, r86, r91 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r54, r86);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r3 * r21;
+    r86 = r86 * r0;
+    r0 = r2 * r21;
+    r0 = r0 * r43;
+    r0 = fma(r45, r0, r67 * r86);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r61 * r61;
+    r86 = r3 * r3;
+    r43 = r2 * r2;
+    r54 = r71 * r43;
+    r71 = fma(r71, r54, r86 * r0);
+    r0 = r88 * r86;
+    r58 = r91 * r91;
+    r58 = fma(r43, r58, r88 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r71, r58);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r58 = r67 * r67;
+    r71 = r45 * r45;
+    r71 = fma(r43, r71, r86 * r58);
+    WriteSum1<double, double>((double*)inout_shared, r71);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = fma(r91, r54, r61 * r0);
+    r58 = r61 * r67;
+    r54 = fma(r45, r54, r86 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r71, r54);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r91 * r45;
+    r54 = fma(r43, r54, r67 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r54);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacKernel<<<n_blocks,
+                                                                 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.cu
@@ -1,0 +1,999 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_principal_point_jac,
+        unsigned int out_principal_point_jac_num_alloc,
+        double* const out_principal_point_njtr,
+        unsigned int out_principal_point_njtr_num_alloc,
+        double* const out_principal_point_precond_diag,
+        unsigned int out_principal_point_precond_diag_num_alloc,
+        double* const out_principal_point_precond_tril,
+        unsigned int out_principal_point_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r7 * r7;
+    r33 = 1.00000000000000008e-15;
+    r28 = r22 * r22;
+    r28 = r29 * r28;
+    r44 = r31 + r28;
+    r44 = r44 + r41;
+    r6 = fma(r8, r44, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r45 = r15 * r11;
+    r45 = r45 * r10;
+    r46 = r16 * r12;
+    r47 = fma(r10, r46, r45);
+    r48 = r11 * r12;
+    r48 = fma(r29, r48, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r47, r6);
+    r6 = fma(r26, r48, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r48);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r48);
+    r46 = fma(r29, r46, r45);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r28 = r31 + r28;
+    r28 = r28 + r43;
+    r8 = fma(r18, r46, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r28, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r33, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = copysign(1.0, r32);
+    r26 = fma(r33, r26, r32);
+    r33 = r26 * r26;
+    r27 = 1.0 / r33;
+    r32 = atan(r32);
+    r34 = r32 * r9;
+    r46 = r32 * r34;
+    r36 = r36 * r27;
+    r36 = r36 * r46;
+    r18 = 3.00000000000000000e+00;
+    r43 = r18 * r46;
+    r38 = r6 * r27;
+    r35 = r6 * r38;
+    r43 = fma(r35, r43, r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r45,
+                                            r48);
+    r20 = r46 * r35;
+    r36 = r36 + r20;
+    r43 = fma(r45, r36, r5 * r43);
+    r25 = r4 * r7;
+    r49 = r10 * r46;
+    r25 = r25 * r38;
+    r43 = fma(r49, r25, r43);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r50,
+                                            r51);
+    r52 = r36 * r36;
+    r53 = fma(r51, r52, r50 * r36);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r54,
+                                            r55);
+    r56 = r36 * r52;
+    r55 = r55 * r56;
+    r53 = fma(r36, r55, r53);
+    r53 = fma(r54, r56, r53);
+    r56 = 1.0 / r37;
+    r57 = 1.0 / r26;
+    r58 = r56 * r57;
+    r59 = r32 * r58;
+    r60 = r53 * r59;
+    r43 = fma(r6, r60, r43);
+    r43 = fma(r6, r59, r43);
+    r43 = fma(r2, r43, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r0, r25);
+    r43 = fma(r0, r21, r43);
+    r0 = r7 * r7;
+    r0 = r0 * r18;
+    r0 = r0 * r27;
+    r0 = fma(r46, r0, r20);
+    r0 = fma(r48, r36, r4 * r0);
+    r20 = r5 * r7;
+    r20 = r20 * r38;
+    r0 = fma(r49, r20, r0);
+    r0 = fma(r7, r60, r0);
+    r0 = fma(r7, r59, r0);
+    r0 = fma(r3, r0, r1);
+    r0 = fma(r25, r21, r0);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r43, r0);
+    r25 = fma(r0, r0, r43 * r43);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r25);
+  if (global_thread_idx < problem_size) {
+    r25 = r21 * r43;
+    r1 = r21 * r0;
+    WriteSum2<double, double>((double*)inout_shared, r25, r1);
+  };
+  FlushSumShared<2, double>(out_principal_point_njtr,
+                            0 * out_principal_point_njtr_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r31, r31);
+  };
+  FlushSumShared<2, double>(out_principal_point_precond_diag,
+                            0 * out_principal_point_precond_diag_num_alloc,
+                            principal_point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r32 * r32;
+    r25 = r27 * r1;
+    r20 = r7 * r7;
+    r8 = r37 * r8;
+    r8 = 1.0 / r8;
+    r37 = r29 * r8;
+    r20 = r20 * r37;
+    r25 = r25 * r20;
+    r61 = r21 * r7;
+    r62 = r10 * r44;
+    r62 = r62 * r6;
+    r62 = fma(r47, r20, r9 * r62);
+    r63 = r47 * r6;
+    r63 = r63 * r6;
+    r62 = fma(r37, r63, r62);
+    r64 = r10 * r24;
+    r64 = r64 * r7;
+    r62 = fma(r9, r64, r62);
+    r33 = r26 * r33;
+    r33 = 1.0 / r33;
+    r26 = r33 * r46;
+    r64 = rsqrt(r30);
+    r63 = r7 * r64;
+    r26 = r26 * r63;
+    r61 = r61 * r62;
+    r61 = fma(r26, r61, r47 * r25);
+    r65 = r62 * r63;
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r31 = r30 * r34;
+    r66 = r7 * r27;
+    r65 = r65 * r31;
+    r61 = fma(r66, r65, r61);
+    r67 = r49 * r66;
+    r61 = fma(r24, r67, r61);
+    r65 = r47 * r37;
+    r1 = r35 * r1;
+    r68 = r62 * r64;
+    r68 = r68 * r31;
+    r68 = fma(r35, r68, r1 * r65);
+    r65 = r44 * r38;
+    r68 = fma(r49, r65, r68);
+    r69 = r21 * r6;
+    r69 = r69 * r6;
+    r69 = r69 * r62;
+    r69 = r69 * r64;
+    r69 = r69 * r33;
+    r68 = fma(r46, r69, r68);
+    r69 = r61 + r68;
+    r65 = -6.00000000000000000e+00;
+    r70 = r65 * r8;
+    r70 = r70 * r1;
+    r71 = r18 * r62;
+    r71 = r71 * r64;
+    r71 = r71 * r31;
+    r71 = fma(r35, r71, r47 * r70);
+    r72 = 6.00000000000000000e+00;
+    r73 = r44 * r72;
+    r73 = r73 * r46;
+    r71 = fma(r38, r73, r71);
+    r74 = r6 * r6;
+    r75 = -3.00000000000000000e+00;
+    r74 = r74 * r75;
+    r74 = r74 * r62;
+    r74 = r74 * r64;
+    r74 = r74 * r33;
+    r71 = fma(r46, r74, r71);
+    r71 = r71 + r61;
+    r71 = fma(r5, r71, r45 * r69);
+    r61 = r6 * r27;
+    r74 = -5.00000000000000000e-01;
+    r61 = r61 * r32;
+    r61 = r61 * r56;
+    r61 = r61 * r74;
+    r61 = r61 * r64;
+    r61 = r61 * r62;
+    r73 = 5.00000000000000000e-01;
+    r76 = r6 * r73;
+    r76 = r76 * r30;
+    r76 = r76 * r64;
+    r76 = r76 * r58;
+    r77 = r53 * r76;
+    r78 = r6 * r53;
+    r79 = r21 * r47;
+    r79 = r79 * r57;
+    r79 = r79 * r34;
+    r71 = fma(r79, r78, r71);
+    r80 = r4 * r62;
+    r81 = r10 * r38;
+    r81 = r81 * r63;
+    r81 = r81 * r31;
+    r71 = fma(r81, r80, r71);
+    r82 = r4 * r29;
+    r82 = r82 * r6;
+    r82 = r82 * r62;
+    r71 = fma(r26, r82, r71);
+    r83 = r4 * r44;
+    r71 = fma(r67, r83, r71);
+    r84 = r51 * r10;
+    r84 = r84 * r36;
+    r84 = fma(r50, r69, r69 * r84);
+    r85 = 4.00000000000000000e+00;
+    r55 = r85 * r55;
+    r54 = r54 * r18;
+    r54 = r54 * r52;
+    r84 = fma(r69, r55, r84);
+    r84 = fma(r69, r54, r84);
+    r52 = r6 * r84;
+    r71 = fma(r59, r52, r71);
+    r85 = r4 * r7;
+    r86 = -4.00000000000000000e+00;
+    r85 = r85 * r32;
+    r85 = r85 * r32;
+    r85 = r85 * r86;
+    r85 = r85 * r8;
+    r85 = r85 * r38;
+    r87 = r4 * r24;
+    r87 = r87 * r38;
+    r71 = fma(r49, r87, r71);
+    r71 = r71 + r61;
+    r71 = fma(r62, r77, r71);
+    r71 = fma(r62, r76, r71);
+    r71 = fma(r6, r79, r71);
+    r71 = fma(r53, r61, r71);
+    r71 = fma(r44, r59, r71);
+    r71 = fma(r47, r85, r71);
+    r71 = fma(r44, r60, r71);
+    r87 = r2 * r71;
+    r52 = r47 * r7;
+    r52 = r52 * r7;
+    r52 = r52 * r32;
+    r52 = r52 * r32;
+    r52 = r52 * r65;
+    r52 = r52 * r27;
+    r61 = r7 * r75;
+    r61 = r61 * r62;
+    r61 = fma(r26, r61, r8 * r52);
+    r52 = r18 * r62;
+    r52 = r52 * r63;
+    r52 = r52 * r31;
+    r61 = fma(r66, r52, r61);
+    r83 = r24 * r7;
+    r83 = r83 * r72;
+    r83 = r83 * r27;
+    r61 = fma(r46, r83, r61);
+    r61 = r61 + r68;
+    r61 = fma(r4, r61, r48 * r69);
+    r69 = r7 * r84;
+    r61 = fma(r59, r69, r61);
+    r68 = r73 * r62;
+    r68 = r68 * r30;
+    r68 = r68 * r63;
+    r61 = fma(r58, r68, r61);
+    r83 = r5 * r62;
+    r61 = fma(r81, r83, r61);
+    r52 = r5 * r29;
+    r52 = r52 * r6;
+    r52 = r52 * r62;
+    r61 = fma(r26, r52, r61);
+    r82 = r5 * r67;
+    r80 = r27 * r63;
+    r78 = r32 * r74;
+    r78 = r78 * r62;
+    r78 = r78 * r56;
+    r61 = fma(r78, r80, r61);
+    r88 = r73 * r53;
+    r88 = r88 * r62;
+    r88 = r88 * r30;
+    r88 = r88 * r63;
+    r61 = fma(r58, r88, r61);
+    r89 = r53 * r27;
+    r89 = r89 * r63;
+    r61 = fma(r78, r89, r61);
+    r78 = r7 * r53;
+    r61 = fma(r79, r78, r61);
+    r90 = r5 * r47;
+    r90 = r90 * r7;
+    r90 = r90 * r32;
+    r90 = r90 * r32;
+    r90 = r90 * r86;
+    r90 = r90 * r8;
+    r61 = fma(r38, r90, r61);
+    r91 = r5 * r24;
+    r91 = r91 * r38;
+    r61 = fma(r49, r91, r61);
+    r61 = fma(r24, r60, r61);
+    r61 = fma(r7, r79, r61);
+    r61 = fma(r44, r82, r61);
+    r61 = fma(r24, r59, r61);
+    r91 = r3 * r61;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r87,
+                                             r91);
+    r91 = r41 * r72;
+    r91 = r91 * r46;
+    r91 = fma(r39, r70, r38 * r91);
+    r87 = r6 * r6;
+    r90 = r39 * r6;
+    r90 = r90 * r6;
+    r78 = r10 * r41;
+    r78 = r78 * r6;
+    r78 = fma(r9, r78, r37 * r90);
+    r90 = r10 * r42;
+    r90 = r90 * r7;
+    r78 = fma(r9, r90, r78);
+    r78 = fma(r39, r20, r78);
+    r90 = r75 * r78;
+    r87 = r87 * r64;
+    r87 = r87 * r33;
+    r87 = r87 * r46;
+    r91 = fma(r90, r87, r91);
+    r89 = r18 * r78;
+    r89 = r89 * r64;
+    r89 = r89 * r31;
+    r91 = fma(r35, r89, r91);
+    r88 = r78 * r63;
+    r88 = r88 * r31;
+    r88 = fma(r66, r88, r39 * r25);
+    r80 = r21 * r7;
+    r80 = r80 * r78;
+    r88 = fma(r26, r80, r88);
+    r88 = fma(r42, r67, r88);
+    r91 = r91 + r88;
+    r89 = r41 * r38;
+    r87 = r39 * r37;
+    r87 = fma(r1, r87, r49 * r89);
+    r89 = r21 * r6;
+    r89 = r89 * r6;
+    r89 = r89 * r78;
+    r89 = r89 * r64;
+    r89 = r89 * r33;
+    r87 = fma(r46, r89, r87);
+    r80 = r78 * r64;
+    r80 = r80 * r31;
+    r87 = fma(r35, r80, r87);
+    r88 = r88 + r87;
+    r91 = fma(r45, r88, r5 * r91);
+    r80 = r21 * r39;
+    r80 = r80 * r6;
+    r80 = r80 * r53;
+    r80 = r80 * r57;
+    r91 = fma(r34, r80, r91);
+    r89 = r51 * r10;
+    r89 = r89 * r36;
+    r89 = fma(r88, r89, r50 * r88);
+    r89 = fma(r88, r54, r89);
+    r89 = fma(r88, r55, r89);
+    r52 = r6 * r89;
+    r91 = fma(r59, r52, r91);
+    r83 = r21 * r39;
+    r83 = r83 * r6;
+    r83 = r83 * r57;
+    r91 = fma(r34, r83, r91);
+    r79 = r4 * r42;
+    r79 = r79 * r38;
+    r91 = fma(r49, r79, r91);
+    r68 = r4 * r41;
+    r91 = fma(r67, r68, r91);
+    r69 = r32 * r74;
+    r69 = r69 * r78;
+    r69 = r69 * r56;
+    r69 = r69 * r64;
+    r91 = fma(r38, r69, r91);
+    r92 = r4 * r78;
+    r91 = fma(r81, r92, r91);
+    r93 = r4 * r29;
+    r93 = r93 * r6;
+    r93 = r93 * r78;
+    r91 = fma(r26, r93, r91);
+    r94 = r32 * r53;
+    r94 = r94 * r74;
+    r94 = r94 * r78;
+    r94 = r94 * r56;
+    r94 = r94 * r64;
+    r91 = fma(r38, r94, r91);
+    r91 = fma(r41, r60, r91);
+    r91 = fma(r78, r76, r91);
+    r91 = fma(r78, r77, r91);
+    r91 = fma(r41, r59, r91);
+    r91 = fma(r39, r85, r91);
+    r94 = r2 * r91;
+    r93 = r39 * r7;
+    r93 = r93 * r7;
+    r93 = r93 * r32;
+    r93 = r93 * r32;
+    r93 = r93 * r65;
+    r93 = r93 * r27;
+    r92 = r18 * r78;
+    r92 = r92 * r63;
+    r92 = r92 * r31;
+    r92 = fma(r66, r92, r8 * r93);
+    r93 = r42 * r7;
+    r93 = r93 * r72;
+    r93 = r93 * r27;
+    r92 = fma(r46, r93, r92);
+    r69 = r7 * r26;
+    r92 = fma(r90, r69, r92);
+    r92 = r92 + r87;
+    r88 = fma(r48, r88, r4 * r92);
+    r92 = r21 * r39;
+    r92 = r92 * r7;
+    r92 = r92 * r57;
+    r88 = fma(r34, r92, r88);
+    r87 = r21 * r39;
+    r87 = r87 * r7;
+    r87 = r87 * r53;
+    r87 = r87 * r57;
+    r88 = fma(r34, r87, r88);
+    r69 = r73 * r78;
+    r69 = r69 * r30;
+    r69 = r69 * r63;
+    r88 = fma(r58, r69, r88);
+    r93 = r5 * r42;
+    r93 = r93 * r38;
+    r88 = fma(r49, r93, r88);
+    r90 = r32 * r74;
+    r90 = r90 * r78;
+    r90 = r90 * r27;
+    r90 = r90 * r56;
+    r88 = fma(r63, r90, r88);
+    r68 = r5 * r78;
+    r88 = fma(r81, r68, r88);
+    r79 = r5 * r29;
+    r79 = r79 * r6;
+    r79 = r79 * r78;
+    r88 = fma(r26, r79, r88);
+    r83 = r5 * r39;
+    r83 = r83 * r7;
+    r83 = r83 * r32;
+    r83 = r83 * r32;
+    r83 = r83 * r86;
+    r83 = r83 * r8;
+    r88 = fma(r38, r83, r88);
+    r52 = r73 * r53;
+    r52 = r52 * r78;
+    r52 = r52 * r30;
+    r52 = r52 * r63;
+    r88 = fma(r58, r52, r88);
+    r80 = r7 * r89;
+    r88 = fma(r59, r80, r88);
+    r95 = r32 * r53;
+    r95 = r95 * r74;
+    r95 = r95 * r78;
+    r95 = r95 * r27;
+    r95 = r95 * r56;
+    r88 = fma(r63, r95, r88);
+    r88 = fma(r42, r60, r88);
+    r88 = fma(r41, r82, r88);
+    r88 = fma(r42, r59, r88);
+    r95 = r3 * r88;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r94,
+                                             r95);
+    r95 = r6 * r6;
+    r94 = r10 * r19;
+    r94 = r94 * r6;
+    r20 = fma(r28, r20, r9 * r94);
+    r94 = r28 * r6;
+    r94 = r94 * r6;
+    r20 = fma(r37, r94, r20);
+    r80 = r10 * r40;
+    r80 = r80 * r7;
+    r20 = fma(r9, r80, r20);
+    r95 = r95 * r75;
+    r95 = r95 * r20;
+    r95 = r95 * r64;
+    r95 = r95 * r33;
+    r95 = fma(r46, r95, r28 * r70);
+    r70 = r18 * r20;
+    r70 = r70 * r64;
+    r70 = r70 * r31;
+    r95 = fma(r35, r70, r95);
+    r80 = r19 * r72;
+    r80 = r80 * r46;
+    r95 = fma(r38, r80, r95);
+    r94 = r21 * r7;
+    r9 = r20 * r26;
+    r94 = fma(r9, r94, r40 * r67);
+    r52 = r20 * r63;
+    r52 = r52 * r31;
+    r94 = fma(r66, r52, r94);
+    r94 = fma(r28, r25, r94);
+    r95 = r95 + r94;
+    r80 = r28 * r37;
+    r70 = r21 * r6;
+    r70 = r70 * r6;
+    r70 = r70 * r20;
+    r70 = r70 * r64;
+    r70 = r70 * r33;
+    r70 = fma(r46, r70, r1 * r80);
+    r80 = r20 * r64;
+    r80 = r80 * r31;
+    r70 = fma(r35, r80, r70);
+    r35 = r19 * r38;
+    r70 = fma(r49, r35, r70);
+    r94 = r94 + r70;
+    r45 = fma(r45, r94, r5 * r95);
+    r95 = r21 * r28;
+    r95 = r95 * r6;
+    r95 = r95 * r57;
+    r45 = fma(r34, r95, r45);
+    r35 = r4 * r40;
+    r35 = r35 * r38;
+    r45 = fma(r49, r35, r45);
+    r80 = r29 * r6;
+    r80 = r80 * r9;
+    r1 = r32 * r74;
+    r1 = r1 * r20;
+    r1 = r1 * r56;
+    r1 = r1 * r64;
+    r45 = fma(r38, r1, r45);
+    r33 = r4 * r20;
+    r45 = fma(r81, r33, r45);
+    r25 = r4 * r19;
+    r45 = fma(r67, r25, r45);
+    r67 = r32 * r53;
+    r67 = r67 * r74;
+    r67 = r67 * r20;
+    r67 = r67 * r56;
+    r67 = r67 * r64;
+    r45 = fma(r38, r67, r45);
+    r52 = r21 * r28;
+    r52 = r52 * r6;
+    r52 = r52 * r53;
+    r52 = r52 * r57;
+    r45 = fma(r34, r52, r45);
+    r83 = r51 * r10;
+    r83 = r83 * r36;
+    r83 = fma(r94, r83, r50 * r94);
+    r83 = fma(r94, r55, r83);
+    r83 = fma(r94, r54, r83);
+    r54 = r6 * r83;
+    r45 = fma(r59, r54, r45);
+    r45 = fma(r19, r60, r45);
+    r45 = fma(r4, r80, r45);
+    r45 = fma(r20, r76, r45);
+    r45 = fma(r20, r77, r45);
+    r45 = fma(r28, r85, r45);
+    r45 = fma(r19, r59, r45);
+    r54 = r2 * r45;
+    r52 = r40 * r7;
+    r52 = r52 * r72;
+    r52 = r52 * r27;
+    r67 = r7 * r75;
+    r67 = fma(r9, r67, r46 * r52);
+    r52 = r18 * r20;
+    r52 = r52 * r63;
+    r52 = r52 * r31;
+    r67 = fma(r66, r52, r67);
+    r66 = r28 * r7;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r65;
+    r66 = r66 * r27;
+    r67 = fma(r8, r66, r67);
+    r67 = r67 + r70;
+    r67 = fma(r4, r67, r48 * r94);
+    r94 = r5 * r40;
+    r94 = r94 * r38;
+    r67 = fma(r49, r94, r67);
+    r49 = r32 * r74;
+    r49 = r49 * r20;
+    r49 = r49 * r27;
+    r49 = r49 * r56;
+    r67 = fma(r63, r49, r67);
+    r48 = r5 * r20;
+    r67 = fma(r81, r48, r67);
+    r81 = r32 * r53;
+    r81 = r81 * r74;
+    r81 = r81 * r20;
+    r81 = r81 * r27;
+    r81 = r81 * r56;
+    r67 = fma(r63, r81, r67);
+    r56 = r73 * r53;
+    r56 = r56 * r20;
+    r56 = r56 * r30;
+    r56 = r56 * r63;
+    r67 = fma(r58, r56, r67);
+    r70 = r21 * r28;
+    r70 = r70 * r7;
+    r70 = r70 * r53;
+    r70 = r70 * r57;
+    r67 = fma(r34, r70, r67);
+    r66 = r5 * r28;
+    r66 = r66 * r7;
+    r66 = r66 * r32;
+    r66 = r66 * r32;
+    r66 = r66 * r86;
+    r66 = r66 * r8;
+    r67 = fma(r38, r66, r67);
+    r8 = r7 * r83;
+    r67 = fma(r59, r8, r67);
+    r86 = r73 * r20;
+    r86 = r86 * r30;
+    r86 = r86 * r63;
+    r67 = fma(r58, r86, r67);
+    r58 = r21 * r28;
+    r58 = r58 * r7;
+    r58 = r58 * r57;
+    r67 = fma(r34, r58, r67);
+    r67 = fma(r5, r80, r67);
+    r67 = fma(r40, r60, r67);
+    r67 = fma(r19, r82, r67);
+    r67 = fma(r40, r59, r67);
+    r58 = r3 * r67;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r54,
+                                             r58);
+    r58 = r3 * r21;
+    r58 = r58 * r0;
+    r54 = r2 * r21;
+    r54 = r54 * r43;
+    r54 = fma(r71, r54, r61 * r58);
+    r58 = r2 * r21;
+    r58 = r58 * r43;
+    r86 = r3 * r21;
+    r86 = r86 * r0;
+    r86 = fma(r88, r86, r91 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r54, r86);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r86 = r3 * r21;
+    r86 = r86 * r0;
+    r0 = r2 * r21;
+    r0 = r0 * r43;
+    r0 = fma(r45, r0, r67 * r86);
+    WriteSum1<double, double>((double*)inout_shared, r0);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r61 * r61;
+    r86 = r3 * r3;
+    r43 = r2 * r2;
+    r54 = r71 * r43;
+    r71 = fma(r71, r54, r86 * r0);
+    r0 = r88 * r86;
+    r58 = r91 * r91;
+    r58 = fma(r43, r58, r88 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r71, r58);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r58 = r67 * r67;
+    r71 = r45 * r45;
+    r71 = fma(r43, r71, r86 * r58);
+    WriteSum1<double, double>((double*)inout_shared, r71);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = fma(r91, r54, r61 * r0);
+    r58 = r61 * r67;
+    r54 = fma(r45, r54, r86 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r71, r54);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r91 * r45;
+    r54 = fma(r43, r54, r67 * r0);
+    WriteSum1<double, double>((double*)inout_shared, r54);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirstKernel<<<n_blocks,
+                                                                      1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_principal_point_jac,
+      out_principal_point_jac_num_alloc,
+      out_principal_point_njtr,
+      out_principal_point_njtr_num_alloc,
+      out_principal_point_precond_diag,
+      out_principal_point_precond_diag_num_alloc,
+      out_principal_point_precond_tril,
+      out_principal_point_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_principal_point_jac,
+    unsigned int out_principal_point_jac_num_alloc,
+    double* const out_principal_point_njtr,
+    unsigned int out_principal_point_njtr_num_alloc,
+    double* const out_principal_point_precond_diag,
+    unsigned int out_principal_point_precond_diag_num_alloc,
+    double* const out_principal_point_precond_tril,
+    unsigned int out_principal_point_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.cu
@@ -1,0 +1,327 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        SharedIndex* principal_point_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex principal_point_indices_loc[1024];
+  principal_point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? principal_point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+  LoadShared<2, double, double>(principal_point,
+                                0 * principal_point_num_alloc,
+                                principal_point_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        principal_point_indices_loc[threadIdx.x].target,
+                        r0,
+                        r1);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            0 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r2,
+                                            r3);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            4 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            8 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r32,
+                                            r45);
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            2 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r8);
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra,
+                                            6 * focal_and_extra_num_alloc,
+                                            global_thread_idx,
+                                            r28,
+                                            r44);
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScoreKernel<<<n_blocks,
+                                                                1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      principal_point_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    SharedIndex* principal_point_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,59 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        double* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        double* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,782 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r24 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r18);
+    r26 = r15 * r16;
+    r26 = r26 * r10;
+    r27 = r11 * r12;
+    r27 = fma(r10, r27, r26);
+    r28 = -2.00000000000000000e+00;
+    r29 = r15 * r15;
+    r29 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r11 * r11;
+    r31 = fma(r28, r31, r30);
+    r32 = r29 + r31;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r33);
+    r34 = r16 * r11;
+    r34 = r34 * r10;
+    r35 = r15 * r12;
+    r35 = fma(r28, r35, r34);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r36);
+    r37 = r10 * r23;
+    r37 = r37 * r22;
+    r38 = r28 * r25;
+    r39 = fma(r19, r38, r37);
+    r40 = r23 * r23;
+    r40 = r28 * r40;
+    r41 = r30 + r40;
+    r42 = r19 * r19;
+    r42 = r28 * r42;
+    r41 = r41 + r42;
+    r24 = fma(r7, r27, r24);
+    r24 = fma(r18, r32, r24);
+    r24 = fma(r33, r35, r24);
+    r24 = fma(r36, r39, r24);
+    r24 = fma(r9, r41, r24);
+    r41 = r24 * r24;
+    r39 = r22 * r22;
+    r39 = r28 * r39;
+    r35 = r30 + r39;
+    r35 = r35 + r40;
+    r35 = fma(r8, r35, r6);
+    r20 = fma(r23, r38, r20);
+    r6 = r10 * r23;
+    r6 = r6 * r19;
+    r40 = r10 * r22;
+    r40 = fma(r25, r40, r6);
+    r32 = r15 * r11;
+    r32 = r32 * r10;
+    r27 = r16 * r12;
+    r43 = fma(r10, r27, r32);
+    r44 = r11 * r12;
+    r44 = fma(r28, r44, r26);
+    r26 = r16 * r16;
+    r26 = r26 * r28;
+    r31 = r26 + r31;
+    r35 = fma(r9, r20, r35);
+    r35 = fma(r36, r40, r35);
+    r35 = fma(r33, r43, r35);
+    r35 = fma(r18, r44, r35);
+    r35 = fma(r7, r31, r35);
+    r31 = r35 * r35;
+    r44 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r43);
+    r38 = fma(r22, r38, r6);
+    r38 = fma(r8, r38, r43);
+    r27 = fma(r28, r27, r32);
+    r26 = r30 + r26;
+    r26 = r26 + r29;
+    r29 = r15 * r12;
+    r29 = fma(r10, r29, r34);
+    r34 = r10 * r19;
+    r34 = fma(r25, r34, r37);
+    r39 = r30 + r39;
+    r39 = r39 + r42;
+    r38 = fma(r7, r27, r38);
+    r38 = fma(r33, r26, r38);
+    r38 = fma(r18, r29, r38);
+    r38 = fma(r9, r34, r38);
+    r38 = fma(r36, r39, r38);
+    r39 = copysign(1.0, r38);
+    r39 = fma(r44, r39, r38);
+    r38 = r39 * r39;
+    r36 = 1.0 / r38;
+    r34 = r24 * r24;
+    r34 = fma(r36, r34, r36 * r31);
+    r34 = sqrt(r34);
+    r31 = atan(r34);
+    r9 = copysign(1.0, r34);
+    r9 = fma(r44, r9, r34);
+    r44 = r9 * r9;
+    r34 = 1.0 / r44;
+    r34 = r36 * r34;
+    r36 = r31 * r34;
+    r41 = r41 * r31;
+    r41 = r41 * r36;
+    r29 = 3.00000000000000000e+00;
+    r18 = r35 * r29;
+    r26 = r35 * r31;
+    r18 = r18 * r26;
+    r18 = fma(r36, r18, r41);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r33,
+                        r27);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r35 * r26;
+    r7 = r7 * r36;
+    r41 = r41 + r7;
+    r33 = fma(r33, r41, r5 * r18);
+    r42 = r24 * r31;
+    r30 = r4 * r42;
+    r37 = r10 * r26;
+    r25 = r34 * r37;
+    r33 = fma(r25, r30, r33);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r41 * r41;
+    r8 = fma(r8, r43, r32 * r41);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r43 * r43;
+    r20 = r41 * r43;
+    r8 = fma(r6, r40, r8);
+    r8 = fma(r32, r20, r8);
+    r32 = r8 * r26;
+    r6 = 1.0 / r39;
+    r45 = 1.0 / r9;
+    r46 = r6 * r45;
+    r33 = fma(r46, r32, r33);
+    r33 = fma(r26, r46, r33);
+    r0 = fma(r2, r33, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r32, r30);
+    r0 = fma(r32, r21, r0);
+    r32 = r24 * r24;
+    r32 = r32 * r31;
+    r32 = r32 * r29;
+    r32 = fma(r36, r32, r7);
+    r27 = fma(r27, r41, r4 * r32);
+    r7 = r8 * r46;
+    r27 = fma(r42, r7, r27);
+    r47 = r5 * r42;
+    r27 = fma(r25, r47, r27);
+    r27 = fma(r46, r42, r27);
+    r1 = fma(r3, r27, r1);
+    r1 = fma(r30, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r30 = r21 * r27;
+    r30 = r30 * r1;
+    r47 = r21 * r0;
+    r7 = r33 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r7, r30);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r21 * r41;
+    r7 = r3 * r42;
+    r30 = r30 * r1;
+    r30 = r30 * r46;
+    r48 = r2 * r26;
+    r49 = r48 * r47;
+    r50 = r46 * r49;
+    r30 = fma(r41, r50, r7 * r30);
+    r51 = r21 * r1;
+    r52 = r43 * r46;
+    r51 = r51 * r7;
+    r49 = fma(r52, r49, r52 * r51);
+    WriteSum2<double, double>((double*)inout_shared, r30, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r21;
+    r49 = r49 * r32;
+    r30 = r28 * r0;
+    r30 = r30 * r42;
+    r30 = r30 * r48;
+    r30 = fma(r34, r30, r1 * r49);
+    r49 = r2 * r18;
+    r51 = r28 * r1;
+    r51 = r51 * r26;
+    r51 = r51 * r7;
+    r51 = fma(r34, r51, r47 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r30, r51);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r21 * r1;
+    r51 = r51 * r20;
+    r51 = r51 * r46;
+    r51 = fma(r20, r50, r7 * r51);
+    r30 = r21 * r1;
+    r30 = r30 * r46;
+    r30 = r30 * r7;
+    r50 = fma(r40, r50, r40 * r30);
+    WriteSum2<double, double>((double*)inout_shared, r51, r50);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r3 * r21;
+    r50 = r50 * r41;
+    r50 = r50 * r1;
+    r51 = r2 * r41;
+    r51 = r51 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r51, r50);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r33 * r33;
+    r51 = r27 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r50, r51);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r2 * r48;
+    r50 = r35 * r51;
+    r47 = r36 * r50;
+    r30 = r24 * r24;
+    r49 = r3 * r3;
+    r30 = r30 * r31;
+    r30 = r30 * r43;
+    r30 = r30 * r36;
+    r30 = fma(r49, r30, r43 * r47);
+    r53 = r40 * r36;
+    r54 = r3 * r7;
+    r55 = r24 * r54;
+    r53 = fma(r55, r53, r40 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r30, r53);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r24 * r42;
+    r56 = r31 * r31;
+    r57 = 4.00000000000000000e+00;
+    r38 = r39 * r38;
+    r39 = r39 * r38;
+    r39 = 1.0 / r39;
+    r44 = r9 * r44;
+    r9 = r9 * r44;
+    r9 = 1.0 / r9;
+    r56 = r56 * r57;
+    r56 = r56 * r39;
+    r56 = r56 * r9;
+    r30 = r30 * r50;
+    r9 = r32 * r32;
+    r49 = fma(r9, r49, r56 * r30);
+    r9 = r35 * r26;
+    r9 = r9 * r55;
+    r30 = r2 * r2;
+    r39 = r18 * r18;
+    r30 = fma(r39, r30, r56 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r30);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r20 * r20;
+    r49 = r36 * r55;
+    r49 = fma(r30, r49, r30 * r47);
+    r9 = r40 * r40;
+    r39 = r36 * r55;
+    r39 = fma(r9, r39, r47 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r2 * r2;
+    r39 = r39 * r43;
+    r9 = r3 * r3;
+    r9 = r9 * r43;
+    WriteSum2<double, double>((double*)inout_shared, r39, r9);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = 0.00000000000000000e+00;
+    r39 = r41 * r33;
+    r39 = r39 * r46;
+    r39 = r39 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r33 * r48;
+    r39 = r39 * r52;
+    r56 = r10 * r33;
+    r56 = r56 * r42;
+    r56 = r56 * r48;
+    r56 = r56 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r39, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r2 * r18;
+    r56 = r56 * r33;
+    r39 = r33 * r20;
+    r39 = r39 * r46;
+    r39 = r39 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r56, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r2 * r41;
+    r39 = r39 * r33;
+    r33 = r33 * r46;
+    r33 = r33 * r48;
+    r33 = r33 * r40;
+    WriteSum2<double, double>((double*)inout_shared, r33, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r41 * r27;
+    r39 = r39 * r46;
+    r39 = r39 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r3 * r32;
+    r39 = r39 * r27;
+    r33 = r27 * r7;
+    r48 = r52 * r33;
+    WriteSum2<double, double>((double*)inout_shared, r48, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r33 = r25 * r33;
+    r39 = r27 * r20;
+    r39 = r39 * r46;
+    r39 = r39 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r33, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r27 * r46;
+    r39 = r39 * r7;
+    r39 = r39 * r40;
+    WriteSum2<double, double>((double*)inout_shared, r39, r9);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r41;
+    r9 = r9 * r27;
+    r27 = r20 * r55;
+    r39 = fma(r36, r27, r20 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r41 * r32;
+    r39 = r39 * r46;
+    r9 = r10 * r42;
+    r38 = 1.0 / r38;
+    r38 = r31 * r38;
+    r44 = 1.0 / r44;
+    r38 = r38 * r44;
+    r9 = r9 * r50;
+    r9 = r9 * r38;
+    r39 = fma(r41, r9, r54 * r39);
+    r50 = r18 * r41;
+    r50 = r50 * r46;
+    r44 = r41 * r55;
+    r44 = r44 * r37;
+    r44 = fma(r38, r44, r51 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r39, r44);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r41 * r40;
+    r39 = r36 * r44;
+    r39 = fma(r55, r39, r44 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r53, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r35 * r31;
+    r53 = r2 * r2;
+    r31 = r31 * r43;
+    r31 = r31 * r6;
+    r31 = r31 * r45;
+    r31 = r31 * r53;
+    r53 = r54 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r31, r53);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r32 * r54;
+    r53 = fma(r43, r9, r52 * r53);
+    r52 = r43 * r55;
+    r52 = r52 * r37;
+    r52 = fma(r38, r52, r18 * r31);
+    WriteSum2<double, double>((double*)inout_shared, r53, r52);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r39, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r20 * r46;
+    r49 = r49 * r51;
+    r39 = r20 * r46;
+    r39 = r39 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r49, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r10 * r18;
+    r39 = r39 * r42;
+    r39 = r39 * r34;
+    r25 = r54 * r25;
+    r39 = fma(r32, r25, r51 * r39);
+    r49 = r32 * r20;
+    r49 = r49 * r46;
+    r49 = fma(r20, r9, r54 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r39, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r10 * r41;
+    r49 = r49 * r42;
+    r49 = r49 * r34;
+    r49 = r49 * r51;
+    r34 = r32 * r46;
+    r34 = r34 * r40;
+    r9 = fma(r40, r9, r54 * r34);
+    WriteSum2<double, double>((double*)inout_shared, r9, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r3;
+    r49 = r49 * r41;
+    r49 = r49 * r32;
+    r9 = r18 * r20;
+    r9 = r9 * r46;
+    r34 = r37 * r38;
+    r34 = fma(r27, r34, r51 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r2 * r2;
+    r34 = r34 * r18;
+    r34 = r34 * r41;
+    r49 = r18 * r46;
+    r49 = r49 * r40;
+    r9 = r40 * r55;
+    r9 = r9 * r37;
+    r9 = fma(r38, r9, r51 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r9, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r41 * r25;
+    r30 = r41 * r30;
+    r34 = r36 * r55;
+    r34 = fma(r30, r34, r47 * r30);
+    WriteSum2<double, double>((double*)inout_shared, r25, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r46 * r40;
+    r34 = r34 * r51;
+    r25 = r46 * r40;
+    r25 = r25 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r34, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r46 * r51;
+    r51 = r51 * r44;
+    r25 = r46 * r54;
+    r25 = r25 * r44;
+    WriteSum2<double, double>((double*)inout_shared, r51, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,796 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r24 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r18);
+    r26 = r15 * r16;
+    r26 = r26 * r10;
+    r27 = r11 * r12;
+    r27 = fma(r10, r27, r26);
+    r28 = -2.00000000000000000e+00;
+    r29 = r15 * r15;
+    r29 = r28 * r29;
+    r30 = 1.00000000000000000e+00;
+    r31 = r11 * r11;
+    r31 = fma(r28, r31, r30);
+    r32 = r29 + r31;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r33);
+    r34 = r16 * r11;
+    r34 = r34 * r10;
+    r35 = r15 * r12;
+    r35 = fma(r28, r35, r34);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r36);
+    r37 = r10 * r23;
+    r37 = r37 * r22;
+    r38 = r28 * r25;
+    r39 = fma(r19, r38, r37);
+    r40 = r23 * r23;
+    r40 = r28 * r40;
+    r41 = r30 + r40;
+    r42 = r19 * r19;
+    r42 = r28 * r42;
+    r41 = r41 + r42;
+    r24 = fma(r7, r27, r24);
+    r24 = fma(r18, r32, r24);
+    r24 = fma(r33, r35, r24);
+    r24 = fma(r36, r39, r24);
+    r24 = fma(r9, r41, r24);
+    r41 = r24 * r24;
+    r39 = r22 * r22;
+    r39 = r28 * r39;
+    r35 = r30 + r39;
+    r35 = r35 + r40;
+    r35 = fma(r8, r35, r6);
+    r20 = fma(r23, r38, r20);
+    r6 = r10 * r23;
+    r6 = r6 * r19;
+    r40 = r10 * r22;
+    r40 = fma(r25, r40, r6);
+    r32 = r15 * r11;
+    r32 = r32 * r10;
+    r27 = r16 * r12;
+    r43 = fma(r10, r27, r32);
+    r44 = r11 * r12;
+    r44 = fma(r28, r44, r26);
+    r26 = r16 * r16;
+    r26 = r26 * r28;
+    r31 = r26 + r31;
+    r35 = fma(r9, r20, r35);
+    r35 = fma(r36, r40, r35);
+    r35 = fma(r33, r43, r35);
+    r35 = fma(r18, r44, r35);
+    r35 = fma(r7, r31, r35);
+    r31 = r35 * r35;
+    r44 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r43);
+    r38 = fma(r22, r38, r6);
+    r38 = fma(r8, r38, r43);
+    r27 = fma(r28, r27, r32);
+    r26 = r30 + r26;
+    r26 = r26 + r29;
+    r29 = r15 * r12;
+    r29 = fma(r10, r29, r34);
+    r34 = r10 * r19;
+    r34 = fma(r25, r34, r37);
+    r39 = r30 + r39;
+    r39 = r39 + r42;
+    r38 = fma(r7, r27, r38);
+    r38 = fma(r33, r26, r38);
+    r38 = fma(r18, r29, r38);
+    r38 = fma(r9, r34, r38);
+    r38 = fma(r36, r39, r38);
+    r39 = copysign(1.0, r38);
+    r39 = fma(r44, r39, r38);
+    r38 = r39 * r39;
+    r36 = 1.0 / r38;
+    r34 = r24 * r24;
+    r34 = fma(r36, r34, r36 * r31);
+    r34 = sqrt(r34);
+    r31 = atan(r34);
+    r9 = copysign(1.0, r34);
+    r9 = fma(r44, r9, r34);
+    r44 = r9 * r9;
+    r34 = 1.0 / r44;
+    r34 = r36 * r34;
+    r36 = r31 * r34;
+    r41 = r41 * r31;
+    r41 = r41 * r36;
+    r29 = 3.00000000000000000e+00;
+    r18 = r35 * r29;
+    r26 = r35 * r31;
+    r18 = r18 * r26;
+    r18 = fma(r36, r18, r41);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r33,
+                        r27);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r35 * r26;
+    r7 = r7 * r36;
+    r41 = r41 + r7;
+    r33 = fma(r33, r41, r5 * r18);
+    r42 = r24 * r31;
+    r30 = r4 * r42;
+    r37 = r10 * r26;
+    r25 = r34 * r37;
+    r33 = fma(r25, r30, r33);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r41 * r41;
+    r8 = fma(r8, r43, r32 * r41);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r43 * r43;
+    r20 = r41 * r43;
+    r8 = fma(r6, r40, r8);
+    r8 = fma(r32, r20, r8);
+    r32 = r8 * r26;
+    r6 = 1.0 / r39;
+    r45 = 1.0 / r9;
+    r46 = r6 * r45;
+    r33 = fma(r46, r32, r33);
+    r33 = fma(r26, r46, r33);
+    r0 = fma(r2, r33, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r32, r30);
+    r0 = fma(r32, r21, r0);
+    r32 = r24 * r24;
+    r32 = r32 * r31;
+    r32 = r32 * r29;
+    r32 = fma(r36, r32, r7);
+    r27 = fma(r27, r41, r4 * r32);
+    r7 = r8 * r46;
+    r27 = fma(r42, r7, r27);
+    r47 = r5 * r42;
+    r27 = fma(r25, r47, r27);
+    r27 = fma(r46, r42, r27);
+    r1 = fma(r3, r27, r1);
+    r1 = fma(r30, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r30 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r30);
+  if (global_thread_idx < problem_size) {
+    r30 = r21 * r27;
+    r30 = r30 * r1;
+    r47 = r21 * r0;
+    r7 = r33 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r7, r30);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r21 * r41;
+    r7 = r3 * r42;
+    r30 = r30 * r1;
+    r30 = r30 * r46;
+    r48 = r2 * r26;
+    r49 = r48 * r47;
+    r50 = r46 * r49;
+    r30 = fma(r41, r50, r7 * r30);
+    r51 = r21 * r1;
+    r52 = r43 * r46;
+    r51 = r51 * r7;
+    r49 = fma(r52, r49, r52 * r51);
+    WriteSum2<double, double>((double*)inout_shared, r30, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r21;
+    r49 = r49 * r32;
+    r30 = r28 * r0;
+    r30 = r30 * r42;
+    r30 = r30 * r48;
+    r30 = fma(r34, r30, r1 * r49);
+    r49 = r2 * r18;
+    r51 = r28 * r1;
+    r51 = r51 * r26;
+    r51 = r51 * r7;
+    r51 = fma(r34, r51, r47 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r30, r51);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r21 * r1;
+    r51 = r51 * r20;
+    r51 = r51 * r46;
+    r51 = fma(r20, r50, r7 * r51);
+    r30 = r21 * r1;
+    r30 = r30 * r46;
+    r30 = r30 * r7;
+    r50 = fma(r40, r50, r40 * r30);
+    WriteSum2<double, double>((double*)inout_shared, r51, r50);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r3 * r21;
+    r50 = r50 * r41;
+    r50 = r50 * r1;
+    r51 = r2 * r41;
+    r51 = r51 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r51, r50);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r50 = r33 * r33;
+    r51 = r27 * r27;
+    WriteSum2<double, double>((double*)inout_shared, r50, r51);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r2 * r48;
+    r50 = r35 * r51;
+    r47 = r36 * r50;
+    r30 = r24 * r24;
+    r49 = r3 * r3;
+    r30 = r30 * r31;
+    r30 = r30 * r43;
+    r30 = r30 * r36;
+    r30 = fma(r49, r30, r43 * r47);
+    r53 = r40 * r36;
+    r54 = r3 * r7;
+    r55 = r24 * r54;
+    r53 = fma(r55, r53, r40 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r30, r53);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r24 * r42;
+    r56 = r31 * r31;
+    r57 = 4.00000000000000000e+00;
+    r38 = r39 * r38;
+    r39 = r39 * r38;
+    r39 = 1.0 / r39;
+    r44 = r9 * r44;
+    r9 = r9 * r44;
+    r9 = 1.0 / r9;
+    r56 = r56 * r57;
+    r56 = r56 * r39;
+    r56 = r56 * r9;
+    r30 = r30 * r50;
+    r9 = r32 * r32;
+    r49 = fma(r9, r49, r56 * r30);
+    r9 = r35 * r26;
+    r9 = r9 * r55;
+    r30 = r2 * r2;
+    r39 = r18 * r18;
+    r30 = fma(r39, r30, r56 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r30);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r30 = r20 * r20;
+    r49 = r36 * r55;
+    r49 = fma(r30, r49, r30 * r47);
+    r9 = r40 * r40;
+    r39 = r36 * r55;
+    r39 = fma(r9, r39, r47 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r2 * r2;
+    r39 = r39 * r43;
+    r9 = r3 * r3;
+    r9 = r9 * r43;
+    WriteSum2<double, double>((double*)inout_shared, r39, r9);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = 0.00000000000000000e+00;
+    r39 = r41 * r33;
+    r39 = r39 * r46;
+    r39 = r39 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r33 * r48;
+    r39 = r39 * r52;
+    r56 = r10 * r33;
+    r56 = r56 * r42;
+    r56 = r56 * r48;
+    r56 = r56 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r39, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r2 * r18;
+    r56 = r56 * r33;
+    r39 = r33 * r20;
+    r39 = r39 * r46;
+    r39 = r39 * r48;
+    WriteSum2<double, double>((double*)inout_shared, r56, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r2 * r41;
+    r39 = r39 * r33;
+    r33 = r33 * r46;
+    r33 = r33 * r48;
+    r33 = r33 * r40;
+    WriteSum2<double, double>((double*)inout_shared, r33, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r41 * r27;
+    r39 = r39 * r46;
+    r39 = r39 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r3 * r32;
+    r39 = r39 * r27;
+    r33 = r27 * r7;
+    r48 = r52 * r33;
+    WriteSum2<double, double>((double*)inout_shared, r48, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r33 = r25 * r33;
+    r39 = r27 * r20;
+    r39 = r39 * r46;
+    r39 = r39 * r7;
+    WriteSum2<double, double>((double*)inout_shared, r33, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r27 * r46;
+    r39 = r39 * r7;
+    r39 = r39 * r40;
+    WriteSum2<double, double>((double*)inout_shared, r39, r9);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r9 = r3 * r41;
+    r9 = r9 * r27;
+    r27 = r20 * r55;
+    r39 = fma(r36, r27, r20 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r9, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r41 * r32;
+    r39 = r39 * r46;
+    r9 = r10 * r42;
+    r38 = 1.0 / r38;
+    r38 = r31 * r38;
+    r44 = 1.0 / r44;
+    r38 = r38 * r44;
+    r9 = r9 * r50;
+    r9 = r9 * r38;
+    r39 = fma(r41, r9, r54 * r39);
+    r50 = r18 * r41;
+    r50 = r50 * r46;
+    r44 = r41 * r55;
+    r44 = r44 * r37;
+    r44 = fma(r38, r44, r51 * r50);
+    WriteSum2<double, double>((double*)inout_shared, r39, r44);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r41 * r40;
+    r39 = r36 * r44;
+    r39 = fma(r55, r39, r44 * r47);
+    WriteSum2<double, double>((double*)inout_shared, r53, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r35 * r31;
+    r53 = r2 * r2;
+    r31 = r31 * r43;
+    r31 = r31 * r6;
+    r31 = r31 * r45;
+    r31 = r31 * r53;
+    r53 = r54 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r31, r53);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r53 = r32 * r54;
+    r53 = fma(r43, r9, r52 * r53);
+    r52 = r43 * r55;
+    r52 = r52 * r37;
+    r52 = fma(r38, r52, r18 * r31);
+    WriteSum2<double, double>((double*)inout_shared, r53, r52);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r39, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r20 * r46;
+    r49 = r49 * r51;
+    r39 = r20 * r46;
+    r39 = r39 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r49, r39);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r39 = r10 * r18;
+    r39 = r39 * r42;
+    r39 = r39 * r34;
+    r25 = r54 * r25;
+    r39 = fma(r32, r25, r51 * r39);
+    r49 = r32 * r20;
+    r49 = r49 * r46;
+    r49 = fma(r20, r9, r54 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r39, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r10 * r41;
+    r49 = r49 * r42;
+    r49 = r49 * r34;
+    r49 = r49 * r51;
+    r34 = r32 * r46;
+    r34 = r34 * r40;
+    r9 = fma(r40, r9, r54 * r34);
+    WriteSum2<double, double>((double*)inout_shared, r9, r49);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r3 * r3;
+    r49 = r49 * r41;
+    r49 = r49 * r32;
+    r9 = r18 * r20;
+    r9 = r9 * r46;
+    r34 = r37 * r38;
+    r34 = fma(r27, r34, r51 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r49, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r2 * r2;
+    r34 = r34 * r18;
+    r34 = r34 * r41;
+    r49 = r18 * r46;
+    r49 = r49 * r40;
+    r9 = r40 * r55;
+    r9 = r9 * r37;
+    r9 = fma(r38, r9, r51 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r9, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r41 * r25;
+    r30 = r41 * r30;
+    r34 = r36 * r55;
+    r34 = fma(r30, r34, r47 * r30);
+    WriteSum2<double, double>((double*)inout_shared, r25, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r46 * r40;
+    r34 = r34 * r51;
+    r25 = r46 * r40;
+    r25 = r25 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r34, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r51 = r46 * r51;
+    r51 = r51 * r44;
+    r25 = r46 * r54;
+    r25 = r25 * r44;
+    WriteSum2<double, double>((double*)inout_shared, r51, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,338 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r44);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScoreKernel<<<
+      n_blocks,
+      1024>>>(sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              pose,
+              pose_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_rTr,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,297 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirectKernel(
+        double* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        double* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            0 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r2);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r3, r4);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r5,
+                        r6);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r7, r8);
+    r9 = fma(r6, r7, r2 * r3);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r10, r11);
+    r9 = fma(r5, r10, r9);
+    r12 = r0 * r9;
+    r6 = fma(r6, r8, r2 * r4);
+    r6 = fma(r5, r11, r6);
+    r5 = r1 * r6;
+    WriteSum2<double, double>((double*)inout_shared, r12, r5);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            2 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r5,
+                                            r12);
+    r2 = fma(r12, r6, r5 * r9);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            4 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+    r15 = fma(r14, r6, r13 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r2, r15);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            6 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r2);
+    r16 = fma(r2, r6, r15 * r9);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            8 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r18, r6, r17 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r16, r19);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            10 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r19,
+                                            r16);
+    r20 = fma(r16, r6, r19 * r9);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            12 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r21,
+                                            r22);
+    r23 = fma(r22, r6, r21 * r9);
+    WriteSum2<double, double>((double*)inout_shared, r20, r23);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            14 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r23,
+                                            r20);
+    r9 = r23 * r9;
+    r6 = r20 * r6;
+    WriteSum2<double, double>((double*)inout_shared, r9, r6);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                2 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r6,
+                        r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                4 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r24,
+                        r25);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r15 = fma(r24, r15, r9 * r13);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                0 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r13,
+                        r26);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                8 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r27,
+                        r28);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                6 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r29,
+                        r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r15 = fma(r13, r0, r15);
+    r15 = fma(r6, r5, r15);
+    r15 = fma(r27, r23, r15);
+    r15 = fma(r25, r17, r15);
+    r15 = fma(r30, r21, r15);
+    r15 = fma(r29, r19, r15);
+    r12 = fma(r6, r12, r9 * r14);
+    r12 = fma(r24, r2, r12);
+    r12 = fma(r26, r1, r12);
+    r12 = fma(r30, r22, r12);
+    r12 = fma(r29, r16, r12);
+    r12 = fma(r28, r20, r12);
+    r12 = fma(r25, r18, r12);
+    r11 = fma(r11, r12, r10 * r15);
+    r8 = fma(r8, r12, r7 * r15);
+    WriteSum2<double, double>((double*)inout_shared, r11, r8);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r12 = fma(r4, r12, r3 * r15);
+    WriteSum1<double, double>((double*)inout_shared, r12);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              point_njtr,
+              point_njtr_num_alloc,
+              point_njtr_indices,
+              point_jac,
+              point_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_point_njtr,
+              out_point_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.cu
@@ -1,0 +1,1569 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r22 * r22;
+    r36 = r29 * r36;
+    r33 = r31 + r36;
+    r33 = r33 + r41;
+    r6 = fma(r8, r33, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r28 = r15 * r11;
+    r28 = r28 * r10;
+    r44 = r16 * r12;
+    r45 = fma(r10, r44, r28);
+    r46 = r11 * r12;
+    r46 = fma(r29, r46, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r45, r6);
+    r6 = fma(r26, r46, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    r46 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r45);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r45);
+    r44 = fma(r29, r44, r28);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r36 = r31 + r36;
+    r36 = r36 + r43;
+    r8 = fma(r18, r44, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r36, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r46, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = atan(r32);
+    r27 = r7 * r26;
+    r34 = copysign(1.0, r32);
+    r34 = fma(r46, r34, r32);
+    r46 = r34 * r34;
+    r32 = 1.0 / r46;
+    r44 = r9 * r32;
+    r18 = r7 * r26;
+    r27 = r27 * r44;
+    r27 = r27 * r18;
+    r43 = 3.00000000000000000e+00;
+    r38 = r6 * r6;
+    r38 = r9 * r38;
+    r35 = r26 * r26;
+    r38 = r38 * r32;
+    r38 = r38 * r35;
+    r35 = fma(r43, r38, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = r38 + r27;
+    r20 = fma(r28, r27, r5 * r35);
+    r25 = r4 * r10;
+    r48 = r6 * r26;
+    r49 = r48 * r44;
+    r25 = r25 * r18;
+    r20 = fma(r49, r25, r20);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r50,
+                        r51);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r52 = r27 * r27;
+    r53 = fma(r51, r52, r50 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r54,
+                        r55);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r56 = r52 * r52;
+    r57 = r27 * r52;
+    r53 = fma(r55, r56, r53);
+    r53 = fma(r54, r57, r53);
+    r58 = 1.0 / r37;
+    r59 = 1.0 / r34;
+    r60 = r58 * r59;
+    r61 = r53 * r60;
+    r20 = fma(r48, r61, r20);
+    r20 = fma(r48, r60, r20);
+    r0 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r25, r62);
+    r0 = fma(r25, r21, r0);
+    r25 = r7 * r26;
+    r25 = r25 * r43;
+    r25 = r25 * r44;
+    r25 = fma(r18, r25, r38);
+    r63 = fma(r45, r27, r4 * r25);
+    r64 = r5 * r10;
+    r64 = r64 * r18;
+    r63 = fma(r49, r64, r63);
+    r63 = fma(r18, r61, r63);
+    r63 = fma(r60, r18, r63);
+    r1 = fma(r3, r63, r1);
+    r1 = fma(r62, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r20,
+        r63);
+    r62 = r2 * r27;
+    r62 = r62 * r48;
+    r62 = r62 * r60;
+    r64 = r27 * r60;
+    r65 = r3 * r18;
+    r64 = r64 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r48;
+    r64 = r64 * r60;
+    r64 = r64 * r52;
+    r62 = r60 * r52;
+    r62 = r62 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r3 * r25;
+    r64 = r2 * r10;
+    r64 = r64 * r18;
+    r64 = r64 * r49;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r2 * r35;
+    r64 = r10 * r49;
+    r64 = r64 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r48;
+    r64 = r64 * r60;
+    r64 = r64 * r57;
+    r62 = r60 * r57;
+    r62 = r62 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r2 * r48;
+    r62 = r62 * r60;
+    r62 = r62 * r56;
+    r64 = r60 * r65;
+    r64 = r64 * r56;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r27;
+    r62 = r3 * r27;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r21 * r63;
+    r62 = r62 * r1;
+    r64 = r21 * r0;
+    r66 = r20 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r66, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r21 * r27;
+    r62 = r62 * r1;
+    r62 = r62 * r60;
+    r66 = r27 * r48;
+    r64 = r2 * r64;
+    r66 = r66 * r60;
+    r66 = fma(r64, r66, r65 * r62);
+    r62 = r21 * r1;
+    r62 = r62 * r60;
+    r62 = r62 * r52;
+    r67 = r48 * r60;
+    r67 = r67 * r52;
+    r67 = fma(r64, r67, r65 * r62);
+    WriteSum2<double, double>((double*)inout_shared, r66, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r3 * r21;
+    r67 = r67 * r25;
+    r66 = r2 * r29;
+    r66 = r66 * r0;
+    r66 = r66 * r18;
+    r66 = fma(r49, r66, r1 * r67);
+    r67 = r29 * r1;
+    r67 = r67 * r49;
+    r67 = fma(r65, r67, r35 * r64);
+    WriteSum2<double, double>((double*)inout_shared, r66, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r21 * r1;
+    r67 = r67 * r60;
+    r67 = r67 * r57;
+    r66 = r48 * r60;
+    r66 = r66 * r57;
+    r66 = fma(r64, r66, r65 * r67);
+    r67 = r21 * r1;
+    r67 = r67 * r60;
+    r67 = r67 * r65;
+    r0 = r48 * r60;
+    r0 = r0 * r56;
+    r0 = fma(r64, r0, r56 * r67);
+    WriteSum2<double, double>((double*)inout_shared, r66, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r21;
+    r0 = r0 * r27;
+    r0 = r0 * r1;
+    r66 = r27 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r66, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r20 * r20;
+    r66 = r63 * r63;
+    WriteSum2<double, double>((double*)inout_shared, r0, r66);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r2 * r2;
+    r38 = r66 * r38;
+    r0 = r7 * r26;
+    r67 = r3 * r65;
+    r0 = r0 * r44;
+    r0 = r0 * r52;
+    r0 = fma(r67, r0, r52 * r38);
+    r62 = r7 * r26;
+    r62 = r62 * r44;
+    r62 = r62 * r56;
+    r62 = fma(r67, r62, r56 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r0, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r48 * r66;
+    r68 = r18 * r0;
+    r69 = r6 * r7;
+    r70 = 4.00000000000000000e+00;
+    r8 = r37 * r8;
+    r37 = r37 * r8;
+    r37 = 1.0 / r37;
+    r46 = r34 * r46;
+    r34 = r34 * r46;
+    r34 = 1.0 / r34;
+    r69 = r69 * r26;
+    r69 = r69 * r26;
+    r69 = r69 * r70;
+    r69 = r69 * r37;
+    r69 = r69 * r34;
+    r34 = r3 * r3;
+    r34 = r34 * r25;
+    r34 = fma(r25, r34, r69 * r68);
+    r68 = r48 * r67;
+    r37 = r35 * r35;
+    r37 = fma(r66, r37, r69 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r37);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r57 * r57;
+    r34 = r7 * r26;
+    r34 = r34 * r44;
+    r34 = r34 * r67;
+    r34 = fma(r37, r34, r37 * r38);
+    r68 = r56 * r56;
+    r69 = r7 * r26;
+    r69 = r69 * r44;
+    r69 = r69 * r67;
+    r69 = fma(r68, r69, r38 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r52 * r66;
+    r68 = r3 * r3;
+    r68 = r68 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r69, r68);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = 0.00000000000000000e+00;
+    r69 = r2 * r27;
+    r69 = r69 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r68, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r2 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    r69 = r69 * r52;
+    r71 = r2 * r10;
+    r71 = r71 * r20;
+    r71 = r71 * r18;
+    r71 = r71 * r49;
+    WriteSum2<double, double>((double*)inout_shared, r69, r71);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r2 * r35;
+    r71 = r71 * r20;
+    r69 = r2 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    r69 = r69 * r57;
+    WriteSum2<double, double>((double*)inout_shared, r71, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r2 * r27;
+    r69 = r69 * r20;
+    r20 = r2 * r20;
+    r20 = r20 * r48;
+    r20 = r20 * r60;
+    r20 = r20 * r56;
+    WriteSum2<double, double>((double*)inout_shared, r20, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r27 * r63;
+    r69 = r69 * r60;
+    r69 = r69 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r68, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r3 * r25;
+    r69 = r69 * r63;
+    r20 = r63 * r60;
+    r20 = r20 * r52;
+    r20 = r20 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r20, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r10 * r63;
+    r69 = r69 * r49;
+    r69 = r69 * r65;
+    r20 = r63 * r60;
+    r20 = r20 * r57;
+    r20 = r20 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r69, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r63 * r60;
+    r20 = r20 * r65;
+    r20 = r20 * r56;
+    WriteSum2<double, double>((double*)inout_shared, r20, r68);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r3 * r27;
+    r68 = r68 * r63;
+    r63 = r7 * r26;
+    r63 = r63 * r44;
+    r63 = r63 * r57;
+    r63 = fma(r67, r63, r57 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r68, r63);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r25 * r67;
+    r68 = r60 * r63;
+    r20 = r6 * r27;
+    r8 = 1.0 / r8;
+    r46 = 1.0 / r46;
+    r65 = r10 * r26;
+    r20 = r20 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r18;
+    r20 = r20 * r65;
+    r20 = fma(r0, r20, r27 * r68);
+    r69 = r60 * r0;
+    r71 = r35 * r69;
+    r72 = r7 * r27;
+    r72 = r72 * r8;
+    r72 = r72 * r46;
+    r72 = r72 * r48;
+    r72 = r72 * r65;
+    r72 = fma(r67, r72, r27 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r72);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r27 * r56;
+    r20 = r7 * r26;
+    r20 = r20 * r44;
+    r20 = r20 * r67;
+    r20 = fma(r72, r20, r72 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r62, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r52 * r69;
+    r73 = r60 * r52;
+    r73 = r73 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r62, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r6 * r8;
+    r73 = r73 * r46;
+    r73 = r73 * r18;
+    r73 = r73 * r52;
+    r73 = r73 * r65;
+    r73 = fma(r0, r73, r52 * r68);
+    r62 = r7 * r8;
+    r62 = r62 * r46;
+    r62 = r62 * r48;
+    r62 = r62 * r52;
+    r62 = r62 * r65;
+    r62 = fma(r67, r62, r52 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r73, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r20, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r57 * r69;
+    r20 = r60 * r57;
+    r20 = r20 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r10 * r35;
+    r20 = r20 * r18;
+    r20 = r20 * r49;
+    r34 = r10 * r49;
+    r34 = fma(r63, r34, r66 * r20);
+    r20 = r6 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r18;
+    r20 = r20 * r57;
+    r20 = r20 * r65;
+    r20 = fma(r0, r20, r57 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r10 * r27;
+    r20 = r20 * r18;
+    r20 = r20 * r49;
+    r20 = r20 * r66;
+    r34 = r6 * r8;
+    r34 = r34 * r46;
+    r34 = r34 * r18;
+    r34 = r34 * r56;
+    r34 = r34 * r65;
+    r34 = fma(r0, r34, r56 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r3 * r3;
+    r20 = r20 * r27;
+    r20 = r20 * r25;
+    r25 = r7 * r8;
+    r25 = r25 * r46;
+    r25 = r25 * r48;
+    r25 = r25 * r57;
+    r25 = r25 * r65;
+    r25 = fma(r67, r25, r57 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r35 * r27;
+    r25 = r25 * r66;
+    r20 = r7 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r48;
+    r20 = r20 * r56;
+    r20 = r20 * r65;
+    r20 = fma(r67, r20, r56 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r10 * r27;
+    r25 = r25 * r49;
+    r25 = r25 * r67;
+    r37 = r27 * r37;
+    r20 = r7 * r26;
+    r20 = r20 * r44;
+    r20 = r20 * r67;
+    r20 = fma(r37, r20, r38 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r25, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r56 * r69;
+    r56 = r60 * r56;
+    r56 = r56 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r20, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r72 * r69;
+    r56 = r60 * r67;
+    r56 = r56 * r72;
+    WriteSum2<double, double>((double*)inout_shared, r69, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r26 * r32;
+    r69 = r7 * r7;
+    r72 = r29 * r8;
+    r69 = r69 * r72;
+    r20 = r26 * r69;
+    r56 = r56 * r20;
+    r25 = r21 * r7;
+    r37 = r10 * r33;
+    r37 = r37 * r6;
+    r37 = fma(r47, r69, r9 * r37);
+    r38 = r47 * r6;
+    r38 = r38 * r6;
+    r37 = fma(r72, r38, r37);
+    r71 = r10 * r24;
+    r71 = r71 * r7;
+    r37 = fma(r9, r71, r37);
+    r71 = rsqrt(r30);
+    r25 = r25 * r7;
+    r25 = r25 * r26;
+    r25 = r25 * r26;
+    r25 = r25 * r37;
+    r25 = r25 * r9;
+    r25 = r25 * r46;
+    r25 = fma(r71, r25, r47 * r56);
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r30 = r30 * r71;
+    r31 = r7 * r30;
+    r38 = r37 * r31;
+    r34 = r44 * r18;
+    r25 = fma(r34, r38, r25);
+    r68 = r65 * r34;
+    r25 = fma(r24, r68, r25);
+    r38 = r47 * r6;
+    r38 = r38 * r26;
+    r38 = r38 * r32;
+    r38 = r38 * r48;
+    r63 = r37 * r30;
+    r62 = r6 * r49;
+    r63 = fma(r62, r63, r72 * r38);
+    r38 = r33 * r49;
+    r63 = fma(r65, r38, r63);
+    r73 = r21 * r6;
+    r73 = r73 * r26;
+    r73 = r73 * r37;
+    r73 = r73 * r9;
+    r73 = r73 * r46;
+    r73 = r73 * r71;
+    r63 = fma(r48, r73, r63);
+    r73 = r25 + r63;
+    r38 = r47 * r26;
+    r74 = -6.00000000000000000e+00;
+    r38 = r38 * r74;
+    r38 = r38 * r32;
+    r38 = r38 * r8;
+    r75 = r6 * r48;
+    r76 = r43 * r37;
+    r76 = r76 * r30;
+    r76 = fma(r62, r76, r38 * r75);
+    r77 = r33 * r26;
+    r78 = 6.00000000000000000e+00;
+    r77 = r77 * r78;
+    r76 = fma(r49, r77, r76);
+    r79 = r6 * r37;
+    r80 = -3.00000000000000000e+00;
+    r80 = r26 * r80;
+    r80 = r80 * r9;
+    r80 = r80 * r46;
+    r80 = r80 * r71;
+    r79 = r79 * r48;
+    r76 = fma(r80, r79, r76);
+    r76 = r76 + r25;
+    r76 = fma(r5, r76, r28 * r73);
+    r25 = r6 * r30;
+    r79 = 5.00000000000000000e-01;
+    r77 = r79 * r61;
+    r25 = r25 * r77;
+    r81 = r21 * r47;
+    r81 = r81 * r53;
+    r81 = r81 * r9;
+    r81 = r81 * r59;
+    r76 = fma(r48, r81, r76);
+    r82 = r4 * r37;
+    r83 = r10 * r49;
+    r83 = r83 * r31;
+    r76 = fma(r83, r82, r76);
+    r84 = r4 * r29;
+    r84 = r84 * r37;
+    r84 = r84 * r9;
+    r84 = r84 * r46;
+    r84 = r84 * r71;
+    r84 = r84 * r48;
+    r76 = fma(r18, r84, r76);
+    r85 = r6 * r79;
+    r85 = r85 * r37;
+    r85 = r85 * r60;
+    r76 = fma(r30, r85, r76);
+    r86 = r4 * r68;
+    r87 = r21 * r47;
+    r87 = r87 * r9;
+    r87 = r87 * r59;
+    r76 = fma(r48, r87, r76);
+    r88 = -5.00000000000000000e-01;
+    r89 = r88 * r37;
+    r89 = r89 * r32;
+    r89 = r89 * r58;
+    r89 = r89 * r71;
+    r90 = r53 * r89;
+    r91 = r51 * r10;
+    r91 = r91 * r27;
+    r91 = fma(r50, r73, r73 * r91);
+    r70 = r55 * r70;
+    r70 = r70 * r57;
+    r54 = r54 * r43;
+    r54 = r54 * r52;
+    r91 = fma(r73, r70, r91);
+    r91 = fma(r73, r54, r91);
+    r52 = r91 * r48;
+    r76 = fma(r60, r52, r76);
+    r57 = r33 * r26;
+    r76 = fma(r60, r57, r76);
+    r55 = r4 * r47;
+    r92 = -4.00000000000000000e+00;
+    r92 = r92 * r32;
+    r92 = r92 * r8;
+    r92 = r92 * r48;
+    r92 = r92 * r18;
+    r76 = fma(r92, r55, r76);
+    r93 = r4 * r24;
+    r93 = r93 * r49;
+    r76 = fma(r65, r93, r76);
+    r94 = r33 * r26;
+    r76 = fma(r61, r94, r76);
+    r76 = fma(r37, r25, r76);
+    r76 = fma(r33, r86, r76);
+    r76 = fma(r48, r90, r76);
+    r76 = fma(r48, r89, r76);
+    r94 = r2 * r76;
+    r93 = r7 * r38;
+    r55 = r37 * r80;
+    r55 = fma(r20, r55, r18 * r93);
+    r93 = r43 * r37;
+    r93 = r93 * r31;
+    r55 = fma(r34, r93, r55);
+    r57 = r24 * r26;
+    r57 = r57 * r78;
+    r57 = r57 * r44;
+    r55 = fma(r18, r57, r55);
+    r55 = r55 + r63;
+    r55 = fma(r4, r55, r45 * r73);
+    r73 = r91 * r60;
+    r55 = fma(r18, r73, r55);
+    r63 = r79 * r37;
+    r63 = r63 * r60;
+    r55 = fma(r31, r63, r55);
+    r57 = r24 * r26;
+    r55 = fma(r61, r57, r55);
+    r93 = r21 * r47;
+    r93 = r93 * r7;
+    r93 = r93 * r26;
+    r93 = r93 * r9;
+    r55 = fma(r59, r93, r55);
+    r52 = r5 * r37;
+    r55 = fma(r83, r52, r55);
+    r87 = r5 * r29;
+    r87 = r87 * r37;
+    r87 = r87 * r9;
+    r87 = r87 * r46;
+    r87 = r87 * r71;
+    r87 = r87 * r48;
+    r55 = fma(r18, r87, r55);
+    r85 = r5 * r33;
+    r55 = fma(r68, r85, r55);
+    r84 = r7 * r26;
+    r55 = fma(r89, r84, r55);
+    r89 = r37 * r31;
+    r55 = fma(r77, r89, r55);
+    r82 = r24 * r26;
+    r55 = fma(r60, r82, r55);
+    r81 = r21 * r47;
+    r81 = r81 * r7;
+    r81 = r81 * r26;
+    r81 = r81 * r53;
+    r81 = r81 * r9;
+    r55 = fma(r59, r81, r55);
+    r95 = r5 * r92;
+    r96 = r5 * r24;
+    r96 = r96 * r49;
+    r55 = fma(r65, r96, r55);
+    r55 = fma(r90, r18, r55);
+    r55 = fma(r47, r95, r55);
+    r96 = r3 * r55;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r94,
+                                             r96);
+    r96 = r41 * r26;
+    r96 = r96 * r78;
+    r94 = r39 * r6;
+    r94 = r94 * r26;
+    r94 = r94 * r74;
+    r94 = r94 * r32;
+    r94 = r94 * r8;
+    r94 = fma(r48, r94, r49 * r96);
+    r96 = r39 * r6;
+    r96 = r96 * r6;
+    r81 = r10 * r41;
+    r81 = r81 * r6;
+    r81 = fma(r9, r81, r72 * r96);
+    r96 = r10 * r42;
+    r96 = r96 * r7;
+    r81 = fma(r9, r96, r81);
+    r81 = fma(r39, r69, r81);
+    r96 = r81 * r80;
+    r90 = r43 * r81;
+    r90 = r90 * r30;
+    r94 = fma(r62, r90, r94);
+    r82 = r81 * r31;
+    r82 = fma(r34, r82, r39 * r56);
+    r89 = r21 * r7;
+    r89 = r89 * r7;
+    r89 = r89 * r26;
+    r89 = r89 * r26;
+    r89 = r89 * r81;
+    r89 = r89 * r9;
+    r89 = r89 * r46;
+    r82 = fma(r71, r89, r82);
+    r82 = fma(r42, r68, r82);
+    r94 = fma(r96, r75, r94);
+    r94 = r94 + r82;
+    r90 = r41 * r49;
+    r75 = r39 * r6;
+    r75 = r75 * r26;
+    r75 = r75 * r32;
+    r75 = r75 * r48;
+    r75 = fma(r72, r75, r65 * r90);
+    r90 = r21 * r6;
+    r90 = r90 * r26;
+    r90 = r90 * r81;
+    r90 = r90 * r9;
+    r90 = r90 * r46;
+    r90 = r90 * r71;
+    r75 = fma(r48, r90, r75);
+    r89 = r81 * r30;
+    r75 = fma(r62, r89, r75);
+    r82 = r82 + r75;
+    r94 = fma(r28, r82, r5 * r94);
+    r89 = r21 * r39;
+    r89 = r89 * r53;
+    r89 = r89 * r9;
+    r89 = r89 * r59;
+    r94 = fma(r48, r89, r94);
+    r90 = r41 * r26;
+    r94 = fma(r61, r90, r94);
+    r84 = r6 * r79;
+    r84 = r84 * r81;
+    r84 = r84 * r60;
+    r94 = fma(r30, r84, r94);
+    r85 = r51 * r10;
+    r85 = r85 * r27;
+    r85 = fma(r82, r85, r50 * r82);
+    r85 = fma(r82, r54, r85);
+    r85 = fma(r82, r70, r85);
+    r87 = r85 * r48;
+    r94 = fma(r60, r87, r94);
+    r52 = r21 * r39;
+    r52 = r52 * r9;
+    r52 = r52 * r59;
+    r94 = fma(r48, r52, r94);
+    r93 = r4 * r42;
+    r93 = r93 * r49;
+    r94 = fma(r65, r93, r94);
+    r57 = r41 * r26;
+    r94 = fma(r60, r57, r94);
+    r63 = r88 * r81;
+    r63 = r63 * r32;
+    r63 = r63 * r58;
+    r63 = r63 * r71;
+    r94 = fma(r48, r63, r94);
+    r73 = r4 * r81;
+    r94 = fma(r83, r73, r94);
+    r97 = r4 * r29;
+    r97 = r97 * r81;
+    r97 = r97 * r9;
+    r97 = r97 * r46;
+    r97 = r97 * r71;
+    r97 = r97 * r48;
+    r94 = fma(r18, r97, r94);
+    r98 = r4 * r39;
+    r94 = fma(r92, r98, r94);
+    r99 = r53 * r88;
+    r99 = r99 * r81;
+    r99 = r99 * r32;
+    r99 = r99 * r58;
+    r99 = r99 * r71;
+    r94 = fma(r48, r99, r94);
+    r94 = fma(r81, r25, r94);
+    r94 = fma(r41, r86, r94);
+    r99 = r2 * r94;
+    r98 = r39 * r7;
+    r98 = r98 * r7;
+    r98 = r98 * r26;
+    r98 = r98 * r26;
+    r98 = r98 * r74;
+    r98 = r98 * r32;
+    r97 = r43 * r81;
+    r97 = r97 * r31;
+    r97 = fma(r34, r97, r8 * r98);
+    r98 = r42 * r26;
+    r98 = r98 * r78;
+    r98 = r98 * r44;
+    r97 = fma(r18, r98, r97);
+    r97 = fma(r20, r96, r97);
+    r97 = r97 + r75;
+    r82 = fma(r45, r82, r4 * r97);
+    r97 = r21 * r39;
+    r97 = r97 * r7;
+    r97 = r97 * r26;
+    r97 = r97 * r9;
+    r82 = fma(r59, r97, r82);
+    r75 = r21 * r39;
+    r75 = r75 * r7;
+    r75 = r75 * r26;
+    r75 = r75 * r53;
+    r75 = r75 * r9;
+    r82 = fma(r59, r75, r82);
+    r96 = r79 * r81;
+    r96 = r96 * r60;
+    r82 = fma(r31, r96, r82);
+    r98 = r42 * r26;
+    r82 = fma(r61, r98, r82);
+    r73 = r5 * r42;
+    r73 = r73 * r49;
+    r82 = fma(r65, r73, r82);
+    r63 = r7 * r26;
+    r63 = r63 * r88;
+    r63 = r63 * r81;
+    r63 = r63 * r32;
+    r63 = r63 * r58;
+    r82 = fma(r71, r63, r82);
+    r57 = r5 * r41;
+    r82 = fma(r68, r57, r82);
+    r93 = r5 * r81;
+    r82 = fma(r83, r93, r82);
+    r52 = r5 * r29;
+    r52 = r52 * r81;
+    r52 = r52 * r9;
+    r52 = r52 * r46;
+    r52 = r52 * r71;
+    r52 = r52 * r48;
+    r82 = fma(r18, r52, r82);
+    r87 = r42 * r26;
+    r82 = fma(r60, r87, r82);
+    r84 = r81 * r31;
+    r82 = fma(r77, r84, r82);
+    r90 = r85 * r60;
+    r82 = fma(r18, r90, r82);
+    r89 = r7 * r26;
+    r89 = r89 * r53;
+    r89 = r89 * r88;
+    r89 = r89 * r81;
+    r89 = r89 * r32;
+    r89 = r89 * r58;
+    r82 = fma(r71, r89, r82);
+    r82 = fma(r39, r95, r82);
+    r89 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r99,
+                                             r89);
+    r89 = r36 * r6;
+    r89 = r89 * r26;
+    r89 = r89 * r74;
+    r89 = r89 * r32;
+    r89 = r89 * r8;
+    r99 = r10 * r19;
+    r99 = r99 * r6;
+    r69 = fma(r36, r69, r9 * r99);
+    r99 = r36 * r6;
+    r99 = r99 * r6;
+    r69 = fma(r72, r99, r69);
+    r90 = r10 * r40;
+    r90 = r90 * r7;
+    r69 = fma(r9, r90, r69);
+    r90 = r6 * r69;
+    r90 = r90 * r48;
+    r90 = fma(r80, r90, r48 * r89);
+    r89 = r43 * r69;
+    r89 = r89 * r30;
+    r90 = fma(r62, r89, r90);
+    r99 = r19 * r26;
+    r99 = r99 * r78;
+    r90 = fma(r49, r99, r90);
+    r84 = r21 * r7;
+    r84 = r84 * r7;
+    r84 = r84 * r26;
+    r84 = r84 * r26;
+    r84 = r84 * r69;
+    r84 = r84 * r9;
+    r84 = r84 * r46;
+    r84 = fma(r71, r84, r40 * r68);
+    r87 = r69 * r31;
+    r84 = fma(r34, r87, r84);
+    r84 = fma(r36, r56, r84);
+    r90 = r90 + r84;
+    r99 = r36 * r6;
+    r99 = r99 * r26;
+    r99 = r99 * r32;
+    r99 = r99 * r48;
+    r89 = r21 * r6;
+    r89 = r89 * r26;
+    r89 = r89 * r69;
+    r89 = r89 * r9;
+    r89 = r89 * r46;
+    r89 = r89 * r71;
+    r89 = fma(r48, r89, r72 * r99);
+    r99 = r69 * r30;
+    r89 = fma(r62, r99, r89);
+    r62 = r19 * r49;
+    r89 = fma(r65, r62, r89);
+    r84 = r84 + r89;
+    r28 = fma(r28, r84, r5 * r90);
+    r90 = r19 * r26;
+    r28 = fma(r61, r90, r28);
+    r62 = r21 * r36;
+    r62 = r62 * r9;
+    r62 = r62 * r59;
+    r28 = fma(r48, r62, r28);
+    r99 = r4 * r40;
+    r99 = r99 * r49;
+    r28 = fma(r65, r99, r28);
+    r72 = r4 * r29;
+    r72 = r72 * r69;
+    r72 = r72 * r9;
+    r72 = r72 * r46;
+    r72 = r72 * r71;
+    r72 = r72 * r48;
+    r28 = fma(r18, r72, r28);
+    r56 = r88 * r69;
+    r56 = r56 * r32;
+    r56 = r56 * r58;
+    r56 = r56 * r71;
+    r28 = fma(r48, r56, r28);
+    r87 = r6 * r79;
+    r87 = r87 * r69;
+    r87 = r87 * r60;
+    r28 = fma(r30, r87, r28);
+    r83 = r69 * r83;
+    r52 = r4 * r36;
+    r28 = fma(r92, r52, r28);
+    r92 = r19 * r26;
+    r28 = fma(r60, r92, r28);
+    r93 = r53 * r88;
+    r93 = r93 * r69;
+    r93 = r93 * r32;
+    r93 = r93 * r58;
+    r93 = r93 * r71;
+    r28 = fma(r48, r93, r28);
+    r57 = r21 * r36;
+    r57 = r57 * r53;
+    r57 = r57 * r9;
+    r57 = r57 * r59;
+    r28 = fma(r48, r57, r28);
+    r63 = r51 * r10;
+    r63 = r63 * r27;
+    r63 = fma(r84, r63, r50 * r84);
+    r63 = fma(r84, r70, r63);
+    r63 = fma(r84, r54, r63);
+    r54 = r63 * r48;
+    r28 = fma(r60, r54, r28);
+    r28 = fma(r69, r25, r28);
+    r28 = fma(r4, r83, r28);
+    r28 = fma(r19, r86, r28);
+    r54 = r2 * r28;
+    r57 = r40 * r26;
+    r57 = r57 * r78;
+    r57 = r57 * r44;
+    r44 = r69 * r80;
+    r44 = fma(r20, r44, r18 * r57);
+    r57 = r43 * r69;
+    r57 = r57 * r31;
+    r44 = fma(r34, r57, r44);
+    r34 = r36 * r7;
+    r34 = r34 * r7;
+    r34 = r34 * r26;
+    r34 = r34 * r26;
+    r34 = r34 * r74;
+    r34 = r34 * r32;
+    r44 = fma(r8, r34, r44);
+    r44 = r44 + r89;
+    r44 = fma(r4, r44, r45 * r84);
+    r84 = r5 * r40;
+    r84 = r84 * r49;
+    r44 = fma(r65, r84, r44);
+    r65 = r5 * r29;
+    r65 = r65 * r69;
+    r65 = r65 * r9;
+    r65 = r65 * r46;
+    r65 = r65 * r71;
+    r65 = r65 * r48;
+    r44 = fma(r18, r65, r44);
+    r46 = r7 * r26;
+    r46 = r46 * r88;
+    r46 = r46 * r69;
+    r46 = r46 * r32;
+    r46 = r46 * r58;
+    r44 = fma(r71, r46, r44);
+    r45 = r7 * r26;
+    r45 = r45 * r53;
+    r45 = r45 * r88;
+    r45 = r45 * r69;
+    r45 = r45 * r32;
+    r45 = r45 * r58;
+    r44 = fma(r71, r45, r44);
+    r71 = r69 * r31;
+    r44 = fma(r77, r71, r44);
+    r77 = r21 * r36;
+    r77 = r77 * r7;
+    r77 = r77 * r26;
+    r77 = r77 * r53;
+    r77 = r77 * r9;
+    r44 = fma(r59, r77, r44);
+    r58 = r40 * r26;
+    r44 = fma(r61, r58, r44);
+    r61 = r5 * r19;
+    r44 = fma(r68, r61, r44);
+    r68 = r40 * r26;
+    r44 = fma(r60, r68, r44);
+    r32 = r63 * r60;
+    r44 = fma(r18, r32, r44);
+    r89 = r79 * r69;
+    r89 = r89 * r60;
+    r44 = fma(r31, r89, r44);
+    r34 = r21 * r36;
+    r34 = r34 * r7;
+    r34 = r34 * r26;
+    r34 = r34 * r9;
+    r44 = fma(r59, r34, r44);
+    r44 = fma(r5, r83, r44);
+    r44 = fma(r36, r95, r44);
+    r34 = r3 * r44;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r54,
+                                             r34);
+    r34 = r3 * r21;
+    r34 = r34 * r1;
+    r34 = fma(r76, r64, r55 * r34);
+    r54 = r3 * r21;
+    r54 = r54 * r1;
+    r54 = fma(r94, r64, r82 * r54);
+    WriteSum2<double, double>((double*)inout_shared, r34, r54);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r3 * r21;
+    r54 = r54 * r1;
+    r64 = fma(r28, r64, r44 * r54);
+    WriteSum1<double, double>((double*)inout_shared, r64);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r3 * r3;
+    r54 = r55 * r55;
+    r34 = r76 * r76;
+    r34 = fma(r66, r34, r54 * r64);
+    r54 = r82 * r82;
+    r89 = r94 * r94;
+    r89 = fma(r66, r89, r54 * r64);
+    WriteSum2<double, double>((double*)inout_shared, r34, r89);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r89 = r44 * r44;
+    r34 = r28 * r28;
+    r34 = fma(r66, r34, r89 * r64);
+    WriteSum1<double, double>((double*)inout_shared, r34);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r3 * r3;
+    r34 = r34 * r55;
+    r64 = r76 * r94;
+    r64 = fma(r66, r64, r82 * r34);
+    r34 = r3 * r3;
+    r34 = r34 * r55;
+    r55 = r76 * r28;
+    r55 = fma(r66, r55, r44 * r34);
+    WriteSum2<double, double>((double*)inout_shared, r64, r55);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r3 * r3;
+    r55 = r55 * r82;
+    r82 = r94 * r28;
+    r82 = fma(r66, r82, r44 * r55);
+    WriteSum1<double, double>((double*)inout_shared, r82);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacKernel<<<n_blocks,
+                                                                  1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,1583 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirstKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r13, r14);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r17, r18);
+    r19 = fma(r15, r18, r12 * r13);
+    r20 = r11 * r14;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r16, r17, r19);
+    r20 = r10 * r19;
+    r22 = r15 * r17;
+    r22 = fma(r21, r22, r12 * r14);
+    r22 = fma(r16, r18, r22);
+    r22 = fma(r11, r13, r22);
+    r20 = r20 * r22;
+    r23 = fma(r15, r14, r12 * r17);
+    r24 = r16 * r13;
+    r23 = fma(r21, r24, r23);
+    r23 = fma(r11, r18, r23);
+    r24 = r10 * r23;
+    r25 = fma(r16, r14, r15 * r13);
+    r25 = fma(r11, r17, r25);
+    r25 = fma(r21, r25, r12 * r18);
+    r24 = fma(r25, r24, r20);
+    r7 = fma(r8, r24, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r18, r26);
+    r27 = r15 * r16;
+    r27 = r27 * r10;
+    r28 = r11 * r12;
+    r28 = fma(r10, r28, r27);
+    r29 = -2.00000000000000000e+00;
+    r30 = r15 * r15;
+    r30 = r29 * r30;
+    r31 = 1.00000000000000000e+00;
+    r32 = r11 * r11;
+    r32 = fma(r29, r32, r31);
+    r33 = r30 + r32;
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r34);
+    r35 = r16 * r11;
+    r35 = r35 * r10;
+    r36 = r15 * r12;
+    r36 = fma(r29, r36, r35);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r37);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r38 = r10 * r23;
+    r38 = r38 * r22;
+    r39 = r19 * r25;
+    r40 = fma(r29, r39, r38);
+    r41 = r23 * r23;
+    r41 = r29 * r41;
+    r42 = r31 + r41;
+    r43 = r19 * r19;
+    r43 = r43 * r29;
+    r42 = r42 + r43;
+    r7 = fma(r18, r28, r7);
+    r7 = fma(r26, r33, r7);
+    r7 = fma(r34, r36, r7);
+    r7 = fma(r37, r40, r7);
+    r7 = fma(r9, r42, r7);
+    r36 = r22 * r22;
+    r36 = r29 * r36;
+    r33 = r31 + r36;
+    r33 = r33 + r41;
+    r6 = fma(r8, r33, r6);
+    r41 = r23 * r29;
+    r41 = fma(r25, r41, r20);
+    r20 = r10 * r23;
+    r20 = r20 * r19;
+    r19 = r10 * r22;
+    r19 = fma(r25, r19, r20);
+    r28 = r15 * r11;
+    r28 = r28 * r10;
+    r44 = r16 * r12;
+    r45 = fma(r10, r44, r28);
+    r46 = r11 * r12;
+    r46 = fma(r29, r46, r27);
+    r27 = r16 * r16;
+    r27 = r27 * r29;
+    r32 = r27 + r32;
+    r6 = fma(r9, r41, r6);
+    r6 = fma(r37, r19, r6);
+    r6 = fma(r34, r45, r6);
+    r6 = fma(r26, r46, r6);
+    r6 = fma(r18, r32, r6);
+    r32 = r6 * r6;
+    r46 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r45);
+    r47 = r29 * r22;
+    r47 = fma(r25, r47, r20);
+    r8 = fma(r8, r47, r45);
+    r44 = fma(r29, r44, r28);
+    r27 = r31 + r27;
+    r27 = r27 + r30;
+    r30 = r15 * r12;
+    r30 = fma(r10, r30, r35);
+    r39 = fma(r10, r39, r38);
+    r36 = r31 + r36;
+    r36 = r36 + r43;
+    r8 = fma(r18, r44, r8);
+    r8 = fma(r34, r27, r8);
+    r8 = fma(r26, r30, r8);
+    r8 = fma(r9, r39, r8);
+    r8 = fma(r37, r36, r8);
+    r37 = copysign(1.0, r8);
+    r37 = fma(r46, r37, r8);
+    r8 = r37 * r37;
+    r9 = 1.0 / r8;
+    r30 = r7 * r7;
+    r30 = fma(r9, r30, r9 * r32);
+    r32 = sqrt(r30);
+    r26 = atan(r32);
+    r27 = r7 * r26;
+    r34 = copysign(1.0, r32);
+    r34 = fma(r46, r34, r32);
+    r46 = r34 * r34;
+    r32 = 1.0 / r46;
+    r44 = r9 * r32;
+    r18 = r7 * r26;
+    r27 = r27 * r44;
+    r27 = r27 * r18;
+    r43 = 3.00000000000000000e+00;
+    r38 = r6 * r6;
+    r38 = r9 * r38;
+    r35 = r26 * r26;
+    r38 = r38 * r32;
+    r38 = r38 * r35;
+    r35 = fma(r43, r38, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r27 = r38 + r27;
+    r20 = fma(r28, r27, r5 * r35);
+    r25 = r4 * r10;
+    r48 = r6 * r26;
+    r49 = r48 * r44;
+    r25 = r25 * r18;
+    r20 = fma(r49, r25, r20);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r50,
+                        r51);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r52 = r27 * r27;
+    r53 = fma(r51, r52, r50 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r54,
+                        r55);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r56 = r52 * r52;
+    r57 = r27 * r52;
+    r53 = fma(r55, r56, r53);
+    r53 = fma(r54, r57, r53);
+    r58 = 1.0 / r37;
+    r59 = 1.0 / r34;
+    r60 = r58 * r59;
+    r61 = r53 * r60;
+    r20 = fma(r48, r61, r20);
+    r20 = fma(r48, r60, r20);
+    r0 = fma(r2, r20, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r25, r62);
+    r0 = fma(r25, r21, r0);
+    r25 = r7 * r26;
+    r25 = r25 * r43;
+    r25 = r25 * r44;
+    r25 = fma(r18, r25, r38);
+    r63 = fma(r45, r27, r4 * r25);
+    r64 = r5 * r10;
+    r64 = r64 * r18;
+    r63 = fma(r49, r64, r63);
+    r63 = fma(r18, r61, r63);
+    r63 = fma(r60, r18, r63);
+    r1 = fma(r3, r63, r1);
+    r1 = fma(r62, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r62 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r62);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r20,
+        r63);
+    r62 = r2 * r27;
+    r62 = r62 * r48;
+    r62 = r62 * r60;
+    r64 = r27 * r60;
+    r65 = r3 * r18;
+    r64 = r64 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r48;
+    r64 = r64 * r60;
+    r64 = r64 * r52;
+    r62 = r60 * r52;
+    r62 = r62 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r3 * r25;
+    r64 = r2 * r10;
+    r64 = r64 * r18;
+    r64 = r64 * r49;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r2 * r35;
+    r64 = r10 * r49;
+    r64 = r64 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r48;
+    r64 = r64 * r60;
+    r64 = r64 * r57;
+    r62 = r60 * r57;
+    r62 = r62 * r65;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r2 * r48;
+    r62 = r62 * r60;
+    r62 = r62 * r56;
+    r64 = r60 * r65;
+    r64 = r64 * r56;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r62,
+        r64);
+    r64 = r2 * r27;
+    r62 = r3 * r27;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r64,
+        r62);
+    r62 = r21 * r63;
+    r62 = r62 * r1;
+    r64 = r21 * r0;
+    r66 = r20 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r66, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r21 * r27;
+    r62 = r62 * r1;
+    r62 = r62 * r60;
+    r66 = r27 * r48;
+    r64 = r2 * r64;
+    r66 = r66 * r60;
+    r66 = fma(r64, r66, r65 * r62);
+    r62 = r21 * r1;
+    r62 = r62 * r60;
+    r62 = r62 * r52;
+    r67 = r48 * r60;
+    r67 = r67 * r52;
+    r67 = fma(r64, r67, r65 * r62);
+    WriteSum2<double, double>((double*)inout_shared, r66, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r3 * r21;
+    r67 = r67 * r25;
+    r66 = r2 * r29;
+    r66 = r66 * r0;
+    r66 = r66 * r18;
+    r66 = fma(r49, r66, r1 * r67);
+    r67 = r29 * r1;
+    r67 = r67 * r49;
+    r67 = fma(r65, r67, r35 * r64);
+    WriteSum2<double, double>((double*)inout_shared, r66, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r67 = r21 * r1;
+    r67 = r67 * r60;
+    r67 = r67 * r57;
+    r66 = r48 * r60;
+    r66 = r66 * r57;
+    r66 = fma(r64, r66, r65 * r67);
+    r67 = r21 * r1;
+    r67 = r67 * r60;
+    r67 = r67 * r65;
+    r0 = r48 * r60;
+    r0 = r0 * r56;
+    r0 = fma(r64, r0, r56 * r67);
+    WriteSum2<double, double>((double*)inout_shared, r66, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r21;
+    r0 = r0 * r27;
+    r0 = r0 * r1;
+    r66 = r27 * r64;
+    WriteSum2<double, double>((double*)inout_shared, r66, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r20 * r20;
+    r66 = r63 * r63;
+    WriteSum2<double, double>((double*)inout_shared, r0, r66);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r66 = r2 * r2;
+    r38 = r66 * r38;
+    r0 = r7 * r26;
+    r67 = r3 * r65;
+    r0 = r0 * r44;
+    r0 = r0 * r52;
+    r0 = fma(r67, r0, r52 * r38);
+    r62 = r7 * r26;
+    r62 = r62 * r44;
+    r62 = r62 * r56;
+    r62 = fma(r67, r62, r56 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r0, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r48 * r66;
+    r68 = r18 * r0;
+    r69 = r6 * r7;
+    r70 = 4.00000000000000000e+00;
+    r8 = r37 * r8;
+    r37 = r37 * r8;
+    r37 = 1.0 / r37;
+    r46 = r34 * r46;
+    r34 = r34 * r46;
+    r34 = 1.0 / r34;
+    r69 = r69 * r26;
+    r69 = r69 * r26;
+    r69 = r69 * r70;
+    r69 = r69 * r37;
+    r69 = r69 * r34;
+    r34 = r3 * r3;
+    r34 = r34 * r25;
+    r34 = fma(r25, r34, r69 * r68);
+    r68 = r48 * r67;
+    r37 = r35 * r35;
+    r37 = fma(r66, r37, r69 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r37);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r37 = r57 * r57;
+    r34 = r7 * r26;
+    r34 = r34 * r44;
+    r34 = r34 * r67;
+    r34 = fma(r37, r34, r37 * r38);
+    r68 = r56 * r56;
+    r69 = r7 * r26;
+    r69 = r69 * r44;
+    r69 = r69 * r67;
+    r69 = fma(r68, r69, r38 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r52 * r66;
+    r68 = r3 * r3;
+    r68 = r68 * r52;
+    WriteSum2<double, double>((double*)inout_shared, r69, r68);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = 0.00000000000000000e+00;
+    r69 = r2 * r27;
+    r69 = r69 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    WriteSum2<double, double>((double*)inout_shared, r68, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r2 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    r69 = r69 * r52;
+    r71 = r2 * r10;
+    r71 = r71 * r20;
+    r71 = r71 * r18;
+    r71 = r71 * r49;
+    WriteSum2<double, double>((double*)inout_shared, r69, r71);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r71 = r2 * r35;
+    r71 = r71 * r20;
+    r69 = r2 * r20;
+    r69 = r69 * r48;
+    r69 = r69 * r60;
+    r69 = r69 * r57;
+    WriteSum2<double, double>((double*)inout_shared, r71, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r2 * r27;
+    r69 = r69 * r20;
+    r20 = r2 * r20;
+    r20 = r20 * r48;
+    r20 = r20 * r60;
+    r20 = r20 * r56;
+    WriteSum2<double, double>((double*)inout_shared, r20, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r27 * r63;
+    r69 = r69 * r60;
+    r69 = r69 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r68, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r3 * r25;
+    r69 = r69 * r63;
+    r20 = r63 * r60;
+    r20 = r20 * r52;
+    r20 = r20 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r20, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r10 * r63;
+    r69 = r69 * r49;
+    r69 = r69 * r65;
+    r20 = r63 * r60;
+    r20 = r20 * r57;
+    r20 = r20 * r65;
+    WriteSum2<double, double>((double*)inout_shared, r69, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r63 * r60;
+    r20 = r20 * r65;
+    r20 = r20 * r56;
+    WriteSum2<double, double>((double*)inout_shared, r20, r68);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r68 = r3 * r27;
+    r68 = r68 * r63;
+    r63 = r7 * r26;
+    r63 = r63 * r44;
+    r63 = r63 * r57;
+    r63 = fma(r67, r63, r57 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r68, r63);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r63 = r25 * r67;
+    r68 = r60 * r63;
+    r20 = r6 * r27;
+    r8 = 1.0 / r8;
+    r46 = 1.0 / r46;
+    r65 = r10 * r26;
+    r20 = r20 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r18;
+    r20 = r20 * r65;
+    r20 = fma(r0, r20, r27 * r68);
+    r69 = r60 * r0;
+    r71 = r35 * r69;
+    r72 = r7 * r27;
+    r72 = r72 * r8;
+    r72 = r72 * r46;
+    r72 = r72 * r48;
+    r72 = r72 * r65;
+    r72 = fma(r67, r72, r27 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r72);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r27 * r56;
+    r20 = r7 * r26;
+    r20 = r20 * r44;
+    r20 = r20 * r67;
+    r20 = fma(r72, r20, r72 * r38);
+    WriteSum2<double, double>((double*)inout_shared, r62, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r62 = r52 * r69;
+    r73 = r60 * r52;
+    r73 = r73 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r62, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r6 * r8;
+    r73 = r73 * r46;
+    r73 = r73 * r18;
+    r73 = r73 * r52;
+    r73 = r73 * r65;
+    r73 = fma(r0, r73, r52 * r68);
+    r62 = r7 * r8;
+    r62 = r62 * r46;
+    r62 = r62 * r48;
+    r62 = r62 * r52;
+    r62 = r62 * r65;
+    r62 = fma(r67, r62, r52 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r73, r62);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r20, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r57 * r69;
+    r20 = r60 * r57;
+    r20 = r20 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r10 * r35;
+    r20 = r20 * r18;
+    r20 = r20 * r49;
+    r34 = r10 * r49;
+    r34 = fma(r63, r34, r66 * r20);
+    r20 = r6 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r18;
+    r20 = r20 * r57;
+    r20 = r20 * r65;
+    r20 = fma(r0, r20, r57 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r10 * r27;
+    r20 = r20 * r18;
+    r20 = r20 * r49;
+    r20 = r20 * r66;
+    r34 = r6 * r8;
+    r34 = r34 * r46;
+    r34 = r34 * r18;
+    r34 = r34 * r56;
+    r34 = r34 * r65;
+    r34 = fma(r0, r34, r56 * r68);
+    WriteSum2<double, double>((double*)inout_shared, r34, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r3 * r3;
+    r20 = r20 * r27;
+    r20 = r20 * r25;
+    r25 = r7 * r8;
+    r25 = r25 * r46;
+    r25 = r25 * r48;
+    r25 = r25 * r57;
+    r25 = r25 * r65;
+    r25 = fma(r67, r25, r57 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r35 * r27;
+    r25 = r25 * r66;
+    r20 = r7 * r8;
+    r20 = r20 * r46;
+    r20 = r20 * r48;
+    r20 = r20 * r56;
+    r20 = r20 * r65;
+    r20 = fma(r67, r20, r56 * r71);
+    WriteSum2<double, double>((double*)inout_shared, r20, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r10 * r27;
+    r25 = r25 * r49;
+    r25 = r25 * r67;
+    r37 = r27 * r37;
+    r20 = r7 * r26;
+    r20 = r20 * r44;
+    r20 = r20 * r67;
+    r20 = fma(r37, r20, r38 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r25, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r20 = r56 * r69;
+    r56 = r60 * r56;
+    r56 = r56 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r20, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r72 * r69;
+    r56 = r60 * r67;
+    r56 = r56 * r72;
+    WriteSum2<double, double>((double*)inout_shared, r69, r56);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r56 = r26 * r32;
+    r69 = r7 * r7;
+    r72 = r29 * r8;
+    r69 = r69 * r72;
+    r20 = r26 * r69;
+    r56 = r56 * r20;
+    r25 = r21 * r7;
+    r37 = r10 * r33;
+    r37 = r37 * r6;
+    r37 = fma(r47, r69, r9 * r37);
+    r38 = r47 * r6;
+    r38 = r38 * r6;
+    r37 = fma(r72, r38, r37);
+    r71 = r10 * r24;
+    r71 = r71 * r7;
+    r37 = fma(r9, r71, r37);
+    r71 = rsqrt(r30);
+    r25 = r25 * r7;
+    r25 = r25 * r26;
+    r25 = r25 * r26;
+    r25 = r25 * r37;
+    r25 = r25 * r9;
+    r25 = r25 * r46;
+    r25 = fma(r71, r25, r47 * r56);
+    r30 = r31 + r30;
+    r30 = 1.0 / r30;
+    r30 = r30 * r71;
+    r31 = r7 * r30;
+    r38 = r37 * r31;
+    r34 = r44 * r18;
+    r25 = fma(r34, r38, r25);
+    r68 = r65 * r34;
+    r25 = fma(r24, r68, r25);
+    r38 = r47 * r6;
+    r38 = r38 * r26;
+    r38 = r38 * r32;
+    r38 = r38 * r48;
+    r63 = r37 * r30;
+    r62 = r6 * r49;
+    r63 = fma(r62, r63, r72 * r38);
+    r38 = r33 * r49;
+    r63 = fma(r65, r38, r63);
+    r73 = r21 * r6;
+    r73 = r73 * r26;
+    r73 = r73 * r37;
+    r73 = r73 * r9;
+    r73 = r73 * r46;
+    r73 = r73 * r71;
+    r63 = fma(r48, r73, r63);
+    r73 = r25 + r63;
+    r38 = r47 * r26;
+    r74 = -6.00000000000000000e+00;
+    r38 = r38 * r74;
+    r38 = r38 * r32;
+    r38 = r38 * r8;
+    r75 = r6 * r48;
+    r76 = r43 * r37;
+    r76 = r76 * r30;
+    r76 = fma(r62, r76, r38 * r75);
+    r77 = r33 * r26;
+    r78 = 6.00000000000000000e+00;
+    r77 = r77 * r78;
+    r76 = fma(r49, r77, r76);
+    r79 = r6 * r37;
+    r80 = -3.00000000000000000e+00;
+    r80 = r26 * r80;
+    r80 = r80 * r9;
+    r80 = r80 * r46;
+    r80 = r80 * r71;
+    r79 = r79 * r48;
+    r76 = fma(r80, r79, r76);
+    r76 = r76 + r25;
+    r76 = fma(r5, r76, r28 * r73);
+    r25 = r6 * r30;
+    r79 = 5.00000000000000000e-01;
+    r77 = r79 * r61;
+    r25 = r25 * r77;
+    r81 = r21 * r47;
+    r81 = r81 * r53;
+    r81 = r81 * r9;
+    r81 = r81 * r59;
+    r76 = fma(r48, r81, r76);
+    r82 = r4 * r37;
+    r83 = r10 * r49;
+    r83 = r83 * r31;
+    r76 = fma(r83, r82, r76);
+    r84 = r4 * r29;
+    r84 = r84 * r37;
+    r84 = r84 * r9;
+    r84 = r84 * r46;
+    r84 = r84 * r71;
+    r84 = r84 * r48;
+    r76 = fma(r18, r84, r76);
+    r85 = r6 * r79;
+    r85 = r85 * r37;
+    r85 = r85 * r60;
+    r76 = fma(r30, r85, r76);
+    r86 = r4 * r68;
+    r87 = r21 * r47;
+    r87 = r87 * r9;
+    r87 = r87 * r59;
+    r76 = fma(r48, r87, r76);
+    r88 = -5.00000000000000000e-01;
+    r89 = r88 * r37;
+    r89 = r89 * r32;
+    r89 = r89 * r58;
+    r89 = r89 * r71;
+    r90 = r53 * r89;
+    r91 = r51 * r10;
+    r91 = r91 * r27;
+    r91 = fma(r50, r73, r73 * r91);
+    r70 = r55 * r70;
+    r70 = r70 * r57;
+    r54 = r54 * r43;
+    r54 = r54 * r52;
+    r91 = fma(r73, r70, r91);
+    r91 = fma(r73, r54, r91);
+    r52 = r91 * r48;
+    r76 = fma(r60, r52, r76);
+    r57 = r33 * r26;
+    r76 = fma(r60, r57, r76);
+    r55 = r4 * r47;
+    r92 = -4.00000000000000000e+00;
+    r92 = r92 * r32;
+    r92 = r92 * r8;
+    r92 = r92 * r48;
+    r92 = r92 * r18;
+    r76 = fma(r92, r55, r76);
+    r93 = r4 * r24;
+    r93 = r93 * r49;
+    r76 = fma(r65, r93, r76);
+    r94 = r33 * r26;
+    r76 = fma(r61, r94, r76);
+    r76 = fma(r37, r25, r76);
+    r76 = fma(r33, r86, r76);
+    r76 = fma(r48, r90, r76);
+    r76 = fma(r48, r89, r76);
+    r94 = r2 * r76;
+    r93 = r7 * r38;
+    r55 = r37 * r80;
+    r55 = fma(r20, r55, r18 * r93);
+    r93 = r43 * r37;
+    r93 = r93 * r31;
+    r55 = fma(r34, r93, r55);
+    r57 = r24 * r26;
+    r57 = r57 * r78;
+    r57 = r57 * r44;
+    r55 = fma(r18, r57, r55);
+    r55 = r55 + r63;
+    r55 = fma(r4, r55, r45 * r73);
+    r73 = r91 * r60;
+    r55 = fma(r18, r73, r55);
+    r63 = r79 * r37;
+    r63 = r63 * r60;
+    r55 = fma(r31, r63, r55);
+    r57 = r24 * r26;
+    r55 = fma(r61, r57, r55);
+    r93 = r21 * r47;
+    r93 = r93 * r7;
+    r93 = r93 * r26;
+    r93 = r93 * r9;
+    r55 = fma(r59, r93, r55);
+    r52 = r5 * r37;
+    r55 = fma(r83, r52, r55);
+    r87 = r5 * r29;
+    r87 = r87 * r37;
+    r87 = r87 * r9;
+    r87 = r87 * r46;
+    r87 = r87 * r71;
+    r87 = r87 * r48;
+    r55 = fma(r18, r87, r55);
+    r85 = r5 * r33;
+    r55 = fma(r68, r85, r55);
+    r84 = r7 * r26;
+    r55 = fma(r89, r84, r55);
+    r89 = r37 * r31;
+    r55 = fma(r77, r89, r55);
+    r82 = r24 * r26;
+    r55 = fma(r60, r82, r55);
+    r81 = r21 * r47;
+    r81 = r81 * r7;
+    r81 = r81 * r26;
+    r81 = r81 * r53;
+    r81 = r81 * r9;
+    r55 = fma(r59, r81, r55);
+    r95 = r5 * r92;
+    r96 = r5 * r24;
+    r96 = r96 * r49;
+    r55 = fma(r65, r96, r55);
+    r55 = fma(r90, r18, r55);
+    r55 = fma(r47, r95, r55);
+    r96 = r3 * r55;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r94,
+                                             r96);
+    r96 = r41 * r26;
+    r96 = r96 * r78;
+    r94 = r39 * r6;
+    r94 = r94 * r26;
+    r94 = r94 * r74;
+    r94 = r94 * r32;
+    r94 = r94 * r8;
+    r94 = fma(r48, r94, r49 * r96);
+    r96 = r39 * r6;
+    r96 = r96 * r6;
+    r81 = r10 * r41;
+    r81 = r81 * r6;
+    r81 = fma(r9, r81, r72 * r96);
+    r96 = r10 * r42;
+    r96 = r96 * r7;
+    r81 = fma(r9, r96, r81);
+    r81 = fma(r39, r69, r81);
+    r96 = r81 * r80;
+    r90 = r43 * r81;
+    r90 = r90 * r30;
+    r94 = fma(r62, r90, r94);
+    r82 = r81 * r31;
+    r82 = fma(r34, r82, r39 * r56);
+    r89 = r21 * r7;
+    r89 = r89 * r7;
+    r89 = r89 * r26;
+    r89 = r89 * r26;
+    r89 = r89 * r81;
+    r89 = r89 * r9;
+    r89 = r89 * r46;
+    r82 = fma(r71, r89, r82);
+    r82 = fma(r42, r68, r82);
+    r94 = fma(r96, r75, r94);
+    r94 = r94 + r82;
+    r90 = r41 * r49;
+    r75 = r39 * r6;
+    r75 = r75 * r26;
+    r75 = r75 * r32;
+    r75 = r75 * r48;
+    r75 = fma(r72, r75, r65 * r90);
+    r90 = r21 * r6;
+    r90 = r90 * r26;
+    r90 = r90 * r81;
+    r90 = r90 * r9;
+    r90 = r90 * r46;
+    r90 = r90 * r71;
+    r75 = fma(r48, r90, r75);
+    r89 = r81 * r30;
+    r75 = fma(r62, r89, r75);
+    r82 = r82 + r75;
+    r94 = fma(r28, r82, r5 * r94);
+    r89 = r21 * r39;
+    r89 = r89 * r53;
+    r89 = r89 * r9;
+    r89 = r89 * r59;
+    r94 = fma(r48, r89, r94);
+    r90 = r41 * r26;
+    r94 = fma(r61, r90, r94);
+    r84 = r6 * r79;
+    r84 = r84 * r81;
+    r84 = r84 * r60;
+    r94 = fma(r30, r84, r94);
+    r85 = r51 * r10;
+    r85 = r85 * r27;
+    r85 = fma(r82, r85, r50 * r82);
+    r85 = fma(r82, r54, r85);
+    r85 = fma(r82, r70, r85);
+    r87 = r85 * r48;
+    r94 = fma(r60, r87, r94);
+    r52 = r21 * r39;
+    r52 = r52 * r9;
+    r52 = r52 * r59;
+    r94 = fma(r48, r52, r94);
+    r93 = r4 * r42;
+    r93 = r93 * r49;
+    r94 = fma(r65, r93, r94);
+    r57 = r41 * r26;
+    r94 = fma(r60, r57, r94);
+    r63 = r88 * r81;
+    r63 = r63 * r32;
+    r63 = r63 * r58;
+    r63 = r63 * r71;
+    r94 = fma(r48, r63, r94);
+    r73 = r4 * r81;
+    r94 = fma(r83, r73, r94);
+    r97 = r4 * r29;
+    r97 = r97 * r81;
+    r97 = r97 * r9;
+    r97 = r97 * r46;
+    r97 = r97 * r71;
+    r97 = r97 * r48;
+    r94 = fma(r18, r97, r94);
+    r98 = r4 * r39;
+    r94 = fma(r92, r98, r94);
+    r99 = r53 * r88;
+    r99 = r99 * r81;
+    r99 = r99 * r32;
+    r99 = r99 * r58;
+    r99 = r99 * r71;
+    r94 = fma(r48, r99, r94);
+    r94 = fma(r81, r25, r94);
+    r94 = fma(r41, r86, r94);
+    r99 = r2 * r94;
+    r98 = r39 * r7;
+    r98 = r98 * r7;
+    r98 = r98 * r26;
+    r98 = r98 * r26;
+    r98 = r98 * r74;
+    r98 = r98 * r32;
+    r97 = r43 * r81;
+    r97 = r97 * r31;
+    r97 = fma(r34, r97, r8 * r98);
+    r98 = r42 * r26;
+    r98 = r98 * r78;
+    r98 = r98 * r44;
+    r97 = fma(r18, r98, r97);
+    r97 = fma(r20, r96, r97);
+    r97 = r97 + r75;
+    r82 = fma(r45, r82, r4 * r97);
+    r97 = r21 * r39;
+    r97 = r97 * r7;
+    r97 = r97 * r26;
+    r97 = r97 * r9;
+    r82 = fma(r59, r97, r82);
+    r75 = r21 * r39;
+    r75 = r75 * r7;
+    r75 = r75 * r26;
+    r75 = r75 * r53;
+    r75 = r75 * r9;
+    r82 = fma(r59, r75, r82);
+    r96 = r79 * r81;
+    r96 = r96 * r60;
+    r82 = fma(r31, r96, r82);
+    r98 = r42 * r26;
+    r82 = fma(r61, r98, r82);
+    r73 = r5 * r42;
+    r73 = r73 * r49;
+    r82 = fma(r65, r73, r82);
+    r63 = r7 * r26;
+    r63 = r63 * r88;
+    r63 = r63 * r81;
+    r63 = r63 * r32;
+    r63 = r63 * r58;
+    r82 = fma(r71, r63, r82);
+    r57 = r5 * r41;
+    r82 = fma(r68, r57, r82);
+    r93 = r5 * r81;
+    r82 = fma(r83, r93, r82);
+    r52 = r5 * r29;
+    r52 = r52 * r81;
+    r52 = r52 * r9;
+    r52 = r52 * r46;
+    r52 = r52 * r71;
+    r52 = r52 * r48;
+    r82 = fma(r18, r52, r82);
+    r87 = r42 * r26;
+    r82 = fma(r60, r87, r82);
+    r84 = r81 * r31;
+    r82 = fma(r77, r84, r82);
+    r90 = r85 * r60;
+    r82 = fma(r18, r90, r82);
+    r89 = r7 * r26;
+    r89 = r89 * r53;
+    r89 = r89 * r88;
+    r89 = r89 * r81;
+    r89 = r89 * r32;
+    r89 = r89 * r58;
+    r82 = fma(r71, r89, r82);
+    r82 = fma(r39, r95, r82);
+    r89 = r3 * r82;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r99,
+                                             r89);
+    r89 = r36 * r6;
+    r89 = r89 * r26;
+    r89 = r89 * r74;
+    r89 = r89 * r32;
+    r89 = r89 * r8;
+    r99 = r10 * r19;
+    r99 = r99 * r6;
+    r69 = fma(r36, r69, r9 * r99);
+    r99 = r36 * r6;
+    r99 = r99 * r6;
+    r69 = fma(r72, r99, r69);
+    r90 = r10 * r40;
+    r90 = r90 * r7;
+    r69 = fma(r9, r90, r69);
+    r90 = r6 * r69;
+    r90 = r90 * r48;
+    r90 = fma(r80, r90, r48 * r89);
+    r89 = r43 * r69;
+    r89 = r89 * r30;
+    r90 = fma(r62, r89, r90);
+    r99 = r19 * r26;
+    r99 = r99 * r78;
+    r90 = fma(r49, r99, r90);
+    r84 = r21 * r7;
+    r84 = r84 * r7;
+    r84 = r84 * r26;
+    r84 = r84 * r26;
+    r84 = r84 * r69;
+    r84 = r84 * r9;
+    r84 = r84 * r46;
+    r84 = fma(r71, r84, r40 * r68);
+    r87 = r69 * r31;
+    r84 = fma(r34, r87, r84);
+    r84 = fma(r36, r56, r84);
+    r90 = r90 + r84;
+    r99 = r36 * r6;
+    r99 = r99 * r26;
+    r99 = r99 * r32;
+    r99 = r99 * r48;
+    r89 = r21 * r6;
+    r89 = r89 * r26;
+    r89 = r89 * r69;
+    r89 = r89 * r9;
+    r89 = r89 * r46;
+    r89 = r89 * r71;
+    r89 = fma(r48, r89, r72 * r99);
+    r99 = r69 * r30;
+    r89 = fma(r62, r99, r89);
+    r62 = r19 * r49;
+    r89 = fma(r65, r62, r89);
+    r84 = r84 + r89;
+    r28 = fma(r28, r84, r5 * r90);
+    r90 = r19 * r26;
+    r28 = fma(r61, r90, r28);
+    r62 = r21 * r36;
+    r62 = r62 * r9;
+    r62 = r62 * r59;
+    r28 = fma(r48, r62, r28);
+    r99 = r4 * r40;
+    r99 = r99 * r49;
+    r28 = fma(r65, r99, r28);
+    r72 = r4 * r29;
+    r72 = r72 * r69;
+    r72 = r72 * r9;
+    r72 = r72 * r46;
+    r72 = r72 * r71;
+    r72 = r72 * r48;
+    r28 = fma(r18, r72, r28);
+    r56 = r88 * r69;
+    r56 = r56 * r32;
+    r56 = r56 * r58;
+    r56 = r56 * r71;
+    r28 = fma(r48, r56, r28);
+    r87 = r6 * r79;
+    r87 = r87 * r69;
+    r87 = r87 * r60;
+    r28 = fma(r30, r87, r28);
+    r83 = r69 * r83;
+    r52 = r4 * r36;
+    r28 = fma(r92, r52, r28);
+    r92 = r19 * r26;
+    r28 = fma(r60, r92, r28);
+    r93 = r53 * r88;
+    r93 = r93 * r69;
+    r93 = r93 * r32;
+    r93 = r93 * r58;
+    r93 = r93 * r71;
+    r28 = fma(r48, r93, r28);
+    r57 = r21 * r36;
+    r57 = r57 * r53;
+    r57 = r57 * r9;
+    r57 = r57 * r59;
+    r28 = fma(r48, r57, r28);
+    r63 = r51 * r10;
+    r63 = r63 * r27;
+    r63 = fma(r84, r63, r50 * r84);
+    r63 = fma(r84, r70, r63);
+    r63 = fma(r84, r54, r63);
+    r54 = r63 * r48;
+    r28 = fma(r60, r54, r28);
+    r28 = fma(r69, r25, r28);
+    r28 = fma(r4, r83, r28);
+    r28 = fma(r19, r86, r28);
+    r54 = r2 * r28;
+    r57 = r40 * r26;
+    r57 = r57 * r78;
+    r57 = r57 * r44;
+    r44 = r69 * r80;
+    r44 = fma(r20, r44, r18 * r57);
+    r57 = r43 * r69;
+    r57 = r57 * r31;
+    r44 = fma(r34, r57, r44);
+    r34 = r36 * r7;
+    r34 = r34 * r7;
+    r34 = r34 * r26;
+    r34 = r34 * r26;
+    r34 = r34 * r74;
+    r34 = r34 * r32;
+    r44 = fma(r8, r34, r44);
+    r44 = r44 + r89;
+    r44 = fma(r4, r44, r45 * r84);
+    r84 = r5 * r40;
+    r84 = r84 * r49;
+    r44 = fma(r65, r84, r44);
+    r65 = r5 * r29;
+    r65 = r65 * r69;
+    r65 = r65 * r9;
+    r65 = r65 * r46;
+    r65 = r65 * r71;
+    r65 = r65 * r48;
+    r44 = fma(r18, r65, r44);
+    r46 = r7 * r26;
+    r46 = r46 * r88;
+    r46 = r46 * r69;
+    r46 = r46 * r32;
+    r46 = r46 * r58;
+    r44 = fma(r71, r46, r44);
+    r45 = r7 * r26;
+    r45 = r45 * r53;
+    r45 = r45 * r88;
+    r45 = r45 * r69;
+    r45 = r45 * r32;
+    r45 = r45 * r58;
+    r44 = fma(r71, r45, r44);
+    r71 = r69 * r31;
+    r44 = fma(r77, r71, r44);
+    r77 = r21 * r36;
+    r77 = r77 * r7;
+    r77 = r77 * r26;
+    r77 = r77 * r53;
+    r77 = r77 * r9;
+    r44 = fma(r59, r77, r44);
+    r58 = r40 * r26;
+    r44 = fma(r61, r58, r44);
+    r61 = r5 * r19;
+    r44 = fma(r68, r61, r44);
+    r68 = r40 * r26;
+    r44 = fma(r60, r68, r44);
+    r32 = r63 * r60;
+    r44 = fma(r18, r32, r44);
+    r89 = r79 * r69;
+    r89 = r89 * r60;
+    r44 = fma(r31, r89, r44);
+    r34 = r21 * r36;
+    r34 = r34 * r7;
+    r34 = r34 * r26;
+    r34 = r34 * r9;
+    r44 = fma(r59, r34, r44);
+    r44 = fma(r5, r83, r44);
+    r44 = fma(r36, r95, r44);
+    r34 = r3 * r44;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r54,
+                                             r34);
+    r34 = r3 * r21;
+    r34 = r34 * r1;
+    r34 = fma(r76, r64, r55 * r34);
+    r54 = r3 * r21;
+    r54 = r54 * r1;
+    r54 = fma(r94, r64, r82 * r54);
+    WriteSum2<double, double>((double*)inout_shared, r34, r54);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r54 = r3 * r21;
+    r54 = r54 * r1;
+    r64 = fma(r28, r64, r44 * r54);
+    WriteSum1<double, double>((double*)inout_shared, r64);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r64 = r3 * r3;
+    r54 = r55 * r55;
+    r34 = r76 * r76;
+    r34 = fma(r66, r34, r54 * r64);
+    r54 = r82 * r82;
+    r89 = r94 * r94;
+    r89 = fma(r66, r89, r54 * r64);
+    WriteSum2<double, double>((double*)inout_shared, r34, r89);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r89 = r44 * r44;
+    r34 = r28 * r28;
+    r34 = fma(r66, r34, r89 * r64);
+    WriteSum1<double, double>((double*)inout_shared, r34);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r34 = r3 * r3;
+    r34 = r34 * r55;
+    r64 = r76 * r94;
+    r64 = fma(r66, r64, r82 * r34);
+    r34 = r3 * r3;
+    r34 = r34 * r55;
+    r55 = r76 * r28;
+    r55 = fma(r66, r55, r44 * r34);
+    WriteSum2<double, double>((double*)inout_shared, r64, r55);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r3 * r3;
+    r55 = r55 * r82;
+    r82 = r94 * r28;
+    r82 = fma(r66, r82, r44 * r55);
+    WriteSum1<double, double>((double*)inout_shared, r82);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirstKernel<<<n_blocks,
+                                                                       1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.cu
@@ -1,0 +1,360 @@
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScoreKernel(
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* pose,
+        unsigned int pose_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r10,
+                                            r11);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 2 * pose_num_alloc, global_thread_idx, r12, r13);
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r14,
+                                            r15);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 0 * pose_num_alloc, global_thread_idx, r16, r17);
+    r18 = fma(r14, r17, r11 * r12);
+    r19 = r15 * r16;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r10, r13, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r14, r13, r11 * r16);
+    r22 = r10 * r17;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r15, r12, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r14 * r12;
+    r24 = fma(r20, r24, r11 * r17);
+    r24 = fma(r15, r13, r24);
+    r24 = fma(r10, r16, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r13 = r25 * r26;
+    r27 = fma(r24, r13, r23);
+    r27 = fma(r8, r27, r7);
+    ReadIdx2<1024, double, double, double2>(
+        pose, 4 * pose_num_alloc, global_thread_idx, r7, r28);
+    r29 = r14 * r10;
+    r29 = r29 * r19;
+    r30 = r15 * r11;
+    r31 = fma(r25, r30, r29);
+    ReadIdx1<1024, double, double, double>(
+        pose, 6 * pose_num_alloc, global_thread_idx, r32);
+    r33 = 1.00000000000000000e+00;
+    r34 = r15 * r15;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r14 * r14;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r15 * r10;
+    r37 = r37 * r19;
+    r38 = r14 * r11;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r13, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r10 * r11;
+    r23 = r14 * r15;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r10 * r10;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r10 * r11;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r14 * r11;
+    r36 = fma(r25, r36, r37);
+    r13 = fma(r21, r13, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r13, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r13 = copysign(1.0, r9);
+    r13 = fma(r6, r13, r9);
+    r6 = r13 * r13;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r44);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r13 = 1.0 / r13;
+    r43 = r43 * r13;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScoreKernel<<<n_blocks,
+                                                                 1024>>>(
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      pose,
+      pose_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* pose,
+    unsigned int pose_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.cu
@@ -1,0 +1,339 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        double* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                2 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            4 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            2 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    r8 = fma(r2, r7, r3 * r5);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                4 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r9,
+                        r10);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            6 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                0 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r13,
+                        r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            0 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                6 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r17,
+                        r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            12 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r19,
+                                            r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            10 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r21,
+                                            r22);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                8 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r23,
+                        r24);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            14 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r25,
+                                            r26);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            8 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r27,
+                                            r28);
+    r8 = fma(r9, r12, r8);
+    r8 = fma(r14, r16, r8);
+    r8 = fma(r18, r20, r8);
+    r8 = fma(r17, r22, r8);
+    r8 = fma(r24, r26, r8);
+    r8 = fma(r10, r28, r8);
+    r9 = fma(r9, r11, r3 * r4);
+    r9 = fma(r13, r15, r9);
+    r9 = fma(r2, r6, r9);
+    r9 = fma(r23, r25, r9);
+    r9 = fma(r10, r27, r9);
+    r9 = fma(r18, r19, r9);
+    r9 = fma(r17, r21, r9);
+    r17 = fma(r0, r9, r1 * r8);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r18, r10);
+    r23 = fma(r18, r9, r10 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r17, r23);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r23, r17);
+    r2 = fma(r23, r9, r17 * r8);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r13, r3);
+    r24 = fma(r13, r9, r3 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r2, r24);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r24, r2);
+    r14 = fma(r24, r9, r2 * r8);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r29, r30);
+    r9 = fma(r29, r9, r30 * r8);
+    WriteSum2<double, double>((double*)inout_shared, r14, r9);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r9,
+                        r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r24 = fma(r9, r24, r14 * r29);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r29,
+                        r8);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r31,
+                        r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r24 = fma(r29, r23, r24);
+    r24 = fma(r8, r13, r24);
+    r24 = fma(r31, r0, r24);
+    r24 = fma(r32, r18, r24);
+    r15 = r15 * r24;
+    r3 = fma(r8, r3, r14 * r30);
+    r3 = fma(r29, r17, r3);
+    r3 = fma(r31, r1, r3);
+    r3 = fma(r32, r10, r3);
+    r3 = fma(r9, r2, r3);
+    r16 = r16 * r3;
+    WriteSum2<double, double>((double*)inout_shared, r15, r16);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = fma(r7, r3, r6 * r24);
+    r5 = fma(r5, r3, r4 * r24);
+    WriteSum2<double, double>((double*)inout_shared, r7, r5);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r12 = fma(r12, r3, r11 * r24);
+    r28 = fma(r28, r3, r27 * r24);
+    WriteSum2<double, double>((double*)inout_shared, r12, r28);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = fma(r22, r3, r21 * r24);
+    r20 = fma(r20, r3, r19 * r24);
+    WriteSum2<double, double>((double*)inout_shared, r22, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r24 = r25 * r24;
+    r3 = r26 * r3;
+    WriteSum2<double, double>((double*)inout_shared, r24, r3);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirectKernel<<<
+      n_blocks,
+      1024>>>(pose_njtr,
+              pose_njtr_num_alloc,
+              pose_njtr_indices,
+              pose_jac,
+              pose_jac_num_alloc,
+              focal_and_extra_njtr,
+              focal_and_extra_njtr_num_alloc,
+              focal_and_extra_njtr_indices,
+              focal_and_extra_jac,
+              focal_and_extra_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.cu
@@ -1,0 +1,2411 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r34 * r24;
+    r45 = r45 * r24;
+    r43 = r35 + r45;
+    r43 = r43 + r44;
+    r43 = fma(r8, r43, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r47 = r17 * r13;
+    r47 = r47 * r10;
+    r48 = r18 * r14;
+    r48 = fma(r10, r48, r47);
+    r49 = r13 * r14;
+    r49 = fma(r34, r49, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r43 = fma(r9, r6, r43);
+    r43 = fma(r41, r44, r43);
+    r43 = fma(r38, r48, r43);
+    r43 = fma(r30, r49, r43);
+    r43 = fma(r7, r36, r43);
+    r44 = r43 * r43;
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r50);
+    r51 = r34 * r24;
+    r51 = fma(r29, r51, r20);
+    r51 = fma(r8, r51, r50);
+    r50 = r18 * r14;
+    r50 = fma(r34, r50, r47);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r45 = r35 + r45;
+    r45 = r45 + r46;
+    r51 = fma(r7, r50, r51);
+    r51 = fma(r38, r31, r51);
+    r51 = fma(r30, r33, r51);
+    r51 = fma(r9, r39, r51);
+    r51 = fma(r41, r45, r51);
+    r45 = copysign(1.0, r51);
+    r45 = fma(r6, r45, r51);
+    r51 = r45 * r45;
+    r39 = 1.0 / r51;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = atan(r44);
+    r7 = r28 * r38;
+    r46 = copysign(1.0, r44);
+    r46 = fma(r6, r46, r44);
+    r6 = r46 * r46;
+    r44 = 1.0 / r6;
+    r42 = r39 * r44;
+    r47 = r28 * r38;
+    r7 = r7 * r42;
+    r7 = r7 * r47;
+    r20 = 3.00000000000000000e+00;
+    r52 = r38 * r20;
+    r53 = r43 * r38;
+    r54 = r53 * r42;
+    r55 = r43 * r54;
+    r52 = fma(r55, r52, r7);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r56,
+                        r57);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r58 = r38 * r55;
+    r7 = r7 + r58;
+    r59 = fma(r56, r7, r5 * r52);
+    r60 = r4 * r10;
+    r60 = r60 * r47;
+    r59 = fma(r54, r60, r59);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r61,
+                        r62);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r63 = r7 * r7;
+    r64 = fma(r62, r63, r61 * r7);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r65,
+                        r66);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r67 = r63 * r63;
+    r68 = r7 * r63;
+    r64 = fma(r66, r67, r64);
+    r64 = fma(r65, r68, r64);
+    r69 = 1.0 / r45;
+    r70 = 1.0 / r46;
+    r71 = r69 * r70;
+    r72 = r64 * r71;
+    r59 = fma(r53, r72, r59);
+    r59 = fma(r53, r71, r59);
+    r0 = fma(r2, r59, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r60, r73);
+    r0 = fma(r60, r21, r0);
+    r60 = r28 * r38;
+    r60 = r60 * r20;
+    r60 = r60 * r42;
+    r60 = fma(r47, r60, r58);
+    r58 = fma(r57, r7, r4 * r60);
+    r74 = r5 * r10;
+    r74 = r74 * r47;
+    r58 = fma(r54, r74, r58);
+    r58 = fma(r47, r72, r58);
+    r58 = fma(r71, r47, r58);
+    r1 = fma(r3, r58, r1);
+    r1 = fma(r73, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r73 = r10 * r24;
+    r74 = -5.00000000000000000e-01;
+    r75 = 5.00000000000000000e-01;
+    r76 = fma(r75, r26, r74 * r22);
+    r76 = fma(r74, r23, r76);
+    r76 = fma(r74, r25, r76);
+    r73 = r73 * r76;
+    r77 = r10 * r27;
+    r78 = r15 * r14;
+    r79 = r12 * r17;
+    r79 = fma(r75, r79, r75 * r78);
+    r78 = r11 * r18;
+    r79 = fma(r74, r78, r79);
+    r80 = r16 * r13;
+    r79 = fma(r75, r80, r79);
+    r77 = fma(r79, r77, r73);
+    r80 = r10 * r19;
+    r78 = r11 * r14;
+    r81 = r16 * r17;
+    r81 = fma(r74, r81, r74 * r78);
+    r78 = r15 * r18;
+    r81 = fma(r74, r78, r81);
+    r82 = r12 * r13;
+    r81 = fma(r75, r82, r81);
+    r80 = r80 * r81;
+    r82 = r10 * r29;
+    r78 = r16 * r14;
+    r83 = r11 * r17;
+    r83 = fma(r74, r83, r75 * r78);
+    r78 = r12 * r18;
+    r83 = fma(r74, r78, r83);
+    r84 = r15 * r13;
+    r83 = fma(r74, r84, r83);
+    r82 = r82 * r83;
+    r84 = r80 + r82;
+    r78 = r77 + r84;
+    r85 = r24 * r81;
+    r86 = r29 * r79;
+    r87 = fma(r34, r86, r34 * r85);
+    r88 = r10 * r19;
+    r89 = r10 * r27;
+    r89 = r89 * r83;
+    r88 = fma(r76, r88, r89);
+    r87 = r87 + r88;
+    r87 = fma(r8, r87, r9 * r78);
+    r78 = r24 * r79;
+    r90 = -4.00000000000000000e+00;
+    r78 = r78 * r90;
+    r91 = r19 * r83;
+    r91 = r91 * r90;
+    r92 = r78 + r91;
+    r87 = fma(r41, r92, r87);
+    r92 = r28 * r28;
+    r51 = r45 * r51;
+    r93 = 1.0 / r51;
+    r94 = r34 * r93;
+    r92 = r92 * r94;
+    r95 = r38 * r92;
+    r96 = r38 * r44;
+    r96 = r96 * r94;
+    r96 = r95 * r96;
+    r97 = r10 * r43;
+    r86 = fma(r10, r86, r10 * r85);
+    r86 = r86 + r88;
+    r98 = r10 * r24;
+    r98 = r98 * r83;
+    r99 = r10 * r19;
+    r99 = r99 * r79;
+    r79 = r98 + r99;
+    r100 = r27 * r34;
+    r79 = fma(r81, r100, r79);
+    r101 = r34 * r29;
+    r79 = fma(r76, r101, r79);
+    r79 = fma(r9, r79, r41 * r86);
+    r86 = r27 * r76;
+    r101 = r90 * r86;
+    r78 = r78 + r101;
+    r79 = fma(r8, r78, r79);
+    r97 = r97 * r79;
+    r78 = r43 * r43;
+    r78 = r78 * r87;
+    r78 = fma(r94, r78, r39 * r97);
+    r97 = r10 * r28;
+    r100 = r19 * r34;
+    r102 = r34 * r29;
+    r102 = r102 * r83;
+    r100 = fma(r81, r100, r102);
+    r100 = r100 + r77;
+    r101 = r91 + r101;
+    r101 = fma(r9, r101, r41 * r100);
+    r100 = r10 * r29;
+    r100 = fma(r76, r100, r99);
+    r99 = r10 * r27;
+    r99 = fma(r81, r99, r98);
+    r100 = r100 + r99;
+    r101 = fma(r8, r100, r101);
+    r97 = r97 * r101;
+    r78 = fma(r39, r97, r78);
+    r78 = fma(r87, r92, r78);
+    r97 = r42 * r47;
+    r100 = r78 * r97;
+    r98 = rsqrt(r30);
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r35 = r98 * r30;
+    r91 = r28 * r35;
+    r100 = fma(r91, r100, r87 * r96);
+    r77 = r21 * r28;
+    r6 = r46 * r6;
+    r103 = 1.0 / r6;
+    r77 = r77 * r28;
+    r77 = r77 * r38;
+    r77 = r77 * r38;
+    r77 = r77 * r78;
+    r77 = r77 * r39;
+    r77 = r77 * r98;
+    r100 = fma(r103, r77, r100);
+    r104 = r10 * r38;
+    r105 = r104 * r97;
+    r100 = fma(r101, r105, r100);
+    r77 = r35 * r55;
+    r106 = r21 * r43;
+    r106 = r106 * r38;
+    r106 = r106 * r78;
+    r106 = r106 * r39;
+    r106 = r106 * r98;
+    r106 = r106 * r103;
+    r106 = fma(r53, r106, r78 * r77);
+    r107 = r79 * r54;
+    r106 = fma(r104, r107, r106);
+    r108 = r43 * r38;
+    r108 = r108 * r87;
+    r108 = r108 * r44;
+    r108 = r108 * r53;
+    r106 = fma(r94, r108, r106);
+    r108 = r100 + r106;
+    r107 = r20 * r78;
+    r109 = r43 * r53;
+    r110 = -3.00000000000000000e+00;
+    r110 = r38 * r110;
+    r110 = r110 * r39;
+    r110 = r110 * r98;
+    r110 = r110 * r103;
+    r109 = r109 * r110;
+    r107 = fma(r78, r109, r77 * r107);
+    r111 = r38 * r79;
+    r112 = 6.00000000000000000e+00;
+    r111 = r111 * r112;
+    r107 = fma(r54, r111, r107);
+    r113 = r43 * r53;
+    r114 = r38 * r87;
+    r115 = -6.00000000000000000e+00;
+    r114 = r114 * r115;
+    r114 = r114 * r44;
+    r114 = r114 * r93;
+    r107 = fma(r114, r113, r107);
+    r107 = r107 + r100;
+    r107 = fma(r5, r107, r56 * r108);
+    r100 = r4 * r105;
+    r113 = r74 * r78;
+    r113 = r113 * r44;
+    r113 = r113 * r69;
+    r113 = r113 * r98;
+    r111 = r64 * r113;
+    r116 = r21 * r64;
+    r116 = r116 * r87;
+    r116 = r116 * r39;
+    r116 = r116 * r70;
+    r107 = fma(r53, r116, r107);
+    r117 = r43 * r78;
+    r118 = r75 * r72;
+    r117 = r117 * r35;
+    r107 = fma(r118, r117, r107);
+    r119 = r4 * r34;
+    r119 = r119 * r78;
+    r119 = r119 * r39;
+    r119 = r119 * r98;
+    r119 = r119 * r103;
+    r119 = r119 * r53;
+    r107 = fma(r47, r119, r107);
+    r120 = r38 * r79;
+    r107 = fma(r72, r120, r107);
+    r121 = r4 * r101;
+    r121 = r121 * r54;
+    r107 = fma(r104, r121, r107);
+    r122 = r4 * r87;
+    r123 = r90 * r44;
+    r123 = r123 * r93;
+    r123 = r123 * r53;
+    r123 = r123 * r47;
+    r107 = fma(r123, r122, r107);
+    r124 = r43 * r75;
+    r124 = r124 * r78;
+    r124 = r124 * r71;
+    r107 = fma(r35, r124, r107);
+    r125 = r4 * r78;
+    r126 = r10 * r54;
+    r126 = r126 * r91;
+    r107 = fma(r126, r125, r107);
+    r127 = r62 * r10;
+    r127 = r127 * r7;
+    r127 = fma(r61, r108, r108 * r127);
+    r65 = r65 * r20;
+    r65 = r65 * r63;
+    r128 = 4.00000000000000000e+00;
+    r66 = r66 * r128;
+    r66 = r66 * r68;
+    r127 = fma(r108, r65, r127);
+    r127 = fma(r108, r66, r127);
+    r129 = r127 * r53;
+    r107 = fma(r71, r129, r107);
+    r130 = r21 * r87;
+    r130 = r130 * r39;
+    r130 = r130 * r70;
+    r107 = fma(r53, r130, r107);
+    r131 = r38 * r79;
+    r107 = fma(r71, r131, r107);
+    r107 = fma(r79, r100, r107);
+    r107 = fma(r53, r113, r107);
+    r107 = fma(r53, r111, r107);
+    r131 = r2 * r107;
+    r130 = r28 * r28;
+    r130 = r130 * r38;
+    r129 = r20 * r78;
+    r129 = r129 * r97;
+    r129 = fma(r91, r129, r114 * r130);
+    r130 = r78 * r110;
+    r129 = fma(r95, r130, r129);
+    r114 = r38 * r101;
+    r114 = r114 * r112;
+    r114 = r114 * r42;
+    r129 = fma(r47, r114, r129);
+    r129 = r129 + r106;
+    r129 = fma(r4, r129, r57 * r108);
+    r108 = r5 * r79;
+    r129 = fma(r105, r108, r129);
+    r106 = r21 * r28;
+    r106 = r106 * r38;
+    r106 = r106 * r87;
+    r106 = r106 * r39;
+    r129 = fma(r70, r106, r129);
+    r114 = r5 * r34;
+    r114 = r114 * r78;
+    r114 = r114 * r39;
+    r114 = r114 * r98;
+    r114 = r114 * r103;
+    r114 = r114 * r53;
+    r129 = fma(r47, r114, r129);
+    r130 = r75 * r78;
+    r130 = r130 * r71;
+    r129 = fma(r91, r130, r129);
+    r125 = r5 * r101;
+    r125 = r125 * r54;
+    r129 = fma(r104, r125, r129);
+    r124 = r5 * r123;
+    r122 = r127 * r71;
+    r129 = fma(r47, r122, r129);
+    r121 = r5 * r78;
+    r129 = fma(r126, r121, r129);
+    r120 = r91 * r118;
+    r119 = r38 * r101;
+    r129 = fma(r72, r119, r129);
+    r117 = r38 * r101;
+    r129 = fma(r71, r117, r129);
+    r116 = r21 * r28;
+    r116 = r116 * r38;
+    r116 = r116 * r64;
+    r116 = r116 * r87;
+    r116 = r116 * r39;
+    r129 = fma(r70, r116, r129);
+    r129 = fma(r47, r111, r129);
+    r129 = fma(r113, r47, r129);
+    r129 = fma(r87, r124, r129);
+    r129 = fma(r78, r120, r129);
+    r116 = r3 * r129;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r116);
+    r116 = r43 * r38;
+    r131 = r34 * r24;
+    r131 = fma(r76, r131, r102);
+    r117 = r10 * r27;
+    r119 = r15 * r14;
+    r121 = r12 * r17;
+    r121 = fma(r74, r121, r74 * r119);
+    r119 = r11 * r18;
+    r121 = fma(r75, r119, r121);
+    r122 = r16 * r13;
+    r121 = fma(r74, r122, r121);
+    r117 = r117 * r121;
+    r122 = r10 * r19;
+    r119 = r11 * r14;
+    r125 = r16 * r17;
+    r125 = fma(r75, r125, r75 * r119);
+    r119 = r15 * r18;
+    r125 = fma(r75, r119, r125);
+    r130 = r12 * r13;
+    r125 = fma(r74, r130, r125);
+    r122 = fma(r125, r122, r117);
+    r131 = r131 + r122;
+    r130 = r10 * r24;
+    r130 = r130 * r125;
+    r119 = r10 * r29;
+    r119 = fma(r121, r119, r130);
+    r119 = r119 + r88;
+    r119 = fma(r9, r119, r8 * r131);
+    r131 = r24 * r83;
+    r131 = r131 * r90;
+    r88 = r19 * r121;
+    r114 = r90 * r88;
+    r113 = r131 + r114;
+    r119 = fma(r41, r113, r119);
+    r116 = r116 * r115;
+    r116 = r116 * r119;
+    r116 = r116 * r44;
+    r116 = r116 * r93;
+    r113 = r38 * r112;
+    r82 = r73 + r82;
+    r82 = r82 + r122;
+    r122 = r27 * r90;
+    r122 = r122 * r125;
+    r131 = r131 + r122;
+    r131 = fma(r8, r131, r41 * r82);
+    r82 = r34 * r29;
+    r82 = fma(r34, r86, r125 * r82);
+    r73 = r10 * r19;
+    r73 = r73 * r83;
+    r111 = r10 * r24;
+    r111 = fma(r121, r111, r73);
+    r82 = r82 + r111;
+    r131 = fma(r9, r82, r131);
+    r113 = r113 * r131;
+    r113 = fma(r54, r113, r53 * r116);
+    r116 = r10 * r43;
+    r116 = r116 * r131;
+    r82 = r10 * r28;
+    r130 = r89 + r130;
+    r89 = r19 * r34;
+    r130 = fma(r76, r89, r130);
+    r76 = r34 * r29;
+    r130 = fma(r121, r76, r130);
+    r76 = r10 * r29;
+    r86 = fma(r10, r86, r125 * r76);
+    r86 = r86 + r111;
+    r86 = fma(r8, r86, r41 * r130);
+    r114 = r122 + r114;
+    r86 = fma(r9, r114, r86);
+    r82 = r82 * r86;
+    r82 = fma(r39, r82, r39 * r116);
+    r116 = r43 * r43;
+    r116 = r116 * r119;
+    r82 = fma(r94, r116, r82);
+    r82 = fma(r119, r92, r82);
+    r116 = r20 * r82;
+    r113 = fma(r77, r116, r113);
+    r114 = r21 * r28;
+    r114 = r114 * r28;
+    r114 = r114 * r38;
+    r114 = r114 * r38;
+    r114 = r114 * r82;
+    r114 = r114 * r39;
+    r114 = r114 * r98;
+    r114 = fma(r103, r114, r86 * r105);
+    r122 = r82 * r97;
+    r114 = fma(r91, r122, r114);
+    r114 = fma(r119, r96, r114);
+    r113 = fma(r82, r109, r113);
+    r113 = r113 + r114;
+    r116 = r43 * r38;
+    r116 = r116 * r119;
+    r116 = r116 * r44;
+    r116 = r116 * r53;
+    r122 = r131 * r54;
+    r122 = fma(r104, r122, r94 * r116);
+    r116 = r21 * r43;
+    r116 = r116 * r38;
+    r116 = r116 * r82;
+    r116 = r116 * r39;
+    r116 = r116 * r98;
+    r116 = r116 * r103;
+    r122 = fma(r53, r116, r122);
+    r122 = fma(r82, r77, r122);
+    r114 = r114 + r122;
+    r113 = fma(r56, r114, r5 * r113);
+    r116 = r21 * r119;
+    r116 = r116 * r39;
+    r116 = r116 * r70;
+    r113 = fma(r53, r116, r113);
+    r130 = r43 * r82;
+    r130 = r130 * r35;
+    r113 = fma(r118, r130, r113);
+    r76 = r43 * r75;
+    r76 = r76 * r82;
+    r76 = r76 * r71;
+    r113 = fma(r35, r76, r113);
+    r125 = r64 * r74;
+    r125 = r125 * r82;
+    r125 = r125 * r44;
+    r125 = r125 * r69;
+    r125 = r125 * r98;
+    r113 = fma(r53, r125, r113);
+    r89 = r62 * r10;
+    r89 = r89 * r7;
+    r89 = fma(r114, r89, r61 * r114);
+    r89 = fma(r114, r66, r89);
+    r89 = fma(r114, r65, r89);
+    r106 = r89 * r53;
+    r113 = fma(r71, r106, r113);
+    r108 = r21 * r64;
+    r108 = r108 * r119;
+    r108 = r108 * r39;
+    r108 = r108 * r70;
+    r113 = fma(r53, r108, r113);
+    r132 = r4 * r119;
+    r113 = fma(r123, r132, r113);
+    r133 = r4 * r82;
+    r113 = fma(r126, r133, r113);
+    r134 = r38 * r131;
+    r113 = fma(r71, r134, r113);
+    r135 = r4 * r34;
+    r135 = r135 * r82;
+    r135 = r135 * r39;
+    r135 = r135 * r98;
+    r135 = r135 * r103;
+    r135 = r135 * r53;
+    r113 = fma(r47, r135, r113);
+    r136 = r38 * r131;
+    r113 = fma(r72, r136, r113);
+    r137 = r4 * r86;
+    r137 = r137 * r54;
+    r113 = fma(r104, r137, r113);
+    r138 = r74 * r82;
+    r138 = r138 * r44;
+    r138 = r138 * r69;
+    r138 = r138 * r98;
+    r113 = fma(r53, r138, r113);
+    r113 = fma(r131, r100, r113);
+    r138 = r2 * r113;
+    r137 = r38 * r112;
+    r137 = r137 * r86;
+    r137 = r137 * r42;
+    r136 = r82 * r110;
+    r136 = fma(r95, r136, r47 * r137);
+    r137 = r28 * r28;
+    r137 = r137 * r38;
+    r137 = r137 * r38;
+    r137 = r137 * r115;
+    r137 = r137 * r119;
+    r137 = r137 * r44;
+    r136 = fma(r93, r137, r136);
+    r135 = r20 * r82;
+    r135 = r135 * r97;
+    r136 = fma(r91, r135, r136);
+    r136 = r136 + r122;
+    r114 = fma(r57, r114, r4 * r136);
+    r136 = r28 * r38;
+    r136 = r136 * r74;
+    r136 = r136 * r82;
+    r136 = r136 * r44;
+    r136 = r136 * r69;
+    r114 = fma(r98, r136, r114);
+    r122 = r38 * r86;
+    r114 = fma(r72, r122, r114);
+    r135 = r89 * r71;
+    r114 = fma(r47, r135, r114);
+    r137 = r75 * r82;
+    r137 = r137 * r71;
+    r114 = fma(r91, r137, r114);
+    r134 = r5 * r82;
+    r114 = fma(r126, r134, r114);
+    r133 = r21 * r28;
+    r133 = r133 * r38;
+    r133 = r133 * r64;
+    r133 = r133 * r119;
+    r133 = r133 * r39;
+    r114 = fma(r70, r133, r114);
+    r132 = r28 * r38;
+    r132 = r132 * r64;
+    r132 = r132 * r74;
+    r132 = r132 * r82;
+    r132 = r132 * r44;
+    r132 = r132 * r69;
+    r114 = fma(r98, r132, r114);
+    r108 = r5 * r34;
+    r108 = r108 * r82;
+    r108 = r108 * r39;
+    r108 = r108 * r98;
+    r108 = r108 * r103;
+    r108 = r108 * r53;
+    r114 = fma(r47, r108, r114);
+    r106 = r21 * r28;
+    r106 = r106 * r38;
+    r106 = r106 * r119;
+    r106 = r106 * r39;
+    r114 = fma(r70, r106, r114);
+    r125 = r38 * r86;
+    r114 = fma(r71, r125, r114);
+    r76 = r5 * r86;
+    r76 = r76 * r54;
+    r114 = fma(r104, r76, r114);
+    r130 = r5 * r131;
+    r114 = fma(r105, r130, r114);
+    r114 = fma(r119, r124, r114);
+    r114 = fma(r82, r120, r114);
+    r130 = r3 * r114;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r130);
+    r130 = r19 * r90;
+    r26 = fma(r74, r26, r75 * r22);
+    r26 = fma(r75, r23, r26);
+    r26 = fma(r75, r25, r26);
+    r130 = r130 * r26;
+    r85 = r90 * r85;
+    r25 = r130 + r85;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r73 = r73 + r23;
+    r22 = r34 * r24;
+    r73 = fma(r121, r22, r73);
+    r138 = r34 * r29;
+    r73 = fma(r81, r138, r73);
+    r73 = fma(r8, r73, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r88, r26 * r25);
+    r25 = r25 + r99;
+    r73 = fma(r9, r25, r73);
+    r25 = r10 * r28;
+    r138 = r10 * r24;
+    r138 = r138 * r26;
+    r117 = r117 + r138;
+    r117 = r117 + r84;
+    r84 = r34 * r29;
+    r88 = fma(r34, r88, r26 * r84);
+    r88 = r88 + r99;
+    r88 = fma(r41, r88, r8 * r117);
+    r83 = r27 * r83;
+    r83 = r83 * r90;
+    r130 = r130 + r83;
+    r88 = fma(r9, r130, r88);
+    r25 = r25 * r88;
+    r130 = r43 * r43;
+    r130 = r130 * r73;
+    r130 = fma(r94, r130, r39 * r25);
+    r25 = r10 * r43;
+    r102 = r80 + r102;
+    r80 = r27 * r34;
+    r102 = fma(r121, r80, r102);
+    r102 = r102 + r138;
+    r85 = r83 + r85;
+    r85 = fma(r8, r85, r9 * r102);
+    r8 = r10 * r29;
+    r8 = fma(r81, r8, r23);
+    r8 = r8 + r111;
+    r85 = fma(r41, r8, r85);
+    r25 = r25 * r85;
+    r130 = fma(r39, r25, r130);
+    r130 = fma(r73, r92, r130);
+    r25 = r130 * r97;
+    r25 = fma(r91, r25, r73 * r96);
+    r8 = r21 * r28;
+    r8 = r8 * r28;
+    r8 = r8 * r38;
+    r8 = r8 * r38;
+    r8 = r8 * r130;
+    r8 = r8 * r39;
+    r8 = r8 * r98;
+    r25 = fma(r103, r8, r25);
+    r25 = fma(r88, r105, r25);
+    r8 = r21 * r43;
+    r8 = r8 * r38;
+    r8 = r8 * r130;
+    r8 = r8 * r39;
+    r8 = r8 * r98;
+    r8 = r8 * r103;
+    r41 = r85 * r54;
+    r41 = fma(r104, r41, r53 * r8);
+    r8 = r43 * r38;
+    r8 = r8 * r73;
+    r8 = r8 * r44;
+    r8 = r8 * r53;
+    r41 = fma(r94, r8, r41);
+    r41 = fma(r130, r77, r41);
+    r8 = r25 + r41;
+    r111 = r38 * r112;
+    r111 = r111 * r85;
+    r111 = fma(r54, r111, r130 * r109);
+    r23 = r43 * r38;
+    r23 = r23 * r115;
+    r23 = r23 * r73;
+    r23 = r23 * r44;
+    r23 = r23 * r93;
+    r111 = fma(r53, r23, r111);
+    r81 = r20 * r130;
+    r111 = fma(r77, r81, r111);
+    r111 = r111 + r25;
+    r111 = fma(r5, r111, r56 * r8);
+    r25 = r62 * r10;
+    r25 = r25 * r7;
+    r25 = fma(r8, r25, r61 * r8);
+    r25 = fma(r8, r65, r25);
+    r25 = fma(r8, r66, r25);
+    r81 = r25 * r53;
+    r111 = fma(r71, r81, r111);
+    r23 = r43 * r75;
+    r23 = r23 * r130;
+    r23 = r23 * r71;
+    r111 = fma(r35, r23, r111);
+    r102 = r4 * r130;
+    r111 = fma(r126, r102, r111);
+    r9 = r21 * r64;
+    r9 = r9 * r73;
+    r9 = r9 * r39;
+    r9 = r9 * r70;
+    r111 = fma(r53, r9, r111);
+    r83 = r43 * r130;
+    r83 = r83 * r35;
+    r111 = fma(r118, r83, r111);
+    r80 = r4 * r34;
+    r80 = r80 * r130;
+    r80 = r80 * r39;
+    r80 = r80 * r98;
+    r80 = r80 * r103;
+    r80 = r80 * r53;
+    r111 = fma(r47, r80, r111);
+    r138 = r38 * r85;
+    r111 = fma(r72, r138, r111);
+    r121 = r21 * r73;
+    r121 = r121 * r39;
+    r121 = r121 * r70;
+    r111 = fma(r53, r121, r111);
+    r90 = r38 * r85;
+    r111 = fma(r71, r90, r111);
+    r117 = r74 * r130;
+    r117 = r117 * r44;
+    r117 = r117 * r69;
+    r117 = r117 * r98;
+    r111 = fma(r53, r117, r111);
+    r99 = r4 * r73;
+    r111 = fma(r123, r99, r111);
+    r84 = r4 * r88;
+    r84 = r84 * r54;
+    r111 = fma(r104, r84, r111);
+    r26 = r64 * r74;
+    r26 = r26 * r130;
+    r26 = r26 * r44;
+    r26 = r26 * r69;
+    r26 = r26 * r98;
+    r111 = fma(r53, r26, r111);
+    r111 = fma(r85, r100, r111);
+    r26 = r2 * r111;
+    r84 = r28 * r28;
+    r84 = r84 * r38;
+    r84 = r84 * r38;
+    r84 = r84 * r115;
+    r84 = r84 * r73;
+    r84 = r84 * r44;
+    r99 = r20 * r130;
+    r99 = r99 * r97;
+    r99 = fma(r91, r99, r93 * r84);
+    r84 = r38 * r112;
+    r84 = r84 * r88;
+    r84 = r84 * r42;
+    r99 = fma(r47, r84, r99);
+    r117 = r130 * r110;
+    r99 = fma(r95, r117, r99);
+    r99 = r99 + r41;
+    r99 = fma(r4, r99, r57 * r8);
+    r8 = r21 * r28;
+    r8 = r8 * r38;
+    r8 = r8 * r64;
+    r8 = r8 * r73;
+    r8 = r8 * r39;
+    r99 = fma(r70, r8, r99);
+    r41 = r21 * r28;
+    r41 = r41 * r38;
+    r41 = r41 * r73;
+    r41 = r41 * r39;
+    r99 = fma(r70, r41, r99);
+    r117 = r38 * r88;
+    r99 = fma(r72, r117, r99);
+    r84 = r5 * r85;
+    r99 = fma(r105, r84, r99);
+    r90 = r28 * r38;
+    r90 = r90 * r64;
+    r90 = r90 * r74;
+    r90 = r90 * r130;
+    r90 = r90 * r44;
+    r90 = r90 * r69;
+    r99 = fma(r98, r90, r99);
+    r121 = r5 * r130;
+    r99 = fma(r126, r121, r99);
+    r138 = r75 * r130;
+    r138 = r138 * r71;
+    r99 = fma(r91, r138, r99);
+    r80 = r38 * r88;
+    r99 = fma(r71, r80, r99);
+    r83 = r5 * r34;
+    r83 = r83 * r130;
+    r83 = r83 * r39;
+    r83 = r83 * r98;
+    r83 = r83 * r103;
+    r83 = r83 * r53;
+    r99 = fma(r47, r83, r99);
+    r9 = r25 * r71;
+    r99 = fma(r47, r9, r99);
+    r102 = r28 * r38;
+    r102 = r102 * r74;
+    r102 = r102 * r130;
+    r102 = r102 * r44;
+    r102 = r102 * r69;
+    r99 = fma(r98, r102, r99);
+    r23 = r5 * r88;
+    r23 = r23 * r54;
+    r99 = fma(r104, r23, r99);
+    r99 = fma(r130, r120, r99);
+    r99 = fma(r73, r124, r99);
+    r23 = r3 * r99;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r26, r23);
+    r23 = r36 * r38;
+    r23 = r23 * r112;
+    r26 = r10 * r32;
+    r26 = r26 * r28;
+    r26 = fma(r50, r92, r39 * r26);
+    r102 = r50 * r43;
+    r102 = r102 * r43;
+    r26 = fma(r94, r102, r26);
+    r9 = r10 * r36;
+    r9 = r9 * r43;
+    r26 = fma(r39, r9, r26);
+    r23 = fma(r26, r109, r54 * r23);
+    r9 = r20 * r26;
+    r23 = fma(r77, r9, r23);
+    r102 = r50 * r43;
+    r102 = r102 * r38;
+    r102 = r102 * r115;
+    r102 = r102 * r44;
+    r102 = r102 * r93;
+    r23 = fma(r53, r102, r23);
+    r83 = r21 * r28;
+    r83 = r83 * r28;
+    r83 = r83 * r38;
+    r83 = r83 * r38;
+    r83 = r83 * r26;
+    r83 = r83 * r39;
+    r83 = r83 * r98;
+    r83 = fma(r103, r83, r32 * r105);
+    r80 = r26 * r97;
+    r83 = fma(r91, r80, r83);
+    r83 = fma(r50, r96, r83);
+    r23 = r23 + r83;
+    r102 = r36 * r54;
+    r9 = r21 * r43;
+    r9 = r9 * r38;
+    r9 = r9 * r26;
+    r9 = r9 * r39;
+    r9 = r9 * r98;
+    r9 = r9 * r103;
+    r9 = fma(r53, r9, r104 * r102);
+    r102 = r50 * r43;
+    r102 = r102 * r38;
+    r102 = r102 * r44;
+    r102 = r102 * r53;
+    r9 = fma(r94, r102, r9);
+    r9 = fma(r26, r77, r9);
+    r83 = r83 + r9;
+    r23 = fma(r56, r83, r5 * r23);
+    r102 = r36 * r38;
+    r23 = fma(r72, r102, r23);
+    r80 = r43 * r26;
+    r80 = r80 * r35;
+    r23 = fma(r118, r80, r23);
+    r138 = r26 * r126;
+    r121 = r43 * r75;
+    r121 = r121 * r26;
+    r121 = r121 * r71;
+    r23 = fma(r35, r121, r23);
+    r90 = r64 * r74;
+    r90 = r90 * r26;
+    r90 = r90 * r44;
+    r90 = r90 * r69;
+    r90 = r90 * r98;
+    r23 = fma(r53, r90, r23);
+    r84 = r74 * r26;
+    r84 = r84 * r44;
+    r84 = r84 * r69;
+    r84 = r84 * r98;
+    r23 = fma(r53, r84, r23);
+    r117 = r4 * r34;
+    r117 = r117 * r26;
+    r117 = r117 * r39;
+    r117 = r117 * r98;
+    r117 = r117 * r103;
+    r117 = r117 * r53;
+    r23 = fma(r47, r117, r23);
+    r41 = r4 * r50;
+    r23 = fma(r123, r41, r23);
+    r8 = r62 * r10;
+    r8 = r8 * r7;
+    r8 = fma(r61, r83, r83 * r8);
+    r8 = fma(r83, r66, r8);
+    r8 = fma(r83, r65, r8);
+    r81 = r8 * r53;
+    r23 = fma(r71, r81, r23);
+    r22 = r21 * r50;
+    r22 = r22 * r64;
+    r22 = r22 * r39;
+    r22 = r22 * r70;
+    r23 = fma(r53, r22, r23);
+    r76 = r21 * r50;
+    r76 = r76 * r39;
+    r76 = r76 * r70;
+    r23 = fma(r53, r76, r23);
+    r125 = r4 * r32;
+    r125 = r125 * r54;
+    r23 = fma(r104, r125, r23);
+    r106 = r36 * r38;
+    r23 = fma(r71, r106, r23);
+    r23 = fma(r4, r138, r23);
+    r23 = fma(r36, r100, r23);
+    r106 = r2 * r23;
+    r125 = r32 * r38;
+    r125 = r125 * r112;
+    r125 = r125 * r42;
+    r76 = r26 * r110;
+    r76 = fma(r95, r76, r47 * r125);
+    r125 = r50 * r28;
+    r125 = r125 * r28;
+    r125 = r125 * r38;
+    r125 = r125 * r38;
+    r125 = r125 * r115;
+    r125 = r125 * r44;
+    r76 = fma(r93, r125, r76);
+    r22 = r20 * r26;
+    r22 = r22 * r97;
+    r76 = fma(r91, r22, r76);
+    r76 = r76 + r9;
+    r83 = fma(r57, r83, r4 * r76);
+    r76 = r75 * r26;
+    r76 = r76 * r71;
+    r83 = fma(r91, r76, r83);
+    r9 = r32 * r38;
+    r83 = fma(r71, r9, r83);
+    r22 = r28 * r38;
+    r22 = r22 * r64;
+    r22 = r22 * r74;
+    r22 = r22 * r26;
+    r22 = r22 * r44;
+    r22 = r22 * r69;
+    r83 = fma(r98, r22, r83);
+    r125 = r21 * r50;
+    r125 = r125 * r28;
+    r125 = r125 * r38;
+    r125 = r125 * r64;
+    r125 = r125 * r39;
+    r83 = fma(r70, r125, r83);
+    r81 = r21 * r50;
+    r81 = r81 * r28;
+    r81 = r81 * r38;
+    r81 = r81 * r39;
+    r83 = fma(r70, r81, r83);
+    r41 = r5 * r34;
+    r41 = r41 * r26;
+    r41 = r41 * r39;
+    r41 = r41 * r98;
+    r41 = r41 * r103;
+    r41 = r41 * r53;
+    r83 = fma(r47, r41, r83);
+    r117 = r8 * r71;
+    r83 = fma(r47, r117, r83);
+    r84 = r32 * r38;
+    r83 = fma(r72, r84, r83);
+    r90 = r5 * r32;
+    r90 = r90 * r54;
+    r83 = fma(r104, r90, r83);
+    r121 = r28 * r38;
+    r121 = r121 * r74;
+    r121 = r121 * r26;
+    r121 = r121 * r44;
+    r121 = r121 * r69;
+    r83 = fma(r98, r121, r83);
+    r80 = r5 * r36;
+    r83 = fma(r105, r80, r83);
+    r83 = fma(r5, r138, r83);
+    r83 = fma(r50, r124, r83);
+    r83 = fma(r26, r120, r83);
+    r80 = r3 * r83;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r106, r80);
+    r80 = r10 * r37;
+    r80 = r80 * r28;
+    r80 = fma(r39, r80, r33 * r92);
+    r106 = r33 * r43;
+    r106 = r106 * r43;
+    r80 = fma(r94, r106, r80);
+    r121 = r10 * r49;
+    r121 = r121 * r43;
+    r80 = fma(r39, r121, r80);
+    r121 = r20 * r80;
+    r106 = r33 * r43;
+    r106 = r106 * r38;
+    r106 = r106 * r115;
+    r106 = r106 * r44;
+    r106 = r106 * r93;
+    r106 = fma(r53, r106, r77 * r121);
+    r121 = r49 * r38;
+    r121 = r121 * r112;
+    r106 = fma(r54, r121, r106);
+    r90 = fma(r37, r105, r33 * r96);
+    r84 = r80 * r97;
+    r90 = fma(r91, r84, r90);
+    r117 = r21 * r28;
+    r117 = r117 * r28;
+    r117 = r117 * r38;
+    r117 = r117 * r38;
+    r117 = r117 * r80;
+    r117 = r117 * r39;
+    r117 = r117 * r98;
+    r90 = fma(r103, r117, r90);
+    r106 = fma(r80, r109, r106);
+    r106 = r106 + r90;
+    r121 = r33 * r43;
+    r121 = r121 * r38;
+    r121 = r121 * r44;
+    r121 = r121 * r53;
+    r121 = fma(r94, r121, r80 * r77);
+    r77 = r21 * r43;
+    r77 = r77 * r38;
+    r77 = r77 * r80;
+    r77 = r77 * r39;
+    r77 = r77 * r98;
+    r77 = r77 * r103;
+    r121 = fma(r53, r77, r121);
+    r117 = r49 * r54;
+    r121 = fma(r104, r117, r121);
+    r90 = r90 + r121;
+    r106 = fma(r56, r90, r5 * r106);
+    r117 = r4 * r37;
+    r117 = r117 * r54;
+    r106 = fma(r104, r117, r106);
+    r77 = r4 * r80;
+    r106 = fma(r126, r77, r106);
+    r84 = r43 * r80;
+    r84 = r84 * r35;
+    r106 = fma(r118, r84, r106);
+    r41 = r49 * r38;
+    r106 = fma(r71, r41, r106);
+    r81 = r21 * r33;
+    r81 = r81 * r39;
+    r81 = r81 * r70;
+    r106 = fma(r53, r81, r106);
+    r138 = r4 * r33;
+    r106 = fma(r123, r138, r106);
+    r125 = r4 * r34;
+    r125 = r125 * r80;
+    r125 = r125 * r39;
+    r125 = r125 * r98;
+    r125 = r125 * r103;
+    r125 = r125 * r53;
+    r106 = fma(r47, r125, r106);
+    r22 = r43 * r75;
+    r22 = r22 * r80;
+    r22 = r22 * r71;
+    r106 = fma(r35, r22, r106);
+    r9 = r49 * r38;
+    r106 = fma(r72, r9, r106);
+    r76 = r74 * r80;
+    r76 = r76 * r44;
+    r76 = r76 * r69;
+    r76 = r76 * r98;
+    r106 = fma(r53, r76, r106);
+    r102 = r62 * r10;
+    r102 = r102 * r7;
+    r102 = fma(r61, r90, r90 * r102);
+    r102 = fma(r90, r65, r102);
+    r102 = fma(r90, r66, r102);
+    r108 = r102 * r53;
+    r106 = fma(r71, r108, r106);
+    r132 = r64 * r74;
+    r132 = r132 * r80;
+    r132 = r132 * r44;
+    r132 = r132 * r69;
+    r132 = r132 * r98;
+    r106 = fma(r53, r132, r106);
+    r133 = r21 * r33;
+    r133 = r133 * r64;
+    r133 = r133 * r39;
+    r133 = r133 * r70;
+    r106 = fma(r53, r133, r106);
+    r106 = fma(r49, r100, r106);
+    r133 = r2 * r106;
+    r132 = r33 * r28;
+    r132 = r132 * r28;
+    r132 = r132 * r38;
+    r132 = r132 * r38;
+    r132 = r132 * r115;
+    r132 = r132 * r44;
+    r108 = r37 * r38;
+    r108 = r108 * r112;
+    r108 = r108 * r42;
+    r108 = fma(r47, r108, r93 * r132);
+    r132 = r20 * r80;
+    r132 = r132 * r97;
+    r108 = fma(r91, r132, r108);
+    r76 = r80 * r110;
+    r108 = fma(r95, r76, r108);
+    r108 = r108 + r121;
+    r108 = fma(r4, r108, r57 * r90);
+    r90 = r21 * r33;
+    r90 = r90 * r28;
+    r90 = r90 * r38;
+    r90 = r90 * r39;
+    r108 = fma(r70, r90, r108);
+    r121 = r37 * r38;
+    r108 = fma(r72, r121, r108);
+    r76 = r5 * r37;
+    r76 = r76 * r54;
+    r108 = fma(r104, r76, r108);
+    r132 = r5 * r80;
+    r108 = fma(r126, r132, r108);
+    r9 = r75 * r80;
+    r9 = r9 * r71;
+    r108 = fma(r91, r9, r108);
+    r22 = r102 * r71;
+    r108 = fma(r47, r22, r108);
+    r125 = r28 * r38;
+    r125 = r125 * r64;
+    r125 = r125 * r74;
+    r125 = r125 * r80;
+    r125 = r125 * r44;
+    r125 = r125 * r69;
+    r108 = fma(r98, r125, r108);
+    r138 = r5 * r34;
+    r138 = r138 * r80;
+    r138 = r138 * r39;
+    r138 = r138 * r98;
+    r138 = r138 * r103;
+    r138 = r138 * r53;
+    r108 = fma(r47, r138, r108);
+    r81 = r28 * r38;
+    r81 = r81 * r74;
+    r81 = r81 * r80;
+    r81 = r81 * r44;
+    r81 = r81 * r69;
+    r108 = fma(r98, r81, r108);
+    r41 = r37 * r38;
+    r108 = fma(r71, r41, r108);
+    r84 = r21 * r33;
+    r84 = r84 * r28;
+    r84 = r84 * r38;
+    r84 = r84 * r64;
+    r84 = r84 * r39;
+    r108 = fma(r70, r84, r108);
+    r77 = r5 * r49;
+    r108 = fma(r105, r77, r108);
+    r108 = fma(r33, r124, r108);
+    r108 = fma(r80, r120, r108);
+    r77 = r3 * r108;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r133, r77);
+    r77 = r10 * r40;
+    r77 = r77 * r28;
+    r92 = fma(r31, r92, r39 * r77);
+    r77 = r10 * r48;
+    r77 = r77 * r43;
+    r92 = fma(r39, r77, r92);
+    r133 = r31 * r43;
+    r133 = r133 * r43;
+    r92 = fma(r94, r133, r92);
+    r133 = r43 * r43;
+    r133 = r39 * r133;
+    r133 = r133 * r44;
+    r133 = r133 * r38;
+    r133 = r133 * r98;
+    r133 = r133 * r30;
+    r133 = r133 * r92;
+    r109 = fma(r20, r133, r92 * r109);
+    r30 = r48 * r38;
+    r30 = r30 * r112;
+    r109 = fma(r54, r30, r109);
+    r77 = r31 * r43;
+    r77 = r77 * r38;
+    r77 = r77 * r115;
+    r77 = r77 * r44;
+    r77 = r77 * r93;
+    r109 = fma(r53, r77, r109);
+    r96 = fma(r40, r105, r31 * r96);
+    r84 = r92 * r97;
+    r96 = fma(r91, r84, r96);
+    r41 = r21 * r28;
+    r41 = r41 * r28;
+    r41 = r41 * r38;
+    r41 = r41 * r38;
+    r41 = r41 * r92;
+    r41 = r41 * r39;
+    r41 = r41 * r98;
+    r96 = fma(r103, r41, r96);
+    r109 = r109 + r96;
+    r77 = r21 * r43;
+    r77 = r77 * r38;
+    r77 = r77 * r92;
+    r77 = r77 * r39;
+    r77 = r77 * r98;
+    r77 = r77 * r103;
+    r77 = fma(r53, r77, r133);
+    r133 = r48 * r54;
+    r77 = fma(r104, r133, r77);
+    r30 = r31 * r43;
+    r30 = r30 * r38;
+    r30 = r30 * r44;
+    r30 = r30 * r53;
+    r77 = fma(r94, r30, r77);
+    r96 = r96 + r77;
+    r56 = fma(r56, r96, r5 * r109);
+    r109 = r48 * r38;
+    r56 = fma(r72, r109, r56);
+    r30 = r4 * r31;
+    r56 = fma(r123, r30, r56);
+    r123 = r4 * r40;
+    r123 = r123 * r54;
+    r56 = fma(r104, r123, r56);
+    r133 = r43 * r92;
+    r133 = r133 * r35;
+    r56 = fma(r118, r133, r56);
+    r118 = r43 * r75;
+    r118 = r118 * r92;
+    r118 = r118 * r71;
+    r56 = fma(r35, r118, r56);
+    r35 = r62 * r10;
+    r35 = r35 * r7;
+    r35 = fma(r96, r35, r61 * r96);
+    r35 = fma(r96, r66, r35);
+    r35 = fma(r96, r65, r35);
+    r65 = r35 * r53;
+    r56 = fma(r71, r65, r56);
+    r66 = r4 * r92;
+    r56 = fma(r126, r66, r56);
+    r61 = r21 * r31;
+    r61 = r61 * r39;
+    r61 = r61 * r70;
+    r56 = fma(r53, r61, r56);
+    r94 = r64 * r74;
+    r94 = r94 * r92;
+    r94 = r94 * r44;
+    r94 = r94 * r69;
+    r94 = r94 * r98;
+    r56 = fma(r53, r94, r56);
+    r41 = r4 * r34;
+    r41 = r41 * r92;
+    r41 = r41 * r39;
+    r41 = r41 * r98;
+    r41 = r41 * r103;
+    r41 = r41 * r53;
+    r56 = fma(r47, r41, r56);
+    r84 = r48 * r38;
+    r56 = fma(r71, r84, r56);
+    r81 = r21 * r31;
+    r81 = r81 * r64;
+    r81 = r81 * r39;
+    r81 = r81 * r70;
+    r56 = fma(r53, r81, r56);
+    r138 = r74 * r92;
+    r138 = r138 * r44;
+    r138 = r138 * r69;
+    r138 = r138 * r98;
+    r56 = fma(r53, r138, r56);
+    r56 = fma(r48, r100, r56);
+    r138 = r2 * r56;
+    r81 = r31 * r28;
+    r81 = r81 * r28;
+    r81 = r81 * r38;
+    r81 = r81 * r38;
+    r81 = r81 * r115;
+    r81 = r81 * r44;
+    r115 = r40 * r38;
+    r115 = r115 * r112;
+    r115 = r115 * r42;
+    r115 = fma(r47, r115, r93 * r81);
+    r81 = r20 * r92;
+    r81 = r81 * r97;
+    r115 = fma(r91, r81, r115);
+    r42 = r92 * r110;
+    r115 = fma(r95, r42, r115);
+    r115 = r115 + r77;
+    r115 = fma(r4, r115, r57 * r96);
+    r96 = r28 * r38;
+    r96 = r96 * r74;
+    r96 = r96 * r92;
+    r96 = r96 * r44;
+    r96 = r96 * r69;
+    r115 = fma(r98, r96, r115);
+    r57 = r21 * r31;
+    r57 = r57 * r28;
+    r57 = r57 * r38;
+    r57 = r57 * r39;
+    r115 = fma(r70, r57, r115);
+    r77 = r40 * r38;
+    r115 = fma(r71, r77, r115);
+    r42 = r5 * r48;
+    r115 = fma(r105, r42, r115);
+    r105 = r21 * r31;
+    r105 = r105 * r28;
+    r105 = r105 * r38;
+    r105 = r105 * r64;
+    r105 = r105 * r39;
+    r115 = fma(r70, r105, r115);
+    r70 = r40 * r38;
+    r115 = fma(r72, r70, r115);
+    r72 = r5 * r40;
+    r72 = r72 * r54;
+    r115 = fma(r104, r72, r115);
+    r81 = r28 * r38;
+    r81 = r81 * r64;
+    r81 = r81 * r74;
+    r81 = r81 * r92;
+    r81 = r81 * r44;
+    r81 = r81 * r69;
+    r115 = fma(r98, r81, r115);
+    r69 = r5 * r92;
+    r115 = fma(r126, r69, r115);
+    r126 = r75 * r92;
+    r126 = r126 * r71;
+    r115 = fma(r91, r126, r115);
+    r91 = r35 * r71;
+    r115 = fma(r47, r91, r115);
+    r44 = r5 * r34;
+    r44 = r44 * r92;
+    r44 = r44 * r39;
+    r44 = r44 * r98;
+    r44 = r44 * r103;
+    r44 = r44 * r53;
+    r115 = fma(r47, r44, r115);
+    r115 = fma(r92, r120, r115);
+    r115 = fma(r31, r124, r115);
+    r44 = r3 * r115;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r44);
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r138 = r21 * r0;
+    r91 = r2 * r138;
+    r44 = fma(r107, r91, r129 * r44);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r113, r91, r114 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r44, r126);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r111, r91, r99 * r126);
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r44 = fma(r23, r91, r83 * r44);
+    WriteSum2<double, double>((double*)inout_shared, r126, r44);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r44 = fma(r106, r91, r108 * r44);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r56, r91, r115 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r44, r126);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r107 * r107;
+    r44 = r2 * r2;
+    r69 = r129 * r129;
+    r81 = r3 * r3;
+    r69 = fma(r81, r69, r44 * r126);
+    r126 = r113 * r113;
+    r72 = r114 * r114;
+    r72 = fma(r81, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r111 * r111;
+    r69 = r99 * r99;
+    r69 = fma(r81, r69, r44 * r72);
+    r72 = r83 * r83;
+    r126 = r23 * r23;
+    r126 = fma(r44, r126, r81 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r106 * r106;
+    r69 = r108 * r108;
+    r69 = fma(r81, r69, r44 * r126);
+    r126 = r115 * r115;
+    r72 = r56 * r56;
+    r72 = fma(r44, r72, r81 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r129 * r114;
+    r69 = r107 * r113;
+    r69 = fma(r44, r69, r81 * r72);
+    r72 = r107 * r111;
+    r126 = r129 * r99;
+    r126 = fma(r81, r126, r44 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r107 * r23;
+    r69 = r129 * r83;
+    r69 = fma(r81, r69, r44 * r126);
+    r126 = r107 * r106;
+    r72 = r129 * r108;
+    r72 = fma(r81, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r129 * r115;
+    r69 = r107 * r56;
+    r69 = fma(r44, r69, r81 * r72);
+    r72 = r114 * r99;
+    r126 = r113 * r111;
+    r126 = fma(r44, r126, r81 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r113 * r23;
+    r69 = r114 * r83;
+    r69 = fma(r81, r69, r44 * r126);
+    r126 = r113 * r106;
+    r72 = r114 * r108;
+    r72 = fma(r81, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r114 * r115;
+    r69 = r113 * r56;
+    r69 = fma(r44, r69, r81 * r72);
+    r72 = r99 * r83;
+    r126 = r111 * r23;
+    r126 = fma(r44, r126, r81 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r111 * r106;
+    r69 = r99 * r108;
+    r69 = fma(r81, r69, r44 * r126);
+    r126 = r99 * r115;
+    r72 = r111 * r56;
+    r72 = fma(r44, r72, r81 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r23 * r106;
+    r69 = r83 * r108;
+    r69 = fma(r81, r69, r44 * r72);
+    r72 = r83 * r115;
+    r126 = r23 * r56;
+    r126 = fma(r44, r126, r81 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r108 * r115;
+    r69 = r106 * r56;
+    r69 = fma(r44, r69, r81 * r126);
+    WriteSum1<double, double>((double*)inout_shared, r69);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r59,
+        r58);
+    r69 = r2 * r7;
+    r69 = r69 * r53;
+    r69 = r69 * r71;
+    r126 = r3 * r7;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r53;
+    r126 = r126 * r71;
+    r126 = r126 * r63;
+    r69 = r3 * r71;
+    r69 = r69 * r47;
+    r69 = r69 * r63;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r3 * r60;
+    r126 = r2 * r10;
+    r126 = r126 * r47;
+    r126 = r126 * r54;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r2 * r52;
+    r126 = r3 * r10;
+    r126 = r126 * r47;
+    r126 = r126 * r54;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r53;
+    r126 = r126 * r71;
+    r126 = r126 * r68;
+    r69 = r3 * r71;
+    r69 = r69 * r47;
+    r69 = r69 * r68;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r2 * r53;
+    r69 = r69 * r71;
+    r69 = r69 * r67;
+    r126 = r3 * r71;
+    r126 = r126 * r47;
+    r126 = r126 * r67;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r7;
+    r69 = r3 * r7;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r21 * r58;
+    r69 = r69 * r1;
+    r138 = r59 * r138;
+    WriteSum2<double, double>((double*)inout_shared, r138, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r3 * r21;
+    r69 = r69 * r7;
+    r69 = r69 * r1;
+    r69 = r69 * r71;
+    r138 = r7 * r53;
+    r138 = r138 * r71;
+    r138 = fma(r91, r138, r47 * r69);
+    r69 = r3 * r21;
+    r69 = r69 * r1;
+    r69 = r69 * r71;
+    r69 = r69 * r47;
+    r126 = r53 * r71;
+    r126 = r126 * r63;
+    r126 = fma(r91, r126, r63 * r69);
+    WriteSum2<double, double>((double*)inout_shared, r138, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r60;
+    r138 = r2 * r34;
+    r138 = r138 * r0;
+    r138 = r138 * r47;
+    r138 = fma(r54, r138, r1 * r126);
+    r126 = r3 * r34;
+    r126 = r126 * r1;
+    r126 = r126 * r47;
+    r126 = fma(r54, r126, r52 * r91);
+    WriteSum2<double, double>((double*)inout_shared, r138, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    r138 = r53 * r71;
+    r138 = r138 * r68;
+    r138 = fma(r91, r138, r68 * r126);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    r0 = r53 * r71;
+    r0 = r0 * r67;
+    r0 = fma(r91, r0, r67 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r138, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r21;
+    r0 = r0 * r7;
+    r0 = r0 * r1;
+    r91 = r7 * r91;
+    WriteSum2<double, double>((double*)inout_shared, r91, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r59 * r59;
+    r91 = r58 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r0, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r38 * r63;
+    r91 = r91 * r44;
+    r0 = r28 * r38;
+    r0 = r0 * r63;
+    r0 = r0 * r81;
+    r0 = fma(r97, r0, r55 * r91);
+    r91 = r38 * r44;
+    r91 = r91 * r67;
+    r1 = r28 * r38;
+    r1 = r1 * r81;
+    r1 = r1 * r97;
+    r1 = fma(r67, r1, r55 * r91);
+    WriteSum2<double, double>((double*)inout_shared, r0, r1);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r53 * r44;
+    r91 = r43 * r28;
+    r51 = r45 * r51;
+    r51 = 1.0 / r51;
+    r6 = r46 * r6;
+    r6 = 1.0 / r6;
+    r91 = r91 * r38;
+    r91 = r91 * r38;
+    r91 = r91 * r128;
+    r91 = r91 * r51;
+    r91 = r91 * r6;
+    r91 = r91 * r47;
+    r6 = r60 * r81;
+    r51 = fma(r60, r6, r0 * r91);
+    r128 = r53 * r81;
+    r46 = r52 * r52;
+    r46 = fma(r44, r46, r91 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r51, r46);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r68 * r68;
+    r51 = r38 * r44;
+    r51 = r51 * r55;
+    r128 = r28 * r38;
+    r128 = r128 * r81;
+    r128 = r128 * r97;
+    r128 = fma(r46, r128, r46 * r51);
+    r91 = r67 * r67;
+    r45 = r81 * r97;
+    r45 = r45 * r47;
+    r91 = fma(r91, r45, r51 * r91);
+    WriteSum2<double, double>((double*)inout_shared, r128, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r63 * r44;
+    r138 = r63 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r91, r138);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r138 = 0.00000000000000000e+00;
+    r91 = r2 * r7;
+    r91 = r91 * r59;
+    r91 = r91 * r53;
+    r91 = r91 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r138, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r2 * r59;
+    r91 = r91 * r53;
+    r91 = r91 * r71;
+    r91 = r91 * r63;
+    r126 = r2 * r10;
+    r126 = r126 * r59;
+    r126 = r126 * r47;
+    r126 = r126 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r91, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r2 * r52;
+    r126 = r126 * r59;
+    r91 = r2 * r59;
+    r91 = r91 * r53;
+    r91 = r91 * r71;
+    r91 = r91 * r68;
+    WriteSum2<double, double>((double*)inout_shared, r126, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r2 * r7;
+    r91 = r91 * r59;
+    r59 = r2 * r59;
+    r59 = r59 * r53;
+    r59 = r59 * r71;
+    r59 = r59 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r59, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r3 * r7;
+    r91 = r91 * r58;
+    r91 = r91 * r71;
+    r91 = r91 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r138, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r3 * r60;
+    r60 = r60 * r58;
+    r91 = r3 * r58;
+    r91 = r91 * r71;
+    r91 = r91 * r47;
+    r91 = r91 * r63;
+    WriteSum2<double, double>((double*)inout_shared, r91, r60);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r3 * r10;
+    r60 = r60 * r58;
+    r60 = r60 * r47;
+    r60 = r60 * r54;
+    r91 = r3 * r58;
+    r91 = r91 * r71;
+    r91 = r91 * r47;
+    r91 = r91 * r68;
+    WriteSum2<double, double>((double*)inout_shared, r60, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r3 * r58;
+    r91 = r91 * r71;
+    r91 = r91 * r47;
+    r91 = r91 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r91, r138);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r138 = r3 * r7;
+    r138 = r138 * r58;
+    r58 = r38 * r68;
+    r58 = r58 * r44;
+    r91 = r28 * r38;
+    r91 = r91 * r68;
+    r91 = r91 * r81;
+    r91 = fma(r97, r91, r55 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r138, r91);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r91 = r47 * r6;
+    r138 = r71 * r91;
+    r58 = r43 * r7;
+    r58 = r58 * r93;
+    r58 = r58 * r103;
+    r58 = r58 * r47;
+    r58 = r58 * r104;
+    r58 = fma(r0, r58, r7 * r138);
+    r60 = r71 * r0;
+    r59 = r52 * r60;
+    r126 = r28 * r7;
+    r126 = r126 * r93;
+    r126 = r126 * r103;
+    r126 = r126 * r53;
+    r126 = r126 * r47;
+    r126 = r126 * r81;
+    r126 = fma(r104, r126, r7 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r58, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r38 * r44;
+    r58 = r7 * r67;
+    r126 = r126 * r55;
+    r55 = r28 * r38;
+    r55 = r55 * r81;
+    r55 = r55 * r97;
+    r55 = fma(r58, r55, r58 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r1, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r63 * r60;
+    r126 = r71 * r47;
+    r126 = r126 * r63;
+    r126 = r126 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r1, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r43 * r93;
+    r126 = r126 * r103;
+    r126 = r126 * r47;
+    r126 = r126 * r63;
+    r126 = r126 * r104;
+    r126 = fma(r0, r126, r63 * r138);
+    r1 = r28 * r93;
+    r1 = r1 * r103;
+    r1 = r1 * r53;
+    r1 = r1 * r47;
+    r1 = r1 * r63;
+    r1 = r1 * r81;
+    r1 = fma(r104, r1, r63 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r126, r1);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r55, r128);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r128 = r68 * r60;
+    r55 = r71 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r128, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r52;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r128 = r10 * r54;
+    r128 = fma(r91, r128, r44 * r55);
+    r55 = r43 * r93;
+    r55 = r55 * r103;
+    r55 = r55 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r104;
+    r55 = fma(r0, r55, r68 * r138);
+    WriteSum2<double, double>((double*)inout_shared, r128, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r7;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r55 = r55 * r44;
+    r128 = r43 * r93;
+    r128 = r128 * r103;
+    r128 = r128 * r47;
+    r128 = r128 * r104;
+    r128 = r128 * r67;
+    r128 = fma(r0, r128, r67 * r138);
+    WriteSum2<double, double>((double*)inout_shared, r128, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r6 = r7 * r6;
+    r55 = r28 * r93;
+    r55 = r55 * r103;
+    r55 = r55 * r53;
+    r55 = r55 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r81;
+    r55 = fma(r104, r55, r68 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r6, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r52 * r7;
+    r55 = r55 * r44;
+    r6 = r28 * r93;
+    r6 = r6 * r103;
+    r6 = r6 * r53;
+    r6 = r6 * r47;
+    r6 = r6 * r81;
+    r6 = r6 * r104;
+    r6 = fma(r67, r6, r67 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r6, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r7;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r55 = r55 * r81;
+    r46 = r7 * r46;
+    r45 = fma(r46, r45, r46 * r51);
+    WriteSum2<double, double>((double*)inout_shared, r55, r45);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r45 = r67 * r60;
+    r55 = r71 * r47;
+    r55 = r55 * r81;
+    r55 = r55 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r45, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r58 * r60;
+    r47 = r71 * r47;
+    r47 = r47 * r81;
+    r47 = r47 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r60, r47);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacKernel<<<n_blocks,
+                                                                   1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      point,
+      point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.cu
@@ -1,0 +1,2432 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r28 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r30);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r31 = r17 * r18;
+    r31 = r31 * r10;
+    r32 = r13 * r14;
+    r32 = fma(r10, r32, r31);
+    r33 = r17 * r17;
+    r34 = -2.00000000000000000e+00;
+    r33 = r33 * r34;
+    r35 = 1.00000000000000000e+00;
+    r36 = r13 * r13;
+    r36 = fma(r34, r36, r35);
+    r37 = r33 + r36;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r39 = r18 * r13;
+    r39 = r39 * r10;
+    r40 = r17 * r14;
+    r40 = fma(r34, r40, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r10 * r27;
+    r42 = r42 * r24;
+    r43 = r19 * r34;
+    r43 = fma(r29, r43, r42);
+    r44 = r27 * r27;
+    r44 = r44 * r34;
+    r45 = r35 + r44;
+    r46 = r19 * r19;
+    r46 = r46 * r34;
+    r45 = r45 + r46;
+    r28 = fma(r7, r32, r28);
+    r28 = fma(r30, r37, r28);
+    r28 = fma(r38, r40, r28);
+    r28 = fma(r41, r43, r28);
+    r28 = fma(r9, r45, r28);
+    r45 = r34 * r24;
+    r45 = r45 * r24;
+    r43 = r35 + r45;
+    r43 = r43 + r44;
+    r43 = fma(r8, r43, r6);
+    r6 = r27 * r34;
+    r6 = fma(r29, r6, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r44 = r10 * r24;
+    r44 = fma(r29, r44, r20);
+    r47 = r17 * r13;
+    r47 = r47 * r10;
+    r48 = r18 * r14;
+    r48 = fma(r10, r48, r47);
+    r49 = r13 * r14;
+    r49 = fma(r34, r49, r31);
+    r31 = r18 * r18;
+    r31 = r31 * r34;
+    r36 = r31 + r36;
+    r43 = fma(r9, r6, r43);
+    r43 = fma(r41, r44, r43);
+    r43 = fma(r38, r48, r43);
+    r43 = fma(r30, r49, r43);
+    r43 = fma(r7, r36, r43);
+    r44 = r43 * r43;
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r50);
+    r51 = r34 * r24;
+    r51 = fma(r29, r51, r20);
+    r51 = fma(r8, r51, r50);
+    r50 = r18 * r14;
+    r50 = fma(r34, r50, r47);
+    r31 = r35 + r31;
+    r31 = r31 + r33;
+    r33 = r17 * r14;
+    r33 = fma(r10, r33, r39);
+    r39 = r10 * r19;
+    r39 = fma(r29, r39, r42);
+    r45 = r35 + r45;
+    r45 = r45 + r46;
+    r51 = fma(r7, r50, r51);
+    r51 = fma(r38, r31, r51);
+    r51 = fma(r30, r33, r51);
+    r51 = fma(r9, r39, r51);
+    r51 = fma(r41, r45, r51);
+    r45 = copysign(1.0, r51);
+    r45 = fma(r6, r45, r51);
+    r51 = r45 * r45;
+    r39 = 1.0 / r51;
+    r30 = r28 * r28;
+    r30 = fma(r39, r30, r39 * r44);
+    r44 = sqrt(r30);
+    r38 = atan(r44);
+    r7 = r28 * r38;
+    r46 = copysign(1.0, r44);
+    r46 = fma(r6, r46, r44);
+    r6 = r46 * r46;
+    r44 = 1.0 / r6;
+    r42 = r39 * r44;
+    r47 = r28 * r38;
+    r7 = r7 * r42;
+    r7 = r7 * r47;
+    r20 = 3.00000000000000000e+00;
+    r52 = r38 * r20;
+    r53 = r43 * r38;
+    r54 = r53 * r42;
+    r55 = r43 * r54;
+    r52 = fma(r55, r52, r7);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r56,
+                        r57);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r58 = r38 * r55;
+    r7 = r7 + r58;
+    r59 = fma(r56, r7, r5 * r52);
+    r60 = r4 * r10;
+    r60 = r60 * r47;
+    r59 = fma(r54, r60, r59);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r61,
+                        r62);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r63 = r7 * r7;
+    r64 = fma(r62, r63, r61 * r7);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r65,
+                        r66);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r67 = r63 * r63;
+    r68 = r7 * r63;
+    r64 = fma(r66, r67, r64);
+    r64 = fma(r65, r68, r64);
+    r69 = 1.0 / r45;
+    r70 = 1.0 / r46;
+    r71 = r69 * r70;
+    r72 = r64 * r71;
+    r59 = fma(r53, r72, r59);
+    r59 = fma(r53, r71, r59);
+    r0 = fma(r2, r59, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r60, r73);
+    r0 = fma(r60, r21, r0);
+    r60 = r28 * r38;
+    r60 = r60 * r20;
+    r60 = r60 * r42;
+    r60 = fma(r47, r60, r58);
+    r58 = fma(r57, r7, r4 * r60);
+    r74 = r5 * r10;
+    r74 = r74 * r47;
+    r58 = fma(r54, r74, r58);
+    r58 = fma(r47, r72, r58);
+    r58 = fma(r71, r47, r58);
+    r1 = fma(r3, r58, r1);
+    r1 = fma(r73, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r73 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r73);
+  if (global_thread_idx < problem_size) {
+    r73 = r43 * r44;
+    r74 = -5.00000000000000000e-01;
+    r75 = rsqrt(r30);
+    r76 = r10 * r43;
+    r77 = r11 * r14;
+    r78 = r16 * r17;
+    r78 = fma(r74, r78, r74 * r77);
+    r77 = r15 * r18;
+    r78 = fma(r74, r77, r78);
+    r79 = r12 * r13;
+    r80 = 5.00000000000000000e-01;
+    r78 = fma(r80, r79, r78);
+    r79 = r24 * r78;
+    r77 = r15 * r14;
+    r81 = r12 * r17;
+    r81 = fma(r80, r81, r80 * r77);
+    r77 = r11 * r18;
+    r81 = fma(r74, r77, r81);
+    r82 = r16 * r13;
+    r81 = fma(r80, r82, r81);
+    r82 = r29 * r81;
+    r77 = fma(r10, r82, r10 * r79);
+    r83 = r10 * r19;
+    r84 = fma(r80, r26, r74 * r22);
+    r84 = fma(r74, r23, r84);
+    r84 = fma(r74, r25, r84);
+    r85 = r10 * r27;
+    r86 = r16 * r14;
+    r87 = r11 * r17;
+    r87 = fma(r74, r87, r80 * r86);
+    r86 = r12 * r18;
+    r87 = fma(r74, r86, r87);
+    r88 = r15 * r13;
+    r87 = fma(r74, r88, r87);
+    r85 = r85 * r87;
+    r83 = fma(r84, r83, r85);
+    r77 = r77 + r83;
+    r88 = r10 * r24;
+    r88 = r88 * r87;
+    r86 = r10 * r19;
+    r86 = r86 * r81;
+    r89 = r88 + r86;
+    r90 = r27 * r34;
+    r89 = fma(r78, r90, r89);
+    r91 = r34 * r29;
+    r89 = fma(r84, r91, r89);
+    r89 = fma(r9, r89, r41 * r77);
+    r77 = r24 * r81;
+    r91 = -4.00000000000000000e+00;
+    r77 = r77 * r91;
+    r90 = r27 * r84;
+    r92 = r91 * r90;
+    r93 = r77 + r92;
+    r89 = fma(r8, r93, r89);
+    r76 = r76 * r89;
+    r93 = r43 * r43;
+    r94 = r10 * r24;
+    r94 = r94 * r84;
+    r95 = r10 * r27;
+    r95 = fma(r81, r95, r94);
+    r81 = r10 * r19;
+    r81 = r81 * r78;
+    r96 = r10 * r29;
+    r96 = r96 * r87;
+    r97 = r81 + r96;
+    r98 = r95 + r97;
+    r82 = fma(r34, r82, r34 * r79);
+    r82 = r82 + r83;
+    r82 = fma(r8, r82, r9 * r98);
+    r98 = r19 * r87;
+    r98 = r98 * r91;
+    r77 = r77 + r98;
+    r82 = fma(r41, r77, r82);
+    r51 = r45 * r51;
+    r77 = 1.0 / r51;
+    r99 = r34 * r77;
+    r93 = r93 * r82;
+    r93 = fma(r99, r93, r39 * r76);
+    r76 = r28 * r28;
+    r76 = r76 * r99;
+    r100 = r10 * r28;
+    r101 = r19 * r34;
+    r102 = r34 * r29;
+    r102 = r102 * r87;
+    r101 = fma(r78, r101, r102);
+    r101 = r101 + r95;
+    r92 = r98 + r92;
+    r92 = fma(r9, r92, r41 * r101);
+    r101 = r10 * r29;
+    r101 = fma(r84, r101, r86);
+    r86 = r10 * r27;
+    r86 = fma(r78, r86, r88);
+    r101 = r101 + r86;
+    r92 = fma(r8, r101, r92);
+    r100 = r100 * r92;
+    r93 = fma(r39, r100, r93);
+    r93 = fma(r82, r76, r93);
+    r73 = r73 * r38;
+    r73 = r73 * r69;
+    r73 = r73 * r74;
+    r73 = r73 * r75;
+    r73 = r73 * r93;
+    r100 = r38 * r76;
+    r101 = r38 * r44;
+    r101 = r101 * r99;
+    r101 = r100 * r101;
+    r88 = r42 * r47;
+    r98 = r93 * r88;
+    r30 = r35 + r30;
+    r30 = 1.0 / r30;
+    r35 = r75 * r30;
+    r95 = r28 * r35;
+    r98 = fma(r95, r98, r82 * r101);
+    r103 = r21 * r28;
+    r6 = r46 * r6;
+    r104 = 1.0 / r6;
+    r103 = r103 * r28;
+    r103 = r103 * r38;
+    r103 = r103 * r38;
+    r103 = r103 * r93;
+    r103 = r103 * r39;
+    r103 = r103 * r75;
+    r98 = fma(r104, r103, r98);
+    r105 = r10 * r38;
+    r106 = r105 * r88;
+    r98 = fma(r92, r106, r98);
+    r103 = r35 * r55;
+    r107 = r21 * r43;
+    r107 = r107 * r38;
+    r107 = r107 * r93;
+    r107 = r107 * r39;
+    r107 = r107 * r75;
+    r107 = r107 * r104;
+    r107 = fma(r53, r107, r93 * r103);
+    r108 = r89 * r54;
+    r107 = fma(r105, r108, r107);
+    r109 = r43 * r38;
+    r109 = r109 * r82;
+    r109 = r109 * r44;
+    r109 = r109 * r53;
+    r107 = fma(r99, r109, r107);
+    r109 = r98 + r107;
+    r108 = fma(r56, r109, r73);
+    r110 = r20 * r93;
+    r111 = r43 * r53;
+    r112 = -3.00000000000000000e+00;
+    r112 = r38 * r112;
+    r112 = r112 * r39;
+    r112 = r112 * r75;
+    r112 = r112 * r104;
+    r111 = r111 * r112;
+    r110 = fma(r93, r111, r103 * r110);
+    r113 = r38 * r89;
+    r114 = 6.00000000000000000e+00;
+    r113 = r113 * r114;
+    r110 = fma(r54, r113, r110);
+    r115 = r43 * r53;
+    r116 = r38 * r82;
+    r117 = -6.00000000000000000e+00;
+    r116 = r116 * r117;
+    r116 = r116 * r44;
+    r116 = r116 * r77;
+    r110 = fma(r116, r115, r110);
+    r110 = r110 + r98;
+    r98 = r4 * r106;
+    r115 = r21 * r64;
+    r115 = r115 * r82;
+    r115 = r115 * r39;
+    r115 = r115 * r70;
+    r108 = fma(r53, r115, r108);
+    r113 = r43 * r93;
+    r118 = r80 * r72;
+    r113 = r113 * r35;
+    r108 = fma(r118, r113, r108);
+    r119 = r4 * r34;
+    r119 = r119 * r93;
+    r119 = r119 * r39;
+    r119 = r119 * r75;
+    r119 = r119 * r104;
+    r119 = r119 * r53;
+    r108 = fma(r47, r119, r108);
+    r120 = r38 * r89;
+    r108 = fma(r72, r120, r108);
+    r121 = r4 * r92;
+    r121 = r121 * r54;
+    r108 = fma(r105, r121, r108);
+    r122 = r4 * r82;
+    r123 = r91 * r44;
+    r123 = r123 * r77;
+    r123 = r123 * r53;
+    r123 = r123 * r47;
+    r108 = fma(r123, r122, r108);
+    r124 = r43 * r80;
+    r124 = r124 * r93;
+    r124 = r124 * r71;
+    r108 = fma(r35, r124, r108);
+    r125 = r4 * r93;
+    r126 = r10 * r54;
+    r126 = r126 * r95;
+    r108 = fma(r126, r125, r108);
+    r127 = r62 * r10;
+    r127 = r127 * r7;
+    r127 = fma(r61, r109, r109 * r127);
+    r65 = r65 * r20;
+    r65 = r65 * r63;
+    r128 = 4.00000000000000000e+00;
+    r66 = r66 * r128;
+    r66 = r66 * r68;
+    r127 = fma(r109, r65, r127);
+    r127 = fma(r109, r66, r127);
+    r129 = r127 * r53;
+    r108 = fma(r71, r129, r108);
+    r130 = r21 * r82;
+    r130 = r130 * r39;
+    r130 = r130 * r70;
+    r108 = fma(r53, r130, r108);
+    r131 = r38 * r89;
+    r108 = fma(r71, r131, r108);
+    r108 = fma(r5, r110, r108);
+    r108 = fma(r89, r98, r108);
+    r108 = fma(r64, r73, r108);
+    r131 = r2 * r108;
+    r130 = r28 * r28;
+    r130 = r130 * r38;
+    r129 = r20 * r93;
+    r129 = r129 * r88;
+    r129 = fma(r95, r129, r116 * r130);
+    r130 = r93 * r112;
+    r129 = fma(r100, r130, r129);
+    r116 = r38 * r92;
+    r116 = r116 * r114;
+    r116 = r116 * r42;
+    r129 = fma(r47, r116, r129);
+    r129 = r129 + r107;
+    r129 = fma(r4, r129, r57 * r109);
+    r109 = r5 * r89;
+    r129 = fma(r106, r109, r129);
+    r107 = r21 * r28;
+    r107 = r107 * r38;
+    r107 = r107 * r82;
+    r107 = r107 * r39;
+    r129 = fma(r70, r107, r129);
+    r116 = r28 * r38;
+    r130 = r74 * r93;
+    r130 = r130 * r44;
+    r130 = r130 * r69;
+    r130 = r130 * r75;
+    r116 = r116 * r64;
+    r129 = fma(r130, r116, r129);
+    r125 = r28 * r38;
+    r129 = fma(r130, r125, r129);
+    r130 = r5 * r34;
+    r130 = r130 * r93;
+    r130 = r130 * r39;
+    r130 = r130 * r75;
+    r130 = r130 * r104;
+    r130 = r130 * r53;
+    r129 = fma(r47, r130, r129);
+    r124 = r80 * r93;
+    r124 = r124 * r71;
+    r129 = fma(r95, r124, r129);
+    r122 = r5 * r92;
+    r122 = r122 * r54;
+    r129 = fma(r105, r122, r129);
+    r121 = r5 * r123;
+    r120 = r127 * r71;
+    r129 = fma(r47, r120, r129);
+    r119 = r5 * r93;
+    r129 = fma(r126, r119, r129);
+    r113 = r95 * r118;
+    r115 = r38 * r92;
+    r129 = fma(r72, r115, r129);
+    r73 = r38 * r92;
+    r129 = fma(r71, r73, r129);
+    r110 = r21 * r28;
+    r110 = r110 * r38;
+    r110 = r110 * r64;
+    r110 = r110 * r82;
+    r110 = r110 * r39;
+    r129 = fma(r70, r110, r129);
+    r129 = fma(r82, r121, r129);
+    r129 = fma(r93, r113, r129);
+    r110 = r3 * r129;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r131,
+                                             r110);
+    r110 = r43 * r38;
+    r131 = r34 * r24;
+    r131 = fma(r84, r131, r102);
+    r73 = r10 * r27;
+    r115 = r15 * r14;
+    r119 = r12 * r17;
+    r119 = fma(r74, r119, r74 * r115);
+    r115 = r11 * r18;
+    r119 = fma(r80, r115, r119);
+    r120 = r16 * r13;
+    r119 = fma(r74, r120, r119);
+    r73 = r73 * r119;
+    r120 = r10 * r19;
+    r115 = r11 * r14;
+    r122 = r16 * r17;
+    r122 = fma(r80, r122, r80 * r115);
+    r115 = r15 * r18;
+    r122 = fma(r80, r115, r122);
+    r124 = r12 * r13;
+    r122 = fma(r74, r124, r122);
+    r120 = fma(r122, r120, r73);
+    r131 = r131 + r120;
+    r124 = r10 * r24;
+    r124 = r124 * r122;
+    r115 = r10 * r29;
+    r115 = fma(r119, r115, r124);
+    r115 = r115 + r83;
+    r115 = fma(r9, r115, r8 * r131);
+    r131 = r24 * r87;
+    r131 = r131 * r91;
+    r83 = r19 * r119;
+    r130 = r91 * r83;
+    r125 = r131 + r130;
+    r115 = fma(r41, r125, r115);
+    r110 = r110 * r117;
+    r110 = r110 * r115;
+    r110 = r110 * r44;
+    r110 = r110 * r77;
+    r125 = r38 * r114;
+    r96 = r94 + r96;
+    r96 = r96 + r120;
+    r120 = r27 * r91;
+    r120 = r120 * r122;
+    r131 = r131 + r120;
+    r131 = fma(r8, r131, r41 * r96);
+    r96 = r34 * r29;
+    r96 = fma(r34, r90, r122 * r96);
+    r94 = r10 * r19;
+    r94 = r94 * r87;
+    r116 = r10 * r24;
+    r116 = fma(r119, r116, r94);
+    r96 = r96 + r116;
+    r131 = fma(r9, r96, r131);
+    r125 = r125 * r131;
+    r125 = fma(r54, r125, r53 * r110);
+    r110 = r10 * r43;
+    r110 = r110 * r131;
+    r96 = r10 * r28;
+    r124 = r85 + r124;
+    r85 = r19 * r34;
+    r124 = fma(r84, r85, r124);
+    r84 = r34 * r29;
+    r124 = fma(r119, r84, r124);
+    r84 = r10 * r29;
+    r90 = fma(r10, r90, r122 * r84);
+    r90 = r90 + r116;
+    r90 = fma(r8, r90, r41 * r124);
+    r130 = r120 + r130;
+    r90 = fma(r9, r130, r90);
+    r96 = r96 * r90;
+    r96 = fma(r39, r96, r39 * r110);
+    r110 = r43 * r43;
+    r110 = r110 * r115;
+    r96 = fma(r99, r110, r96);
+    r96 = fma(r115, r76, r96);
+    r110 = r20 * r96;
+    r125 = fma(r103, r110, r125);
+    r130 = r21 * r28;
+    r130 = r130 * r28;
+    r130 = r130 * r38;
+    r130 = r130 * r38;
+    r130 = r130 * r96;
+    r130 = r130 * r39;
+    r130 = r130 * r75;
+    r130 = fma(r104, r130, r90 * r106);
+    r120 = r96 * r88;
+    r130 = fma(r95, r120, r130);
+    r130 = fma(r115, r101, r130);
+    r125 = fma(r96, r111, r125);
+    r125 = r125 + r130;
+    r110 = r43 * r38;
+    r110 = r110 * r115;
+    r110 = r110 * r44;
+    r110 = r110 * r53;
+    r120 = r131 * r54;
+    r120 = fma(r105, r120, r99 * r110);
+    r110 = r21 * r43;
+    r110 = r110 * r38;
+    r110 = r110 * r96;
+    r110 = r110 * r39;
+    r110 = r110 * r75;
+    r110 = r110 * r104;
+    r120 = fma(r53, r110, r120);
+    r120 = fma(r96, r103, r120);
+    r130 = r130 + r120;
+    r125 = fma(r56, r130, r5 * r125);
+    r110 = r21 * r115;
+    r110 = r110 * r39;
+    r110 = r110 * r70;
+    r125 = fma(r53, r110, r125);
+    r124 = r43 * r96;
+    r124 = r124 * r35;
+    r125 = fma(r118, r124, r125);
+    r84 = r43 * r80;
+    r84 = r84 * r96;
+    r84 = r84 * r71;
+    r125 = fma(r35, r84, r125);
+    r122 = r64 * r74;
+    r122 = r122 * r96;
+    r122 = r122 * r44;
+    r122 = r122 * r69;
+    r122 = r122 * r75;
+    r125 = fma(r53, r122, r125);
+    r85 = r62 * r10;
+    r85 = r85 * r7;
+    r85 = fma(r130, r85, r61 * r130);
+    r85 = fma(r130, r66, r85);
+    r85 = fma(r130, r65, r85);
+    r107 = r85 * r53;
+    r125 = fma(r71, r107, r125);
+    r109 = r21 * r64;
+    r109 = r109 * r115;
+    r109 = r109 * r39;
+    r109 = r109 * r70;
+    r125 = fma(r53, r109, r125);
+    r132 = r4 * r115;
+    r125 = fma(r123, r132, r125);
+    r133 = r96 * r126;
+    r134 = r38 * r131;
+    r125 = fma(r71, r134, r125);
+    r135 = r4 * r34;
+    r135 = r135 * r96;
+    r135 = r135 * r39;
+    r135 = r135 * r75;
+    r135 = r135 * r104;
+    r135 = r135 * r53;
+    r125 = fma(r47, r135, r125);
+    r136 = r38 * r131;
+    r125 = fma(r72, r136, r125);
+    r137 = r4 * r90;
+    r137 = r137 * r54;
+    r125 = fma(r105, r137, r125);
+    r138 = r74 * r96;
+    r138 = r138 * r44;
+    r138 = r138 * r69;
+    r138 = r138 * r75;
+    r125 = fma(r53, r138, r125);
+    r125 = fma(r4, r133, r125);
+    r125 = fma(r131, r98, r125);
+    r138 = r2 * r125;
+    r137 = r38 * r114;
+    r137 = r137 * r90;
+    r137 = r137 * r42;
+    r136 = r96 * r112;
+    r136 = fma(r100, r136, r47 * r137);
+    r137 = r28 * r28;
+    r137 = r137 * r38;
+    r137 = r137 * r38;
+    r137 = r137 * r117;
+    r137 = r137 * r115;
+    r137 = r137 * r44;
+    r136 = fma(r77, r137, r136);
+    r135 = r20 * r96;
+    r135 = r135 * r88;
+    r136 = fma(r95, r135, r136);
+    r136 = r136 + r120;
+    r130 = fma(r57, r130, r4 * r136);
+    r136 = r28 * r38;
+    r136 = r136 * r74;
+    r136 = r136 * r96;
+    r136 = r136 * r44;
+    r136 = r136 * r69;
+    r130 = fma(r75, r136, r130);
+    r120 = r38 * r90;
+    r130 = fma(r72, r120, r130);
+    r135 = r85 * r71;
+    r130 = fma(r47, r135, r130);
+    r137 = r80 * r96;
+    r137 = r137 * r71;
+    r130 = fma(r95, r137, r130);
+    r134 = r21 * r28;
+    r134 = r134 * r38;
+    r134 = r134 * r64;
+    r134 = r134 * r115;
+    r134 = r134 * r39;
+    r130 = fma(r70, r134, r130);
+    r132 = r28 * r38;
+    r132 = r132 * r64;
+    r132 = r132 * r74;
+    r132 = r132 * r96;
+    r132 = r132 * r44;
+    r132 = r132 * r69;
+    r130 = fma(r75, r132, r130);
+    r109 = r5 * r34;
+    r109 = r109 * r96;
+    r109 = r109 * r39;
+    r109 = r109 * r75;
+    r109 = r109 * r104;
+    r109 = r109 * r53;
+    r130 = fma(r47, r109, r130);
+    r107 = r21 * r28;
+    r107 = r107 * r38;
+    r107 = r107 * r115;
+    r107 = r107 * r39;
+    r130 = fma(r70, r107, r130);
+    r122 = r38 * r90;
+    r130 = fma(r71, r122, r130);
+    r84 = r5 * r90;
+    r84 = r84 * r54;
+    r130 = fma(r105, r84, r130);
+    r124 = r5 * r131;
+    r130 = fma(r106, r124, r130);
+    r130 = fma(r115, r121, r130);
+    r130 = fma(r5, r133, r130);
+    r130 = fma(r96, r113, r130);
+    r124 = r3 * r130;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r138,
+                                             r124);
+    r124 = r19 * r91;
+    r26 = fma(r74, r26, r80 * r22);
+    r26 = fma(r80, r23, r26);
+    r26 = fma(r80, r25, r26);
+    r124 = r124 * r26;
+    r79 = r91 * r79;
+    r25 = r124 + r79;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r94 = r94 + r23;
+    r22 = r34 * r24;
+    r94 = fma(r119, r22, r94);
+    r138 = r34 * r29;
+    r94 = fma(r78, r138, r94);
+    r94 = fma(r8, r94, r41 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r83, r26 * r25);
+    r25 = r25 + r86;
+    r94 = fma(r9, r25, r94);
+    r25 = r10 * r28;
+    r138 = r10 * r24;
+    r138 = r138 * r26;
+    r73 = r73 + r138;
+    r73 = r73 + r97;
+    r97 = r34 * r29;
+    r83 = fma(r34, r83, r26 * r97);
+    r83 = r83 + r86;
+    r83 = fma(r41, r83, r8 * r73);
+    r87 = r27 * r87;
+    r87 = r87 * r91;
+    r124 = r124 + r87;
+    r83 = fma(r9, r124, r83);
+    r25 = r25 * r83;
+    r124 = r43 * r43;
+    r124 = r124 * r94;
+    r124 = fma(r99, r124, r39 * r25);
+    r25 = r10 * r43;
+    r102 = r81 + r102;
+    r81 = r27 * r34;
+    r102 = fma(r119, r81, r102);
+    r102 = r102 + r138;
+    r79 = r87 + r79;
+    r79 = fma(r8, r79, r9 * r102);
+    r8 = r10 * r29;
+    r8 = fma(r78, r8, r23);
+    r8 = r8 + r116;
+    r79 = fma(r41, r8, r79);
+    r25 = r25 * r79;
+    r124 = fma(r39, r25, r124);
+    r124 = fma(r94, r76, r124);
+    r25 = r124 * r88;
+    r25 = fma(r95, r25, r94 * r101);
+    r8 = r21 * r28;
+    r8 = r8 * r28;
+    r8 = r8 * r38;
+    r8 = r8 * r38;
+    r8 = r8 * r124;
+    r8 = r8 * r39;
+    r8 = r8 * r75;
+    r25 = fma(r104, r8, r25);
+    r25 = fma(r83, r106, r25);
+    r8 = r21 * r43;
+    r8 = r8 * r38;
+    r8 = r8 * r124;
+    r8 = r8 * r39;
+    r8 = r8 * r75;
+    r8 = r8 * r104;
+    r41 = r79 * r54;
+    r41 = fma(r105, r41, r53 * r8);
+    r8 = r43 * r38;
+    r8 = r8 * r94;
+    r8 = r8 * r44;
+    r8 = r8 * r53;
+    r41 = fma(r99, r8, r41);
+    r41 = fma(r124, r103, r41);
+    r8 = r25 + r41;
+    r116 = r38 * r114;
+    r116 = r116 * r79;
+    r116 = fma(r54, r116, r124 * r111);
+    r23 = r43 * r38;
+    r23 = r23 * r117;
+    r23 = r23 * r94;
+    r23 = r23 * r44;
+    r23 = r23 * r77;
+    r116 = fma(r53, r23, r116);
+    r78 = r20 * r124;
+    r116 = fma(r103, r78, r116);
+    r116 = r116 + r25;
+    r116 = fma(r5, r116, r56 * r8);
+    r25 = r62 * r10;
+    r25 = r25 * r7;
+    r25 = fma(r8, r25, r61 * r8);
+    r25 = fma(r8, r65, r25);
+    r25 = fma(r8, r66, r25);
+    r78 = r25 * r53;
+    r116 = fma(r71, r78, r116);
+    r23 = r43 * r80;
+    r23 = r23 * r124;
+    r23 = r23 * r71;
+    r116 = fma(r35, r23, r116);
+    r102 = r4 * r124;
+    r116 = fma(r126, r102, r116);
+    r9 = r21 * r64;
+    r9 = r9 * r94;
+    r9 = r9 * r39;
+    r9 = r9 * r70;
+    r116 = fma(r53, r9, r116);
+    r87 = r43 * r124;
+    r87 = r87 * r35;
+    r116 = fma(r118, r87, r116);
+    r81 = r4 * r34;
+    r81 = r81 * r124;
+    r81 = r81 * r39;
+    r81 = r81 * r75;
+    r81 = r81 * r104;
+    r81 = r81 * r53;
+    r116 = fma(r47, r81, r116);
+    r138 = r38 * r79;
+    r116 = fma(r72, r138, r116);
+    r119 = r21 * r94;
+    r119 = r119 * r39;
+    r119 = r119 * r70;
+    r116 = fma(r53, r119, r116);
+    r91 = r38 * r79;
+    r116 = fma(r71, r91, r116);
+    r73 = r74 * r124;
+    r73 = r73 * r44;
+    r73 = r73 * r69;
+    r73 = r73 * r75;
+    r116 = fma(r53, r73, r116);
+    r86 = r4 * r94;
+    r116 = fma(r123, r86, r116);
+    r97 = r4 * r83;
+    r97 = r97 * r54;
+    r116 = fma(r105, r97, r116);
+    r26 = r64 * r74;
+    r26 = r26 * r124;
+    r26 = r26 * r44;
+    r26 = r26 * r69;
+    r26 = r26 * r75;
+    r116 = fma(r53, r26, r116);
+    r116 = fma(r79, r98, r116);
+    r26 = r2 * r116;
+    r97 = r28 * r28;
+    r97 = r97 * r38;
+    r97 = r97 * r38;
+    r97 = r97 * r117;
+    r97 = r97 * r94;
+    r97 = r97 * r44;
+    r86 = r20 * r124;
+    r86 = r86 * r88;
+    r86 = fma(r95, r86, r77 * r97);
+    r97 = r38 * r114;
+    r97 = r97 * r83;
+    r97 = r97 * r42;
+    r86 = fma(r47, r97, r86);
+    r73 = r124 * r112;
+    r86 = fma(r100, r73, r86);
+    r86 = r86 + r41;
+    r86 = fma(r4, r86, r57 * r8);
+    r8 = r21 * r28;
+    r8 = r8 * r38;
+    r8 = r8 * r64;
+    r8 = r8 * r94;
+    r8 = r8 * r39;
+    r86 = fma(r70, r8, r86);
+    r41 = r21 * r28;
+    r41 = r41 * r38;
+    r41 = r41 * r94;
+    r41 = r41 * r39;
+    r86 = fma(r70, r41, r86);
+    r73 = r38 * r83;
+    r86 = fma(r72, r73, r86);
+    r97 = r5 * r79;
+    r86 = fma(r106, r97, r86);
+    r91 = r28 * r38;
+    r91 = r91 * r64;
+    r91 = r91 * r74;
+    r91 = r91 * r124;
+    r91 = r91 * r44;
+    r91 = r91 * r69;
+    r86 = fma(r75, r91, r86);
+    r119 = r5 * r124;
+    r86 = fma(r126, r119, r86);
+    r138 = r80 * r124;
+    r138 = r138 * r71;
+    r86 = fma(r95, r138, r86);
+    r81 = r38 * r83;
+    r86 = fma(r71, r81, r86);
+    r87 = r5 * r34;
+    r87 = r87 * r124;
+    r87 = r87 * r39;
+    r87 = r87 * r75;
+    r87 = r87 * r104;
+    r87 = r87 * r53;
+    r86 = fma(r47, r87, r86);
+    r9 = r25 * r71;
+    r86 = fma(r47, r9, r86);
+    r102 = r28 * r38;
+    r102 = r102 * r74;
+    r102 = r102 * r124;
+    r102 = r102 * r44;
+    r102 = r102 * r69;
+    r86 = fma(r75, r102, r86);
+    r23 = r5 * r83;
+    r23 = r23 * r54;
+    r86 = fma(r105, r23, r86);
+    r86 = fma(r124, r113, r86);
+    r86 = fma(r94, r121, r86);
+    r23 = r3 * r86;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 4 * out_pose_jac_num_alloc, global_thread_idx, r26, r23);
+    r23 = r36 * r38;
+    r23 = r23 * r114;
+    r26 = r10 * r32;
+    r26 = r26 * r28;
+    r26 = fma(r50, r76, r39 * r26);
+    r102 = r50 * r43;
+    r102 = r102 * r43;
+    r26 = fma(r99, r102, r26);
+    r9 = r10 * r36;
+    r9 = r9 * r43;
+    r26 = fma(r39, r9, r26);
+    r23 = fma(r26, r111, r54 * r23);
+    r9 = r20 * r26;
+    r23 = fma(r103, r9, r23);
+    r102 = r50 * r43;
+    r102 = r102 * r38;
+    r102 = r102 * r117;
+    r102 = r102 * r44;
+    r102 = r102 * r77;
+    r23 = fma(r53, r102, r23);
+    r87 = r21 * r28;
+    r87 = r87 * r28;
+    r87 = r87 * r38;
+    r87 = r87 * r38;
+    r87 = r87 * r26;
+    r87 = r87 * r39;
+    r87 = r87 * r75;
+    r87 = fma(r104, r87, r32 * r106);
+    r81 = r26 * r88;
+    r87 = fma(r95, r81, r87);
+    r87 = fma(r50, r101, r87);
+    r23 = r23 + r87;
+    r102 = r36 * r54;
+    r9 = r21 * r43;
+    r9 = r9 * r38;
+    r9 = r9 * r26;
+    r9 = r9 * r39;
+    r9 = r9 * r75;
+    r9 = r9 * r104;
+    r9 = fma(r53, r9, r105 * r102);
+    r102 = r50 * r43;
+    r102 = r102 * r38;
+    r102 = r102 * r44;
+    r102 = r102 * r53;
+    r9 = fma(r99, r102, r9);
+    r9 = fma(r26, r103, r9);
+    r87 = r87 + r9;
+    r23 = fma(r56, r87, r5 * r23);
+    r102 = r36 * r38;
+    r23 = fma(r72, r102, r23);
+    r81 = r43 * r26;
+    r81 = r81 * r35;
+    r23 = fma(r118, r81, r23);
+    r138 = r4 * r26;
+    r23 = fma(r126, r138, r23);
+    r119 = r43 * r80;
+    r119 = r119 * r26;
+    r119 = r119 * r71;
+    r23 = fma(r35, r119, r23);
+    r91 = r64 * r74;
+    r91 = r91 * r26;
+    r91 = r91 * r44;
+    r91 = r91 * r69;
+    r91 = r91 * r75;
+    r23 = fma(r53, r91, r23);
+    r97 = r74 * r26;
+    r97 = r97 * r44;
+    r97 = r97 * r69;
+    r97 = r97 * r75;
+    r23 = fma(r53, r97, r23);
+    r73 = r4 * r34;
+    r73 = r73 * r26;
+    r73 = r73 * r39;
+    r73 = r73 * r75;
+    r73 = r73 * r104;
+    r73 = r73 * r53;
+    r23 = fma(r47, r73, r23);
+    r41 = r4 * r50;
+    r23 = fma(r123, r41, r23);
+    r8 = r62 * r10;
+    r8 = r8 * r7;
+    r8 = fma(r61, r87, r87 * r8);
+    r8 = fma(r87, r66, r8);
+    r8 = fma(r87, r65, r8);
+    r78 = r8 * r53;
+    r23 = fma(r71, r78, r23);
+    r22 = r21 * r50;
+    r22 = r22 * r64;
+    r22 = r22 * r39;
+    r22 = r22 * r70;
+    r23 = fma(r53, r22, r23);
+    r84 = r21 * r50;
+    r84 = r84 * r39;
+    r84 = r84 * r70;
+    r23 = fma(r53, r84, r23);
+    r122 = r4 * r32;
+    r122 = r122 * r54;
+    r23 = fma(r105, r122, r23);
+    r107 = r36 * r38;
+    r23 = fma(r71, r107, r23);
+    r23 = fma(r36, r98, r23);
+    r107 = r2 * r23;
+    r122 = r32 * r38;
+    r122 = r122 * r114;
+    r122 = r122 * r42;
+    r84 = r26 * r112;
+    r84 = fma(r100, r84, r47 * r122);
+    r122 = r50 * r28;
+    r122 = r122 * r28;
+    r122 = r122 * r38;
+    r122 = r122 * r38;
+    r122 = r122 * r117;
+    r122 = r122 * r44;
+    r84 = fma(r77, r122, r84);
+    r22 = r20 * r26;
+    r22 = r22 * r88;
+    r84 = fma(r95, r22, r84);
+    r84 = r84 + r9;
+    r87 = fma(r57, r87, r4 * r84);
+    r84 = r80 * r26;
+    r84 = r84 * r71;
+    r87 = fma(r95, r84, r87);
+    r9 = r32 * r38;
+    r87 = fma(r71, r9, r87);
+    r22 = r28 * r38;
+    r22 = r22 * r64;
+    r22 = r22 * r74;
+    r22 = r22 * r26;
+    r22 = r22 * r44;
+    r22 = r22 * r69;
+    r87 = fma(r75, r22, r87);
+    r122 = r21 * r50;
+    r122 = r122 * r28;
+    r122 = r122 * r38;
+    r122 = r122 * r64;
+    r122 = r122 * r39;
+    r87 = fma(r70, r122, r87);
+    r78 = r5 * r26;
+    r87 = fma(r126, r78, r87);
+    r41 = r21 * r50;
+    r41 = r41 * r28;
+    r41 = r41 * r38;
+    r41 = r41 * r39;
+    r87 = fma(r70, r41, r87);
+    r73 = r5 * r34;
+    r73 = r73 * r26;
+    r73 = r73 * r39;
+    r73 = r73 * r75;
+    r73 = r73 * r104;
+    r73 = r73 * r53;
+    r87 = fma(r47, r73, r87);
+    r97 = r8 * r71;
+    r87 = fma(r47, r97, r87);
+    r91 = r32 * r38;
+    r87 = fma(r72, r91, r87);
+    r119 = r5 * r32;
+    r119 = r119 * r54;
+    r87 = fma(r105, r119, r87);
+    r138 = r28 * r38;
+    r138 = r138 * r74;
+    r138 = r138 * r26;
+    r138 = r138 * r44;
+    r138 = r138 * r69;
+    r87 = fma(r75, r138, r87);
+    r81 = r5 * r36;
+    r87 = fma(r106, r81, r87);
+    r87 = fma(r50, r121, r87);
+    r87 = fma(r26, r113, r87);
+    r81 = r3 * r87;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r107, r81);
+    r81 = r10 * r37;
+    r81 = r81 * r28;
+    r81 = fma(r39, r81, r33 * r76);
+    r107 = r33 * r43;
+    r107 = r107 * r43;
+    r81 = fma(r99, r107, r81);
+    r138 = r10 * r49;
+    r138 = r138 * r43;
+    r81 = fma(r39, r138, r81);
+    r138 = r20 * r81;
+    r107 = r33 * r43;
+    r107 = r107 * r38;
+    r107 = r107 * r117;
+    r107 = r107 * r44;
+    r107 = r107 * r77;
+    r107 = fma(r53, r107, r103 * r138);
+    r138 = r49 * r38;
+    r138 = r138 * r114;
+    r107 = fma(r54, r138, r107);
+    r119 = fma(r37, r106, r33 * r101);
+    r91 = r81 * r88;
+    r119 = fma(r95, r91, r119);
+    r97 = r21 * r28;
+    r97 = r97 * r28;
+    r97 = r97 * r38;
+    r97 = r97 * r38;
+    r97 = r97 * r81;
+    r97 = r97 * r39;
+    r97 = r97 * r75;
+    r119 = fma(r104, r97, r119);
+    r107 = fma(r81, r111, r107);
+    r107 = r107 + r119;
+    r138 = r33 * r43;
+    r138 = r138 * r38;
+    r138 = r138 * r44;
+    r138 = r138 * r53;
+    r138 = fma(r99, r138, r81 * r103);
+    r103 = r21 * r43;
+    r103 = r103 * r38;
+    r103 = r103 * r81;
+    r103 = r103 * r39;
+    r103 = r103 * r75;
+    r103 = r103 * r104;
+    r138 = fma(r53, r103, r138);
+    r97 = r49 * r54;
+    r138 = fma(r105, r97, r138);
+    r119 = r119 + r138;
+    r107 = fma(r56, r119, r5 * r107);
+    r97 = r4 * r37;
+    r97 = r97 * r54;
+    r107 = fma(r105, r97, r107);
+    r103 = r4 * r81;
+    r107 = fma(r126, r103, r107);
+    r91 = r43 * r81;
+    r91 = r91 * r35;
+    r107 = fma(r118, r91, r107);
+    r73 = r49 * r38;
+    r107 = fma(r71, r73, r107);
+    r41 = r21 * r33;
+    r41 = r41 * r39;
+    r41 = r41 * r70;
+    r107 = fma(r53, r41, r107);
+    r78 = r4 * r33;
+    r107 = fma(r123, r78, r107);
+    r122 = r4 * r34;
+    r122 = r122 * r81;
+    r122 = r122 * r39;
+    r122 = r122 * r75;
+    r122 = r122 * r104;
+    r122 = r122 * r53;
+    r107 = fma(r47, r122, r107);
+    r22 = r43 * r80;
+    r22 = r22 * r81;
+    r22 = r22 * r71;
+    r107 = fma(r35, r22, r107);
+    r9 = r49 * r38;
+    r107 = fma(r72, r9, r107);
+    r84 = r74 * r81;
+    r84 = r84 * r44;
+    r84 = r84 * r69;
+    r84 = r84 * r75;
+    r107 = fma(r53, r84, r107);
+    r102 = r62 * r10;
+    r102 = r102 * r7;
+    r102 = fma(r61, r119, r119 * r102);
+    r102 = fma(r119, r65, r102);
+    r102 = fma(r119, r66, r102);
+    r109 = r102 * r53;
+    r107 = fma(r71, r109, r107);
+    r132 = r64 * r74;
+    r132 = r132 * r81;
+    r132 = r132 * r44;
+    r132 = r132 * r69;
+    r132 = r132 * r75;
+    r107 = fma(r53, r132, r107);
+    r134 = r21 * r33;
+    r134 = r134 * r64;
+    r134 = r134 * r39;
+    r134 = r134 * r70;
+    r107 = fma(r53, r134, r107);
+    r107 = fma(r49, r98, r107);
+    r134 = r2 * r107;
+    r132 = r33 * r28;
+    r132 = r132 * r28;
+    r132 = r132 * r38;
+    r132 = r132 * r38;
+    r132 = r132 * r117;
+    r132 = r132 * r44;
+    r109 = r37 * r38;
+    r109 = r109 * r114;
+    r109 = r109 * r42;
+    r109 = fma(r47, r109, r77 * r132);
+    r132 = r20 * r81;
+    r132 = r132 * r88;
+    r109 = fma(r95, r132, r109);
+    r84 = r81 * r112;
+    r109 = fma(r100, r84, r109);
+    r109 = r109 + r138;
+    r109 = fma(r4, r109, r57 * r119);
+    r119 = r21 * r33;
+    r119 = r119 * r28;
+    r119 = r119 * r38;
+    r119 = r119 * r39;
+    r109 = fma(r70, r119, r109);
+    r138 = r37 * r38;
+    r109 = fma(r72, r138, r109);
+    r84 = r5 * r37;
+    r84 = r84 * r54;
+    r109 = fma(r105, r84, r109);
+    r132 = r5 * r81;
+    r109 = fma(r126, r132, r109);
+    r9 = r80 * r81;
+    r9 = r9 * r71;
+    r109 = fma(r95, r9, r109);
+    r22 = r102 * r71;
+    r109 = fma(r47, r22, r109);
+    r122 = r28 * r38;
+    r122 = r122 * r64;
+    r122 = r122 * r74;
+    r122 = r122 * r81;
+    r122 = r122 * r44;
+    r122 = r122 * r69;
+    r109 = fma(r75, r122, r109);
+    r78 = r5 * r34;
+    r78 = r78 * r81;
+    r78 = r78 * r39;
+    r78 = r78 * r75;
+    r78 = r78 * r104;
+    r78 = r78 * r53;
+    r109 = fma(r47, r78, r109);
+    r41 = r28 * r38;
+    r41 = r41 * r74;
+    r41 = r41 * r81;
+    r41 = r41 * r44;
+    r41 = r41 * r69;
+    r109 = fma(r75, r41, r109);
+    r73 = r37 * r38;
+    r109 = fma(r71, r73, r109);
+    r91 = r21 * r33;
+    r91 = r91 * r28;
+    r91 = r91 * r38;
+    r91 = r91 * r64;
+    r91 = r91 * r39;
+    r109 = fma(r70, r91, r109);
+    r103 = r5 * r49;
+    r109 = fma(r106, r103, r109);
+    r109 = fma(r33, r121, r109);
+    r109 = fma(r81, r113, r109);
+    r103 = r3 * r109;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             8 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r134,
+                                             r103);
+    r103 = r10 * r40;
+    r103 = r103 * r28;
+    r76 = fma(r31, r76, r39 * r103);
+    r103 = r10 * r48;
+    r103 = r103 * r43;
+    r76 = fma(r39, r103, r76);
+    r134 = r31 * r43;
+    r134 = r134 * r43;
+    r76 = fma(r99, r134, r76);
+    r134 = r43 * r43;
+    r134 = r39 * r134;
+    r134 = r134 * r44;
+    r134 = r134 * r38;
+    r134 = r134 * r75;
+    r134 = r134 * r30;
+    r134 = r134 * r76;
+    r111 = fma(r20, r134, r76 * r111);
+    r30 = r48 * r38;
+    r30 = r30 * r114;
+    r111 = fma(r54, r30, r111);
+    r103 = r31 * r43;
+    r103 = r103 * r38;
+    r103 = r103 * r117;
+    r103 = r103 * r44;
+    r103 = r103 * r77;
+    r111 = fma(r53, r103, r111);
+    r101 = fma(r40, r106, r31 * r101);
+    r91 = r76 * r88;
+    r101 = fma(r95, r91, r101);
+    r73 = r21 * r28;
+    r73 = r73 * r28;
+    r73 = r73 * r38;
+    r73 = r73 * r38;
+    r73 = r73 * r76;
+    r73 = r73 * r39;
+    r73 = r73 * r75;
+    r101 = fma(r104, r73, r101);
+    r111 = r111 + r101;
+    r103 = r21 * r43;
+    r103 = r103 * r38;
+    r103 = r103 * r76;
+    r103 = r103 * r39;
+    r103 = r103 * r75;
+    r103 = r103 * r104;
+    r103 = fma(r53, r103, r134);
+    r134 = r48 * r54;
+    r103 = fma(r105, r134, r103);
+    r30 = r31 * r43;
+    r30 = r30 * r38;
+    r30 = r30 * r44;
+    r30 = r30 * r53;
+    r103 = fma(r99, r30, r103);
+    r101 = r101 + r103;
+    r56 = fma(r56, r101, r5 * r111);
+    r111 = r48 * r38;
+    r56 = fma(r72, r111, r56);
+    r30 = r4 * r31;
+    r56 = fma(r123, r30, r56);
+    r123 = r4 * r40;
+    r123 = r123 * r54;
+    r56 = fma(r105, r123, r56);
+    r134 = r43 * r76;
+    r134 = r134 * r35;
+    r56 = fma(r118, r134, r56);
+    r118 = r43 * r80;
+    r118 = r118 * r76;
+    r118 = r118 * r71;
+    r56 = fma(r35, r118, r56);
+    r35 = r62 * r10;
+    r35 = r35 * r7;
+    r35 = fma(r101, r35, r61 * r101);
+    r35 = fma(r101, r66, r35);
+    r35 = fma(r101, r65, r35);
+    r65 = r35 * r53;
+    r56 = fma(r71, r65, r56);
+    r66 = r4 * r76;
+    r56 = fma(r126, r66, r56);
+    r61 = r21 * r31;
+    r61 = r61 * r39;
+    r61 = r61 * r70;
+    r56 = fma(r53, r61, r56);
+    r99 = r64 * r74;
+    r99 = r99 * r76;
+    r99 = r99 * r44;
+    r99 = r99 * r69;
+    r99 = r99 * r75;
+    r56 = fma(r53, r99, r56);
+    r73 = r4 * r34;
+    r73 = r73 * r76;
+    r73 = r73 * r39;
+    r73 = r73 * r75;
+    r73 = r73 * r104;
+    r73 = r73 * r53;
+    r56 = fma(r47, r73, r56);
+    r91 = r48 * r38;
+    r56 = fma(r71, r91, r56);
+    r41 = r21 * r31;
+    r41 = r41 * r64;
+    r41 = r41 * r39;
+    r41 = r41 * r70;
+    r56 = fma(r53, r41, r56);
+    r78 = r74 * r76;
+    r78 = r78 * r44;
+    r78 = r78 * r69;
+    r78 = r78 * r75;
+    r56 = fma(r53, r78, r56);
+    r56 = fma(r48, r98, r56);
+    r78 = r2 * r56;
+    r41 = r31 * r28;
+    r41 = r41 * r28;
+    r41 = r41 * r38;
+    r41 = r41 * r38;
+    r41 = r41 * r117;
+    r41 = r41 * r44;
+    r117 = r40 * r38;
+    r117 = r117 * r114;
+    r117 = r117 * r42;
+    r117 = fma(r47, r117, r77 * r41);
+    r41 = r20 * r76;
+    r41 = r41 * r88;
+    r117 = fma(r95, r41, r117);
+    r42 = r76 * r112;
+    r117 = fma(r100, r42, r117);
+    r117 = r117 + r103;
+    r117 = fma(r4, r117, r57 * r101);
+    r101 = r28 * r38;
+    r101 = r101 * r74;
+    r101 = r101 * r76;
+    r101 = r101 * r44;
+    r101 = r101 * r69;
+    r117 = fma(r75, r101, r117);
+    r57 = r21 * r31;
+    r57 = r57 * r28;
+    r57 = r57 * r38;
+    r57 = r57 * r39;
+    r117 = fma(r70, r57, r117);
+    r103 = r40 * r38;
+    r117 = fma(r71, r103, r117);
+    r42 = r5 * r48;
+    r117 = fma(r106, r42, r117);
+    r106 = r21 * r31;
+    r106 = r106 * r28;
+    r106 = r106 * r38;
+    r106 = r106 * r64;
+    r106 = r106 * r39;
+    r117 = fma(r70, r106, r117);
+    r70 = r40 * r38;
+    r117 = fma(r72, r70, r117);
+    r72 = r5 * r40;
+    r72 = r72 * r54;
+    r117 = fma(r105, r72, r117);
+    r41 = r28 * r38;
+    r41 = r41 * r64;
+    r41 = r41 * r74;
+    r41 = r41 * r76;
+    r41 = r41 * r44;
+    r41 = r41 * r69;
+    r117 = fma(r75, r41, r117);
+    r69 = r5 * r76;
+    r117 = fma(r126, r69, r117);
+    r126 = r80 * r76;
+    r126 = r126 * r71;
+    r117 = fma(r95, r126, r117);
+    r95 = r35 * r71;
+    r117 = fma(r47, r95, r117);
+    r44 = r5 * r34;
+    r44 = r44 * r76;
+    r44 = r44 * r39;
+    r44 = r44 * r75;
+    r44 = r44 * r104;
+    r44 = r44 * r53;
+    r117 = fma(r47, r44, r117);
+    r117 = fma(r76, r113, r117);
+    r117 = fma(r31, r121, r117);
+    r44 = r3 * r117;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 10 * out_pose_jac_num_alloc, global_thread_idx, r78, r44);
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r78 = r21 * r0;
+    r95 = r2 * r78;
+    r44 = fma(r108, r95, r129 * r44);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r125, r95, r130 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r44, r126);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r116, r95, r86 * r126);
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r44 = fma(r23, r95, r87 * r44);
+    WriteSum2<double, double>((double*)inout_shared, r126, r44);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r44 = r3 * r21;
+    r44 = r44 * r1;
+    r44 = fma(r107, r95, r109 * r44);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = fma(r56, r95, r117 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r44, r126);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r108 * r108;
+    r44 = r2 * r2;
+    r69 = r129 * r129;
+    r41 = r3 * r3;
+    r69 = fma(r41, r69, r44 * r126);
+    r126 = r125 * r125;
+    r72 = r130 * r130;
+    r72 = fma(r41, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r116 * r116;
+    r69 = r86 * r86;
+    r69 = fma(r41, r69, r44 * r72);
+    r72 = r87 * r87;
+    r126 = r23 * r23;
+    r126 = fma(r44, r126, r41 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r107 * r107;
+    r69 = r109 * r109;
+    r69 = fma(r41, r69, r44 * r126);
+    r126 = r117 * r117;
+    r72 = r56 * r56;
+    r72 = fma(r44, r72, r41 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r129 * r130;
+    r69 = r108 * r125;
+    r69 = fma(r44, r69, r41 * r72);
+    r72 = r108 * r116;
+    r126 = r129 * r86;
+    r126 = fma(r41, r126, r44 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r108 * r23;
+    r69 = r129 * r87;
+    r69 = fma(r41, r69, r44 * r126);
+    r126 = r108 * r107;
+    r72 = r129 * r109;
+    r72 = fma(r41, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r129 * r117;
+    r69 = r108 * r56;
+    r69 = fma(r44, r69, r41 * r72);
+    r72 = r130 * r86;
+    r126 = r125 * r116;
+    r126 = fma(r44, r126, r41 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r125 * r23;
+    r69 = r130 * r87;
+    r69 = fma(r41, r69, r44 * r126);
+    r126 = r125 * r107;
+    r72 = r130 * r109;
+    r72 = fma(r41, r72, r44 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r130 * r117;
+    r69 = r125 * r56;
+    r69 = fma(r44, r69, r41 * r72);
+    r72 = r86 * r87;
+    r126 = r116 * r23;
+    r126 = fma(r44, r126, r41 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r116 * r107;
+    r69 = r86 * r109;
+    r69 = fma(r41, r69, r44 * r126);
+    r126 = r86 * r117;
+    r72 = r116 * r56;
+    r72 = fma(r44, r72, r41 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r69, r72);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r23 * r107;
+    r69 = r87 * r109;
+    r69 = fma(r41, r69, r44 * r72);
+    r72 = r87 * r117;
+    r126 = r23 * r56;
+    r126 = fma(r44, r126, r41 * r72);
+    WriteSum2<double, double>((double*)inout_shared, r69, r126);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r109 * r117;
+    r69 = r107 * r56;
+    r69 = fma(r44, r69, r41 * r126);
+    WriteSum1<double, double>((double*)inout_shared, r69);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r59,
+        r58);
+    r69 = r2 * r7;
+    r69 = r69 * r53;
+    r69 = r69 * r71;
+    r126 = r3 * r7;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r53;
+    r126 = r126 * r71;
+    r126 = r126 * r63;
+    r69 = r3 * r71;
+    r69 = r69 * r47;
+    r69 = r69 * r63;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r3 * r60;
+    r126 = r2 * r10;
+    r126 = r126 * r47;
+    r126 = r126 * r54;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r2 * r52;
+    r126 = r3 * r10;
+    r126 = r126 * r47;
+    r126 = r126 * r54;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r53;
+    r126 = r126 * r71;
+    r126 = r126 * r68;
+    r69 = r3 * r71;
+    r69 = r69 * r47;
+    r69 = r69 * r68;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r2 * r53;
+    r69 = r69 * r71;
+    r69 = r69 * r67;
+    r126 = r3 * r71;
+    r126 = r126 * r47;
+    r126 = r126 * r67;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r69,
+        r126);
+    r126 = r2 * r7;
+    r69 = r3 * r7;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r126,
+        r69);
+    r69 = r21 * r58;
+    r69 = r69 * r1;
+    r78 = r59 * r78;
+    WriteSum2<double, double>((double*)inout_shared, r78, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r3 * r21;
+    r69 = r69 * r7;
+    r69 = r69 * r1;
+    r69 = r69 * r71;
+    r78 = r7 * r53;
+    r78 = r78 * r71;
+    r78 = fma(r95, r78, r47 * r69);
+    r69 = r3 * r21;
+    r69 = r69 * r1;
+    r69 = r69 * r71;
+    r69 = r69 * r47;
+    r126 = r53 * r71;
+    r126 = r126 * r63;
+    r126 = fma(r95, r126, r63 * r69);
+    WriteSum2<double, double>((double*)inout_shared, r78, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r60;
+    r78 = r2 * r34;
+    r78 = r78 * r0;
+    r78 = r78 * r47;
+    r78 = fma(r54, r78, r1 * r126);
+    r126 = r3 * r34;
+    r126 = r126 * r1;
+    r126 = r126 * r47;
+    r126 = fma(r54, r126, r52 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r78, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    r78 = r53 * r71;
+    r78 = r78 * r68;
+    r78 = fma(r95, r78, r68 * r126);
+    r126 = r3 * r21;
+    r126 = r126 * r1;
+    r126 = r126 * r71;
+    r126 = r126 * r47;
+    r0 = r53 * r71;
+    r0 = r0 * r67;
+    r0 = fma(r95, r0, r67 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r78, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r21;
+    r0 = r0 * r7;
+    r0 = r0 * r1;
+    r95 = r7 * r95;
+    WriteSum2<double, double>((double*)inout_shared, r95, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r59 * r59;
+    r95 = r58 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r0, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r38 * r63;
+    r95 = r95 * r44;
+    r0 = r28 * r38;
+    r0 = r0 * r63;
+    r0 = r0 * r41;
+    r0 = fma(r88, r0, r55 * r95);
+    r95 = r38 * r44;
+    r95 = r95 * r67;
+    r1 = r28 * r38;
+    r1 = r1 * r41;
+    r1 = r1 * r88;
+    r1 = fma(r67, r1, r55 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r0, r1);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r53 * r44;
+    r95 = r43 * r28;
+    r51 = r45 * r51;
+    r51 = 1.0 / r51;
+    r6 = r46 * r6;
+    r6 = 1.0 / r6;
+    r95 = r95 * r38;
+    r95 = r95 * r38;
+    r95 = r95 * r128;
+    r95 = r95 * r51;
+    r95 = r95 * r6;
+    r95 = r95 * r47;
+    r6 = r60 * r41;
+    r51 = fma(r60, r6, r0 * r95);
+    r128 = r53 * r41;
+    r46 = r52 * r52;
+    r46 = fma(r44, r46, r95 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r51, r46);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r46 = r68 * r68;
+    r51 = r38 * r46;
+    r128 = r44 * r55;
+    r95 = r38 * r46;
+    r45 = r28 * r41;
+    r45 = r45 * r88;
+    r95 = fma(r45, r95, r128 * r51);
+    r51 = r7 * r46;
+    r51 = r38 * r51;
+    r78 = r7 * r51;
+    r78 = fma(r45, r78, r128 * r78);
+    WriteSum2<double, double>((double*)inout_shared, r95, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r63 * r44;
+    r126 = r63 * r41;
+    WriteSum2<double, double>((double*)inout_shared, r78, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = 0.00000000000000000e+00;
+    r78 = r2 * r7;
+    r78 = r78 * r59;
+    r78 = r78 * r53;
+    r78 = r78 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r126, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r2 * r59;
+    r78 = r78 * r53;
+    r78 = r78 * r71;
+    r78 = r78 * r63;
+    r69 = r2 * r10;
+    r69 = r69 * r59;
+    r69 = r69 * r47;
+    r69 = r69 * r54;
+    WriteSum2<double, double>((double*)inout_shared, r78, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r2 * r52;
+    r69 = r69 * r59;
+    r78 = r2 * r59;
+    r78 = r78 * r53;
+    r78 = r78 * r71;
+    r78 = r78 * r68;
+    WriteSum2<double, double>((double*)inout_shared, r69, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r2 * r7;
+    r78 = r78 * r59;
+    r59 = r2 * r59;
+    r59 = r59 * r53;
+    r59 = r59 * r71;
+    r59 = r59 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r59, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r3 * r7;
+    r78 = r78 * r58;
+    r78 = r78 * r71;
+    r78 = r78 * r47;
+    WriteSum2<double, double>((double*)inout_shared, r126, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r3 * r60;
+    r60 = r60 * r58;
+    r78 = r3 * r58;
+    r78 = r78 * r71;
+    r78 = r78 * r47;
+    r78 = r78 * r63;
+    WriteSum2<double, double>((double*)inout_shared, r78, r60);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r3 * r10;
+    r60 = r60 * r58;
+    r60 = r60 * r47;
+    r60 = r60 * r54;
+    r78 = r3 * r58;
+    r78 = r78 * r71;
+    r78 = r78 * r47;
+    r78 = r78 * r68;
+    WriteSum2<double, double>((double*)inout_shared, r60, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r3 * r58;
+    r78 = r78 * r71;
+    r78 = r78 * r47;
+    r78 = r78 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r78, r126);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r3 * r7;
+    r126 = r126 * r58;
+    r58 = r38 * r68;
+    r58 = r58 * r44;
+    r78 = r28 * r38;
+    r78 = r78 * r68;
+    r78 = r78 * r41;
+    r78 = fma(r88, r78, r55 * r58);
+    WriteSum2<double, double>((double*)inout_shared, r126, r78);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r78 = r47 * r6;
+    r126 = r71 * r78;
+    r58 = r43 * r7;
+    r58 = r58 * r77;
+    r58 = r58 * r104;
+    r58 = r58 * r47;
+    r58 = r58 * r105;
+    r58 = fma(r0, r58, r7 * r126);
+    r60 = r71 * r0;
+    r59 = r52 * r60;
+    r69 = r28 * r7;
+    r69 = r69 * r77;
+    r69 = r69 * r104;
+    r69 = r69 * r53;
+    r69 = r69 * r47;
+    r69 = r69 * r41;
+    r69 = fma(r105, r69, r7 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r58, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r38 * r44;
+    r58 = r7 * r67;
+    r69 = r69 * r55;
+    r55 = r28 * r38;
+    r55 = r55 * r41;
+    r55 = r55 * r88;
+    r55 = fma(r58, r55, r58 * r69);
+    WriteSum2<double, double>((double*)inout_shared, r1, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r63 * r60;
+    r69 = r71 * r47;
+    r69 = r69 * r63;
+    r69 = r69 * r41;
+    WriteSum2<double, double>((double*)inout_shared, r1, r69);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r69 = r43 * r77;
+    r69 = r69 * r104;
+    r69 = r69 * r47;
+    r69 = r69 * r63;
+    r69 = r69 * r105;
+    r69 = fma(r0, r69, r63 * r126);
+    r1 = r28 * r77;
+    r1 = r1 * r104;
+    r1 = r1 * r53;
+    r1 = r1 * r47;
+    r1 = r1 * r63;
+    r1 = r1 * r41;
+    r1 = fma(r105, r1, r63 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r69, r1);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r55, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r68 * r60;
+    r55 = r71 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r41;
+    WriteSum2<double, double>((double*)inout_shared, r95, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r52;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r95 = r10 * r54;
+    r95 = fma(r78, r95, r44 * r55);
+    r55 = r43 * r77;
+    r55 = r55 * r104;
+    r55 = r55 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r105;
+    r55 = fma(r0, r55, r68 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r95, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r7;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r55 = r55 * r44;
+    r95 = r43 * r77;
+    r95 = r95 * r104;
+    r95 = r95 * r47;
+    r95 = r95 * r105;
+    r95 = r95 * r67;
+    r95 = fma(r0, r95, r67 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r95, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r6 = r7 * r6;
+    r55 = r28 * r77;
+    r55 = r55 * r104;
+    r55 = r55 * r53;
+    r55 = r55 * r47;
+    r55 = r55 * r68;
+    r55 = r55 * r41;
+    r55 = fma(r105, r55, r68 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r6, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r52 * r7;
+    r55 = r55 * r44;
+    r6 = r28 * r77;
+    r6 = r6 * r104;
+    r6 = r6 * r53;
+    r6 = r6 * r47;
+    r6 = r6 * r41;
+    r6 = r6 * r105;
+    r6 = fma(r67, r6, r67 * r59);
+    WriteSum2<double, double>((double*)inout_shared, r6, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r55 = r10 * r7;
+    r55 = r55 * r47;
+    r55 = r55 * r54;
+    r55 = r55 * r41;
+    r45 = fma(r51, r45, r51 * r128);
+    WriteSum2<double, double>((double*)inout_shared, r55, r45);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r45 = r67 * r60;
+    r55 = r71 * r47;
+    r55 = r55 * r41;
+    r55 = r55 * r67;
+    WriteSum2<double, double>((double*)inout_shared, r45, r55);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r60 = r58 * r60;
+    r47 = r71 * r47;
+    r47 = r47 * r41;
+    r47 = r47 * r58;
+    WriteSum2<double, double>((double*)inout_shared, r60, r47);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirstKernel<<<
+      n_blocks,
+      1024>>>(pose,
+              pose_num_alloc,
+              pose_indices,
+              sensor_from_rig,
+              sensor_from_rig_num_alloc,
+              focal_and_extra,
+              focal_and_extra_num_alloc,
+              focal_and_extra_indices,
+              pixel,
+              pixel_num_alloc,
+              principal_point,
+              principal_point_num_alloc,
+              point,
+              point_num_alloc,
+              out_res,
+              out_res_num_alloc,
+              out_rTr,
+              out_pose_jac,
+              out_pose_jac_num_alloc,
+              out_pose_njtr,
+              out_pose_njtr_num_alloc,
+              out_pose_precond_diag,
+              out_pose_precond_diag_num_alloc,
+              out_pose_precond_tril,
+              out_pose_precond_tril_num_alloc,
+              out_focal_and_extra_jac,
+              out_focal_and_extra_jac_num_alloc,
+              out_focal_and_extra_njtr,
+              out_focal_and_extra_njtr_num_alloc,
+              out_focal_and_extra_precond_diag,
+              out_focal_and_extra_precond_diag_num_alloc,
+              out_focal_and_extra_precond_tril,
+              out_focal_and_extra_precond_tril_num_alloc,
+              problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.cu
@@ -1,0 +1,375 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* point,
+        unsigned int point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+    ReadIdx2<1024, double, double, double2>(
+        point, 0 * point_num_alloc, global_thread_idx, r8, r9);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+    ReadIdx1<1024, double, double, double>(
+        point, 2 * point_num_alloc, global_thread_idx, r41);
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r44);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScoreKernel<<<n_blocks,
+                                                                  1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      point,
+      point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* point,
+    unsigned int point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.cu
@@ -1,0 +1,423 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirectKernel(
+        double* pose_njtr,
+        unsigned int pose_njtr_num_alloc,
+        SharedIndex* pose_njtr_indices,
+        double* pose_jac,
+        unsigned int pose_jac_num_alloc,
+        double* focal_and_extra_njtr,
+        unsigned int focal_and_extra_njtr_num_alloc,
+        SharedIndex* focal_and_extra_njtr_indices,
+        double* focal_and_extra_jac,
+        unsigned int focal_and_extra_jac_num_alloc,
+        double* point_njtr,
+        unsigned int point_njtr_num_alloc,
+        SharedIndex* point_njtr_indices,
+        double* point_jac,
+        unsigned int point_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_njtr_indices_loc[1024];
+  pose_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_njtr_indices_loc[1024];
+  focal_and_extra_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex point_njtr_indices_loc[1024];
+  point_njtr_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_njtr_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 0 * pose_jac_num_alloc, global_thread_idx, r0, r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                2 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            4 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r4,
+                                            r5);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            2 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+    r8 = fma(r2, r7, r3 * r5);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                4 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r9,
+                        r10);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            6 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r11,
+                                            r12);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                0 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r13,
+                        r14);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            0 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r15,
+                                            r16);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                6 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r17,
+                        r18);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            12 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r19,
+                                            r20);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            10 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r21,
+                                            r22);
+  };
+  LoadShared<2, double, double>(focal_and_extra_njtr,
+                                8 * focal_and_extra_njtr_num_alloc,
+                                focal_and_extra_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_njtr_indices_loc[threadIdx.x].target,
+                        r23,
+                        r24);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            14 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r25,
+                                            r26);
+    ReadIdx2<1024, double, double, double2>(focal_and_extra_jac,
+                                            8 * focal_and_extra_jac_num_alloc,
+                                            global_thread_idx,
+                                            r27,
+                                            r28);
+    r8 = fma(r9, r12, r8);
+    r8 = fma(r14, r16, r8);
+    r8 = fma(r18, r20, r8);
+    r8 = fma(r17, r22, r8);
+    r8 = fma(r24, r26, r8);
+    r8 = fma(r10, r28, r8);
+  };
+  LoadShared<1, double, double>(point_njtr,
+                                2 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_njtr_indices_loc[threadIdx.x].target, r24);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 4 * point_jac_num_alloc, global_thread_idx, r14, r29);
+  };
+  LoadShared<2, double, double>(point_njtr,
+                                0 * point_njtr_num_alloc,
+                                point_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        point_njtr_indices_loc[threadIdx.x].target,
+                        r30,
+                        r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 2 * point_jac_num_alloc, global_thread_idx, r32, r33);
+    r34 = fma(r31, r33, r24 * r29);
+    ReadIdx2<1024, double, double, double2>(
+        point_jac, 0 * point_jac_num_alloc, global_thread_idx, r35, r36);
+    r34 = fma(r30, r36, r34);
+    r37 = r8 + r34;
+    r9 = fma(r9, r11, r3 * r4);
+    r9 = fma(r13, r15, r9);
+    r9 = fma(r2, r6, r9);
+    r9 = fma(r23, r25, r9);
+    r9 = fma(r10, r27, r9);
+    r9 = fma(r18, r19, r9);
+    r9 = fma(r17, r21, r9);
+    r31 = fma(r31, r32, r24 * r14);
+    r31 = fma(r30, r35, r31);
+    r30 = r9 + r31;
+    r24 = fma(r0, r30, r1 * r37);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 2 * pose_jac_num_alloc, global_thread_idx, r17, r18);
+    r10 = fma(r17, r30, r18 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r24, r10);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 4 * pose_jac_num_alloc, global_thread_idx, r10, r24);
+    r23 = fma(r10, r30, r24 * r37);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 6 * pose_jac_num_alloc, global_thread_idx, r2, r13);
+    r3 = fma(r2, r30, r13 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r23, r3);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 8 * pose_jac_num_alloc, global_thread_idx, r3, r23);
+    r38 = fma(r3, r30, r23 * r37);
+    ReadIdx2<1024, double, double, double2>(
+        pose_jac, 10 * pose_jac_num_alloc, global_thread_idx, r39, r40);
+    r30 = fma(r39, r30, r40 * r37);
+    WriteSum2<double, double>((double*)inout_shared, r38, r30);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_njtr_indices_loc,
+                            (double*)inout_shared);
+  LoadShared<2, double, double>(pose_njtr,
+                                4 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r30,
+                        r38);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r3 = fma(r30, r3, r38 * r39);
+  };
+  LoadShared<2, double, double>(pose_njtr,
+                                2 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r39,
+                        r37);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(pose_njtr,
+                                0 * pose_njtr_num_alloc,
+                                pose_njtr_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        pose_njtr_indices_loc[threadIdx.x].target,
+                        r41,
+                        r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r3 = fma(r39, r10, r3);
+    r3 = fma(r37, r2, r3);
+    r3 = fma(r41, r0, r3);
+    r3 = fma(r42, r17, r3);
+    r31 = r3 + r31;
+    r15 = r15 * r31;
+    r13 = fma(r37, r13, r38 * r40);
+    r13 = fma(r39, r24, r13);
+    r13 = fma(r41, r1, r13);
+    r13 = fma(r42, r18, r13);
+    r13 = fma(r30, r23, r13);
+    r34 = r13 + r34;
+    r16 = r16 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r15, r16);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r7 = fma(r7, r34, r6 * r31);
+    r5 = fma(r5, r34, r4 * r31);
+    WriteSum2<double, double>((double*)inout_shared, r7, r5);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r12 = fma(r12, r34, r11 * r31);
+    r28 = fma(r28, r34, r27 * r31);
+    WriteSum2<double, double>((double*)inout_shared, r12, r28);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r22 = fma(r22, r34, r21 * r31);
+    r20 = fma(r20, r34, r19 * r31);
+    WriteSum2<double, double>((double*)inout_shared, r22, r20);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r25 * r31;
+    r34 = r26 * r34;
+    WriteSum2<double, double>((double*)inout_shared, r31, r34);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r13 = r8 + r13;
+    r3 = r9 + r3;
+    r35 = fma(r35, r3, r36 * r13);
+    r32 = fma(r32, r3, r33 * r13);
+    WriteSum2<double, double>((double*)inout_shared, r35, r32);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r3 = fma(r14, r3, r29 * r13);
+    WriteSum1<double, double>((double*)inout_shared, r3);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_njtr_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirectKernel<<<n_blocks,
+                                                                1024>>>(
+      pose_njtr,
+      pose_njtr_num_alloc,
+      pose_njtr_indices,
+      pose_jac,
+      pose_jac_num_alloc,
+      focal_and_extra_njtr,
+      focal_and_extra_njtr_num_alloc,
+      focal_and_extra_njtr_indices,
+      focal_and_extra_jac,
+      focal_and_extra_jac_num_alloc,
+      point_njtr,
+      point_njtr_num_alloc,
+      point_njtr_indices,
+      point_jac,
+      point_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+    double* pose_njtr,
+    unsigned int pose_njtr_num_alloc,
+    SharedIndex* pose_njtr_indices,
+    double* pose_jac,
+    unsigned int pose_jac_num_alloc,
+    double* focal_and_extra_njtr,
+    unsigned int focal_and_extra_njtr_num_alloc,
+    SharedIndex* focal_and_extra_njtr_indices,
+    double* focal_and_extra_jac,
+    unsigned int focal_and_extra_jac_num_alloc,
+    double* point_njtr,
+    unsigned int point_njtr_num_alloc,
+    SharedIndex* point_njtr_indices,
+    double* point_jac,
+    unsigned int point_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.cu
@@ -1,0 +1,2945 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointResJacKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r64,
+                        r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r67 = fma(r64, r48, r5 * r61);
+    r68 = 1.0 / r31;
+    r69 = 1.0 / r47;
+    r70 = r68 * r69;
+    r71 = r56 * r70;
+    r72 = r6 * r71;
+    r73 = r4 * r7;
+    r74 = r10 * r59;
+    r73 = r73 * r62;
+    r67 = fma(r74, r73, r67);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r75,
+                        r76);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r77 = r48 * r48;
+    r78 = fma(r76, r77, r75 * r48);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r79,
+                        r80);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r81 = r77 * r77;
+    r82 = r48 * r77;
+    r78 = fma(r80, r81, r78);
+    r78 = fma(r79, r82, r78);
+    r83 = r78 * r71;
+    r67 = r67 + r72;
+    r67 = fma(r6, r83, r67);
+    r0 = fma(r2, r67, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r73, r84);
+    r0 = fma(r73, r21, r0);
+    r73 = r7 * r7;
+    r73 = r73 * r60;
+    r73 = r73 * r43;
+    r73 = fma(r59, r73, r66);
+    r66 = fma(r65, r48, r4 * r73);
+    r85 = r5 * r7;
+    r85 = r85 * r62;
+    r66 = fma(r74, r85, r66);
+    r66 = fma(r7, r83, r66);
+    r66 = fma(r7, r71, r66);
+    r1 = fma(r3, r66, r1);
+    r1 = fma(r84, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r84 = 5.00000000000000000e-01;
+    r85 = r6 * r84;
+    r86 = rsqrt(r30);
+    r87 = r10 * r6;
+    r88 = r11 * r14;
+    r89 = -5.00000000000000000e-01;
+    r90 = r16 * r17;
+    r90 = fma(r89, r90, r89 * r88);
+    r88 = r15 * r18;
+    r90 = fma(r89, r88, r90);
+    r91 = r12 * r13;
+    r90 = fma(r84, r91, r90);
+    r91 = r24 * r90;
+    r88 = r15 * r14;
+    r92 = r12 * r17;
+    r92 = fma(r84, r92, r84 * r88);
+    r88 = r11 * r18;
+    r92 = fma(r89, r88, r92);
+    r93 = r16 * r13;
+    r92 = fma(r84, r93, r92);
+    r93 = r29 * r92;
+    r88 = fma(r10, r93, r10 * r91);
+    r94 = r10 * r19;
+    r95 = fma(r84, r26, r89 * r22);
+    r95 = fma(r89, r23, r95);
+    r95 = fma(r89, r25, r95);
+    r96 = r10 * r27;
+    r97 = r16 * r14;
+    r98 = r11 * r17;
+    r98 = fma(r89, r98, r84 * r97);
+    r97 = r12 * r18;
+    r98 = fma(r89, r97, r98);
+    r99 = r15 * r13;
+    r98 = fma(r89, r99, r98);
+    r96 = r96 * r98;
+    r94 = fma(r95, r94, r96);
+    r88 = r88 + r94;
+    r99 = r10 * r24;
+    r99 = r99 * r98;
+    r97 = r10 * r19;
+    r97 = r97 * r92;
+    r100 = r99 + r97;
+    r101 = r27 * r35;
+    r100 = fma(r90, r101, r100);
+    r102 = r35 * r29;
+    r100 = fma(r95, r102, r100);
+    r100 = fma(r9, r100, r42 * r88);
+    r88 = r24 * r92;
+    r102 = -4.00000000000000000e+00;
+    r88 = r88 * r102;
+    r101 = r27 * r95;
+    r103 = r102 * r101;
+    r104 = r88 + r103;
+    r100 = fma(r8, r104, r100);
+    r87 = r87 * r100;
+    r104 = r6 * r6;
+    r105 = r10 * r24;
+    r105 = r105 * r95;
+    r106 = r10 * r27;
+    r106 = fma(r92, r106, r105);
+    r92 = r10 * r19;
+    r92 = r92 * r90;
+    r107 = r10 * r29;
+    r107 = r107 * r98;
+    r108 = r92 + r107;
+    r109 = r106 + r108;
+    r93 = fma(r35, r93, r35 * r91);
+    r93 = r93 + r94;
+    r93 = fma(r8, r93, r9 * r109);
+    r109 = r19 * r98;
+    r109 = r109 * r102;
+    r88 = r88 + r109;
+    r93 = fma(r42, r88, r93);
+    r57 = r31 * r57;
+    r88 = 1.0 / r57;
+    r110 = r35 * r88;
+    r104 = r104 * r93;
+    r104 = fma(r110, r104, r39 * r87);
+    r87 = r93 * r110;
+    r111 = r7 * r7;
+    r104 = fma(r111, r87, r104);
+    r112 = r10 * r7;
+    r113 = r19 * r35;
+    r114 = r35 * r29;
+    r114 = r114 * r98;
+    r113 = fma(r90, r113, r114);
+    r113 = r113 + r106;
+    r103 = r109 + r103;
+    r103 = fma(r9, r103, r42 * r113);
+    r113 = r10 * r29;
+    r113 = fma(r95, r113, r97);
+    r97 = r10 * r27;
+    r97 = fma(r90, r97, r99);
+    r113 = r113 + r97;
+    r103 = fma(r8, r113, r103);
+    r112 = r112 * r103;
+    r104 = fma(r39, r112, r104);
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r85 = r85 * r68;
+    r85 = r85 * r69;
+    r85 = r85 * r86;
+    r85 = r85 * r104;
+    r85 = r85 * r30;
+    r36 = r43 * r111;
+    r112 = r56 * r56;
+    r87 = r110 * r112;
+    r36 = r36 * r87;
+    r113 = r7 * r86;
+    r99 = r104 * r113;
+    r109 = r30 * r53;
+    r106 = r7 * r43;
+    r99 = r99 * r109;
+    r99 = fma(r106, r99, r93 * r36);
+    r115 = r21 * r7;
+    r49 = r47 * r49;
+    r116 = 1.0 / r49;
+    r117 = r116 * r59;
+    r117 = r117 * r113;
+    r115 = r115 * r104;
+    r99 = fma(r117, r115, r99);
+    r118 = r74 * r106;
+    r99 = fma(r103, r118, r99);
+    r115 = r86 * r109;
+    r115 = r115 * r63;
+    r119 = r21 * r6;
+    r119 = r119 * r6;
+    r119 = r119 * r104;
+    r119 = r119 * r86;
+    r119 = r119 * r116;
+    r119 = fma(r59, r119, r104 * r115);
+    r120 = r100 * r62;
+    r119 = fma(r74, r120, r119);
+    r121 = r93 * r63;
+    r119 = fma(r87, r121, r119);
+    r121 = r99 + r119;
+    r120 = fma(r64, r121, r85);
+    r122 = r60 * r104;
+    r123 = r6 * r6;
+    r124 = -3.00000000000000000e+00;
+    r123 = r123 * r124;
+    r123 = r123 * r104;
+    r123 = r123 * r86;
+    r123 = r123 * r116;
+    r123 = fma(r59, r123, r115 * r122);
+    r122 = 6.00000000000000000e+00;
+    r125 = r100 * r122;
+    r125 = r125 * r59;
+    r123 = fma(r62, r125, r123);
+    r126 = r63 * r112;
+    r127 = -6.00000000000000000e+00;
+    r128 = r93 * r127;
+    r128 = r128 * r88;
+    r123 = fma(r128, r126, r123);
+    r123 = r123 + r99;
+    r99 = r4 * r100;
+    r120 = fma(r118, r99, r120);
+    r126 = r56 * r89;
+    r126 = r126 * r104;
+    r126 = r126 * r68;
+    r126 = r126 * r86;
+    r120 = fma(r62, r126, r120);
+    r125 = r56 * r78;
+    r125 = r125 * r89;
+    r125 = r125 * r104;
+    r125 = r125 * r68;
+    r125 = r125 * r86;
+    r120 = fma(r62, r125, r120);
+    r129 = r21 * r6;
+    r129 = r129 * r78;
+    r129 = r129 * r93;
+    r129 = r129 * r69;
+    r120 = fma(r53, r129, r120);
+    r130 = r4 * r104;
+    r131 = r35 * r6;
+    r131 = r131 * r117;
+    r120 = fma(r131, r130, r120);
+    r132 = r4 * r103;
+    r132 = r132 * r62;
+    r120 = fma(r74, r132, r120);
+    r133 = r4 * r7;
+    r133 = r133 * r56;
+    r133 = r133 * r56;
+    r133 = r133 * r102;
+    r133 = r133 * r88;
+    r133 = r133 * r62;
+    r134 = r4 * r104;
+    r135 = r10 * r62;
+    r135 = r135 * r113;
+    r135 = r135 * r109;
+    r120 = fma(r135, r134, r120);
+    r136 = r76 * r10;
+    r136 = r136 * r48;
+    r136 = fma(r75, r121, r121 * r136);
+    r79 = r79 * r60;
+    r79 = r79 * r77;
+    r137 = 4.00000000000000000e+00;
+    r80 = r80 * r137;
+    r80 = r80 * r82;
+    r136 = fma(r121, r79, r136);
+    r136 = fma(r121, r80, r136);
+    r138 = r6 * r136;
+    r120 = fma(r71, r138, r120);
+    r139 = r21 * r6;
+    r139 = r139 * r93;
+    r139 = r139 * r69;
+    r120 = fma(r53, r139, r120);
+    r120 = fma(r5, r123, r120);
+    r120 = fma(r78, r85, r120);
+    r120 = fma(r100, r83, r120);
+    r120 = fma(r93, r133, r120);
+    r120 = fma(r100, r71, r120);
+    r139 = r2 * r120;
+    r138 = r7 * r7;
+    r138 = r138 * r56;
+    r138 = r138 * r56;
+    r138 = r138 * r43;
+    r134 = r60 * r104;
+    r134 = r134 * r113;
+    r134 = r134 * r109;
+    r134 = fma(r106, r134, r128 * r138);
+    r138 = r7 * r124;
+    r138 = r138 * r104;
+    r134 = fma(r117, r138, r134);
+    r128 = r7 * r103;
+    r128 = r128 * r122;
+    r128 = r128 * r43;
+    r134 = fma(r59, r128, r134);
+    r134 = r134 + r119;
+    r134 = fma(r4, r134, r65 * r121);
+    r121 = r5 * r118;
+    r119 = r21 * r7;
+    r119 = r119 * r93;
+    r119 = r119 * r69;
+    r134 = fma(r53, r119, r134);
+    r128 = r56 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r68;
+    r128 = r128 * r113;
+    r138 = r78 * r128;
+    r132 = r5 * r104;
+    r134 = fma(r131, r132, r134);
+    r130 = r84 * r104;
+    r130 = r130 * r30;
+    r130 = r130 * r70;
+    r85 = r5 * r103;
+    r85 = r85 * r62;
+    r134 = fma(r74, r85, r134);
+    r129 = r5 * r7;
+    r129 = r129 * r56;
+    r129 = r129 * r56;
+    r129 = r129 * r102;
+    r129 = r129 * r93;
+    r129 = r129 * r88;
+    r134 = fma(r62, r129, r134);
+    r125 = r7 * r136;
+    r134 = fma(r71, r125, r134);
+    r126 = r5 * r104;
+    r134 = fma(r135, r126, r134);
+    r99 = r78 * r113;
+    r134 = fma(r130, r99, r134);
+    r123 = r21 * r7;
+    r123 = r123 * r78;
+    r123 = r123 * r93;
+    r123 = r123 * r69;
+    r134 = fma(r53, r123, r134);
+    r134 = fma(r100, r121, r134);
+    r134 = fma(r104, r138, r134);
+    r134 = fma(r104, r128, r134);
+    r134 = fma(r113, r130, r134);
+    r134 = fma(r103, r83, r134);
+    r134 = fma(r103, r71, r134);
+    r123 = r3 * r134;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r139,
+                                             r123);
+    r123 = r35 * r24;
+    r123 = fma(r95, r123, r114);
+    r139 = r10 * r27;
+    r99 = r15 * r14;
+    r126 = r12 * r17;
+    r126 = fma(r89, r126, r89 * r99);
+    r99 = r11 * r18;
+    r126 = fma(r84, r99, r126);
+    r125 = r16 * r13;
+    r126 = fma(r89, r125, r126);
+    r139 = r139 * r126;
+    r125 = r10 * r19;
+    r99 = r11 * r14;
+    r129 = r16 * r17;
+    r129 = fma(r84, r129, r84 * r99);
+    r99 = r15 * r18;
+    r129 = fma(r84, r99, r129);
+    r85 = r12 * r13;
+    r129 = fma(r89, r85, r129);
+    r125 = fma(r129, r125, r139);
+    r123 = r123 + r125;
+    r85 = r10 * r24;
+    r85 = r85 * r129;
+    r99 = r10 * r29;
+    r99 = fma(r126, r99, r85);
+    r99 = r99 + r94;
+    r99 = fma(r9, r99, r8 * r123);
+    r123 = r24 * r98;
+    r123 = r123 * r102;
+    r94 = r19 * r126;
+    r130 = r102 * r94;
+    r132 = r123 + r130;
+    r99 = fma(r42, r132, r99);
+    r132 = r127 * r99;
+    r132 = r132 * r88;
+    r132 = r132 * r63;
+    r107 = r105 + r107;
+    r107 = r107 + r125;
+    r125 = r27 * r102;
+    r125 = r125 * r129;
+    r123 = r123 + r125;
+    r123 = fma(r8, r123, r42 * r107);
+    r107 = r35 * r29;
+    r107 = fma(r35, r101, r129 * r107);
+    r105 = r10 * r19;
+    r105 = r105 * r98;
+    r119 = r10 * r24;
+    r119 = fma(r126, r119, r105);
+    r107 = r107 + r119;
+    r123 = fma(r9, r107, r123);
+    r107 = r122 * r123;
+    r107 = r107 * r59;
+    r107 = fma(r62, r107, r112 * r132);
+    r132 = r6 * r6;
+    r140 = r10 * r6;
+    r140 = r140 * r123;
+    r141 = r10 * r7;
+    r85 = r96 + r85;
+    r96 = r19 * r35;
+    r85 = fma(r95, r96, r85);
+    r95 = r35 * r29;
+    r85 = fma(r126, r95, r85);
+    r95 = r10 * r29;
+    r101 = fma(r10, r101, r129 * r95);
+    r101 = r101 + r119;
+    r101 = fma(r8, r101, r42 * r85);
+    r130 = r125 + r130;
+    r101 = fma(r9, r130, r101);
+    r141 = r141 * r101;
+    r141 = fma(r39, r141, r39 * r140);
+    r140 = r99 * r110;
+    r141 = fma(r111, r140, r141);
+    r130 = r6 * r6;
+    r130 = r130 * r99;
+    r141 = fma(r110, r130, r141);
+    r130 = r124 * r141;
+    r132 = r132 * r86;
+    r132 = r132 * r116;
+    r132 = r132 * r59;
+    r107 = fma(r130, r132, r107);
+    r140 = r60 * r141;
+    r107 = fma(r115, r140, r107);
+    r125 = r21 * r7;
+    r125 = r125 * r141;
+    r125 = fma(r117, r125, r101 * r118);
+    r85 = r141 * r113;
+    r85 = r85 * r109;
+    r125 = fma(r106, r85, r125);
+    r125 = fma(r99, r36, r125);
+    r107 = r107 + r125;
+    r140 = r99 * r63;
+    r132 = r123 * r62;
+    r132 = fma(r74, r132, r87 * r140);
+    r140 = r21 * r6;
+    r140 = r140 * r6;
+    r140 = r140 * r141;
+    r140 = r140 * r86;
+    r140 = r140 * r116;
+    r132 = fma(r59, r140, r132);
+    r132 = fma(r141, r115, r132);
+    r125 = r125 + r132;
+    r107 = fma(r64, r125, r5 * r107);
+    r140 = r21 * r6;
+    r140 = r140 * r99;
+    r140 = r140 * r69;
+    r107 = fma(r53, r140, r107);
+    r85 = r6 * r84;
+    r85 = r85 * r78;
+    r85 = r85 * r141;
+    r85 = r85 * r86;
+    r85 = r85 * r30;
+    r107 = fma(r70, r85, r107);
+    r95 = r6 * r84;
+    r95 = r95 * r141;
+    r95 = r95 * r86;
+    r95 = r95 * r30;
+    r107 = fma(r70, r95, r107);
+    r129 = r56 * r78;
+    r129 = r129 * r89;
+    r129 = r129 * r141;
+    r129 = r129 * r68;
+    r129 = r129 * r86;
+    r107 = fma(r62, r129, r107);
+    r96 = r76 * r10;
+    r96 = r96 * r48;
+    r96 = fma(r125, r96, r75 * r125);
+    r96 = fma(r125, r80, r96);
+    r96 = fma(r125, r79, r96);
+    r142 = r6 * r96;
+    r107 = fma(r71, r142, r107);
+    r143 = r21 * r6;
+    r143 = r143 * r78;
+    r143 = r143 * r99;
+    r143 = r143 * r69;
+    r107 = fma(r53, r143, r107);
+    r144 = r4 * r141;
+    r107 = fma(r135, r144, r107);
+    r145 = r4 * r141;
+    r107 = fma(r131, r145, r107);
+    r146 = r4 * r101;
+    r146 = r146 * r62;
+    r107 = fma(r74, r146, r107);
+    r147 = r4 * r123;
+    r107 = fma(r118, r147, r107);
+    r148 = r56 * r89;
+    r148 = r148 * r141;
+    r148 = r148 * r68;
+    r148 = r148 * r86;
+    r107 = fma(r62, r148, r107);
+    r107 = fma(r99, r133, r107);
+    r107 = fma(r123, r71, r107);
+    r107 = fma(r123, r83, r107);
+    r148 = r2 * r107;
+    r147 = r7 * r122;
+    r147 = r147 * r101;
+    r147 = r147 * r43;
+    r146 = r7 * r117;
+    r146 = fma(r130, r146, r59 * r147);
+    r147 = r7 * r7;
+    r147 = r147 * r56;
+    r147 = r147 * r56;
+    r147 = r147 * r127;
+    r147 = r147 * r99;
+    r147 = r147 * r43;
+    r146 = fma(r88, r147, r146);
+    r130 = r60 * r141;
+    r130 = r130 * r113;
+    r130 = r130 * r109;
+    r146 = fma(r106, r130, r146);
+    r146 = r146 + r132;
+    r125 = fma(r65, r125, r4 * r146);
+    r146 = r7 * r96;
+    r125 = fma(r71, r146, r125);
+    r132 = r84 * r141;
+    r132 = r132 * r30;
+    r132 = r132 * r70;
+    r125 = fma(r113, r132, r125);
+    r130 = r5 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r102;
+    r130 = r130 * r99;
+    r130 = r130 * r88;
+    r125 = fma(r62, r130, r125);
+    r147 = r5 * r141;
+    r125 = fma(r135, r147, r125);
+    r145 = r21 * r7;
+    r145 = r145 * r78;
+    r145 = r145 * r99;
+    r145 = r145 * r69;
+    r125 = fma(r53, r145, r125);
+    r144 = r5 * r141;
+    r125 = fma(r131, r144, r125);
+    r143 = r21 * r7;
+    r143 = r143 * r99;
+    r143 = r143 * r69;
+    r125 = fma(r53, r143, r125);
+    r142 = r5 * r101;
+    r142 = r142 * r62;
+    r125 = fma(r74, r142, r125);
+    r129 = r84 * r78;
+    r129 = r129 * r141;
+    r129 = r129 * r30;
+    r129 = r129 * r70;
+    r125 = fma(r113, r129, r125);
+    r125 = fma(r141, r128, r125);
+    r125 = fma(r101, r83, r125);
+    r125 = fma(r141, r138, r125);
+    r125 = fma(r101, r71, r125);
+    r125 = fma(r123, r121, r125);
+    r129 = r3 * r125;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r148,
+                                             r129);
+    r129 = r19 * r102;
+    r26 = fma(r89, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r129 = r129 * r26;
+    r91 = r102 * r91;
+    r25 = r129 + r91;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r105 = r105 + r23;
+    r22 = r35 * r24;
+    r105 = fma(r126, r22, r105);
+    r148 = r35 * r29;
+    r105 = fma(r90, r148, r105);
+    r105 = fma(r8, r105, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r94, r26 * r25);
+    r25 = r25 + r97;
+    r105 = fma(r9, r25, r105);
+    r25 = r10 * r7;
+    r148 = r10 * r24;
+    r148 = r148 * r26;
+    r139 = r139 + r148;
+    r139 = r139 + r108;
+    r108 = r35 * r29;
+    r94 = fma(r35, r94, r26 * r108);
+    r94 = r94 + r97;
+    r94 = fma(r42, r94, r8 * r139);
+    r98 = r27 * r98;
+    r98 = r98 * r102;
+    r129 = r129 + r98;
+    r94 = fma(r9, r129, r94);
+    r25 = r25 * r94;
+    r129 = r6 * r6;
+    r129 = r129 * r105;
+    r129 = fma(r110, r129, r39 * r25);
+    r25 = r10 * r6;
+    r114 = r92 + r114;
+    r92 = r27 * r35;
+    r114 = fma(r126, r92, r114);
+    r114 = r114 + r148;
+    r91 = r98 + r91;
+    r91 = fma(r8, r91, r9 * r114);
+    r8 = r10 * r29;
+    r8 = fma(r90, r8, r23);
+    r8 = r8 + r119;
+    r91 = fma(r42, r8, r91);
+    r25 = r25 * r91;
+    r129 = fma(r39, r25, r129);
+    r8 = r105 * r110;
+    r129 = fma(r111, r8, r129);
+    r8 = r129 * r113;
+    r8 = r8 * r109;
+    r8 = fma(r106, r8, r105 * r36);
+    r25 = r21 * r7;
+    r25 = r25 * r129;
+    r8 = fma(r117, r25, r8);
+    r8 = fma(r94, r118, r8);
+    r25 = r21 * r6;
+    r25 = r25 * r6;
+    r25 = r25 * r129;
+    r25 = r25 * r86;
+    r25 = r25 * r116;
+    r42 = r91 * r62;
+    r42 = fma(r74, r42, r59 * r25);
+    r25 = r105 * r63;
+    r42 = fma(r87, r25, r42);
+    r42 = fma(r129, r115, r42);
+    r25 = r8 + r42;
+    r119 = r6 * r6;
+    r119 = r119 * r124;
+    r119 = r119 * r129;
+    r119 = r119 * r86;
+    r119 = r119 * r116;
+    r23 = r122 * r91;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r119);
+    r119 = r127 * r105;
+    r119 = r119 * r88;
+    r119 = r119 * r63;
+    r23 = fma(r112, r119, r23);
+    r90 = r60 * r129;
+    r23 = fma(r115, r90, r23);
+    r23 = r23 + r8;
+    r23 = fma(r5, r23, r64 * r25);
+    r8 = r76 * r10;
+    r8 = r8 * r48;
+    r8 = fma(r25, r8, r75 * r25);
+    r8 = fma(r25, r79, r8);
+    r8 = fma(r25, r80, r8);
+    r90 = r6 * r8;
+    r23 = fma(r71, r90, r23);
+    r119 = r4 * r91;
+    r23 = fma(r118, r119, r23);
+    r114 = r6 * r84;
+    r114 = r114 * r129;
+    r114 = r114 * r86;
+    r114 = r114 * r30;
+    r23 = fma(r70, r114, r23);
+    r9 = r4 * r129;
+    r23 = fma(r135, r9, r23);
+    r98 = r21 * r6;
+    r98 = r98 * r78;
+    r98 = r98 * r105;
+    r98 = r98 * r69;
+    r23 = fma(r53, r98, r23);
+    r92 = r6 * r84;
+    r92 = r92 * r78;
+    r92 = r92 * r129;
+    r92 = r92 * r86;
+    r92 = r92 * r30;
+    r23 = fma(r70, r92, r23);
+    r148 = r4 * r129;
+    r23 = fma(r131, r148, r23);
+    r126 = r21 * r6;
+    r126 = r126 * r105;
+    r126 = r126 * r69;
+    r23 = fma(r53, r126, r23);
+    r139 = r56 * r89;
+    r139 = r139 * r129;
+    r139 = r139 * r68;
+    r139 = r139 * r86;
+    r23 = fma(r62, r139, r23);
+    r97 = r4 * r94;
+    r97 = r97 * r62;
+    r23 = fma(r74, r97, r23);
+    r108 = r56 * r78;
+    r108 = r108 * r89;
+    r108 = r108 * r129;
+    r108 = r108 * r68;
+    r108 = r108 * r86;
+    r23 = fma(r62, r108, r23);
+    r23 = fma(r91, r83, r23);
+    r23 = fma(r91, r71, r23);
+    r23 = fma(r105, r133, r23);
+    r108 = r2 * r23;
+    r97 = r7 * r7;
+    r97 = r97 * r56;
+    r97 = r97 * r56;
+    r97 = r97 * r127;
+    r97 = r97 * r105;
+    r97 = r97 * r43;
+    r139 = r60 * r129;
+    r139 = r139 * r113;
+    r139 = r139 * r109;
+    r139 = fma(r106, r139, r88 * r97);
+    r97 = r7 * r122;
+    r97 = r97 * r94;
+    r97 = r97 * r43;
+    r139 = fma(r59, r97, r139);
+    r126 = r7 * r124;
+    r126 = r126 * r129;
+    r139 = fma(r117, r126, r139);
+    r139 = r139 + r42;
+    r139 = fma(r4, r139, r65 * r25);
+    r25 = r21 * r7;
+    r25 = r25 * r78;
+    r25 = r25 * r105;
+    r25 = r25 * r69;
+    r139 = fma(r53, r25, r139);
+    r42 = r21 * r7;
+    r42 = r42 * r105;
+    r42 = r42 * r69;
+    r139 = fma(r53, r42, r139);
+    r126 = r5 * r129;
+    r139 = fma(r135, r126, r139);
+    r97 = r84 * r129;
+    r97 = r97 * r30;
+    r97 = r97 * r70;
+    r139 = fma(r113, r97, r139);
+    r148 = r5 * r129;
+    r139 = fma(r131, r148, r139);
+    r92 = r7 * r8;
+    r139 = fma(r71, r92, r139);
+    r98 = r84 * r78;
+    r98 = r98 * r129;
+    r98 = r98 * r30;
+    r98 = r98 * r70;
+    r139 = fma(r113, r98, r139);
+    r9 = r5 * r7;
+    r9 = r9 * r56;
+    r9 = r9 * r56;
+    r9 = r9 * r102;
+    r9 = r9 * r105;
+    r9 = r9 * r88;
+    r139 = fma(r62, r9, r139);
+    r114 = r5 * r94;
+    r114 = r114 * r62;
+    r139 = fma(r74, r114, r139);
+    r139 = fma(r94, r83, r139);
+    r139 = fma(r91, r121, r139);
+    r139 = fma(r129, r138, r139);
+    r139 = fma(r94, r71, r139);
+    r139 = fma(r129, r128, r139);
+    r114 = r3 * r139;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r108,
+                                             r114);
+    r114 = r37 * r122;
+    r114 = r114 * r59;
+    r108 = r6 * r6;
+    r9 = r10 * r33;
+    r9 = r9 * r7;
+    r98 = r20 * r110;
+    r98 = fma(r111, r98, r39 * r9);
+    r9 = r20 * r6;
+    r9 = r9 * r6;
+    r98 = fma(r110, r9, r98);
+    r92 = r10 * r37;
+    r92 = r92 * r6;
+    r98 = fma(r39, r92, r98);
+    r108 = r108 * r124;
+    r108 = r108 * r98;
+    r108 = r108 * r86;
+    r108 = r108 * r116;
+    r108 = fma(r59, r108, r62 * r114);
+    r114 = r60 * r98;
+    r108 = fma(r115, r114, r108);
+    r92 = r20 * r127;
+    r92 = r92 * r88;
+    r92 = r92 * r63;
+    r108 = fma(r112, r92, r108);
+    r9 = r21 * r7;
+    r9 = r9 * r98;
+    r9 = fma(r117, r9, r33 * r118);
+    r148 = r98 * r113;
+    r148 = r148 * r109;
+    r9 = fma(r106, r148, r9);
+    r9 = fma(r20, r36, r9);
+    r108 = r108 + r9;
+    r92 = r37 * r62;
+    r114 = r21 * r6;
+    r114 = r114 * r6;
+    r114 = r114 * r98;
+    r114 = r114 * r86;
+    r114 = r114 * r116;
+    r114 = fma(r59, r114, r74 * r92);
+    r92 = r20 * r63;
+    r114 = fma(r87, r92, r114);
+    r114 = fma(r98, r115, r114);
+    r9 = r9 + r114;
+    r108 = fma(r64, r9, r5 * r108);
+    r92 = r6 * r84;
+    r92 = r92 * r78;
+    r92 = r92 * r98;
+    r92 = r92 * r86;
+    r92 = r92 * r30;
+    r108 = fma(r70, r92, r108);
+    r148 = r98 * r135;
+    r97 = r6 * r84;
+    r97 = r97 * r98;
+    r97 = r97 * r86;
+    r97 = r97 * r30;
+    r108 = fma(r70, r97, r108);
+    r126 = r56 * r78;
+    r126 = r126 * r89;
+    r126 = r126 * r98;
+    r126 = r126 * r68;
+    r126 = r126 * r86;
+    r108 = fma(r62, r126, r108);
+    r42 = r56 * r89;
+    r42 = r42 * r98;
+    r42 = r42 * r68;
+    r42 = r42 * r86;
+    r108 = fma(r62, r42, r108);
+    r25 = r4 * r98;
+    r108 = fma(r131, r25, r108);
+    r119 = r76 * r10;
+    r119 = r119 * r48;
+    r119 = fma(r75, r9, r9 * r119);
+    r119 = fma(r9, r80, r119);
+    r119 = fma(r9, r79, r119);
+    r90 = r6 * r119;
+    r108 = fma(r71, r90, r108);
+    r26 = r21 * r20;
+    r26 = r26 * r6;
+    r26 = r26 * r78;
+    r26 = r26 * r69;
+    r108 = fma(r53, r26, r108);
+    r22 = r21 * r20;
+    r22 = r22 * r6;
+    r22 = r22 * r69;
+    r108 = fma(r53, r22, r108);
+    r142 = r4 * r33;
+    r142 = r142 * r62;
+    r108 = fma(r74, r142, r108);
+    r143 = r4 * r37;
+    r108 = fma(r118, r143, r108);
+    r108 = fma(r37, r83, r108);
+    r108 = fma(r4, r148, r108);
+    r108 = fma(r20, r133, r108);
+    r108 = fma(r37, r71, r108);
+    r143 = r2 * r108;
+    r142 = r33 * r7;
+    r142 = r142 * r122;
+    r142 = r142 * r43;
+    r22 = r7 * r124;
+    r22 = r22 * r98;
+    r22 = fma(r117, r22, r59 * r142);
+    r142 = r20 * r7;
+    r142 = r142 * r7;
+    r142 = r142 * r56;
+    r142 = r142 * r56;
+    r142 = r142 * r127;
+    r142 = r142 * r43;
+    r22 = fma(r88, r142, r22);
+    r26 = r60 * r98;
+    r26 = r26 * r113;
+    r26 = r26 * r109;
+    r22 = fma(r106, r26, r22);
+    r22 = r22 + r114;
+    r9 = fma(r65, r9, r4 * r22);
+    r22 = r84 * r98;
+    r22 = r22 * r30;
+    r22 = r22 * r70;
+    r9 = fma(r113, r22, r9);
+    r114 = r21 * r20;
+    r114 = r114 * r7;
+    r114 = r114 * r78;
+    r114 = r114 * r69;
+    r9 = fma(r53, r114, r9);
+    r26 = r21 * r20;
+    r26 = r26 * r7;
+    r26 = r26 * r69;
+    r9 = fma(r53, r26, r9);
+    r142 = r5 * r98;
+    r9 = fma(r131, r142, r9);
+    r90 = r5 * r20;
+    r90 = r90 * r7;
+    r90 = r90 * r56;
+    r90 = r90 * r56;
+    r90 = r90 * r102;
+    r90 = r90 * r88;
+    r9 = fma(r62, r90, r9);
+    r25 = r7 * r119;
+    r9 = fma(r71, r25, r9);
+    r42 = r84 * r78;
+    r42 = r42 * r98;
+    r42 = r42 * r30;
+    r42 = r42 * r70;
+    r9 = fma(r113, r42, r9);
+    r126 = r5 * r33;
+    r126 = r126 * r62;
+    r9 = fma(r74, r126, r9);
+    r9 = fma(r33, r71, r9);
+    r9 = fma(r98, r138, r9);
+    r9 = fma(r5, r148, r9);
+    r9 = fma(r33, r83, r9);
+    r9 = fma(r98, r128, r9);
+    r9 = fma(r37, r121, r9);
+    r126 = r3 * r9;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             6 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r143,
+                                             r126);
+    r126 = r34 * r110;
+    r143 = r10 * r38;
+    r143 = r143 * r7;
+    r143 = fma(r39, r143, r111 * r126);
+    r126 = r34 * r6;
+    r126 = r126 * r6;
+    r143 = fma(r110, r126, r143);
+    r42 = r10 * r55;
+    r42 = r42 * r6;
+    r143 = fma(r39, r42, r143);
+    r42 = r60 * r143;
+    r126 = r34 * r127;
+    r126 = r126 * r88;
+    r126 = r126 * r63;
+    r126 = fma(r112, r126, r115 * r42);
+    r42 = r6 * r6;
+    r42 = r42 * r124;
+    r42 = r42 * r143;
+    r42 = r42 * r86;
+    r42 = r42 * r116;
+    r126 = fma(r59, r42, r126);
+    r25 = r55 * r122;
+    r25 = r25 * r59;
+    r126 = fma(r62, r25, r126);
+    r90 = fma(r38, r118, r34 * r36);
+    r142 = r143 * r113;
+    r142 = r142 * r109;
+    r90 = fma(r106, r142, r90);
+    r26 = r21 * r7;
+    r26 = r26 * r143;
+    r90 = fma(r117, r26, r90);
+    r126 = r126 + r90;
+    r25 = r34 * r63;
+    r25 = fma(r87, r25, r143 * r115);
+    r42 = r21 * r6;
+    r42 = r42 * r6;
+    r42 = r42 * r143;
+    r42 = r42 * r86;
+    r42 = r42 * r116;
+    r25 = fma(r59, r42, r25);
+    r26 = r55 * r62;
+    r25 = fma(r74, r26, r25);
+    r90 = r90 + r25;
+    r126 = fma(r64, r90, r5 * r126);
+    r26 = r4 * r38;
+    r26 = r26 * r62;
+    r126 = fma(r74, r26, r126);
+    r42 = r4 * r143;
+    r126 = fma(r135, r42, r126);
+    r142 = r6 * r84;
+    r142 = r142 * r78;
+    r142 = r142 * r143;
+    r142 = r142 * r86;
+    r142 = r142 * r30;
+    r126 = fma(r70, r142, r126);
+    r148 = r21 * r34;
+    r148 = r148 * r6;
+    r148 = r148 * r69;
+    r126 = fma(r53, r148, r126);
+    r114 = r4 * r143;
+    r126 = fma(r131, r114, r126);
+    r22 = r6 * r84;
+    r22 = r22 * r143;
+    r22 = r22 * r86;
+    r22 = r22 * r30;
+    r126 = fma(r70, r22, r126);
+    r97 = r56 * r89;
+    r97 = r97 * r143;
+    r97 = r97 * r68;
+    r97 = r97 * r86;
+    r126 = fma(r62, r97, r126);
+    r92 = r76 * r10;
+    r92 = r92 * r48;
+    r92 = fma(r75, r90, r90 * r92);
+    r92 = fma(r90, r79, r92);
+    r92 = fma(r90, r80, r92);
+    r144 = r6 * r92;
+    r126 = fma(r71, r144, r126);
+    r145 = r56 * r78;
+    r145 = r145 * r89;
+    r145 = r145 * r143;
+    r145 = r145 * r68;
+    r145 = r145 * r86;
+    r126 = fma(r62, r145, r126);
+    r147 = r21 * r34;
+    r147 = r147 * r6;
+    r147 = r147 * r78;
+    r147 = r147 * r69;
+    r126 = fma(r53, r147, r126);
+    r130 = r4 * r55;
+    r126 = fma(r118, r130, r126);
+    r126 = fma(r55, r71, r126);
+    r126 = fma(r34, r133, r126);
+    r126 = fma(r55, r83, r126);
+    r130 = r2 * r126;
+    r147 = r34 * r7;
+    r147 = r147 * r7;
+    r147 = r147 * r56;
+    r147 = r147 * r56;
+    r147 = r147 * r127;
+    r147 = r147 * r43;
+    r145 = r38 * r7;
+    r145 = r145 * r122;
+    r145 = r145 * r43;
+    r145 = fma(r59, r145, r88 * r147);
+    r147 = r60 * r143;
+    r147 = r147 * r113;
+    r147 = r147 * r109;
+    r145 = fma(r106, r147, r145);
+    r144 = r7 * r124;
+    r144 = r144 * r143;
+    r145 = fma(r117, r144, r145);
+    r145 = r145 + r25;
+    r145 = fma(r4, r145, r65 * r90);
+    r90 = r21 * r34;
+    r90 = r90 * r7;
+    r90 = r90 * r69;
+    r145 = fma(r53, r90, r145);
+    r25 = r5 * r38;
+    r25 = r25 * r62;
+    r145 = fma(r74, r25, r145);
+    r144 = r5 * r143;
+    r145 = fma(r135, r144, r145);
+    r147 = r84 * r143;
+    r147 = r147 * r30;
+    r147 = r147 * r70;
+    r145 = fma(r113, r147, r145);
+    r97 = r7 * r92;
+    r145 = fma(r71, r97, r145);
+    r22 = r5 * r34;
+    r22 = r22 * r7;
+    r22 = r22 * r56;
+    r22 = r22 * r56;
+    r22 = r22 * r102;
+    r22 = r22 * r88;
+    r145 = fma(r62, r22, r145);
+    r114 = r5 * r143;
+    r145 = fma(r131, r114, r145);
+    r148 = r84 * r78;
+    r148 = r148 * r143;
+    r148 = r148 * r30;
+    r148 = r148 * r70;
+    r145 = fma(r113, r148, r145);
+    r142 = r21 * r34;
+    r142 = r142 * r7;
+    r142 = r142 * r78;
+    r142 = r142 * r69;
+    r145 = fma(r53, r142, r145);
+    r145 = fma(r38, r83, r145);
+    r145 = fma(r143, r138, r145);
+    r145 = fma(r143, r128, r145);
+    r145 = fma(r38, r71, r145);
+    r145 = fma(r55, r121, r145);
+    r142 = r3 * r145;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             8 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r130,
+                                             r142);
+    r142 = r6 * r6;
+    r130 = r10 * r41;
+    r130 = r130 * r7;
+    r148 = r32 * r110;
+    r148 = fma(r111, r148, r39 * r130);
+    r130 = r10 * r54;
+    r130 = r130 * r6;
+    r148 = fma(r39, r130, r148);
+    r114 = r32 * r6;
+    r114 = r114 * r6;
+    r148 = fma(r110, r114, r148);
+    r142 = r142 * r124;
+    r142 = r142 * r148;
+    r142 = r142 * r86;
+    r142 = r142 * r116;
+    r114 = r60 * r148;
+    r114 = fma(r115, r114, r59 * r142);
+    r142 = r54 * r122;
+    r142 = r142 * r59;
+    r114 = fma(r62, r142, r114);
+    r130 = r32 * r127;
+    r130 = r130 * r88;
+    r130 = r130 * r63;
+    r114 = fma(r112, r130, r114);
+    r22 = fma(r41, r118, r32 * r36);
+    r97 = r148 * r113;
+    r97 = r97 * r109;
+    r22 = fma(r106, r97, r22);
+    r147 = r21 * r7;
+    r147 = r147 * r148;
+    r22 = fma(r117, r147, r22);
+    r114 = r114 + r22;
+    r130 = r21 * r6;
+    r130 = r130 * r6;
+    r130 = r130 * r148;
+    r130 = r130 * r86;
+    r130 = r130 * r116;
+    r130 = fma(r148, r115, r59 * r130);
+    r142 = r54 * r62;
+    r130 = fma(r74, r142, r130);
+    r147 = r32 * r63;
+    r130 = fma(r87, r147, r130);
+    r22 = r22 + r130;
+    r114 = fma(r64, r22, r5 * r114);
+    r147 = r4 * r54;
+    r114 = fma(r118, r147, r114);
+    r142 = r4 * r41;
+    r142 = r142 * r62;
+    r114 = fma(r74, r142, r114);
+    r97 = r6 * r84;
+    r97 = r97 * r78;
+    r97 = r97 * r148;
+    r97 = r97 * r86;
+    r97 = r97 * r30;
+    r114 = fma(r70, r97, r114);
+    r144 = r6 * r84;
+    r144 = r144 * r148;
+    r144 = r144 * r86;
+    r144 = r144 * r30;
+    r114 = fma(r70, r144, r114);
+    r25 = r76 * r10;
+    r25 = r25 * r48;
+    r25 = fma(r22, r25, r75 * r22);
+    r25 = fma(r22, r80, r25);
+    r25 = fma(r22, r79, r25);
+    r90 = r6 * r25;
+    r114 = fma(r71, r90, r114);
+    r42 = r4 * r148;
+    r114 = fma(r135, r42, r114);
+    r26 = r21 * r32;
+    r26 = r26 * r6;
+    r26 = r26 * r69;
+    r114 = fma(r53, r26, r114);
+    r132 = r56 * r78;
+    r132 = r132 * r89;
+    r132 = r132 * r148;
+    r132 = r132 * r68;
+    r132 = r132 * r86;
+    r114 = fma(r62, r132, r114);
+    r146 = r4 * r148;
+    r114 = fma(r131, r146, r114);
+    r95 = r21 * r32;
+    r95 = r95 * r6;
+    r95 = r95 * r78;
+    r95 = r95 * r69;
+    r114 = fma(r53, r95, r114);
+    r85 = r56 * r89;
+    r85 = r85 * r148;
+    r85 = r85 * r68;
+    r85 = r85 * r86;
+    r114 = fma(r62, r85, r114);
+    r114 = fma(r54, r83, r114);
+    r114 = fma(r32, r133, r114);
+    r114 = fma(r54, r71, r114);
+    r85 = r2 * r114;
+    r95 = r32 * r7;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r56;
+    r95 = r95 * r127;
+    r95 = r95 * r43;
+    r146 = r41 * r7;
+    r146 = r146 * r122;
+    r146 = r146 * r43;
+    r146 = fma(r59, r146, r88 * r95);
+    r95 = r60 * r148;
+    r95 = r95 * r113;
+    r95 = r95 * r109;
+    r146 = fma(r106, r95, r146);
+    r132 = r7 * r124;
+    r132 = r132 * r148;
+    r146 = fma(r117, r132, r146);
+    r146 = r146 + r130;
+    r146 = fma(r4, r146, r65 * r22);
+    r22 = r21 * r32;
+    r22 = r22 * r7;
+    r22 = r22 * r69;
+    r146 = fma(r53, r22, r146);
+    r130 = r21 * r32;
+    r130 = r130 * r7;
+    r130 = r130 * r78;
+    r130 = r130 * r69;
+    r146 = fma(r53, r130, r146);
+    r132 = r84 * r78;
+    r132 = r132 * r148;
+    r132 = r132 * r30;
+    r132 = r132 * r70;
+    r146 = fma(r113, r132, r146);
+    r95 = r5 * r32;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r56;
+    r95 = r95 * r102;
+    r95 = r95 * r88;
+    r146 = fma(r62, r95, r146);
+    r26 = r5 * r41;
+    r26 = r26 * r62;
+    r146 = fma(r74, r26, r146);
+    r42 = r5 * r148;
+    r146 = fma(r135, r42, r146);
+    r90 = r84 * r148;
+    r90 = r90 * r30;
+    r90 = r90 * r70;
+    r146 = fma(r113, r90, r146);
+    r144 = r7 * r25;
+    r146 = fma(r71, r144, r146);
+    r97 = r5 * r148;
+    r146 = fma(r131, r97, r146);
+    r146 = fma(r148, r128, r146);
+    r146 = fma(r41, r71, r146);
+    r146 = fma(r54, r121, r146);
+    r146 = fma(r41, r83, r146);
+    r146 = fma(r148, r138, r146);
+    r97 = r3 * r146;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 10 * out_pose_jac_num_alloc, global_thread_idx, r85, r97);
+    r97 = r3 * r21;
+    r97 = r97 * r1;
+    r85 = r21 * r0;
+    r144 = r2 * r85;
+    r97 = fma(r120, r144, r134 * r97);
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r90 = fma(r107, r144, r125 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r97, r90);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r90 = fma(r23, r144, r139 * r90);
+    r97 = r3 * r21;
+    r97 = r97 * r1;
+    r97 = fma(r108, r144, r9 * r97);
+    WriteSum2<double, double>((double*)inout_shared, r90, r97);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r97 = r3 * r21;
+    r97 = r97 * r1;
+    r97 = fma(r126, r144, r145 * r97);
+    r90 = r3 * r21;
+    r90 = r90 * r1;
+    r90 = fma(r114, r144, r146 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r97, r90);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r120 * r120;
+    r97 = r2 * r2;
+    r42 = r134 * r134;
+    r26 = r3 * r3;
+    r42 = fma(r26, r42, r97 * r90);
+    r90 = r107 * r107;
+    r95 = r125 * r125;
+    r95 = fma(r26, r95, r97 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r23 * r23;
+    r42 = r139 * r139;
+    r42 = fma(r26, r42, r97 * r95);
+    r95 = r9 * r9;
+    r90 = r108 * r108;
+    r90 = fma(r97, r90, r26 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r126 * r126;
+    r42 = r145 * r145;
+    r42 = fma(r26, r42, r97 * r90);
+    r90 = r146 * r146;
+    r95 = r114 * r114;
+    r95 = fma(r97, r95, r26 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r134 * r125;
+    r42 = r120 * r107;
+    r42 = fma(r97, r42, r26 * r95);
+    r95 = r120 * r23;
+    r90 = r134 * r139;
+    r90 = fma(r26, r90, r97 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r120 * r108;
+    r42 = r134 * r9;
+    r42 = fma(r26, r42, r97 * r90);
+    r90 = r120 * r126;
+    r95 = r134 * r145;
+    r95 = fma(r26, r95, r97 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r134 * r146;
+    r42 = r120 * r114;
+    r42 = fma(r97, r42, r26 * r95);
+    r95 = r125 * r139;
+    r90 = r107 * r23;
+    r90 = fma(r97, r90, r26 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r107 * r108;
+    r42 = r125 * r9;
+    r42 = fma(r26, r42, r97 * r90);
+    r90 = r107 * r126;
+    r95 = r125 * r145;
+    r95 = fma(r26, r95, r97 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r125 * r146;
+    r42 = r107 * r114;
+    r42 = fma(r97, r42, r26 * r95);
+    r95 = r139 * r9;
+    r90 = r23 * r108;
+    r90 = fma(r97, r90, r26 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r23 * r126;
+    r42 = r139 * r145;
+    r42 = fma(r26, r42, r97 * r90);
+    r90 = r139 * r146;
+    r95 = r23 * r114;
+    r95 = fma(r97, r95, r26 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r108 * r126;
+    r42 = r9 * r145;
+    r42 = fma(r26, r42, r97 * r95);
+    r95 = r9 * r146;
+    r90 = r108 * r114;
+    r90 = fma(r97, r90, r26 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r145 * r146;
+    r42 = r126 * r114;
+    r42 = fma(r97, r42, r26 * r90);
+    WriteSum1<double, double>((double*)inout_shared, r42);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r67,
+        r66);
+    r42 = r2 * r6;
+    r42 = r42 * r48;
+    r42 = r42 * r71;
+    r90 = r3 * r7;
+    r90 = r90 * r48;
+    r90 = r90 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r42,
+        r90);
+    r90 = r2 * r6;
+    r90 = r90 * r71;
+    r90 = r90 * r77;
+    r42 = r3 * r7;
+    r42 = r42 * r71;
+    r42 = r42 * r77;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r42);
+    r42 = r3 * r73;
+    r90 = r2 * r7;
+    r90 = r90 * r62;
+    r90 = r90 * r74;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r42);
+    r42 = r2 * r61;
+    r90 = r3 * r7;
+    r90 = r90 * r62;
+    r90 = r90 * r74;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r42,
+        r90);
+    r90 = r2 * r6;
+    r90 = r90 * r71;
+    r90 = r90 * r82;
+    r42 = r3 * r7;
+    r42 = r42 * r71;
+    r42 = r42 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r42);
+    r42 = r2 * r6;
+    r42 = r42 * r71;
+    r42 = r42 * r81;
+    r90 = r3 * r7;
+    r90 = r90 * r71;
+    r90 = r90 * r81;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r42,
+        r90);
+    r90 = r2 * r48;
+    r42 = r3 * r48;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r42);
+    r42 = r21 * r66;
+    r42 = r42 * r1;
+    r85 = r67 * r85;
+    WriteSum2<double, double>((double*)inout_shared, r85, r42);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r3 * r21;
+    r42 = r42 * r7;
+    r42 = r42 * r48;
+    r42 = r42 * r1;
+    r85 = r144 * r72;
+    r42 = fma(r48, r85, r71 * r42);
+    r90 = r3 * r21;
+    r90 = r90 * r7;
+    r90 = r90 * r1;
+    r90 = r90 * r71;
+    r90 = fma(r77, r85, r77 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r73;
+    r42 = r2 * r35;
+    r42 = r42 * r7;
+    r42 = r42 * r0;
+    r42 = r42 * r59;
+    r42 = fma(r62, r42, r1 * r90);
+    r90 = r3 * r35;
+    r90 = r90 * r7;
+    r90 = r90 * r1;
+    r90 = r90 * r59;
+    r90 = fma(r62, r90, r61 * r144);
+    WriteSum2<double, double>((double*)inout_shared, r42, r90);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r7;
+    r90 = r90 * r1;
+    r90 = r90 * r71;
+    r90 = fma(r82, r85, r82 * r90);
+    r42 = r3 * r21;
+    r42 = r42 * r7;
+    r42 = r42 * r1;
+    r42 = r42 * r71;
+    r85 = fma(r81, r85, r81 * r42);
+    WriteSum2<double, double>((double*)inout_shared, r90, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r3 * r21;
+    r85 = r85 * r48;
+    r85 = r85 * r1;
+    r90 = r48 * r144;
+    WriteSum2<double, double>((double*)inout_shared, r90, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r67 * r67;
+    r90 = r66 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r85, r90);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r59 * r77;
+    r90 = r90 * r97;
+    r85 = r7 * r59;
+    r85 = r85 * r77;
+    r85 = r85 * r26;
+    r85 = fma(r106, r85, r63 * r90);
+    r90 = r59 * r97;
+    r90 = r90 * r63;
+    r42 = r7 * r59;
+    r42 = r42 * r26;
+    r42 = r42 * r106;
+    r42 = fma(r81, r42, r81 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r85, r42);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r6 * r6;
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r85 = r85 * r56;
+    r85 = r85 * r56;
+    r85 = r85 * r137;
+    r85 = r85 * r57;
+    r85 = r85 * r49;
+    r85 = r85 * r112;
+    r85 = r85 * r111;
+    r49 = r73 * r26;
+    r57 = fma(r73, r49, r97 * r85);
+    r137 = r61 * r97;
+    r85 = fma(r61, r137, r26 * r85);
+    WriteSum2<double, double>((double*)inout_shared, r57, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r59 * r97;
+    r57 = r82 * r82;
+    r85 = r85 * r63;
+    r47 = r7 * r59;
+    r47 = r47 * r26;
+    r47 = r47 * r106;
+    r85 = fma(r57, r47, r57 * r85);
+    r31 = r81 * r81;
+    r90 = r59 * r97;
+    r90 = r90 * r63;
+    r31 = fma(r47, r31, r31 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r85, r31);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r77 * r97;
+    r0 = r77 * r26;
+    WriteSum2<double, double>((double*)inout_shared, r31, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = 0.00000000000000000e+00;
+    r31 = r2 * r6;
+    r31 = r31 * r48;
+    r31 = r31 * r67;
+    r31 = r31 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r0, r31);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r2 * r6;
+    r31 = r31 * r67;
+    r31 = r31 * r71;
+    r31 = r31 * r77;
+    r95 = r2 * r7;
+    r95 = r95 * r67;
+    r95 = r95 * r62;
+    r95 = r95 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r31, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r2 * r61;
+    r61 = r61 * r67;
+    r95 = r2 * r6;
+    r95 = r95 * r67;
+    r95 = r95 * r71;
+    r95 = r95 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r61, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r2 * r48;
+    r95 = r95 * r67;
+    r61 = r2 * r6;
+    r61 = r61 * r67;
+    r61 = r61 * r71;
+    r61 = r61 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r61, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r3 * r7;
+    r95 = r95 * r48;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r0, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r3 * r73;
+    r73 = r73 * r66;
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r77;
+    WriteSum2<double, double>((double*)inout_shared, r95, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r3 * r7;
+    r73 = r73 * r66;
+    r73 = r73 * r62;
+    r73 = r73 * r74;
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r73, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r95, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r48;
+    r0 = r0 * r66;
+    r66 = r59 * r82;
+    r66 = r66 * r97;
+    r95 = r7 * r59;
+    r95 = r95 * r82;
+    r95 = r95 * r26;
+    r95 = fma(r106, r95, r63 * r66);
+    WriteSum2<double, double>((double*)inout_shared, r0, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r7 * r49;
+    r0 = r71 * r95;
+    r66 = r10 * r6;
+    r66 = r66 * r6;
+    r66 = r66 * r7;
+    r66 = r66 * r56;
+    r66 = r66 * r48;
+    r66 = r66 * r88;
+    r66 = r66 * r116;
+    r66 = r66 * r97;
+    r66 = fma(r112, r66, r48 * r0);
+    r73 = r48 * r137;
+    r61 = r10 * r6;
+    r61 = r61 * r56;
+    r61 = r61 * r48;
+    r61 = r61 * r88;
+    r61 = r61 * r116;
+    r61 = r61 * r26;
+    r61 = r61 * r112;
+    r61 = fma(r111, r61, r72 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r66, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r59 * r97;
+    r66 = r48 * r81;
+    r61 = r61 * r63;
+    r61 = fma(r66, r47, r66 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r42, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r42 = r6 * r71;
+    r42 = r42 * r77;
+    r42 = r42 * r97;
+    r73 = r7 * r71;
+    r73 = r73 * r77;
+    r73 = r73 * r26;
+    WriteSum2<double, double>((double*)inout_shared, r42, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r10 * r6;
+    r73 = r73 * r6;
+    r73 = r73 * r7;
+    r73 = r73 * r56;
+    r73 = r73 * r88;
+    r73 = r73 * r116;
+    r73 = r73 * r77;
+    r73 = r73 * r97;
+    r73 = fma(r112, r73, r77 * r0);
+    r42 = r77 * r137;
+    r67 = r10 * r6;
+    r67 = r67 * r56;
+    r67 = r67 * r88;
+    r67 = r67 * r116;
+    r67 = r67 * r77;
+    r67 = r67 * r26;
+    r67 = r67 * r112;
+    r67 = fma(r111, r67, r72 * r42);
+    WriteSum2<double, double>((double*)inout_shared, r73, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r61, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r6 * r71;
+    r85 = r85 * r82;
+    r85 = r85 * r97;
+    r61 = r7 * r71;
+    r61 = r61 * r82;
+    r61 = r61 * r26;
+    WriteSum2<double, double>((double*)inout_shared, r85, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r7 * r137;
+    r85 = r62 * r74;
+    r85 = fma(r95, r85, r85 * r61);
+    r95 = r10 * r6;
+    r95 = r95 * r6;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r88;
+    r95 = r95 * r116;
+    r95 = r95 * r82;
+    r95 = r95 * r97;
+    r95 = fma(r112, r95, r82 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r85, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r7 * r48;
+    r95 = r95 * r62;
+    r95 = r95 * r74;
+    r95 = r95 * r97;
+    r85 = r10 * r6;
+    r85 = r85 * r6;
+    r85 = r85 * r7;
+    r85 = r85 * r56;
+    r85 = r85 * r88;
+    r85 = r85 * r116;
+    r85 = r85 * r97;
+    r85 = r85 * r112;
+    r85 = fma(r81, r85, r81 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r85, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r48 * r49;
+    r95 = r82 * r137;
+    r85 = r10 * r6;
+    r85 = r85 * r56;
+    r85 = r85 * r88;
+    r85 = r85 * r116;
+    r85 = r85 * r82;
+    r85 = r85 * r26;
+    r85 = r85 * r112;
+    r85 = fma(r111, r85, r72 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r49, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r48 * r137;
+    r49 = r81 * r137;
+    r95 = r10 * r6;
+    r95 = r95 * r56;
+    r95 = r95 * r88;
+    r95 = r95 * r116;
+    r95 = r95 * r26;
+    r95 = r95 * r112;
+    r95 = r95 * r81;
+    r95 = fma(r111, r95, r72 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r95, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r7 * r48;
+    r85 = r85 * r62;
+    r85 = r85 * r74;
+    r85 = r85 * r26;
+    r57 = r48 * r57;
+    r47 = fma(r57, r47, r57 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r85, r47);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r6 * r71;
+    r47 = r47 * r97;
+    r47 = r47 * r81;
+    r85 = r7 * r71;
+    r85 = r85 * r26;
+    r85 = r85 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r47, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r97 * r66;
+    r85 = r85 * r72;
+    r72 = r7 * r71;
+    r72 = r72 * r26;
+    r72 = r72 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r85, r72);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r21 * r7;
+    r85 = r10 * r51;
+    r85 = r85 * r6;
+    r66 = r58 * r110;
+    r66 = fma(r111, r66, r39 * r85);
+    r85 = r58 * r6;
+    r85 = r85 * r6;
+    r66 = fma(r110, r85, r66);
+    r47 = r10 * r28;
+    r47 = r47 * r7;
+    r66 = fma(r39, r47, r66);
+    r72 = r72 * r66;
+    r72 = fma(r117, r72, r58 * r36);
+    r47 = r66 * r113;
+    r47 = r47 * r109;
+    r72 = fma(r106, r47, r72);
+    r72 = fma(r28, r118, r72);
+    r47 = r58 * r63;
+    r47 = fma(r66, r115, r87 * r47);
+    r85 = r51 * r62;
+    r47 = fma(r74, r85, r47);
+    r57 = r21 * r6;
+    r57 = r57 * r6;
+    r57 = r57 * r66;
+    r57 = r57 * r86;
+    r57 = r57 * r116;
+    r47 = fma(r59, r57, r47);
+    r57 = r72 + r47;
+    r85 = r58 * r127;
+    r85 = r85 * r88;
+    r85 = r85 * r63;
+    r90 = r60 * r66;
+    r90 = fma(r115, r90, r112 * r85);
+    r85 = r51 * r122;
+    r85 = r85 * r59;
+    r90 = fma(r62, r85, r90);
+    r95 = r6 * r6;
+    r95 = r95 * r124;
+    r95 = r95 * r66;
+    r95 = r95 * r86;
+    r95 = r95 * r116;
+    r90 = fma(r59, r95, r90);
+    r90 = r90 + r72;
+    r90 = fma(r5, r90, r64 * r57);
+    r72 = r6 * r84;
+    r72 = r72 * r78;
+    r72 = r72 * r66;
+    r72 = r72 * r86;
+    r72 = r72 * r30;
+    r90 = fma(r70, r72, r90);
+    r95 = r21 * r58;
+    r95 = r95 * r6;
+    r95 = r95 * r78;
+    r95 = r95 * r69;
+    r90 = fma(r53, r95, r90);
+    r85 = r4 * r66;
+    r90 = fma(r135, r85, r90);
+    r49 = r66 * r131;
+    r0 = r6 * r84;
+    r0 = r0 * r66;
+    r0 = r0 * r86;
+    r0 = r0 * r30;
+    r90 = fma(r70, r0, r90);
+    r61 = r4 * r51;
+    r90 = fma(r118, r61, r90);
+    r67 = r21 * r58;
+    r67 = r67 * r6;
+    r67 = r67 * r69;
+    r90 = fma(r53, r67, r90);
+    r73 = r56 * r78;
+    r73 = r73 * r89;
+    r73 = r73 * r66;
+    r73 = r73 * r68;
+    r73 = r73 * r86;
+    r90 = fma(r62, r73, r90);
+    r42 = r76 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r75, r57, r57 * r42);
+    r42 = fma(r57, r80, r42);
+    r42 = fma(r57, r79, r42);
+    r31 = r6 * r42;
+    r90 = fma(r71, r31, r90);
+    r132 = r4 * r28;
+    r132 = r132 * r62;
+    r90 = fma(r74, r132, r90);
+    r130 = r56 * r89;
+    r130 = r130 * r66;
+    r130 = r130 * r68;
+    r130 = r130 * r86;
+    r90 = fma(r62, r130, r90);
+    r90 = fma(r4, r49, r90);
+    r90 = fma(r51, r71, r90);
+    r90 = fma(r58, r133, r90);
+    r90 = fma(r51, r83, r90);
+    r130 = r2 * r90;
+    r132 = r58 * r7;
+    r132 = r132 * r7;
+    r132 = r132 * r56;
+    r132 = r132 * r56;
+    r132 = r132 * r127;
+    r132 = r132 * r43;
+    r31 = r7 * r124;
+    r31 = r31 * r66;
+    r31 = fma(r117, r31, r88 * r132);
+    r132 = r60 * r66;
+    r132 = r132 * r113;
+    r132 = r132 * r109;
+    r31 = fma(r106, r132, r31);
+    r73 = r28 * r7;
+    r73 = r73 * r122;
+    r73 = r73 * r43;
+    r31 = fma(r59, r73, r31);
+    r31 = r31 + r47;
+    r31 = fma(r4, r31, r65 * r57);
+    r57 = r7 * r42;
+    r31 = fma(r71, r57, r31);
+    r47 = r84 * r66;
+    r47 = r47 * r30;
+    r47 = r47 * r70;
+    r31 = fma(r113, r47, r31);
+    r73 = r21 * r58;
+    r73 = r73 * r7;
+    r73 = r73 * r69;
+    r31 = fma(r53, r73, r31);
+    r132 = r5 * r66;
+    r31 = fma(r135, r132, r31);
+    r67 = r84 * r78;
+    r67 = r67 * r66;
+    r67 = r67 * r30;
+    r67 = r67 * r70;
+    r31 = fma(r113, r67, r31);
+    r61 = r21 * r58;
+    r61 = r61 * r7;
+    r61 = r61 * r78;
+    r61 = r61 * r69;
+    r31 = fma(r53, r61, r31);
+    r0 = r5 * r58;
+    r0 = r0 * r7;
+    r0 = r0 * r56;
+    r0 = r0 * r56;
+    r0 = r0 * r102;
+    r0 = r0 * r88;
+    r31 = fma(r62, r0, r31);
+    r85 = r5 * r28;
+    r85 = r85 * r62;
+    r31 = fma(r74, r85, r31);
+    r31 = fma(r28, r83, r31);
+    r31 = fma(r5, r49, r31);
+    r31 = fma(r51, r121, r31);
+    r31 = fma(r66, r128, r31);
+    r31 = fma(r28, r71, r31);
+    r31 = fma(r66, r138, r31);
+    r85 = r3 * r31;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r130,
+                                             r85);
+    r85 = r45 * r122;
+    r85 = r85 * r59;
+    r130 = r40 * r127;
+    r130 = r130 * r88;
+    r130 = r130 * r63;
+    r130 = fma(r112, r130, r62 * r85);
+    r85 = r6 * r6;
+    r0 = r40 * r6;
+    r0 = r0 * r6;
+    r61 = r10 * r45;
+    r61 = r61 * r6;
+    r61 = fma(r39, r61, r110 * r0);
+    r0 = r10 * r46;
+    r0 = r0 * r7;
+    r61 = fma(r39, r0, r61);
+    r67 = r40 * r110;
+    r61 = fma(r111, r67, r61);
+    r85 = r85 * r124;
+    r85 = r85 * r61;
+    r85 = r85 * r86;
+    r85 = r85 * r116;
+    r130 = fma(r59, r85, r130);
+    r67 = r6 * r6;
+    r67 = r39 * r67;
+    r67 = r67 * r43;
+    r67 = r67 * r56;
+    r67 = r67 * r86;
+    r67 = r67 * r30;
+    r67 = r67 * r61;
+    r0 = r61 * r113;
+    r0 = r0 * r109;
+    r0 = fma(r106, r0, r40 * r36);
+    r49 = r21 * r7;
+    r49 = r49 * r61;
+    r0 = fma(r117, r49, r0);
+    r0 = fma(r46, r118, r0);
+    r130 = fma(r60, r67, r130);
+    r130 = r130 + r0;
+    r85 = r45 * r62;
+    r85 = fma(r74, r85, r67);
+    r67 = r40 * r63;
+    r85 = fma(r87, r67, r85);
+    r49 = r21 * r6;
+    r49 = r49 * r6;
+    r49 = r49 * r61;
+    r49 = r49 * r86;
+    r49 = r49 * r116;
+    r85 = fma(r59, r49, r85);
+    r0 = r0 + r85;
+    r130 = fma(r64, r0, r5 * r130);
+    r49 = r21 * r40;
+    r49 = r49 * r6;
+    r49 = r49 * r78;
+    r49 = r49 * r69;
+    r130 = fma(r53, r49, r130);
+    r67 = r6 * r84;
+    r67 = r67 * r61;
+    r67 = r67 * r86;
+    r67 = r67 * r30;
+    r130 = fma(r70, r67, r130);
+    r132 = r6 * r84;
+    r132 = r132 * r78;
+    r132 = r132 * r61;
+    r132 = r132 * r86;
+    r132 = r132 * r30;
+    r130 = fma(r70, r132, r130);
+    r73 = r76 * r10;
+    r73 = r73 * r48;
+    r73 = fma(r0, r73, r75 * r0);
+    r73 = fma(r0, r79, r73);
+    r73 = fma(r0, r80, r73);
+    r47 = r6 * r73;
+    r130 = fma(r71, r47, r130);
+    r57 = r21 * r40;
+    r57 = r57 * r6;
+    r57 = r57 * r69;
+    r130 = fma(r53, r57, r130);
+    r95 = r4 * r46;
+    r95 = r95 * r62;
+    r130 = fma(r74, r95, r130);
+    r72 = r4 * r45;
+    r130 = fma(r118, r72, r130);
+    r22 = r56 * r89;
+    r22 = r22 * r61;
+    r22 = r22 * r68;
+    r22 = r22 * r86;
+    r130 = fma(r62, r22, r130);
+    r142 = r4 * r61;
+    r130 = fma(r135, r142, r130);
+    r147 = r4 * r61;
+    r130 = fma(r131, r147, r130);
+    r140 = r56 * r78;
+    r140 = r140 * r89;
+    r140 = r140 * r61;
+    r140 = r140 * r68;
+    r140 = r140 * r86;
+    r130 = fma(r62, r140, r130);
+    r130 = fma(r45, r83, r130);
+    r130 = fma(r45, r71, r130);
+    r130 = fma(r40, r133, r130);
+    r140 = r2 * r130;
+    r147 = r40 * r7;
+    r147 = r147 * r7;
+    r147 = r147 * r56;
+    r147 = r147 * r56;
+    r147 = r147 * r127;
+    r147 = r147 * r43;
+    r142 = r60 * r61;
+    r142 = r142 * r113;
+    r142 = r142 * r109;
+    r142 = fma(r106, r142, r88 * r147);
+    r147 = r46 * r7;
+    r147 = r147 * r122;
+    r147 = r147 * r43;
+    r142 = fma(r59, r147, r142);
+    r22 = r7 * r124;
+    r22 = r22 * r61;
+    r142 = fma(r117, r22, r142);
+    r142 = r142 + r85;
+    r0 = fma(r65, r0, r4 * r142);
+    r142 = r21 * r40;
+    r142 = r142 * r7;
+    r142 = r142 * r69;
+    r0 = fma(r53, r142, r0);
+    r85 = r21 * r40;
+    r85 = r85 * r7;
+    r85 = r85 * r78;
+    r85 = r85 * r69;
+    r0 = fma(r53, r85, r0);
+    r22 = r84 * r61;
+    r22 = r22 * r30;
+    r22 = r22 * r70;
+    r0 = fma(r113, r22, r0);
+    r147 = r5 * r46;
+    r147 = r147 * r62;
+    r0 = fma(r74, r147, r0);
+    r72 = r5 * r61;
+    r0 = fma(r135, r72, r0);
+    r95 = r5 * r61;
+    r0 = fma(r131, r95, r0);
+    r57 = r5 * r40;
+    r57 = r57 * r7;
+    r57 = r57 * r56;
+    r57 = r57 * r56;
+    r57 = r57 * r102;
+    r57 = r57 * r88;
+    r0 = fma(r62, r57, r0);
+    r47 = r84 * r78;
+    r47 = r47 * r61;
+    r47 = r47 * r30;
+    r47 = r47 * r70;
+    r0 = fma(r113, r47, r0);
+    r132 = r7 * r73;
+    r0 = fma(r71, r132, r0);
+    r0 = fma(r46, r83, r0);
+    r0 = fma(r61, r128, r0);
+    r0 = fma(r45, r121, r0);
+    r0 = fma(r46, r71, r0);
+    r0 = fma(r61, r138, r0);
+    r132 = r3 * r0;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r140,
+                                             r132);
+    r132 = r50 * r127;
+    r132 = r132 * r88;
+    r132 = r132 * r63;
+    r140 = r6 * r6;
+    r47 = r10 * r52;
+    r47 = r47 * r6;
+    r57 = r50 * r110;
+    r57 = fma(r111, r57, r39 * r47);
+    r47 = r50 * r6;
+    r47 = r47 * r6;
+    r57 = fma(r110, r47, r57);
+    r111 = r10 * r44;
+    r111 = r111 * r7;
+    r57 = fma(r39, r111, r57);
+    r140 = r140 * r124;
+    r140 = r140 * r57;
+    r140 = r140 * r86;
+    r140 = r140 * r116;
+    r140 = fma(r59, r140, r112 * r132);
+    r132 = r60 * r57;
+    r140 = fma(r115, r132, r140);
+    r111 = r52 * r122;
+    r111 = r111 * r59;
+    r140 = fma(r62, r111, r140);
+    r47 = r21 * r7;
+    r47 = r47 * r57;
+    r47 = fma(r117, r47, r44 * r118);
+    r39 = r57 * r113;
+    r39 = r39 * r109;
+    r47 = fma(r106, r39, r47);
+    r47 = fma(r50, r36, r47);
+    r140 = r140 + r47;
+    r111 = r50 * r63;
+    r132 = r21 * r6;
+    r132 = r132 * r6;
+    r132 = r132 * r57;
+    r132 = r132 * r86;
+    r132 = r132 * r116;
+    r132 = fma(r59, r132, r87 * r111);
+    r111 = r52 * r62;
+    r132 = fma(r74, r111, r132);
+    r132 = fma(r57, r115, r132);
+    r47 = r47 + r132;
+    r64 = fma(r64, r47, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r69;
+    r64 = fma(r53, r140, r64);
+    r111 = r4 * r44;
+    r111 = r111 * r62;
+    r64 = fma(r74, r111, r64);
+    r115 = r4 * r57;
+    r64 = fma(r131, r115, r64);
+    r87 = r56 * r89;
+    r87 = r87 * r57;
+    r87 = r87 * r68;
+    r87 = r87 * r86;
+    r64 = fma(r62, r87, r64);
+    r116 = r6 * r84;
+    r116 = r116 * r57;
+    r116 = r116 * r86;
+    r116 = r116 * r30;
+    r64 = fma(r70, r116, r64);
+    r36 = r6 * r84;
+    r36 = r36 * r78;
+    r36 = r36 * r57;
+    r36 = r36 * r86;
+    r36 = r36 * r30;
+    r64 = fma(r70, r36, r64);
+    r39 = r4 * r57;
+    r64 = fma(r135, r39, r64);
+    r95 = r4 * r52;
+    r64 = fma(r118, r95, r64);
+    r118 = r56 * r78;
+    r118 = r118 * r89;
+    r118 = r118 * r57;
+    r118 = r118 * r68;
+    r118 = r118 * r86;
+    r64 = fma(r62, r118, r64);
+    r86 = r21 * r50;
+    r86 = r86 * r6;
+    r86 = r86 * r78;
+    r86 = r86 * r69;
+    r64 = fma(r53, r86, r64);
+    r68 = r76 * r10;
+    r68 = r68 * r48;
+    r68 = fma(r47, r68, r75 * r47);
+    r68 = fma(r47, r80, r68);
+    r68 = fma(r47, r79, r68);
+    r79 = r6 * r68;
+    r64 = fma(r71, r79, r64);
+    r64 = fma(r52, r83, r64);
+    r64 = fma(r50, r133, r64);
+    r64 = fma(r52, r71, r64);
+    r79 = r2 * r64;
+    r86 = r44 * r7;
+    r86 = r86 * r122;
+    r86 = r86 * r43;
+    r118 = r7 * r124;
+    r118 = r118 * r57;
+    r118 = fma(r117, r118, r59 * r86);
+    r86 = r60 * r57;
+    r86 = r86 * r113;
+    r86 = r86 * r109;
+    r118 = fma(r106, r86, r118);
+    r106 = r50 * r7;
+    r106 = r106 * r7;
+    r106 = r106 * r56;
+    r106 = r106 * r56;
+    r106 = r106 * r127;
+    r106 = r106 * r43;
+    r118 = fma(r88, r106, r118);
+    r118 = r118 + r132;
+    r118 = fma(r4, r118, r65 * r47);
+    r47 = r5 * r44;
+    r47 = r47 * r62;
+    r118 = fma(r74, r47, r118);
+    r74 = r5 * r57;
+    r118 = fma(r131, r74, r118);
+    r131 = r5 * r57;
+    r118 = fma(r135, r131, r118);
+    r135 = r84 * r78;
+    r135 = r135 * r57;
+    r135 = r135 * r30;
+    r135 = r135 * r70;
+    r118 = fma(r113, r135, r118);
+    r65 = r21 * r50;
+    r65 = r65 * r7;
+    r65 = r65 * r78;
+    r65 = r65 * r69;
+    r118 = fma(r53, r65, r118);
+    r132 = r5 * r50;
+    r132 = r132 * r7;
+    r132 = r132 * r56;
+    r132 = r132 * r56;
+    r132 = r132 * r102;
+    r132 = r132 * r88;
+    r118 = fma(r62, r132, r118);
+    r88 = r7 * r68;
+    r118 = fma(r71, r88, r118);
+    r102 = r84 * r57;
+    r102 = r102 * r30;
+    r102 = r102 * r70;
+    r118 = fma(r113, r102, r118);
+    r70 = r21 * r50;
+    r70 = r70 * r7;
+    r70 = r70 * r69;
+    r118 = fma(r53, r70, r118);
+    r118 = fma(r57, r128, r118);
+    r118 = fma(r57, r138, r118);
+    r118 = fma(r44, r83, r118);
+    r118 = fma(r52, r121, r118);
+    r118 = fma(r44, r71, r118);
+    r70 = r3 * r118;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r79,
+                                             r70);
+    r70 = r3 * r21;
+    r70 = r70 * r1;
+    r70 = fma(r90, r144, r31 * r70);
+    r79 = r3 * r21;
+    r79 = r79 * r1;
+    r79 = fma(r130, r144, r0 * r79);
+    WriteSum2<double, double>((double*)inout_shared, r70, r79);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r3 * r21;
+    r79 = r79 * r1;
+    r144 = fma(r64, r144, r118 * r79);
+    WriteSum1<double, double>((double*)inout_shared, r144);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r31 * r31;
+    r79 = r90 * r90;
+    r79 = fma(r97, r79, r26 * r144);
+    r144 = r0 * r0;
+    r1 = r130 * r130;
+    r1 = fma(r97, r1, r26 * r144);
+    WriteSum2<double, double>((double*)inout_shared, r79, r1);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r118 * r118;
+    r79 = r64 * r64;
+    r79 = fma(r97, r79, r26 * r1);
+    WriteSum1<double, double>((double*)inout_shared, r79);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r31 * r0;
+    r1 = r90 * r130;
+    r1 = fma(r97, r1, r26 * r79);
+    r79 = r31 * r118;
+    r144 = r90 * r64;
+    r144 = fma(r97, r144, r26 * r79);
+    WriteSum2<double, double>((double*)inout_shared, r1, r144);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r144 = r0 * r118;
+    r1 = r130 * r64;
+    r1 = fma(r97, r1, r26 * r144);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.cu
@@ -1,0 +1,2956 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointResJacFirstKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* out_res,
+        unsigned int out_res_num_alloc,
+        double* const out_rTr,
+        double* out_pose_jac,
+        unsigned int out_pose_jac_num_alloc,
+        double* const out_pose_njtr,
+        unsigned int out_pose_njtr_num_alloc,
+        double* const out_pose_precond_diag,
+        unsigned int out_pose_precond_diag_num_alloc,
+        double* const out_pose_precond_tril,
+        unsigned int out_pose_precond_tril_num_alloc,
+        double* out_focal_and_extra_jac,
+        unsigned int out_focal_and_extra_jac_num_alloc,
+        double* const out_focal_and_extra_njtr,
+        unsigned int out_focal_and_extra_njtr_num_alloc,
+        double* const out_focal_and_extra_precond_diag,
+        unsigned int out_focal_and_extra_precond_diag_num_alloc,
+        double* const out_focal_and_extra_precond_tril,
+        unsigned int out_focal_and_extra_precond_tril_num_alloc,
+        double* out_point_jac,
+        unsigned int out_point_jac_num_alloc,
+        double* const out_point_njtr,
+        unsigned int out_point_njtr_num_alloc,
+        double* const out_point_precond_diag,
+        unsigned int out_point_precond_diag_num_alloc,
+        double* const out_point_precond_tril,
+        unsigned int out_point_precond_tril_num_alloc,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45,
+      r46, r47, r48, r49, r50, r51, r52, r53, r54, r55, r56, r57, r58, r59, r60,
+      r61, r62, r63, r64, r65, r66, r67, r68, r69, r70, r71, r72, r73, r74, r75,
+      r76, r77, r78, r79, r80, r81, r82, r83, r84, r85, r86, r87, r88, r89, r90,
+      r91, r92, r93, r94, r95, r96, r97, r98, r99, r100, r101, r102, r103, r104,
+      r105, r106, r107, r108, r109, r110, r111, r112, r113, r114, r115, r116,
+      r117, r118, r119, r120, r121, r122, r123, r124, r125, r126, r127, r128,
+      r129, r130, r131, r132, r133, r134, r135, r136, r137, r138, r139, r140,
+      r141, r142, r143, r144, r145, r146, r147, r148;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r6,
+                                            r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r10 = 2.00000000000000000e+00;
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r11, r12);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r13,
+                                            r14);
+  };
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r15, r16);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r17,
+                                            r18);
+    r19 = fma(r16, r17, r11 * r14);
+    r20 = r12 * r13;
+    r21 = -1.00000000000000000e+00;
+    r19 = fma(r21, r20, r19);
+    r19 = fma(r15, r18, r19);
+    r20 = r10 * r19;
+    r22 = r12 * r14;
+    r23 = r16 * r18;
+    r24 = r22 + r23;
+    r25 = r11 * r13;
+    r26 = r15 * r17;
+    r24 = r24 + r25;
+    r24 = fma(r21, r26, r24);
+    r20 = r20 * r24;
+    r27 = fma(r12, r17, r15 * r14);
+    r28 = r11 * r18;
+    r27 = fma(r21, r28, r27);
+    r27 = fma(r16, r13, r27);
+    r28 = r10 * r27;
+    r29 = fma(r12, r18, r11 * r17);
+    r29 = fma(r15, r13, r29);
+    r29 = fma(r21, r29, r16 * r14);
+    r28 = fma(r29, r28, r20);
+    r7 = fma(r8, r28, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r30, r31);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r32 = r17 * r18;
+    r32 = r32 * r10;
+    r33 = r13 * r14;
+    r33 = fma(r10, r33, r32);
+    r34 = r17 * r17;
+    r35 = -2.00000000000000000e+00;
+    r34 = r34 * r35;
+    r36 = 1.00000000000000000e+00;
+    r37 = r13 * r13;
+    r37 = fma(r35, r37, r36);
+    r38 = r34 + r37;
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r39);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r40 = r18 * r13;
+    r40 = r40 * r10;
+    r41 = r17 * r14;
+    r41 = fma(r35, r41, r40);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r42);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r43 = r10 * r27;
+    r43 = r43 * r24;
+    r44 = r19 * r35;
+    r44 = fma(r29, r44, r43);
+    r45 = r27 * r27;
+    r45 = r45 * r35;
+    r46 = r36 + r45;
+    r47 = r19 * r19;
+    r47 = r47 * r35;
+    r46 = r46 + r47;
+    r7 = fma(r30, r33, r7);
+    r7 = fma(r31, r38, r7);
+    r7 = fma(r39, r41, r7);
+    r7 = fma(r42, r44, r7);
+    r7 = fma(r9, r46, r7);
+    r48 = r7 * r7;
+    r49 = 1.00000000000000008e-15;
+    r50 = r35 * r24;
+    r50 = r50 * r24;
+    r51 = r36 + r50;
+    r51 = r51 + r45;
+    r6 = fma(r8, r51, r6);
+    r45 = r27 * r35;
+    r45 = fma(r29, r45, r20);
+    r20 = r10 * r27;
+    r20 = r20 * r19;
+    r52 = r10 * r24;
+    r52 = fma(r29, r52, r20);
+    r53 = r17 * r13;
+    r53 = r53 * r10;
+    r54 = r18 * r14;
+    r54 = fma(r10, r54, r53);
+    r55 = r13 * r14;
+    r55 = fma(r35, r55, r32);
+    r32 = r18 * r18;
+    r32 = r32 * r35;
+    r37 = r32 + r37;
+    r6 = fma(r9, r45, r6);
+    r6 = fma(r42, r52, r6);
+    r6 = fma(r39, r54, r6);
+    r6 = fma(r31, r55, r6);
+    r6 = fma(r30, r37, r6);
+    r56 = r6 * r6;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r57);
+    r58 = r35 * r24;
+    r58 = fma(r29, r58, r20);
+    r57 = fma(r8, r58, r57);
+    r20 = r18 * r14;
+    r20 = fma(r35, r20, r53);
+    r32 = r36 + r32;
+    r32 = r32 + r34;
+    r34 = r17 * r14;
+    r34 = fma(r10, r34, r40);
+    r40 = r10 * r19;
+    r40 = fma(r29, r40, r43);
+    r50 = r36 + r50;
+    r50 = r50 + r47;
+    r57 = fma(r30, r20, r57);
+    r57 = fma(r39, r32, r57);
+    r57 = fma(r31, r34, r57);
+    r57 = fma(r9, r40, r57);
+    r57 = fma(r42, r50, r57);
+    r31 = copysign(1.0, r57);
+    r31 = fma(r49, r31, r57);
+    r57 = r31 * r31;
+    r39 = 1.0 / r57;
+    r30 = r7 * r7;
+    r30 = fma(r39, r30, r39 * r56);
+    r56 = sqrt(r30);
+    r47 = copysign(1.0, r56);
+    r47 = fma(r49, r47, r56);
+    r49 = r47 * r47;
+    r43 = 1.0 / r49;
+    r56 = atan(r56);
+    r53 = r56 * r39;
+    r59 = r56 * r53;
+    r48 = r48 * r43;
+    r48 = r48 * r59;
+    r60 = 3.00000000000000000e+00;
+    r61 = r60 * r59;
+    r62 = r6 * r43;
+    r63 = r6 * r62;
+    r61 = fma(r63, r61, r48);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r64,
+                        r65);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r66 = r59 * r63;
+    r48 = r48 + r66;
+    r67 = fma(r64, r48, r5 * r61);
+    r68 = 1.0 / r31;
+    r69 = 1.0 / r47;
+    r70 = r68 * r69;
+    r71 = r56 * r70;
+    r72 = r6 * r71;
+    r73 = r4 * r7;
+    r74 = r10 * r59;
+    r73 = r73 * r62;
+    r67 = fma(r74, r73, r67);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r75,
+                        r76);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r77 = r48 * r48;
+    r78 = fma(r76, r77, r75 * r48);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r79,
+                        r80);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r81 = r77 * r77;
+    r82 = r48 * r77;
+    r78 = fma(r80, r81, r78);
+    r78 = fma(r79, r82, r78);
+    r83 = r78 * r71;
+    r67 = r67 + r72;
+    r67 = fma(r6, r83, r67);
+    r0 = fma(r2, r67, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r73, r84);
+    r0 = fma(r73, r21, r0);
+    r73 = r7 * r7;
+    r73 = r73 * r60;
+    r73 = r73 * r43;
+    r73 = fma(r59, r73, r66);
+    r66 = fma(r65, r48, r4 * r73);
+    r85 = r5 * r7;
+    r85 = r85 * r62;
+    r66 = fma(r74, r85, r66);
+    r66 = fma(r7, r83, r66);
+    r66 = fma(r7, r71, r66);
+    r1 = fma(r3, r66, r1);
+    r1 = fma(r84, r21, r1);
+    WriteIdx2<1024, double, double, double2>(
+        out_res, 0 * out_res_num_alloc, global_thread_idx, r0, r1);
+    r84 = fma(r1, r1, r0 * r0);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r84);
+  if (global_thread_idx < problem_size) {
+    r84 = 5.00000000000000000e-01;
+    r85 = r6 * r84;
+    r86 = rsqrt(r30);
+    r87 = r10 * r6;
+    r88 = r11 * r14;
+    r89 = -5.00000000000000000e-01;
+    r90 = r16 * r17;
+    r90 = fma(r89, r90, r89 * r88);
+    r88 = r15 * r18;
+    r90 = fma(r89, r88, r90);
+    r91 = r12 * r13;
+    r90 = fma(r84, r91, r90);
+    r91 = r24 * r90;
+    r88 = r15 * r14;
+    r92 = r12 * r17;
+    r92 = fma(r84, r92, r84 * r88);
+    r88 = r11 * r18;
+    r92 = fma(r89, r88, r92);
+    r93 = r16 * r13;
+    r92 = fma(r84, r93, r92);
+    r93 = r29 * r92;
+    r88 = fma(r10, r93, r10 * r91);
+    r94 = r10 * r19;
+    r95 = fma(r84, r26, r89 * r22);
+    r95 = fma(r89, r23, r95);
+    r95 = fma(r89, r25, r95);
+    r96 = r10 * r27;
+    r97 = r16 * r14;
+    r98 = r11 * r17;
+    r98 = fma(r89, r98, r84 * r97);
+    r97 = r12 * r18;
+    r98 = fma(r89, r97, r98);
+    r99 = r15 * r13;
+    r98 = fma(r89, r99, r98);
+    r96 = r96 * r98;
+    r94 = fma(r95, r94, r96);
+    r88 = r88 + r94;
+    r99 = r10 * r24;
+    r99 = r99 * r98;
+    r97 = r10 * r19;
+    r97 = r97 * r92;
+    r100 = r99 + r97;
+    r101 = r27 * r35;
+    r100 = fma(r90, r101, r100);
+    r102 = r35 * r29;
+    r100 = fma(r95, r102, r100);
+    r100 = fma(r9, r100, r42 * r88);
+    r88 = r24 * r92;
+    r102 = -4.00000000000000000e+00;
+    r88 = r88 * r102;
+    r101 = r27 * r95;
+    r103 = r102 * r101;
+    r104 = r88 + r103;
+    r100 = fma(r8, r104, r100);
+    r87 = r87 * r100;
+    r104 = r6 * r6;
+    r105 = r10 * r24;
+    r105 = r105 * r95;
+    r106 = r10 * r27;
+    r106 = fma(r92, r106, r105);
+    r92 = r10 * r19;
+    r92 = r92 * r90;
+    r107 = r10 * r29;
+    r107 = r107 * r98;
+    r108 = r92 + r107;
+    r109 = r106 + r108;
+    r93 = fma(r35, r93, r35 * r91);
+    r93 = r93 + r94;
+    r93 = fma(r8, r93, r9 * r109);
+    r109 = r19 * r98;
+    r109 = r109 * r102;
+    r88 = r88 + r109;
+    r93 = fma(r42, r88, r93);
+    r57 = r31 * r57;
+    r88 = 1.0 / r57;
+    r110 = r35 * r88;
+    r104 = r104 * r93;
+    r104 = fma(r110, r104, r39 * r87);
+    r87 = r93 * r110;
+    r111 = r7 * r7;
+    r104 = fma(r111, r87, r104);
+    r112 = r10 * r7;
+    r113 = r19 * r35;
+    r114 = r35 * r29;
+    r114 = r114 * r98;
+    r113 = fma(r90, r113, r114);
+    r113 = r113 + r106;
+    r103 = r109 + r103;
+    r103 = fma(r9, r103, r42 * r113);
+    r113 = r10 * r29;
+    r113 = fma(r95, r113, r97);
+    r97 = r10 * r27;
+    r97 = fma(r90, r97, r99);
+    r113 = r113 + r97;
+    r103 = fma(r8, r113, r103);
+    r112 = r112 * r103;
+    r104 = fma(r39, r112, r104);
+    r30 = r36 + r30;
+    r30 = 1.0 / r30;
+    r85 = r85 * r68;
+    r85 = r85 * r69;
+    r85 = r85 * r86;
+    r85 = r85 * r104;
+    r85 = r85 * r30;
+    r36 = r43 * r111;
+    r112 = r56 * r56;
+    r87 = r110 * r112;
+    r36 = r36 * r87;
+    r113 = r7 * r86;
+    r99 = r104 * r113;
+    r109 = r30 * r53;
+    r106 = r7 * r43;
+    r99 = r99 * r109;
+    r99 = fma(r106, r99, r93 * r36);
+    r115 = r21 * r7;
+    r49 = r47 * r49;
+    r116 = 1.0 / r49;
+    r117 = r116 * r59;
+    r117 = r117 * r113;
+    r115 = r115 * r104;
+    r99 = fma(r117, r115, r99);
+    r118 = r74 * r106;
+    r99 = fma(r103, r118, r99);
+    r115 = r86 * r109;
+    r115 = r115 * r63;
+    r119 = r21 * r6;
+    r119 = r119 * r6;
+    r119 = r119 * r104;
+    r119 = r119 * r86;
+    r119 = r119 * r116;
+    r119 = fma(r59, r119, r104 * r115);
+    r120 = r100 * r62;
+    r119 = fma(r74, r120, r119);
+    r121 = r93 * r63;
+    r119 = fma(r87, r121, r119);
+    r121 = r99 + r119;
+    r120 = fma(r64, r121, r85);
+    r122 = r60 * r104;
+    r123 = r6 * r6;
+    r124 = -3.00000000000000000e+00;
+    r123 = r123 * r124;
+    r123 = r123 * r104;
+    r123 = r123 * r86;
+    r123 = r123 * r116;
+    r123 = fma(r59, r123, r115 * r122);
+    r122 = 6.00000000000000000e+00;
+    r125 = r100 * r122;
+    r125 = r125 * r59;
+    r123 = fma(r62, r125, r123);
+    r126 = r63 * r112;
+    r127 = -6.00000000000000000e+00;
+    r128 = r93 * r127;
+    r128 = r128 * r88;
+    r123 = fma(r128, r126, r123);
+    r123 = r123 + r99;
+    r99 = r4 * r100;
+    r120 = fma(r118, r99, r120);
+    r126 = r56 * r89;
+    r126 = r126 * r104;
+    r126 = r126 * r68;
+    r126 = r126 * r86;
+    r120 = fma(r62, r126, r120);
+    r125 = r56 * r78;
+    r125 = r125 * r89;
+    r125 = r125 * r104;
+    r125 = r125 * r68;
+    r125 = r125 * r86;
+    r120 = fma(r62, r125, r120);
+    r129 = r21 * r6;
+    r129 = r129 * r78;
+    r129 = r129 * r93;
+    r129 = r129 * r69;
+    r120 = fma(r53, r129, r120);
+    r130 = r4 * r104;
+    r131 = r35 * r6;
+    r131 = r131 * r117;
+    r120 = fma(r131, r130, r120);
+    r132 = r4 * r103;
+    r132 = r132 * r62;
+    r120 = fma(r74, r132, r120);
+    r133 = r4 * r7;
+    r133 = r133 * r56;
+    r133 = r133 * r56;
+    r133 = r133 * r102;
+    r133 = r133 * r88;
+    r133 = r133 * r62;
+    r134 = r4 * r104;
+    r135 = r10 * r62;
+    r135 = r135 * r113;
+    r135 = r135 * r109;
+    r120 = fma(r135, r134, r120);
+    r136 = r76 * r10;
+    r136 = r136 * r48;
+    r136 = fma(r75, r121, r121 * r136);
+    r79 = r79 * r60;
+    r79 = r79 * r77;
+    r137 = 4.00000000000000000e+00;
+    r80 = r80 * r137;
+    r80 = r80 * r82;
+    r136 = fma(r121, r79, r136);
+    r136 = fma(r121, r80, r136);
+    r138 = r6 * r136;
+    r120 = fma(r71, r138, r120);
+    r139 = r21 * r6;
+    r139 = r139 * r93;
+    r139 = r139 * r69;
+    r120 = fma(r53, r139, r120);
+    r120 = fma(r5, r123, r120);
+    r120 = fma(r78, r85, r120);
+    r120 = fma(r100, r83, r120);
+    r120 = fma(r93, r133, r120);
+    r120 = fma(r100, r71, r120);
+    r139 = r2 * r120;
+    r138 = r7 * r7;
+    r138 = r138 * r56;
+    r138 = r138 * r56;
+    r138 = r138 * r43;
+    r134 = r60 * r104;
+    r134 = r134 * r113;
+    r134 = r134 * r109;
+    r134 = fma(r106, r134, r128 * r138);
+    r138 = r7 * r124;
+    r138 = r138 * r104;
+    r134 = fma(r117, r138, r134);
+    r128 = r7 * r103;
+    r128 = r128 * r122;
+    r128 = r128 * r43;
+    r134 = fma(r59, r128, r134);
+    r134 = r134 + r119;
+    r134 = fma(r4, r134, r65 * r121);
+    r121 = r5 * r118;
+    r119 = r21 * r7;
+    r119 = r119 * r93;
+    r119 = r119 * r69;
+    r134 = fma(r53, r119, r134);
+    r128 = r56 * r89;
+    r128 = r128 * r43;
+    r128 = r128 * r68;
+    r128 = r128 * r113;
+    r138 = r78 * r128;
+    r132 = r5 * r104;
+    r134 = fma(r131, r132, r134);
+    r130 = r84 * r104;
+    r130 = r130 * r30;
+    r130 = r130 * r70;
+    r85 = r5 * r103;
+    r85 = r85 * r62;
+    r134 = fma(r74, r85, r134);
+    r129 = r5 * r7;
+    r129 = r129 * r56;
+    r129 = r129 * r56;
+    r129 = r129 * r102;
+    r129 = r129 * r93;
+    r129 = r129 * r88;
+    r134 = fma(r62, r129, r134);
+    r125 = r7 * r136;
+    r134 = fma(r71, r125, r134);
+    r126 = r5 * r104;
+    r134 = fma(r135, r126, r134);
+    r99 = r78 * r113;
+    r134 = fma(r130, r99, r134);
+    r123 = r21 * r7;
+    r123 = r123 * r78;
+    r123 = r123 * r93;
+    r123 = r123 * r69;
+    r134 = fma(r53, r123, r134);
+    r134 = fma(r100, r121, r134);
+    r134 = fma(r104, r138, r134);
+    r134 = fma(r104, r128, r134);
+    r134 = fma(r113, r130, r134);
+    r134 = fma(r103, r83, r134);
+    r134 = fma(r103, r71, r134);
+    r123 = r3 * r134;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             0 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r139,
+                                             r123);
+    r123 = r35 * r24;
+    r123 = fma(r95, r123, r114);
+    r139 = r10 * r27;
+    r99 = r15 * r14;
+    r126 = r12 * r17;
+    r126 = fma(r89, r126, r89 * r99);
+    r99 = r11 * r18;
+    r126 = fma(r84, r99, r126);
+    r125 = r16 * r13;
+    r126 = fma(r89, r125, r126);
+    r139 = r139 * r126;
+    r125 = r10 * r19;
+    r99 = r11 * r14;
+    r129 = r16 * r17;
+    r129 = fma(r84, r129, r84 * r99);
+    r99 = r15 * r18;
+    r129 = fma(r84, r99, r129);
+    r85 = r12 * r13;
+    r129 = fma(r89, r85, r129);
+    r125 = fma(r129, r125, r139);
+    r123 = r123 + r125;
+    r85 = r10 * r24;
+    r85 = r85 * r129;
+    r99 = r10 * r29;
+    r99 = fma(r126, r99, r85);
+    r99 = r99 + r94;
+    r99 = fma(r9, r99, r8 * r123);
+    r123 = r24 * r98;
+    r123 = r123 * r102;
+    r94 = r19 * r126;
+    r130 = r102 * r94;
+    r132 = r123 + r130;
+    r99 = fma(r42, r132, r99);
+    r132 = r127 * r99;
+    r132 = r132 * r88;
+    r132 = r132 * r63;
+    r107 = r105 + r107;
+    r107 = r107 + r125;
+    r125 = r27 * r102;
+    r125 = r125 * r129;
+    r123 = r123 + r125;
+    r123 = fma(r8, r123, r42 * r107);
+    r107 = r35 * r29;
+    r107 = fma(r35, r101, r129 * r107);
+    r105 = r10 * r19;
+    r105 = r105 * r98;
+    r119 = r10 * r24;
+    r119 = fma(r126, r119, r105);
+    r107 = r107 + r119;
+    r123 = fma(r9, r107, r123);
+    r107 = r122 * r123;
+    r107 = r107 * r59;
+    r107 = fma(r62, r107, r112 * r132);
+    r132 = r6 * r6;
+    r140 = r10 * r6;
+    r140 = r140 * r123;
+    r141 = r10 * r7;
+    r85 = r96 + r85;
+    r96 = r19 * r35;
+    r85 = fma(r95, r96, r85);
+    r95 = r35 * r29;
+    r85 = fma(r126, r95, r85);
+    r95 = r10 * r29;
+    r101 = fma(r10, r101, r129 * r95);
+    r101 = r101 + r119;
+    r101 = fma(r8, r101, r42 * r85);
+    r130 = r125 + r130;
+    r101 = fma(r9, r130, r101);
+    r141 = r141 * r101;
+    r141 = fma(r39, r141, r39 * r140);
+    r140 = r99 * r110;
+    r141 = fma(r111, r140, r141);
+    r130 = r6 * r6;
+    r130 = r130 * r99;
+    r141 = fma(r110, r130, r141);
+    r130 = r124 * r141;
+    r132 = r132 * r86;
+    r132 = r132 * r116;
+    r132 = r132 * r59;
+    r107 = fma(r130, r132, r107);
+    r140 = r60 * r141;
+    r107 = fma(r115, r140, r107);
+    r125 = r21 * r7;
+    r125 = r125 * r141;
+    r125 = fma(r117, r125, r101 * r118);
+    r85 = r141 * r113;
+    r85 = r85 * r109;
+    r125 = fma(r106, r85, r125);
+    r125 = fma(r99, r36, r125);
+    r107 = r107 + r125;
+    r140 = r99 * r63;
+    r132 = r123 * r62;
+    r132 = fma(r74, r132, r87 * r140);
+    r140 = r21 * r6;
+    r140 = r140 * r6;
+    r140 = r140 * r141;
+    r140 = r140 * r86;
+    r140 = r140 * r116;
+    r132 = fma(r59, r140, r132);
+    r132 = fma(r141, r115, r132);
+    r125 = r125 + r132;
+    r107 = fma(r64, r125, r5 * r107);
+    r140 = r21 * r6;
+    r140 = r140 * r99;
+    r140 = r140 * r69;
+    r107 = fma(r53, r140, r107);
+    r85 = r6 * r84;
+    r85 = r85 * r78;
+    r85 = r85 * r141;
+    r85 = r85 * r86;
+    r85 = r85 * r30;
+    r107 = fma(r70, r85, r107);
+    r95 = r6 * r84;
+    r95 = r95 * r141;
+    r95 = r95 * r86;
+    r95 = r95 * r30;
+    r107 = fma(r70, r95, r107);
+    r129 = r56 * r78;
+    r129 = r129 * r89;
+    r129 = r129 * r141;
+    r129 = r129 * r68;
+    r129 = r129 * r86;
+    r107 = fma(r62, r129, r107);
+    r96 = r76 * r10;
+    r96 = r96 * r48;
+    r96 = fma(r125, r96, r75 * r125);
+    r96 = fma(r125, r80, r96);
+    r96 = fma(r125, r79, r96);
+    r142 = r6 * r96;
+    r107 = fma(r71, r142, r107);
+    r143 = r21 * r6;
+    r143 = r143 * r78;
+    r143 = r143 * r99;
+    r143 = r143 * r69;
+    r107 = fma(r53, r143, r107);
+    r144 = r4 * r141;
+    r107 = fma(r135, r144, r107);
+    r145 = r4 * r141;
+    r107 = fma(r131, r145, r107);
+    r146 = r4 * r101;
+    r146 = r146 * r62;
+    r107 = fma(r74, r146, r107);
+    r147 = r4 * r123;
+    r107 = fma(r118, r147, r107);
+    r148 = r56 * r89;
+    r148 = r148 * r141;
+    r148 = r148 * r68;
+    r148 = r148 * r86;
+    r107 = fma(r62, r148, r107);
+    r107 = fma(r99, r133, r107);
+    r107 = fma(r123, r71, r107);
+    r107 = fma(r123, r83, r107);
+    r148 = r2 * r107;
+    r147 = r7 * r122;
+    r147 = r147 * r101;
+    r147 = r147 * r43;
+    r146 = r7 * r117;
+    r146 = fma(r130, r146, r59 * r147);
+    r147 = r7 * r7;
+    r147 = r147 * r56;
+    r147 = r147 * r56;
+    r147 = r147 * r127;
+    r147 = r147 * r99;
+    r147 = r147 * r43;
+    r146 = fma(r88, r147, r146);
+    r130 = r60 * r141;
+    r130 = r130 * r113;
+    r130 = r130 * r109;
+    r146 = fma(r106, r130, r146);
+    r146 = r146 + r132;
+    r125 = fma(r65, r125, r4 * r146);
+    r146 = r7 * r96;
+    r125 = fma(r71, r146, r125);
+    r132 = r84 * r141;
+    r132 = r132 * r30;
+    r132 = r132 * r70;
+    r125 = fma(r113, r132, r125);
+    r130 = r5 * r7;
+    r130 = r130 * r56;
+    r130 = r130 * r56;
+    r130 = r130 * r102;
+    r130 = r130 * r99;
+    r130 = r130 * r88;
+    r125 = fma(r62, r130, r125);
+    r147 = r5 * r141;
+    r125 = fma(r135, r147, r125);
+    r145 = r21 * r7;
+    r145 = r145 * r78;
+    r145 = r145 * r99;
+    r145 = r145 * r69;
+    r125 = fma(r53, r145, r125);
+    r144 = r5 * r141;
+    r125 = fma(r131, r144, r125);
+    r143 = r21 * r7;
+    r143 = r143 * r99;
+    r143 = r143 * r69;
+    r125 = fma(r53, r143, r125);
+    r142 = r5 * r101;
+    r142 = r142 * r62;
+    r125 = fma(r74, r142, r125);
+    r129 = r84 * r78;
+    r129 = r129 * r141;
+    r129 = r129 * r30;
+    r129 = r129 * r70;
+    r125 = fma(r113, r129, r125);
+    r125 = fma(r141, r128, r125);
+    r125 = fma(r101, r83, r125);
+    r125 = fma(r141, r138, r125);
+    r125 = fma(r101, r71, r125);
+    r125 = fma(r123, r121, r125);
+    r129 = r3 * r125;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             2 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r148,
+                                             r129);
+    r129 = r19 * r102;
+    r26 = fma(r89, r26, r84 * r22);
+    r26 = fma(r84, r23, r26);
+    r26 = fma(r84, r25, r26);
+    r129 = r129 * r26;
+    r91 = r102 * r91;
+    r25 = r129 + r91;
+    r23 = r10 * r27;
+    r23 = r23 * r26;
+    r105 = r105 + r23;
+    r22 = r35 * r24;
+    r105 = fma(r126, r22, r105);
+    r148 = r35 * r29;
+    r105 = fma(r90, r148, r105);
+    r105 = fma(r8, r105, r42 * r25);
+    r25 = r10 * r29;
+    r25 = fma(r10, r94, r26 * r25);
+    r25 = r25 + r97;
+    r105 = fma(r9, r25, r105);
+    r25 = r10 * r7;
+    r148 = r10 * r24;
+    r148 = r148 * r26;
+    r139 = r139 + r148;
+    r139 = r139 + r108;
+    r108 = r35 * r29;
+    r94 = fma(r35, r94, r26 * r108);
+    r94 = r94 + r97;
+    r94 = fma(r42, r94, r8 * r139);
+    r98 = r27 * r98;
+    r98 = r98 * r102;
+    r129 = r129 + r98;
+    r94 = fma(r9, r129, r94);
+    r25 = r25 * r94;
+    r129 = r6 * r6;
+    r129 = r129 * r105;
+    r129 = fma(r110, r129, r39 * r25);
+    r25 = r10 * r6;
+    r114 = r92 + r114;
+    r92 = r27 * r35;
+    r114 = fma(r126, r92, r114);
+    r114 = r114 + r148;
+    r91 = r98 + r91;
+    r91 = fma(r8, r91, r9 * r114);
+    r8 = r10 * r29;
+    r8 = fma(r90, r8, r23);
+    r8 = r8 + r119;
+    r91 = fma(r42, r8, r91);
+    r25 = r25 * r91;
+    r129 = fma(r39, r25, r129);
+    r8 = r105 * r110;
+    r129 = fma(r111, r8, r129);
+    r8 = r129 * r113;
+    r8 = r8 * r109;
+    r8 = fma(r106, r8, r105 * r36);
+    r25 = r21 * r7;
+    r25 = r25 * r129;
+    r8 = fma(r117, r25, r8);
+    r8 = fma(r94, r118, r8);
+    r25 = r21 * r6;
+    r25 = r25 * r6;
+    r25 = r25 * r129;
+    r25 = r25 * r86;
+    r25 = r25 * r116;
+    r42 = r91 * r62;
+    r42 = fma(r74, r42, r59 * r25);
+    r25 = r105 * r63;
+    r42 = fma(r87, r25, r42);
+    r42 = fma(r129, r115, r42);
+    r25 = r8 + r42;
+    r119 = r6 * r6;
+    r119 = r119 * r124;
+    r119 = r119 * r129;
+    r119 = r119 * r86;
+    r119 = r119 * r116;
+    r23 = r122 * r91;
+    r23 = r23 * r59;
+    r23 = fma(r62, r23, r59 * r119);
+    r119 = r127 * r105;
+    r119 = r119 * r88;
+    r119 = r119 * r63;
+    r23 = fma(r112, r119, r23);
+    r90 = r60 * r129;
+    r23 = fma(r115, r90, r23);
+    r23 = r23 + r8;
+    r23 = fma(r5, r23, r64 * r25);
+    r8 = r76 * r10;
+    r8 = r8 * r48;
+    r8 = fma(r25, r8, r75 * r25);
+    r8 = fma(r25, r79, r8);
+    r8 = fma(r25, r80, r8);
+    r90 = r6 * r8;
+    r23 = fma(r71, r90, r23);
+    r119 = r4 * r91;
+    r23 = fma(r118, r119, r23);
+    r114 = r6 * r84;
+    r114 = r114 * r129;
+    r114 = r114 * r86;
+    r114 = r114 * r30;
+    r23 = fma(r70, r114, r23);
+    r9 = r4 * r129;
+    r23 = fma(r135, r9, r23);
+    r98 = r21 * r6;
+    r98 = r98 * r78;
+    r98 = r98 * r105;
+    r98 = r98 * r69;
+    r23 = fma(r53, r98, r23);
+    r92 = r6 * r84;
+    r92 = r92 * r78;
+    r92 = r92 * r129;
+    r92 = r92 * r86;
+    r92 = r92 * r30;
+    r23 = fma(r70, r92, r23);
+    r148 = r129 * r131;
+    r126 = r21 * r6;
+    r126 = r126 * r105;
+    r126 = r126 * r69;
+    r23 = fma(r53, r126, r23);
+    r139 = r56 * r89;
+    r139 = r139 * r129;
+    r139 = r139 * r68;
+    r139 = r139 * r86;
+    r23 = fma(r62, r139, r23);
+    r97 = r4 * r94;
+    r97 = r97 * r62;
+    r23 = fma(r74, r97, r23);
+    r108 = r56 * r78;
+    r108 = r108 * r89;
+    r108 = r108 * r129;
+    r108 = r108 * r68;
+    r108 = r108 * r86;
+    r23 = fma(r62, r108, r23);
+    r23 = fma(r4, r148, r23);
+    r23 = fma(r91, r83, r23);
+    r23 = fma(r91, r71, r23);
+    r23 = fma(r105, r133, r23);
+    r108 = r2 * r23;
+    r97 = r7 * r7;
+    r97 = r97 * r56;
+    r97 = r97 * r56;
+    r97 = r97 * r127;
+    r97 = r97 * r105;
+    r97 = r97 * r43;
+    r139 = r60 * r129;
+    r139 = r139 * r113;
+    r139 = r139 * r109;
+    r139 = fma(r106, r139, r88 * r97);
+    r97 = r7 * r122;
+    r97 = r97 * r94;
+    r97 = r97 * r43;
+    r139 = fma(r59, r97, r139);
+    r126 = r7 * r124;
+    r126 = r126 * r129;
+    r139 = fma(r117, r126, r139);
+    r139 = r139 + r42;
+    r139 = fma(r4, r139, r65 * r25);
+    r25 = r21 * r7;
+    r25 = r25 * r78;
+    r25 = r25 * r105;
+    r25 = r25 * r69;
+    r139 = fma(r53, r25, r139);
+    r42 = r21 * r7;
+    r42 = r42 * r105;
+    r42 = r42 * r69;
+    r139 = fma(r53, r42, r139);
+    r126 = r5 * r129;
+    r139 = fma(r135, r126, r139);
+    r97 = r84 * r129;
+    r97 = r97 * r30;
+    r97 = r97 * r70;
+    r139 = fma(r113, r97, r139);
+    r92 = r7 * r8;
+    r139 = fma(r71, r92, r139);
+    r98 = r84 * r78;
+    r98 = r98 * r129;
+    r98 = r98 * r30;
+    r98 = r98 * r70;
+    r139 = fma(r113, r98, r139);
+    r9 = r5 * r7;
+    r9 = r9 * r56;
+    r9 = r9 * r56;
+    r9 = r9 * r102;
+    r9 = r9 * r105;
+    r9 = r9 * r88;
+    r139 = fma(r62, r9, r139);
+    r114 = r5 * r94;
+    r114 = r114 * r62;
+    r139 = fma(r74, r114, r139);
+    r139 = fma(r94, r83, r139);
+    r139 = fma(r91, r121, r139);
+    r139 = fma(r129, r138, r139);
+    r139 = fma(r94, r71, r139);
+    r139 = fma(r5, r148, r139);
+    r139 = fma(r129, r128, r139);
+    r114 = r3 * r139;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             4 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r108,
+                                             r114);
+    r114 = r37 * r122;
+    r114 = r114 * r59;
+    r108 = r6 * r6;
+    r9 = r10 * r33;
+    r9 = r9 * r7;
+    r98 = r20 * r110;
+    r98 = fma(r111, r98, r39 * r9);
+    r9 = r20 * r6;
+    r9 = r9 * r6;
+    r98 = fma(r110, r9, r98);
+    r92 = r10 * r37;
+    r92 = r92 * r6;
+    r98 = fma(r39, r92, r98);
+    r108 = r108 * r124;
+    r108 = r108 * r98;
+    r108 = r108 * r86;
+    r108 = r108 * r116;
+    r108 = fma(r59, r108, r62 * r114);
+    r114 = r60 * r98;
+    r108 = fma(r115, r114, r108);
+    r92 = r20 * r127;
+    r92 = r92 * r88;
+    r92 = r92 * r63;
+    r108 = fma(r112, r92, r108);
+    r9 = r21 * r7;
+    r9 = r9 * r98;
+    r9 = fma(r117, r9, r33 * r118);
+    r148 = r98 * r113;
+    r148 = r148 * r109;
+    r9 = fma(r106, r148, r9);
+    r9 = fma(r20, r36, r9);
+    r108 = r108 + r9;
+    r92 = r37 * r62;
+    r114 = r21 * r6;
+    r114 = r114 * r6;
+    r114 = r114 * r98;
+    r114 = r114 * r86;
+    r114 = r114 * r116;
+    r114 = fma(r59, r114, r74 * r92);
+    r92 = r20 * r63;
+    r114 = fma(r87, r92, r114);
+    r114 = fma(r98, r115, r114);
+    r9 = r9 + r114;
+    r108 = fma(r64, r9, r5 * r108);
+    r92 = r6 * r84;
+    r92 = r92 * r78;
+    r92 = r92 * r98;
+    r92 = r92 * r86;
+    r92 = r92 * r30;
+    r108 = fma(r70, r92, r108);
+    r148 = r4 * r98;
+    r108 = fma(r135, r148, r108);
+    r97 = r6 * r84;
+    r97 = r97 * r98;
+    r97 = r97 * r86;
+    r97 = r97 * r30;
+    r108 = fma(r70, r97, r108);
+    r126 = r56 * r78;
+    r126 = r126 * r89;
+    r126 = r126 * r98;
+    r126 = r126 * r68;
+    r126 = r126 * r86;
+    r108 = fma(r62, r126, r108);
+    r42 = r56 * r89;
+    r42 = r42 * r98;
+    r42 = r42 * r68;
+    r42 = r42 * r86;
+    r108 = fma(r62, r42, r108);
+    r25 = r4 * r98;
+    r108 = fma(r131, r25, r108);
+    r119 = r76 * r10;
+    r119 = r119 * r48;
+    r119 = fma(r75, r9, r9 * r119);
+    r119 = fma(r9, r80, r119);
+    r119 = fma(r9, r79, r119);
+    r90 = r6 * r119;
+    r108 = fma(r71, r90, r108);
+    r26 = r21 * r20;
+    r26 = r26 * r6;
+    r26 = r26 * r78;
+    r26 = r26 * r69;
+    r108 = fma(r53, r26, r108);
+    r22 = r21 * r20;
+    r22 = r22 * r6;
+    r22 = r22 * r69;
+    r108 = fma(r53, r22, r108);
+    r142 = r4 * r33;
+    r142 = r142 * r62;
+    r108 = fma(r74, r142, r108);
+    r143 = r4 * r37;
+    r108 = fma(r118, r143, r108);
+    r108 = fma(r37, r83, r108);
+    r108 = fma(r20, r133, r108);
+    r108 = fma(r37, r71, r108);
+    r143 = r2 * r108;
+    r142 = r33 * r7;
+    r142 = r142 * r122;
+    r142 = r142 * r43;
+    r22 = r7 * r124;
+    r22 = r22 * r98;
+    r22 = fma(r117, r22, r59 * r142);
+    r142 = r20 * r7;
+    r142 = r142 * r7;
+    r142 = r142 * r56;
+    r142 = r142 * r56;
+    r142 = r142 * r127;
+    r142 = r142 * r43;
+    r22 = fma(r88, r142, r22);
+    r26 = r60 * r98;
+    r26 = r26 * r113;
+    r26 = r26 * r109;
+    r22 = fma(r106, r26, r22);
+    r22 = r22 + r114;
+    r9 = fma(r65, r9, r4 * r22);
+    r22 = r84 * r98;
+    r22 = r22 * r30;
+    r22 = r22 * r70;
+    r9 = fma(r113, r22, r9);
+    r114 = r21 * r20;
+    r114 = r114 * r7;
+    r114 = r114 * r78;
+    r114 = r114 * r69;
+    r9 = fma(r53, r114, r9);
+    r26 = r5 * r98;
+    r9 = fma(r135, r26, r9);
+    r142 = r21 * r20;
+    r142 = r142 * r7;
+    r142 = r142 * r69;
+    r9 = fma(r53, r142, r9);
+    r90 = r5 * r98;
+    r9 = fma(r131, r90, r9);
+    r25 = r5 * r20;
+    r25 = r25 * r7;
+    r25 = r25 * r56;
+    r25 = r25 * r56;
+    r25 = r25 * r102;
+    r25 = r25 * r88;
+    r9 = fma(r62, r25, r9);
+    r42 = r7 * r119;
+    r9 = fma(r71, r42, r9);
+    r126 = r84 * r78;
+    r126 = r126 * r98;
+    r126 = r126 * r30;
+    r126 = r126 * r70;
+    r9 = fma(r113, r126, r9);
+    r97 = r5 * r33;
+    r97 = r97 * r62;
+    r9 = fma(r74, r97, r9);
+    r9 = fma(r33, r71, r9);
+    r9 = fma(r98, r138, r9);
+    r9 = fma(r33, r83, r9);
+    r9 = fma(r98, r128, r9);
+    r9 = fma(r37, r121, r9);
+    r97 = r3 * r9;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 6 * out_pose_jac_num_alloc, global_thread_idx, r143, r97);
+    r97 = r34 * r110;
+    r143 = r10 * r38;
+    r143 = r143 * r7;
+    r143 = fma(r39, r143, r111 * r97);
+    r97 = r34 * r6;
+    r97 = r97 * r6;
+    r143 = fma(r110, r97, r143);
+    r126 = r10 * r55;
+    r126 = r126 * r6;
+    r143 = fma(r39, r126, r143);
+    r126 = r60 * r143;
+    r97 = r34 * r127;
+    r97 = r97 * r88;
+    r97 = r97 * r63;
+    r97 = fma(r112, r97, r115 * r126);
+    r126 = r6 * r6;
+    r126 = r126 * r124;
+    r126 = r126 * r143;
+    r126 = r126 * r86;
+    r126 = r126 * r116;
+    r97 = fma(r59, r126, r97);
+    r42 = r55 * r122;
+    r42 = r42 * r59;
+    r97 = fma(r62, r42, r97);
+    r25 = fma(r38, r118, r34 * r36);
+    r90 = r143 * r113;
+    r90 = r90 * r109;
+    r25 = fma(r106, r90, r25);
+    r142 = r21 * r7;
+    r142 = r142 * r143;
+    r25 = fma(r117, r142, r25);
+    r97 = r97 + r25;
+    r42 = r34 * r63;
+    r42 = fma(r87, r42, r143 * r115);
+    r126 = r21 * r6;
+    r126 = r126 * r6;
+    r126 = r126 * r143;
+    r126 = r126 * r86;
+    r126 = r126 * r116;
+    r42 = fma(r59, r126, r42);
+    r142 = r55 * r62;
+    r42 = fma(r74, r142, r42);
+    r25 = r25 + r42;
+    r97 = fma(r64, r25, r5 * r97);
+    r142 = r4 * r38;
+    r142 = r142 * r62;
+    r97 = fma(r74, r142, r97);
+    r126 = r143 * r135;
+    r90 = r6 * r84;
+    r90 = r90 * r78;
+    r90 = r90 * r143;
+    r90 = r90 * r86;
+    r90 = r90 * r30;
+    r97 = fma(r70, r90, r97);
+    r26 = r21 * r34;
+    r26 = r26 * r6;
+    r26 = r26 * r69;
+    r97 = fma(r53, r26, r97);
+    r114 = r4 * r143;
+    r97 = fma(r131, r114, r97);
+    r22 = r6 * r84;
+    r22 = r22 * r143;
+    r22 = r22 * r86;
+    r22 = r22 * r30;
+    r97 = fma(r70, r22, r97);
+    r148 = r56 * r89;
+    r148 = r148 * r143;
+    r148 = r148 * r68;
+    r148 = r148 * r86;
+    r97 = fma(r62, r148, r97);
+    r92 = r76 * r10;
+    r92 = r92 * r48;
+    r92 = fma(r75, r25, r25 * r92);
+    r92 = fma(r25, r79, r92);
+    r92 = fma(r25, r80, r92);
+    r144 = r6 * r92;
+    r97 = fma(r71, r144, r97);
+    r145 = r56 * r78;
+    r145 = r145 * r89;
+    r145 = r145 * r143;
+    r145 = r145 * r68;
+    r145 = r145 * r86;
+    r97 = fma(r62, r145, r97);
+    r147 = r21 * r34;
+    r147 = r147 * r6;
+    r147 = r147 * r78;
+    r147 = r147 * r69;
+    r97 = fma(r53, r147, r97);
+    r130 = r4 * r55;
+    r97 = fma(r118, r130, r97);
+    r97 = fma(r4, r126, r97);
+    r97 = fma(r55, r71, r97);
+    r97 = fma(r34, r133, r97);
+    r97 = fma(r55, r83, r97);
+    r130 = r2 * r97;
+    r147 = r34 * r7;
+    r147 = r147 * r7;
+    r147 = r147 * r56;
+    r147 = r147 * r56;
+    r147 = r147 * r127;
+    r147 = r147 * r43;
+    r145 = r38 * r7;
+    r145 = r145 * r122;
+    r145 = r145 * r43;
+    r145 = fma(r59, r145, r88 * r147);
+    r147 = r60 * r143;
+    r147 = r147 * r113;
+    r147 = r147 * r109;
+    r145 = fma(r106, r147, r145);
+    r144 = r7 * r124;
+    r144 = r144 * r143;
+    r145 = fma(r117, r144, r145);
+    r145 = r145 + r42;
+    r145 = fma(r4, r145, r65 * r25);
+    r25 = r21 * r34;
+    r25 = r25 * r7;
+    r25 = r25 * r69;
+    r145 = fma(r53, r25, r145);
+    r42 = r5 * r38;
+    r42 = r42 * r62;
+    r145 = fma(r74, r42, r145);
+    r144 = r84 * r143;
+    r144 = r144 * r30;
+    r144 = r144 * r70;
+    r145 = fma(r113, r144, r145);
+    r147 = r7 * r92;
+    r145 = fma(r71, r147, r145);
+    r148 = r5 * r34;
+    r148 = r148 * r7;
+    r148 = r148 * r56;
+    r148 = r148 * r56;
+    r148 = r148 * r102;
+    r148 = r148 * r88;
+    r145 = fma(r62, r148, r145);
+    r22 = r5 * r143;
+    r145 = fma(r131, r22, r145);
+    r114 = r84 * r78;
+    r114 = r114 * r143;
+    r114 = r114 * r30;
+    r114 = r114 * r70;
+    r145 = fma(r113, r114, r145);
+    r26 = r21 * r34;
+    r26 = r26 * r7;
+    r26 = r26 * r78;
+    r26 = r26 * r69;
+    r145 = fma(r53, r26, r145);
+    r145 = fma(r38, r83, r145);
+    r145 = fma(r5, r126, r145);
+    r145 = fma(r143, r138, r145);
+    r145 = fma(r143, r128, r145);
+    r145 = fma(r38, r71, r145);
+    r145 = fma(r55, r121, r145);
+    r26 = r3 * r145;
+    WriteIdx2<1024, double, double, double2>(
+        out_pose_jac, 8 * out_pose_jac_num_alloc, global_thread_idx, r130, r26);
+    r26 = r6 * r6;
+    r130 = r10 * r41;
+    r130 = r130 * r7;
+    r114 = r32 * r110;
+    r114 = fma(r111, r114, r39 * r130);
+    r130 = r10 * r54;
+    r130 = r130 * r6;
+    r114 = fma(r39, r130, r114);
+    r22 = r32 * r6;
+    r22 = r22 * r6;
+    r114 = fma(r110, r22, r114);
+    r26 = r26 * r124;
+    r26 = r26 * r114;
+    r26 = r26 * r86;
+    r26 = r26 * r116;
+    r22 = r60 * r114;
+    r22 = fma(r115, r22, r59 * r26);
+    r26 = r54 * r122;
+    r26 = r26 * r59;
+    r22 = fma(r62, r26, r22);
+    r130 = r32 * r127;
+    r130 = r130 * r88;
+    r130 = r130 * r63;
+    r22 = fma(r112, r130, r22);
+    r148 = fma(r41, r118, r32 * r36);
+    r147 = r114 * r113;
+    r147 = r147 * r109;
+    r148 = fma(r106, r147, r148);
+    r144 = r21 * r7;
+    r144 = r144 * r114;
+    r148 = fma(r117, r144, r148);
+    r22 = r22 + r148;
+    r130 = r21 * r6;
+    r130 = r130 * r6;
+    r130 = r130 * r114;
+    r130 = r130 * r86;
+    r130 = r130 * r116;
+    r130 = fma(r114, r115, r59 * r130);
+    r26 = r54 * r62;
+    r130 = fma(r74, r26, r130);
+    r144 = r32 * r63;
+    r130 = fma(r87, r144, r130);
+    r148 = r148 + r130;
+    r22 = fma(r64, r148, r5 * r22);
+    r144 = r4 * r54;
+    r22 = fma(r118, r144, r22);
+    r26 = r4 * r41;
+    r26 = r26 * r62;
+    r22 = fma(r74, r26, r22);
+    r147 = r6 * r84;
+    r147 = r147 * r78;
+    r147 = r147 * r114;
+    r147 = r147 * r86;
+    r147 = r147 * r30;
+    r22 = fma(r70, r147, r22);
+    r126 = r6 * r84;
+    r126 = r126 * r114;
+    r126 = r126 * r86;
+    r126 = r126 * r30;
+    r22 = fma(r70, r126, r22);
+    r42 = r76 * r10;
+    r42 = r42 * r48;
+    r42 = fma(r148, r42, r75 * r148);
+    r42 = fma(r148, r80, r42);
+    r42 = fma(r148, r79, r42);
+    r25 = r6 * r42;
+    r22 = fma(r71, r25, r22);
+    r90 = r4 * r114;
+    r22 = fma(r135, r90, r22);
+    r142 = r21 * r32;
+    r142 = r142 * r6;
+    r142 = r142 * r69;
+    r22 = fma(r53, r142, r22);
+    r132 = r56 * r78;
+    r132 = r132 * r89;
+    r132 = r132 * r114;
+    r132 = r132 * r68;
+    r132 = r132 * r86;
+    r22 = fma(r62, r132, r22);
+    r146 = r4 * r114;
+    r22 = fma(r131, r146, r22);
+    r95 = r21 * r32;
+    r95 = r95 * r6;
+    r95 = r95 * r78;
+    r95 = r95 * r69;
+    r22 = fma(r53, r95, r22);
+    r85 = r56 * r89;
+    r85 = r85 * r114;
+    r85 = r85 * r68;
+    r85 = r85 * r86;
+    r22 = fma(r62, r85, r22);
+    r22 = fma(r54, r83, r22);
+    r22 = fma(r32, r133, r22);
+    r22 = fma(r54, r71, r22);
+    r85 = r2 * r22;
+    r95 = r32 * r7;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r56;
+    r95 = r95 * r127;
+    r95 = r95 * r43;
+    r146 = r41 * r7;
+    r146 = r146 * r122;
+    r146 = r146 * r43;
+    r146 = fma(r59, r146, r88 * r95);
+    r95 = r60 * r114;
+    r95 = r95 * r113;
+    r95 = r95 * r109;
+    r146 = fma(r106, r95, r146);
+    r132 = r7 * r124;
+    r132 = r132 * r114;
+    r146 = fma(r117, r132, r146);
+    r146 = r146 + r130;
+    r146 = fma(r4, r146, r65 * r148);
+    r148 = r21 * r32;
+    r148 = r148 * r7;
+    r148 = r148 * r69;
+    r146 = fma(r53, r148, r146);
+    r130 = r21 * r32;
+    r130 = r130 * r7;
+    r130 = r130 * r78;
+    r130 = r130 * r69;
+    r146 = fma(r53, r130, r146);
+    r132 = r84 * r78;
+    r132 = r132 * r114;
+    r132 = r132 * r30;
+    r132 = r132 * r70;
+    r146 = fma(r113, r132, r146);
+    r95 = r5 * r32;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r56;
+    r95 = r95 * r102;
+    r95 = r95 * r88;
+    r146 = fma(r62, r95, r146);
+    r142 = r5 * r41;
+    r142 = r142 * r62;
+    r146 = fma(r74, r142, r146);
+    r90 = r5 * r114;
+    r146 = fma(r135, r90, r146);
+    r25 = r84 * r114;
+    r25 = r25 * r30;
+    r25 = r25 * r70;
+    r146 = fma(r113, r25, r146);
+    r126 = r7 * r42;
+    r146 = fma(r71, r126, r146);
+    r147 = r5 * r114;
+    r146 = fma(r131, r147, r146);
+    r146 = fma(r114, r128, r146);
+    r146 = fma(r41, r71, r146);
+    r146 = fma(r54, r121, r146);
+    r146 = fma(r41, r83, r146);
+    r146 = fma(r114, r138, r146);
+    r147 = r3 * r146;
+    WriteIdx2<1024, double, double, double2>(out_pose_jac,
+                                             10 * out_pose_jac_num_alloc,
+                                             global_thread_idx,
+                                             r85,
+                                             r147);
+    r147 = r3 * r21;
+    r147 = r147 * r1;
+    r85 = r21 * r0;
+    r126 = r2 * r85;
+    r147 = fma(r120, r126, r134 * r147);
+    r25 = r3 * r21;
+    r25 = r25 * r1;
+    r25 = fma(r107, r126, r125 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r147, r25);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            0 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r3 * r21;
+    r25 = r25 * r1;
+    r25 = fma(r23, r126, r139 * r25);
+    r147 = r3 * r21;
+    r147 = r147 * r1;
+    r147 = fma(r108, r126, r9 * r147);
+    WriteSum2<double, double>((double*)inout_shared, r25, r147);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            2 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r147 = r3 * r21;
+    r147 = r147 * r1;
+    r147 = fma(r97, r126, r145 * r147);
+    r25 = r3 * r21;
+    r25 = r25 * r1;
+    r25 = fma(r22, r126, r146 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r147, r25);
+  };
+  FlushSumShared<2, double>(out_pose_njtr,
+                            4 * out_pose_njtr_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r120 * r120;
+    r147 = r2 * r2;
+    r90 = r134 * r134;
+    r142 = r3 * r3;
+    r90 = fma(r142, r90, r147 * r25);
+    r25 = r107 * r107;
+    r95 = r125 * r125;
+    r95 = fma(r142, r95, r147 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            0 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r23 * r23;
+    r90 = r139 * r139;
+    r90 = fma(r142, r90, r147 * r95);
+    r95 = r9 * r9;
+    r25 = r108 * r108;
+    r25 = fma(r147, r25, r142 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            2 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r97 * r97;
+    r90 = r145 * r145;
+    r90 = fma(r142, r90, r147 * r25);
+    r25 = r146 * r146;
+    r95 = r22 * r22;
+    r95 = fma(r147, r95, r142 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_diag,
+                            4 * out_pose_precond_diag_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r134 * r125;
+    r90 = r120 * r107;
+    r90 = fma(r147, r90, r142 * r95);
+    r95 = r120 * r23;
+    r25 = r134 * r139;
+    r25 = fma(r142, r25, r147 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            0 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r120 * r108;
+    r90 = r134 * r9;
+    r90 = fma(r142, r90, r147 * r25);
+    r25 = r120 * r97;
+    r95 = r134 * r145;
+    r95 = fma(r142, r95, r147 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            2 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r134 * r146;
+    r90 = r120 * r22;
+    r90 = fma(r147, r90, r142 * r95);
+    r95 = r125 * r139;
+    r25 = r107 * r23;
+    r25 = fma(r147, r25, r142 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            4 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r107 * r108;
+    r90 = r125 * r9;
+    r90 = fma(r142, r90, r147 * r25);
+    r25 = r107 * r97;
+    r95 = r125 * r145;
+    r95 = fma(r142, r95, r147 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            6 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r125 * r146;
+    r90 = r107 * r22;
+    r90 = fma(r147, r90, r142 * r95);
+    r95 = r139 * r9;
+    r25 = r23 * r108;
+    r25 = fma(r147, r25, r142 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            8 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r23 * r97;
+    r90 = r139 * r145;
+    r90 = fma(r142, r90, r147 * r25);
+    r25 = r139 * r146;
+    r95 = r23 * r22;
+    r95 = fma(r147, r95, r142 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r95);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            10 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r108 * r97;
+    r90 = r9 * r145;
+    r90 = fma(r142, r90, r147 * r95);
+    r95 = r9 * r146;
+    r25 = r108 * r22;
+    r25 = fma(r147, r25, r142 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_pose_precond_tril,
+                            12 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r145 * r146;
+    r90 = r97 * r22;
+    r90 = fma(r147, r90, r142 * r25);
+    WriteSum1<double, double>((double*)inout_shared, r90);
+  };
+  FlushSumShared<1, double>(out_pose_precond_tril,
+                            14 * out_pose_precond_tril_num_alloc,
+                            pose_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        0 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r67,
+        r66);
+    r90 = r2 * r6;
+    r90 = r90 * r48;
+    r90 = r90 * r71;
+    r25 = r3 * r7;
+    r25 = r25 * r48;
+    r25 = r25 * r71;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        2 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r25);
+    r25 = r2 * r6;
+    r25 = r25 * r71;
+    r25 = r25 * r77;
+    r90 = r3 * r7;
+    r90 = r90 * r71;
+    r90 = r90 * r77;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        4 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r25,
+        r90);
+    r90 = r3 * r73;
+    r25 = r2 * r7;
+    r25 = r25 * r62;
+    r25 = r25 * r74;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        6 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r25,
+        r90);
+    r90 = r2 * r61;
+    r25 = r3 * r7;
+    r25 = r25 * r62;
+    r25 = r25 * r74;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        8 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r25);
+    r25 = r2 * r6;
+    r25 = r25 * r71;
+    r25 = r25 * r82;
+    r90 = r3 * r7;
+    r90 = r90 * r71;
+    r90 = r90 * r82;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        10 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r25,
+        r90);
+    r90 = r2 * r6;
+    r90 = r90 * r71;
+    r90 = r90 * r81;
+    r25 = r3 * r7;
+    r25 = r25 * r71;
+    r25 = r25 * r81;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        12 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r90,
+        r25);
+    r25 = r2 * r48;
+    r90 = r3 * r48;
+    WriteIdx2<1024, double, double, double2>(
+        out_focal_and_extra_jac,
+        14 * out_focal_and_extra_jac_num_alloc,
+        global_thread_idx,
+        r25,
+        r90);
+    r90 = r21 * r66;
+    r90 = r90 * r1;
+    r85 = r67 * r85;
+    WriteSum2<double, double>((double*)inout_shared, r85, r90);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            0 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r3 * r21;
+    r90 = r90 * r7;
+    r90 = r90 * r48;
+    r90 = r90 * r1;
+    r85 = r126 * r72;
+    r90 = fma(r48, r85, r71 * r90);
+    r25 = r3 * r21;
+    r25 = r25 * r7;
+    r25 = r25 * r1;
+    r25 = r25 * r71;
+    r25 = fma(r77, r85, r77 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            2 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r3 * r21;
+    r25 = r25 * r73;
+    r90 = r2 * r35;
+    r90 = r90 * r7;
+    r90 = r90 * r0;
+    r90 = r90 * r59;
+    r90 = fma(r62, r90, r1 * r25);
+    r25 = r3 * r35;
+    r25 = r25 * r7;
+    r25 = r25 * r1;
+    r25 = r25 * r59;
+    r25 = fma(r62, r25, r61 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r90, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            4 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r3 * r21;
+    r25 = r25 * r7;
+    r25 = r25 * r1;
+    r25 = r25 * r71;
+    r25 = fma(r82, r85, r82 * r25);
+    r90 = r3 * r21;
+    r90 = r90 * r7;
+    r90 = r90 * r1;
+    r90 = r90 * r71;
+    r85 = fma(r81, r85, r81 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r25, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            6 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r3 * r21;
+    r85 = r85 * r48;
+    r85 = r85 * r1;
+    r25 = r48 * r126;
+    WriteSum2<double, double>((double*)inout_shared, r25, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_njtr,
+                            8 * out_focal_and_extra_njtr_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r67 * r67;
+    r25 = r66 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r85, r25);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            0 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r25 = r59 * r77;
+    r25 = r25 * r147;
+    r85 = r7 * r59;
+    r85 = r85 * r77;
+    r85 = r85 * r142;
+    r85 = fma(r106, r85, r63 * r25);
+    r25 = r59 * r147;
+    r25 = r25 * r63;
+    r90 = r7 * r59;
+    r90 = r90 * r142;
+    r90 = r90 * r106;
+    r90 = fma(r81, r90, r81 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r85, r90);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            2 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r6 * r6;
+    r57 = r31 * r57;
+    r57 = 1.0 / r57;
+    r49 = r47 * r49;
+    r49 = 1.0 / r49;
+    r85 = r85 * r56;
+    r85 = r85 * r56;
+    r85 = r85 * r137;
+    r85 = r85 * r57;
+    r85 = r85 * r49;
+    r85 = r85 * r112;
+    r85 = r85 * r111;
+    r49 = r73 * r142;
+    r57 = fma(r73, r49, r147 * r85);
+    r137 = r61 * r147;
+    r85 = fma(r61, r137, r142 * r85);
+    WriteSum2<double, double>((double*)inout_shared, r57, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            4 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r59 * r147;
+    r57 = r82 * r82;
+    r85 = r85 * r63;
+    r47 = r7 * r59;
+    r47 = r47 * r142;
+    r47 = r47 * r106;
+    r85 = fma(r57, r47, r57 * r85);
+    r31 = r81 * r81;
+    r25 = r59 * r147;
+    r25 = r25 * r63;
+    r31 = fma(r47, r31, r31 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r85, r31);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            6 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r77 * r147;
+    r0 = r77 * r142;
+    WriteSum2<double, double>((double*)inout_shared, r31, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_diag,
+                            8 * out_focal_and_extra_precond_diag_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = 0.00000000000000000e+00;
+    r31 = r2 * r6;
+    r31 = r31 * r48;
+    r31 = r31 * r67;
+    r31 = r31 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r0, r31);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            0 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r31 = r2 * r6;
+    r31 = r31 * r67;
+    r31 = r31 * r71;
+    r31 = r31 * r77;
+    r95 = r2 * r7;
+    r95 = r95 * r67;
+    r95 = r95 * r62;
+    r95 = r95 * r74;
+    WriteSum2<double, double>((double*)inout_shared, r31, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            2 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r2 * r61;
+    r61 = r61 * r67;
+    r95 = r2 * r6;
+    r95 = r95 * r67;
+    r95 = r95 * r71;
+    r95 = r95 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r61, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            4 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r2 * r48;
+    r95 = r95 * r67;
+    r61 = r2 * r6;
+    r61 = r61 * r67;
+    r61 = r61 * r71;
+    r61 = r61 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r61, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            6 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r3 * r7;
+    r95 = r95 * r48;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    WriteSum2<double, double>((double*)inout_shared, r0, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            8 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r3 * r73;
+    r73 = r73 * r66;
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r77;
+    WriteSum2<double, double>((double*)inout_shared, r95, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            10 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r3 * r7;
+    r73 = r73 * r66;
+    r73 = r73 * r62;
+    r73 = r73 * r74;
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r82;
+    WriteSum2<double, double>((double*)inout_shared, r73, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            12 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r3 * r7;
+    r95 = r95 * r66;
+    r95 = r95 * r71;
+    r95 = r95 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r95, r0);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            14 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r0 = r3 * r48;
+    r0 = r0 * r66;
+    r66 = r59 * r82;
+    r66 = r66 * r147;
+    r95 = r7 * r59;
+    r95 = r95 * r82;
+    r95 = r95 * r142;
+    r95 = fma(r106, r95, r63 * r66);
+    WriteSum2<double, double>((double*)inout_shared, r0, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            16 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r7 * r49;
+    r0 = r71 * r95;
+    r66 = r10 * r6;
+    r66 = r66 * r6;
+    r66 = r66 * r7;
+    r66 = r66 * r56;
+    r66 = r66 * r48;
+    r66 = r66 * r88;
+    r66 = r66 * r116;
+    r66 = r66 * r147;
+    r66 = fma(r112, r66, r48 * r0);
+    r73 = r48 * r137;
+    r61 = r10 * r6;
+    r61 = r61 * r56;
+    r61 = r61 * r48;
+    r61 = r61 * r88;
+    r61 = r61 * r116;
+    r61 = r61 * r142;
+    r61 = r61 * r112;
+    r61 = fma(r111, r61, r72 * r73);
+    WriteSum2<double, double>((double*)inout_shared, r66, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            18 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r59 * r147;
+    r66 = r48 * r81;
+    r61 = r61 * r63;
+    r61 = fma(r66, r47, r66 * r61);
+    WriteSum2<double, double>((double*)inout_shared, r90, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            20 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r90 = r6 * r71;
+    r90 = r90 * r77;
+    r90 = r90 * r147;
+    r73 = r7 * r71;
+    r73 = r73 * r77;
+    r73 = r73 * r142;
+    WriteSum2<double, double>((double*)inout_shared, r90, r73);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            22 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r73 = r10 * r6;
+    r73 = r73 * r6;
+    r73 = r73 * r7;
+    r73 = r73 * r56;
+    r73 = r73 * r88;
+    r73 = r73 * r116;
+    r73 = r73 * r77;
+    r73 = r73 * r147;
+    r73 = fma(r112, r73, r77 * r0);
+    r90 = r77 * r137;
+    r67 = r10 * r6;
+    r67 = r67 * r56;
+    r67 = r67 * r88;
+    r67 = r67 * r116;
+    r67 = r67 * r77;
+    r67 = r67 * r142;
+    r67 = r67 * r112;
+    r67 = fma(r111, r67, r72 * r90);
+    WriteSum2<double, double>((double*)inout_shared, r73, r67);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            24 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    WriteSum2<double, double>((double*)inout_shared, r61, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            26 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r6 * r71;
+    r85 = r85 * r82;
+    r85 = r85 * r147;
+    r61 = r7 * r71;
+    r61 = r61 * r82;
+    r61 = r61 * r142;
+    WriteSum2<double, double>((double*)inout_shared, r85, r61);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            28 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r61 = r7 * r137;
+    r85 = r62 * r74;
+    r85 = fma(r95, r85, r85 * r61);
+    r95 = r10 * r6;
+    r95 = r95 * r6;
+    r95 = r95 * r7;
+    r95 = r95 * r56;
+    r95 = r95 * r88;
+    r95 = r95 * r116;
+    r95 = r95 * r82;
+    r95 = r95 * r147;
+    r95 = fma(r112, r95, r82 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r85, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            30 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r95 = r7 * r48;
+    r95 = r95 * r62;
+    r95 = r95 * r74;
+    r95 = r95 * r147;
+    r85 = r10 * r6;
+    r85 = r85 * r6;
+    r85 = r85 * r7;
+    r85 = r85 * r56;
+    r85 = r85 * r88;
+    r85 = r85 * r116;
+    r85 = r85 * r147;
+    r85 = r85 * r112;
+    r85 = fma(r81, r85, r81 * r0);
+    WriteSum2<double, double>((double*)inout_shared, r85, r95);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            32 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r49 = r48 * r49;
+    r95 = r82 * r137;
+    r85 = r10 * r6;
+    r85 = r85 * r56;
+    r85 = r85 * r88;
+    r85 = r85 * r116;
+    r85 = r85 * r82;
+    r85 = r85 * r142;
+    r85 = r85 * r112;
+    r85 = fma(r111, r85, r72 * r95);
+    WriteSum2<double, double>((double*)inout_shared, r49, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            34 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r48 * r137;
+    r49 = r81 * r137;
+    r95 = r10 * r6;
+    r95 = r95 * r56;
+    r95 = r95 * r88;
+    r95 = r95 * r116;
+    r95 = r95 * r142;
+    r95 = r95 * r112;
+    r95 = r95 * r81;
+    r95 = fma(r111, r95, r72 * r49);
+    WriteSum2<double, double>((double*)inout_shared, r95, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            36 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r7 * r48;
+    r85 = r85 * r62;
+    r85 = r85 * r74;
+    r85 = r85 * r142;
+    r57 = r48 * r57;
+    r47 = fma(r57, r47, r57 * r25);
+    WriteSum2<double, double>((double*)inout_shared, r85, r47);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            38 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r47 = r6 * r71;
+    r47 = r47 * r147;
+    r47 = r47 * r81;
+    r85 = r7 * r71;
+    r85 = r85 * r142;
+    r85 = r85 * r81;
+    WriteSum2<double, double>((double*)inout_shared, r47, r85);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            40 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r85 = r147 * r66;
+    r85 = r85 * r72;
+    r72 = r7 * r71;
+    r72 = r72 * r142;
+    r72 = r72 * r66;
+    WriteSum2<double, double>((double*)inout_shared, r85, r72);
+  };
+  FlushSumShared<2, double>(out_focal_and_extra_precond_tril,
+                            42 * out_focal_and_extra_precond_tril_num_alloc,
+                            focal_and_extra_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r72 = r21 * r7;
+    r85 = r10 * r51;
+    r85 = r85 * r6;
+    r66 = r58 * r110;
+    r66 = fma(r111, r66, r39 * r85);
+    r85 = r58 * r6;
+    r85 = r85 * r6;
+    r66 = fma(r110, r85, r66);
+    r47 = r10 * r28;
+    r47 = r47 * r7;
+    r66 = fma(r39, r47, r66);
+    r72 = r72 * r66;
+    r72 = fma(r117, r72, r58 * r36);
+    r47 = r66 * r113;
+    r47 = r47 * r109;
+    r72 = fma(r106, r47, r72);
+    r72 = fma(r28, r118, r72);
+    r47 = r58 * r63;
+    r47 = fma(r66, r115, r87 * r47);
+    r85 = r51 * r62;
+    r47 = fma(r74, r85, r47);
+    r57 = r21 * r6;
+    r57 = r57 * r6;
+    r57 = r57 * r66;
+    r57 = r57 * r86;
+    r57 = r57 * r116;
+    r47 = fma(r59, r57, r47);
+    r57 = r72 + r47;
+    r85 = r58 * r127;
+    r85 = r85 * r88;
+    r85 = r85 * r63;
+    r25 = r60 * r66;
+    r25 = fma(r115, r25, r112 * r85);
+    r85 = r51 * r122;
+    r85 = r85 * r59;
+    r25 = fma(r62, r85, r25);
+    r95 = r6 * r6;
+    r95 = r95 * r124;
+    r95 = r95 * r66;
+    r95 = r95 * r86;
+    r95 = r95 * r116;
+    r25 = fma(r59, r95, r25);
+    r25 = r25 + r72;
+    r25 = fma(r5, r25, r64 * r57);
+    r72 = r6 * r84;
+    r72 = r72 * r78;
+    r72 = r72 * r66;
+    r72 = r72 * r86;
+    r72 = r72 * r30;
+    r25 = fma(r70, r72, r25);
+    r95 = r21 * r58;
+    r95 = r95 * r6;
+    r95 = r95 * r78;
+    r95 = r95 * r69;
+    r25 = fma(r53, r95, r25);
+    r85 = r4 * r66;
+    r25 = fma(r135, r85, r25);
+    r49 = r4 * r66;
+    r25 = fma(r131, r49, r25);
+    r0 = r6 * r84;
+    r0 = r0 * r66;
+    r0 = r0 * r86;
+    r0 = r0 * r30;
+    r25 = fma(r70, r0, r25);
+    r61 = r4 * r51;
+    r25 = fma(r118, r61, r25);
+    r67 = r21 * r58;
+    r67 = r67 * r6;
+    r67 = r67 * r69;
+    r25 = fma(r53, r67, r25);
+    r73 = r56 * r78;
+    r73 = r73 * r89;
+    r73 = r73 * r66;
+    r73 = r73 * r68;
+    r73 = r73 * r86;
+    r25 = fma(r62, r73, r25);
+    r90 = r76 * r10;
+    r90 = r90 * r48;
+    r90 = fma(r75, r57, r57 * r90);
+    r90 = fma(r57, r80, r90);
+    r90 = fma(r57, r79, r90);
+    r31 = r6 * r90;
+    r25 = fma(r71, r31, r25);
+    r132 = r4 * r28;
+    r132 = r132 * r62;
+    r25 = fma(r74, r132, r25);
+    r130 = r56 * r89;
+    r130 = r130 * r66;
+    r130 = r130 * r68;
+    r130 = r130 * r86;
+    r25 = fma(r62, r130, r25);
+    r25 = fma(r51, r71, r25);
+    r25 = fma(r58, r133, r25);
+    r25 = fma(r51, r83, r25);
+    r130 = r2 * r25;
+    r132 = r58 * r7;
+    r132 = r132 * r7;
+    r132 = r132 * r56;
+    r132 = r132 * r56;
+    r132 = r132 * r127;
+    r132 = r132 * r43;
+    r31 = r7 * r124;
+    r31 = r31 * r66;
+    r31 = fma(r117, r31, r88 * r132);
+    r132 = r60 * r66;
+    r132 = r132 * r113;
+    r132 = r132 * r109;
+    r31 = fma(r106, r132, r31);
+    r73 = r28 * r7;
+    r73 = r73 * r122;
+    r73 = r73 * r43;
+    r31 = fma(r59, r73, r31);
+    r31 = r31 + r47;
+    r31 = fma(r4, r31, r65 * r57);
+    r57 = r7 * r90;
+    r31 = fma(r71, r57, r31);
+    r47 = r84 * r66;
+    r47 = r47 * r30;
+    r47 = r47 * r70;
+    r31 = fma(r113, r47, r31);
+    r73 = r21 * r58;
+    r73 = r73 * r7;
+    r73 = r73 * r69;
+    r31 = fma(r53, r73, r31);
+    r132 = r5 * r66;
+    r31 = fma(r135, r132, r31);
+    r67 = r5 * r66;
+    r31 = fma(r131, r67, r31);
+    r61 = r84 * r78;
+    r61 = r61 * r66;
+    r61 = r61 * r30;
+    r61 = r61 * r70;
+    r31 = fma(r113, r61, r31);
+    r0 = r21 * r58;
+    r0 = r0 * r7;
+    r0 = r0 * r78;
+    r0 = r0 * r69;
+    r31 = fma(r53, r0, r31);
+    r49 = r5 * r58;
+    r49 = r49 * r7;
+    r49 = r49 * r56;
+    r49 = r49 * r56;
+    r49 = r49 * r102;
+    r49 = r49 * r88;
+    r31 = fma(r62, r49, r31);
+    r85 = r5 * r28;
+    r85 = r85 * r62;
+    r31 = fma(r74, r85, r31);
+    r31 = fma(r28, r83, r31);
+    r31 = fma(r51, r121, r31);
+    r31 = fma(r66, r128, r31);
+    r31 = fma(r28, r71, r31);
+    r31 = fma(r66, r138, r31);
+    r85 = r3 * r31;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             0 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r130,
+                                             r85);
+    r85 = r45 * r122;
+    r85 = r85 * r59;
+    r130 = r40 * r127;
+    r130 = r130 * r88;
+    r130 = r130 * r63;
+    r130 = fma(r112, r130, r62 * r85);
+    r85 = r6 * r6;
+    r49 = r40 * r6;
+    r49 = r49 * r6;
+    r0 = r10 * r45;
+    r0 = r0 * r6;
+    r0 = fma(r39, r0, r110 * r49);
+    r49 = r10 * r46;
+    r49 = r49 * r7;
+    r0 = fma(r39, r49, r0);
+    r61 = r40 * r110;
+    r0 = fma(r111, r61, r0);
+    r85 = r85 * r124;
+    r85 = r85 * r0;
+    r85 = r85 * r86;
+    r85 = r85 * r116;
+    r130 = fma(r59, r85, r130);
+    r61 = r6 * r6;
+    r61 = r39 * r61;
+    r61 = r61 * r43;
+    r61 = r61 * r56;
+    r61 = r61 * r86;
+    r61 = r61 * r30;
+    r61 = r61 * r0;
+    r49 = r0 * r113;
+    r49 = r49 * r109;
+    r49 = fma(r106, r49, r40 * r36);
+    r67 = r21 * r7;
+    r67 = r67 * r0;
+    r49 = fma(r117, r67, r49);
+    r49 = fma(r46, r118, r49);
+    r130 = fma(r60, r61, r130);
+    r130 = r130 + r49;
+    r85 = r45 * r62;
+    r85 = fma(r74, r85, r61);
+    r61 = r40 * r63;
+    r85 = fma(r87, r61, r85);
+    r67 = r21 * r6;
+    r67 = r67 * r6;
+    r67 = r67 * r0;
+    r67 = r67 * r86;
+    r67 = r67 * r116;
+    r85 = fma(r59, r67, r85);
+    r49 = r49 + r85;
+    r130 = fma(r64, r49, r5 * r130);
+    r67 = r21 * r40;
+    r67 = r67 * r6;
+    r67 = r67 * r78;
+    r67 = r67 * r69;
+    r130 = fma(r53, r67, r130);
+    r61 = r6 * r84;
+    r61 = r61 * r0;
+    r61 = r61 * r86;
+    r61 = r61 * r30;
+    r130 = fma(r70, r61, r130);
+    r132 = r6 * r84;
+    r132 = r132 * r78;
+    r132 = r132 * r0;
+    r132 = r132 * r86;
+    r132 = r132 * r30;
+    r130 = fma(r70, r132, r130);
+    r73 = r76 * r10;
+    r73 = r73 * r48;
+    r73 = fma(r49, r73, r75 * r49);
+    r73 = fma(r49, r79, r73);
+    r73 = fma(r49, r80, r73);
+    r47 = r6 * r73;
+    r130 = fma(r71, r47, r130);
+    r57 = r21 * r40;
+    r57 = r57 * r6;
+    r57 = r57 * r69;
+    r130 = fma(r53, r57, r130);
+    r95 = r4 * r46;
+    r95 = r95 * r62;
+    r130 = fma(r74, r95, r130);
+    r72 = r4 * r45;
+    r130 = fma(r118, r72, r130);
+    r148 = r56 * r89;
+    r148 = r148 * r0;
+    r148 = r148 * r68;
+    r148 = r148 * r86;
+    r130 = fma(r62, r148, r130);
+    r26 = r4 * r0;
+    r130 = fma(r135, r26, r130);
+    r144 = r4 * r0;
+    r130 = fma(r131, r144, r130);
+    r140 = r56 * r78;
+    r140 = r140 * r89;
+    r140 = r140 * r0;
+    r140 = r140 * r68;
+    r140 = r140 * r86;
+    r130 = fma(r62, r140, r130);
+    r130 = fma(r45, r83, r130);
+    r130 = fma(r45, r71, r130);
+    r130 = fma(r40, r133, r130);
+    r140 = r2 * r130;
+    r144 = r40 * r7;
+    r144 = r144 * r7;
+    r144 = r144 * r56;
+    r144 = r144 * r56;
+    r144 = r144 * r127;
+    r144 = r144 * r43;
+    r26 = r60 * r0;
+    r26 = r26 * r113;
+    r26 = r26 * r109;
+    r26 = fma(r106, r26, r88 * r144);
+    r144 = r46 * r7;
+    r144 = r144 * r122;
+    r144 = r144 * r43;
+    r26 = fma(r59, r144, r26);
+    r148 = r7 * r124;
+    r148 = r148 * r0;
+    r26 = fma(r117, r148, r26);
+    r26 = r26 + r85;
+    r49 = fma(r65, r49, r4 * r26);
+    r26 = r21 * r40;
+    r26 = r26 * r7;
+    r26 = r26 * r69;
+    r49 = fma(r53, r26, r49);
+    r85 = r21 * r40;
+    r85 = r85 * r7;
+    r85 = r85 * r78;
+    r85 = r85 * r69;
+    r49 = fma(r53, r85, r49);
+    r148 = r84 * r0;
+    r148 = r148 * r30;
+    r148 = r148 * r70;
+    r49 = fma(r113, r148, r49);
+    r144 = r5 * r46;
+    r144 = r144 * r62;
+    r49 = fma(r74, r144, r49);
+    r72 = r5 * r0;
+    r49 = fma(r135, r72, r49);
+    r95 = r5 * r0;
+    r49 = fma(r131, r95, r49);
+    r57 = r5 * r40;
+    r57 = r57 * r7;
+    r57 = r57 * r56;
+    r57 = r57 * r56;
+    r57 = r57 * r102;
+    r57 = r57 * r88;
+    r49 = fma(r62, r57, r49);
+    r47 = r84 * r78;
+    r47 = r47 * r0;
+    r47 = r47 * r30;
+    r47 = r47 * r70;
+    r49 = fma(r113, r47, r49);
+    r132 = r7 * r73;
+    r49 = fma(r71, r132, r49);
+    r49 = fma(r46, r83, r49);
+    r49 = fma(r0, r128, r49);
+    r49 = fma(r45, r121, r49);
+    r49 = fma(r46, r71, r49);
+    r49 = fma(r0, r138, r49);
+    r132 = r3 * r49;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             2 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r140,
+                                             r132);
+    r132 = r50 * r127;
+    r132 = r132 * r88;
+    r132 = r132 * r63;
+    r140 = r6 * r6;
+    r47 = r10 * r52;
+    r47 = r47 * r6;
+    r57 = r50 * r110;
+    r57 = fma(r111, r57, r39 * r47);
+    r47 = r50 * r6;
+    r47 = r47 * r6;
+    r57 = fma(r110, r47, r57);
+    r111 = r10 * r44;
+    r111 = r111 * r7;
+    r57 = fma(r39, r111, r57);
+    r140 = r140 * r124;
+    r140 = r140 * r57;
+    r140 = r140 * r86;
+    r140 = r140 * r116;
+    r140 = fma(r59, r140, r112 * r132);
+    r132 = r60 * r57;
+    r140 = fma(r115, r132, r140);
+    r111 = r52 * r122;
+    r111 = r111 * r59;
+    r140 = fma(r62, r111, r140);
+    r47 = r21 * r7;
+    r47 = r47 * r57;
+    r47 = fma(r117, r47, r44 * r118);
+    r39 = r57 * r113;
+    r39 = r39 * r109;
+    r47 = fma(r106, r39, r47);
+    r47 = fma(r50, r36, r47);
+    r140 = r140 + r47;
+    r111 = r50 * r63;
+    r132 = r21 * r6;
+    r132 = r132 * r6;
+    r132 = r132 * r57;
+    r132 = r132 * r86;
+    r132 = r132 * r116;
+    r132 = fma(r59, r132, r87 * r111);
+    r111 = r52 * r62;
+    r132 = fma(r74, r111, r132);
+    r132 = fma(r57, r115, r132);
+    r47 = r47 + r132;
+    r64 = fma(r64, r47, r5 * r140);
+    r140 = r21 * r50;
+    r140 = r140 * r6;
+    r140 = r140 * r69;
+    r64 = fma(r53, r140, r64);
+    r111 = r4 * r44;
+    r111 = r111 * r62;
+    r64 = fma(r74, r111, r64);
+    r115 = r4 * r57;
+    r64 = fma(r131, r115, r64);
+    r87 = r56 * r89;
+    r87 = r87 * r57;
+    r87 = r87 * r68;
+    r87 = r87 * r86;
+    r64 = fma(r62, r87, r64);
+    r116 = r6 * r84;
+    r116 = r116 * r57;
+    r116 = r116 * r86;
+    r116 = r116 * r30;
+    r64 = fma(r70, r116, r64);
+    r36 = r6 * r84;
+    r36 = r36 * r78;
+    r36 = r36 * r57;
+    r36 = r36 * r86;
+    r36 = r36 * r30;
+    r64 = fma(r70, r36, r64);
+    r39 = r4 * r57;
+    r64 = fma(r135, r39, r64);
+    r95 = r4 * r52;
+    r64 = fma(r118, r95, r64);
+    r118 = r56 * r78;
+    r118 = r118 * r89;
+    r118 = r118 * r57;
+    r118 = r118 * r68;
+    r118 = r118 * r86;
+    r64 = fma(r62, r118, r64);
+    r86 = r21 * r50;
+    r86 = r86 * r6;
+    r86 = r86 * r78;
+    r86 = r86 * r69;
+    r64 = fma(r53, r86, r64);
+    r68 = r76 * r10;
+    r68 = r68 * r48;
+    r68 = fma(r47, r68, r75 * r47);
+    r68 = fma(r47, r80, r68);
+    r68 = fma(r47, r79, r68);
+    r79 = r6 * r68;
+    r64 = fma(r71, r79, r64);
+    r64 = fma(r52, r83, r64);
+    r64 = fma(r50, r133, r64);
+    r64 = fma(r52, r71, r64);
+    r79 = r2 * r64;
+    r86 = r44 * r7;
+    r86 = r86 * r122;
+    r86 = r86 * r43;
+    r118 = r7 * r124;
+    r118 = r118 * r57;
+    r118 = fma(r117, r118, r59 * r86);
+    r86 = r60 * r57;
+    r86 = r86 * r113;
+    r86 = r86 * r109;
+    r118 = fma(r106, r86, r118);
+    r106 = r50 * r7;
+    r106 = r106 * r7;
+    r106 = r106 * r56;
+    r106 = r106 * r56;
+    r106 = r106 * r127;
+    r106 = r106 * r43;
+    r118 = fma(r88, r106, r118);
+    r118 = r118 + r132;
+    r118 = fma(r4, r118, r65 * r47);
+    r47 = r5 * r44;
+    r47 = r47 * r62;
+    r118 = fma(r74, r47, r118);
+    r74 = r5 * r57;
+    r118 = fma(r131, r74, r118);
+    r131 = r5 * r57;
+    r118 = fma(r135, r131, r118);
+    r135 = r84 * r78;
+    r135 = r135 * r57;
+    r135 = r135 * r30;
+    r135 = r135 * r70;
+    r118 = fma(r113, r135, r118);
+    r65 = r21 * r50;
+    r65 = r65 * r7;
+    r65 = r65 * r78;
+    r65 = r65 * r69;
+    r118 = fma(r53, r65, r118);
+    r132 = r5 * r50;
+    r132 = r132 * r7;
+    r132 = r132 * r56;
+    r132 = r132 * r56;
+    r132 = r132 * r102;
+    r132 = r132 * r88;
+    r118 = fma(r62, r132, r118);
+    r88 = r7 * r68;
+    r118 = fma(r71, r88, r118);
+    r102 = r84 * r57;
+    r102 = r102 * r30;
+    r102 = r102 * r70;
+    r118 = fma(r113, r102, r118);
+    r70 = r21 * r50;
+    r70 = r70 * r7;
+    r70 = r70 * r69;
+    r118 = fma(r53, r70, r118);
+    r118 = fma(r57, r128, r118);
+    r118 = fma(r57, r138, r118);
+    r118 = fma(r44, r83, r118);
+    r118 = fma(r52, r121, r118);
+    r118 = fma(r44, r71, r118);
+    r70 = r3 * r118;
+    WriteIdx2<1024, double, double, double2>(out_point_jac,
+                                             4 * out_point_jac_num_alloc,
+                                             global_thread_idx,
+                                             r79,
+                                             r70);
+    r70 = r3 * r21;
+    r70 = r70 * r1;
+    r70 = fma(r25, r126, r31 * r70);
+    r79 = r3 * r21;
+    r79 = r79 * r1;
+    r79 = fma(r130, r126, r49 * r79);
+    WriteSum2<double, double>((double*)inout_shared, r70, r79);
+  };
+  FlushSumShared<2, double>(out_point_njtr,
+                            0 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r3 * r21;
+    r79 = r79 * r1;
+    r126 = fma(r64, r126, r118 * r79);
+    WriteSum1<double, double>((double*)inout_shared, r126);
+  };
+  FlushSumShared<1, double>(out_point_njtr,
+                            2 * out_point_njtr_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r31 * r31;
+    r79 = r25 * r25;
+    r79 = fma(r147, r79, r142 * r126);
+    r126 = r49 * r49;
+    r1 = r130 * r130;
+    r1 = fma(r147, r1, r142 * r126);
+    WriteSum2<double, double>((double*)inout_shared, r79, r1);
+  };
+  FlushSumShared<2, double>(out_point_precond_diag,
+                            0 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r1 = r118 * r118;
+    r79 = r64 * r64;
+    r79 = fma(r147, r79, r142 * r1);
+    WriteSum1<double, double>((double*)inout_shared, r79);
+  };
+  FlushSumShared<1, double>(out_point_precond_diag,
+                            2 * out_point_precond_diag_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r79 = r31 * r49;
+    r1 = r25 * r130;
+    r1 = fma(r147, r1, r142 * r79);
+    r79 = r31 * r118;
+    r126 = r25 * r64;
+    r126 = fma(r147, r126, r142 * r79);
+    WriteSum2<double, double>((double*)inout_shared, r1, r126);
+  };
+  FlushSumShared<2, double>(out_point_precond_tril,
+                            0 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    r126 = r49 * r118;
+    r1 = r130 * r64;
+    r1 = fma(r147, r1, r142 * r126);
+    WriteSum1<double, double>((double*)inout_shared, r1);
+  };
+  FlushSumShared<1, double>(out_point_precond_tril,
+                            2 * out_point_precond_tril_num_alloc,
+                            point_indices_loc,
+                            (double*)inout_shared);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacFirstKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_res,
+      out_res_num_alloc,
+      out_rTr,
+      out_pose_jac,
+      out_pose_jac_num_alloc,
+      out_pose_njtr,
+      out_pose_njtr_num_alloc,
+      out_pose_precond_diag,
+      out_pose_precond_diag_num_alloc,
+      out_pose_precond_tril,
+      out_pose_precond_tril_num_alloc,
+      out_focal_and_extra_jac,
+      out_focal_and_extra_jac_num_alloc,
+      out_focal_and_extra_njtr,
+      out_focal_and_extra_njtr_num_alloc,
+      out_focal_and_extra_precond_diag,
+      out_focal_and_extra_precond_diag_num_alloc,
+      out_focal_and_extra_precond_tril,
+      out_focal_and_extra_precond_tril_num_alloc,
+      out_point_jac,
+      out_point_jac_num_alloc,
+      out_point_njtr,
+      out_point_njtr_num_alloc,
+      out_point_precond_diag,
+      out_point_precond_diag_num_alloc,
+      out_point_precond_tril,
+      out_point_precond_tril_num_alloc,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* out_res,
+    unsigned int out_res_num_alloc,
+    double* const out_rTr,
+    double* out_pose_jac,
+    unsigned int out_pose_jac_num_alloc,
+    double* const out_pose_njtr,
+    unsigned int out_pose_njtr_num_alloc,
+    double* const out_pose_precond_diag,
+    unsigned int out_pose_precond_diag_num_alloc,
+    double* const out_pose_precond_tril,
+    unsigned int out_pose_precond_tril_num_alloc,
+    double* out_focal_and_extra_jac,
+    unsigned int out_focal_and_extra_jac_num_alloc,
+    double* const out_focal_and_extra_njtr,
+    unsigned int out_focal_and_extra_njtr_num_alloc,
+    double* const out_focal_and_extra_precond_diag,
+    unsigned int out_focal_and_extra_precond_diag_num_alloc,
+    double* const out_focal_and_extra_precond_tril,
+    unsigned int out_focal_and_extra_precond_tril_num_alloc,
+    double* out_point_jac,
+    unsigned int out_point_jac_num_alloc,
+    double* const out_point_njtr,
+    unsigned int out_point_njtr_num_alloc,
+    double* const out_point_precond_diag,
+    unsigned int out_point_precond_diag_num_alloc,
+    double* const out_point_precond_tril,
+    unsigned int out_point_precond_tril_num_alloc,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_score.cu
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_score.cu
@@ -1,0 +1,394 @@
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_score.h"
+#include "memops.cuh"
+#include <cooperative_groups.h>
+#include <cooperative_groups/details/partitioning.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda_runtime.h>
+
+namespace cg = cooperative_groups;
+
+namespace caspar {
+
+__global__ void __launch_bounds__(1024, 1)
+    ThinPrismFisheyeSplitFixedPrincipalPointScoreKernel(
+        double* pose,
+        unsigned int pose_num_alloc,
+        SharedIndex* pose_indices,
+        double* sensor_from_rig,
+        unsigned int sensor_from_rig_num_alloc,
+        double* focal_and_extra,
+        unsigned int focal_and_extra_num_alloc,
+        SharedIndex* focal_and_extra_indices,
+        double* point,
+        unsigned int point_num_alloc,
+        SharedIndex* point_indices,
+        double* pixel,
+        unsigned int pixel_num_alloc,
+        double* principal_point,
+        unsigned int principal_point_num_alloc,
+        double* const out_rTr,
+        size_t problem_size) {
+  const int global_thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  __shared__ uint8_t inout_shared[16384];
+
+  __shared__ SharedIndex pose_indices_loc[1024];
+  pose_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? pose_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ SharedIndex focal_and_extra_indices_loc[1024];
+  focal_and_extra_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? focal_and_extra_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+  __shared__ SharedIndex point_indices_loc[1024];
+  point_indices_loc[threadIdx.x] =
+      (global_thread_idx < problem_size
+           ? point_indices[global_thread_idx]
+           : SharedIndex{0xffffffff, 0xffff, 0xffff});
+
+  __shared__ double out_rTr_local[1];
+
+  double r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15,
+      r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+      r31, r32, r33, r34, r35, r36, r37, r38, r39, r40, r41, r42, r43, r44, r45;
+
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(principal_point,
+                                            0 * principal_point_num_alloc,
+                                            global_thread_idx,
+                                            r0,
+                                            r1);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                0 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r2,
+                        r3);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(focal_and_extra,
+                                4 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r4,
+                        r5);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r6 = 1.00000000000000008e-15;
+    ReadIdx1<1024, double, double, double>(
+        sensor_from_rig, 6 * sensor_from_rig_num_alloc, global_thread_idx, r7);
+  };
+  LoadShared<2, double, double>(
+      point, 0 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r8, r9);
+  };
+  __syncthreads();
+  LoadShared<2, double, double>(
+      pose, 2 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r10, r11);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            2 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r12,
+                                            r13);
+  };
+  LoadShared<2, double, double>(
+      pose, 0 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r14, r15);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            0 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r16,
+                                            r17);
+    r18 = fma(r15, r16, r10 * r13);
+    r19 = r14 * r17;
+    r20 = -1.00000000000000000e+00;
+    r18 = fma(r20, r19, r18);
+    r18 = fma(r11, r12, r18);
+    r19 = 2.00000000000000000e+00;
+    r21 = fma(r11, r16, r14 * r13);
+    r22 = r15 * r12;
+    r21 = fma(r20, r22, r21);
+    r21 = fma(r10, r17, r21);
+    r22 = r19 * r21;
+    r23 = r18 * r22;
+    r24 = r10 * r16;
+    r24 = fma(r20, r24, r15 * r13);
+    r24 = fma(r11, r17, r24);
+    r24 = fma(r14, r12, r24);
+    r25 = -2.00000000000000000e+00;
+    r26 = fma(r15, r17, r14 * r16);
+    r26 = fma(r10, r12, r26);
+    r26 = fma(r20, r26, r11 * r13);
+    r11 = r25 * r26;
+    r27 = fma(r24, r11, r23);
+    r27 = fma(r8, r27, r7);
+  };
+  LoadShared<2, double, double>(
+      pose, 4 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r7, r28);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r29 = r16 * r12;
+    r29 = r29 * r19;
+    r30 = r17 * r13;
+    r31 = fma(r25, r30, r29);
+  };
+  LoadShared<1, double, double>(
+      pose, 6 * pose_num_alloc, pose_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, pose_indices_loc[threadIdx.x].target, r32);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = 1.00000000000000000e+00;
+    r34 = r17 * r17;
+    r34 = r34 * r25;
+    r35 = r33 + r34;
+    r36 = r16 * r16;
+    r36 = r25 * r36;
+    r35 = r35 + r36;
+    r37 = r17 * r12;
+    r37 = r37 * r19;
+    r38 = r16 * r13;
+    r38 = fma(r19, r38, r37);
+    r39 = r19 * r18;
+    r39 = r39 * r24;
+    r40 = fma(r26, r22, r39);
+  };
+  LoadShared<1, double, double>(
+      point, 2 * point_num_alloc, point_indices_loc, (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared1<double>(
+        (double*)inout_shared, point_indices_loc[threadIdx.x].target, r41);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r42 = r24 * r24;
+    r42 = r25 * r42;
+    r43 = r33 + r42;
+    r44 = r21 * r21;
+    r44 = r44 * r25;
+    r43 = r43 + r44;
+    r27 = fma(r7, r31, r27);
+    r27 = fma(r32, r35, r27);
+    r27 = fma(r28, r38, r27);
+    r27 = fma(r9, r40, r27);
+    r27 = fma(r41, r43, r27);
+    r43 = copysign(1.0, r27);
+    r43 = fma(r6, r43, r27);
+    r27 = r43 * r43;
+    r27 = 1.0 / r27;
+    ReadIdx2<1024, double, double, double2>(sensor_from_rig,
+                                            4 * sensor_from_rig_num_alloc,
+                                            global_thread_idx,
+                                            r40,
+                                            r38);
+    r42 = r33 + r42;
+    r35 = r18 * r18;
+    r35 = r25 * r35;
+    r42 = r42 + r35;
+    r42 = fma(r8, r42, r40);
+    r22 = r24 * r22;
+    r40 = fma(r18, r11, r22);
+    r31 = r19 * r24;
+    r31 = fma(r26, r31, r23);
+    r30 = fma(r19, r30, r29);
+    r29 = r12 * r13;
+    r23 = r16 * r17;
+    r23 = r23 * r19;
+    r29 = fma(r25, r29, r23);
+    r45 = r12 * r12;
+    r45 = fma(r25, r45, r33);
+    r34 = r34 + r45;
+    r42 = fma(r9, r40, r42);
+    r42 = fma(r41, r31, r42);
+    r42 = fma(r32, r30, r42);
+    r42 = fma(r28, r29, r42);
+    r42 = fma(r7, r34, r42);
+    r34 = r42 * r42;
+    r29 = r19 * r18;
+    r29 = fma(r26, r29, r22);
+    r29 = fma(r8, r29, r38);
+    r8 = r12 * r13;
+    r8 = fma(r19, r8, r23);
+    r45 = r36 + r45;
+    r36 = r16 * r13;
+    r36 = fma(r25, r36, r37);
+    r11 = fma(r21, r11, r39);
+    r35 = r33 + r35;
+    r35 = r35 + r44;
+    r29 = fma(r7, r8, r29);
+    r29 = fma(r28, r45, r29);
+    r29 = fma(r32, r36, r29);
+    r29 = fma(r41, r11, r29);
+    r29 = fma(r9, r35, r29);
+    r35 = r29 * r29;
+    r9 = fma(r27, r35, r27 * r34);
+    r9 = sqrt(r9);
+    r11 = copysign(1.0, r9);
+    r11 = fma(r6, r11, r9);
+    r6 = r11 * r11;
+    r6 = 1.0 / r6;
+    r6 = r27 * r6;
+    r9 = atan(r9);
+    r27 = r9 * r9;
+    r6 = r6 * r27;
+    r27 = r6 * r35;
+    r41 = 3.00000000000000000e+00;
+    r41 = r41 * r6;
+    r36 = fma(r34, r41, r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                8 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r32,
+                        r45);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r34 = r6 * r34;
+    r27 = r27 + r34;
+    r32 = fma(r32, r27, r5 * r36);
+    r36 = r4 * r19;
+    r36 = r36 * r42;
+    r36 = r36 * r29;
+    r32 = fma(r6, r36, r32);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                2 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r8);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r7 = r27 * r27;
+    r8 = fma(r8, r7, r28 * r27);
+  };
+  LoadShared<2, double, double>(focal_and_extra,
+                                6 * focal_and_extra_num_alloc,
+                                focal_and_extra_indices_loc,
+                                (double*)inout_shared);
+  if (global_thread_idx < problem_size) {
+    ReadShared2<double>((double*)inout_shared,
+                        focal_and_extra_indices_loc[threadIdx.x].target,
+                        r28,
+                        r44);
+  };
+  __syncthreads();
+  if (global_thread_idx < problem_size) {
+    r33 = r7 * r7;
+    r7 = r27 * r7;
+    r8 = fma(r44, r33, r8);
+    r8 = fma(r28, r7, r8);
+    r43 = 1.0 / r43;
+    r43 = r9 * r43;
+    r11 = 1.0 / r11;
+    r43 = r43 * r11;
+    r8 = r8 * r43;
+    r32 = fma(r42, r8, r32);
+    r32 = fma(r42, r43, r32);
+    r32 = fma(r2, r32, r0);
+    ReadIdx2<1024, double, double, double2>(
+        pixel, 0 * pixel_num_alloc, global_thread_idx, r2, r0);
+    r32 = fma(r2, r20, r32);
+    r41 = fma(r35, r41, r34);
+    r27 = fma(r45, r27, r4 * r41);
+    r45 = r5 * r19;
+    r45 = r45 * r42;
+    r45 = r45 * r29;
+    r27 = fma(r6, r45, r27);
+    r27 = fma(r29, r8, r27);
+    r27 = fma(r29, r43, r27);
+    r27 = fma(r3, r27, r1);
+    r27 = fma(r0, r20, r27);
+    r27 = fma(r27, r27, r32 * r32);
+  };
+  SumStore<double>(out_rTr_local,
+                   (double*)inout_shared,
+                   0,
+                   global_thread_idx < problem_size,
+                   r27);
+  SumFlushFinal<double>(out_rTr_local, out_rTr, 1);
+}
+
+void ThinPrismFisheyeSplitFixedPrincipalPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size) {
+  if (problem_size == 0) {
+    return;
+  }
+
+  const int n_blocks = (problem_size + 1024 - 1) / 1024;
+  ThinPrismFisheyeSplitFixedPrincipalPointScoreKernel<<<n_blocks, 1024>>>(
+      pose,
+      pose_num_alloc,
+      pose_indices,
+      sensor_from_rig,
+      sensor_from_rig_num_alloc,
+      focal_and_extra,
+      focal_and_extra_num_alloc,
+      focal_and_extra_indices,
+      point,
+      point_num_alloc,
+      point_indices,
+      pixel,
+      pixel_num_alloc,
+      principal_point,
+      principal_point_num_alloc,
+      out_rTr,
+      problem_size);
+}
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_score.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/kernel_thin_prism_fisheye_split_fixed_principal_point_score.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "shared_indices.h"
+#include <cuda_runtime.h>
+
+namespace caspar {
+
+void ThinPrismFisheyeSplitFixedPrincipalPointScore(
+    double* pose,
+    unsigned int pose_num_alloc,
+    SharedIndex* pose_indices,
+    double* sensor_from_rig,
+    unsigned int sensor_from_rig_num_alloc,
+    double* focal_and_extra,
+    unsigned int focal_and_extra_num_alloc,
+    SharedIndex* focal_and_extra_indices,
+    double* point,
+    unsigned int point_num_alloc,
+    SharedIndex* point_indices,
+    double* pixel,
+    unsigned int pixel_num_alloc,
+    double* principal_point,
+    unsigned int principal_point_num_alloc,
+    double* const out_rTr,
+    size_t problem_size);
+
+}  // namespace caspar

--- a/src/thirdparty/Symforce-Caspar/generated/f64/solver.cc
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/solver.cc
@@ -122,6 +122,58 @@
 #include "kernel_SimpleRadialPrincipalPoint_update_r_first.h"
 #include "kernel_SimpleRadialPrincipalPoint_update_step.h"
 #include "kernel_SimpleRadialPrincipalPoint_update_step_first.h"
+#include "kernel_ThinPrismFisheyeCalib_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyeCalib_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyeCalib_normalize.h"
+#include "kernel_ThinPrismFisheyeCalib_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyeCalib_retract.h"
+#include "kernel_ThinPrismFisheyeCalib_start_w.h"
+#include "kernel_ThinPrismFisheyeCalib_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyeCalib_update_Mp.h"
+#include "kernel_ThinPrismFisheyeCalib_update_p.h"
+#include "kernel_ThinPrismFisheyeCalib_update_r.h"
+#include "kernel_ThinPrismFisheyeCalib_update_r_first.h"
+#include "kernel_ThinPrismFisheyeCalib_update_step.h"
+#include "kernel_ThinPrismFisheyeCalib_update_step_first.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_normalize.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_retract.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_Mp.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_p.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_r_first.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step.h"
+#include "kernel_ThinPrismFisheyeFocalAndExtra_update_step_first.h"
+#include "kernel_ThinPrismFisheyePose_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyePose_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyePose_normalize.h"
+#include "kernel_ThinPrismFisheyePose_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyePose_retract.h"
+#include "kernel_ThinPrismFisheyePose_start_w.h"
+#include "kernel_ThinPrismFisheyePose_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyePose_update_Mp.h"
+#include "kernel_ThinPrismFisheyePose_update_p.h"
+#include "kernel_ThinPrismFisheyePose_update_r.h"
+#include "kernel_ThinPrismFisheyePose_update_r_first.h"
+#include "kernel_ThinPrismFisheyePose_update_step.h"
+#include "kernel_ThinPrismFisheyePose_update_step_first.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_denominator_or_beta_numerator.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_alpha_numerator_denominator.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_normalize.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_pred_decrease_times_two.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_retract.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_start_w_contribute.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_Mp.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_p.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_r_first.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step.h"
+#include "kernel_ThinPrismFisheyePrincipalPoint_update_step_first.h"
 #include "kernel_pinhole_fixed_point_jtjnjtr_direct.h"
 #include "kernel_pinhole_fixed_point_res_jac.h"
 #include "kernel_pinhole_fixed_point_res_jac_first.h"
@@ -242,6 +294,66 @@
 #include "kernel_simple_radial_split_fixed_principal_point_res_jac.h"
 #include "kernel_simple_radial_split_fixed_principal_point_res_jac_first.h"
 #include "kernel_simple_radial_split_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_fixed_pose_score.h"
+#include "kernel_thin_prism_fisheye_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_res_jac.h"
+#include "kernel_thin_prism_fisheye_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_focal_and_extra_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_pose_fixed_principal_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_fixed_point_score.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_jtjnjtr_direct.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_res_jac_first.h"
+#include "kernel_thin_prism_fisheye_split_fixed_principal_point_score.h"
 #include "shared_indices.h"
 #include "solver_tools.h"
 #include "sort_indices.h"
@@ -286,6 +398,10 @@ GraphSolver::GraphSolver(
     size_t SimpleRadialFocalAndExtra_num_max,
     size_t SimpleRadialPose_num_max,
     size_t SimpleRadialPrincipalPoint_num_max,
+    size_t ThinPrismFisheyeCalib_num_max,
+    size_t ThinPrismFisheyeFocalAndExtra_num_max,
+    size_t ThinPrismFisheyePose_num_max,
+    size_t ThinPrismFisheyePrincipalPoint_num_max,
     size_t simple_radial_num_max,
     size_t simple_radial_fixed_pose_num_max,
     size_t simple_radial_fixed_point_num_max,
@@ -294,6 +410,10 @@ GraphSolver::GraphSolver(
     size_t pinhole_fixed_pose_num_max,
     size_t pinhole_fixed_point_num_max,
     size_t pinhole_fixed_pose_fixed_point_num_max,
+    size_t thin_prism_fisheye_num_max,
+    size_t thin_prism_fisheye_fixed_pose_num_max,
+    size_t thin_prism_fisheye_fixed_point_num_max,
+    size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max,
     size_t simple_radial_split_fixed_focal_and_extra_num_max,
     size_t simple_radial_split_fixed_principal_point_num_max,
     size_t simple_radial_split_fixed_pose_fixed_focal_and_extra_num_max,
@@ -321,6 +441,22 @@ GraphSolver::GraphSolver(
     size_t pinhole_split_fixed_pose_fixed_focal_fixed_point_num_max,
     size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
     size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max,
+    size_t thin_prism_fisheye_split_fixed_principal_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max,
+    size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max,
+    size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
+    size_t
+        thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max,
     int device_id)
     : params_(params),
       device_id_(device_id),
@@ -342,6 +478,17 @@ GraphSolver::GraphSolver(
       SimpleRadialPose_num_max_(SimpleRadialPose_num_max),
       SimpleRadialPrincipalPoint_num_(SimpleRadialPrincipalPoint_num_max),
       SimpleRadialPrincipalPoint_num_max_(SimpleRadialPrincipalPoint_num_max),
+      ThinPrismFisheyeCalib_num_(ThinPrismFisheyeCalib_num_max),
+      ThinPrismFisheyeCalib_num_max_(ThinPrismFisheyeCalib_num_max),
+      ThinPrismFisheyeFocalAndExtra_num_(ThinPrismFisheyeFocalAndExtra_num_max),
+      ThinPrismFisheyeFocalAndExtra_num_max_(
+          ThinPrismFisheyeFocalAndExtra_num_max),
+      ThinPrismFisheyePose_num_(ThinPrismFisheyePose_num_max),
+      ThinPrismFisheyePose_num_max_(ThinPrismFisheyePose_num_max),
+      ThinPrismFisheyePrincipalPoint_num_(
+          ThinPrismFisheyePrincipalPoint_num_max),
+      ThinPrismFisheyePrincipalPoint_num_max_(
+          ThinPrismFisheyePrincipalPoint_num_max),
       simple_radial_num_(simple_radial_num_max),
       simple_radial_num_max_(simple_radial_num_max),
       simple_radial_fixed_pose_num_(simple_radial_fixed_pose_num_max),
@@ -362,6 +509,19 @@ GraphSolver::GraphSolver(
           pinhole_fixed_pose_fixed_point_num_max),
       pinhole_fixed_pose_fixed_point_num_max_(
           pinhole_fixed_pose_fixed_point_num_max),
+      thin_prism_fisheye_num_(thin_prism_fisheye_num_max),
+      thin_prism_fisheye_num_max_(thin_prism_fisheye_num_max),
+      thin_prism_fisheye_fixed_pose_num_(thin_prism_fisheye_fixed_pose_num_max),
+      thin_prism_fisheye_fixed_pose_num_max_(
+          thin_prism_fisheye_fixed_pose_num_max),
+      thin_prism_fisheye_fixed_point_num_(
+          thin_prism_fisheye_fixed_point_num_max),
+      thin_prism_fisheye_fixed_point_num_max_(
+          thin_prism_fisheye_fixed_point_num_max),
+      thin_prism_fisheye_fixed_pose_fixed_point_num_(
+          thin_prism_fisheye_fixed_pose_fixed_point_num_max),
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_(
+          thin_prism_fisheye_fixed_pose_fixed_point_num_max),
       simple_radial_split_fixed_focal_and_extra_num_(
           simple_radial_split_fixed_focal_and_extra_num_max),
       simple_radial_split_fixed_focal_and_extra_num_max_(
@@ -447,7 +607,51 @@ GraphSolver::GraphSolver(
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_(
           pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max),
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_(
-          pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max) {
+          pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max),
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_(
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max) {
   indices_valid_ = false;
   if (params.pcg_rel_error_exit <= 0.0f) {
     throw std::runtime_error("params.pcg_rel_error_exit must be positive");
@@ -537,6 +741,37 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__storage_new_best_ =
       assign_and_increment<double>(
           origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_current_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_check_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__storage_new_best_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_current_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_check_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_current_ = assign_and_increment<double>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_check_ = assign_and_increment<double>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__storage_new_best_ = assign_and_increment<double>(
+      origin_ptr_, offset, 8 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_current_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_check_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   facs__simple_radial__args__pose__idx_shared_ =
       assign_and_increment<SharedIndex>(
           origin_ptr_, offset, 1 * simple_radial_num_, 4);
@@ -662,6 +897,80 @@ GraphSolver::GraphSolver(
   facs__pinhole_fixed_pose_fixed_point__args__point__data_ =
       assign_and_increment<double>(
           origin_ptr_, offset, 4 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__pixel__data_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 8 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_, offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 4 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__args__pose__idx_shared_ =
       assign_and_increment<SharedIndex>(
           origin_ptr_,
@@ -1418,6 +1727,406 @@ GraphSolver::GraphSolver(
           offset,
           4 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_ =
+      assign_and_increment<SharedIndex>(
+          origin_ptr_,
+          offset,
+          1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          10 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   marker__scratch_inout_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   facs__simple_radial__res_ = assign_and_increment<double>(
@@ -1440,6 +2149,18 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * pinhole_fixed_point_num_, 4);
   facs__pinhole_fixed_pose_fixed_point__res_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__res_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__res_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__res_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__res_ =
       assign_and_increment<double>(
           origin_ptr_,
@@ -1565,6 +2286,72 @@ GraphSolver::GraphSolver(
           offset,
           2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   facs__simple_radial__args__pose__jac_ = assign_and_increment<double>(
       origin_ptr_, offset, 12 * simple_radial_num_, 4);
   facs__simple_radial__args__calib__jac_ = assign_and_increment<double>(
@@ -1606,6 +2393,30 @@ GraphSolver::GraphSolver(
   facs__pinhole_fixed_pose_fixed_point__args__calib__jac_ =
       assign_and_increment<double>(
           origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__args__pose__jac_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__calib__jac_ = assign_and_increment<double>(
+      origin_ptr_, offset, 16 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye__args__point__jac_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__calib__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 16 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 6 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 12 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__args__calib__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 16 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__args__pose__jac_ =
       assign_and_increment<double>(
           origin_ptr_,
@@ -1833,6 +2644,129 @@ GraphSolver::GraphSolver(
           offset,
           12 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          16 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          16 *
+              thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__jac_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          12 *
+              thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   nodes__PinholeCalib__z_ = assign_and_increment<double>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
   nodes__PinholeCalib__z_end__ =
@@ -1868,6 +2802,22 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__z_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__z_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__z_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__z_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__z_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__z_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__z_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__z_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__z_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__z_end__ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__p_ = assign_and_increment<double>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
@@ -1905,6 +2855,22 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__p_end__ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__p_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__p_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__p_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__p_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__p_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__p_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__p_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__p_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__step_ = assign_and_increment<double>(
       origin_ptr_, offset, 4 * PinholeCalib_num_, 4);
   nodes__PinholeCalib__step_end__ =
@@ -1941,6 +2907,22 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   nodes__SimpleRadialPrincipalPoint__step_end__ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeCalib__step_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__step_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__step_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__step_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePose__step_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__step_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__step_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__step_end__ =
+      assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   marker__w_start_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   nodes__PinholeCalib__w_ = assign_and_increment<double>(
@@ -1961,6 +2943,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__w_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__w_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__w_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__w_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__w_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__w_end_ = assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 1);
   marker__r_0_start_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
@@ -1982,6 +2972,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__r_0_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__r_0_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__r_0_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__r_0_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__r_0_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__r_0_end_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   marker__r_k_start_ =
@@ -2004,6 +3002,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__r_k_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__r_k_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__r_k_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__r_k_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__r_k_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__r_k_end_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   marker__Mp_start_ =
@@ -2026,6 +3032,14 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 6 * SimpleRadialPose_num_, 4);
   nodes__SimpleRadialPrincipalPoint__Mp_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__Mp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__Mp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__Mp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__Mp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__Mp_end_ = assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
   marker__precond_start_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 4);
@@ -2069,6 +3083,26 @@ GraphSolver::GraphSolver(
   nodes__SimpleRadialPrincipalPoint__precond_tril_ =
       assign_and_increment<double>(
           origin_ptr_, offset, 1 * SimpleRadialPrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyeCalib__precond_diag_ = assign_and_increment<double>(
+      origin_ptr_, offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeCalib__precond_tril_ = assign_and_increment<double>(
+      origin_ptr_, offset, 66 * ThinPrismFisheyeCalib_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 45 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  nodes__ThinPrismFisheyePose__precond_diag_ = assign_and_increment<double>(
+      origin_ptr_, offset, 6 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePose__precond_tril_ = assign_and_increment<double>(
+      origin_ptr_, offset, 16 * ThinPrismFisheyePose_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__precond_diag_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  nodes__ThinPrismFisheyePrincipalPoint__precond_tril_ =
+      assign_and_increment<double>(
+          origin_ptr_, offset, 1 * ThinPrismFisheyePrincipalPoint_num_, 4);
   marker__precond_end_ =
       assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 1);
   marker__jp_start_ =
@@ -2093,6 +3127,18 @@ GraphSolver::GraphSolver(
       origin_ptr_, offset, 2 * pinhole_fixed_point_num_, 4);
   facs__pinhole_fixed_pose_fixed_point__jp_ = assign_and_increment<double>(
       origin_ptr_, offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  facs__thin_prism_fisheye__jp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose__jp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  facs__thin_prism_fisheye_fixed_point__jp_ = assign_and_increment<double>(
+      origin_ptr_, offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  facs__thin_prism_fisheye_fixed_pose_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_fixed_pose_fixed_point_num_,
+          4);
   facs__simple_radial_split_fixed_focal_and_extra__jp_ =
       assign_and_increment<double>(
           origin_ptr_,
@@ -2217,6 +3263,72 @@ GraphSolver::GraphSolver(
           offset,
           2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
           4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+          4);
+  facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__jp_ =
+      assign_and_increment<double>(
+          origin_ptr_,
+          offset,
+          2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+          4);
   marker__jp_end_ = assign_and_increment<double>(origin_ptr_, offset, 0 * 0, 1);
   solver__current_diag_ =
       assign_and_increment<double>(origin_ptr_, offset, 1 * 1, 1);
@@ -2270,6 +3382,7 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
       std::chrono::steady_clock::now();
   std::chrono::time_point<std::chrono::steady_clock> t_prev = t0;
   score_best = DoResJacFirst();
+  result.initial_score = score_best;
   if (print_progress) {
     printf("                                 score_init: % .6e\n", score_best);
   }
@@ -2322,6 +3435,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                   nodes__SimpleRadialPose__storage_new_best_);
         std::swap(nodes__SimpleRadialPrincipalPoint__storage_check_,
                   nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyeCalib__storage_check_,
+                  nodes__ThinPrismFisheyeCalib__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+                  nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyePose__storage_check_,
+                  nodes__ThinPrismFisheyePose__storage_new_best_);
+        std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+                  nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
         score_best_pcg = score_new_pcg;
         if (params_.pcg_rel_score_exit != -1.0f &&
             score_best_pcg < score_best * params_.pcg_rel_score_exit) {
@@ -2354,6 +3475,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                 nodes__SimpleRadialPose__storage_new_best_);
       std::swap(nodes__SimpleRadialPrincipalPoint__storage_check_,
                 nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeCalib__storage_check_,
+                nodes__ThinPrismFisheyeCalib__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+                nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePose__storage_check_,
+                nodes__ThinPrismFisheyePose__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+                nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
     }
 
     const double diag_current = diag;
@@ -2386,6 +3515,14 @@ SolveResult GraphSolver::solve(bool print_progress, bool verbose_logging) {
                 nodes__SimpleRadialPose__storage_new_best_);
       std::swap(nodes__SimpleRadialPrincipalPoint__storage_current_,
                 nodes__SimpleRadialPrincipalPoint__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeCalib__storage_current_,
+                nodes__ThinPrismFisheyeCalib__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+                nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePose__storage_current_,
+                nodes__ThinPrismFisheyePose__storage_new_best_);
+      std::swap(nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+                nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_);
 
     } else {
       quality = 0.0f;
@@ -2718,6 +3855,144 @@ double GraphSolver::DoResJacFirst() {
       nodes__PinholeCalib__precond_tril_,
       PinholeCalib_num_,
       pinhole_fixed_pose_fixed_point_num_);
+
+  ThinPrismFisheyeResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye__args__pose__idx_shared_,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye__args__point__idx_shared_,
+      facs__thin_prism_fisheye__args__pixel__data_,
+      thin_prism_fisheye_num_max_,
+
+      facs__thin_prism_fisheye__res_,
+      thin_prism_fisheye_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye__args__pose__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye__args__calib__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye__args__point__jac_,
+      thin_prism_fisheye_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_num_);
+
+  ThinPrismFisheyeFixedPoseResJacFirst(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose__res_,
+      thin_prism_fisheye_fixed_pose_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+
+  ThinPrismFisheyeFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_point__res_,
+      thin_prism_fisheye_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
+
+  ThinPrismFisheyeFixedPoseFixedPointResJacFirst(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__res_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
 
   SimpleRadialSplitFixedFocalAndExtraResJacFirst(
       nodes__SimpleRadialPose__storage_current_,
@@ -3480,6 +4755,387 @@ double GraphSolver::DoResJacFirst() {
       nodes__PinholePose__precond_tril_,
       PinholePose_num_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      solver__res_tot_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJacFirst(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJacFirst(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      solver__res_tot_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__r_0_start_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__Mp_start_);
   return 0.5 * ReadCuMem(solver__res_tot_);
@@ -3760,6 +5416,143 @@ void GraphSolver::DoResJac() {
       nodes__PinholeCalib__precond_tril_,
       PinholeCalib_num_,
       pinhole_fixed_pose_fixed_point_num_);
+
+  ThinPrismFisheyeResJac(nodes__ThinPrismFisheyePose__storage_current_,
+                         ThinPrismFisheyePose_num_max_,
+                         facs__thin_prism_fisheye__args__pose__idx_shared_,
+                         facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+                         thin_prism_fisheye_num_max_,
+                         nodes__ThinPrismFisheyeCalib__storage_current_,
+                         ThinPrismFisheyeCalib_num_max_,
+                         facs__thin_prism_fisheye__args__calib__idx_shared_,
+                         nodes__Point__storage_current_,
+                         Point_num_max_,
+                         facs__thin_prism_fisheye__args__point__idx_shared_,
+                         facs__thin_prism_fisheye__args__pixel__data_,
+                         thin_prism_fisheye_num_max_,
+
+                         facs__thin_prism_fisheye__res_,
+                         thin_prism_fisheye_num_,
+
+                         facs__thin_prism_fisheye__args__pose__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__ThinPrismFisheyePose__r_k_,
+                         ThinPrismFisheyePose_num_,
+                         nodes__ThinPrismFisheyePose__precond_diag_,
+                         ThinPrismFisheyePose_num_,
+                         nodes__ThinPrismFisheyePose__precond_tril_,
+                         ThinPrismFisheyePose_num_,
+                         facs__thin_prism_fisheye__args__calib__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__ThinPrismFisheyeCalib__r_k_,
+                         ThinPrismFisheyeCalib_num_,
+                         nodes__ThinPrismFisheyeCalib__precond_diag_,
+                         ThinPrismFisheyeCalib_num_,
+                         nodes__ThinPrismFisheyeCalib__precond_tril_,
+                         ThinPrismFisheyeCalib_num_,
+                         facs__thin_prism_fisheye__args__point__jac_,
+                         thin_prism_fisheye_num_,
+                         nodes__Point__r_k_,
+                         Point_num_,
+                         nodes__Point__precond_diag_,
+                         Point_num_,
+                         nodes__Point__precond_tril_,
+                         Point_num_,
+                         thin_prism_fisheye_num_);
+
+  ThinPrismFisheyeFixedPoseResJac(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose__res_,
+      thin_prism_fisheye_fixed_pose_num_,
+
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+
+  ThinPrismFisheyeFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_point__res_,
+      thin_prism_fisheye_fixed_point_num_,
+
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
+
+  ThinPrismFisheyeFixedPoseFixedPointResJac(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__res_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_,
+
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_tril_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
 
   SimpleRadialSplitFixedFocalAndExtraResJac(
       nodes__SimpleRadialPose__storage_current_,
@@ -4522,6 +6315,387 @@ void GraphSolver::DoResJac() {
       nodes__PinholePose__precond_tril_,
       PinholePose_num_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_current_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+
+      nodes__Point__r_k_,
+      Point_num_,
+      nodes__Point__precond_diag_,
+      Point_num_,
+      nodes__Point__precond_tril_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointResJac(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointResJac(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_tril_,
+      ThinPrismFisheyePose_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__r_0_start_);
   Copy(marker__r_k_start_, marker__r_k_end_, marker__Mp_start_);
 }
@@ -4635,6 +6809,56 @@ void GraphSolver::DoNormalize() {
       z,
       SimpleRadialPrincipalPoint_num_,
       SimpleRadialPrincipalPoint_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyeCalib__p_
+                     : nodes__ThinPrismFisheyeCalib__z_;
+  ThinPrismFisheyeCalibNormalize(nodes__ThinPrismFisheyeCalib__precond_diag_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 nodes__ThinPrismFisheyeCalib__precond_tril_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 nodes__ThinPrismFisheyeCalib__r_k_,
+                                 ThinPrismFisheyeCalib_num_,
+                                 solver__current_diag_,
+                                 z,
+                                 ThinPrismFisheyeCalib_num_,
+                                 ThinPrismFisheyeCalib_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyeFocalAndExtra__p_
+                     : nodes__ThinPrismFisheyeFocalAndExtra__z_;
+  ThinPrismFisheyeFocalAndExtraNormalize(
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__current_diag_,
+      z,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyePose__p_
+                     : nodes__ThinPrismFisheyePose__z_;
+  ThinPrismFisheyePoseNormalize(nodes__ThinPrismFisheyePose__precond_diag_,
+                                ThinPrismFisheyePose_num_,
+                                nodes__ThinPrismFisheyePose__precond_tril_,
+                                ThinPrismFisheyePose_num_,
+                                nodes__ThinPrismFisheyePose__r_k_,
+                                ThinPrismFisheyePose_num_,
+                                solver__current_diag_,
+                                z,
+                                ThinPrismFisheyePose_num_,
+                                ThinPrismFisheyePose_num_);
+  z = pcg_iter_ == 0 ? nodes__ThinPrismFisheyePrincipalPoint__p_
+                     : nodes__ThinPrismFisheyePrincipalPoint__z_;
+  ThinPrismFisheyePrincipalPointNormalize(
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_tril_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__current_diag_,
+      z,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateMp() {
@@ -4728,6 +6952,48 @@ void GraphSolver::DoUpdateMp() {
                                      nodes__SimpleRadialPrincipalPoint__w_,
                                      SimpleRadialPrincipalPoint_num_,
                                      SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateMp(nodes__ThinPrismFisheyeCalib__r_k_,
+                                ThinPrismFisheyeCalib_num_,
+                                nodes__ThinPrismFisheyeCalib__Mp_,
+                                ThinPrismFisheyeCalib_num_,
+                                solver__beta_,
+                                nodes__ThinPrismFisheyeCalib__Mp_,
+                                ThinPrismFisheyeCalib_num_,
+                                nodes__ThinPrismFisheyeCalib__w_,
+                                ThinPrismFisheyeCalib_num_,
+                                ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateMp(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__Mp_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyeFocalAndExtra__Mp_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateMp(nodes__ThinPrismFisheyePose__r_k_,
+                               ThinPrismFisheyePose_num_,
+                               nodes__ThinPrismFisheyePose__Mp_,
+                               ThinPrismFisheyePose_num_,
+                               solver__beta_,
+                               nodes__ThinPrismFisheyePose__Mp_,
+                               ThinPrismFisheyePose_num_,
+                               nodes__ThinPrismFisheyePose__w_,
+                               ThinPrismFisheyePose_num_,
+                               ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateMp(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__Mp_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyePrincipalPoint__Mp_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoJtjpDirect() {
@@ -4839,6 +7105,61 @@ void GraphSolver::DoJtjpDirect() {
       nodes__PinholeCalib__w_,
       PinholeCalib_num_,
       pinhole_fixed_point_num_);
+  ThinPrismFisheyeJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye__args__pose__idx_shared_,
+      facs__thin_prism_fisheye__args__pose__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye__args__calib__idx_shared_,
+      facs__thin_prism_fisheye__args__calib__jac_,
+      thin_prism_fisheye_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye__args__point__idx_shared_,
+      facs__thin_prism_fisheye__args__point__jac_,
+      thin_prism_fisheye_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_num_);
+  ThinPrismFisheyeFixedPoseJtjnjtrDirect(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__jac_,
+      thin_prism_fisheye_fixed_pose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_fixed_pose_num_);
+  ThinPrismFisheyeFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__jac_,
+      thin_prism_fisheye_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      thin_prism_fisheye_fixed_point_num_);
   SimpleRadialSplitFixedFocalAndExtraJtjnjtrDirect(
       nodes__SimpleRadialPose__p_,
       SimpleRadialPose_num_,
@@ -5091,6 +7412,132 @@ void GraphSolver::DoJtjpDirect() {
       nodes__PinholeFocal__w_,
       PinholeFocal_num_,
       pinhole_split_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraJtjnjtrDirect(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__Point__p_,
+      Point_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__Point__w_,
+      Point_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointJtjnjtrDirect(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
 }
 
 void GraphSolver::DoAlphaFirst() {
@@ -5181,6 +7628,46 @@ void GraphSolver::DoAlphaFirst() {
       solver__alpha_numerator_,
       solver__alpha_denominator_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointAlphaNumeratorDenominator(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_numerator_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePrincipalPoint_num_);
 
   AlphaFromNumDenom(solver__alpha_numerator_,
                     solver__alpha_denominator_,
@@ -5247,6 +7734,34 @@ void GraphSolver::DoAlpha() {
       SimpleRadialPrincipalPoint_num_,
       solver__alpha_denominator_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeCalib__p_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__w_,
+      ThinPrismFisheyeCalib_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePose__p_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__w_,
+      ThinPrismFisheyePose_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_denominator_,
+      ThinPrismFisheyePrincipalPoint_num_);
 
   AlphaFromNumDenom(solver__beta_numerator_,
                     solver__alpha_denominator_,
@@ -5311,6 +7826,32 @@ void GraphSolver::DoUpdateStepFirst() {
       nodes__SimpleRadialPrincipalPoint__step_,
       SimpleRadialPrincipalPoint_num_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateStepFirst(nodes__ThinPrismFisheyeCalib__p_,
+                                       ThinPrismFisheyeCalib_num_,
+                                       solver__alpha_,
+                                       nodes__ThinPrismFisheyeCalib__step_,
+                                       ThinPrismFisheyeCalib_num_,
+                                       ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateStepFirst(
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateStepFirst(nodes__ThinPrismFisheyePose__p_,
+                                      ThinPrismFisheyePose_num_,
+                                      solver__alpha_,
+                                      nodes__ThinPrismFisheyePose__step_,
+                                      ThinPrismFisheyePose_num_,
+                                      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateStepFirst(
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateStep() {
@@ -5386,6 +7927,40 @@ void GraphSolver::DoUpdateStep() {
                                        nodes__SimpleRadialPrincipalPoint__step_,
                                        SimpleRadialPrincipalPoint_num_,
                                        SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateStep(nodes__ThinPrismFisheyeCalib__step_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  nodes__ThinPrismFisheyeCalib__p_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  solver__alpha_,
+                                  nodes__ThinPrismFisheyeCalib__step_,
+                                  ThinPrismFisheyeCalib_num_,
+                                  ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateStep(
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__p_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateStep(nodes__ThinPrismFisheyePose__step_,
+                                 ThinPrismFisheyePose_num_,
+                                 nodes__ThinPrismFisheyePose__p_,
+                                 ThinPrismFisheyePose_num_,
+                                 solver__alpha_,
+                                 nodes__ThinPrismFisheyePose__step_,
+                                 ThinPrismFisheyePose_num_,
+                                 ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateStep(
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 void GraphSolver::DoUpdateRFirst() {
@@ -5491,6 +8066,52 @@ void GraphSolver::DoUpdateRFirst() {
       solver__r_kp1_norm2_tot_,
       SimpleRadialPrincipalPoint_num_);
 
+  ThinPrismFisheyeCalibUpdateRFirst(nodes__ThinPrismFisheyeCalib__r_k_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    nodes__ThinPrismFisheyeCalib__w_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    solver__neg_alpha_,
+                                    nodes__ThinPrismFisheyeCalib__r_k_,
+                                    ThinPrismFisheyeCalib_num_,
+                                    solver__r_0_norm2_tot_,
+                                    solver__r_kp1_norm2_tot_,
+                                    ThinPrismFisheyeCalib_num_);
+
+  ThinPrismFisheyeFocalAndExtraUpdateRFirst(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__r_0_norm2_tot_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+
+  ThinPrismFisheyePoseUpdateRFirst(nodes__ThinPrismFisheyePose__r_k_,
+                                   ThinPrismFisheyePose_num_,
+                                   nodes__ThinPrismFisheyePose__w_,
+                                   ThinPrismFisheyePose_num_,
+                                   solver__neg_alpha_,
+                                   nodes__ThinPrismFisheyePose__r_k_,
+                                   ThinPrismFisheyePose_num_,
+                                   solver__r_0_norm2_tot_,
+                                   solver__r_kp1_norm2_tot_,
+                                   ThinPrismFisheyePose_num_);
+
+  ThinPrismFisheyePrincipalPointUpdateRFirst(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__r_0_norm2_tot_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
+
   pcg_r_0_norm2_ = ReadCuMem(solver__r_0_norm2_tot_);
   pcg_r_kp1_norm2_ = ReadCuMem(solver__r_kp1_norm2_tot_);
 }
@@ -5579,6 +8200,44 @@ void GraphSolver::DoUpdateR() {
                                     SimpleRadialPrincipalPoint_num_,
                                     solver__r_kp1_norm2_tot_,
                                     SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateR(nodes__ThinPrismFisheyeCalib__r_k_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__w_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__neg_alpha_,
+                               nodes__ThinPrismFisheyeCalib__r_k_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__r_kp1_norm2_tot_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateR(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__w_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateR(nodes__ThinPrismFisheyePose__r_k_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__w_,
+                              ThinPrismFisheyePose_num_,
+                              solver__neg_alpha_,
+                              nodes__ThinPrismFisheyePose__r_k_,
+                              ThinPrismFisheyePose_num_,
+                              solver__r_kp1_norm2_tot_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateR(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__w_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__neg_alpha_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__r_kp1_norm2_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
   pcg_r_kp1_norm2_ = ReadCuMem(solver__r_kp1_norm2_tot_);
 }
 
@@ -5648,6 +8307,36 @@ double GraphSolver::DoRetractScore() {
       nodes__SimpleRadialPrincipalPoint__storage_check_,
       SimpleRadialPrincipalPoint_num_max_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibRetract(nodes__ThinPrismFisheyeCalib__storage_current_,
+                               ThinPrismFisheyeCalib_num_max_,
+                               nodes__ThinPrismFisheyeCalib__step_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__storage_check_,
+                               ThinPrismFisheyeCalib_num_max_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraRetract(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseRetract(nodes__ThinPrismFisheyePose__storage_current_,
+                              ThinPrismFisheyePose_num_max_,
+                              nodes__ThinPrismFisheyePose__step_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__storage_check_,
+                              ThinPrismFisheyePose_num_max_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointRetract(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      ThinPrismFisheyePrincipalPoint_num_);
   Zero(solver__res_tot_, solver__res_tot_ + 1);
   SimpleRadialScore(nodes__SimpleRadialPose__storage_check_,
                     SimpleRadialPose_num_max_,
@@ -5766,6 +8455,65 @@ double GraphSolver::DoRetractScore() {
       pinhole_fixed_pose_fixed_point_num_max_,
       solver__res_tot_,
       pinhole_fixed_pose_fixed_point_num_);
+  ThinPrismFisheyeScore(nodes__ThinPrismFisheyePose__storage_check_,
+                        ThinPrismFisheyePose_num_max_,
+                        facs__thin_prism_fisheye__args__pose__idx_shared_,
+                        facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+                        thin_prism_fisheye_num_max_,
+                        nodes__ThinPrismFisheyeCalib__storage_check_,
+                        ThinPrismFisheyeCalib_num_max_,
+                        facs__thin_prism_fisheye__args__calib__idx_shared_,
+                        nodes__Point__storage_check_,
+                        Point_num_max_,
+                        facs__thin_prism_fisheye__args__point__idx_shared_,
+                        facs__thin_prism_fisheye__args__pixel__data_,
+                        thin_prism_fisheye_num_max_,
+                        solver__res_tot_,
+                        thin_prism_fisheye_num_);
+  ThinPrismFisheyeFixedPoseScore(
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_pose_num_);
+  ThinPrismFisheyeFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_point_num_);
+  ThinPrismFisheyeFixedPoseFixedPointScore(
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeCalib__storage_check_,
+      ThinPrismFisheyeCalib_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_);
   SimpleRadialSplitFixedFocalAndExtraScore(
       nodes__SimpleRadialPose__storage_check_,
       SimpleRadialPose_num_max_,
@@ -6136,6 +8884,191 @@ double GraphSolver::DoRetractScore() {
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_,
       solver__res_tot_,
       pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPrincipalPointFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      nodes__Point__storage_check_,
+      Point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_check_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointScore(
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_check_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_);
+  ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointScore(
+      nodes__ThinPrismFisheyePose__storage_check_,
+      ThinPrismFisheyePose_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      solver__res_tot_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_);
   return 0.5 * ReadCuMem(solver__res_tot_);
 }
 
@@ -6208,6 +9141,38 @@ void GraphSolver::DoBeta() {
       SimpleRadialPrincipalPoint_num_,
       solver__beta_numerator_,
       SimpleRadialPrincipalPoint_num_);
+
+  ThinPrismFisheyeCalibAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeCalib__r_k_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__z_,
+      ThinPrismFisheyeCalib_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyeCalib_num_);
+
+  ThinPrismFisheyeFocalAndExtraAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyeFocalAndExtra__r_k_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__z_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+
+  ThinPrismFisheyePoseAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePose__r_k_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__z_,
+      ThinPrismFisheyePose_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyePose_num_);
+
+  ThinPrismFisheyePrincipalPointAlphaDenominatorOrBetaNumerator(
+      nodes__ThinPrismFisheyePrincipalPoint__r_k_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__z_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_numerator_,
+      ThinPrismFisheyePrincipalPoint_num_);
   BetaFromNumDenom(
       solver__beta_numerator_, solver__alpha_numerator_, solver__beta_);
 }
@@ -6285,6 +9250,39 @@ void GraphSolver::DoUpdateP() {
                                     nodes__SimpleRadialPrincipalPoint__p_,
                                     SimpleRadialPrincipalPoint_num_,
                                     SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibUpdateP(nodes__ThinPrismFisheyeCalib__z_,
+                               ThinPrismFisheyeCalib_num_,
+                               nodes__ThinPrismFisheyeCalib__p_,
+                               ThinPrismFisheyeCalib_num_,
+                               solver__beta_,
+                               nodes__ThinPrismFisheyeCalib__p_,
+                               ThinPrismFisheyeCalib_num_,
+                               ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraUpdateP(nodes__ThinPrismFisheyeFocalAndExtra__z_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       nodes__ThinPrismFisheyeFocalAndExtra__p_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       solver__beta_,
+                                       nodes__ThinPrismFisheyeFocalAndExtra__p_,
+                                       ThinPrismFisheyeFocalAndExtra_num_,
+                                       ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePoseUpdateP(nodes__ThinPrismFisheyePose__z_,
+                              ThinPrismFisheyePose_num_,
+                              nodes__ThinPrismFisheyePose__p_,
+                              ThinPrismFisheyePose_num_,
+                              solver__beta_,
+                              nodes__ThinPrismFisheyePose__p_,
+                              ThinPrismFisheyePose_num_,
+                              ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointUpdateP(
+      nodes__ThinPrismFisheyePrincipalPoint__z_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__beta_,
+      nodes__ThinPrismFisheyePrincipalPoint__p_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      ThinPrismFisheyePrincipalPoint_num_);
 }
 
 double GraphSolver::GetPredDecrease() {
@@ -6373,6 +9371,46 @@ double GraphSolver::GetPredDecrease() {
       SimpleRadialPrincipalPoint_num_,
       solver__pred_decrease_tot_,
       SimpleRadialPrincipalPoint_num_);
+  ThinPrismFisheyeCalibPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyeCalib__step_,
+      ThinPrismFisheyeCalib_num_,
+      nodes__ThinPrismFisheyeCalib__precond_diag_,
+      ThinPrismFisheyeCalib_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyeCalib__r_0_,
+      ThinPrismFisheyeCalib_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyeCalib_num_);
+  ThinPrismFisheyeFocalAndExtraPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyeFocalAndExtra__step_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyeFocalAndExtra__r_0_,
+      ThinPrismFisheyeFocalAndExtra_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyeFocalAndExtra_num_);
+  ThinPrismFisheyePosePredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyePose__step_,
+      ThinPrismFisheyePose_num_,
+      nodes__ThinPrismFisheyePose__precond_diag_,
+      ThinPrismFisheyePose_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyePose__r_0_,
+      ThinPrismFisheyePose_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyePose_num_);
+  ThinPrismFisheyePrincipalPointPredDecreaseTimesTwo(
+      nodes__ThinPrismFisheyePrincipalPoint__step_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      nodes__ThinPrismFisheyePrincipalPoint__precond_diag_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__current_diag_,
+      nodes__ThinPrismFisheyePrincipalPoint__r_0_,
+      ThinPrismFisheyePrincipalPoint_num_,
+      solver__pred_decrease_tot_,
+      ThinPrismFisheyePrincipalPoint_num_);
   return 0.5 * ReadCuMem(solver__pred_decrease_tot_);
 }
 
@@ -7047,6 +10085,315 @@ void GraphSolver::GetSimpleRadialPrincipalPointNodesToStackedDevice(
       nodes__SimpleRadialPrincipalPoint__storage_current_,
       data,
       SimpleRadialPrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyeCalib_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyeCalib_num_max_");
+  }
+  ThinPrismFisheyeCalib_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNodesFromStackedHost(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             12 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyeCalibStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibNodesFromStackedDevice(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyeCalibNodesToStackedHost(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibCasparToStacked(
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             12 * num * sizeof(double),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyeCalibNodesToStackedDevice(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeCalib_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeCalib_num_");
+  }
+  ThinPrismFisheyeCalibCasparToStacked(
+      nodes__ThinPrismFisheyeCalib__storage_current_,
+      data,
+      ThinPrismFisheyeCalib_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyeFocalAndExtra_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_max_");
+  }
+  ThinPrismFisheyeFocalAndExtra_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNodesFromStackedHost(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFocalAndExtraNodesFromStackedDevice(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyeFocalAndExtraNodesToStackedHost(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraCasparToStacked(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             10 * num * sizeof(double),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyeFocalAndExtraNodesToStackedDevice(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyeFocalAndExtra_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyeFocalAndExtra_num_");
+  }
+  ThinPrismFisheyeFocalAndExtraCasparToStacked(
+      nodes__ThinPrismFisheyeFocalAndExtra__storage_current_,
+      data,
+      ThinPrismFisheyeFocalAndExtra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyePose_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyePose_num_max_");
+  }
+  ThinPrismFisheyePose_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNodesFromStackedHost(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseNodesFromStackedDevice(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyePose__storage_current_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyePoseNodesToStackedHost(double* const data,
+                                                            const size_t offset,
+                                                            const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseCasparToStacked(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             7 * num * sizeof(double),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyePoseNodesToStackedDevice(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePose_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePose_num_");
+  }
+  ThinPrismFisheyePoseCasparToStacked(
+      nodes__ThinPrismFisheyePose__storage_current_,
+      data,
+      ThinPrismFisheyePose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNum(const size_t num) {
+  cudaSetDevice(device_id_);
+  if (num > ThinPrismFisheyePrincipalPoint_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_max_");
+  }
+  ThinPrismFisheyePrincipalPoint_num_ = num;
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNodesFromStackedHost(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyePrincipalPointNodesFromStackedDevice(
+    const double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::GetThinPrismFisheyePrincipalPointNodesToStackedHost(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointCasparToStacked(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      marker__scratch_inout_,
+      ThinPrismFisheyePrincipalPoint_num_max_,
+      offset,
+      num);
+  cudaMemcpy(data,
+             marker__scratch_inout_,
+             2 * num * sizeof(double),
+             cudaMemcpyDeviceToHost);
+}
+
+void GraphSolver::GetThinPrismFisheyePrincipalPointNodesToStackedDevice(
+    double* const data, const size_t offset, const size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > ThinPrismFisheyePrincipalPoint_num_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > ThinPrismFisheyePrincipalPoint_num_");
+  }
+  ThinPrismFisheyePrincipalPointCasparToStacked(
+      nodes__ThinPrismFisheyePrincipalPoint__storage_current_,
+      data,
+      ThinPrismFisheyePrincipalPoint_num_max_,
       offset,
       num);
 }
@@ -8493,6 +11840,766 @@ void GraphSolver::SetPinholeFixedPoseFixedPointPointDataFromStackedDevice(
       data,
       facs__pinhole_fixed_pose_fixed_point__args__point__data_,
       pinhole_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeNum(const size_t num) {
+  if (num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  thin_prism_fisheye_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyePoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyePoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyePoseIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__pose__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyeCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__calib__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyePointIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyePointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyePointIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_num_. Use Setthin_prism_fisheyeNum before "
+        "setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices, facs__thin_prism_fisheye__args__point__idx_shared_, num);
+}
+void GraphSolver::SetThinPrismFisheyeSensorFromRigDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeSensorFromRigDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye__args__sensor_from_rig__data_,
+      thin_prism_fisheye_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyePixelDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(marker__scratch_inout_,
+                            facs__thin_prism_fisheye__args__pixel__data_,
+                            thin_prism_fisheye_num_max_,
+                            offset,
+                            num);
+}
+
+void GraphSolver::SetThinPrismFisheyePixelDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_num_max_");
+  }
+  ConstPixelStackedToCaspar(data,
+                            facs__thin_prism_fisheye__args__pixel__data_,
+                            thin_prism_fisheye_num_max_,
+                            offset,
+                            num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  thin_prism_fisheye_fixed_pose_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePointIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_num_. Use "
+        "Setthin_prism_fisheye_fixed_poseNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePixelDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePixelDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPosePoseDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPosePoseDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_pose_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_fixed_point_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(indices,
+                facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_,
+                num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPixelDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPixelDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPointPointDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPointPointDataFromStackedDevice(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > thin_prism_fisheye_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointNum(const size_t num) {
+  if (num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_fixed_pose_fixed_point_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_fixed_pose_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pose_fixed_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+    const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_fixed_pose_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_fixed_pose_fixed_point_num_. Use "
+        "Setthin_prism_fisheye_fixed_pose_fixed_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedHost(
+    const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_fixed_pose_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_fixed_pose_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_,
+      thin_prism_fisheye_fixed_pose_fixed_point_num_max_,
       offset,
       num);
 }
@@ -14062,6 +18169,2930 @@ void GraphSolver::
       offset,
       num);
 }
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraNum(
+    const size_t num) {
+  if (num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_num_ = num;
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromHost(
+    const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extraNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPrincipalPointNum(
+    const size_t num) {
+  if (num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_principal_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_principal_pointNum before setting "
+        "indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num > thin_prism_fisheye_split_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > thin_prism_fisheye_split_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extraNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_pose_fixed_principal_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointNum(
+    const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_ = num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_. "
+        "Use Setthin_prism_fisheye_split_fixed_principal_point_fixed_pointNum "
+        "before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(
+        std::to_string(offset + num) +
+        " > "
+        "thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "principal_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_principal_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_focal_"
+                             "and_extra_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_"
+        "pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_"
+        "num_. Use "
+        "Setthin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_"
+        "pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePoseStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_pose_fixed_"
+                             "principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointNum(
+        const size_t num) {
+  if (num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_ =
+      num;
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromHost(
+        const unsigned int* const indices, size_t num) {
+  cudaSetDevice(device_id_);
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "fixed_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "point_fixed_pointNum before setting indices.");
+  }
+  cudaMemcpy((unsigned int*)marker__scratch_inout_,
+             indices,
+             num * sizeof(unsigned int),
+             cudaMemcpyHostToDevice);
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      (unsigned int*)marker__scratch_inout_, num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+        const unsigned int* const indices, size_t num) {
+  indices_valid_ = false;
+  cudaSetDevice(device_id_);
+
+  if (num !=
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_) {
+    throw std::runtime_error(
+        std::to_string(num) +
+        " != "
+        "thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_"
+        "fixed_point_num_. Use "
+        "Setthin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_"
+        "point_fixed_pointNum before setting indices.");
+  }
+
+  size_t tmp_size = SortIndicesGetTmpNbytes(num);
+  if (tmp_size + num > scratch_inout_size_) {
+    throw std::runtime_error(
+        "Scratch_inout_size too small. tmp_size: " + std::to_string(tmp_size) +
+        ", num: " + std::to_string(num) +
+        ", scratch_inout_size_: " + std::to_string(scratch_inout_size_));
+  }
+  SharedIndices(
+      indices,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             7 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeSensorFromRigStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPixelStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPixelStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             10 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyeFocalAndExtraStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             2 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstThinPrismFisheyePrincipalPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedHost(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  cudaMemcpy(marker__scratch_inout_,
+             data,
+             3 * num * sizeof(double),
+             cudaMemcpyHostToDevice);
+  ConstPointStackedToCaspar(
+      marker__scratch_inout_,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
+
+void GraphSolver::
+    SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+        const double* const data, size_t offset, size_t num) {
+  cudaSetDevice(device_id_);
+  if (offset + num >
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_) {
+    throw std::runtime_error(std::to_string(offset + num) +
+                             " > "
+                             "thin_prism_fisheye_split_fixed_focal_and_extra_"
+                             "fixed_principal_point_fixed_point_num_max_");
+  }
+  ConstPointStackedToCaspar(
+      data,
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_,
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_,
+      offset,
+      num);
+}
 
 size_t GraphSolver::get_nbytes() {
   size_t offset = 0;
@@ -14094,6 +21125,18 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 8 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<SharedIndex>(offset, 1 * simple_radial_num_, 4);
   increment_offset<double>(offset, 8 * simple_radial_num_, 4);
   increment_offset<SharedIndex>(offset, 1 * simple_radial_num_, 4);
@@ -14140,6 +21183,35 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
   increment_offset<double>(offset, 8 * pinhole_fixed_pose_fixed_point_num_, 4);
   increment_offset<double>(offset, 4 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 8 * thin_prism_fisheye_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<SharedIndex>(offset, 1 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 8 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(offset, 8 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(offset, 4 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 8 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 8 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 4 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<SharedIndex>(
       offset, 1 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<double>(
@@ -14518,18 +21590,266 @@ size_t GraphSolver::get_nbytes() {
       offset,
       4 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
-  at_least =
-      std::max(at_least,
-               offset + std::max({4 * PinholeCalib_num_max_,
-                                  2 * PinholeFocal_num_max_,
-                                  7 * PinholePose_num_max_,
-                                  2 * PinholePrincipalPoint_num_max_,
-                                  3 * Point_num_max_,
-                                  4 * SimpleRadialCalib_num_max_,
-                                  2 * SimpleRadialFocalAndExtra_num_max_,
-                                  7 * SimpleRadialPose_num_max_,
-                                  2 * SimpleRadialPrincipalPoint_num_max_}) *
-                            sizeof(double));
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 8 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 10 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset, 8 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<SharedIndex>(
+      offset, 1 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<SharedIndex>(
+      offset,
+      1 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      8 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      10 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      4 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
+  at_least = std::max(
+      at_least,
+      offset + std::max({4 * PinholeCalib_num_max_,
+                         2 * PinholeFocal_num_max_,
+                         7 * PinholePose_num_max_,
+                         2 * PinholePrincipalPoint_num_max_,
+                         3 * Point_num_max_,
+                         4 * SimpleRadialCalib_num_max_,
+                         2 * SimpleRadialFocalAndExtra_num_max_,
+                         7 * SimpleRadialPose_num_max_,
+                         2 * SimpleRadialPrincipalPoint_num_max_,
+                         12 * ThinPrismFisheyeCalib_num_max_,
+                         10 * ThinPrismFisheyeFocalAndExtra_num_max_,
+                         7 * ThinPrismFisheyePose_num_max_,
+                         2 * ThinPrismFisheyePrincipalPoint_num_max_}) *
+                   sizeof(double));
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 2 * simple_radial_num_, 4);
   increment_offset<double>(offset, 2 * simple_radial_fixed_pose_num_, 4);
@@ -14540,6 +21860,11 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<double>(
       offset, 2 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<double>(
@@ -14603,6 +21928,46 @@ size_t GraphSolver::get_nbytes() {
       offset,
       2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
   increment_offset<double>(offset, 12 * simple_radial_num_, 4);
   increment_offset<double>(offset, 4 * simple_radial_num_, 4);
   increment_offset<double>(offset, 6 * simple_radial_num_, 4);
@@ -14620,6 +21985,15 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 12 * pinhole_fixed_point_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(offset, 12 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 16 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 6 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 16 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 6 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 12 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(offset, 16 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 16 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<double>(
       offset, 12 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<double>(
@@ -14724,6 +22098,77 @@ size_t GraphSolver::get_nbytes() {
       offset,
       12 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
       4);
+  increment_offset<double>(
+      offset, 12 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 0 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 6 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 12 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset, 16 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset, 6 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      16 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      12 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      12 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      12 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      16 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      6 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      0 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      16 *
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      12 *
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
+      4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 2 * PinholeFocal_num_, 4);
@@ -14742,23 +22187,13 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 2 * PinholeFocal_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 6 * PinholePose_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 2 * PinholePrincipalPoint_num_, 4);
-  increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 4 * Point_num_, 4);
-  increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 4 * SimpleRadialCalib_num_, 4);
-  increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
-  increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
-  increment_offset<double>(offset, 0 * 0, 4);
-  increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
@@ -14778,6 +22213,40 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * PinholeFocal_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 6 * PinholePose_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * PinholePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 4 * Point_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 4 * SimpleRadialCalib_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
   increment_offset<double>(offset, 2 * PinholeFocal_num_, 4);
@@ -14788,6 +22257,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 1);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
@@ -14799,6 +22272,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
@@ -14810,6 +22287,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
@@ -14821,6 +22302,10 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * SimpleRadialFocalAndExtra_num_, 4);
   increment_offset<double>(offset, 6 * SimpleRadialPose_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 4 * PinholeCalib_num_, 4);
@@ -14841,6 +22326,14 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 16 * SimpleRadialPose_num_, 4);
   increment_offset<double>(offset, 2 * SimpleRadialPrincipalPoint_num_, 4);
   increment_offset<double>(offset, 1 * SimpleRadialPrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 12 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 66 * ThinPrismFisheyeCalib_num_, 4);
+  increment_offset<double>(offset, 10 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 45 * ThinPrismFisheyeFocalAndExtra_num_, 4);
+  increment_offset<double>(offset, 6 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 16 * ThinPrismFisheyePose_num_, 4);
+  increment_offset<double>(offset, 2 * ThinPrismFisheyePrincipalPoint_num_, 4);
+  increment_offset<double>(offset, 1 * ThinPrismFisheyePrincipalPoint_num_, 4);
   increment_offset<double>(offset, 0 * 0, 1);
   increment_offset<double>(offset, 0 * 0, 4);
   increment_offset<double>(offset, 2 * simple_radial_num_, 4);
@@ -14852,6 +22345,11 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_point_num_, 4);
   increment_offset<double>(offset, 2 * pinhole_fixed_pose_fixed_point_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_pose_num_, 4);
+  increment_offset<double>(offset, 2 * thin_prism_fisheye_fixed_point_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_fixed_pose_fixed_point_num_, 4);
   increment_offset<double>(
       offset, 2 * simple_radial_split_fixed_focal_and_extra_num_, 4);
   increment_offset<double>(
@@ -14914,6 +22412,46 @@ size_t GraphSolver::get_nbytes() {
   increment_offset<double>(
       offset,
       2 * pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_focal_and_extra_num_, 4);
+  increment_offset<double>(
+      offset, 2 * thin_prism_fisheye_split_fixed_principal_point_num_, 4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_,
+      4);
+  increment_offset<double>(
+      offset,
+      2 * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_,
       4);
   increment_offset<double>(offset, 0 * 0, 1);
   increment_offset<double>(offset, 1 * 1, 1);

--- a/src/thirdparty/Symforce-Caspar/generated/f64/solver.h
+++ b/src/thirdparty/Symforce-Caspar/generated/f64/solver.h
@@ -54,6 +54,14 @@ class GraphSolver {
    * @param SimpleRadialPose_num_max the maximum number of SimpleRadialPoses
    * @param SimpleRadialPrincipalPoint_num_max the maximum number of
    * SimpleRadialPrincipalPoints
+   * @param ThinPrismFisheyeCalib_num_max the maximum number of
+   * ThinPrismFisheyeCalibs
+   * @param ThinPrismFisheyeFocalAndExtra_num_max the maximum number of
+   * ThinPrismFisheyeFocalAndExtras
+   * @param ThinPrismFisheyePose_num_max the maximum number of
+   * ThinPrismFisheyePoses
+   * @param ThinPrismFisheyePrincipalPoint_num_max the maximum number of
+   * ThinPrismFisheyePrincipalPoints
    * @param simple_radial_num_max the maximum number of simple_radials
    * @param simple_radial_fixed_pose_num_max the maximum number of
    * simple_radial_fixed_poses
@@ -67,6 +75,13 @@ class GraphSolver {
    * pinhole_fixed_points
    * @param pinhole_fixed_pose_fixed_point_num_max the maximum number of
    * pinhole_fixed_pose_fixed_points
+   * @param thin_prism_fisheye_num_max the maximum number of thin_prism_fisheyes
+   * @param thin_prism_fisheye_fixed_pose_num_max the maximum number of
+   * thin_prism_fisheye_fixed_poses
+   * @param thin_prism_fisheye_fixed_point_num_max the maximum number of
+   * thin_prism_fisheye_fixed_points
+   * @param thin_prism_fisheye_fixed_pose_fixed_point_num_max the maximum number
+   * of thin_prism_fisheye_fixed_pose_fixed_points
    * @param simple_radial_split_fixed_focal_and_extra_num_max the maximum number
    * of simple_radial_split_fixed_focal_and_extras
    * @param simple_radial_split_fixed_principal_point_num_max the maximum number
@@ -124,6 +139,42 @@ class GraphSolver {
    * @param pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max
    * the maximum number of
    * pinhole_split_fixed_focal_fixed_principal_point_fixed_points
+   * @param thin_prism_fisheye_split_fixed_focal_and_extra_num_max the maximum
+   * number of thin_prism_fisheye_split_fixed_focal_and_extras
+   * @param thin_prism_fisheye_split_fixed_principal_point_num_max the maximum
+   * number of thin_prism_fisheye_split_fixed_principal_points
+   * @param thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extras
+   * @param thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_points
+   * @param
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_points
+   * @param thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_points
+   * @param thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_principal_point_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_points
+   * @param
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max
+   * the maximum number of
+   * thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_points
    */
   GraphSolver(
       const SolverParams<double>& params,
@@ -136,6 +187,10 @@ class GraphSolver {
       size_t SimpleRadialFocalAndExtra_num_max,
       size_t SimpleRadialPose_num_max,
       size_t SimpleRadialPrincipalPoint_num_max,
+      size_t ThinPrismFisheyeCalib_num_max,
+      size_t ThinPrismFisheyeFocalAndExtra_num_max,
+      size_t ThinPrismFisheyePose_num_max,
+      size_t ThinPrismFisheyePrincipalPoint_num_max,
       size_t simple_radial_num_max,
       size_t simple_radial_fixed_pose_num_max,
       size_t simple_radial_fixed_point_num_max,
@@ -144,6 +199,10 @@ class GraphSolver {
       size_t pinhole_fixed_pose_num_max,
       size_t pinhole_fixed_point_num_max,
       size_t pinhole_fixed_pose_fixed_point_num_max,
+      size_t thin_prism_fisheye_num_max,
+      size_t thin_prism_fisheye_fixed_pose_num_max,
+      size_t thin_prism_fisheye_fixed_point_num_max,
+      size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max,
       size_t simple_radial_split_fixed_focal_and_extra_num_max,
       size_t simple_radial_split_fixed_principal_point_num_max,
       size_t simple_radial_split_fixed_pose_fixed_focal_and_extra_num_max,
@@ -172,6 +231,22 @@ class GraphSolver {
       size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
       size_t
           pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max,
+      size_t thin_prism_fisheye_split_fixed_principal_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max,
+      size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max,
+      size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max,
+      size_t
+          thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max,
       int device_id = 0);
 
   // This class is managing cuda memory and cannot be copied.
@@ -639,6 +714,200 @@ class GraphSolver {
    * progress and can have performance impacts.
    */
   void SetSimpleRadialPrincipalPointNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeCalib nodes from the stacked
+   * host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeCalibNodesFromStackedHost(const double* const data,
+                                                    size_t offset,
+                                                    size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeCalib nodes from the stacked
+   * device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeCalibNodesFromStackedDevice(const double* const data,
+                                                      size_t offset,
+                                                      size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeCalib nodes into the stacked
+   * output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeCalibNodesToStackedHost(double* const data,
+                                                  size_t offset,
+                                                  size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeCalib nodes into the stacked
+   * output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeCalibNodesToStackedDevice(double* const data,
+                                                    size_t offset,
+                                                    size_t num);
+
+  /**
+   * Set the current number of active nodes of type ThinPrismFisheyeCalib.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeCalibNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeFocalAndExtra nodes from the
+   * stacked host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNodesFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyeFocalAndExtra nodes from the
+   * stacked device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNodesFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeFocalAndExtra nodes into the
+   * stacked output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeFocalAndExtraNodesToStackedHost(double* const data,
+                                                          size_t offset,
+                                                          size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyeFocalAndExtra nodes into the
+   * stacked output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyeFocalAndExtraNodesToStackedDevice(double* const data,
+                                                            size_t offset,
+                                                            size_t num);
+
+  /**
+   * Set the current number of active nodes of type
+   * ThinPrismFisheyeFocalAndExtra.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePose nodes from the stacked
+   * host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePoseNodesFromStackedHost(const double* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePose nodes from the stacked
+   * device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePoseNodesFromStackedDevice(const double* const data,
+                                                     size_t offset,
+                                                     size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePose nodes into the stacked
+   * output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePoseNodesToStackedHost(double* const data,
+                                                 size_t offset,
+                                                 size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePose nodes into the stacked
+   * output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePoseNodesToStackedDevice(double* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the current number of active nodes of type ThinPrismFisheyePose.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyePoseNum(size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePrincipalPoint nodes from the
+   * stacked host data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePrincipalPointNodesFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current value for the ThinPrismFisheyePrincipalPoint nodes from the
+   * stacked device data.
+   *
+   * The offset can be used to start writing at a specific index.
+   */
+  void SetThinPrismFisheyePrincipalPointNodesFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePrincipalPoint nodes into
+   * the stacked output host data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePrincipalPointNodesToStackedHost(double* const data,
+                                                           size_t offset,
+                                                           size_t num);
+
+  /**
+   * Read the current value for the ThinPrismFisheyePrincipalPoint nodes into
+   * the stacked output device data.
+   *
+   * The offset can be used to start reading from a specific index.
+   */
+  void GetThinPrismFisheyePrincipalPointNodesToStackedDevice(double* const data,
+                                                             size_t offset,
+                                                             size_t num);
+
+  /**
+   * Set the current number of active nodes of type
+   * ThinPrismFisheyePrincipalPoint.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyePrincipalPointNum(size_t num);
 
   /**
    * Set the indices for the pose argument for the SimpleRadial factor from
@@ -1376,6 +1645,372 @@ class GraphSolver {
    * progress and can have performance impacts.
    */
   void SetPinholeFixedPoseFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyePoseIndicesFromHost(const unsigned int* const indices,
+                                              size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyePoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyeCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyeCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheye factor from
+   * host.
+   */
+  void SetThinPrismFisheyePointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheye factor from
+   * device.
+   */
+  void SetThinPrismFisheyePointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheye factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheye factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheye factor from stacked
+   * host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyePixelDataFromStackedHost(const double* const data,
+                                                   size_t offset,
+                                                   size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheye factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyePixelDataFromStackedDevice(const double* const data,
+                                                     size_t offset,
+                                                     size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheye factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeNum(size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPose
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPoseCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPose
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPoseCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheyeFixedPose
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPosePointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the ThinPrismFisheyeFixedPose
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPosePointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPose
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPose
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPose factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPose factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPose factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPose factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPosePoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPose factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPoseNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheyeFixedPoint
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the ThinPrismFisheyeFixedPoint
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPoint
+   * factor from host.
+   */
+  void SetThinPrismFisheyeFixedPointCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the ThinPrismFisheyeFixedPoint
+   * factor from device.
+   */
+  void SetThinPrismFisheyeFixedPointCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts ThinPrismFisheyeFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the calib argument for the
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the calib argument for the
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from device.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointCalibIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeFixedPoseFixedPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts ThinPrismFisheyeFixedPoseFixedPoint
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeFixedPoseFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeFixedPoseFixedPointNum(size_t num);
 
   /**
    * Set the indices for the pose argument for the
@@ -4066,6 +4701,1437 @@ class GraphSolver {
    */
   void SetPinholeSplitFixedFocalFixedPrincipalPointFixedPointNum(size_t num);
 
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeSplitFixedFocalAndExtra
+   * factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts ThinPrismFisheyeSplitFixedFocalAndExtra
+   * factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtra factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedFocalAndExtra factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from device.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPoint factor from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPrincipalPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointNum(size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra factor from stacked device
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtra
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraNum(size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedPoseFixedPrincipalPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of ThinPrismFisheyeSplitFixedFocalAndExtraFixedPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from host.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked host
+   * data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factor from stacked
+   * device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPrincipalPointFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPrincipalPointFixedPointNum(size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPrincipalPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the principal_point argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPrincipalPointIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedFocalAndExtraFixedPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the focal_and_extra argument for the
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointFocalAndExtraIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pose consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPoseDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factor from
+   * stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPoint factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void SetThinPrismFisheyeSplitFixedPoseFixedPrincipalPointFixedPointNum(
+      size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from host.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromHost(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the indices for the pose argument for the
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from device.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPoseIndicesFromDevice(
+      const unsigned int* const indices, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the sensor_from_rig consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointSensorFromRigDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the pixel consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPixelDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the focal_and_extra consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointFocalAndExtraDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the principal_point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPrincipalPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked host data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedHost(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the values for the point consts
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint factor
+   * from stacked device data.
+   *
+   * The offset can be used to start writing from a specific index.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointPointDataFromStackedDevice(
+      const double* const data, size_t offset, size_t num);
+
+  /**
+   * Set the current number of
+   * ThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPoint
+   * factors.
+   *
+   * The value is set during initialization and this function is only needed if
+   * you want to change the problem between optimization runs. This is work in
+   * progress and can have performance impacts.
+   */
+  void
+  SetThinPrismFisheyeSplitFixedFocalAndExtraFixedPrincipalPointFixedPointNum(
+      size_t num);
+
  private:
   SolverParams<double> params_;
   int device_id_;
@@ -4099,6 +6165,14 @@ class GraphSolver {
   size_t SimpleRadialPose_num_max_;
   size_t SimpleRadialPrincipalPoint_num_;
   size_t SimpleRadialPrincipalPoint_num_max_;
+  size_t ThinPrismFisheyeCalib_num_;
+  size_t ThinPrismFisheyeCalib_num_max_;
+  size_t ThinPrismFisheyeFocalAndExtra_num_;
+  size_t ThinPrismFisheyeFocalAndExtra_num_max_;
+  size_t ThinPrismFisheyePose_num_;
+  size_t ThinPrismFisheyePose_num_max_;
+  size_t ThinPrismFisheyePrincipalPoint_num_;
+  size_t ThinPrismFisheyePrincipalPoint_num_max_;
   size_t simple_radial_num_;
   size_t simple_radial_num_max_;
   size_t simple_radial_fixed_pose_num_;
@@ -4115,6 +6189,14 @@ class GraphSolver {
   size_t pinhole_fixed_point_num_max_;
   size_t pinhole_fixed_pose_fixed_point_num_;
   size_t pinhole_fixed_pose_fixed_point_num_max_;
+  size_t thin_prism_fisheye_num_;
+  size_t thin_prism_fisheye_num_max_;
+  size_t thin_prism_fisheye_fixed_pose_num_;
+  size_t thin_prism_fisheye_fixed_pose_num_max_;
+  size_t thin_prism_fisheye_fixed_point_num_;
+  size_t thin_prism_fisheye_fixed_point_num_max_;
+  size_t thin_prism_fisheye_fixed_pose_fixed_point_num_;
+  size_t thin_prism_fisheye_fixed_pose_fixed_point_num_max_;
   size_t simple_radial_split_fixed_focal_and_extra_num_;
   size_t simple_radial_split_fixed_focal_and_extra_num_max_;
   size_t simple_radial_split_fixed_principal_point_num_;
@@ -4166,6 +6248,38 @@ class GraphSolver {
   size_t pinhole_split_fixed_pose_fixed_principal_point_fixed_point_num_max_;
   size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_;
   size_t pinhole_split_fixed_focal_fixed_principal_point_fixed_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_num_max_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_num_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_num_max_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_;
+  size_t thin_prism_fisheye_split_fixed_pose_fixed_principal_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_;
+  size_t thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point_num_max_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_;
+  size_t thin_prism_fisheye_split_fixed_principal_point_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point_num_max_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_;
+  size_t
+      thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point_num_max_;
 
   size_t get_nbytes();
   double LinearizeFirst();
@@ -4214,6 +6328,18 @@ class GraphSolver {
   double* nodes__SimpleRadialPrincipalPoint__storage_current_;
   double* nodes__SimpleRadialPrincipalPoint__storage_check_;
   double* nodes__SimpleRadialPrincipalPoint__storage_new_best_;
+  double* nodes__ThinPrismFisheyeCalib__storage_current_;
+  double* nodes__ThinPrismFisheyeCalib__storage_check_;
+  double* nodes__ThinPrismFisheyeCalib__storage_new_best_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__storage_current_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__storage_check_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__storage_new_best_;
+  double* nodes__ThinPrismFisheyePose__storage_current_;
+  double* nodes__ThinPrismFisheyePose__storage_check_;
+  double* nodes__ThinPrismFisheyePose__storage_new_best_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__storage_current_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__storage_check_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__storage_new_best_;
   SharedIndex* facs__simple_radial__args__pose__idx_shared_;
   double* facs__simple_radial__args__sensor_from_rig__data_;
   SharedIndex* facs__simple_radial__args__calib__idx_shared_;
@@ -4256,6 +6382,28 @@ class GraphSolver {
   double* facs__pinhole_fixed_pose_fixed_point__args__pixel__data_;
   double* facs__pinhole_fixed_pose_fixed_point__args__pose__data_;
   double* facs__pinhole_fixed_pose_fixed_point__args__point__data_;
+  SharedIndex* facs__thin_prism_fisheye__args__pose__idx_shared_;
+  double* facs__thin_prism_fisheye__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye__args__calib__idx_shared_;
+  SharedIndex* facs__thin_prism_fisheye__args__point__idx_shared_;
+  double* facs__thin_prism_fisheye__args__pixel__data_;
+  double* facs__thin_prism_fisheye_fixed_pose__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_pose__args__calib__idx_shared_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_pose__args__point__idx_shared_;
+  double* facs__thin_prism_fisheye_fixed_pose__args__pixel__data_;
+  double* facs__thin_prism_fisheye_fixed_pose__args__pose__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_point__args__pose__idx_shared_;
+  double* facs__thin_prism_fisheye_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex* facs__thin_prism_fisheye_fixed_point__args__calib__idx_shared_;
+  double* facs__thin_prism_fisheye_fixed_point__args__pixel__data_;
+  double* facs__thin_prism_fisheye_fixed_point__args__point__data_;
+  double*
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__idx_shared_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pixel__data_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__pose__data_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__point__data_;
   SharedIndex*
       facs__simple_radial_split_fixed_focal_and_extra__args__pose__idx_shared_;
   double*
@@ -4506,6 +6654,138 @@ class GraphSolver {
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__principal_point__data_;
   double*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__focal_and_extra__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__principal_point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__pose__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__idx_shared_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__pose__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__principal_point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__principal_point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__pose__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__principal_point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__pose__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__pose__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__principal_point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__point__data_;
+  SharedIndex*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__idx_shared_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__sensor_from_rig__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pixel__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__focal_and_extra__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__principal_point__data_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__point__data_;
   double* marker__scratch_inout_;
   double* facs__simple_radial__res_;
   double* facs__simple_radial_fixed_pose__res_;
@@ -4515,6 +6795,10 @@ class GraphSolver {
   double* facs__pinhole_fixed_pose__res_;
   double* facs__pinhole_fixed_point__res_;
   double* facs__pinhole_fixed_pose_fixed_point__res_;
+  double* facs__thin_prism_fisheye__res_;
+  double* facs__thin_prism_fisheye_fixed_pose__res_;
+  double* facs__thin_prism_fisheye_fixed_point__res_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__res_;
   double* facs__simple_radial_split_fixed_focal_and_extra__res_;
   double* facs__simple_radial_split_fixed_principal_point__res_;
   double* facs__simple_radial_split_fixed_pose_fixed_focal_and_extra__res_;
@@ -4545,6 +6829,24 @@ class GraphSolver {
       facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__res_;
   double*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__res_;
+  double* facs__thin_prism_fisheye_split_fixed_focal_and_extra__res_;
+  double* facs__thin_prism_fisheye_split_fixed_principal_point__res_;
+  double* facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__res_;
+  double* facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__res_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__res_;
   double* facs__simple_radial__args__pose__jac_;
   double* facs__simple_radial__args__calib__jac_;
   double* facs__simple_radial__args__point__jac_;
@@ -4561,6 +6863,14 @@ class GraphSolver {
   double* facs__pinhole_fixed_point__args__pose__jac_;
   double* facs__pinhole_fixed_point__args__calib__jac_;
   double* facs__pinhole_fixed_pose_fixed_point__args__calib__jac_;
+  double* facs__thin_prism_fisheye__args__pose__jac_;
+  double* facs__thin_prism_fisheye__args__calib__jac_;
+  double* facs__thin_prism_fisheye__args__point__jac_;
+  double* facs__thin_prism_fisheye_fixed_pose__args__calib__jac_;
+  double* facs__thin_prism_fisheye_fixed_pose__args__point__jac_;
+  double* facs__thin_prism_fisheye_fixed_point__args__pose__jac_;
+  double* facs__thin_prism_fisheye_fixed_point__args__calib__jac_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__args__calib__jac_;
   double* facs__simple_radial_split_fixed_focal_and_extra__args__pose__jac_;
   double*
       facs__simple_radial_split_fixed_focal_and_extra__args__principal_point__jac_;
@@ -4629,6 +6939,46 @@ class GraphSolver {
       facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__args__focal__jac_;
   double*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__principal_point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__focal_and_extra__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__principal_point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__focal_and_extra__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__args__principal_point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__pose__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__args__focal_and_extra__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__args__point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__args__principal_point__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__args__focal_and_extra__jac_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__args__pose__jac_;
   double* nodes__PinholeCalib__z_;
   double* nodes__PinholeCalib__z_end__;
   double* nodes__PinholeFocal__z_;
@@ -4647,6 +6997,14 @@ class GraphSolver {
   double* nodes__SimpleRadialPose__z_end__;
   double* nodes__SimpleRadialPrincipalPoint__z_;
   double* nodes__SimpleRadialPrincipalPoint__z_end__;
+  double* nodes__ThinPrismFisheyeCalib__z_;
+  double* nodes__ThinPrismFisheyeCalib__z_end__;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__z_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__z_end__;
+  double* nodes__ThinPrismFisheyePose__z_;
+  double* nodes__ThinPrismFisheyePose__z_end__;
+  double* nodes__ThinPrismFisheyePrincipalPoint__z_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__z_end__;
   double* nodes__PinholeCalib__p_;
   double* nodes__PinholeCalib__p_end__;
   double* nodes__PinholeFocal__p_;
@@ -4665,6 +7023,14 @@ class GraphSolver {
   double* nodes__SimpleRadialPose__p_end__;
   double* nodes__SimpleRadialPrincipalPoint__p_;
   double* nodes__SimpleRadialPrincipalPoint__p_end__;
+  double* nodes__ThinPrismFisheyeCalib__p_;
+  double* nodes__ThinPrismFisheyeCalib__p_end__;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__p_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__p_end__;
+  double* nodes__ThinPrismFisheyePose__p_;
+  double* nodes__ThinPrismFisheyePose__p_end__;
+  double* nodes__ThinPrismFisheyePrincipalPoint__p_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__p_end__;
   double* nodes__PinholeCalib__step_;
   double* nodes__PinholeCalib__step_end__;
   double* nodes__PinholeFocal__step_;
@@ -4683,6 +7049,14 @@ class GraphSolver {
   double* nodes__SimpleRadialPose__step_end__;
   double* nodes__SimpleRadialPrincipalPoint__step_;
   double* nodes__SimpleRadialPrincipalPoint__step_end__;
+  double* nodes__ThinPrismFisheyeCalib__step_;
+  double* nodes__ThinPrismFisheyeCalib__step_end__;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__step_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__step_end__;
+  double* nodes__ThinPrismFisheyePose__step_;
+  double* nodes__ThinPrismFisheyePose__step_end__;
+  double* nodes__ThinPrismFisheyePrincipalPoint__step_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__step_end__;
   double* marker__w_start_;
   double* nodes__PinholeCalib__w_;
   double* nodes__PinholeFocal__w_;
@@ -4693,6 +7067,10 @@ class GraphSolver {
   double* nodes__SimpleRadialFocalAndExtra__w_;
   double* nodes__SimpleRadialPose__w_;
   double* nodes__SimpleRadialPrincipalPoint__w_;
+  double* nodes__ThinPrismFisheyeCalib__w_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__w_;
+  double* nodes__ThinPrismFisheyePose__w_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__w_;
   double* marker__w_end_;
   double* marker__r_0_start_;
   double* nodes__PinholeCalib__r_0_;
@@ -4704,6 +7082,10 @@ class GraphSolver {
   double* nodes__SimpleRadialFocalAndExtra__r_0_;
   double* nodes__SimpleRadialPose__r_0_;
   double* nodes__SimpleRadialPrincipalPoint__r_0_;
+  double* nodes__ThinPrismFisheyeCalib__r_0_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__r_0_;
+  double* nodes__ThinPrismFisheyePose__r_0_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__r_0_;
   double* marker__r_0_end_;
   double* marker__r_k_start_;
   double* nodes__PinholeCalib__r_k_;
@@ -4715,6 +7097,10 @@ class GraphSolver {
   double* nodes__SimpleRadialFocalAndExtra__r_k_;
   double* nodes__SimpleRadialPose__r_k_;
   double* nodes__SimpleRadialPrincipalPoint__r_k_;
+  double* nodes__ThinPrismFisheyeCalib__r_k_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__r_k_;
+  double* nodes__ThinPrismFisheyePose__r_k_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__r_k_;
   double* marker__r_k_end_;
   double* marker__Mp_start_;
   double* nodes__PinholeCalib__Mp_;
@@ -4726,6 +7112,10 @@ class GraphSolver {
   double* nodes__SimpleRadialFocalAndExtra__Mp_;
   double* nodes__SimpleRadialPose__Mp_;
   double* nodes__SimpleRadialPrincipalPoint__Mp_;
+  double* nodes__ThinPrismFisheyeCalib__Mp_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__Mp_;
+  double* nodes__ThinPrismFisheyePose__Mp_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__Mp_;
   double* marker__Mp_end_;
   double* marker__precond_start_;
   double* nodes__PinholeCalib__precond_diag_;
@@ -4746,6 +7136,14 @@ class GraphSolver {
   double* nodes__SimpleRadialPose__precond_tril_;
   double* nodes__SimpleRadialPrincipalPoint__precond_diag_;
   double* nodes__SimpleRadialPrincipalPoint__precond_tril_;
+  double* nodes__ThinPrismFisheyeCalib__precond_diag_;
+  double* nodes__ThinPrismFisheyeCalib__precond_tril_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__precond_diag_;
+  double* nodes__ThinPrismFisheyeFocalAndExtra__precond_tril_;
+  double* nodes__ThinPrismFisheyePose__precond_diag_;
+  double* nodes__ThinPrismFisheyePose__precond_tril_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__precond_diag_;
+  double* nodes__ThinPrismFisheyePrincipalPoint__precond_tril_;
   double* marker__precond_end_;
   double* marker__jp_start_;
   double* facs__simple_radial__jp_;
@@ -4756,6 +7154,10 @@ class GraphSolver {
   double* facs__pinhole_fixed_pose__jp_;
   double* facs__pinhole_fixed_point__jp_;
   double* facs__pinhole_fixed_pose_fixed_point__jp_;
+  double* facs__thin_prism_fisheye__jp_;
+  double* facs__thin_prism_fisheye_fixed_pose__jp_;
+  double* facs__thin_prism_fisheye_fixed_point__jp_;
+  double* facs__thin_prism_fisheye_fixed_pose_fixed_point__jp_;
   double* facs__simple_radial_split_fixed_focal_and_extra__jp_;
   double* facs__simple_radial_split_fixed_principal_point__jp_;
   double* facs__simple_radial_split_fixed_pose_fixed_focal_and_extra__jp_;
@@ -4784,6 +7186,22 @@ class GraphSolver {
   double* facs__pinhole_split_fixed_pose_fixed_principal_point_fixed_point__jp_;
   double*
       facs__pinhole_split_fixed_focal_fixed_principal_point_fixed_point__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_focal_and_extra__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_principal_point__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point__jp_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_point__jp_;
+  double* facs__thin_prism_fisheye_split_fixed_principal_point_fixed_point__jp_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_principal_point__jp_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_focal_and_extra_fixed_point__jp_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_pose_fixed_principal_point_fixed_point__jp_;
+  double*
+      facs__thin_prism_fisheye_split_fixed_focal_and_extra_fixed_principal_point_fixed_point__jp_;
   double* marker__jp_end_;
   double* solver__current_diag_;
   double* solver__alpha_numerator_;


### PR DESCRIPTION
## Summary

This draft PR adds CASPAR support for COLMAP's `THIN_PRISM_FISHEYE` camera model.

Compared to my previous draft, this branch removes the unrelated generated-code churn for existing `PINHOLE` and `SIMPLE_RADIAL` kernels. The remaining large diff is still mostly generated CASPAR code, but it is limited to:
- `THIN_PRISM_FISHEYE` generated node/factor kernels
- generated solver/mapping glue needed to expose the new camera model
- handwritten model adapter / BA wiring
- small tests

## Camera model

COLMAP parameter order is preserved exactly:

```text
fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1
```

Projection convention follows COLMAP's `THIN_PRISM_FISHEYE` implementation:
1. normalized pinhole coordinates
2. fisheye theta mapping
3. radial, tangential, and thin-prism distortion in fisheye coordinates
4. pixel projection

## Supported scope

The conservative tested scope is:
- THIN_PRISM_FISHEYE cameras in CASPAR BA
- fixed sensor-from-rig for rigs
- fixed-calibration / points-only BA
- generated factor variants for pose, point, merged calibration, and split calibration blocks

Current limitations intentionally preserved:
- `refine_sensor_from_rig=true` is not supported for non-reference rig sensors
- partial calibration refinement is constrained; focal length and extra params must be refined together
- this PR does not include my local experimental Target-B active-pose research policy as production behavior

## Tests

Validated locally with CUDA/CASPAR, `CASPAR_USE_DOUBLE=OFF`:

```text
bundle_adjustment_caspar_test: 19/19 passed
```

New tests:
- `DefaultBundleAdjuster.ThinPrismFisheyeRigPointsOnlyFixedCalibration`
- `DefaultBundleAdjuster.ThinPrismFisheyeMatchesCeresPointsOnly`

## Diff hygiene

This branch has no changes to existing generated `pinhole_*` or `simple_radial_*` kernel files. The generated part is separated into its own commit for review.

Remaining generated churn is still large because CASPAR materializes many factor variants for each camera model and precision. I am keeping this PR as draft until maintainers confirm the preferred generated-code policy.
