### PR TITLE
Enforce Python function type annotations

### DIFF
--- a/benchmark/reconstruction/evaluation/blended_mvs.py
+++ b/benchmark/reconstruction/evaluation/blended_mvs.py
@@ -151,7 +151,9 @@ class DatasetBlendedMVS(Dataset):
             frame = pycolmap.Frame(frame_id=i)
             frame.rig_id = i
             frame.add_data_id(image.data_id)
-            frame.rig_from_world = pycolmap.Rigid3d(extrinsic)
+            frame.rig_from_world = pycolmap.Rigid3d(  # type: ignore[arg-type]
+                extrinsic  # type: ignore[arg-type]
+            )
             sparse_gt.add_camera(camera)
             sparse_gt.add_rig(rig)
             sparse_gt.add_frame(frame)

--- a/benchmark/reconstruction/evaluation/blended_mvs.py
+++ b/benchmark/reconstruction/evaluation/blended_mvs.py
@@ -27,6 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from pathlib import Path
 
 import numpy as np
 from PIL import Image
@@ -38,14 +39,14 @@ from .utils import Dataset, SceneInfo
 
 class DatasetBlendedMVS(Dataset):
     @property
-    def position_accuracy_gt(self):
+    def position_accuracy_gt(self) -> float:
         return 0.001
 
     @property
     def supports_covisibility_filtering(self) -> bool:
         return True
 
-    def list_scenes(self):
+    def list_scenes(self) -> list[SceneInfo]:
         scene_infos = []
         for category_path in (self.data_path / "blended-mvs").iterdir():
             if not category_path.is_dir() or (
@@ -84,7 +85,10 @@ class DatasetBlendedMVS(Dataset):
                             num_images += 1
 
                 sparse_gt_path = scene_path / "sparse_gt"
-                colmap_extra_args = ["--image_list_path", image_list_path]
+                colmap_extra_args: list[str | Path] = [
+                    "--image_list_path",
+                    image_list_path,
+                ]
 
                 scene_info = SceneInfo(
                     dataset="blended-mvs",
@@ -102,7 +106,7 @@ class DatasetBlendedMVS(Dataset):
 
         return scene_infos
 
-    def prepare_scene(self, scene_info):
+    def prepare_scene(self, scene_info: SceneInfo) -> None:
         if scene_info.sparse_gt_path.exists():
             return
 

--- a/benchmark/reconstruction/evaluation/covisibility_test.py
+++ b/benchmark/reconstruction/evaluation/covisibility_test.py
@@ -27,6 +27,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from collections.abc import Sequence
+
 import numpy as np
 
 import pycolmap
@@ -85,7 +87,7 @@ def _add_image(
 
 
 class TestEstimateDepthRanges:
-    def test_single_image_with_points(self):
+    def test_single_image_with_points(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -106,7 +108,7 @@ class TestEstimateDepthRanges:
         np.testing.assert_almost_equal(near, np.percentile(depths, 2.0))
         np.testing.assert_almost_equal(far, np.percentile(depths, 98.0))
 
-    def test_insufficient_points_returns_default(self):
+    def test_insufficient_points_returns_default(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -121,7 +123,7 @@ class TestEstimateDepthRanges:
         ranges = _estimate_depth_ranges(recon)
         assert ranges[1] == (0.1, 100.0)
 
-    def test_per_image_ranges_differ(self):
+    def test_per_image_ranges_differ(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -153,7 +155,7 @@ class TestEstimateDepthRanges:
 
 
 class TestSampleFrustumPoints:
-    def test_identity_camera_shape(self):
+    def test_identity_camera_shape(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -163,7 +165,7 @@ class TestSampleFrustumPoints:
         # num_steps=5 default: 5*5 grid at 5 depths = 125 points
         assert verts.shape == (125, 3)
 
-    def test_custom_num_steps(self):
+    def test_custom_num_steps(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -174,7 +176,7 @@ class TestSampleFrustumPoints:
         )
         assert verts.shape == (27, 3)
 
-    def test_vertices_depth_range(self):
+    def test_vertices_depth_range(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -187,7 +189,7 @@ class TestSampleFrustumPoints:
         np.testing.assert_almost_equal(verts[:, 2].min(), near)
         np.testing.assert_almost_equal(verts[:, 2].max(), far)
 
-    def test_translated_camera(self):
+    def test_translated_camera(self) -> None:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
         recon.add_camera_with_trivial_rig(cam)
@@ -205,7 +207,11 @@ class TestSampleFrustumPoints:
 
 class TestCheckFrustumCovisibility:
     def _build_two_camera_recon(
-        self, pos1, pos2, rot1=None, rot2=None
+        self,
+        pos1: Sequence[float],
+        pos2: Sequence[float],
+        rot1: pycolmap.Rotation3d | None = None,
+        rot2: pycolmap.Rotation3d | None = None,
     ) -> pycolmap.Reconstruction:
         recon = pycolmap.Reconstruction()
         cam = _make_camera()
@@ -214,7 +220,13 @@ class TestCheckFrustumCovisibility:
         _add_image(recon, 2, "img2.jpg", np.array(pos2), rot2)
         return recon
 
-    def _check(self, recon, max_angle=90.0, near=1.0, far=100.0):
+    def _check(
+        self,
+        recon: pycolmap.Reconstruction,
+        max_angle: float = 90.0,
+        near: float = 1.0,
+        far: float = 100.0,
+    ) -> bool:
         cam = recon.cameras[1]
         imgs = [recon.images[1], recon.images[2]]
         frustums = {
@@ -228,18 +240,18 @@ class TestCheckFrustumCovisibility:
             imgs[0], imgs[1], recon, frustums, max_angle
         )
 
-    def test_covisible_side_by_side(self):
+    def test_covisible_side_by_side(self) -> None:
         recon = self._build_two_camera_recon([-0.5, 0, -5], [0.5, 0, -5])
         assert self._check(recon)
 
-    def test_not_covisible_opposite_directions(self):
+    def test_not_covisible_opposite_directions(self) -> None:
         rot_180_y = pycolmap.Rotation3d(np.array([0, 1, 0, 0]))
         recon = self._build_two_camera_recon(
             [0, 0, -5], [0, 0, 5], rot2=rot_180_y
         )
         assert not self._check(recon)
 
-    def test_rejected_by_viewing_angle(self):
+    def test_rejected_by_viewing_angle(self) -> None:
         # 90 deg rotation around y-axis
         rot = pycolmap.Rotation3d(
             np.array([0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)])
@@ -248,7 +260,7 @@ class TestCheckFrustumCovisibility:
         # Viewing angle is 90 deg, threshold is 45 -> should be rejected
         assert not self._check(recon, max_angle=45.0)
 
-    def test_covisible_converging_cameras(self):
+    def test_covisible_converging_cameras(self) -> None:
         # Two cameras angled inward looking at the same point
         # Camera 1 at (-2,0,0) looking at +x (toward origin)
         rot1 = pycolmap.Rotation3d(
@@ -263,12 +275,12 @@ class TestCheckFrustumCovisibility:
         )
         assert self._check(recon, max_angle=180.0)
 
-    def test_not_covisible_far_apart_narrow_fov(self):
+    def test_not_covisible_far_apart_narrow_fov(self) -> None:
         # Two cameras far apart, both looking +z, with small frustum depth
         recon = self._build_two_camera_recon([0, 0, 0], [1000, 0, 0])
         assert self._check(recon, near=1.0, far=2.0) is False
 
-    def test_not_covisible_depth_out_of_range(self):
+    def test_not_covisible_depth_out_of_range(self) -> None:
         # Two cameras side by side looking +z. Their frustums project into
         # each other's images, but the depth ranges don't overlap: camera 1
         # expects depths 1-5 while camera 2 expects 50-100. Each camera's
@@ -292,7 +304,7 @@ class TestCheckFrustumCovisibility:
         # Sanity: with matching depth ranges, these cameras are covisible.
         assert self._check(recon, near=1.0, far=100.0)
 
-    def test_covisible_identical_cameras(self):
+    def test_covisible_identical_cameras(self) -> None:
         recon = self._build_two_camera_recon([0, 0, 0], [0, 0, 0])
         assert self._check(recon)
 
@@ -332,7 +344,7 @@ def _make_recon_with_tracks(
 
 
 class TestBuildImagePoint3DSets:
-    def test_basic_tracks(self):
+    def test_basic_tracks(self) -> None:
         # 2 images, 5 points2D each, 3 shared tracks
         recon = _make_recon_with_tracks(
             num_images=2,
@@ -348,7 +360,7 @@ class TestBuildImagePoint3DSets:
         assert len(sets[2]) == 3
         assert len(sets[1] & sets[2]) == 3
 
-    def test_no_shared_tracks(self):
+    def test_no_shared_tracks(self) -> None:
         recon = _make_recon_with_tracks(
             num_images=2,
             num_points2D_per_image=5,
@@ -362,7 +374,7 @@ class TestBuildImagePoint3DSets:
         sets = _build_image_point3D_sets(recon)
         assert len(sets[1] & sets[2]) == 0
 
-    def test_no_tracks(self):
+    def test_no_tracks(self) -> None:
         recon = _make_recon_with_tracks(
             num_images=2,
             num_points2D_per_image=5,
@@ -372,7 +384,7 @@ class TestBuildImagePoint3DSets:
         assert len(sets[1]) == 0
         assert len(sets[2]) == 0
 
-    def test_partial_overlap(self):
+    def test_partial_overlap(self) -> None:
         # 3 images: img1-img2 share 5 points
         # img2-img3 share 2, img1-img3 share 0
         recon = _make_recon_with_tracks(

--- a/benchmark/reconstruction/evaluation/eth3d.py
+++ b/benchmark/reconstruction/evaluation/eth3d.py
@@ -27,20 +27,21 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from pathlib import Path
 
 from .utils import Dataset, SceneInfo
 
 
 class DatasetETH3D(Dataset):
     @property
-    def position_accuracy_gt(self):
+    def position_accuracy_gt(self) -> float:
         return 0.001
 
     @property
     def supports_covisibility_filtering(self) -> bool:
         return True
 
-    def list_scenes(self):
+    def list_scenes(self) -> list[SceneInfo]:
         scene_infos = []
         for category_path in (self.data_path / "eth3d").iterdir():
             if not category_path.is_dir() or (
@@ -66,7 +67,7 @@ class DatasetETH3D(Dataset):
                     scene_path.glob("*_calibration_undistorted")
                 )[0]
 
-                colmap_extra_args = []
+                colmap_extra_args: list[str | Path] = []
                 if category == "dslr":
                     colmap_extra_args.extend(["--data_type", "individual"])
                 elif category == "rig":
@@ -95,6 +96,6 @@ class DatasetETH3D(Dataset):
 
         return scene_infos
 
-    def prepare_scene(self, scene_info):
+    def prepare_scene(self, scene_info: SceneInfo) -> None:
         # Nothing to prepare for ETH3D.
         pass

--- a/benchmark/reconstruction/evaluation/geometry_test.py
+++ b/benchmark/reconstruction/evaluation/geometry_test.py
@@ -33,51 +33,51 @@ from .geometry import normalize_vec, vec_angular_dist_deg
 
 
 class TestNormalizeVec:
-    def test_unit_vector(self):
+    def test_unit_vector(self) -> None:
         vec = np.array([1.0, 0.0, 0.0])
         normalized = normalize_vec(vec)
         np.testing.assert_allclose(normalized, vec)
         np.testing.assert_almost_equal(np.linalg.norm(normalized), 1.0)
 
-    def test_non_unit_vector(self):
+    def test_non_unit_vector(self) -> None:
         vec = np.array([3.0, 4.0, 0.0])
         normalized = normalize_vec(vec)
         expected = np.array([0.6, 0.8, 0.0])
         np.testing.assert_allclose(normalized, expected)
         np.testing.assert_almost_equal(np.linalg.norm(normalized), 1.0)
 
-    def test_zero_vector(self):
+    def test_zero_vector(self) -> None:
         vec = np.array([0.0, 0.0, 0.0])
         normalized = normalize_vec(vec)
         assert np.linalg.norm(normalized) < 1e-8
 
 
 class TestVecAngularDistDeg:
-    def test_identical_vectors(self):
+    def test_identical_vectors(self) -> None:
         vec1 = np.array([1.0, 0.0, 0.0])
         vec2 = np.array([1.0, 0.0, 0.0])
         dist = vec_angular_dist_deg(vec1, vec2)
         np.testing.assert_almost_equal(dist, 0.0)
 
-    def test_opposite_vectors(self):
+    def test_opposite_vectors(self) -> None:
         vec1 = np.array([1.0, 0.0, 0.0])
         vec2 = np.array([-1.0, 0.0, 0.0])
         dist = vec_angular_dist_deg(vec1, vec2)
         np.testing.assert_almost_equal(dist, 180.0)
 
-    def test_perpendicular_vectors(self):
+    def test_perpendicular_vectors(self) -> None:
         vec1 = np.array([1.0, 0.0, 0.0])
         vec2 = np.array([0.0, 1.0, 0.0])
         dist = vec_angular_dist_deg(vec1, vec2)
         np.testing.assert_almost_equal(dist, 90.0)
 
-    def test_45_degree_vectors(self):
+    def test_45_degree_vectors(self) -> None:
         vec1 = np.array([1.0, 0.0, 0.0])
         vec2 = np.array([1.0, 1.0, 0.0])
         dist = vec_angular_dist_deg(vec1, vec2)
         np.testing.assert_almost_equal(dist, 45.0)
 
-    def test_non_unit_vectors(self):
+    def test_non_unit_vectors(self) -> None:
         vec1 = np.array([2.0, 0.0, 0.0])
         vec2 = np.array([0.0, 3.0, 0.0])
         dist = vec_angular_dist_deg(vec1, vec2)

--- a/benchmark/reconstruction/evaluation/imc.py
+++ b/benchmark/reconstruction/evaluation/imc.py
@@ -107,7 +107,7 @@ def _read_sparse_sfm_without_points3D(
 
 class _DatasetIMC(Dataset):
     @property
-    def position_accuracy_gt(self):
+    def position_accuracy_gt(self) -> float:
         return 0.02
 
     @property
@@ -136,7 +136,7 @@ class _DatasetIMC(Dataset):
             if p.is_file() and p.suffix.lower() in {".jpg", ".jpeg", ".png"}
         )
 
-    def list_scenes(self):
+    def list_scenes(self) -> list[SceneInfo]:
         folder_name = f"imc{self.year}"
 
         scene_infos = []
@@ -192,7 +192,7 @@ class _DatasetIMC(Dataset):
 
         return scene_infos
 
-    def prepare_scene(self, scene_info):
+    def prepare_scene(self, scene_info: SceneInfo) -> None:
         if scene_info.sparse_gt_path.exists():
             return
 
@@ -249,7 +249,7 @@ class DatasetIMC2023(_DatasetIMC):
         scenes: list[Path],
         run_path: Path,
         run_name: str,
-    ):
+    ) -> None:
         super().__init__(
             data_path=data_path,
             categories=categories,
@@ -268,7 +268,7 @@ class DatasetIMC2024(_DatasetIMC):
         scenes: list[Path],
         run_path: Path,
         run_name: str,
-    ):
+    ) -> None:
         super().__init__(
             data_path=data_path,
             categories=categories,
@@ -314,7 +314,7 @@ class DatasetIMC2025(_DatasetIMC):
         scenes: list[Path],
         run_path: Path,
         run_name: str,
-    ):
+    ) -> None:
         super().__init__(
             data_path=data_path,
             categories=categories,
@@ -496,7 +496,7 @@ class DatasetIMC2025(_DatasetIMC):
             )
         return num_images
 
-    def prepare_scene(self, scene_info):
+    def prepare_scene(self, scene_info: SceneInfo) -> None:
         gt_rows_by_scene, _ = self._read_imc2025_labels(self._labels_path())
         dataset = scene_info.scene
 

--- a/benchmark/reconstruction/evaluation/imc.py
+++ b/benchmark/reconstruction/evaluation/imc.py
@@ -106,6 +106,8 @@ def _read_sparse_sfm_without_points3D(
 
 
 class _DatasetIMC(Dataset):
+    year: int
+
     @property
     def position_accuracy_gt(self) -> float:
         return 0.02

--- a/benchmark/reconstruction/evaluation/tartanair/depth_covisibility_test.py
+++ b/benchmark/reconstruction/evaluation/tartanair/depth_covisibility_test.py
@@ -3,7 +3,7 @@ import numpy as np
 from .depth_covisibility import compute_covisibility_counts
 
 
-def test_compute_covisibility_counts_identical_views():
+def test_compute_covisibility_counts_identical_views() -> None:
     depths = np.full((2, 4, 8), 80, dtype=np.uint16)
     world_from_cameras = np.repeat(np.eye(4)[np.newaxis], 2, axis=0)
     counts = compute_covisibility_counts(
@@ -12,7 +12,7 @@ def test_compute_covisibility_counts_identical_views():
     np.testing.assert_array_equal(counts, np.full((2, 2), 32))
 
 
-def test_compute_covisibility_counts_rejects_disjoint_views():
+def test_compute_covisibility_counts_rejects_disjoint_views() -> None:
     depths = np.full((2, 4, 8), 80, dtype=np.uint16)
     world_from_cameras = np.repeat(np.eye(4)[np.newaxis], 2, axis=0)
     world_from_cameras[1, 0, 3] = 100.0

--- a/benchmark/reconstruction/evaluation/tartanair/package_tartanair_v2.py
+++ b/benchmark/reconstruction/evaluation/tartanair/package_tartanair_v2.py
@@ -61,7 +61,7 @@ class ZipMember:
 class RemoteZip:
     """Read selected members of a remote ZIP using HTTP range requests."""
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         self.url = url
         self.session = requests.Session()
         self.members = self._read_central_directory()

--- a/benchmark/reconstruction/evaluation/tartanair/package_tartanair_v2_test.py
+++ b/benchmark/reconstruction/evaluation/tartanair/package_tartanair_v2_test.py
@@ -16,14 +16,14 @@ from .package_tartanair_v2 import (  # noqa: E402
 
 
 class FakeResponse:
-    def __init__(self, content: bytes):
+    def __init__(self, content: bytes) -> None:
         self.content = content
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         pass
 
 
-def test_download_tartanair_license(monkeypatch):
+def test_download_tartanair_license(monkeypatch: pytest.MonkeyPatch) -> None:
     license_data = b"license text"
     monkeypatch.setattr(
         package_tartanair_v2,
@@ -38,7 +38,9 @@ def test_download_tartanair_license(monkeypatch):
     assert package_tartanair_v2.download_tartanair_license() == license_data
 
 
-def test_download_tartanair_license_rejects_unexpected_content(monkeypatch):
+def test_download_tartanair_license_rejects_unexpected_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         package_tartanair_v2.requests,
         "get",
@@ -48,7 +50,7 @@ def test_download_tartanair_license_rejects_unexpected_content(monkeypatch):
         package_tartanair_v2.download_tartanair_license()
 
 
-def test_encode_depth_png_min_pools_and_quantizes():
+def test_encode_depth_png_min_pools_and_quantizes() -> None:
     depth = np.full((1024, 2048), 10.0, dtype="<f4")
     depth[:4, :4] = 2.0
     rgba = depth.view(np.uint8).reshape(1024, 2048, 4)
@@ -64,7 +66,7 @@ def test_encode_depth_png_min_pools_and_quantizes():
     assert decoded[0, 1] == round(10.0 * DEPTH_SCALE)
 
 
-def test_encode_image_jpeg():
+def test_encode_image_jpeg() -> None:
     source = io.BytesIO()
     PILImage.new("RGB", (64, 32), (10, 20, 30)).save(source, format="PNG")
     encoded = encode_image_jpeg(source.getvalue())

--- a/benchmark/reconstruction/evaluation/tartanair/tartanair_test.py
+++ b/benchmark/reconstruction/evaluation/tartanair/tartanair_test.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import numpy as np
 
@@ -11,7 +12,7 @@ from . import (
 )
 
 
-def test_tartanair_world_from_camera():
+def test_tartanair_world_from_camera() -> None:
     translation = np.array([1.0, 2.0, 3.0])
     quaternion = np.array([0.0, 0.0, 0.0, 1.0])
 
@@ -23,7 +24,7 @@ def test_tartanair_world_from_camera():
     np.testing.assert_allclose(world_from_camera.translation, translation)
 
 
-def test_dataset_prepares_ground_truth(tmp_path):
+def test_dataset_prepares_ground_truth(tmp_path: Path) -> None:
     scene_path = (
         tmp_path / "data" / "tartanair-v2" / "domestic" / "House-easy-P000"
     )

--- a/benchmark/reconstruction/evaluation/tartanair/tartanair_v2_test.py
+++ b/benchmark/reconstruction/evaluation/tartanair/tartanair_v2_test.py
@@ -13,7 +13,7 @@ from .tartanair_v2 import (
 )
 
 
-def test_manifest_invariants():
+def test_manifest_invariants() -> None:
     manifest = load_manifest()
     scenes = list_scenes(manifest)
 
@@ -43,7 +43,7 @@ def test_manifest_invariants():
     }
 
 
-def test_select_frame_window_maximizes_extent():
+def test_select_frame_window_maximizes_extent() -> None:
     poses = np.zeros((8, 7))
     poses[:, 6] = 1.0
     poses[:, 0] = [0.0, 0.1, 0.2, 0.3, 0.4, 1.3, 2.2, 3.1]
@@ -58,7 +58,7 @@ def test_select_frame_window_maximizes_extent():
     assert selected == range(4, 8)
 
 
-def test_select_frame_window_rejects_motion_gaps():
+def test_select_frame_window_rejects_motion_gaps() -> None:
     poses = np.zeros((4, 7))
     poses[:, 6] = 1.0
     poses[:, 0] = [0.0, 0.1, 2.0, 2.1]

--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -46,6 +46,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -82,7 +83,7 @@ def _init_pool_worker() -> None:
 
 
 def _run_with_log(
-    cmd: list, log_path: Path, check: bool = True, **kwargs
+    cmd: list, log_path: Path, check: bool = True, **kwargs: Any
 ) -> int:
     """Run a subprocess, redirecting stdout+stderr to log_path (overwrite).
 
@@ -118,7 +119,7 @@ class SceneInfo:
     # Whether the dataset has camera priors.
     has_camera_priors: bool
     # Additional arguments for the COLMAP reconstruction command.
-    colmap_extra_args: list[str]
+    colmap_extra_args: list[str | Path] | None
     # Reconstruction backend. The default uses automatic_reconstructor.
     reconstruction_backend: str = "automatic"
     # Subdirectory below workspace_path containing models to evaluate.
@@ -195,7 +196,7 @@ class Dataset(ABC):
         scenes: list[Path],
         run_path: Path,
         run_name: str,
-    ):
+    ) -> None:
         self.data_path = data_path
         self.categories = categories
         self.scenes = scenes
@@ -235,7 +236,7 @@ class _PhaseTracker:
     """Worker-side helper that publishes the current phase for a scene to a
     shared dict. No-op when status_dict is None."""
 
-    def __init__(self, status_dict=None, scene_key: str = "") -> None:
+    def __init__(self, status_dict: Any = None, scene_key: str = "") -> None:
         self._dict = status_dict
         self._key = scene_key
 
@@ -249,7 +250,7 @@ def _scene_key(scene_info: SceneInfo) -> str:
 
 
 def _run_progress_monitor(
-    status_dict, total: int, stop_event: threading.Event
+    status_dict: Any, total: int, stop_event: threading.Event
 ) -> None:
     """Render a live progress display of in-flight scenes until stop_event is
     set. Counts entries marked "done" toward overall completion; everything
@@ -631,7 +632,7 @@ def colmap_reconstruction(
     image_path: Path,
     camera_priors_sparse_gt: pycolmap.Reconstruction | None = None,
     covisibility_sparse_gt: pycolmap.Reconstruction | None = None,
-    colmap_extra_args: list | None = None,
+    colmap_extra_args: list[str | Path] | None = None,
     num_threads: int = 1,
     gpu_index: str = "-1",
     phase_tracker: _PhaseTracker | None = None,
@@ -911,7 +912,7 @@ def process_scene(
     dataset: Dataset,
     num_threads: int,
     gpu_index: str = "-1",
-    progress_status=None,
+    progress_status: Any = None,
 ) -> SceneResult:
     pycolmap.logging.info(
         f"Processing dataset={scene_info.dataset}, "
@@ -1053,7 +1054,7 @@ def _process_scene_with_gpu(
     args: argparse.Namespace,
     dataset: Dataset,
     num_threads: int,
-    progress_status=None,
+    progress_status: Any = None,
 ) -> SceneResult:
     scene_info, gpu_index = scene_info_and_gpu
     return process_scene(
@@ -1579,7 +1580,7 @@ def compute_auc(
         recalls = np.r_[0, recalls]
         errors = np.r_[0, errors]
 
-    aucs = np.zeros(len(thresholds), dtype=np.float64)
+    aucs: npt.NDArray[np.float64] = np.zeros(len(thresholds), dtype=np.float64)
     for i, t in enumerate(thresholds):
         last_index = np.searchsorted(errors, t, side="right")
         r = np.r_[recalls[:last_index], recalls[last_index - 1]]
@@ -1599,7 +1600,9 @@ def compute_recall(
     if num_elems == 0:
         raise ValueError("No errors to evaluate")
 
-    recalls = np.zeros(len(thresholds), dtype=np.float64)
+    recalls: npt.NDArray[np.float64] = np.zeros(
+        len(thresholds), dtype=np.float64
+    )
     for i, t in enumerate(thresholds):
         recalls[i] = 100 * np.sum(errors <= t) / num_elems
 
@@ -1631,7 +1634,7 @@ def compute_avg_metrics(
 def diff_metrics(
     metrics_a: MetricsByDatasetByCatByScene,
     metrics_b: MetricsByDatasetByCatByScene,
-):
+) -> MetricsByDatasetByCatByScene:
     """Computes difference between two sets of metrics.
 
     Raises exception if the metrics are inconsistent.

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -633,7 +633,10 @@ class TestComputeAbsErrors:
         for frame in reconstruction.frames.values():
             world_from_rig = frame.rig_from_world.inverse()
             world_from_rig.rotation = (
-                world_from_rig.rotation * pycolmap.Rotation3d([0, 1, 0, 0])
+                world_from_rig.rotation
+                * pycolmap.Rotation3d(  # type: ignore[call-overload]
+                    [0, 1, 0, 0]
+                )
             )
             world_from_rig.translation += translation
             frame.rig_from_world = world_from_rig.inverse()

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -28,7 +28,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+from collections.abc import Iterable, Sequence
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -69,7 +71,9 @@ def _make_scene_info(category: str, scene: str, num_images: int) -> SceneInfo:
     )
 
 
-def test_panorama_reconstruction_uses_library_api(tmp_path, monkeypatch):
+def test_panorama_reconstruction_uses_library_api(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     covisibility_path = tmp_path / "covisibility.npz"
     covisibility_path.touch()
     scene_info = SceneInfo(
@@ -96,9 +100,11 @@ def test_panorama_reconstruction_uses_library_api(tmp_path, monkeypatch):
         random_seed=7,
         use_gpu=False,
     )
-    call = {}
+    call: dict[str, Any] = {}
 
-    def reconstruct(input_image_path, output_path, options):
+    def reconstruct(
+        input_image_path: Path, output_path: Path, options: Any
+    ) -> dict[str, Any]:
         call.update(
             input_image_path=input_image_path,
             output_path=output_path,
@@ -124,7 +130,7 @@ def test_panorama_reconstruction_uses_library_api(tmp_path, monkeypatch):
 
 
 class TestFilterSmallestScenesPerCategory:
-    def test_picks_smallest_per_category(self):
+    def test_picks_smallest_per_category(self) -> None:
         scenes = [
             _make_scene_info("a", "a3", 30),
             _make_scene_info("a", "a1", 10),
@@ -136,7 +142,7 @@ class TestFilterSmallestScenesPerCategory:
         names = [(s.category, s.scene) for s in result]
         assert names == [("a", "a1"), ("a", "a2"), ("b", "b2"), ("b", "b1")]
 
-    def test_preserves_input_order(self):
+    def test_preserves_input_order(self) -> None:
         scenes = [
             _make_scene_info("a", "a3", 30),
             _make_scene_info("a", "a1", 10),
@@ -147,7 +153,7 @@ class TestFilterSmallestScenesPerCategory:
         # be preserved among the kept scenes.
         assert [s.scene for s in result] == ["a1", "a2"]
 
-    def test_num_scenes_larger_than_category_size(self):
+    def test_num_scenes_larger_than_category_size(self) -> None:
         scenes = [
             _make_scene_info("a", "a1", 10),
             _make_scene_info("a", "a2", 20),
@@ -157,7 +163,7 @@ class TestFilterSmallestScenesPerCategory:
         # All scenes are kept since each category has fewer than num_scenes.
         assert [s.scene for s in result] == ["a1", "a2", "b1"]
 
-    def test_num_scenes_one(self):
+    def test_num_scenes_one(self) -> None:
         scenes = [
             _make_scene_info("a", "a1", 10),
             _make_scene_info("a", "a2", 5),
@@ -170,10 +176,10 @@ class TestFilterSmallestScenesPerCategory:
             ("b", "b2"),
         ]
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         assert filter_smallest_scenes_per_category([], num_scenes=3) == []
 
-    def test_ties_broken_stably(self):
+    def test_ties_broken_stably(self) -> None:
         # When several scenes share the same num_images, sorting must be
         # stable so we keep the ones that appeared first in the input.
         scenes = [
@@ -190,29 +196,31 @@ class TestParseGpuIndex:
     def _make_args(gpu_index: str) -> argparse.Namespace:
         return argparse.Namespace(gpu_index=gpu_index)
 
-    def test_single_gpu(self):
+    def test_single_gpu(self) -> None:
         assert _parse_gpu_index(self._make_args("0")) == [0]
 
-    def test_multiple_gpus(self):
+    def test_multiple_gpus(self) -> None:
         assert _parse_gpu_index(self._make_args("0,1,2")) == [0, 1, 2]
 
-    def test_trailing_comma(self):
+    def test_trailing_comma(self) -> None:
         assert _parse_gpu_index(self._make_args("1,")) == [1]
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         assert _parse_gpu_index(self._make_args("")) == [-1]
 
-    def test_only_commas(self):
+    def test_only_commas(self) -> None:
         assert _parse_gpu_index(self._make_args(",")) == [-1]
 
-    def test_auto_detect(self, monkeypatch):
+    def test_auto_detect(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(pycolmap, "has_cuda", True)
         monkeypatch.setattr(
             pycolmap, "get_num_cuda_devices", lambda: 3, raising=False
         )
         assert _parse_gpu_index(self._make_args("-1")) == [0, 1, 2]
 
-    def test_auto_detect_no_devices(self, monkeypatch):
+    def test_auto_detect_no_devices(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(pycolmap, "has_cuda", True)
         monkeypatch.setattr(
             pycolmap, "get_num_cuda_devices", lambda: 0, raising=False
@@ -221,7 +229,7 @@ class TestParseGpuIndex:
 
 
 class TestComputeAuc:
-    def test_simple_uniform_errors(self):
+    def test_simple_uniform_errors(self) -> None:
         errors = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
         thresholds = np.array([0.25, 0.5, 1.0])
         aucs = compute_auc(errors, thresholds)
@@ -229,38 +237,38 @@ class TestComputeAuc:
         np.testing.assert_almost_equal(aucs[1], 50.0, decimal=5)
         np.testing.assert_almost_equal(aucs[2], 75.0, decimal=5)
 
-    def test_all_errors_zero(self):
+    def test_all_errors_zero(self) -> None:
         errors = np.array([0.0, 0.0, 0.0])
         thresholds = np.array([0.5, 1.0])
         aucs = compute_auc(errors, thresholds)
         np.testing.assert_array_almost_equal(aucs, [100.0, 100.0])
 
-    def test_empty_errors(self):
+    def test_empty_errors(self) -> None:
         errors = np.array([])
         thresholds = np.array([0.5, 1.0])
         with pytest.raises(ValueError, match="No errors to evaluate"):
             compute_auc(errors, thresholds)
 
-    def test_all_errors_above_threshold(self):
+    def test_all_errors_above_threshold(self) -> None:
         errors = np.array([10.0, 20.0, 30.0])
         thresholds = np.array([5.0])
         aucs = compute_auc(errors, thresholds)
         np.testing.assert_almost_equal(aucs[0], 0.0)
 
-    def test_all_errors_below_threshold(self):
+    def test_all_errors_below_threshold(self) -> None:
         errors = np.array([0.1, 0.2, 0.3])
         thresholds = np.array([1.0])
         aucs = compute_auc(errors, thresholds)
         np.testing.assert_almost_equal(aucs[0], 85.0, decimal=5)
 
-    def test_inf_errors(self):
+    def test_inf_errors(self) -> None:
         errors = np.array([0.1, 0.2, np.inf, np.inf])
         thresholds = np.array([0.5, 1.0])
         aucs = compute_auc(errors, thresholds)
         assert np.all(aucs >= 0)
         assert np.all(aucs <= 100)
 
-    def test_single_error(self):
+    def test_single_error(self) -> None:
         errors = np.array([0.5])
         thresholds = np.array([0.3, 1.0])
         aucs = compute_auc(errors, thresholds)
@@ -270,7 +278,7 @@ class TestComputeAuc:
 
 
 class TestComputeRecall:
-    def test_basic_recall(self):
+    def test_basic_recall(self) -> None:
         errors = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
         thresholds = np.array([0.05, 0.25, 0.5, 1.0])
         recalls = compute_recall(errors, thresholds)
@@ -279,31 +287,31 @@ class TestComputeRecall:
         assert np.all(recalls >= 0)
         assert np.all(recalls <= 100)
 
-    def test_empty_errors(self):
+    def test_empty_errors(self) -> None:
         errors = np.array([])
         thresholds = np.array([0.5, 1.0])
         with pytest.raises(ValueError, match="No errors to evaluate"):
             compute_recall(errors, thresholds)
 
-    def test_all_errors_above_threshold(self):
+    def test_all_errors_above_threshold(self) -> None:
         errors = np.array([10.0, 20.0, 30.0])
         thresholds = np.array([5.0])
         recalls = compute_recall(errors, thresholds)
         np.testing.assert_almost_equal(recalls[0], 0.0)
 
-    def test_all_errors_below_threshold(self):
+    def test_all_errors_below_threshold(self) -> None:
         errors = np.array([0.1, 0.2, 0.3])
         thresholds = np.array([1.0])
         recalls = compute_recall(errors, thresholds)
         np.testing.assert_almost_equal(recalls[0], 100.0)
 
-    def test_exact_threshold(self):
+    def test_exact_threshold(self) -> None:
         errors = np.array([0.1, 0.5, 0.9])
         thresholds = np.array([0.5])
         recalls = compute_recall(errors, thresholds)
         np.testing.assert_almost_equal(recalls[0], 200.0 / 3.0)
 
-    def test_multiple_thresholds(self):
+    def test_multiple_thresholds(self) -> None:
         errors = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         thresholds = np.array([2.0, 3.0, 4.0])
         recalls = compute_recall(errors, thresholds)
@@ -313,7 +321,7 @@ class TestComputeRecall:
 
 
 class TestComputeAvgMetrics:
-    def test_single_scene(self):
+    def test_single_scene(self) -> None:
         scene_metrics = {
             "scene1": Metrics(
                 aucs=np.array([10.0, 20.0, 30.0]),
@@ -330,7 +338,7 @@ class TestComputeAvgMetrics:
         np.testing.assert_array_equal(aucs, [10.0, 20.0, 30.0])
         np.testing.assert_array_equal(recalls, [15.0, 25.0, 35.0])
 
-    def test_multiple_scenes(self):
+    def test_multiple_scenes(self) -> None:
         scene_metrics = {
             "scene1": Metrics(
                 aucs=np.array([10.0, 20.0, 30.0]),
@@ -357,7 +365,7 @@ class TestComputeAvgMetrics:
         np.testing.assert_array_equal(aucs, [15.0, 25.0, 35.0])
         np.testing.assert_array_equal(recalls, [20.0, 30.0, 40.0])
 
-    def test_skip_special_scenes(self):
+    def test_skip_special_scenes(self) -> None:
         scene_metrics = {
             "scene1": Metrics(
                 aucs=np.array([10.0, 20.0, 30.0]),
@@ -398,7 +406,13 @@ class TestComputeAvgMetrics:
 
 class TestAggregateSceneMetrics:
     @staticmethod
-    def _make_metrics(aucs, recalls, errors, num_images=100, num_reg_images=90):
+    def _make_metrics(
+        aucs: Sequence[float],
+        recalls: Sequence[float],
+        errors: Sequence[float],
+        num_images: int = 100,
+        num_reg_images: int = 90,
+    ) -> Metrics:
         return Metrics(
             aucs=np.array(aucs, dtype=float),
             recalls=np.array(recalls, dtype=float),
@@ -412,7 +426,7 @@ class TestAggregateSceneMetrics:
             position_accuracy_gt=0.01,
         )
 
-    def test_avg_and_all(self):
+    def test_avg_and_all(self) -> None:
         scene_metrics = [
             (
                 "scene1",
@@ -443,7 +457,7 @@ class TestAggregateSceneMetrics:
         assert summary["__all__"].num_images == 200
         assert summary["__all__"].num_reg_images == 180
 
-    def test_skips_special_entries(self):
+    def test_skips_special_entries(self) -> None:
         real = self._make_metrics([10, 20, 30], [15, 25, 35], [0.1])
         special = self._make_metrics(
             [99, 99, 99], [99, 99, 99], [9.0], num_images=999
@@ -456,7 +470,7 @@ class TestAggregateSceneMetrics:
         np.testing.assert_array_equal(summary["__avg__"].aucs, real.aucs)
         np.testing.assert_array_equal(summary["__all__"].errors, [0.1])
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         assert (
             aggregate_scene_metrics(
                 [],
@@ -466,7 +480,7 @@ class TestAggregateSceneMetrics:
             == {}
         )
 
-    def test_no_errors_omits_all(self):
+    def test_no_errors_omits_all(self) -> None:
         # When no scene carries raw errors (e.g. metrics restored without
         # the errors field), __all__ cannot be reconstructed.
         scene_metrics = [
@@ -483,7 +497,7 @@ class TestAggregateSceneMetrics:
 
 
 class TestGetScores:
-    def test_get_auc_scores(self):
+    def test_get_auc_scores(self) -> None:
         metrics = Metrics(
             aucs=np.array([10.0, 20.0, 30.0]),
             recalls=np.array([15.0, 25.0, 35.0]),
@@ -497,7 +511,7 @@ class TestGetScores:
         scores = get_scores("relative_auc", metrics)
         np.testing.assert_array_equal(scores, metrics.aucs)
 
-    def test_get_recall_scores(self):
+    def test_get_recall_scores(self) -> None:
         metrics = Metrics(
             aucs=np.array([10.0, 20.0, 30.0]),
             recalls=np.array([15.0, 25.0, 35.0]),
@@ -513,7 +527,7 @@ class TestGetScores:
 
 
 class TestDiffMetrics:
-    def test_nominal(self):
+    def test_nominal(self) -> None:
         metrics_a = {
             "dataset1": {
                 "category1": {
@@ -555,7 +569,7 @@ class TestDiffMetrics:
         assert scene_diff.num_components == 1
 
 
-def create_test_reconstruction():
+def create_test_reconstruction() -> pycolmap.Reconstruction:
     pycolmap.set_random_seed(0)
     synthetic_dataset_options = pycolmap.SyntheticDatasetOptions()
     synthetic_dataset_options.num_cameras_per_rig = 1
@@ -564,7 +578,9 @@ def create_test_reconstruction():
     return pycolmap.synthesize_dataset(synthetic_dataset_options)
 
 
-def extract_sub_reconstruction(reconstruction, keep_names):
+def extract_sub_reconstruction(
+    reconstruction: pycolmap.Reconstruction, keep_names: Iterable[str]
+) -> pycolmap.Reconstruction:
     """Build a copy of reconstruction containing only the given image names.
 
     Mirrors what a real sub-model loaded from disk looks like: its images map
@@ -598,7 +614,7 @@ def extract_sub_reconstruction(reconstruction, keep_names):
 
 
 class TestComputeAbsErrors:
-    def test_identical_reconstruction(self):
+    def test_identical_reconstruction(self) -> None:
         reconstruction = create_test_reconstruction()
 
         dts, dRs = compute_abs_errors(
@@ -610,7 +626,7 @@ class TestComputeAbsErrors:
         np.testing.assert_allclose(dts, 0.0, atol=1e-10)
         np.testing.assert_allclose(dRs, 0.0, atol=1e-10)
 
-    def test_transformed_reconstruction(self):
+    def test_transformed_reconstruction(self) -> None:
         gt_reconstruction = create_test_reconstruction()
         reconstruction = create_test_reconstruction()
         translation = np.array([1, 2, 3])
@@ -632,13 +648,15 @@ class TestComputeAbsErrors:
         np.testing.assert_allclose(dRs, 180.0, atol=1e-10)
 
 
-def _single_gt_cluster(reconstruction) -> dict[str, int]:
+def _single_gt_cluster(
+    reconstruction: pycolmap.Reconstruction,
+) -> dict[str, int]:
     """Map every image of a reconstruction to a single GT cluster (id 0)."""
     return {image.name: 0 for image in reconstruction.images.values()}
 
 
 class TestComputeGroupedRelErrors:
-    def test_identical_reconstruction(self):
+    def test_identical_reconstruction(self) -> None:
         reconstruction = create_test_reconstruction()
 
         errors = compute_grouped_rel_errors(
@@ -653,7 +671,7 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_images * (num_images - 1)
         np.testing.assert_allclose(errors, 0.0, atol=1e-5)
 
-    def test_transformed_reconstruction(self):
+    def test_transformed_reconstruction(self) -> None:
         gt_reconstruction = create_test_reconstruction()
         reconstruction = create_test_reconstruction()
         # A global similarity transform leaves relative poses unchanged.
@@ -676,7 +694,7 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_images * (num_images - 1)
         np.testing.assert_allclose(errors, 0.0, atol=1e-5)
 
-    def test_different_reconstructions(self):
+    def test_different_reconstructions(self) -> None:
         gt_reconstruction = create_test_reconstruction()
         reconstruction = create_test_reconstruction()
         for image in reconstruction.images.values():
@@ -697,7 +715,7 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_images * (num_images - 1)
         assert np.all(errors > 0.1)
 
-    def test_nothing_registered_maxes_all_gt_edges(self):
+    def test_nothing_registered_maxes_all_gt_edges(self) -> None:
         # No estimated sub-models: set A is empty, so every GT edge is in
         # B - A and must be scored as the maximum (180 degrees).
         reconstruction = create_test_reconstruction()
@@ -713,7 +731,9 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_images * (num_images - 1)
         np.testing.assert_allclose(errors, 180.0)
 
-    def test_merged_estimate_of_separate_gt_clusters_maxes_cross_edges(self):
+    def test_merged_estimate_of_separate_gt_clusters_maxes_cross_edges(
+        self,
+    ) -> None:
         # Two GT clusters, each perfectly reconstructed in its own sub-model.
         # There are no cross-cluster edges in B, and the within-cluster edges
         # are all in A n B with ~0 error.
@@ -741,7 +761,7 @@ class TestComputeGroupedRelErrors:
         np.testing.assert_allclose(np.sort(errors)[:num_within], 0.0, atol=1e-5)
         assert int(np.sum(np.isclose(errors, 180.0))) == num_cross
 
-    def test_fragmented_estimate_of_merged_gt_maxes_cross_edges(self):
+    def test_fragmented_estimate_of_merged_gt_maxes_cross_edges(self) -> None:
         # One GT cluster (merged reconstruction) that the estimate splits into
         # two disjoint sub-models (fragmented estimation). Within-fragment edges
         # are in A n B (scored ~0); the GT edges bridging the two fragments are
@@ -768,7 +788,7 @@ class TestComputeGroupedRelErrors:
         np.testing.assert_allclose(np.sort(errors)[:num_within], 0.0, atol=1e-5)
         assert int(np.sum(np.isclose(errors, 180.0))) == num_cross
 
-    def test_mismatched_gt_and_estimate_cluster_boundaries(self):
+    def test_mismatched_gt_and_estimate_cluster_boundaries(self) -> None:
         # GT splits the images 1/3 vs 2/3, but the estimate splits them 2/3 vs
         # 1/3, so the two cluster boundaries disagree. Ordered pairs that share
         # both an estimated sub-model and a GT cluster are scored (~0 for a
@@ -812,7 +832,7 @@ class TestComputeGroupedRelErrors:
         np.testing.assert_allclose(np.sort(errors)[:num_scored], 0.0, atol=1e-5)
         assert int(np.sum(np.isclose(errors, 180.0))) == num_maxed
 
-    def test_registered_outlier_edges_are_maxed(self):
+    def test_registered_outlier_edges_are_maxed(self) -> None:
         # A single sub-model connects an outlier to every real image. The
         # outlier is never in a GT reconstruction, so all edges touching it are
         # in A - B and set to 180; the remaining real edges are A n B (~0).
@@ -837,7 +857,7 @@ class TestComputeGroupedRelErrors:
         num_maxed = int(np.sum(np.isclose(errors, 180.0)))
         assert num_maxed == 2 * (num_images - 1)
 
-    def test_outlier_present_in_gt_maxes_its_edges(self):
+    def test_outlier_present_in_gt_maxes_its_edges(self) -> None:
         # An image that exists in the GT reconstruction and is perfectly
         # registered, but is flagged as an outlier, must still have large
         # edges: every edge touching it is in A - B and set to 180, while the
@@ -867,7 +887,7 @@ class TestComputeGroupedRelErrors:
             np.sort(errors)[: (n - 1) * (n - 2)], 0.0, atol=1e-5
         )
 
-    def test_outliers_excluded_from_gt_edges(self):
+    def test_outliers_excluded_from_gt_edges(self) -> None:
         # Nothing is registered, so every scored pair comes from B - A. The
         # outlier forms no GT edges, so it contributes none of them.
         reconstruction = create_test_reconstruction()
@@ -889,7 +909,7 @@ class TestComputeGroupedRelErrors:
         assert len(errors) == num_real * (num_real - 1)
         np.testing.assert_allclose(errors, 180.0)
 
-    def test_gt_names_absent_from_sparse_gt_form_no_edges(self):
+    def test_gt_names_absent_from_sparse_gt_form_no_edges(self) -> None:
         # A name in image_name_to_component that does not exist in sparse_gt
         # cannot form a measurable GT edge and must not add spurious B - A
         # edges. Nothing is registered, so every scored pair comes from B - A.
@@ -914,7 +934,7 @@ class TestComputeGroupedRelErrors:
 
 
 class TestComputeGroupedAbsErrors:
-    def test_identical_single_cluster(self):
+    def test_identical_single_cluster(self) -> None:
         reconstruction = create_test_reconstruction()
 
         errors = compute_grouped_abs_errors(
@@ -926,7 +946,7 @@ class TestComputeGroupedAbsErrors:
         assert len(errors) == reconstruction.num_images()
         np.testing.assert_allclose(errors, 0.0, atol=1e-10)
 
-    def test_keeps_one_error_per_reconstruction(self):
+    def test_keeps_one_error_per_reconstruction(self) -> None:
         # An image registered in n sub-models contributes n errors (not just
         # the smallest). Here every image appears in both sub-models.
         reconstruction = create_test_reconstruction()
@@ -940,7 +960,7 @@ class TestComputeGroupedAbsErrors:
         assert len(errors) == 2 * reconstruction.num_images()
         np.testing.assert_allclose(errors, 0.0, atol=1e-10)
 
-    def test_keeps_only_best_cluster(self):
+    def test_keeps_only_best_cluster(self) -> None:
         # Cluster 0 is reconstructed perfectly; cluster 1 is offset. The
         # best-mean cluster (0) is kept intact and cluster 1 is maxed out.
         gt_reconstruction = create_test_reconstruction()
@@ -971,7 +991,7 @@ class TestComputeGroupedAbsErrors:
         np.testing.assert_allclose(finite, 0.0, atol=1e-10)
         assert int(np.sum(~np.isfinite(errors))) == len(names) - half
 
-    def test_images_without_cluster_id_are_maxed(self):
+    def test_images_without_cluster_id_are_maxed(self) -> None:
         # GT images missing from the mapping (cluster id None) are always maxed
         # out, even when perfectly registered.
         reconstruction = create_test_reconstruction()
@@ -993,7 +1013,7 @@ class TestComputeGroupedAbsErrors:
         assert len(finite) == len(names) - half
         np.testing.assert_allclose(finite, 0.0, atol=1e-10)
 
-    def test_outlier_cluster_is_maxed(self):
+    def test_outlier_cluster_is_maxed(self) -> None:
         # An outlier is never a selectable cluster, so it is maxed out even
         # though it is perfectly aligned; the real cluster is kept intact.
         reconstruction = create_test_reconstruction()
@@ -1015,7 +1035,7 @@ class TestComputeGroupedAbsErrors:
         assert len(finite) == len(names) - 1
         np.testing.assert_allclose(finite, 0.0, atol=1e-10)
 
-    def test_outlier_present_in_gt_gets_large_error(self):
+    def test_outlier_present_in_gt_gets_large_error(self) -> None:
         # An image that exists in the GT reconstruction and is perfectly
         # registered, but is flagged as an outlier, must still receive a large
         # error: being present and well-aligned does not rescue an outlier.
@@ -1042,7 +1062,7 @@ class TestComputeGroupedAbsErrors:
         others = [v for n, v in error_by_name.items() if n != outlier]
         np.testing.assert_allclose(others, 0.0, atol=1e-10)
 
-    def test_credits_multiple_clusters_across_sub_models(self):
+    def test_credits_multiple_clusters_across_sub_models(self) -> None:
         # Two sub-models each perfectly reconstruct a different GT cluster and
         # offset the other. Per-sub-model selection credits both clusters,
         # which a single global choice could not do.
@@ -1097,7 +1117,7 @@ class TestComputeGroupedAbsErrors:
                 assert not np.isfinite(err_sub0)
                 np.testing.assert_allclose(err_sub1, 0.0, atol=1e-10)
 
-    def test_mismatched_gt_and_estimate_cluster_boundaries(self):
+    def test_mismatched_gt_and_estimate_cluster_boundaries(self) -> None:
         # GT splits the images 1/3 vs 2/3 while the estimate splits them 2/3 vs
         # 1/3. sub_model_0 spans all of GT cluster 0 plus the cluster-1 images
         # that leaked in; it can credit only one GT cluster, so the leaked

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -393,7 +393,7 @@ def sort_members(
 # autodoc_member_order=bysource does not work for C++-defined classes since they
 # cannot be introspected and do not have an __all__ list. Instead,
 # we extract the definition order from object.__dict__.
-autodoc.ClassDocumenter.sort_members = sort_members  # type: ignore[method-assign]
+autodoc.ClassDocumenter.sort_members = sort_members  # type: ignore[assignment, method-assign]
 
 
 def process_doc(

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,11 +12,12 @@
 
 import re
 import subprocess
+from typing import Any
 
 from sphinx.ext import autodoc
 
 
-def get_git_revision():
+def get_git_revision() -> str:
     try:
         commit_id = (
             subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
@@ -211,7 +212,7 @@ html_logo = "_static/colmap-logo.svg"
 html_favicon = "_static/favicon.svg"
 
 # Give the landing page a full-width layout by dropping the left sidebar.
-html_sidebars = {"index": [], "viewer": []}
+html_sidebars: dict[str, list[str]] = {"index": [], "viewer": []}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -272,7 +273,7 @@ htmlhelp_basename = "COLMAPdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'a4paper',
     # The font size ('10pt', '11pt' or '12pt').
@@ -371,7 +372,9 @@ autodoc_use_legacy_class_based = True
 
 
 def sort_members(
-    self, documenters: list[tuple[autodoc.Documenter, bool]], order: str
+    self: autodoc.ClassDocumenter,
+    documenters: list[tuple[autodoc.Documenter, bool]],
+    order: str,
 ) -> list[tuple[autodoc.Documenter, bool]]:
     """Order the members by their definition order."""
     class_names = list(self.object.__dict__)
@@ -390,10 +393,12 @@ def sort_members(
 # autodoc_member_order=bysource does not work for C++-defined classes since they
 # cannot be introspected and do not have an __all__ list. Instead,
 # we extract the definition order from object.__dict__.
-autodoc.ClassDocumenter.sort_members = sort_members
+autodoc.ClassDocumenter.sort_members = sort_members  # type: ignore[method-assign]
 
 
-def process_doc(app, what, name, obj, options, lines):
+def process_doc(
+    app: Any, what: str, name: str, obj: Any, options: Any, lines: list[str]
+) -> None:
     if not lines:
         return
     has_overload = lines[0] == "Overloaded function."
@@ -405,7 +410,15 @@ def process_doc(app, what, name, obj, options, lines):
             lines[i] = ". ".join([index, signature])
 
 
-def process_sig(app, what, name, obj, options, signature, return_annotation):
+def process_sig(
+    app: Any,
+    what: str,
+    name: str,
+    obj: Any,
+    options: Any,
+    signature: str | None,
+    return_annotation: Any,
+) -> tuple[str | None, Any]:
     if signature is None:
         return None, return_annotation
     signature = signature.replace("pycolmap._core", "pycolmap")
@@ -416,7 +429,7 @@ def process_sig(app, what, name, obj, options, signature, return_annotation):
     return signature, return_annotation
 
 
-def setup(app):
+def setup(app: Any) -> None:
     # Remap types from the C++ module pycolmap._core to the Python namespace.
     app.connect("autodoc-process-docstring", process_doc)
     app.connect("autodoc-process-signature", process_sig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,10 @@ module = [
   "src.pycolmap.*",
 ]
 disable_error_code = ["attr-defined", "name-defined"]
+
+# Stubs generated from pybind11 signatures still contain untyped overloads.
+[[tool.mypy.overrides]]
+module = ["pycolmap._core", "pycolmap._core.*"]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ test-command = """\
     python -c "import pycolmap; print(pycolmap.__version__)" && \
     cd {project} && \
     mypy --package pycolmap && \
-    mypy --install-types --non-interactive python benchmark && \
-    mypy src/pycolmap && \
+    mypy --install-types --non-interactive python benchmark doc && \
+    mypy src/pycolmap src/thirdparty/Symforce-Caspar/caspar_generate.py && \
     pytest\
 """
 
@@ -83,7 +83,7 @@ test-command = """\
     python -c "import pycolmap; print(pycolmap.__version__)" && \
     cd {project} && \
     mypy --package pycolmap && \
-    mypy src/pycolmap && \
+    mypy src/pycolmap src/thirdparty/Symforce-Caspar/caspar_generate.py && \
     pytest\
 """
 
@@ -101,6 +101,21 @@ norecursedirs = [
 ]
 
 [tool.mypy]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
 implicit_optional = true
 ignore_missing_imports = true
 explicit_package_bases = true
+
+# PyCOLMAP's public API is populated dynamically from the compiled extension,
+# so source-only checks cannot resolve its exported names.
+[[tool.mypy.overrides]]
+module = [
+  "benchmark.*",
+  "doc.tests.*",
+  "pycolmap",
+  "pycolmap.*",
+  "src.pycolmap.*",
+]
+disable_error_code = ["attr-defined", "name-defined"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,21 @@ module = [
   "doc.tests.*",
   "pycolmap",
   "pycolmap.*",
-  "src.pycolmap.*",
 ]
 disable_error_code = ["attr-defined", "name-defined"]
+
+# The generated pybind11 stubs use fixed-shape NumPy annotations that vary
+# between Python platforms and are stricter than the arrays accepted at
+# runtime. Keep annotation checks enabled while suppressing those binding-only
+# incompatibilities in the PyCOLMAP tests.
+[[tool.mypy.overrides]]
+module = ["src.pycolmap.*"]
+disable_error_code = [
+  "arg-type",
+  "assignment",
+  "attr-defined",
+  "name-defined",
+]
 
 # Stubs generated from pybind11 signatures still contain untyped overloads.
 [[tool.mypy.overrides]]

--- a/python/examples/convert_legacy_rotation_averaging_format.py
+++ b/python/examples/convert_legacy_rotation_averaging_format.py
@@ -236,7 +236,7 @@ def create_database_from_relative_poses(
     return image_name_to_id
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Convert rotation averaging files to database format"
     )

--- a/python/examples/custom_incremental_pipeline.py
+++ b/python/examples/custom_incremental_pipeline.py
@@ -414,7 +414,7 @@ def main_incremental_mapper(controller: IncrementalPipeline) -> None:
     ):
         return
 
-    def should_stop():
+    def should_stop() -> bool:
         return (
             mapper.num_total_reg_images() == num_images
             or controller.check_reached_max_runtime()

--- a/python/examples/panorama_sfm_test.py
+++ b/python/examples/panorama_sfm_test.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 
-def test_help():
+def test_help() -> None:
     script_path = Path(__file__).with_name("panorama_sfm.py")
     subprocess.run(
         [sys.executable, script_path, "--help"],

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from .utils import import_module_symbols
 
 
-def _preload_cuda_lib(module_name: str, lib_name: str):
+def _preload_cuda_lib(module_name: str, lib_name: str) -> None:
     """Preload a single library."""
     try:
         module = importlib.import_module(module_name)
@@ -33,7 +33,7 @@ def _preload_cuda_lib(module_name: str, lib_name: str):
                 ctypes.CDLL(str(lib_path))
 
 
-def _preload_cuda_deps():
+def _preload_cuda_deps() -> None:
     """Preloads CUDA dependencies from pip packages on Linux."""
     if platform.system() != "Linux":
         return

--- a/python/pycolmap/panorama.py
+++ b/python/pycolmap/panorama.py
@@ -222,7 +222,7 @@ class PanoProcessor:
         output_image_dir: Path,
         mask_dir: Path,
         render_options: PanoRenderOptions,
-    ):
+    ) -> None:
         self.render_options = render_options
         self.pano_image_dir = pano_image_dir
         self.output_image_dir = output_image_dir

--- a/python/pycolmap/panorama_test.py
+++ b/python/pycolmap/panorama_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 
 import pycolmap
@@ -8,7 +10,7 @@ from .panorama import (
 )
 
 
-def test_get_virtual_rotations():
+def test_get_virtual_rotations() -> None:
     rotations = get_virtual_rotations(4, [-35.0, 0.0, 35.0])
 
     assert len(rotations) == 12
@@ -31,7 +33,7 @@ def test_get_virtual_rotations():
         np.testing.assert_allclose(np.linalg.det(rotation), 1.0, atol=1e-15)
 
 
-def test_filter_database_by_covisibility(tmp_path):
+def test_filter_database_by_covisibility(tmp_path: Path) -> None:
     database_path = tmp_path / "database.db"
     with pycolmap.Database.open(database_path) as database:
         camera = pycolmap.Camera.create_from_model_name(

--- a/python/pycolmap/panorama_test.py
+++ b/python/pycolmap/panorama_test.py
@@ -48,7 +48,9 @@ def test_filter_database_by_covisibility(tmp_path: Path) -> None:
                 use_image_id=True,
             )
         geometry = pycolmap.TwoViewGeometry()
-        geometry.inlier_matches = np.array([[0, 0]], dtype=np.uint32)
+        geometry.inlier_matches = np.array(  # type: ignore[arg-type, assignment]
+            [[0, 0]], dtype=np.uint32
+        )
         database.write_two_view_geometry(1, 2, geometry)
         database.write_two_view_geometry(1, 3, geometry)
 

--- a/src/pycolmap/conftest.py
+++ b/src/pycolmap/conftest.py
@@ -1,17 +1,20 @@
+from collections.abc import Iterator
+from pathlib import Path
+
 import pytest
 
 import pycolmap
 
 
 @pytest.fixture
-def simple_camera():
+def simple_camera() -> pycolmap.Camera:
     return pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768
     )
 
 
 @pytest.fixture(scope="session")
-def synthetic_reconstruction():
+def synthetic_reconstruction() -> pycolmap.Reconstruction:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_cameras_per_rig = 1
     options.num_frames_per_rig = 3
@@ -20,13 +23,15 @@ def synthetic_reconstruction():
 
 
 @pytest.fixture
-def database(tmp_path):
+def database(tmp_path: Path) -> Iterator[pycolmap.Database]:
     with pycolmap.Database.open(str(tmp_path / "test.db")) as db:
         yield db
 
 
 @pytest.fixture
-def populated_database(database):
+def populated_database(
+    database: pycolmap.Database,
+) -> tuple[pycolmap.Database, int, int]:
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768
     )

--- a/src/pycolmap/dataclass_test.py
+++ b/src/pycolmap/dataclass_test.py
@@ -6,28 +6,28 @@ import pycolmap
 # --- Tests on RANSACOptions (flat dataclass) ---
 
 
-def test_ransac_options_summary():
+def test_ransac_options_summary() -> None:
     options = pycolmap.RANSACOptions()
     summary = options.summary()
     assert isinstance(summary, str)
     assert "RANSACOptions" in summary
 
 
-def test_ransac_options_summary_write_type():
+def test_ransac_options_summary_write_type() -> None:
     options = pycolmap.RANSACOptions()
     summary = options.summary(write_type=True)
     assert isinstance(summary, str)
     assert "RANSACOptions" in summary
 
 
-def test_ransac_options_repr():
+def test_ransac_options_repr() -> None:
     options = pycolmap.RANSACOptions()
     representation = repr(options)
     assert isinstance(representation, str)
     assert len(representation) > 0
 
 
-def test_ransac_options_todict():
+def test_ransac_options_todict() -> None:
     options = pycolmap.RANSACOptions()
     dictionary = options.todict()
     assert isinstance(dictionary, dict)
@@ -35,21 +35,21 @@ def test_ransac_options_todict():
     assert "confidence" in dictionary
 
 
-def test_ransac_options_todict_recursive():
+def test_ransac_options_todict_recursive() -> None:
     options = pycolmap.RANSACOptions()
     dictionary = options.todict(recursive=True)
     assert isinstance(dictionary, dict)
     assert "max_error" in dictionary
 
 
-def test_ransac_options_mergedict():
+def test_ransac_options_mergedict() -> None:
     options = pycolmap.RANSACOptions()
     options.mergedict({"max_error": 12.0, "confidence": 0.99})
     assert options.max_error == 12.0
     assert options.confidence == 0.99
 
 
-def test_ransac_options_copy():
+def test_ransac_options_copy() -> None:
     options = pycolmap.RANSACOptions()
     options.max_error = 7.5
     copied = copy.copy(options)
@@ -57,7 +57,7 @@ def test_ransac_options_copy():
     assert copied is not options
 
 
-def test_ransac_options_deepcopy():
+def test_ransac_options_deepcopy() -> None:
     options = pycolmap.RANSACOptions()
     options.max_error = 3.3
     deep = copy.deepcopy(options)
@@ -65,7 +65,7 @@ def test_ransac_options_deepcopy():
     assert deep is not options
 
 
-def test_ransac_options_eq():
+def test_ransac_options_eq() -> None:
     options_a = pycolmap.RANSACOptions()
     options_b = pycolmap.RANSACOptions()
     assert options_a == options_b
@@ -73,7 +73,7 @@ def test_ransac_options_eq():
     assert options_a != options_b
 
 
-def test_ransac_options_pickle_roundtrip():
+def test_ransac_options_pickle_roundtrip() -> None:
     options = pycolmap.RANSACOptions()
     options.max_error = 5.5
     options.confidence = 0.95
@@ -83,13 +83,13 @@ def test_ransac_options_pickle_roundtrip():
     assert restored.confidence == 0.95
 
 
-def test_ransac_options_dict_constructor():
+def test_ransac_options_dict_constructor() -> None:
     options = pycolmap.RANSACOptions({"max_error": 11.0, "confidence": 0.98})
     assert options.max_error == 11.0
     assert options.confidence == 0.98
 
 
-def test_ransac_options_kwargs_constructor():
+def test_ransac_options_kwargs_constructor() -> None:
     options = pycolmap.RANSACOptions(max_error=22.0, min_num_trials=200)
     assert options.max_error == 22.0
     assert options.min_num_trials == 200
@@ -98,27 +98,27 @@ def test_ransac_options_kwargs_constructor():
 # --- Tests on IncrementalPipelineOptions (nested dataclass) ---
 
 
-def test_incremental_pipeline_options_todict_recursive():
+def test_incremental_pipeline_options_todict_recursive() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     dictionary = options.todict(recursive=True)
     assert isinstance(dictionary, dict)
     assert "min_num_matches" in dictionary
 
 
-def test_incremental_pipeline_options_mergedict():
+def test_incremental_pipeline_options_mergedict() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     options.mergedict({"min_num_matches": 30})
     assert options.min_num_matches == 30
 
 
-def test_incremental_pipeline_options_summary():
+def test_incremental_pipeline_options_summary() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     summary = options.summary()
     assert isinstance(summary, str)
     assert "IncrementalPipelineOptions" in summary
 
 
-def test_incremental_pipeline_options_pickle():
+def test_incremental_pipeline_options_pickle() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     options.min_num_matches = 42
     data = pickle.dumps(options)
@@ -129,20 +129,20 @@ def test_incremental_pipeline_options_pickle():
 # --- Tests on Rigid3d ---
 
 
-def test_rigid3d_summary():
+def test_rigid3d_summary() -> None:
     rigid = pycolmap.Rigid3d()
     summary = rigid.summary()
     assert isinstance(summary, str)
     assert "Rigid3d" in summary
 
 
-def test_rigid3d_todict():
+def test_rigid3d_todict() -> None:
     rigid = pycolmap.Rigid3d()
     dictionary = rigid.todict()
     assert isinstance(dictionary, dict)
 
 
-def test_rigid3d_pickle_roundtrip():
+def test_rigid3d_pickle_roundtrip() -> None:
     rigid = pycolmap.Rigid3d()
     data = pickle.dumps(rigid)
     restored = pickle.loads(data)

--- a/src/pycolmap/estimators/affine_transform_test.py
+++ b/src/pycolmap/estimators/affine_transform_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pycolmap
 
 
-def test_estimate_affine2d_with_points():
+def test_estimate_affine2d_with_points() -> None:
     source = [
         np.array([0.0, 0.0]),
         np.array([1.0, 0.0]),
@@ -20,5 +20,5 @@ def test_estimate_affine2d_with_points():
     assert result_array.shape == (2, 3)
 
 
-def test_estimate_affine2d_robust_is_callable():
+def test_estimate_affine2d_robust_is_callable() -> None:
     assert callable(pycolmap.estimate_affine2d_robust)

--- a/src/pycolmap/estimators/affine_transform_test.py
+++ b/src/pycolmap/estimators/affine_transform_test.py
@@ -14,7 +14,7 @@ def test_estimate_affine2d_with_points() -> None:
         np.array([2.0, 1.0]),
         np.array([1.0, 2.0]),
     ]
-    result = pycolmap.estimate_affine2d(source, target)
+    result = pycolmap.estimate_affine2d(source, target)  # type: ignore[arg-type]
     assert result is not None
     result_array = np.array(result)
     assert result_array.shape == (2, 3)

--- a/src/pycolmap/estimators/alignment_test.py
+++ b/src/pycolmap/estimators/alignment_test.py
@@ -3,24 +3,24 @@ import pytest
 import pycolmap
 
 
-def test_image_alignment_error_default_init():
+def test_image_alignment_error_default_init() -> None:
     error = pycolmap.ImageAlignmentError()
     assert error is not None
 
 
-def test_image_alignment_error_image_name_readwrite():
+def test_image_alignment_error_image_name_readwrite() -> None:
     error = pycolmap.ImageAlignmentError()
     error.image_name = "test_image.jpg"
     assert error.image_name == "test_image.jpg"
 
 
-def test_image_alignment_error_rotation_error_deg_readwrite():
+def test_image_alignment_error_rotation_error_deg_readwrite() -> None:
     error = pycolmap.ImageAlignmentError()
     error.rotation_error_deg = 1.5
     assert error.rotation_error_deg == 1.5
 
 
-def test_image_alignment_error_proj_center_error_readwrite():
+def test_image_alignment_error_proj_center_error_readwrite() -> None:
     error = pycolmap.ImageAlignmentError()
     error.proj_center_error = 0.01
     assert error.proj_center_error == 0.01
@@ -35,11 +35,13 @@ def test_image_alignment_error_proj_center_error_readwrite():
         "compare_reconstructions",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))
 
 
-def test_compare_reconstructions_with_synthetic(synthetic_reconstruction):
+def test_compare_reconstructions_with_synthetic(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     result = pycolmap.compare_reconstructions(
         synthetic_reconstruction, synthetic_reconstruction
     )

--- a/src/pycolmap/estimators/bundle_adjustment_test.py
+++ b/src/pycolmap/estimators/bundle_adjustment_test.py
@@ -1,7 +1,7 @@
 import pycolmap
 
 
-def test_bundle_adjustment_termination_type_enum():
+def test_bundle_adjustment_termination_type_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.BundleAdjustmentTerminationType.__members__.items()
@@ -14,7 +14,7 @@ def test_bundle_adjustment_termination_type_enum():
     }
 
 
-def test_bundle_adjustment_gauge_enum():
+def test_bundle_adjustment_gauge_enum() -> None:
     assert {
         k: int(v) for k, v in pycolmap.BundleAdjustmentGauge.__members__.items()
     } == {
@@ -24,7 +24,7 @@ def test_bundle_adjustment_gauge_enum():
     }
 
 
-def test_bundle_adjustment_backend_enum():
+def test_bundle_adjustment_backend_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.BundleAdjustmentBackend.__members__.items()
@@ -38,7 +38,7 @@ def test_bundle_adjustment_backend_enum():
     )
 
 
-def test_loss_function_type_enum():
+def test_loss_function_type_enum() -> None:
     assert {
         k: int(v) for k, v in pycolmap.LossFunctionType.__members__.items()
     } == {
@@ -49,18 +49,18 @@ def test_loss_function_type_enum():
     }
 
 
-def test_bundle_adjustment_summary_default_init():
+def test_bundle_adjustment_summary_default_init() -> None:
     summary = pycolmap.BundleAdjustmentSummary()
     assert summary is not None
 
 
-def test_bundle_adjustment_summary_num_residuals_readwrite():
+def test_bundle_adjustment_summary_num_residuals_readwrite() -> None:
     summary = pycolmap.BundleAdjustmentSummary()
     summary.num_residuals = 100
     assert summary.num_residuals == 100
 
 
-def test_bundle_adjustment_summary_termination_type_readwrite():
+def test_bundle_adjustment_summary_termination_type_readwrite() -> None:
     summary = pycolmap.BundleAdjustmentSummary()
     summary.termination_type = (
         pycolmap.BundleAdjustmentTerminationType.CONVERGENCE
@@ -71,56 +71,56 @@ def test_bundle_adjustment_summary_termination_type_readwrite():
     )
 
 
-def test_bundle_adjustment_summary_is_solution_usable():
+def test_bundle_adjustment_summary_is_solution_usable() -> None:
     summary = pycolmap.BundleAdjustmentSummary()
     result = summary.is_solution_usable()
     assert isinstance(result, bool)
 
 
-def test_bundle_adjustment_summary_brief_report():
+def test_bundle_adjustment_summary_brief_report() -> None:
     summary = pycolmap.BundleAdjustmentSummary()
     report = summary.brief_report()
     assert isinstance(report, str)
 
 
-def test_ceres_bundle_adjustment_summary_default_init():
+def test_ceres_bundle_adjustment_summary_default_init() -> None:
     summary = pycolmap.CeresBundleAdjustmentSummary()
     assert summary is not None
 
 
-def test_ceres_bundle_adjustment_summary_inherits():
+def test_ceres_bundle_adjustment_summary_inherits() -> None:
     summary = pycolmap.CeresBundleAdjustmentSummary()
     assert isinstance(summary, pycolmap.BundleAdjustmentSummary)
 
 
-def test_bundle_adjustment_config_default_init():
+def test_bundle_adjustment_config_default_init() -> None:
     config = pycolmap.BundleAdjustmentConfig()
     assert config is not None
 
 
-def test_bundle_adjustment_config_images_property():
+def test_bundle_adjustment_config_images_property() -> None:
     config = pycolmap.BundleAdjustmentConfig()
     images = config.images
     assert len(images) == 0
 
 
-def test_ceres_ba_options_default_init():
+def test_ceres_ba_options_default_init() -> None:
     options = pycolmap.CeresBundleAdjustmentOptions()
     assert options is not None
 
 
-def test_ceres_ba_options_check():
+def test_ceres_ba_options_check() -> None:
     options = pycolmap.CeresBundleAdjustmentOptions()
     result = options.check()
     assert isinstance(result, bool)
 
 
-def test_caspar_ba_options_default_init():
+def test_caspar_ba_options_default_init() -> None:
     options = pycolmap.CasparBundleAdjustmentOptions()
     assert options is not None
 
 
-def test_caspar_ba_options_readwrite():
+def test_caspar_ba_options_readwrite() -> None:
     options = pycolmap.CasparBundleAdjustmentOptions()
     options.solver_iter_max = 17
     options.pcg_iter_max = 11
@@ -132,12 +132,12 @@ def test_caspar_ba_options_readwrite():
     assert options.gpu_index == "0"
 
 
-def test_ba_options_default_init():
+def test_ba_options_default_init() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     assert options is not None
 
 
-def test_ba_options_refine_focal_length_readwrite():
+def test_ba_options_refine_focal_length_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     original = options.refine_focal_length
     assert isinstance(original, bool)
@@ -145,7 +145,7 @@ def test_ba_options_refine_focal_length_readwrite():
     assert options.refine_focal_length == (not original)
 
 
-def test_ba_options_refine_principal_point_readwrite():
+def test_ba_options_refine_principal_point_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     original = options.refine_principal_point
     assert isinstance(original, bool)
@@ -153,7 +153,7 @@ def test_ba_options_refine_principal_point_readwrite():
     assert options.refine_principal_point == (not original)
 
 
-def test_ba_options_refine_extra_params_readwrite():
+def test_ba_options_refine_extra_params_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     original = options.refine_extra_params
     assert isinstance(original, bool)
@@ -161,7 +161,7 @@ def test_ba_options_refine_extra_params_readwrite():
     assert options.refine_extra_params == (not original)
 
 
-def test_ba_options_refine_points3d_readwrite():
+def test_ba_options_refine_points3d_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     original = options.refine_points3D
     assert isinstance(original, bool)
@@ -169,14 +169,14 @@ def test_ba_options_refine_points3d_readwrite():
     assert options.refine_points3D == (not original)
 
 
-def test_ba_options_min_track_length_readwrite():
+def test_ba_options_min_track_length_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     assert isinstance(options.min_track_length, int)
     options.min_track_length = 5
     assert options.min_track_length == 5
 
 
-def test_ba_options_print_summary_readwrite():
+def test_ba_options_print_summary_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     original = options.print_summary
     assert isinstance(original, bool)
@@ -184,7 +184,7 @@ def test_ba_options_print_summary_readwrite():
     assert options.print_summary == (not original)
 
 
-def test_ba_options_backend_readwrite():
+def test_ba_options_backend_readwrite() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     options.backend = pycolmap.BundleAdjustmentBackend.CERES
     assert options.backend == pycolmap.BundleAdjustmentBackend.CERES
@@ -192,48 +192,52 @@ def test_ba_options_backend_readwrite():
     assert options.backend == pycolmap.BundleAdjustmentBackend.CASPAR
 
 
-def test_ba_options_ceres_property():
+def test_ba_options_ceres_property() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     ceres = options.ceres
     assert isinstance(ceres, pycolmap.CeresBundleAdjustmentOptions)
 
 
-def test_ba_options_caspar_property():
+def test_ba_options_caspar_property() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     caspar = options.caspar
     assert isinstance(caspar, pycolmap.CasparBundleAdjustmentOptions)
 
 
-def test_ba_options_check():
+def test_ba_options_check() -> None:
     options = pycolmap.BundleAdjustmentOptions()
     result = options.check()
     assert isinstance(result, bool)
 
 
-def test_pose_prior_ba_options_default_init():
+def test_pose_prior_ba_options_default_init() -> None:
     options = pycolmap.PosePriorBundleAdjustmentOptions()
     assert options is not None
 
 
-def test_pose_prior_ba_options_prior_position_fallback_stddev_readwrite():
+def test_pose_prior_ba_options_prior_position_fallback_stddev_readwrite() -> (
+    None
+):
     options = pycolmap.PosePriorBundleAdjustmentOptions()
     assert isinstance(options.prior_position_fallback_stddev, float)
     options.prior_position_fallback_stddev = 5.0
     assert options.prior_position_fallback_stddev == 5.0
 
 
-def test_ceres_pose_prior_ba_options_default_init():
+def test_ceres_pose_prior_ba_options_default_init() -> None:
     options = pycolmap.CeresPosePriorBundleAdjustmentOptions()
     assert options is not None
 
 
-def test_ceres_pose_prior_ba_options_check():
+def test_ceres_pose_prior_ba_options_check() -> None:
     options = pycolmap.CeresPosePriorBundleAdjustmentOptions()
     result = options.check()
     assert isinstance(result, bool)
 
 
-def test_create_default_bundle_adjuster(synthetic_reconstruction):
+def test_create_default_bundle_adjuster(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     options = pycolmap.BundleAdjustmentOptions()
     config = pycolmap.BundleAdjustmentConfig()
     adjuster = pycolmap.create_default_bundle_adjuster(
@@ -242,7 +246,9 @@ def test_create_default_bundle_adjuster(synthetic_reconstruction):
     assert adjuster is not None
 
 
-def test_create_default_ceres_bundle_adjuster(synthetic_reconstruction):
+def test_create_default_ceres_bundle_adjuster(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     options = pycolmap.BundleAdjustmentOptions()
     config = pycolmap.BundleAdjustmentConfig()
     adjuster = pycolmap.create_default_ceres_bundle_adjuster(
@@ -251,7 +257,9 @@ def test_create_default_ceres_bundle_adjuster(synthetic_reconstruction):
     assert adjuster is not None
 
 
-def test_bundle_adjustment_pipeline(synthetic_reconstruction):
+def test_bundle_adjustment_pipeline(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction = pycolmap.Reconstruction(synthetic_reconstruction)
     options = pycolmap.BundleAdjustmentOptions()
     options.print_summary = False

--- a/src/pycolmap/estimators/ceres_bindings_test.py
+++ b/src/pycolmap/estimators/ceres_bindings_test.py
@@ -1,11 +1,11 @@
 import pycolmap
 
 
-def test_pyceres_submodule_exists():
+def test_pyceres_submodule_exists() -> None:
     assert hasattr(pycolmap._core, "pyceres")
 
 
-def test_minimizer_type_enum():
+def test_minimizer_type_enum() -> None:
     pyceres = pycolmap._core.pyceres
     assert {
         k: int(v) for k, v in pyceres.MinimizerType.__members__.items()
@@ -15,7 +15,7 @@ def test_minimizer_type_enum():
     }
 
 
-def test_linear_solver_type_enum():
+def test_linear_solver_type_enum() -> None:
     pyceres = pycolmap._core.pyceres
     assert {
         k: int(v) for k, v in pyceres.LinearSolverType.__members__.items()
@@ -30,7 +30,7 @@ def test_linear_solver_type_enum():
     }
 
 
-def test_trust_region_strategy_type_enum():
+def test_trust_region_strategy_type_enum() -> None:
     pyceres = pycolmap._core.pyceres
     assert {
         k: int(v)
@@ -41,7 +41,7 @@ def test_trust_region_strategy_type_enum():
     }
 
 
-def test_logging_type_enum():
+def test_logging_type_enum() -> None:
     pyceres = pycolmap._core.pyceres
     assert {k: int(v) for k, v in pyceres.LoggingType.__members__.items()} == {
         "SILENT": 0,
@@ -49,7 +49,7 @@ def test_logging_type_enum():
     }
 
 
-def test_termination_type_enum():
+def test_termination_type_enum() -> None:
     pyceres = pycolmap._core.pyceres
     assert {
         k: int(v) for k, v in pyceres.TerminationType.__members__.items()
@@ -62,41 +62,41 @@ def test_termination_type_enum():
     }
 
 
-def test_solver_options_default_init():
+def test_solver_options_default_init() -> None:
     options = pycolmap._core.pyceres.SolverOptions()
     assert options is not None
 
 
-def test_solver_options_is_valid():
+def test_solver_options_is_valid() -> None:
     options = pycolmap._core.pyceres.SolverOptions()
     valid, error = options.IsValid()
     assert valid is True
     assert error == ""
 
 
-def test_solver_summary_default_init():
+def test_solver_summary_default_init() -> None:
     summary = pycolmap._core.pyceres.SolverSummary()
     assert summary is not None
 
 
-def test_solver_summary_brief_report():
+def test_solver_summary_brief_report() -> None:
     summary = pycolmap._core.pyceres.SolverSummary()
     report = summary.BriefReport()
     assert isinstance(report, str)
 
 
-def test_solver_summary_full_report():
+def test_solver_summary_full_report() -> None:
     summary = pycolmap._core.pyceres.SolverSummary()
     report = summary.FullReport()
     assert isinstance(report, str)
 
 
-def test_solver_summary_is_solution_usable():
+def test_solver_summary_is_solution_usable() -> None:
     summary = pycolmap._core.pyceres.SolverSummary()
     result = summary.IsSolutionUsable()
     assert isinstance(result, bool)
 
 
-def test_iteration_summary_accessible():
+def test_iteration_summary_accessible() -> None:
     summary = pycolmap._core.pyceres.IterationSummary()
     assert summary is not None

--- a/src/pycolmap/estimators/cost_functions_test.py
+++ b/src/pycolmap/estimators/cost_functions_test.py
@@ -1,31 +1,31 @@
 import pycolmap
 
 
-def test_cost_functions_submodule_exists():
+def test_cost_functions_submodule_exists() -> None:
     assert hasattr(pycolmap._core, "cost_functions")
 
 
-def test_reproj_error_cost_exists():
+def test_reproj_error_cost_exists() -> None:
     assert hasattr(pycolmap._core.cost_functions, "ReprojErrorCost")
 
 
-def test_sampson_error_cost_exists():
+def test_sampson_error_cost_exists() -> None:
     assert hasattr(pycolmap._core.cost_functions, "SampsonErrorCost")
 
 
-def test_absolute_pose_prior_cost_exists():
+def test_absolute_pose_prior_cost_exists() -> None:
     assert hasattr(pycolmap._core.cost_functions, "AbsolutePosePriorCost")
 
 
-def test_absolute_pose_position_prior_cost_exists():
+def test_absolute_pose_position_prior_cost_exists() -> None:
     assert hasattr(
         pycolmap._core.cost_functions, "AbsolutePosePositionPriorCost"
     )
 
 
-def test_relative_pose_prior_cost_exists():
+def test_relative_pose_prior_cost_exists() -> None:
     assert hasattr(pycolmap._core.cost_functions, "RelativePosePriorCost")
 
 
-def test_point3d_alignment_cost_exists():
+def test_point3d_alignment_cost_exists() -> None:
     assert hasattr(pycolmap._core.cost_functions, "Point3DAlignmentCost")

--- a/src/pycolmap/estimators/covariance_test.py
+++ b/src/pycolmap/estimators/covariance_test.py
@@ -1,7 +1,7 @@
 import pycolmap
 
 
-def test_ba_covariance_options_params_enum():
+def test_ba_covariance_options_params_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.BACovarianceOptionsParams.__members__.items()
@@ -13,34 +13,34 @@ def test_ba_covariance_options_params_enum():
     }
 
 
-def test_ba_covariance_options_default_init():
+def test_ba_covariance_options_default_init() -> None:
     options = pycolmap.BACovarianceOptions()
     assert options is not None
 
 
-def test_ba_covariance_options_params_readwrite():
+def test_ba_covariance_options_params_readwrite() -> None:
     options = pycolmap.BACovarianceOptions()
     options.params = pycolmap.BACovarianceOptionsParams.POINTS
     assert options.params == pycolmap.BACovarianceOptionsParams.POINTS
 
 
-def test_ba_covariance_options_damping_readwrite():
+def test_ba_covariance_options_damping_readwrite() -> None:
     options = pycolmap.BACovarianceOptions()
     assert isinstance(options.damping, float)
     options.damping = 1e-6
     assert options.damping == 1e-6
 
 
-def test_experimental_pose_param_default_init():
+def test_experimental_pose_param_default_init() -> None:
     param = pycolmap.ExperimentalPoseParam()
     assert param is not None
 
 
-def test_experimental_pose_param_image_id_readwrite():
+def test_experimental_pose_param_image_id_readwrite() -> None:
     param = pycolmap.ExperimentalPoseParam()
     param.image_id = 42
     assert param.image_id == 42
 
 
-def test_estimate_ba_covariance_is_callable():
+def test_estimate_ba_covariance_is_callable() -> None:
     assert callable(pycolmap.estimate_ba_covariance)

--- a/src/pycolmap/estimators/essential_matrix_test.py
+++ b/src/pycolmap/estimators/essential_matrix_test.py
@@ -1,5 +1,5 @@
 import pycolmap
 
 
-def test_estimate_essential_matrix_is_callable():
+def test_estimate_essential_matrix_is_callable() -> None:
     assert callable(pycolmap.estimate_essential_matrix)

--- a/src/pycolmap/estimators/fundamental_matrix_test.py
+++ b/src/pycolmap/estimators/fundamental_matrix_test.py
@@ -1,5 +1,5 @@
 import pycolmap
 
 
-def test_estimate_fundamental_matrix_is_callable():
+def test_estimate_fundamental_matrix_is_callable() -> None:
     assert callable(pycolmap.estimate_fundamental_matrix)

--- a/src/pycolmap/estimators/generalized_pose_test.py
+++ b/src/pycolmap/estimators/generalized_pose_test.py
@@ -12,5 +12,5 @@ import pycolmap
         "estimate_generalized_relative_pose",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/estimators/homography_matrix_test.py
+++ b/src/pycolmap/estimators/homography_matrix_test.py
@@ -1,5 +1,5 @@
 import pycolmap
 
 
-def test_estimate_homography_matrix_is_callable():
+def test_estimate_homography_matrix_is_callable() -> None:
     assert callable(pycolmap.estimate_homography_matrix)

--- a/src/pycolmap/estimators/motion_averaging_test.py
+++ b/src/pycolmap/estimators/motion_averaging_test.py
@@ -3,7 +3,7 @@ import pytest
 import pycolmap
 
 
-def test_rotation_weight_type_enum():
+def test_rotation_weight_type_enum() -> None:
     assert {
         k: int(v) for k, v in pycolmap.RotationWeightType.__members__.items()
     } == {
@@ -12,7 +12,7 @@ def test_rotation_weight_type_enum():
     }
 
 
-def test_rotation_averaging_reweighting_enum():
+def test_rotation_averaging_reweighting_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.RotationAveragingReweighting.__members__.items()
@@ -22,13 +22,13 @@ def test_rotation_averaging_reweighting_enum():
     }
 
 
-def test_rotation_estimator_options_default_init():
+def test_rotation_estimator_options_default_init() -> None:
     options = pycolmap.RotationEstimatorOptions()
     assert options is not None
     assert options.reweighting == pycolmap.RotationAveragingReweighting.UNIFORM
 
 
-def test_rotation_estimator_options_reweighting_readwrite():
+def test_rotation_estimator_options_reweighting_readwrite() -> None:
     options = pycolmap.RotationEstimatorOptions()
     options.reweighting = (
         pycolmap.RotationAveragingReweighting.INLIER_MATCH_COUNT
@@ -41,33 +41,33 @@ def test_rotation_estimator_options_reweighting_readwrite():
     assert options.reweighting == pycolmap.RotationAveragingReweighting.UNIFORM
 
 
-def test_gravity_refiner_options_default_init():
+def test_gravity_refiner_options_default_init() -> None:
     options = pycolmap.GravityRefinerOptions()
     assert options is not None
 
 
-def test_gravity_refiner_options_max_outlier_ratio_readwrite():
+def test_gravity_refiner_options_max_outlier_ratio_readwrite() -> None:
     options = pycolmap.GravityRefinerOptions()
     assert isinstance(options.max_outlier_ratio, float)
     options.max_outlier_ratio = 0.5
     assert options.max_outlier_ratio == 0.5
 
 
-def test_gravity_refiner_options_max_gravity_error_readwrite():
+def test_gravity_refiner_options_max_gravity_error_readwrite() -> None:
     options = pycolmap.GravityRefinerOptions()
     assert isinstance(options.max_gravity_error, float)
     options.max_gravity_error = 10.0
     assert options.max_gravity_error == 10.0
 
 
-def test_gravity_refiner_options_min_num_neighbors_readwrite():
+def test_gravity_refiner_options_min_num_neighbors_readwrite() -> None:
     options = pycolmap.GravityRefinerOptions()
     assert isinstance(options.min_num_neighbors, int)
     options.min_num_neighbors = 5
     assert options.min_num_neighbors == 5
 
 
-def test_global_positioner_options_default_init():
+def test_global_positioner_options_default_init() -> None:
     options = pycolmap.GlobalPositionerOptions()
     assert options is not None
 
@@ -80,5 +80,5 @@ def test_global_positioner_options_default_init():
         "run_global_positioning",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/estimators/motion_averaging_test.py
+++ b/src/pycolmap/estimators/motion_averaging_test.py
@@ -37,7 +37,7 @@ def test_rotation_estimator_options_reweighting_readwrite() -> None:
         options.reweighting
         == pycolmap.RotationAveragingReweighting.INLIER_MATCH_COUNT
     )
-    options.reweighting = "UNIFORM"
+    options.reweighting = "UNIFORM"  # type: ignore[assignment]
     assert options.reweighting == pycolmap.RotationAveragingReweighting.UNIFORM
 
 

--- a/src/pycolmap/estimators/pose_test.py
+++ b/src/pycolmap/estimators/pose_test.py
@@ -4,12 +4,14 @@ import pytest
 import pycolmap
 
 
-def test_absolute_pose_estimation_options_default_init():
+def test_absolute_pose_estimation_options_default_init() -> None:
     options = pycolmap.AbsolutePoseEstimationOptions()
     assert options is not None
 
 
-def test_absolute_pose_estimation_options_estimate_focal_length_readwrite():
+def test_absolute_pose_estimation_options_estimate_focal_length_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseEstimationOptions()
     original = options.estimate_focal_length
     assert isinstance(original, bool)
@@ -17,39 +19,47 @@ def test_absolute_pose_estimation_options_estimate_focal_length_readwrite():
     assert options.estimate_focal_length == (not original)
 
 
-def test_absolute_pose_estimation_options_ransac_property():
+def test_absolute_pose_estimation_options_ransac_property() -> None:
     options = pycolmap.AbsolutePoseEstimationOptions()
     ransac = options.ransac
     assert isinstance(ransac, pycolmap.RANSACOptions)
 
 
-def test_absolute_pose_refinement_options_default_init():
+def test_absolute_pose_refinement_options_default_init() -> None:
     options = pycolmap.AbsolutePoseRefinementOptions()
     assert options is not None
 
 
-def test_absolute_pose_refinement_options_gradient_tolerance_readwrite():
+def test_absolute_pose_refinement_options_gradient_tolerance_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     assert isinstance(options.gradient_tolerance, float)
     options.gradient_tolerance = 0.5
     assert options.gradient_tolerance == 0.5
 
 
-def test_absolute_pose_refinement_options_max_num_iterations_readwrite():
+def test_absolute_pose_refinement_options_max_num_iterations_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     assert isinstance(options.max_num_iterations, int)
     options.max_num_iterations = 200
     assert options.max_num_iterations == 200
 
 
-def test_absolute_pose_refinement_options_loss_function_scale_readwrite():
+def test_absolute_pose_refinement_options_loss_function_scale_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     assert isinstance(options.loss_function_scale, float)
     options.loss_function_scale = 2.0
     assert options.loss_function_scale == 2.0
 
 
-def test_absolute_pose_refinement_options_refine_focal_length_readwrite():
+def test_absolute_pose_refinement_options_refine_focal_length_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     original = options.refine_focal_length
     assert isinstance(original, bool)
@@ -57,7 +67,9 @@ def test_absolute_pose_refinement_options_refine_focal_length_readwrite():
     assert options.refine_focal_length == (not original)
 
 
-def test_absolute_pose_refinement_options_refine_extra_params_readwrite():
+def test_absolute_pose_refinement_options_refine_extra_params_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     original = options.refine_extra_params
     assert isinstance(original, bool)
@@ -65,7 +77,7 @@ def test_absolute_pose_refinement_options_refine_extra_params_readwrite():
     assert options.refine_extra_params == (not original)
 
 
-def test_absolute_pose_refinement_options_print_summary_readwrite():
+def test_absolute_pose_refinement_options_print_summary_readwrite() -> None:
     options = pycolmap.AbsolutePoseRefinementOptions()
     original = options.print_summary
     assert isinstance(original, bool)
@@ -73,7 +85,9 @@ def test_absolute_pose_refinement_options_print_summary_readwrite():
     assert options.print_summary == (not original)
 
 
-def test_absolute_pose_refinement_options_use_position_prior_readwrite():
+def test_absolute_pose_refinement_options_use_position_prior_readwrite() -> (
+    None
+):
     options = pycolmap.AbsolutePoseRefinementOptions()
     original = options.use_position_prior
     assert isinstance(original, bool)
@@ -81,7 +95,7 @@ def test_absolute_pose_refinement_options_use_position_prior_readwrite():
     assert options.use_position_prior == (not original)
 
 
-def test_absolute_pose_refinement_options_position_prior_covariance_readwrite():
+def test_absolute_pose_refinement_position_prior_covariance_readwrite() -> None:
     options = pycolmap.AbsolutePoseRefinementOptions()
     covariance = options.position_prior_covariance
     assert covariance is not None
@@ -101,11 +115,11 @@ def test_absolute_pose_refinement_options_position_prior_covariance_readwrite():
         "refine_relative_pose",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))
 
 
-def test_relative_pose_ray_overloads():
+def test_relative_pose_ray_overloads() -> None:
     rng = np.random.default_rng(0)
     points3D = rng.uniform(-1.0, 1.0, size=(20, 3))
     points3D[:, 2] += 4.0

--- a/src/pycolmap/estimators/similarity_transform_test.py
+++ b/src/pycolmap/estimators/similarity_transform_test.py
@@ -4,7 +4,7 @@ import pytest
 import pycolmap
 
 
-def test_estimate_rigid3d_with_coplanar_points():
+def test_estimate_rigid3d_with_coplanar_points() -> None:
     source = [
         np.array([0.0, 0.0, 0.0]),
         np.array([1.0, 0.0, 0.0]),
@@ -22,7 +22,7 @@ def test_estimate_rigid3d_with_coplanar_points():
     assert result is None or isinstance(result, pycolmap.Rigid3d)
 
 
-def test_estimate_sim3d_with_points():
+def test_estimate_sim3d_with_points() -> None:
     source = [
         np.array([0.0, 0.0, 0.0]),
         np.array([1.0, 0.0, 0.0]),
@@ -46,5 +46,5 @@ def test_estimate_sim3d_with_points():
         "estimate_sim3d_robust",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/estimators/similarity_transform_test.py
+++ b/src/pycolmap/estimators/similarity_transform_test.py
@@ -17,7 +17,7 @@ def test_estimate_rigid3d_with_coplanar_points() -> None:
         np.array([0.0, 1.0, 0.0]),
         np.array([1.0, 1.0, 0.0]),
     ]
-    result = pycolmap.estimate_rigid3d(source, target)
+    result = pycolmap.estimate_rigid3d(source, target)  # type: ignore[arg-type]
     # May return None for degenerate configurations, but call should succeed
     assert result is None or isinstance(result, pycolmap.Rigid3d)
 
@@ -35,7 +35,7 @@ def test_estimate_sim3d_with_points() -> None:
         np.array([0.0, 2.0, 0.0]),
         np.array([0.0, 0.0, 2.0]),
     ]
-    result = pycolmap.estimate_sim3d(source, target)
+    result = pycolmap.estimate_sim3d(source, target)  # type: ignore[arg-type]
     assert result is None or isinstance(result, pycolmap.Sim3d)
 
 

--- a/src/pycolmap/estimators/triangulation_test.py
+++ b/src/pycolmap/estimators/triangulation_test.py
@@ -1,7 +1,7 @@
 import pycolmap
 
 
-def test_triangulation_residual_type_enum():
+def test_triangulation_residual_type_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.TriangulationResidualType.__members__.items()
@@ -11,19 +11,19 @@ def test_triangulation_residual_type_enum():
     }
 
 
-def test_estimate_triangulation_options_default_init():
+def test_estimate_triangulation_options_default_init() -> None:
     options = pycolmap.EstimateTriangulationOptions()
     assert options is not None
 
 
-def test_estimate_triangulation_options_min_tri_angle_readwrite():
+def test_estimate_triangulation_options_min_tri_angle_readwrite() -> None:
     options = pycolmap.EstimateTriangulationOptions()
     assert isinstance(options.min_tri_angle, float)
     options.min_tri_angle = 0.1
     assert options.min_tri_angle == 0.1
 
 
-def test_estimate_triangulation_options_residual_type_readwrite():
+def test_estimate_triangulation_options_residual_type_readwrite() -> None:
     options = pycolmap.EstimateTriangulationOptions()
     options.residual_type = (
         pycolmap.TriangulationResidualType.REPROJECTION_ERROR
@@ -34,11 +34,11 @@ def test_estimate_triangulation_options_residual_type_readwrite():
     )
 
 
-def test_estimate_triangulation_options_ransac_property():
+def test_estimate_triangulation_options_ransac_property() -> None:
     options = pycolmap.EstimateTriangulationOptions()
     ransac = options.ransac
     assert isinstance(ransac, pycolmap.RANSACOptions)
 
 
-def test_estimate_triangulation_is_callable():
+def test_estimate_triangulation_is_callable() -> None:
     assert callable(pycolmap.estimate_triangulation)

--- a/src/pycolmap/estimators/two_view_geometry_test.py
+++ b/src/pycolmap/estimators/two_view_geometry_test.py
@@ -33,6 +33,6 @@ def test_compute_squared_sampson_error_with_identity() -> None:
     points1 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     points2 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     matrix = np.eye(3)
-    residuals = pycolmap.compute_squared_sampson_error(points1, points2, matrix)
+    residuals = pycolmap.compute_squared_sampson_error(points1, points2, matrix)  # type: ignore[arg-type]
     assert isinstance(residuals, list)
     assert len(residuals) == 2

--- a/src/pycolmap/estimators/two_view_geometry_test.py
+++ b/src/pycolmap/estimators/two_view_geometry_test.py
@@ -4,12 +4,12 @@ import pytest
 import pycolmap
 
 
-def test_two_view_geometry_options_default_init():
+def test_two_view_geometry_options_default_init() -> None:
     options = pycolmap.TwoViewGeometryOptions()
     assert options is not None
 
 
-def test_two_view_geometry_options_min_num_inliers_readwrite():
+def test_two_view_geometry_options_min_num_inliers_readwrite() -> None:
     options = pycolmap.TwoViewGeometryOptions()
     assert isinstance(options.min_num_inliers, int)
     options.min_num_inliers = 30
@@ -25,11 +25,11 @@ def test_two_view_geometry_options_min_num_inliers_readwrite():
         "compute_squared_sampson_error",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))
 
 
-def test_compute_squared_sampson_error_with_identity():
+def test_compute_squared_sampson_error_with_identity() -> None:
     points1 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     points2 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     matrix = np.eye(3)

--- a/src/pycolmap/feature/extraction_test.py
+++ b/src/pycolmap/feature/extraction_test.py
@@ -1,17 +1,17 @@
 import pycolmap
 
 
-def test_normalization_enum():
+def test_normalization_enum() -> None:
     assert pycolmap.Normalization.L1_ROOT is not None
     assert pycolmap.Normalization.L2 is not None
 
 
-def test_sift_extraction_options_default_init():
+def test_sift_extraction_options_default_init() -> None:
     options = pycolmap.SiftExtractionOptions()
     assert options is not None
 
 
-def test_sift_extraction_options_num_octaves_readwrite():
+def test_sift_extraction_options_num_octaves_readwrite() -> None:
     options = pycolmap.SiftExtractionOptions()
     original = options.num_octaves
     assert isinstance(original, int)
@@ -19,94 +19,94 @@ def test_sift_extraction_options_num_octaves_readwrite():
     assert options.num_octaves == 5
 
 
-def test_sift_extraction_options_max_num_features_readwrite():
+def test_sift_extraction_options_max_num_features_readwrite() -> None:
     options = pycolmap.SiftExtractionOptions()
     assert isinstance(options.max_num_features, int)
     options.max_num_features = 4096
     assert options.max_num_features == 4096
 
 
-def test_sift_extraction_options_peak_threshold_readwrite():
+def test_sift_extraction_options_peak_threshold_readwrite() -> None:
     options = pycolmap.SiftExtractionOptions()
     assert isinstance(options.peak_threshold, float)
     options.peak_threshold = 0.01
     assert abs(options.peak_threshold - 0.01) < 1e-6
 
 
-def test_sift_extraction_options_check():
+def test_sift_extraction_options_check() -> None:
     options = pycolmap.SiftExtractionOptions()
     result = options.check()
     assert isinstance(result, bool)
     assert result is True
 
 
-def test_feature_extraction_options_default_init():
+def test_feature_extraction_options_default_init() -> None:
     options = pycolmap.FeatureExtractionOptions()
     assert options is not None
 
 
-def test_feature_extraction_options_type_readwrite():
+def test_feature_extraction_options_type_readwrite() -> None:
     options = pycolmap.FeatureExtractionOptions()
     options.type = pycolmap.FeatureExtractorType.SIFT
     assert options.type == pycolmap.FeatureExtractorType.SIFT
 
 
-def test_feature_extraction_options_max_image_size_readwrite():
+def test_feature_extraction_options_max_image_size_readwrite() -> None:
     options = pycolmap.FeatureExtractionOptions()
     options.max_image_size = 2048
     assert options.max_image_size == 2048
 
 
-def test_feature_extraction_options_num_threads_readwrite():
+def test_feature_extraction_options_num_threads_readwrite() -> None:
     options = pycolmap.FeatureExtractionOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_feature_extraction_options_use_gpu_readwrite():
+def test_feature_extraction_options_use_gpu_readwrite() -> None:
     options = pycolmap.FeatureExtractionOptions()
     options.use_gpu = False
     assert options.use_gpu is False
 
 
-def test_feature_extraction_options_sift_property():
+def test_feature_extraction_options_sift_property() -> None:
     options = pycolmap.FeatureExtractionOptions()
     sift = options.sift
     assert isinstance(sift, pycolmap.SiftExtractionOptions)
 
 
-def test_feature_extraction_options_requires_rgb():
+def test_feature_extraction_options_requires_rgb() -> None:
     options = pycolmap.FeatureExtractionOptions()
     result = options.requires_rgb()
     assert isinstance(result, bool)
 
 
-def test_feature_extraction_options_requires_opengl():
+def test_feature_extraction_options_requires_opengl() -> None:
     options = pycolmap.FeatureExtractionOptions()
     result = options.requires_opengl()
     assert isinstance(result, bool)
 
 
-def test_feature_extraction_options_eff_max_image_size():
+def test_feature_extraction_options_eff_max_image_size() -> None:
     options = pycolmap.FeatureExtractionOptions()
     result = options.eff_max_image_size()
     assert isinstance(result, int)
     assert result > 0
 
 
-def test_feature_extraction_options_check():
+def test_feature_extraction_options_check() -> None:
     options = pycolmap.FeatureExtractionOptions()
     result = options.check()
     assert isinstance(result, bool)
     assert result is True
 
 
-def test_feature_extractor_create():
+def test_feature_extractor_create() -> None:
     extractor = pycolmap.FeatureExtractor.create(device=pycolmap.Device.cpu)
     assert extractor is not None
 
 
-def test_sift_deprecated_class():
+def test_sift_deprecated_class() -> None:
     if hasattr(pycolmap, "Sift"):
         import warnings
 

--- a/src/pycolmap/feature/matching_test.py
+++ b/src/pycolmap/feature/matching_test.py
@@ -1,53 +1,53 @@
 import pycolmap
 
 
-def test_feature_matcher_type_enum():
+def test_feature_matcher_type_enum() -> None:
     assert pycolmap.FeatureMatcherType.UNDEFINED is not None
     assert pycolmap.FeatureMatcherType.SIFT_BRUTEFORCE is not None
 
 
-def test_sift_matching_options_default_init():
+def test_sift_matching_options_default_init() -> None:
     options = pycolmap.SiftMatchingOptions()
     assert options is not None
 
 
-def test_sift_matching_options_check():
+def test_sift_matching_options_check() -> None:
     options = pycolmap.SiftMatchingOptions()
     result = options.check()
     assert isinstance(result, bool)
     assert result is True
 
 
-def test_feature_matching_options_default_init():
+def test_feature_matching_options_default_init() -> None:
     options = pycolmap.FeatureMatchingOptions()
     assert options is not None
 
 
-def test_feature_matching_options_type_readwrite():
+def test_feature_matching_options_type_readwrite() -> None:
     options = pycolmap.FeatureMatchingOptions()
     options.type = pycolmap.FeatureMatcherType.SIFT_BRUTEFORCE
     assert options.type == pycolmap.FeatureMatcherType.SIFT_BRUTEFORCE
 
 
-def test_feature_matching_options_num_threads_readwrite():
+def test_feature_matching_options_num_threads_readwrite() -> None:
     options = pycolmap.FeatureMatchingOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_feature_matching_options_use_gpu_readwrite():
+def test_feature_matching_options_use_gpu_readwrite() -> None:
     options = pycolmap.FeatureMatchingOptions()
     options.use_gpu = False
     assert options.use_gpu is False
 
 
-def test_feature_matching_options_max_num_matches_readwrite():
+def test_feature_matching_options_max_num_matches_readwrite() -> None:
     options = pycolmap.FeatureMatchingOptions()
     options.max_num_matches = 16384
     assert options.max_num_matches == 16384
 
 
-def test_feature_matching_options_guided_matching_readwrite():
+def test_feature_matching_options_guided_matching_readwrite() -> None:
     options = pycolmap.FeatureMatchingOptions()
     options.guided_matching = True
     assert options.guided_matching is True
@@ -55,7 +55,9 @@ def test_feature_matching_options_guided_matching_readwrite():
     assert options.guided_matching is False
 
 
-def test_feature_matching_options_skip_geometric_verification_readwrite():
+def test_feature_matching_options_skip_geometric_verification_readwrite() -> (
+    None
+):
     options = pycolmap.FeatureMatchingOptions()
     options.skip_geometric_verification = True
     assert options.skip_geometric_verification is True
@@ -63,13 +65,13 @@ def test_feature_matching_options_skip_geometric_verification_readwrite():
     assert options.skip_geometric_verification is False
 
 
-def test_feature_matching_options_check():
+def test_feature_matching_options_check() -> None:
     options = pycolmap.FeatureMatchingOptions()
     result = options.check()
     assert isinstance(result, bool)
     assert result is True
 
 
-def test_feature_matcher_create():
+def test_feature_matcher_create() -> None:
     matcher = pycolmap.FeatureMatcher.create(device=pycolmap.Device.cpu)
     assert matcher is not None

--- a/src/pycolmap/feature/types_test.py
+++ b/src/pycolmap/feature/types_test.py
@@ -182,7 +182,7 @@ def test_keypoints_to_from_matrix_roundtrip() -> None:
     keypoint.a21 = 0.0
     keypoint.a22 = 1.0
     keypoints.append(keypoint)
-    matrix = pycolmap.keypoints_to_matrix(keypoints)
+    matrix = pycolmap.keypoints_to_matrix(keypoints)  # type: ignore[var-annotated]
     assert matrix.shape[0] == 1
     assert matrix.shape[1] == 4
     recovered = pycolmap.keypoints_from_matrix(matrix)
@@ -195,7 +195,7 @@ def test_matches_to_from_matrix_roundtrip() -> None:
     matches = pycolmap.FeatureMatches()
     matches.append(pycolmap.FeatureMatch(0, 5))
     matches.append(pycolmap.FeatureMatch(1, 3))
-    matrix = pycolmap.matches_to_matrix(matches)
+    matrix = pycolmap.matches_to_matrix(matches)  # type: ignore[var-annotated]
     assert matrix.shape == (2, 2)
     recovered = pycolmap.matches_from_matrix(matrix)
     assert len(recovered) == 2

--- a/src/pycolmap/feature/types_test.py
+++ b/src/pycolmap/feature/types_test.py
@@ -5,29 +5,29 @@ import numpy as np
 import pycolmap
 
 
-def test_feature_extractor_type_enum():
+def test_feature_extractor_type_enum() -> None:
     assert pycolmap.FeatureExtractorType.UNDEFINED is not None
     assert pycolmap.FeatureExtractorType.SIFT is not None
 
 
-def test_feature_extractor_type_int_construction():
+def test_feature_extractor_type_int_construction() -> None:
     sift = pycolmap.FeatureExtractorType.SIFT
     value = int(sift)
     assert isinstance(value, int)
 
 
-def test_feature_descriptors_default_init():
+def test_feature_descriptors_default_init() -> None:
     descriptors = pycolmap.FeatureDescriptors()
     assert descriptors is not None
 
 
-def test_feature_descriptors_type_readwrite():
+def test_feature_descriptors_type_readwrite() -> None:
     descriptors = pycolmap.FeatureDescriptors()
     descriptors.type = pycolmap.FeatureExtractorType.SIFT
     assert descriptors.type == pycolmap.FeatureExtractorType.SIFT
 
 
-def test_feature_descriptors_data_readwrite():
+def test_feature_descriptors_data_readwrite() -> None:
     data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
     descriptors = pycolmap.FeatureDescriptors(
         type=pycolmap.FeatureExtractorType.SIFT, data=data
@@ -38,18 +38,18 @@ def test_feature_descriptors_data_readwrite():
     np.testing.assert_array_equal(descriptors.data, new_data)
 
 
-def test_feature_descriptors_float_default_init():
+def test_feature_descriptors_float_default_init() -> None:
     descriptors = pycolmap.FeatureDescriptorsFloat()
     assert descriptors is not None
 
 
-def test_feature_descriptors_float_type_readwrite():
+def test_feature_descriptors_float_type_readwrite() -> None:
     descriptors = pycolmap.FeatureDescriptorsFloat()
     descriptors.type = pycolmap.FeatureExtractorType.SIFT
     assert descriptors.type == pycolmap.FeatureExtractorType.SIFT
 
 
-def test_feature_descriptors_float_data_readwrite():
+def test_feature_descriptors_float_data_readwrite() -> None:
     data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
     descriptors = pycolmap.FeatureDescriptorsFloat(
         type=pycolmap.FeatureExtractorType.SIFT, data=data
@@ -60,12 +60,12 @@ def test_feature_descriptors_float_data_readwrite():
     np.testing.assert_array_almost_equal(descriptors.data, new_data)
 
 
-def test_feature_keypoint_default_init():
+def test_feature_keypoint_default_init() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     assert keypoint is not None
 
 
-def test_feature_keypoint_xy_readwrite():
+def test_feature_keypoint_xy_readwrite() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     keypoint.x = 10.5
     keypoint.y = 20.5
@@ -73,7 +73,7 @@ def test_feature_keypoint_xy_readwrite():
     assert keypoint.y == 20.5
 
 
-def test_feature_keypoint_affine_readwrite():
+def test_feature_keypoint_affine_readwrite() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     keypoint.a11 = 1.0
     keypoint.a12 = 0.5
@@ -85,37 +85,37 @@ def test_feature_keypoint_affine_readwrite():
     assert keypoint.a22 == 1.0
 
 
-def test_feature_keypoint_compute_scale():
+def test_feature_keypoint_compute_scale() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     scale = keypoint.compute_scale()
     assert isinstance(scale, float)
 
 
-def test_feature_keypoint_compute_scale_x():
+def test_feature_keypoint_compute_scale_x() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     scale_x = keypoint.compute_scale_x()
     assert isinstance(scale_x, float)
 
 
-def test_feature_keypoint_compute_scale_y():
+def test_feature_keypoint_compute_scale_y() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     scale_y = keypoint.compute_scale_y()
     assert isinstance(scale_y, float)
 
 
-def test_feature_keypoint_compute_orientation():
+def test_feature_keypoint_compute_orientation() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     orientation = keypoint.compute_orientation()
     assert isinstance(orientation, float)
 
 
-def test_feature_keypoint_compute_shear():
+def test_feature_keypoint_compute_shear() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     shear = keypoint.compute_shear()
     assert isinstance(shear, float)
 
 
-def test_feature_keypoint_rescale():
+def test_feature_keypoint_rescale() -> None:
     keypoint = pycolmap.FeatureKeypoint()
     keypoint.x = 10.0
     keypoint.y = 20.0
@@ -128,7 +128,7 @@ def test_feature_keypoint_rescale():
     assert keypoint.y == 40.0
 
 
-def test_feature_keypoint_from_shape_parameters():
+def test_feature_keypoint_from_shape_parameters() -> None:
     keypoint = pycolmap.FeatureKeypoint.from_shape_parameters(
         1.0, 2.0, 2.0, 2.0, math.pi, 0.0
     )
@@ -137,12 +137,12 @@ def test_feature_keypoint_from_shape_parameters():
     assert keypoint.y == 2.0
 
 
-def test_feature_match_default_init():
+def test_feature_match_default_init() -> None:
     match = pycolmap.FeatureMatch()
     assert match is not None
 
 
-def test_feature_match_readwrite():
+def test_feature_match_readwrite() -> None:
     match = pycolmap.FeatureMatch()
     match.point2D_idx1 = 5
     match.point2D_idx2 = 10
@@ -150,7 +150,7 @@ def test_feature_match_readwrite():
     assert match.point2D_idx2 == 10
 
 
-def test_feature_keypoints_vector():
+def test_feature_keypoints_vector() -> None:
     keypoints = pycolmap.FeatureKeypoints()
     keypoint = pycolmap.FeatureKeypoint()
     keypoint.x = 1.0
@@ -165,14 +165,14 @@ def test_feature_keypoints_vector():
     assert count == 2
 
 
-def test_feature_matches_vector():
+def test_feature_matches_vector() -> None:
     matches = pycolmap.FeatureMatches()
     matches.append(pycolmap.FeatureMatch(0, 1))
     matches.append(pycolmap.FeatureMatch(2, 3))
     assert len(matches) == 2
 
 
-def test_keypoints_to_from_matrix_roundtrip():
+def test_keypoints_to_from_matrix_roundtrip() -> None:
     keypoints = pycolmap.FeatureKeypoints()
     keypoint = pycolmap.FeatureKeypoint()
     keypoint.x = 10.0
@@ -191,7 +191,7 @@ def test_keypoints_to_from_matrix_roundtrip():
     assert recovered[0].y == keypoint.y
 
 
-def test_matches_to_from_matrix_roundtrip():
+def test_matches_to_from_matrix_roundtrip() -> None:
     matches = pycolmap.FeatureMatches()
     matches.append(pycolmap.FeatureMatch(0, 5))
     matches.append(pycolmap.FeatureMatch(1, 3))

--- a/src/pycolmap/geometry/eigen_test.py
+++ b/src/pycolmap/geometry/eigen_test.py
@@ -3,33 +3,33 @@ import numpy as np
 import pycolmap
 
 
-def test_rotation3d_default_init():
+def test_rotation3d_default_init() -> None:
     rotation = pycolmap.Rotation3d()
     assert rotation is not None
 
 
-def test_rotation3d_init_from_xyzw():
+def test_rotation3d_init_from_xyzw() -> None:
     rotation = pycolmap.Rotation3d(xyzw=np.array([0.0, 0.0, 0.0, 1.0]))
     assert rotation is not None
 
 
-def test_rotation3d_init_from_matrix():
+def test_rotation3d_init_from_matrix() -> None:
     rotation = pycolmap.Rotation3d(matrix=np.eye(3))
     assert rotation is not None
 
 
-def test_rotation3d_init_from_axis_angle():
+def test_rotation3d_init_from_axis_angle() -> None:
     rotation = pycolmap.Rotation3d(axis_angle=np.zeros(3))
     assert rotation is not None
 
 
-def test_rotation3d_from_buffer():
+def test_rotation3d_from_buffer() -> None:
     array = np.array([0.0, 0.0, 0.0, 1.0])
     rotation = pycolmap.Rotation3d.from_buffer(array)
     assert rotation is not None
 
 
-def test_rotation3d_quat_readwrite():
+def test_rotation3d_quat_readwrite() -> None:
     rotation = pycolmap.Rotation3d()
     quat = rotation.quat
     assert quat.shape == (4,)
@@ -37,71 +37,71 @@ def test_rotation3d_quat_readwrite():
     np.testing.assert_array_almost_equal(rotation.quat, [0.0, 0.0, 0.0, 1.0])
 
 
-def test_rotation3d_matrix():
+def test_rotation3d_matrix() -> None:
     rotation = pycolmap.Rotation3d(xyzw=np.array([0.0, 0.0, 0.0, 1.0]))
     matrix = rotation.matrix()
     assert matrix.shape == (3, 3)
     np.testing.assert_array_almost_equal(matrix, np.eye(3))
 
 
-def test_rotation3d_norm():
+def test_rotation3d_norm() -> None:
     rotation = pycolmap.Rotation3d(xyzw=np.array([0.0, 0.0, 0.0, 1.0]))
     assert isinstance(rotation.norm(), float)
 
 
-def test_rotation3d_angle():
+def test_rotation3d_angle() -> None:
     rotation = pycolmap.Rotation3d(axis_angle=np.zeros(3))
     angle = rotation.angle()
     assert isinstance(angle, float)
     assert angle >= 0.0
 
 
-def test_rotation3d_angle_to():
+def test_rotation3d_angle_to() -> None:
     rotation1 = pycolmap.Rotation3d()
     rotation2 = pycolmap.Rotation3d()
     angle = rotation1.angle_to(rotation2)
     assert isinstance(angle, float)
 
 
-def test_rotation3d_inverse():
+def test_rotation3d_inverse() -> None:
     rotation = pycolmap.Rotation3d(xyzw=np.array([0.0, 0.0, 0.0, 1.0]))
     inverse = rotation.inverse()
     assert inverse is not None
 
 
-def test_rotation3d_normalize():
+def test_rotation3d_normalize() -> None:
     rotation = pycolmap.Rotation3d(xyzw=np.array([0.0, 0.0, 0.0, 1.0]))
     rotation.normalize()
     assert abs(rotation.norm() - 1.0) < 1e-10
 
 
-def test_rotation3d_multiply_rotation3d():
+def test_rotation3d_multiply_rotation3d() -> None:
     rotation1 = pycolmap.Rotation3d()
     rotation2 = pycolmap.Rotation3d()
     result = rotation1 * rotation2
     assert result is not None
 
 
-def test_rotation3d_multiply_vector3d():
+def test_rotation3d_multiply_vector3d() -> None:
     rotation = pycolmap.Rotation3d()
     vector = np.array([1.0, 2.0, 3.0])
     result = rotation * vector
     assert result.shape == (3,)
 
 
-def test_rotation3d_multiply_nx3_matrix():
+def test_rotation3d_multiply_nx3_matrix() -> None:
     rotation = pycolmap.Rotation3d()
     points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     result = rotation * points
     assert result.shape == (2, 3)
 
 
-def test_alignedbox3d_default_init():
+def test_alignedbox3d_default_init() -> None:
     bbox = pycolmap.AlignedBox3d()
     assert bbox is not None
 
 
-def test_alignedbox3d_init_min_max():
+def test_alignedbox3d_init_min_max() -> None:
     bbox = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([1.0, 1.0, 1.0]),
@@ -109,7 +109,7 @@ def test_alignedbox3d_init_min_max():
     assert bbox is not None
 
 
-def test_alignedbox3d_min_max_readwrite():
+def test_alignedbox3d_min_max_readwrite() -> None:
     bbox = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([1.0, 1.0, 1.0]),
@@ -122,7 +122,7 @@ def test_alignedbox3d_min_max_readwrite():
     np.testing.assert_array_almost_equal(bbox.max, [2.0, 2.0, 2.0])
 
 
-def test_alignedbox3d_diagonal():
+def test_alignedbox3d_diagonal() -> None:
     bbox = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([1.0, 2.0, 3.0]),
@@ -131,7 +131,7 @@ def test_alignedbox3d_diagonal():
     np.testing.assert_array_almost_equal(diagonal, [1.0, 2.0, 3.0])
 
 
-def test_alignedbox3d_contains_point_inside():
+def test_alignedbox3d_contains_point_inside() -> None:
     bbox = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([1.0, 1.0, 1.0]),
@@ -139,7 +139,7 @@ def test_alignedbox3d_contains_point_inside():
     assert bbox.contains_point(np.array([0.5, 0.5, 0.5]))
 
 
-def test_alignedbox3d_contains_point_outside():
+def test_alignedbox3d_contains_point_outside() -> None:
     bbox = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([1.0, 1.0, 1.0]),
@@ -147,7 +147,7 @@ def test_alignedbox3d_contains_point_outside():
     assert not bbox.contains_point(np.array([2.0, 2.0, 2.0]))
 
 
-def test_alignedbox3d_contains_bbox():
+def test_alignedbox3d_contains_bbox() -> None:
     outer = pycolmap.AlignedBox3d(
         min=np.array([0.0, 0.0, 0.0]),
         max=np.array([10.0, 10.0, 10.0]),

--- a/src/pycolmap/geometry/essential_matrix_test.py
+++ b/src/pycolmap/geometry/essential_matrix_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pycolmap
 
 
-def test_essential_matrix_from_pose():
+def test_essential_matrix_from_pose() -> None:
     rotation = pycolmap.Rotation3d(axis_angle=np.array([0.0, 0.1, 0.0]))
     translation = np.array([1.0, 0.0, 0.0])
     rigid = pycolmap.Rigid3d(rotation=rotation, translation=translation)

--- a/src/pycolmap/geometry/gps_test.py
+++ b/src/pycolmap/geometry/gps_test.py
@@ -3,22 +3,22 @@ import numpy as np
 import pycolmap
 
 
-def test_gps_transform_ellipsoid_enum():
+def test_gps_transform_ellipsoid_enum() -> None:
     assert pycolmap.GPSTransformEllipsoid.GRS80 is not None
     assert pycolmap.GPSTransformEllipsoid.WGS84 is not None
 
 
-def test_gps_transform_default_init():
+def test_gps_transform_default_init() -> None:
     transform = pycolmap.GPSTransform()
     assert transform is not None
 
 
-def test_gps_transform_init_with_wgs84():
+def test_gps_transform_init_with_wgs84() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     assert transform is not None
 
 
-def test_gps_transform_ellipsoid_to_ecef():
+def test_gps_transform_ellipsoid_to_ecef() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     result = transform.ellipsoid_to_ecef(lat_lon_alt)
@@ -26,7 +26,7 @@ def test_gps_transform_ellipsoid_to_ecef():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_ecef_to_ellipsoid():
+def test_gps_transform_ecef_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
@@ -35,7 +35,7 @@ def test_gps_transform_ecef_to_ellipsoid():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_ellipsoid_ecef_roundtrip():
+def test_gps_transform_ellipsoid_ecef_roundtrip() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
@@ -45,7 +45,7 @@ def test_gps_transform_ellipsoid_ecef_roundtrip():
     )
 
 
-def test_gps_transform_ellipsoid_to_enu():
+def test_gps_transform_ellipsoid_to_enu() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     ref_lat = 47.0
@@ -56,7 +56,7 @@ def test_gps_transform_ellipsoid_to_enu():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_ecef_to_enu():
+def test_gps_transform_ecef_to_enu() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
@@ -66,7 +66,7 @@ def test_gps_transform_ecef_to_enu():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_enu_to_ellipsoid():
+def test_gps_transform_enu_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     ref_lat = 47.0
     ref_lon = 8.0
@@ -77,7 +77,7 @@ def test_gps_transform_enu_to_ellipsoid():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_enu_to_ecef():
+def test_gps_transform_enu_to_ecef() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     ref_lat = 47.0
     ref_lon = 8.0
@@ -88,7 +88,7 @@ def test_gps_transform_enu_to_ecef():
     assert result[0].shape == (3,)
 
 
-def test_gps_transform_ellipsoid_to_utm():
+def test_gps_transform_ellipsoid_to_utm() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)
@@ -97,7 +97,7 @@ def test_gps_transform_ellipsoid_to_utm():
     assert isinstance(zone, int)
 
 
-def test_gps_transform_utm_to_ellipsoid():
+def test_gps_transform_utm_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
     utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)

--- a/src/pycolmap/geometry/gps_test.py
+++ b/src/pycolmap/geometry/gps_test.py
@@ -21,7 +21,7 @@ def test_gps_transform_init_with_wgs84() -> None:
 def test_gps_transform_ellipsoid_to_ecef() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    result = transform.ellipsoid_to_ecef(lat_lon_alt)
+    result = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -29,7 +29,7 @@ def test_gps_transform_ellipsoid_to_ecef() -> None:
 def test_gps_transform_ecef_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     result = transform.ecef_to_ellipsoid(ecef)
     assert len(result) == 1
     assert result[0].shape == (3,)
@@ -38,7 +38,7 @@ def test_gps_transform_ecef_to_ellipsoid() -> None:
 def test_gps_transform_ellipsoid_ecef_roundtrip() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     roundtrip = transform.ecef_to_ellipsoid(ecef)
     np.testing.assert_array_almost_equal(
         roundtrip[0], lat_lon_alt[0], decimal=5
@@ -51,7 +51,7 @@ def test_gps_transform_ellipsoid_to_enu() -> None:
     ref_lat = 47.0
     ref_lon = 8.0
     ref_alt = 500.0
-    result = transform.ellipsoid_to_enu(lat_lon_alt, ref_lat, ref_lon, ref_alt)
+    result = transform.ellipsoid_to_enu(lat_lon_alt, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -59,7 +59,7 @@ def test_gps_transform_ellipsoid_to_enu() -> None:
 def test_gps_transform_ecef_to_enu() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     ref_ecef = ecef[0]
     result = transform.ecef_to_enu(ecef, ref_ecef)
     assert len(result) == 1
@@ -72,7 +72,7 @@ def test_gps_transform_enu_to_ellipsoid() -> None:
     ref_lon = 8.0
     ref_alt = 500.0
     enu_coords = [np.array([0.0, 0.0, 0.0])]
-    result = transform.enu_to_ellipsoid(enu_coords, ref_lat, ref_lon, ref_alt)
+    result = transform.enu_to_ellipsoid(enu_coords, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -83,7 +83,7 @@ def test_gps_transform_enu_to_ecef() -> None:
     ref_lon = 8.0
     ref_alt = 500.0
     enu_coords = [np.array([100.0, 200.0, 50.0])]
-    result = transform.enu_to_ecef(enu_coords, ref_lat, ref_lon, ref_alt)
+    result = transform.enu_to_ecef(enu_coords, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -91,7 +91,7 @@ def test_gps_transform_enu_to_ecef() -> None:
 def test_gps_transform_ellipsoid_to_utm() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)
+    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     assert len(utm_coords) == 1
     assert utm_coords[0].shape == (3,)
     assert isinstance(zone, int)
@@ -100,7 +100,7 @@ def test_gps_transform_ellipsoid_to_utm() -> None:
 def test_gps_transform_utm_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)
+    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
     is_north = lat_lon_alt[0][0] >= 0
     result = transform.utm_to_ellipsoid(utm_coords, zone, is_north)
     assert len(result) == 1

--- a/src/pycolmap/geometry/homography_matrix_test.py
+++ b/src/pycolmap/geometry/homography_matrix_test.py
@@ -1,6 +1,6 @@
 import pycolmap
 
 
-def test_pose_from_homography_matrix_exists():
+def test_pose_from_homography_matrix_exists() -> None:
     assert hasattr(pycolmap, "pose_from_homography_matrix")
     assert callable(pycolmap.pose_from_homography_matrix)

--- a/src/pycolmap/geometry/pose_prior_test.py
+++ b/src/pycolmap/geometry/pose_prior_test.py
@@ -3,24 +3,24 @@ import numpy as np
 import pycolmap
 
 
-def test_pose_prior_coordinate_system_enum():
+def test_pose_prior_coordinate_system_enum() -> None:
     assert pycolmap.PosePriorCoordinateSystem.UNDEFINED is not None
     assert pycolmap.PosePriorCoordinateSystem.WGS84 is not None
     assert pycolmap.PosePriorCoordinateSystem.CARTESIAN is not None
 
 
-def test_pose_prior_default_init():
+def test_pose_prior_default_init() -> None:
     pose_prior = pycolmap.PosePrior()
     assert pose_prior is not None
 
 
-def test_pose_prior_position_readwrite():
+def test_pose_prior_position_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     pose_prior.position = np.array([1.0, 2.0, 3.0])
     np.testing.assert_array_almost_equal(pose_prior.position, [1.0, 2.0, 3.0])
 
 
-def test_pose_prior_position_covariance_readwrite():
+def test_pose_prior_position_covariance_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     covariance = np.eye(3) * 0.5
     pose_prior.position_covariance = covariance
@@ -29,7 +29,7 @@ def test_pose_prior_position_covariance_readwrite():
     )
 
 
-def test_pose_prior_coordinate_system_readwrite():
+def test_pose_prior_coordinate_system_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     pose_prior.coordinate_system = pycolmap.PosePriorCoordinateSystem.WGS84
     assert (
@@ -37,35 +37,35 @@ def test_pose_prior_coordinate_system_readwrite():
     )
 
 
-def test_pose_prior_gravity_readwrite():
+def test_pose_prior_gravity_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     gravity = np.array([0.0, 0.0, -9.81])
     pose_prior.gravity = gravity
     np.testing.assert_array_almost_equal(pose_prior.gravity, gravity)
 
 
-def test_pose_prior_has_position():
+def test_pose_prior_has_position() -> None:
     pose_prior = pycolmap.PosePrior()
     assert isinstance(pose_prior.has_position(), bool)
 
 
-def test_pose_prior_has_position_cov():
+def test_pose_prior_has_position_cov() -> None:
     pose_prior = pycolmap.PosePrior()
     assert isinstance(pose_prior.has_position_cov(), bool)
 
 
-def test_pose_prior_has_gravity():
+def test_pose_prior_has_gravity() -> None:
     pose_prior = pycolmap.PosePrior()
     assert isinstance(pose_prior.has_gravity(), bool)
 
 
-def test_pose_prior_pose_prior_id_readwrite():
+def test_pose_prior_pose_prior_id_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     pose_prior.pose_prior_id = 42
     assert pose_prior.pose_prior_id == 42
 
 
-def test_pose_prior_corr_data_id_readwrite():
+def test_pose_prior_corr_data_id_readwrite() -> None:
     pose_prior = pycolmap.PosePrior()
     data_id = pycolmap.data_t(
         pycolmap.sensor_t(pycolmap.SensorType.CAMERA, 0), 5

--- a/src/pycolmap/geometry/rigid3_test.py
+++ b/src/pycolmap/geometry/rigid3_test.py
@@ -109,7 +109,7 @@ def test_rigid3d_interpolate() -> None:
 def test_get_covariance_for_inverse() -> None:
     rigid = pycolmap.Rigid3d()
     covariance = np.eye(6)
-    result = pycolmap.get_covariance_for_inverse(rigid, covariance)
+    result = pycolmap.get_covariance_for_inverse(rigid, covariance)  # type: ignore[arg-type]
     assert result.shape == (6, 6)
 
 
@@ -117,7 +117,8 @@ def test_get_covariance_for_composed_rigid3d() -> None:
     rigid = pycolmap.Rigid3d()
     joint_covariance = np.eye(12)
     result = pycolmap.get_covariance_for_composed_rigid3d(
-        rigid, joint_covariance
+        rigid,
+        joint_covariance,  # type: ignore[arg-type]
     )
     assert result.shape == (6, 6)
 
@@ -127,7 +128,9 @@ def test_get_covariance_for_relative_rigid3d() -> None:
     rigid2 = pycolmap.Rigid3d()
     joint_covariance = np.eye(12)
     result = pycolmap.get_covariance_for_relative_rigid3d(
-        rigid1, rigid2, joint_covariance
+        rigid1,
+        rigid2,
+        joint_covariance,  # type: ignore[arg-type]
     )
     assert result.shape == (6, 6)
 

--- a/src/pycolmap/geometry/rigid3_test.py
+++ b/src/pycolmap/geometry/rigid3_test.py
@@ -3,25 +3,25 @@ import numpy as np
 import pycolmap
 
 
-def test_rigid3d_default_init():
+def test_rigid3d_default_init() -> None:
     rigid = pycolmap.Rigid3d()
     assert rigid is not None
 
 
-def test_rigid3d_init_rotation_translation():
+def test_rigid3d_init_rotation_translation() -> None:
     rotation = pycolmap.Rotation3d()
     translation = np.array([1.0, 2.0, 3.0])
     rigid = pycolmap.Rigid3d(rotation=rotation, translation=translation)
     assert rigid is not None
 
 
-def test_rigid3d_init_from_matrix():
+def test_rigid3d_init_from_matrix() -> None:
     matrix = np.eye(3, 4)
     rigid = pycolmap.Rigid3d(matrix=matrix)
     assert rigid is not None
 
 
-def test_rigid3d_params_readwrite():
+def test_rigid3d_params_readwrite() -> None:
     rigid = pycolmap.Rigid3d()
     params = rigid.params
     assert params.shape == (7,)
@@ -30,13 +30,13 @@ def test_rigid3d_params_readwrite():
     np.testing.assert_array_almost_equal(rigid.params, new_params)
 
 
-def test_rigid3d_rotation_property():
+def test_rigid3d_rotation_property() -> None:
     rigid = pycolmap.Rigid3d()
     rotation = rigid.rotation
     assert isinstance(rotation, pycolmap.Rotation3d)
 
 
-def test_rigid3d_translation_readwrite():
+def test_rigid3d_translation_readwrite() -> None:
     rigid = pycolmap.Rigid3d()
     translation = rigid.translation
     assert np.array(translation).shape == (3,)
@@ -44,46 +44,46 @@ def test_rigid3d_translation_readwrite():
     np.testing.assert_array_almost_equal(rigid.translation, [4.0, 5.0, 6.0])
 
 
-def test_rigid3d_matrix():
+def test_rigid3d_matrix() -> None:
     rigid = pycolmap.Rigid3d()
     matrix = rigid.matrix()
     assert matrix.shape == (3, 4)
 
 
-def test_rigid3d_tgt_origin_in_src():
+def test_rigid3d_tgt_origin_in_src() -> None:
     rigid = pycolmap.Rigid3d()
     rigid.translation = np.array([1.0, 2.0, 3.0])
     result = rigid.tgt_origin_in_src()
     assert result.shape == (3,)
 
 
-def test_rigid3d_adjoint():
+def test_rigid3d_adjoint() -> None:
     rigid = pycolmap.Rigid3d()
     adjoint = rigid.adjoint()
     assert adjoint.shape == (6, 6)
 
 
-def test_rigid3d_adjoint_inverse():
+def test_rigid3d_adjoint_inverse() -> None:
     rigid = pycolmap.Rigid3d()
     adjoint_inverse = rigid.adjoint_inverse()
     assert adjoint_inverse.shape == (6, 6)
 
 
-def test_rigid3d_inverse():
+def test_rigid3d_inverse() -> None:
     rigid = pycolmap.Rigid3d()
     rigid.translation = np.array([1.0, 2.0, 3.0])
     inverse = rigid.inverse()
     assert isinstance(inverse, pycolmap.Rigid3d)
 
 
-def test_rigid3d_multiply_rigid3d():
+def test_rigid3d_multiply_rigid3d() -> None:
     rigid1 = pycolmap.Rigid3d()
     rigid2 = pycolmap.Rigid3d()
     result = rigid1 * rigid2
     assert isinstance(result, pycolmap.Rigid3d)
 
 
-def test_rigid3d_multiply_vector3d():
+def test_rigid3d_multiply_vector3d() -> None:
     rigid = pycolmap.Rigid3d()
     rigid.translation = np.array([1.0, 0.0, 0.0])
     vector = np.array([0.0, 0.0, 0.0])
@@ -91,14 +91,14 @@ def test_rigid3d_multiply_vector3d():
     assert result.shape == (3,)
 
 
-def test_rigid3d_multiply_nx3_matrix():
+def test_rigid3d_multiply_nx3_matrix() -> None:
     rigid = pycolmap.Rigid3d()
     points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     result = rigid * points
     assert result.shape == (2, 3)
 
 
-def test_rigid3d_interpolate():
+def test_rigid3d_interpolate() -> None:
     rigid1 = pycolmap.Rigid3d()
     rigid2 = pycolmap.Rigid3d()
     rigid2.translation = np.array([2.0, 0.0, 0.0])
@@ -106,14 +106,14 @@ def test_rigid3d_interpolate():
     assert isinstance(result, pycolmap.Rigid3d)
 
 
-def test_get_covariance_for_inverse():
+def test_get_covariance_for_inverse() -> None:
     rigid = pycolmap.Rigid3d()
     covariance = np.eye(6)
     result = pycolmap.get_covariance_for_inverse(rigid, covariance)
     assert result.shape == (6, 6)
 
 
-def test_get_covariance_for_composed_rigid3d():
+def test_get_covariance_for_composed_rigid3d() -> None:
     rigid = pycolmap.Rigid3d()
     joint_covariance = np.eye(12)
     result = pycolmap.get_covariance_for_composed_rigid3d(
@@ -122,7 +122,7 @@ def test_get_covariance_for_composed_rigid3d():
     assert result.shape == (6, 6)
 
 
-def test_get_covariance_for_relative_rigid3d():
+def test_get_covariance_for_relative_rigid3d() -> None:
     rigid1 = pycolmap.Rigid3d()
     rigid2 = pycolmap.Rigid3d()
     joint_covariance = np.eye(12)
@@ -132,14 +132,14 @@ def test_get_covariance_for_relative_rigid3d():
     assert result.shape == (6, 6)
 
 
-def test_average_quaternions():
+def test_average_quaternions() -> None:
     rotation1 = pycolmap.Rotation3d()
     rotation2 = pycolmap.Rotation3d()
     result = pycolmap.average_quaternions([rotation1, rotation2], [1.0, 1.0])
     assert result is not None
 
 
-def test_interpolate_camera_poses():
+def test_interpolate_camera_poses() -> None:
     rigid1 = pycolmap.Rigid3d()
     rigid2 = pycolmap.Rigid3d()
     rigid2.translation = np.array([2.0, 0.0, 0.0])

--- a/src/pycolmap/geometry/sim3_test.py
+++ b/src/pycolmap/geometry/sim3_test.py
@@ -3,12 +3,12 @@ import numpy as np
 import pycolmap
 
 
-def test_sim3d_default_init():
+def test_sim3d_default_init() -> None:
     similarity = pycolmap.Sim3d()
     assert similarity is not None
 
 
-def test_sim3d_init_scale_rotation_translation():
+def test_sim3d_init_scale_rotation_translation() -> None:
     rotation = pycolmap.Rotation3d()
     translation = np.array([1.0, 2.0, 3.0])
     similarity = pycolmap.Sim3d(
@@ -17,13 +17,13 @@ def test_sim3d_init_scale_rotation_translation():
     assert similarity is not None
 
 
-def test_sim3d_init_from_matrix():
+def test_sim3d_init_from_matrix() -> None:
     matrix = np.eye(3, 4)
     similarity = pycolmap.Sim3d(matrix=matrix)
     assert similarity is not None
 
 
-def test_sim3d_params_readwrite():
+def test_sim3d_params_readwrite() -> None:
     similarity = pycolmap.Sim3d()
     params = similarity.params
     assert params.shape == (8,)
@@ -32,7 +32,7 @@ def test_sim3d_params_readwrite():
     np.testing.assert_array_almost_equal(similarity.params, new_params)
 
 
-def test_sim3d_scale_readwrite():
+def test_sim3d_scale_readwrite() -> None:
     similarity = pycolmap.Sim3d()
     scale = float(np.array(similarity.scale))
     assert isinstance(scale, float)
@@ -40,7 +40,7 @@ def test_sim3d_scale_readwrite():
     assert float(np.array(similarity.scale)) == 3.0
 
 
-def test_sim3d_rotation_readwrite():
+def test_sim3d_rotation_readwrite() -> None:
     similarity = pycolmap.Sim3d()
     rotation = similarity.rotation
     assert isinstance(rotation, pycolmap.Rotation3d)
@@ -49,7 +49,7 @@ def test_sim3d_rotation_readwrite():
     assert similarity.rotation is not None
 
 
-def test_sim3d_translation_readwrite():
+def test_sim3d_translation_readwrite() -> None:
     similarity = pycolmap.Sim3d()
     translation = similarity.translation
     assert np.array(translation).shape == (3,)
@@ -59,13 +59,13 @@ def test_sim3d_translation_readwrite():
     )
 
 
-def test_sim3d_matrix():
+def test_sim3d_matrix() -> None:
     similarity = pycolmap.Sim3d()
     matrix = similarity.matrix()
     assert matrix.shape == (3, 4)
 
 
-def test_sim3d_inverse():
+def test_sim3d_inverse() -> None:
     similarity = pycolmap.Sim3d(
         scale=2.0,
         rotation=pycolmap.Rotation3d(),
@@ -75,28 +75,28 @@ def test_sim3d_inverse():
     assert isinstance(inverse, pycolmap.Sim3d)
 
 
-def test_sim3d_multiply_sim3d():
+def test_sim3d_multiply_sim3d() -> None:
     similarity1 = pycolmap.Sim3d()
     similarity2 = pycolmap.Sim3d()
     result = similarity1 * similarity2
     assert isinstance(result, pycolmap.Sim3d)
 
 
-def test_sim3d_multiply_vector3d():
+def test_sim3d_multiply_vector3d() -> None:
     similarity = pycolmap.Sim3d()
     vector = np.array([1.0, 2.0, 3.0])
     result = similarity * vector
     assert result.shape == (3,)
 
 
-def test_sim3d_multiply_nx3_matrix():
+def test_sim3d_multiply_nx3_matrix() -> None:
     similarity = pycolmap.Sim3d()
     points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     result = similarity * points
     assert result.shape == (2, 3)
 
 
-def test_sim3d_transform_camera_world():
+def test_sim3d_transform_camera_world() -> None:
     similarity = pycolmap.Sim3d()
     rigid = pycolmap.Rigid3d()
     result = similarity.transform_camera_world(rigid)

--- a/src/pycolmap/geometry/triangulation_test.py
+++ b/src/pycolmap/geometry/triangulation_test.py
@@ -10,7 +10,10 @@ def test_triangulate_point() -> None:
     point1 = np.array([0.0, 0.0])
     point2 = np.array([0.1, 0.0])
     result = pycolmap.triangulate_point(
-        cam1_from_world, cam2_from_world, point1, point2
+        cam1_from_world,  # type: ignore[arg-type]
+        cam2_from_world,  # type: ignore[arg-type]
+        point1,
+        point2,  # type: ignore[arg-type]
     )
     if result is not None:
         assert result.shape == (3,)
@@ -39,7 +42,10 @@ def test_triangulate_point_from_rays() -> None:
     ray2 = cam2_from_world @ np.append(point3d, 1.0)
     ray2 /= np.linalg.norm(ray2)
     result = pycolmap.triangulate_point(
-        cam1_from_world, cam2_from_world, ray1, ray2
+        cam1_from_world,  # type: ignore[arg-type]
+        cam2_from_world,  # type: ignore[arg-type]
+        ray1,
+        ray2,  # type: ignore[arg-type]
     )
     assert result is not None
     np.testing.assert_allclose(result, point3d, atol=1e-6)
@@ -54,6 +60,6 @@ def test_triangulate_multi_view_point() -> None:
     for cam_from_world in cams_from_world:
         ray = cam_from_world @ np.append(point3d, 1.0)
         cam_rays.append(ray / np.linalg.norm(ray))
-    result = pycolmap.triangulate_multi_view_point(cams_from_world, cam_rays)
+    result = pycolmap.triangulate_multi_view_point(cams_from_world, cam_rays)  # type: ignore[arg-type]
     assert result is not None
     np.testing.assert_allclose(result, point3d, atol=1e-6)

--- a/src/pycolmap/geometry/triangulation_test.py
+++ b/src/pycolmap/geometry/triangulation_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pycolmap
 
 
-def test_triangulate_point():
+def test_triangulate_point() -> None:
     cam1_from_world = np.eye(3, 4)
     cam2_from_world = np.eye(3, 4)
     cam2_from_world[0, 3] = -1.0
@@ -16,7 +16,7 @@ def test_triangulate_point():
         assert result.shape == (3,)
 
 
-def test_calculate_triangulation_angle():
+def test_calculate_triangulation_angle() -> None:
     center1 = np.array([0.0, 0.0, 0.0])
     center2 = np.array([1.0, 0.0, 0.0])
     point3d = np.array([0.5, 0.0, 1.0])
@@ -25,11 +25,11 @@ def test_calculate_triangulation_angle():
     assert angle >= 0.0
 
 
-def test_triangulate_mid_point_callable():
+def test_triangulate_mid_point_callable() -> None:
     assert callable(pycolmap.triangulate_mid_point)
 
 
-def test_triangulate_point_from_rays():
+def test_triangulate_point_from_rays() -> None:
     cam1_from_world = np.eye(3, 4)
     cam2_from_world = np.eye(3, 4)
     cam2_from_world[0, 3] = -1.0
@@ -45,7 +45,7 @@ def test_triangulate_point_from_rays():
     np.testing.assert_allclose(result, point3d, atol=1e-6)
 
 
-def test_triangulate_multi_view_point():
+def test_triangulate_multi_view_point() -> None:
     cams_from_world = [np.eye(3, 4), np.eye(3, 4), np.eye(3, 4)]
     cams_from_world[1][0, 3] = -1.0
     cams_from_world[2][1, 3] = -1.0

--- a/src/pycolmap/image/undistortion_test.py
+++ b/src/pycolmap/image/undistortion_test.py
@@ -3,12 +3,12 @@ import numpy as np
 import pycolmap
 
 
-def test_undistort_camera_options_default_init():
+def test_undistort_camera_options_default_init() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert options is not None
 
 
-def test_warp_image_interpolation_enum():
+def test_warp_image_interpolation_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.WarpImageOptions.Interpolation.__members__.items()
@@ -18,7 +18,7 @@ def test_warp_image_interpolation_enum():
     }
 
 
-def test_warp_image_options_interpolation_readwrite():
+def test_warp_image_options_interpolation_readwrite() -> None:
     options = pycolmap.WarpImageOptions()
     assert (
         options.interpolation
@@ -33,77 +33,77 @@ def test_warp_image_options_interpolation_readwrite():
     )
 
 
-def test_warp_image_options_direct_warp_min_scale_readwrite():
+def test_warp_image_options_direct_warp_min_scale_readwrite() -> None:
     options = pycolmap.WarpImageOptions()
     assert options.direct_warp_min_scale == 0.5
     options.direct_warp_min_scale = 0.4
     assert options.direct_warp_min_scale == 0.4
 
 
-def test_undistort_camera_options_warp_options_readwrite():
+def test_undistort_camera_options_warp_options_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.warp_options, pycolmap.WarpImageOptions)
     options.warp_options.direct_warp_min_scale = 0.5
     assert options.warp_options.direct_warp_min_scale == 0.5
 
 
-def test_undistort_camera_options_blank_pixels_readwrite():
+def test_undistort_camera_options_blank_pixels_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.blank_pixels, float)
     options.blank_pixels = 1.0
     assert options.blank_pixels == 1.0
 
 
-def test_undistort_camera_options_min_scale_readwrite():
+def test_undistort_camera_options_min_scale_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.min_scale, float)
     options.min_scale = 0.5
     assert options.min_scale == 0.5
 
 
-def test_undistort_camera_options_max_scale_readwrite():
+def test_undistort_camera_options_max_scale_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.max_scale, float)
     options.max_scale = 1.5
     assert options.max_scale == 1.5
 
 
-def test_undistort_camera_options_max_image_size_readwrite():
+def test_undistort_camera_options_max_image_size_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.max_image_size, int)
     options.max_image_size = 2048
     assert options.max_image_size == 2048
 
 
-def test_undistort_camera_options_roi_min_x_readwrite():
+def test_undistort_camera_options_roi_min_x_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.roi_min_x, float)
     options.roi_min_x = 0.1
     assert options.roi_min_x == 0.1
 
 
-def test_undistort_camera_options_roi_min_y_readwrite():
+def test_undistort_camera_options_roi_min_y_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.roi_min_y, float)
     options.roi_min_y = 0.2
     assert options.roi_min_y == 0.2
 
 
-def test_undistort_camera_options_roi_max_x_readwrite():
+def test_undistort_camera_options_roi_max_x_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.roi_max_x, float)
     options.roi_max_x = 0.9
     assert options.roi_max_x == 0.9
 
 
-def test_undistort_camera_options_roi_max_y_readwrite():
+def test_undistort_camera_options_roi_max_y_readwrite() -> None:
     options = pycolmap.UndistortCameraOptions()
     assert isinstance(options.roi_max_y, float)
     options.roi_max_y = 0.8
     assert options.roi_max_y == 0.8
 
 
-def test_undistort_camera():
+def test_undistort_camera() -> None:
     options = pycolmap.UndistortCameraOptions()
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768
@@ -112,7 +112,7 @@ def test_undistort_camera():
     assert isinstance(undistorted_camera, pycolmap.Camera)
 
 
-def test_undistort_image():
+def test_undistort_image() -> None:
     options = pycolmap.UndistortCameraOptions()
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768

--- a/src/pycolmap/main_test.py
+++ b/src/pycolmap/main_test.py
@@ -1,35 +1,35 @@
 import pycolmap
 
 
-def test_version_is_str():
+def test_version_is_str() -> None:
     assert isinstance(pycolmap.__version__, str)
     assert len(pycolmap.__version__) > 0
 
 
-def test_ceres_version_is_str():
+def test_ceres_version_is_str() -> None:
     assert isinstance(pycolmap.__ceres_version__, str)
     assert len(pycolmap.__ceres_version__) > 0
 
 
-def test_has_cuda_is_bool():
+def test_has_cuda_is_bool() -> None:
     assert isinstance(pycolmap.has_cuda, bool)
 
 
-def test_colmap_version_is_str():
+def test_colmap_version_is_str() -> None:
     assert isinstance(pycolmap.COLMAP_version, str)
     assert len(pycolmap.COLMAP_version) > 0
 
 
-def test_colmap_build_is_str():
+def test_colmap_build_is_str() -> None:
     assert isinstance(pycolmap.COLMAP_build, str)
     assert len(pycolmap.COLMAP_build) > 0
 
 
-def test_device_enum():
+def test_device_enum() -> None:
     assert pycolmap.Device.auto is not None
     assert pycolmap.Device.cpu is not None
     assert pycolmap.Device.cuda is not None
 
 
-def test_set_random_seed():
+def test_set_random_seed() -> None:
     pycolmap.set_random_seed(42)

--- a/src/pycolmap/mvs/depth_map_test.py
+++ b/src/pycolmap/mvs/depth_map_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -9,12 +11,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_depth_map_default_init():
+def test_depth_map_default_init() -> None:
     depth_map = pycolmap.DepthMap()
     assert depth_map is not None
 
 
-def test_depth_map_init_with_params():
+def test_depth_map_init_with_params() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.1, 100.0)
     assert depth_map.width == 64
     assert depth_map.height == 48
@@ -22,31 +24,31 @@ def test_depth_map_init_with_params():
     assert depth_map.depth_max == pytest.approx(100.0)
 
 
-def test_depth_map_readonly_width():
+def test_depth_map_readonly_width() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.1, 100.0)
     assert isinstance(depth_map.width, int)
     assert depth_map.width == 64
 
 
-def test_depth_map_readonly_height():
+def test_depth_map_readonly_height() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.1, 100.0)
     assert isinstance(depth_map.height, int)
     assert depth_map.height == 48
 
 
-def test_depth_map_readonly_depth_min():
+def test_depth_map_readonly_depth_min() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.5, 50.0)
     assert isinstance(depth_map.depth_min, float)
     assert depth_map.depth_min == pytest.approx(0.5)
 
 
-def test_depth_map_readonly_depth_max():
+def test_depth_map_readonly_depth_max() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.5, 50.0)
     assert isinstance(depth_map.depth_max, float)
     assert depth_map.depth_max == pytest.approx(50.0)
 
 
-def test_depth_map_from_array_to_array_roundtrip():
+def test_depth_map_from_array_to_array_roundtrip() -> None:
     array = np.random.rand(48, 64).astype(np.float32)
     depth_map = pycolmap.DepthMap.from_array(
         array, depth_min=0.1, depth_max=10.0
@@ -55,21 +57,21 @@ def test_depth_map_from_array_to_array_roundtrip():
     np.testing.assert_array_almost_equal(array, result)
 
 
-def test_depth_map_rescale():
+def test_depth_map_rescale() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.1, 100.0)
     depth_map.rescale(0.5)
     assert depth_map.width == 32
     assert depth_map.height == 24
 
 
-def test_depth_map_downsize():
+def test_depth_map_downsize() -> None:
     depth_map = pycolmap.DepthMap(64, 48, 0.1, 100.0)
     depth_map.downsize(32, 24)
     assert depth_map.width == 32
     assert depth_map.height == 24
 
 
-def test_depth_map_to_bitmap():
+def test_depth_map_to_bitmap() -> None:
     array = np.random.rand(48, 64).astype(np.float32)
     depth_map = pycolmap.DepthMap.from_array(
         array, depth_min=0.0, depth_max=1.0
@@ -78,7 +80,7 @@ def test_depth_map_to_bitmap():
     assert bitmap is not None
 
 
-def test_depth_map_write_read_roundtrip(tmp_path):
+def test_depth_map_write_read_roundtrip(tmp_path: Path) -> None:
     array = np.random.rand(48, 64).astype(np.float32)
     depth_map = pycolmap.DepthMap.from_array(
         array, depth_min=0.1, depth_max=10.0

--- a/src/pycolmap/mvs/model_test.py
+++ b/src/pycolmap/mvs/model_test.py
@@ -8,6 +8,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_mvs_model_init():
+def test_mvs_model_init() -> None:
     model = pycolmap.MVSModel()
     assert model is not None

--- a/src/pycolmap/mvs/normal_map_test.py
+++ b/src/pycolmap/mvs/normal_map_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -9,58 +11,58 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_normal_map_default_init():
+def test_normal_map_default_init() -> None:
     normal_map = pycolmap.NormalMap()
     assert normal_map is not None
 
 
-def test_normal_map_init_with_params():
+def test_normal_map_init_with_params() -> None:
     normal_map = pycolmap.NormalMap(64, 48)
     assert normal_map.width == 64
     assert normal_map.height == 48
 
 
-def test_normal_map_readonly_width():
+def test_normal_map_readonly_width() -> None:
     normal_map = pycolmap.NormalMap(64, 48)
     assert isinstance(normal_map.width, int)
     assert normal_map.width == 64
 
 
-def test_normal_map_readonly_height():
+def test_normal_map_readonly_height() -> None:
     normal_map = pycolmap.NormalMap(64, 48)
     assert isinstance(normal_map.height, int)
     assert normal_map.height == 48
 
 
-def test_normal_map_from_array_to_array_roundtrip():
+def test_normal_map_from_array_to_array_roundtrip() -> None:
     array = np.random.rand(48, 64, 3).astype(np.float32)
     normal_map = pycolmap.NormalMap.from_array(array)
     result = normal_map.to_array()
     np.testing.assert_array_almost_equal(array, result)
 
 
-def test_normal_map_rescale():
+def test_normal_map_rescale() -> None:
     normal_map = pycolmap.NormalMap(64, 48)
     normal_map.rescale(0.5)
     assert normal_map.width == 32
     assert normal_map.height == 24
 
 
-def test_normal_map_downsize():
+def test_normal_map_downsize() -> None:
     normal_map = pycolmap.NormalMap(64, 48)
     normal_map.downsize(32, 24)
     assert normal_map.width <= 32
     assert normal_map.height <= 24
 
 
-def test_normal_map_to_bitmap():
+def test_normal_map_to_bitmap() -> None:
     array = np.random.rand(48, 64, 3).astype(np.float32)
     normal_map = pycolmap.NormalMap.from_array(array)
     bitmap = normal_map.to_bitmap()
     assert bitmap is not None
 
 
-def test_normal_map_write_read_roundtrip(tmp_path):
+def test_normal_map_write_read_roundtrip(tmp_path: Path) -> None:
     array = np.random.rand(48, 64, 3).astype(np.float32)
     normal_map = pycolmap.NormalMap.from_array(array)
     filepath = str(tmp_path / "normal.bin")

--- a/src/pycolmap/optim/ransac_test.py
+++ b/src/pycolmap/optim/ransac_test.py
@@ -1,65 +1,65 @@
 import pycolmap
 
 
-def test_ransac_options_default_init():
+def test_ransac_options_default_init() -> None:
     options = pycolmap.RANSACOptions()
     assert options is not None
 
 
-def test_ransac_options_max_error_readwrite():
+def test_ransac_options_max_error_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.max_error, float)
     options.max_error = 8.0
     assert options.max_error == 8.0
 
 
-def test_ransac_options_min_inlier_ratio_readwrite():
+def test_ransac_options_min_inlier_ratio_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.min_inlier_ratio, float)
     options.min_inlier_ratio = 0.05
     assert options.min_inlier_ratio == 0.05
 
 
-def test_ransac_options_confidence_readwrite():
+def test_ransac_options_confidence_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.confidence, float)
     options.confidence = 0.999
     assert options.confidence == 0.999
 
 
-def test_ransac_options_dyn_num_trials_multiplier_readwrite():
+def test_ransac_options_dyn_num_trials_multiplier_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.dyn_num_trials_multiplier, float)
     options.dyn_num_trials_multiplier = 5.0
     assert options.dyn_num_trials_multiplier == 5.0
 
 
-def test_ransac_options_min_num_trials_readwrite():
+def test_ransac_options_min_num_trials_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.min_num_trials, int)
     options.min_num_trials = 500
     assert options.min_num_trials == 500
 
 
-def test_ransac_options_max_num_trials_readwrite():
+def test_ransac_options_max_num_trials_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     assert isinstance(options.max_num_trials, int)
     options.max_num_trials = 50000
     assert options.max_num_trials == 50000
 
 
-def test_ransac_options_random_seed_readwrite():
+def test_ransac_options_random_seed_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     options.random_seed = 42
     assert options.random_seed == 42
 
 
-def test_ransac_options_num_threads_readwrite():
+def test_ransac_options_num_threads_readwrite() -> None:
     options = pycolmap.RANSACOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_ransac_options_check():
+def test_ransac_options_check() -> None:
     options = pycolmap.RANSACOptions()
     options.check()

--- a/src/pycolmap/pipeline/extract_features_test.py
+++ b/src/pycolmap/pipeline/extract_features_test.py
@@ -1,5 +1,5 @@
 import pycolmap
 
 
-def test_extract_features_callable():
+def test_extract_features_callable() -> None:
     assert callable(pycolmap.extract_features)

--- a/src/pycolmap/pipeline/images_test.py
+++ b/src/pycolmap/pipeline/images_test.py
@@ -3,7 +3,7 @@ import pytest
 import pycolmap
 
 
-def test_camera_mode_enum():
+def test_camera_mode_enum() -> None:
     assert {k: int(v) for k, v in pycolmap.CameraMode.__members__.items()} == {
         "AUTO": 0,
         "SINGLE": 1,
@@ -12,7 +12,7 @@ def test_camera_mode_enum():
     }
 
 
-def test_file_copy_type_enum():
+def test_file_copy_type_enum() -> None:
     assert {
         k: int(v) for k, v in pycolmap.FileCopyType.__members__.items()
     } == {
@@ -22,18 +22,18 @@ def test_file_copy_type_enum():
     }
 
 
-def test_image_reader_options_init():
+def test_image_reader_options_init() -> None:
     options = pycolmap.ImageReaderOptions()
     assert options is not None
 
 
-def test_image_reader_options_camera_model():
+def test_image_reader_options_camera_model() -> None:
     options = pycolmap.ImageReaderOptions()
     options.camera_model = "SIMPLE_PINHOLE"
     assert options.camera_model == "SIMPLE_PINHOLE"
 
 
-def test_image_reader_options_check():
+def test_image_reader_options_check() -> None:
     options = pycolmap.ImageReaderOptions()
     assert options.check()
 
@@ -46,5 +46,5 @@ def test_image_reader_options_check():
         "undistort_images",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/pipeline/match_features_test.py
+++ b/src/pycolmap/pipeline/match_features_test.py
@@ -3,137 +3,137 @@ import pytest
 import pycolmap
 
 
-def test_exhaustive_pairing_options_init():
+def test_exhaustive_pairing_options_init() -> None:
     options = pycolmap.ExhaustivePairingOptions()
     assert options is not None
 
 
-def test_exhaustive_pairing_options_block_size():
+def test_exhaustive_pairing_options_block_size() -> None:
     options = pycolmap.ExhaustivePairingOptions()
     options.block_size = 100
     assert options.block_size == 100
 
 
-def test_exhaustive_pairing_options_check():
+def test_exhaustive_pairing_options_check() -> None:
     options = pycolmap.ExhaustivePairingOptions()
     assert options.check()
 
 
-def test_spatial_pairing_options_init():
+def test_spatial_pairing_options_init() -> None:
     options = pycolmap.SpatialPairingOptions()
     assert options is not None
 
 
-def test_spatial_pairing_options_max_num_neighbors():
+def test_spatial_pairing_options_max_num_neighbors() -> None:
     options = pycolmap.SpatialPairingOptions()
     options.max_num_neighbors = 100
     assert options.max_num_neighbors == 100
 
 
-def test_spatial_pairing_options_max_distance():
+def test_spatial_pairing_options_max_distance() -> None:
     options = pycolmap.SpatialPairingOptions()
     options.max_distance = 200.0
     assert options.max_distance == 200.0
 
 
-def test_spatial_pairing_options_check():
+def test_spatial_pairing_options_check() -> None:
     options = pycolmap.SpatialPairingOptions()
     assert options.check()
 
 
-def test_vocab_tree_pairing_options_init():
+def test_vocab_tree_pairing_options_init() -> None:
     options = pycolmap.VocabTreePairingOptions()
     assert options is not None
 
 
-def test_vocab_tree_pairing_options_num_images():
+def test_vocab_tree_pairing_options_num_images() -> None:
     options = pycolmap.VocabTreePairingOptions()
     options.num_images = 50
     assert options.num_images == 50
 
 
-def test_vocab_tree_pairing_options_num_nearest_neighbors():
+def test_vocab_tree_pairing_options_num_nearest_neighbors() -> None:
     options = pycolmap.VocabTreePairingOptions()
     options.num_nearest_neighbors = 3
     assert options.num_nearest_neighbors == 3
 
 
-def test_vocab_tree_pairing_options_check():
+def test_vocab_tree_pairing_options_check() -> None:
     options = pycolmap.VocabTreePairingOptions()
     assert options.check()
 
 
-def test_sequential_pairing_options_init():
+def test_sequential_pairing_options_init() -> None:
     options = pycolmap.SequentialPairingOptions()
     assert options is not None
 
 
-def test_sequential_pairing_options_overlap():
+def test_sequential_pairing_options_overlap() -> None:
     options = pycolmap.SequentialPairingOptions()
     options.overlap = 15
     assert options.overlap == 15
 
 
-def test_sequential_pairing_options_quadratic_overlap():
+def test_sequential_pairing_options_quadratic_overlap() -> None:
     options = pycolmap.SequentialPairingOptions()
     options.quadratic_overlap = True
     assert options.quadratic_overlap is True
 
 
-def test_sequential_pairing_options_vocab_tree_options():
+def test_sequential_pairing_options_vocab_tree_options() -> None:
     options = pycolmap.SequentialPairingOptions()
     vocab_tree_options = options.vocab_tree_options()
     assert vocab_tree_options is not None
 
 
-def test_sequential_pairing_options_check():
+def test_sequential_pairing_options_check() -> None:
     options = pycolmap.SequentialPairingOptions()
     assert options.check()
 
 
-def test_imported_pairing_options_init():
+def test_imported_pairing_options_init() -> None:
     options = pycolmap.ImportedPairingOptions()
     assert options is not None
 
 
-def test_imported_pairing_options_block_size():
+def test_imported_pairing_options_block_size() -> None:
     options = pycolmap.ImportedPairingOptions()
     options.block_size = 200
     assert options.block_size == 200
 
 
-def test_imported_pairing_options_check():
+def test_imported_pairing_options_check() -> None:
     options = pycolmap.ImportedPairingOptions()
     assert options.check()
 
 
-def test_existing_matched_pairing_options_init():
+def test_existing_matched_pairing_options_init() -> None:
     options = pycolmap.ExistingMatchedPairingOptions()
     assert options is not None
 
 
-def test_existing_matched_pairing_options_batch_size():
+def test_existing_matched_pairing_options_batch_size() -> None:
     options = pycolmap.ExistingMatchedPairingOptions()
     options.batch_size = 500
     assert options.batch_size == 500
 
 
-def test_geometric_verifier_options_init():
+def test_geometric_verifier_options_init() -> None:
     options = pycolmap.GeometricVerifierOptions()
     assert options is not None
 
 
-def test_geometric_verifier_options_num_threads():
+def test_geometric_verifier_options_num_threads() -> None:
     options = pycolmap.GeometricVerifierOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_pair_generator_class_exists():
+def test_pair_generator_class_exists() -> None:
     assert hasattr(pycolmap, "PairGenerator")
 
 
-def test_exhaustive_pair_generator_class_exists():
+def test_exhaustive_pair_generator_class_exists() -> None:
     assert hasattr(pycolmap, "ExhaustivePairGenerator")
 
 
@@ -146,5 +146,5 @@ def test_exhaustive_pair_generator_class_exists():
         "geometric_verification",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/pipeline/meshing_test.py
+++ b/src/pycolmap/pipeline/meshing_test.py
@@ -8,40 +8,40 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_poisson_meshing_options_init():
+def test_poisson_meshing_options_init() -> None:
     options = pycolmap.PoissonMeshingOptions()
     assert options is not None
 
 
-def test_poisson_meshing_options_depth():
+def test_poisson_meshing_options_depth() -> None:
     options = pycolmap.PoissonMeshingOptions()
     options.depth = 10
     assert options.depth == 10
 
 
-def test_poisson_meshing_options_num_threads():
+def test_poisson_meshing_options_num_threads() -> None:
     options = pycolmap.PoissonMeshingOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_poisson_meshing_options_check():
+def test_poisson_meshing_options_check() -> None:
     options = pycolmap.PoissonMeshingOptions()
     assert options.check()
 
 
-def test_mesh_simplification_options_init():
+def test_mesh_simplification_options_init() -> None:
     options = pycolmap.MeshSimplificationOptions()
     assert options is not None
 
 
-def test_mesh_simplification_options_target_face_ratio():
+def test_mesh_simplification_options_target_face_ratio() -> None:
     options = pycolmap.MeshSimplificationOptions()
     options.target_face_ratio = 0.5
     assert options.target_face_ratio == pytest.approx(0.5)
 
 
-def test_mesh_simplification_options_check():
+def test_mesh_simplification_options_check() -> None:
     options = pycolmap.MeshSimplificationOptions()
     assert options.check()
 
@@ -50,6 +50,6 @@ def test_mesh_simplification_options_check():
     not hasattr(pycolmap, "DelaunayMeshingOptions"),
     reason="DelaunayMeshingOptions not available",
 )
-def test_delaunay_meshing_options_init():
+def test_delaunay_meshing_options_init() -> None:
     options = pycolmap.DelaunayMeshingOptions()
     assert options is not None

--- a/src/pycolmap/pipeline/mvs_test.py
+++ b/src/pycolmap/pipeline/mvs_test.py
@@ -8,12 +8,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_patch_match_options_init():
+def test_patch_match_options_init() -> None:
     options = pycolmap.PatchMatchOptions()
     assert options is not None
 
 
-def test_stereo_fusion_options_init():
+def test_stereo_fusion_options_init() -> None:
     options = pycolmap.StereoFusionOptions()
     assert options is not None
 
@@ -25,5 +25,5 @@ def test_stereo_fusion_options_init():
         "stereo_fusion",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))

--- a/src/pycolmap/pipeline/sfm_test.py
+++ b/src/pycolmap/pipeline/sfm_test.py
@@ -5,22 +5,22 @@ import pytest
 import pycolmap
 
 
-def test_view_graph_calibration_options_init():
+def test_view_graph_calibration_options_init() -> None:
     options = pycolmap.ViewGraphCalibrationOptions()
     assert options is not None
 
 
-def test_global_mapper_options_init():
+def test_global_mapper_options_init() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options is not None
 
 
-def test_global_pipeline_options_init():
+def test_global_pipeline_options_init() -> None:
     options = pycolmap.GlobalPipelineOptions()
     assert options is not None
 
 
-def test_global_pipeline_options_min_num_matches():
+def test_global_pipeline_options_min_num_matches() -> None:
     options = pycolmap.GlobalPipelineOptions()
     options.min_num_matches = 20
     assert options.min_num_matches == 20
@@ -37,16 +37,16 @@ def test_global_pipeline_options_min_num_matches():
         "bundle_adjustment",
     ],
 )
-def test_public_api_callable(name):
+def test_public_api_callable(name: str) -> None:
     assert callable(getattr(pycolmap, name))
 
 
-def test_hierarchical_pipeline_options_init():
+def test_hierarchical_pipeline_options_init() -> None:
     options = pycolmap.HierarchicalPipelineOptions()
     assert options is not None
 
 
-def test_incremental_mapping(tmp_path: Path):
+def test_incremental_mapping(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"
@@ -78,7 +78,7 @@ def test_incremental_mapping(tmp_path: Path):
     assert (output_path / "0").exists()
 
 
-def test_global_mapping(tmp_path: Path):
+def test_global_mapping(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"
@@ -123,7 +123,7 @@ def test_global_mapping(tmp_path: Path):
         assert error.proj_center_error < 1e-4
 
 
-def test_hierarchical_mapping(tmp_path: Path):
+def test_hierarchical_mapping(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"

--- a/src/pycolmap/retrieval/visual_index_test.py
+++ b/src/pycolmap/retrieval/visual_index_test.py
@@ -1,115 +1,115 @@
 import pycolmap
 
 
-def test_image_score_class_exists():
+def test_image_score_class_exists() -> None:
     score = pycolmap.ImageScore()
     assert score is not None
 
 
-def test_image_score_readonly_image_id():
+def test_image_score_readonly_image_id() -> None:
     score = pycolmap.ImageScore()
     assert isinstance(score.image_id, int)
 
 
-def test_image_score_readonly_score():
+def test_image_score_readonly_score() -> None:
     score = pycolmap.ImageScore()
     assert isinstance(score.score, (int, float))
 
 
-def test_visual_index_index_options_init():
+def test_visual_index_index_options_init() -> None:
     options = pycolmap.VisualIndex.IndexOptions()
     assert options is not None
 
 
-def test_visual_index_index_options_num_neighbors():
+def test_visual_index_index_options_num_neighbors() -> None:
     options = pycolmap.VisualIndex.IndexOptions()
     options.num_neighbors = 5
     assert options.num_neighbors == 5
 
 
-def test_visual_index_index_options_num_checks():
+def test_visual_index_index_options_num_checks() -> None:
     options = pycolmap.VisualIndex.IndexOptions()
     options.num_checks = 128
     assert options.num_checks == 128
 
 
-def test_visual_index_index_options_num_threads():
+def test_visual_index_index_options_num_threads() -> None:
     options = pycolmap.VisualIndex.IndexOptions()
     options.num_threads = 4
     assert options.num_threads == 4
 
 
-def test_visual_index_query_options_init():
+def test_visual_index_query_options_init() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     assert options is not None
 
 
-def test_visual_index_query_options_max_num_images():
+def test_visual_index_query_options_max_num_images() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     options.max_num_images = 50
     assert options.max_num_images == 50
 
 
-def test_visual_index_query_options_num_neighbors():
+def test_visual_index_query_options_num_neighbors() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     options.num_neighbors = 3
     assert options.num_neighbors == 3
 
 
-def test_visual_index_query_options_num_checks():
+def test_visual_index_query_options_num_checks() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     options.num_checks = 64
     assert options.num_checks == 64
 
 
-def test_visual_index_query_options_num_threads():
+def test_visual_index_query_options_num_threads() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     options.num_threads = 2
     assert options.num_threads == 2
 
 
-def test_visual_index_query_options_num_images_after_verification():
+def test_visual_index_query_options_num_images_after_verification() -> None:
     options = pycolmap.VisualIndex.QueryOptions()
     options.num_images_after_verification = 10
     assert options.num_images_after_verification == 10
 
 
-def test_visual_index_build_options_init():
+def test_visual_index_build_options_init() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     assert options is not None
 
 
-def test_visual_index_build_options_num_visual_words():
+def test_visual_index_build_options_num_visual_words() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     options.num_visual_words = 1024
     assert options.num_visual_words == 1024
 
 
-def test_visual_index_build_options_num_iterations():
+def test_visual_index_build_options_num_iterations() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     options.num_iterations = 5
     assert options.num_iterations == 5
 
 
-def test_visual_index_build_options_num_rounds():
+def test_visual_index_build_options_num_rounds() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     options.num_rounds = 3
     assert options.num_rounds == 3
 
 
-def test_visual_index_build_options_num_checks():
+def test_visual_index_build_options_num_checks() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     options.num_checks = 256
     assert options.num_checks == 256
 
 
-def test_visual_index_build_options_num_threads():
+def test_visual_index_build_options_num_threads() -> None:
     options = pycolmap.VisualIndex.BuildOptions()
     options.num_threads = 8
     assert options.num_threads == 8
 
 
-def test_visual_index_create():
+def test_visual_index_create() -> None:
     index = pycolmap.VisualIndex.create(128, 64)
     assert index is not None
     assert index.num_visual_words() == 0

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -3,41 +3,41 @@ import numpy as np
 import pycolmap
 
 
-def test_camera_model_id_invalid():
+def test_camera_model_id_invalid() -> None:
     assert pycolmap.CameraModelId.INVALID is not None
 
 
-def test_camera_model_id_pinhole():
+def test_camera_model_id_pinhole() -> None:
     assert pycolmap.CameraModelId.PINHOLE is not None
 
 
-def test_camera_model_id_simple_pinhole():
+def test_camera_model_id_simple_pinhole() -> None:
     assert pycolmap.CameraModelId.SIMPLE_PINHOLE is not None
 
 
-def test_camera_model_id_simple_radial():
+def test_camera_model_id_simple_radial() -> None:
     assert pycolmap.CameraModelId.SIMPLE_RADIAL is not None
 
 
-def test_camera_model_id_radial():
+def test_camera_model_id_radial() -> None:
     assert pycolmap.CameraModelId.RADIAL is not None
 
 
-def test_camera_model_id_opencv():
+def test_camera_model_id_opencv() -> None:
     assert pycolmap.CameraModelId.OPENCV is not None
 
 
-def test_camera_model_id_string_construction():
+def test_camera_model_id_string_construction() -> None:
     model = pycolmap.CameraModelId("PINHOLE")
     assert model == pycolmap.CameraModelId.PINHOLE
 
 
-def test_camera_default_init():
+def test_camera_default_init() -> None:
     camera = pycolmap.Camera()
     assert camera is not None
 
 
-def test_camera_create_from_model_id():
+def test_camera_create_from_model_id() -> None:
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768
     )
@@ -45,7 +45,7 @@ def test_camera_create_from_model_id():
     assert camera.camera_id == 1
 
 
-def test_camera_create_from_model_name():
+def test_camera_create_from_model_name() -> None:
     camera = pycolmap.Camera.create_from_model_name(
         2, "PINHOLE", 500.0, 1024, 768
     )
@@ -53,18 +53,18 @@ def test_camera_create_from_model_name():
     assert camera.camera_id == 2
 
 
-def test_camera_camera_id_readwrite(simple_camera):
+def test_camera_camera_id_readwrite(simple_camera: pycolmap.Camera) -> None:
     simple_camera.camera_id = 10
     assert simple_camera.camera_id == 10
 
 
-def test_camera_model_readwrite(simple_camera):
+def test_camera_model_readwrite(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.model == pycolmap.CameraModelId.PINHOLE
     simple_camera.model = pycolmap.CameraModelId.SIMPLE_PINHOLE
     assert simple_camera.model == pycolmap.CameraModelId.SIMPLE_PINHOLE
 
 
-def test_camera_width_height_readwrite(simple_camera):
+def test_camera_width_height_readwrite(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.width == 1024
     assert simple_camera.height == 768
     simple_camera.width = 2048
@@ -73,7 +73,7 @@ def test_camera_width_height_readwrite(simple_camera):
     assert simple_camera.height == 1536
 
 
-def test_camera_params_readwrite(simple_camera):
+def test_camera_params_readwrite(simple_camera: pycolmap.Camera) -> None:
     params = simple_camera.params
     assert len(params) > 0
     new_params = list(params)
@@ -82,14 +82,16 @@ def test_camera_params_readwrite(simple_camera):
     assert simple_camera.params[0] == 600.0
 
 
-def test_camera_has_prior_focal_length_readwrite(simple_camera):
+def test_camera_has_prior_focal_length_readwrite(
+    simple_camera: pycolmap.Camera,
+) -> None:
     simple_camera.has_prior_focal_length = True
     assert simple_camera.has_prior_focal_length is True
     simple_camera.has_prior_focal_length = False
     assert simple_camera.has_prior_focal_length is False
 
 
-def test_camera_focal_length_readwrite():
+def test_camera_focal_length_readwrite() -> None:
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.SIMPLE_PINHOLE, 500.0, 1024, 768
     )
@@ -97,51 +99,51 @@ def test_camera_focal_length_readwrite():
     assert camera.focal_length == 600.0
 
 
-def test_camera_focal_length_x_y(simple_camera):
+def test_camera_focal_length_x_y(simple_camera: pycolmap.Camera) -> None:
     assert isinstance(simple_camera.focal_length_x, float)
     assert isinstance(simple_camera.focal_length_y, float)
 
 
-def test_camera_principal_point_x_y(simple_camera):
+def test_camera_principal_point_x_y(simple_camera: pycolmap.Camera) -> None:
     assert isinstance(simple_camera.principal_point_x, float)
     assert isinstance(simple_camera.principal_point_y, float)
 
 
-def test_camera_sensor_id_readonly(simple_camera):
+def test_camera_sensor_id_readonly(simple_camera: pycolmap.Camera) -> None:
     sensor_id = simple_camera.sensor_id
     assert sensor_id is not None
 
 
-def test_camera_model_name_readonly(simple_camera):
+def test_camera_model_name_readonly(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.model_name == "PINHOLE"
 
 
-def test_camera_params_info_readonly(simple_camera):
+def test_camera_params_info_readonly(simple_camera: pycolmap.Camera) -> None:
     info = simple_camera.params_info
     assert isinstance(info, str)
 
 
-def test_camera_mean_focal_length(simple_camera):
+def test_camera_mean_focal_length(simple_camera: pycolmap.Camera) -> None:
     mean_focal = simple_camera.mean_focal_length()
     assert isinstance(mean_focal, float)
 
 
-def test_camera_focal_length_idxs(simple_camera):
+def test_camera_focal_length_idxs(simple_camera: pycolmap.Camera) -> None:
     idxs = simple_camera.focal_length_idxs()
     assert len(idxs) > 0
 
 
-def test_camera_principal_point_idxs(simple_camera):
+def test_camera_principal_point_idxs(simple_camera: pycolmap.Camera) -> None:
     idxs = simple_camera.principal_point_idxs()
     assert len(idxs) > 0
 
 
-def test_camera_extra_params_idxs(simple_camera):
+def test_camera_extra_params_idxs(simple_camera: pycolmap.Camera) -> None:
     idxs = simple_camera.extra_params_idxs()
     assert isinstance(idxs, list)
 
 
-def test_camera_metadata_params_idxs(simple_camera):
+def test_camera_metadata_params_idxs(simple_camera: pycolmap.Camera) -> None:
     # Perspective models have no metadata parameters.
     assert simple_camera.metadata_params_idxs() == []
     # Spherical models carry their (w, h) image dimensions as metadata.
@@ -151,24 +153,26 @@ def test_camera_metadata_params_idxs(simple_camera):
     assert spherical_camera.metadata_params_idxs() == [0, 1]
 
 
-def test_camera_calibration_matrix(simple_camera):
+def test_camera_calibration_matrix(simple_camera: pycolmap.Camera) -> None:
     matrix = simple_camera.calibration_matrix()
     assert matrix.shape == (3, 3)
 
 
-def test_camera_cam_from_img_point2d(simple_camera):
+def test_camera_cam_from_img_point2d(simple_camera: pycolmap.Camera) -> None:
     point2d = np.array([512.0, 384.0])
     result = simple_camera.cam_from_img(point2d)
     assert result is not None
 
 
-def test_camera_cam_from_img_matrix(simple_camera):
+def test_camera_cam_from_img_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[512.0, 384.0], [100.0, 200.0]])
     result = simple_camera.cam_from_img(points)
     assert len(result) == 2
 
 
-def test_camera_cam_ray_from_img_point2d(simple_camera):
+def test_camera_cam_ray_from_img_point2d(
+    simple_camera: pycolmap.Camera,
+) -> None:
     point2d = np.array([512.0, 384.0])
     result = simple_camera.cam_ray_from_img(point2d)
     assert result is not None
@@ -176,7 +180,7 @@ def test_camera_cam_ray_from_img_point2d(simple_camera):
     assert np.isclose(np.linalg.norm(result), 1.0)
 
 
-def test_camera_cam_ray_from_img_matrix(simple_camera):
+def test_camera_cam_ray_from_img_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[512.0, 384.0], [100.0, 200.0]])
     result = simple_camera.cam_ray_from_img(points)
     assert len(result) == 2
@@ -184,33 +188,33 @@ def test_camera_cam_ray_from_img_matrix(simple_camera):
         assert np.isclose(np.linalg.norm(ray), 1.0)
 
 
-def test_camera_img_from_cam_point3d(simple_camera):
+def test_camera_img_from_cam_point3d(simple_camera: pycolmap.Camera) -> None:
     point3d = np.array([0.0, 0.0, 1.0])
     result = simple_camera.img_from_cam(point3d)
     assert result is not None
 
 
-def test_camera_img_from_cam_matrix(simple_camera):
+def test_camera_img_from_cam_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[0.0, 0.0, 1.0], [0.1, 0.2, 1.0]])
     result = simple_camera.img_from_cam(points)
     assert len(result) == 2
 
 
-def test_camera_cam_from_img_threshold(simple_camera):
+def test_camera_cam_from_img_threshold(simple_camera: pycolmap.Camera) -> None:
     threshold = simple_camera.cam_from_img_threshold(1.0)
     assert isinstance(threshold, float)
 
 
-def test_camera_verify_params(simple_camera):
+def test_camera_verify_params(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.verify_params()
 
 
-def test_camera_is_undistorted(simple_camera):
+def test_camera_is_undistorted(simple_camera: pycolmap.Camera) -> None:
     result = simple_camera.is_undistorted()
     assert isinstance(result, bool)
 
 
-def test_camera_is_perspective(simple_camera):
+def test_camera_is_perspective(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.is_perspective() is True
     spherical_camera = pycolmap.Camera.create_from_model_name(
         3, "EQUIRECTANGULAR", 0.0, 1024, 512
@@ -218,7 +222,7 @@ def test_camera_is_perspective(simple_camera):
     assert spherical_camera.is_perspective() is False
 
 
-def test_camera_is_spherical(simple_camera):
+def test_camera_is_spherical(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.is_spherical() is False
     spherical_camera = pycolmap.Camera.create_from_model_name(
         3, "EQUIRECTANGULAR", 0.0, 1024, 512
@@ -226,7 +230,7 @@ def test_camera_is_spherical(simple_camera):
     assert spherical_camera.is_spherical() is True
 
 
-def test_camera_is_perspective_pinhole(simple_camera):
+def test_camera_is_perspective_pinhole(simple_camera: pycolmap.Camera) -> None:
     assert simple_camera.is_perspective_pinhole() is True
     fisheye_camera = pycolmap.Camera.create_from_model_name(
         3, "OPENCV_FISHEYE", 1.0, 1024, 512
@@ -240,41 +244,41 @@ def test_camera_is_perspective_pinhole(simple_camera):
     assert spherical_camera.is_perspective_pinhole() is False
 
 
-def test_camera_has_bogus_params(simple_camera):
+def test_camera_has_bogus_params(simple_camera: pycolmap.Camera) -> None:
     result = simple_camera.has_bogus_params(0.1, 100.0, 1.0)
     assert isinstance(result, bool)
 
 
-def test_camera_rescale_factor(simple_camera):
+def test_camera_rescale_factor(simple_camera: pycolmap.Camera) -> None:
     simple_camera.rescale(2.0)
     assert simple_camera.width == 2048
     assert simple_camera.height == 1536
 
 
-def test_camera_rescale_dimensions(simple_camera):
+def test_camera_rescale_dimensions(simple_camera: pycolmap.Camera) -> None:
     simple_camera.rescale(512, 384)
     assert simple_camera.width == 512
     assert simple_camera.height == 384
 
 
-def test_camera_params_to_string(simple_camera):
+def test_camera_params_to_string(simple_camera: pycolmap.Camera) -> None:
     params_string = simple_camera.params_to_string()
     assert isinstance(params_string, str)
     assert len(params_string) > 0
 
 
-def test_camera_set_params_from_string(simple_camera):
+def test_camera_set_params_from_string(simple_camera: pycolmap.Camera) -> None:
     params_string = simple_camera.params_to_string()
     simple_camera.set_params_from_string(params_string)
     assert simple_camera.verify_params()
 
 
-def test_camera_map_empty():
+def test_camera_map_empty() -> None:
     camera_map = pycolmap.CameraMap()
     assert len(camera_map) == 0
 
 
-def test_camera_map_insert_and_access(simple_camera):
+def test_camera_map_insert_and_access(simple_camera: pycolmap.Camera) -> None:
     camera_map = pycolmap.CameraMap()
     camera_map[1] = simple_camera
     assert len(camera_map) == 1

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -77,7 +77,7 @@ def test_camera_params_readwrite(simple_camera: pycolmap.Camera) -> None:
     params = simple_camera.params
     assert len(params) > 0
     new_params = list(params)
-    new_params[0] = 600.0
+    new_params[0] = 600.0  # type: ignore[call-overload]
     simple_camera.params = new_params
     assert simple_camera.params[0] == 600.0
 

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -167,6 +167,7 @@ def test_camera_cam_from_img_point2d(simple_camera: pycolmap.Camera) -> None:
 def test_camera_cam_from_img_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[512.0, 384.0], [100.0, 200.0]])
     result = simple_camera.cam_from_img(points)
+    assert result is not None
     assert len(result) == 2
 
 
@@ -183,6 +184,7 @@ def test_camera_cam_ray_from_img_point2d(
 def test_camera_cam_ray_from_img_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[512.0, 384.0], [100.0, 200.0]])
     result = simple_camera.cam_ray_from_img(points)
+    assert result is not None
     assert len(result) == 2
     for ray in result:
         assert np.isclose(np.linalg.norm(ray), 1.0)
@@ -197,6 +199,7 @@ def test_camera_img_from_cam_point3d(simple_camera: pycolmap.Camera) -> None:
 def test_camera_img_from_cam_matrix(simple_camera: pycolmap.Camera) -> None:
     points = np.array([[0.0, 0.0, 1.0], [0.1, 0.2, 1.0]])
     result = simple_camera.img_from_cam(points)
+    assert result is not None
     assert len(result) == 2
 
 

--- a/src/pycolmap/scene/constants_test.py
+++ b/src/pycolmap/scene/constants_test.py
@@ -1,37 +1,37 @@
 import pycolmap
 
 
-def test_invalid_camera_id():
+def test_invalid_camera_id() -> None:
     assert pycolmap.INVALID_CAMERA_ID is not None
 
 
-def test_invalid_image_id():
+def test_invalid_image_id() -> None:
     assert pycolmap.INVALID_IMAGE_ID is not None
 
 
-def test_invalid_image_pair_id():
+def test_invalid_image_pair_id() -> None:
     assert pycolmap.INVALID_IMAGE_PAIR_ID is not None
 
 
-def test_invalid_point2d_idx():
+def test_invalid_point2d_idx() -> None:
     assert pycolmap.INVALID_POINT2D_IDX is not None
 
 
-def test_invalid_point3d_id():
+def test_invalid_point3d_id() -> None:
     assert pycolmap.INVALID_POINT3D_ID is not None
 
 
-def test_invalid_pose_prior_id():
+def test_invalid_pose_prior_id() -> None:
     assert pycolmap.INVALID_POSE_PRIOR_ID is not None
 
 
-def test_invalid_sensor_id():
+def test_invalid_sensor_id() -> None:
     assert pycolmap.INVALID_SENSOR_ID is not None
 
 
-def test_invalid_data_id():
+def test_invalid_data_id() -> None:
     assert pycolmap.INVALID_DATA_ID is not None
 
 
-def test_invalid_timestamp():
+def test_invalid_timestamp() -> None:
     assert pycolmap.INVALID_TIMESTAMP is not None

--- a/src/pycolmap/scene/correspondence_graph_test.py
+++ b/src/pycolmap/scene/correspondence_graph_test.py
@@ -112,7 +112,7 @@ def test_correspondence_graph_with_two_view_geometry(
 def test_correspondence_graph_extract_matches(
     graph_with_matches: pycolmap.CorrespondenceGraph,
 ) -> None:
-    matches = graph_with_matches.extract_matches_between_images(1, 2)
+    matches = graph_with_matches.extract_matches_between_images(1, 2)  # type: ignore[var-annotated]
     assert matches.shape[0] == 2
 
 

--- a/src/pycolmap/scene/correspondence_graph_test.py
+++ b/src/pycolmap/scene/correspondence_graph_test.py
@@ -4,62 +4,62 @@ import pytest
 import pycolmap
 
 
-def test_correspondence_default_init():
+def test_correspondence_default_init() -> None:
     correspondence = pycolmap.Correspondence()
     assert correspondence is not None
 
 
-def test_correspondence_init_with_args():
+def test_correspondence_init_with_args() -> None:
     correspondence = pycolmap.Correspondence(image_id=1, point2D_idx=5)
     assert correspondence.image_id == 1
     assert correspondence.point2D_idx == 5
 
 
-def test_correspondence_image_id_readwrite():
+def test_correspondence_image_id_readwrite() -> None:
     correspondence = pycolmap.Correspondence()
     correspondence.image_id = 10
     assert correspondence.image_id == 10
 
 
-def test_correspondence_point2d_idx_readwrite():
+def test_correspondence_point2d_idx_readwrite() -> None:
     correspondence = pycolmap.Correspondence()
     correspondence.point2D_idx = 20
     assert correspondence.point2D_idx == 20
 
 
-def test_correspondence_graph_default_init():
+def test_correspondence_graph_default_init() -> None:
     graph = pycolmap.CorrespondenceGraph()
     assert graph.num_images() == 0
 
 
-def test_correspondence_graph_add_image():
+def test_correspondence_graph_add_image() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 10)
     assert graph.exists_image(1)
 
 
-def test_correspondence_graph_exists_image():
+def test_correspondence_graph_exists_image() -> None:
     graph = pycolmap.CorrespondenceGraph()
     assert not graph.exists_image(99)
     graph.add_image(1, 10)
     assert graph.exists_image(1)
 
 
-def test_correspondence_graph_num_images():
+def test_correspondence_graph_num_images() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 10)
     graph.add_image(2, 10)
     assert graph.num_images() == 2
 
 
-def test_correspondence_graph_finalize():
+def test_correspondence_graph_finalize() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.finalize()
     assert graph.num_images() == 1
 
 
-def test_correspondence_graph_num_image_pairs():
+def test_correspondence_graph_num_image_pairs() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.add_image(2, 5)
@@ -67,21 +67,21 @@ def test_correspondence_graph_num_image_pairs():
     assert graph.num_image_pairs() >= 0
 
 
-def test_correspondence_graph_num_observations_for_image():
+def test_correspondence_graph_num_observations_for_image() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.finalize()
     assert graph.num_observations_for_image(1) >= 0
 
 
-def test_correspondence_graph_num_correspondences_for_image():
+def test_correspondence_graph_num_correspondences_for_image() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.finalize()
     assert graph.num_correspondences_for_image(1) >= 0
 
 
-def test_correspondence_graph_image_pairs():
+def test_correspondence_graph_image_pairs() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.add_image(2, 5)
@@ -91,7 +91,7 @@ def test_correspondence_graph_image_pairs():
 
 
 @pytest.fixture
-def graph_with_matches():
+def graph_with_matches() -> pycolmap.CorrespondenceGraph:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.add_image(2, 5)
@@ -103,25 +103,33 @@ def graph_with_matches():
     return graph
 
 
-def test_correspondence_graph_with_two_view_geometry(graph_with_matches):
+def test_correspondence_graph_with_two_view_geometry(
+    graph_with_matches: pycolmap.CorrespondenceGraph,
+) -> None:
     assert graph_with_matches.num_matches_between_images(1, 2) == 2
 
 
-def test_correspondence_graph_extract_matches(graph_with_matches):
+def test_correspondence_graph_extract_matches(
+    graph_with_matches: pycolmap.CorrespondenceGraph,
+) -> None:
     matches = graph_with_matches.extract_matches_between_images(1, 2)
     assert matches.shape[0] == 2
 
 
-def test_correspondence_graph_has_correspondences(graph_with_matches):
+def test_correspondence_graph_has_correspondences(
+    graph_with_matches: pycolmap.CorrespondenceGraph,
+) -> None:
     assert graph_with_matches.has_correspondences(1, 0)
 
 
-def test_correspondence_graph_find_correspondences(graph_with_matches):
+def test_correspondence_graph_find_correspondences(
+    graph_with_matches: pycolmap.CorrespondenceGraph,
+) -> None:
     result = graph_with_matches.find_correspondences(1, 0)
     assert result is not None
 
 
-def test_correspondence_graph_is_two_view_observation():
+def test_correspondence_graph_is_two_view_observation() -> None:
     graph = pycolmap.CorrespondenceGraph()
     graph.add_image(1, 5)
     graph.add_image(2, 5)

--- a/src/pycolmap/scene/database_cache_test.py
+++ b/src/pycolmap/scene/database_cache_test.py
@@ -1,30 +1,32 @@
 import pycolmap
 
 
-def test_database_cache_options_default_init():
+def test_database_cache_options_default_init() -> None:
     options = pycolmap.DatabaseCacheOptions()
     assert options is not None
 
 
-def test_database_cache_options_min_num_matches_readwrite():
+def test_database_cache_options_min_num_matches_readwrite() -> None:
     options = pycolmap.DatabaseCacheOptions()
     options.min_num_matches = 20
     assert options.min_num_matches == 20
 
 
-def test_database_cache_options_ignore_watermarks_readwrite():
+def test_database_cache_options_ignore_watermarks_readwrite() -> None:
     options = pycolmap.DatabaseCacheOptions()
     options.ignore_watermarks = True
     assert options.ignore_watermarks is True
 
 
-def test_database_cache_options_load_all_images_readwrite():
+def test_database_cache_options_load_all_images_readwrite() -> None:
     options = pycolmap.DatabaseCacheOptions()
     options.load_all_images = True
     assert options.load_all_images is True
 
 
-def test_database_cache_create(populated_database):
+def test_database_cache_create(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     options = pycolmap.DatabaseCacheOptions()
     options.load_all_images = True
@@ -33,7 +35,9 @@ def test_database_cache_create(populated_database):
     assert cache.num_images() > 0
 
 
-def test_database_cache_cameras_property(populated_database):
+def test_database_cache_cameras_property(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     options = pycolmap.DatabaseCacheOptions()
     options.load_all_images = True
@@ -41,7 +45,9 @@ def test_database_cache_cameras_property(populated_database):
     assert cache.cameras is not None
 
 
-def test_database_cache_images_property(populated_database):
+def test_database_cache_images_property(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     options = pycolmap.DatabaseCacheOptions()
     options.load_all_images = True

--- a/src/pycolmap/scene/database_test.py
+++ b/src/pycolmap/scene/database_test.py
@@ -78,7 +78,7 @@ def test_database_write_and_read_keypoints(
         dtype=np.float32,
     )
     database.write_keypoints(image_id, keypoints)
-    read_keypoints = database.read_keypoints(image_id)
+    read_keypoints = database.read_keypoints(image_id)  # type: ignore[var-annotated]
     assert read_keypoints.shape[0] == 2
 
 
@@ -105,7 +105,7 @@ def test_database_write_and_read_matches(
     image_id2 = database.write_image(image2)
     matches = np.array([[0, 0], [1, 1]], dtype=np.uint32)
     database.write_matches(image_id, image_id2, matches)
-    read_matches = database.read_matches(image_id, image_id2)
+    read_matches = database.read_matches(image_id, image_id2)  # type: ignore[var-annotated]
     assert read_matches.shape[0] == 2
 
 

--- a/src/pycolmap/scene/database_test.py
+++ b/src/pycolmap/scene/database_test.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 import pycolmap
 
 
-def test_database_direct_construction_is_disallowed():
+def test_database_direct_construction_is_disallowed() -> None:
     # Regression test for https://github.com/colmap/colmap/issues/4422:
     # Database is abstract, so direct construction is disallowed. Use
     # Database.open() instead.
@@ -12,20 +14,24 @@ def test_database_direct_construction_is_disallowed():
         pycolmap.Database()
 
 
-def test_database_open_and_context_manager(tmp_path):
+def test_database_open_and_context_manager(tmp_path: Path) -> None:
     database_path = str(tmp_path / "test.db")
     with pycolmap.Database.open(database_path) as database:
         assert database is not None
 
 
-def test_database_write_and_read_camera(database, simple_camera):
+def test_database_write_and_read_camera(
+    database: pycolmap.Database, simple_camera: pycolmap.Camera
+) -> None:
     camera_id = database.write_camera(simple_camera)
     assert camera_id > 0
     read_camera = database.read_camera(camera_id)
     assert read_camera.model == pycolmap.CameraModelId.PINHOLE
 
 
-def test_database_update_camera(database, simple_camera):
+def test_database_update_camera(
+    database: pycolmap.Database, simple_camera: pycolmap.Camera
+) -> None:
     camera_id = database.write_camera(simple_camera)
     simple_camera.camera_id = camera_id
     simple_camera.width = 2048
@@ -34,14 +40,18 @@ def test_database_update_camera(database, simple_camera):
     assert updated_camera.width == 2048
 
 
-def test_database_write_and_read_image(populated_database):
+def test_database_write_and_read_image(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     assert image_id > 0
     read_image = database.read_image(image_id)
     assert read_image.name == "test.jpg"
 
 
-def test_database_update_image(populated_database):
+def test_database_update_image(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     image = database.read_image(image_id)
     image.name = "updated.jpg"
@@ -50,14 +60,18 @@ def test_database_update_image(populated_database):
     assert updated_image.name == "updated.jpg"
 
 
-def test_database_clear_cameras(database, simple_camera):
+def test_database_clear_cameras(
+    database: pycolmap.Database, simple_camera: pycolmap.Camera
+) -> None:
     database.write_camera(simple_camera)
     assert database.num_cameras() > 0
     database.clear_cameras()
     assert database.num_cameras() == 0
 
 
-def test_database_write_and_read_keypoints(populated_database):
+def test_database_write_and_read_keypoints(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     keypoints = np.array(
         [[10.0, 20.0, 1.0, 0.0, 0.0, 1.0], [30.0, 40.0, 1.0, 0.0, 0.0, 1.0]],
@@ -68,7 +82,9 @@ def test_database_write_and_read_keypoints(populated_database):
     assert read_keypoints.shape[0] == 2
 
 
-def test_database_write_and_read_descriptors(populated_database):
+def test_database_write_and_read_descriptors(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     descriptors = pycolmap.FeatureDescriptors(
         type=pycolmap.FeatureExtractorType.SIFT,
@@ -79,7 +95,9 @@ def test_database_write_and_read_descriptors(populated_database):
     assert read_descriptors is not None
 
 
-def test_database_write_and_read_matches(populated_database):
+def test_database_write_and_read_matches(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     image2 = pycolmap.Image()
     image2.name = "test2.jpg"
@@ -91,7 +109,9 @@ def test_database_write_and_read_matches(populated_database):
     assert read_matches.shape[0] == 2
 
 
-def test_database_write_and_read_two_view_geometry(populated_database):
+def test_database_write_and_read_two_view_geometry(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, image_id = populated_database
     image2 = pycolmap.Image()
     image2.name = "test2.jpg"
@@ -107,65 +127,83 @@ def test_database_write_and_read_two_view_geometry(populated_database):
     )
 
 
-def test_database_num_cameras(populated_database):
+def test_database_num_cameras(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     assert database.num_cameras() >= 1
 
 
-def test_database_num_images(populated_database):
+def test_database_num_images(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     assert database.num_images() >= 1
 
 
-def test_database_num_keypoints(database):
+def test_database_num_keypoints(database: pycolmap.Database) -> None:
     assert database.num_keypoints() >= 0
 
 
-def test_database_num_descriptors(database):
+def test_database_num_descriptors(database: pycolmap.Database) -> None:
     assert database.num_descriptors() >= 0
 
 
-def test_database_num_matches(database):
+def test_database_num_matches(database: pycolmap.Database) -> None:
     assert database.num_matches() >= 0
 
 
-def test_database_exists_camera(populated_database):
+def test_database_exists_camera(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, camera_id, _ = populated_database
     assert database.exists_camera(camera_id)
 
 
-def test_database_exists_image(populated_database):
+def test_database_exists_image(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, image_id = populated_database
     assert database.exists_image(image_id)
 
 
-def test_database_exists_keypoints(populated_database):
+def test_database_exists_keypoints(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, image_id = populated_database
     assert isinstance(database.exists_keypoints(image_id), bool)
 
 
-def test_database_exists_descriptors(populated_database):
+def test_database_exists_descriptors(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, image_id = populated_database
     assert isinstance(database.exists_descriptors(image_id), bool)
 
 
-def test_database_read_all_cameras(populated_database):
+def test_database_read_all_cameras(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     assert len(database.read_all_cameras()) >= 1
 
 
-def test_database_read_all_images(populated_database):
+def test_database_read_all_images(
+    populated_database: tuple[pycolmap.Database, int, int],
+) -> None:
     database, _, _ = populated_database
     assert len(database.read_all_images()) >= 1
 
 
-def test_database_clear_all_tables(database, simple_camera):
+def test_database_clear_all_tables(
+    database: pycolmap.Database, simple_camera: pycolmap.Camera
+) -> None:
     database.write_camera(simple_camera)
     database.clear_all_tables()
     assert database.num_cameras() == 0
 
 
-def test_database_merge(tmp_path):
+def test_database_merge(tmp_path: Path) -> None:
     path1 = str(tmp_path / "db1.db")
     path2 = str(tmp_path / "db2.db")
     path_merged = str(tmp_path / "merged.db")
@@ -186,7 +224,9 @@ def test_database_merge(tmp_path):
                 assert merged_database.num_cameras() == 2
 
 
-def test_database_transaction(database, simple_camera):
+def test_database_transaction(
+    database: pycolmap.Database, simple_camera: pycolmap.Camera
+) -> None:
     with pycolmap.DatabaseTransaction(database):
         database.write_camera(simple_camera)
     assert database.num_cameras() == 1

--- a/src/pycolmap/scene/frame_test.py
+++ b/src/pycolmap/scene/frame_test.py
@@ -1,30 +1,30 @@
 import pycolmap
 
 
-def test_frame_default_init():
+def test_frame_default_init() -> None:
     frame = pycolmap.Frame()
     assert frame is not None
 
 
-def test_frame_frame_id_readwrite():
+def test_frame_frame_id_readwrite() -> None:
     frame = pycolmap.Frame()
     frame.frame_id = 5
     assert frame.frame_id == 5
 
 
-def test_frame_rig_id_readwrite():
+def test_frame_rig_id_readwrite() -> None:
     frame = pycolmap.Frame()
     frame.rig_id = 3
     assert frame.rig_id == 3
 
 
-def test_frame_has_rig_id():
+def test_frame_has_rig_id() -> None:
     frame = pycolmap.Frame()
     frame.rig_id = 1
     assert frame.has_rig_id()
 
 
-def test_frame_add_data_id():
+def test_frame_add_data_id() -> None:
     frame = pycolmap.Frame()
     data_id = pycolmap.data_t()
     data_id.sensor_id = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=0)
@@ -33,12 +33,12 @@ def test_frame_add_data_id():
     assert frame.num_data_ids() == 1
 
 
-def test_frame_num_data_ids():
+def test_frame_num_data_ids() -> None:
     frame = pycolmap.Frame()
     assert frame.num_data_ids() == 0
 
 
-def test_frame_has_data():
+def test_frame_has_data() -> None:
     frame = pycolmap.Frame()
     data_id = pycolmap.data_t()
     data_id.sensor_id = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=0)
@@ -47,7 +47,7 @@ def test_frame_has_data():
     assert frame.has_data(data_id)
 
 
-def test_frame_clear_data_ids():
+def test_frame_clear_data_ids() -> None:
     frame = pycolmap.Frame()
     data_id = pycolmap.data_t()
     data_id.sensor_id = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=0)
@@ -57,7 +57,7 @@ def test_frame_clear_data_ids():
     assert frame.num_data_ids() == 0
 
 
-def test_frame_finalize_data_ids():
+def test_frame_finalize_data_ids() -> None:
     frame = pycolmap.Frame()
     data_id = pycolmap.data_t()
     data_id.sensor_id = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=0)
@@ -67,46 +67,46 @@ def test_frame_finalize_data_ids():
     assert frame.has_final_data_ids()
 
 
-def test_frame_has_final_data_ids():
+def test_frame_has_final_data_ids() -> None:
     frame = pycolmap.Frame()
     assert not frame.has_final_data_ids()
 
 
-def test_frame_data_ids_property():
+def test_frame_data_ids_property() -> None:
     frame = pycolmap.Frame()
     data_ids = frame.data_ids
     assert hasattr(data_ids, "__len__")
 
 
-def test_frame_data_ids_by_sensor():
+def test_frame_data_ids_by_sensor() -> None:
     frame = pycolmap.Frame()
     data_ids = frame.data_ids_by_sensor(pycolmap.SensorType.CAMERA)
     assert isinstance(data_ids, list)
 
 
-def test_frame_image_ids_property():
+def test_frame_image_ids_property() -> None:
     frame = pycolmap.Frame()
     image_ids = frame.image_ids
     assert isinstance(image_ids, list)
 
 
-def test_frame_has_pose():
+def test_frame_has_pose() -> None:
     frame = pycolmap.Frame()
     assert not frame.has_pose()
 
 
-def test_frame_reset_pose():
+def test_frame_reset_pose() -> None:
     frame = pycolmap.Frame()
     frame.reset_pose()
     assert not frame.has_pose()
 
 
-def test_frame_map_empty():
+def test_frame_map_empty() -> None:
     frame_map = pycolmap.FrameMap()
     assert len(frame_map) == 0
 
 
-def test_frame_map_insert_and_access():
+def test_frame_map_insert_and_access() -> None:
     frame_map = pycolmap.FrameMap()
     frame = pycolmap.Frame()
     frame.frame_id = 1

--- a/src/pycolmap/scene/image_test.py
+++ b/src/pycolmap/scene/image_test.py
@@ -3,36 +3,36 @@ import numpy as np
 import pycolmap
 
 
-def test_image_default_init():
+def test_image_default_init() -> None:
     image = pycolmap.Image()
     assert image is not None
 
 
-def test_image_image_id_readwrite():
+def test_image_image_id_readwrite() -> None:
     image = pycolmap.Image()
     image.image_id = 10
     assert image.image_id == 10
 
 
-def test_image_camera_id_readwrite():
+def test_image_camera_id_readwrite() -> None:
     image = pycolmap.Image()
     image.camera_id = 5
     assert image.camera_id == 5
 
 
-def test_image_frame_id_readwrite():
+def test_image_frame_id_readwrite() -> None:
     image = pycolmap.Image()
     image.frame_id = 3
     assert image.frame_id == 3
 
 
-def test_image_name_readwrite():
+def test_image_name_readwrite() -> None:
     image = pycolmap.Image()
     image.name = "test_image.jpg"
     assert image.name == "test_image.jpg"
 
 
-def test_image_points2d_readwrite():
+def test_image_points2d_readwrite() -> None:
     image = pycolmap.Image()
     point_list = pycolmap.Point2DList()
     point_list.append(pycolmap.Point2D(xy=np.array([1.0, 2.0])))
@@ -41,27 +41,27 @@ def test_image_points2d_readwrite():
     assert len(image.points2D) == 2
 
 
-def test_image_data_id_readonly():
+def test_image_data_id_readonly() -> None:
     image = pycolmap.Image()
     data_id = image.data_id
     assert data_id is not None
 
 
-def test_image_has_camera_id():
+def test_image_has_camera_id() -> None:
     image = pycolmap.Image()
     assert not image.has_camera_id()
     image.camera_id = 1
     assert image.has_camera_id()
 
 
-def test_image_has_frame_id():
+def test_image_has_frame_id() -> None:
     image = pycolmap.Image()
     assert not image.has_frame_id()
     image.frame_id = 1
     assert image.has_frame_id()
 
 
-def test_image_num_points2d():
+def test_image_num_points2d() -> None:
     image = pycolmap.Image()
     assert image.num_points2D() == 0
     point_list = pycolmap.Point2DList()
@@ -70,22 +70,22 @@ def test_image_num_points2d():
     assert image.num_points2D() == 1
 
 
-def test_image_num_points3d_readonly():
+def test_image_num_points3d_readonly() -> None:
     image = pycolmap.Image()
     assert image.num_points3D == 0
 
 
-def test_image_has_pose_readonly():
+def test_image_has_pose_readonly() -> None:
     image = pycolmap.Image()
     assert isinstance(image.has_pose, bool)
 
 
-def test_image_map_empty():
+def test_image_map_empty() -> None:
     image_map = pycolmap.ImageMap()
     assert len(image_map) == 0
 
 
-def test_image_map_insert_and_access():
+def test_image_map_insert_and_access() -> None:
     image_map = pycolmap.ImageMap()
     image = pycolmap.Image()
     image.image_id = 1

--- a/src/pycolmap/scene/point2d_test.py
+++ b/src/pycolmap/scene/point2d_test.py
@@ -3,55 +3,55 @@ import numpy as np
 import pycolmap
 
 
-def test_point2d_default_init():
+def test_point2d_default_init() -> None:
     point = pycolmap.Point2D()
     assert point is not None
 
 
-def test_point2d_init_with_xy():
+def test_point2d_init_with_xy() -> None:
     point = pycolmap.Point2D(xy=np.array([1.0, 2.0]))
     assert point is not None
 
 
-def test_point2d_init_with_xy_and_point3d_id():
+def test_point2d_init_with_xy_and_point3d_id() -> None:
     point = pycolmap.Point2D(xy=np.array([1.0, 2.0]), point3D_id=5)
     assert point.point3D_id == 5
 
 
-def test_point2d_xy_readwrite():
+def test_point2d_xy_readwrite() -> None:
     point = pycolmap.Point2D()
     point.xy = np.array([3.0, 4.0])
     np.testing.assert_array_almost_equal(point.xy, [3.0, 4.0])
 
 
-def test_point2d_x():
+def test_point2d_x() -> None:
     point = pycolmap.Point2D(xy=np.array([10.0, 20.0]))
     assert point.x() == 10.0
 
 
-def test_point2d_y():
+def test_point2d_y() -> None:
     point = pycolmap.Point2D(xy=np.array([10.0, 20.0]))
     assert point.y() == 20.0
 
 
-def test_point2d_point3d_id_readwrite():
+def test_point2d_point3d_id_readwrite() -> None:
     point = pycolmap.Point2D()
     point.point3D_id = 42
     assert point.point3D_id == 42
 
 
-def test_point2d_has_point3d_false():
+def test_point2d_has_point3d_false() -> None:
     point = pycolmap.Point2D()
     assert not point.has_point3D()
 
 
-def test_point2d_has_point3d_true():
+def test_point2d_has_point3d_true() -> None:
     point = pycolmap.Point2D()
     point.point3D_id = 1
     assert point.has_point3D()
 
 
-def test_point2d_list_append_and_len():
+def test_point2d_list_append_and_len() -> None:
     point_list = pycolmap.Point2DList()
     point_list.append(pycolmap.Point2D(xy=np.array([1.0, 2.0])))
     point_list.append(pycolmap.Point2D(xy=np.array([3.0, 4.0])))

--- a/src/pycolmap/scene/point3d_test.py
+++ b/src/pycolmap/scene/point3d_test.py
@@ -3,36 +3,36 @@ import numpy as np
 import pycolmap
 
 
-def test_point3d_default_init():
+def test_point3d_default_init() -> None:
     point = pycolmap.Point3D()
     assert point is not None
 
 
-def test_point3d_xyz_readwrite():
+def test_point3d_xyz_readwrite() -> None:
     point = pycolmap.Point3D()
     point.xyz = np.array([1.0, 2.0, 3.0])
     np.testing.assert_array_almost_equal(point.xyz, [1.0, 2.0, 3.0])
 
 
-def test_point3d_color_readwrite():
+def test_point3d_color_readwrite() -> None:
     point = pycolmap.Point3D()
     point.color = np.array([255, 128, 0], dtype=np.uint8)
     np.testing.assert_array_equal(point.color, [255, 128, 0])
 
 
-def test_point3d_error_readwrite():
+def test_point3d_error_readwrite() -> None:
     point = pycolmap.Point3D()
     point.error = 0.5
     assert point.error == 0.5
 
 
-def test_point3d_has_error():
+def test_point3d_has_error() -> None:
     point = pycolmap.Point3D()
     result = point.has_error()
     assert isinstance(result, bool)
 
 
-def test_point3d_track_readwrite():
+def test_point3d_track_readwrite() -> None:
     point = pycolmap.Point3D()
     track = pycolmap.Track()
     track.add_element(image_id=1, point2D_idx=0)
@@ -40,6 +40,6 @@ def test_point3d_track_readwrite():
     assert point.track.length() == 1
 
 
-def test_point3d_map_empty():
+def test_point3d_map_empty() -> None:
     point_map = pycolmap.Point3DMap()
     assert len(point_map) == 0

--- a/src/pycolmap/scene/pose_graph_test.py
+++ b/src/pycolmap/scene/pose_graph_test.py
@@ -1,31 +1,31 @@
 import pycolmap
 
 
-def test_pose_graph_edge_default_init():
+def test_pose_graph_edge_default_init() -> None:
     edge = pycolmap.PoseGraphEdge()
     assert edge is not None
 
 
-def test_pose_graph_edge_init_with_rigid3d():
+def test_pose_graph_edge_init_with_rigid3d() -> None:
     rigid = pycolmap.Rigid3d()
     edge = pycolmap.PoseGraphEdge(cam2_from_cam1=rigid)
     assert edge is not None
 
 
-def test_pose_graph_edge_cam2_from_cam1_readwrite():
+def test_pose_graph_edge_cam2_from_cam1_readwrite() -> None:
     edge = pycolmap.PoseGraphEdge()
     rigid = pycolmap.Rigid3d()
     edge.cam2_from_cam1 = rigid
     assert isinstance(edge.cam2_from_cam1, pycolmap.Rigid3d)
 
 
-def test_pose_graph_edge_num_matches_readwrite():
+def test_pose_graph_edge_num_matches_readwrite() -> None:
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 100
     assert edge.num_matches == 100
 
 
-def test_pose_graph_edge_valid_readwrite():
+def test_pose_graph_edge_valid_readwrite() -> None:
     edge = pycolmap.PoseGraphEdge()
     edge.valid = True
     assert edge.valid is True
@@ -33,29 +33,29 @@ def test_pose_graph_edge_valid_readwrite():
     assert edge.valid is False
 
 
-def test_pose_graph_edge_invert():
+def test_pose_graph_edge_invert() -> None:
     edge = pycolmap.PoseGraphEdge()
     edge.valid = True
     edge.num_matches = 50
     edge.invert()
 
 
-def test_pose_graph_default_init():
+def test_pose_graph_default_init() -> None:
     graph = pycolmap.PoseGraph()
     assert graph is not None
 
 
-def test_pose_graph_empty():
+def test_pose_graph_empty() -> None:
     graph = pycolmap.PoseGraph()
     assert graph.empty is True
 
 
-def test_pose_graph_num_edges():
+def test_pose_graph_num_edges() -> None:
     graph = pycolmap.PoseGraph()
     assert graph.num_edges == 0
 
 
-def test_pose_graph_add_edge():
+def test_pose_graph_add_edge() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -64,7 +64,7 @@ def test_pose_graph_add_edge():
     assert graph.num_edges == 1
 
 
-def test_pose_graph_has_edge():
+def test_pose_graph_has_edge() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -74,7 +74,7 @@ def test_pose_graph_has_edge():
     assert not graph.has_edge(3, 4)
 
 
-def test_pose_graph_get_edge():
+def test_pose_graph_get_edge() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 42
@@ -84,7 +84,7 @@ def test_pose_graph_get_edge():
     assert retrieved_edge.num_matches == 42
 
 
-def test_pose_graph_delete_edge():
+def test_pose_graph_delete_edge() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -95,7 +95,7 @@ def test_pose_graph_delete_edge():
     assert graph.num_edges == 0
 
 
-def test_pose_graph_update_edge():
+def test_pose_graph_update_edge() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -109,7 +109,7 @@ def test_pose_graph_update_edge():
     assert retrieved.num_matches == 99
 
 
-def test_pose_graph_clear():
+def test_pose_graph_clear() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -120,7 +120,7 @@ def test_pose_graph_clear():
     assert graph.empty is True
 
 
-def test_pose_graph_edges_property():
+def test_pose_graph_edges_property() -> None:
     graph = pycolmap.PoseGraph()
     edge = pycolmap.PoseGraphEdge()
     edge.num_matches = 10
@@ -130,7 +130,7 @@ def test_pose_graph_edges_property():
     assert len(edges) == 1
 
 
-def test_pose_graph_edge_map_type():
+def test_pose_graph_edge_map_type() -> None:
     graph = pycolmap.PoseGraph()
     edges = graph.edges
     assert isinstance(edges, pycolmap.PoseGraphEdgeMap)

--- a/src/pycolmap/scene/reconstruction_manager_test.py
+++ b/src/pycolmap/scene/reconstruction_manager_test.py
@@ -1,40 +1,41 @@
 import os
+from pathlib import Path
 
 import pycolmap
 
 
-def test_reconstruction_manager_init():
+def test_reconstruction_manager_init() -> None:
     manager = pycolmap.ReconstructionManager()
     assert manager is not None
 
 
-def test_reconstruction_manager_size():
+def test_reconstruction_manager_size() -> None:
     manager = pycolmap.ReconstructionManager()
     assert manager.size() == 0
 
 
-def test_reconstruction_manager_add():
+def test_reconstruction_manager_add() -> None:
     manager = pycolmap.ReconstructionManager()
     idx = manager.add()
     assert idx == 0
     assert manager.size() == 1
 
 
-def test_reconstruction_manager_get():
+def test_reconstruction_manager_get() -> None:
     manager = pycolmap.ReconstructionManager()
     idx = manager.add()
     reconstruction = manager.get(idx)
     assert reconstruction is not None
 
 
-def test_reconstruction_manager_delete():
+def test_reconstruction_manager_delete() -> None:
     manager = pycolmap.ReconstructionManager()
     idx = manager.add()
     manager.delete(idx)
     assert manager.size() == 0
 
 
-def test_reconstruction_manager_clear():
+def test_reconstruction_manager_clear() -> None:
     manager = pycolmap.ReconstructionManager()
     manager.add()
     manager.add()
@@ -43,7 +44,9 @@ def test_reconstruction_manager_clear():
     assert manager.size() == 0
 
 
-def test_reconstruction_manager_write_read_roundtrip(tmp_path, simple_camera):
+def test_reconstruction_manager_write_read_roundtrip(
+    tmp_path: Path, simple_camera: pycolmap.Camera
+) -> None:
     manager = pycolmap.ReconstructionManager()
     idx = manager.add()
     reconstruction = manager.get(idx)

--- a/src/pycolmap/scene/reconstruction_test.py
+++ b/src/pycolmap/scene/reconstruction_test.py
@@ -1,14 +1,17 @@
 import os
+from pathlib import Path
 
 import pycolmap
 
 
-def test_reconstruction_default_init():
+def test_reconstruction_default_init() -> None:
     reconstruction = pycolmap.Reconstruction()
     assert reconstruction is not None
 
 
-def test_reconstruction_copy_init(synthetic_reconstruction):
+def test_reconstruction_copy_init(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     assert (
         reconstruction_copy.num_cameras()
@@ -16,176 +19,236 @@ def test_reconstruction_copy_init(synthetic_reconstruction):
     )
 
 
-def test_reconstruction_num_rigs(synthetic_reconstruction):
+def test_reconstruction_num_rigs(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_rigs(), int)
     assert synthetic_reconstruction.num_rigs() > 0
 
 
-def test_reconstruction_num_cameras(synthetic_reconstruction):
+def test_reconstruction_num_cameras(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_cameras(), int)
     assert synthetic_reconstruction.num_cameras() > 0
 
 
-def test_reconstruction_num_frames(synthetic_reconstruction):
+def test_reconstruction_num_frames(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_frames(), int)
     assert synthetic_reconstruction.num_frames() > 0
 
 
-def test_reconstruction_num_images(synthetic_reconstruction):
+def test_reconstruction_num_images(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_images(), int)
     assert synthetic_reconstruction.num_images() > 0
 
 
-def test_reconstruction_num_points3d(synthetic_reconstruction):
+def test_reconstruction_num_points3d(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_points3D(), int)
     assert synthetic_reconstruction.num_points3D() > 0
 
 
-def test_reconstruction_num_reg_frames(synthetic_reconstruction):
+def test_reconstruction_num_reg_frames(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_reg_frames(), int)
 
 
-def test_reconstruction_num_reg_images(synthetic_reconstruction):
+def test_reconstruction_num_reg_images(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     assert isinstance(synthetic_reconstruction.num_reg_images(), int)
 
 
-def test_reconstruction_cameras_property(synthetic_reconstruction):
+def test_reconstruction_cameras_property(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     cameras = synthetic_reconstruction.cameras
     assert len(cameras) > 0
 
 
-def test_reconstruction_frames_property(synthetic_reconstruction):
+def test_reconstruction_frames_property(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     frames = synthetic_reconstruction.frames
     assert frames is not None
 
 
-def test_reconstruction_images_property(synthetic_reconstruction):
+def test_reconstruction_images_property(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     images = synthetic_reconstruction.images
     assert len(images) > 0
 
 
-def test_reconstruction_points3d_property(synthetic_reconstruction):
+def test_reconstruction_points3d_property(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     points = synthetic_reconstruction.points3D
     assert len(points) > 0
 
 
-def test_reconstruction_camera_access(synthetic_reconstruction):
+def test_reconstruction_camera_access(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     camera_ids = list(synthetic_reconstruction.cameras.keys())
     camera = synthetic_reconstruction.camera(camera_ids[0])
     assert camera is not None
 
 
-def test_reconstruction_frame_access(synthetic_reconstruction):
+def test_reconstruction_frame_access(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     frame_ids = list(synthetic_reconstruction.frames.keys())
     frame = synthetic_reconstruction.frame(frame_ids[0])
     assert frame is not None
 
 
-def test_reconstruction_image_access(synthetic_reconstruction):
+def test_reconstruction_image_access(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     image_ids = list(synthetic_reconstruction.images.keys())
     image = synthetic_reconstruction.image(image_ids[0])
     assert image is not None
 
 
-def test_reconstruction_point3d_access(synthetic_reconstruction):
+def test_reconstruction_point3d_access(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     point_ids = list(synthetic_reconstruction.points3D.keys())
     point = synthetic_reconstruction.point3D(point_ids[0])
     assert point is not None
 
 
-def test_reconstruction_exists_camera(synthetic_reconstruction):
+def test_reconstruction_exists_camera(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     camera_ids = list(synthetic_reconstruction.cameras.keys())
     assert synthetic_reconstruction.exists_camera(camera_ids[0])
     assert not synthetic_reconstruction.exists_camera(99999)
 
 
-def test_reconstruction_exists_frame(synthetic_reconstruction):
+def test_reconstruction_exists_frame(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     frame_ids = list(synthetic_reconstruction.frames.keys())
     assert synthetic_reconstruction.exists_frame(frame_ids[0])
 
 
-def test_reconstruction_exists_image(synthetic_reconstruction):
+def test_reconstruction_exists_image(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     image_ids = list(synthetic_reconstruction.images.keys())
     assert synthetic_reconstruction.exists_image(image_ids[0])
     assert not synthetic_reconstruction.exists_image(99999)
 
 
-def test_reconstruction_exists_point3d(synthetic_reconstruction):
+def test_reconstruction_exists_point3d(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     point_ids = list(synthetic_reconstruction.points3D.keys())
     assert synthetic_reconstruction.exists_point3D(point_ids[0])
     assert not synthetic_reconstruction.exists_point3D(99999)
 
 
-def test_reconstruction_reg_image_ids(synthetic_reconstruction):
+def test_reconstruction_reg_image_ids(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reg_ids = synthetic_reconstruction.reg_image_ids()
     assert isinstance(reg_ids, list)
 
 
-def test_reconstruction_reg_frame_ids(synthetic_reconstruction):
+def test_reconstruction_reg_frame_ids(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reg_ids = synthetic_reconstruction.reg_frame_ids()
     assert isinstance(reg_ids, list)
 
 
-def test_reconstruction_point3d_ids(synthetic_reconstruction):
+def test_reconstruction_point3d_ids(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     point_ids = synthetic_reconstruction.point3D_ids()
     assert len(point_ids) > 0
 
 
-def test_reconstruction_is_valid(synthetic_reconstruction):
+def test_reconstruction_is_valid(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     result = synthetic_reconstruction.is_valid()
     assert isinstance(result, bool)
 
 
-def test_reconstruction_compute_num_observations(synthetic_reconstruction):
+def test_reconstruction_compute_num_observations(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     count = synthetic_reconstruction.compute_num_observations()
     assert isinstance(count, int)
 
 
-def test_reconstruction_compute_mean_track_length(synthetic_reconstruction):
+def test_reconstruction_compute_mean_track_length(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     length = synthetic_reconstruction.compute_mean_track_length()
     assert isinstance(length, float)
 
 
 def test_reconstruction_compute_mean_reprojection_error(
-    synthetic_reconstruction,
-):
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     error = reconstruction_copy.compute_mean_reprojection_error()
     assert isinstance(error, float)
 
 
 def test_reconstruction_compute_mean_observations_per_reg_image(
-    synthetic_reconstruction,
-):
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     mean_obs = (
         synthetic_reconstruction.compute_mean_observations_per_reg_image()
     )
     assert isinstance(mean_obs, float)
 
 
-def test_reconstruction_summary(synthetic_reconstruction):
+def test_reconstruction_summary(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     summary = synthetic_reconstruction.summary()
     assert isinstance(summary, str)
     assert "Reconstruction" in summary
 
 
-def test_reconstruction_compute_bounding_box(synthetic_reconstruction):
+def test_reconstruction_compute_bounding_box(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     bbox = synthetic_reconstruction.compute_bounding_box()
     assert bbox is not None
 
 
-def test_reconstruction_compute_centroid(synthetic_reconstruction):
+def test_reconstruction_compute_centroid(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     centroid = synthetic_reconstruction.compute_centroid()
     assert centroid.shape == (3,)
 
 
-def test_reconstruction_normalize(synthetic_reconstruction):
+def test_reconstruction_normalize(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     reconstruction_copy.normalize()
     assert reconstruction_copy.num_points3D() > 0
 
 
-def test_reconstruction_transform(synthetic_reconstruction):
+def test_reconstruction_transform(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     transform = pycolmap.Sim3d()
     reconstruction_copy.transform(transform)
@@ -193,8 +256,8 @@ def test_reconstruction_transform(synthetic_reconstruction):
 
 
 def test_reconstruction_write_read_binary_roundtrip(
-    synthetic_reconstruction, tmp_path
-):
+    synthetic_reconstruction: pycolmap.Reconstruction, tmp_path: Path
+) -> None:
     output_dir = str(tmp_path / "binary")
 
     os.makedirs(output_dir)
@@ -206,8 +269,8 @@ def test_reconstruction_write_read_binary_roundtrip(
 
 
 def test_reconstruction_write_read_text_roundtrip(
-    synthetic_reconstruction, tmp_path
-):
+    synthetic_reconstruction: pycolmap.Reconstruction, tmp_path: Path
+) -> None:
     output_dir = str(tmp_path / "text")
 
     os.makedirs(output_dir)
@@ -218,7 +281,7 @@ def test_reconstruction_write_read_text_roundtrip(
     assert loaded.num_images() == synthetic_reconstruction.num_images()
 
 
-def test_reconstruction_add_camera():
+def test_reconstruction_add_camera() -> None:
     reconstruction = pycolmap.Reconstruction()
     camera = pycolmap.Camera.create_from_model_id(
         1, pycolmap.CameraModelId.PINHOLE, 500.0, 1024, 768
@@ -227,14 +290,18 @@ def test_reconstruction_add_camera():
     assert reconstruction.exists_camera(1)
 
 
-def test_reconstruction_find_image_with_name(synthetic_reconstruction):
+def test_reconstruction_find_image_with_name(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     image_ids = list(synthetic_reconstruction.images.keys())
     first_image = synthetic_reconstruction.image(image_ids[0])
     found = synthetic_reconstruction.find_image_with_name(first_image.name)
     assert found is not None
 
 
-def test_reconstruction_find_common_reg_image_ids(synthetic_reconstruction):
+def test_reconstruction_find_common_reg_image_ids(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     common_ids = synthetic_reconstruction.find_common_reg_image_ids(
         reconstruction_copy
@@ -243,8 +310,8 @@ def test_reconstruction_find_common_reg_image_ids(synthetic_reconstruction):
 
 
 def test_reconstruction_export_import_ply_roundtrip(
-    synthetic_reconstruction, tmp_path
-):
+    synthetic_reconstruction: pycolmap.Reconstruction, tmp_path: Path
+) -> None:
     ply_path = str(tmp_path / "points.ply")
     synthetic_reconstruction.export_PLY(ply_path)
     new_reconstruction = pycolmap.Reconstruction()
@@ -252,7 +319,9 @@ def test_reconstruction_export_import_ply_roundtrip(
     assert new_reconstruction.num_points3D() > 0
 
 
-def test_reconstruction_crop(synthetic_reconstruction):
+def test_reconstruction_crop(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     bbox = reconstruction_copy.compute_bounding_box()
     reconstruction_copy.crop(bbox)
@@ -260,8 +329,8 @@ def test_reconstruction_crop(synthetic_reconstruction):
 
 
 def test_reconstruction_delete_all_points2d_and_points3d(
-    synthetic_reconstruction,
-):
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     reconstruction_copy = pycolmap.Reconstruction(synthetic_reconstruction)
     reconstruction_copy.delete_all_points2D_and_points3D()
     assert reconstruction_copy.num_points3D() == 0

--- a/src/pycolmap/scene/rig_test.py
+++ b/src/pycolmap/scene/rig_test.py
@@ -1,12 +1,12 @@
 import pycolmap
 
 
-def test_rig_config_camera_default_init():
+def test_rig_config_camera_default_init() -> None:
     rig_camera = pycolmap.RigConfigCamera()
     assert rig_camera is not None
 
 
-def test_rig_config_camera_ref_sensor_readwrite():
+def test_rig_config_camera_ref_sensor_readwrite() -> None:
     rig_camera = pycolmap.RigConfigCamera()
     rig_camera.ref_sensor = True
     assert rig_camera.ref_sensor is True
@@ -14,18 +14,18 @@ def test_rig_config_camera_ref_sensor_readwrite():
     assert rig_camera.ref_sensor is False
 
 
-def test_rig_config_camera_image_prefix_readwrite():
+def test_rig_config_camera_image_prefix_readwrite() -> None:
     rig_camera = pycolmap.RigConfigCamera()
     rig_camera.image_prefix = "cam0_"
     assert rig_camera.image_prefix == "cam0_"
 
 
-def test_rig_config_default_init():
+def test_rig_config_default_init() -> None:
     config = pycolmap.RigConfig()
     assert config is not None
 
 
-def test_rig_config_cameras_readwrite():
+def test_rig_config_cameras_readwrite() -> None:
     config = pycolmap.RigConfig()
     rig_camera = pycolmap.RigConfigCamera()
     rig_camera.ref_sensor = True

--- a/src/pycolmap/scene/synthetic_test.py
+++ b/src/pycolmap/scene/synthetic_test.py
@@ -1,7 +1,7 @@
 import pycolmap
 
 
-def test_synthetic_dataset_match_config_enum():
+def test_synthetic_dataset_match_config_enum() -> None:
     assert {
         k: int(v)
         for k, v in pycolmap.SyntheticDatasetMatchConfig.__members__.items()
@@ -12,54 +12,54 @@ def test_synthetic_dataset_match_config_enum():
     }
 
 
-def test_synthetic_dataset_options_default_init():
+def test_synthetic_dataset_options_default_init() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     assert options is not None
 
 
-def test_synthetic_dataset_options_num_rigs_readwrite():
+def test_synthetic_dataset_options_num_rigs_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_rigs = 2
     assert options.num_rigs == 2
 
 
-def test_synthetic_dataset_options_num_cameras_per_rig_readwrite():
+def test_synthetic_dataset_options_num_cameras_per_rig_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_cameras_per_rig = 3
     assert options.num_cameras_per_rig == 3
 
 
-def test_synthetic_dataset_options_num_frames_per_rig_readwrite():
+def test_synthetic_dataset_options_num_frames_per_rig_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_frames_per_rig = 5
     assert options.num_frames_per_rig == 5
 
 
-def test_synthetic_dataset_options_num_points3d_readwrite():
+def test_synthetic_dataset_options_num_points3d_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_points3D = 100
     assert options.num_points3D == 100
 
 
-def test_synthetic_dataset_options_track_length_readwrite():
+def test_synthetic_dataset_options_track_length_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.track_length = 3
     assert options.track_length == 3
 
 
-def test_synthetic_dataset_options_camera_model_id_readwrite():
+def test_synthetic_dataset_options_camera_model_id_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.camera_model_id = pycolmap.CameraModelId.PINHOLE
     assert options.camera_model_id == pycolmap.CameraModelId.PINHOLE
 
 
-def test_synthetic_dataset_options_match_config_readwrite():
+def test_synthetic_dataset_options_match_config_readwrite() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.match_config = pycolmap.SyntheticDatasetMatchConfig.CHAINED
     assert options.match_config == pycolmap.SyntheticDatasetMatchConfig.CHAINED
 
 
-def test_synthesize_dataset():
+def test_synthesize_dataset() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_cameras_per_rig = 1
     options.num_frames_per_rig = 2
@@ -70,24 +70,24 @@ def test_synthesize_dataset():
     assert reconstruction.num_points3D() > 0
 
 
-def test_synthetic_noise_options_default_init():
+def test_synthetic_noise_options_default_init() -> None:
     options = pycolmap.SyntheticNoiseOptions()
     assert options is not None
 
 
-def test_synthetic_noise_options_point2d_stddev_readwrite():
+def test_synthetic_noise_options_point2d_stddev_readwrite() -> None:
     options = pycolmap.SyntheticNoiseOptions()
     options.point2D_stddev = 0.5
     assert options.point2D_stddev == 0.5
 
 
-def test_synthetic_noise_options_point3d_stddev_readwrite():
+def test_synthetic_noise_options_point3d_stddev_readwrite() -> None:
     options = pycolmap.SyntheticNoiseOptions()
     options.point3D_stddev = 0.1
     assert options.point3D_stddev == 0.1
 
 
-def test_synthesize_noise():
+def test_synthesize_noise() -> None:
     dataset_options = pycolmap.SyntheticDatasetOptions()
     dataset_options.num_cameras_per_rig = 1
     dataset_options.num_frames_per_rig = 2
@@ -100,12 +100,12 @@ def test_synthesize_noise():
     assert reconstruction.num_points3D() > 0
 
 
-def test_synthetic_image_options_default_init():
+def test_synthetic_image_options_default_init() -> None:
     options = pycolmap.SyntheticImageOptions()
     assert options is not None
 
 
-def test_synthetic_image_options_feature_peak_radius_readwrite():
+def test_synthetic_image_options_feature_peak_radius_readwrite() -> None:
     options = pycolmap.SyntheticImageOptions()
     options.feature_peak_radius = 5
     assert options.feature_peak_radius == 5

--- a/src/pycolmap/scene/track_test.py
+++ b/src/pycolmap/scene/track_test.py
@@ -1,46 +1,46 @@
 import pycolmap
 
 
-def test_track_element_default_init():
+def test_track_element_default_init() -> None:
     element = pycolmap.TrackElement()
     assert element is not None
 
 
-def test_track_element_init_with_args():
+def test_track_element_init_with_args() -> None:
     element = pycolmap.TrackElement(image_id=1, point2D_idx=5)
     assert element.image_id == 1
     assert element.point2D_idx == 5
 
 
-def test_track_element_image_id_readwrite():
+def test_track_element_image_id_readwrite() -> None:
     element = pycolmap.TrackElement()
     element.image_id = 10
     assert element.image_id == 10
 
 
-def test_track_element_point2d_idx_readwrite():
+def test_track_element_point2d_idx_readwrite() -> None:
     element = pycolmap.TrackElement()
     element.point2D_idx = 20
     assert element.point2D_idx == 20
 
 
-def test_track_default_init():
+def test_track_default_init() -> None:
     track = pycolmap.Track()
     assert track is not None
 
 
-def test_track_length():
+def test_track_length() -> None:
     track = pycolmap.Track()
     assert track.length() == 0
 
 
-def test_track_add_element():
+def test_track_add_element() -> None:
     track = pycolmap.Track()
     track.add_element(image_id=1, point2D_idx=0)
     assert track.length() == 1
 
 
-def test_track_add_elements():
+def test_track_add_elements() -> None:
     track = pycolmap.Track()
     elements = [
         pycolmap.TrackElement(image_id=1, point2D_idx=0),
@@ -50,7 +50,7 @@ def test_track_add_elements():
     assert track.length() == 2
 
 
-def test_track_element_access():
+def test_track_element_access() -> None:
     track = pycolmap.Track()
     track.add_element(image_id=5, point2D_idx=10)
     element = track.element(0)
@@ -58,7 +58,7 @@ def test_track_element_access():
     assert element.point2D_idx == 10
 
 
-def test_track_set_element():
+def test_track_set_element() -> None:
     track = pycolmap.Track()
     track.add_element(image_id=1, point2D_idx=0)
     new_element = pycolmap.TrackElement(image_id=99, point2D_idx=88)
@@ -67,7 +67,7 @@ def test_track_set_element():
     assert track.element(0).point2D_idx == 88
 
 
-def test_track_delete_element():
+def test_track_delete_element() -> None:
     track = pycolmap.Track()
     track.add_element(image_id=1, point2D_idx=0)
     track.add_element(image_id=2, point2D_idx=1)
@@ -75,13 +75,13 @@ def test_track_delete_element():
     assert track.length() == 1
 
 
-def test_track_reserve():
+def test_track_reserve() -> None:
     track = pycolmap.Track()
     track.reserve(100)
     assert track.length() == 0
 
 
-def test_track_compress():
+def test_track_compress() -> None:
     track = pycolmap.Track()
     track.reserve(100)
     track.add_element(image_id=1, point2D_idx=0)
@@ -89,7 +89,7 @@ def test_track_compress():
     assert track.length() == 1
 
 
-def test_track_elements_readwrite():
+def test_track_elements_readwrite() -> None:
     track = pycolmap.Track()
     track.add_element(image_id=1, point2D_idx=0)
     track.add_element(image_id=2, point2D_idx=1)

--- a/src/pycolmap/scene/two_view_geometry_test.py
+++ b/src/pycolmap/scene/two_view_geometry_test.py
@@ -3,82 +3,82 @@ import numpy as np
 import pycolmap
 
 
-def test_two_view_geometry_configuration_undefined():
+def test_two_view_geometry_configuration_undefined() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.UNDEFINED is not None
 
 
-def test_two_view_geometry_configuration_degenerate():
+def test_two_view_geometry_configuration_degenerate() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.DEGENERATE is not None
 
 
-def test_two_view_geometry_configuration_calibrated():
+def test_two_view_geometry_configuration_calibrated() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.CALIBRATED is not None
 
 
-def test_two_view_geometry_configuration_uncalibrated():
+def test_two_view_geometry_configuration_uncalibrated() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.UNCALIBRATED is not None
 
 
-def test_two_view_geometry_configuration_planar():
+def test_two_view_geometry_configuration_planar() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.PLANAR is not None
 
 
-def test_two_view_geometry_configuration_panoramic():
+def test_two_view_geometry_configuration_panoramic() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.PANORAMIC is not None
 
 
-def test_two_view_geometry_configuration_planar_or_panoramic():
+def test_two_view_geometry_configuration_planar_or_panoramic() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.PLANAR_OR_PANORAMIC is not None
 
 
-def test_two_view_geometry_configuration_watermark():
+def test_two_view_geometry_configuration_watermark() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.WATERMARK is not None
 
 
-def test_two_view_geometry_configuration_multiple():
+def test_two_view_geometry_configuration_multiple() -> None:
     assert pycolmap.TwoViewGeometryConfiguration.MULTIPLE is not None
 
 
-def test_two_view_geometry_default_init():
+def test_two_view_geometry_default_init() -> None:
     geometry = pycolmap.TwoViewGeometry()
     assert geometry is not None
 
 
-def test_two_view_geometry_config_readwrite():
+def test_two_view_geometry_config_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     geometry.config = pycolmap.TwoViewGeometryConfiguration.CALIBRATED
     assert geometry.config == pycolmap.TwoViewGeometryConfiguration.CALIBRATED
 
 
-def test_two_view_geometry_e_readwrite():
+def test_two_view_geometry_e_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     essential = np.eye(3)
     geometry.E = essential
     np.testing.assert_array_almost_equal(geometry.E, essential)
 
 
-def test_two_view_geometry_f_readwrite():
+def test_two_view_geometry_f_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     fundamental = np.eye(3)
     geometry.F = fundamental
     np.testing.assert_array_almost_equal(geometry.F, fundamental)
 
 
-def test_two_view_geometry_h_readwrite():
+def test_two_view_geometry_h_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     homography = np.eye(3)
     geometry.H = homography
     np.testing.assert_array_almost_equal(geometry.H, homography)
 
 
-def test_two_view_geometry_cam2_from_cam1_readwrite():
+def test_two_view_geometry_cam2_from_cam1_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     rigid = pycolmap.Rigid3d()
     geometry.cam2_from_cam1 = rigid
     assert isinstance(geometry.cam2_from_cam1, pycolmap.Rigid3d)
 
 
-def test_two_view_geometry_inlier_matches_readwrite():
+def test_two_view_geometry_inlier_matches_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     matches = np.array([[0, 1], [2, 3]], dtype=np.uint32)
     geometry.inlier_matches = matches
@@ -86,13 +86,13 @@ def test_two_view_geometry_inlier_matches_readwrite():
     assert result.shape[0] == 2
 
 
-def test_two_view_geometry_tri_angle_readwrite():
+def test_two_view_geometry_tri_angle_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     geometry.tri_angle = 1.5
     assert geometry.tri_angle == 1.5
 
 
-def test_two_view_geometry_invert():
+def test_two_view_geometry_invert() -> None:
     geometry = pycolmap.TwoViewGeometry()
     geometry.config = pycolmap.TwoViewGeometryConfiguration.CALIBRATED
     geometry.invert()

--- a/src/pycolmap/scene/two_view_geometry_test.py
+++ b/src/pycolmap/scene/two_view_geometry_test.py
@@ -53,22 +53,22 @@ def test_two_view_geometry_config_readwrite() -> None:
 def test_two_view_geometry_e_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     essential = np.eye(3)
-    geometry.E = essential
-    np.testing.assert_array_almost_equal(geometry.E, essential)
+    geometry.E = essential  # type: ignore[assignment]
+    np.testing.assert_array_almost_equal(geometry.E, essential)  # type: ignore[arg-type]
 
 
 def test_two_view_geometry_f_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     fundamental = np.eye(3)
-    geometry.F = fundamental
-    np.testing.assert_array_almost_equal(geometry.F, fundamental)
+    geometry.F = fundamental  # type: ignore[assignment]
+    np.testing.assert_array_almost_equal(geometry.F, fundamental)  # type: ignore[arg-type]
 
 
 def test_two_view_geometry_h_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     homography = np.eye(3)
-    geometry.H = homography
-    np.testing.assert_array_almost_equal(geometry.H, homography)
+    geometry.H = homography  # type: ignore[assignment]
+    np.testing.assert_array_almost_equal(geometry.H, homography)  # type: ignore[arg-type]
 
 
 def test_two_view_geometry_cam2_from_cam1_readwrite() -> None:

--- a/src/pycolmap/sensor/bitmap_test.py
+++ b/src/pycolmap/sensor/bitmap_test.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 import numpy as np
 
 import pycolmap
 
 
-def test_bitmap_rescale_filter_enum():
+def test_bitmap_rescale_filter_enum() -> None:
     assert {
         k: int(v) for k, v in pycolmap.BitmapRescaleFilter.__members__.items()
     } == {
@@ -12,27 +14,27 @@ def test_bitmap_rescale_filter_enum():
     }
 
 
-def test_bitmap_default_init():
+def test_bitmap_default_init() -> None:
     bitmap = pycolmap.Bitmap()
     assert bitmap is not None
     assert bitmap.is_empty
 
 
-def test_bitmap_init_width_height_rgb():
+def test_bitmap_init_width_height_rgb() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=True)
     assert bitmap.width == 64
     assert bitmap.height == 48
     assert bitmap.is_rgb
 
 
-def test_bitmap_init_width_height_grey():
+def test_bitmap_init_width_height_grey() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=False)
     assert bitmap.width == 64
     assert bitmap.height == 48
     assert bitmap.is_grey
 
 
-def test_bitmap_init_with_linear_colorspace():
+def test_bitmap_init_with_linear_colorspace() -> None:
     bitmap = pycolmap.Bitmap(
         width=64, height=48, as_rgb=True, linear_colorspace=True
     )
@@ -40,7 +42,7 @@ def test_bitmap_init_with_linear_colorspace():
     assert bitmap.height == 48
 
 
-def test_bitmap_readonly_props():
+def test_bitmap_readonly_props() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     assert isinstance(bitmap.width, int)
     assert isinstance(bitmap.height, int)
@@ -55,7 +57,7 @@ def test_bitmap_readonly_props():
     assert not bitmap.is_empty
 
 
-def test_bitmap_readonly_props_grey():
+def test_bitmap_readonly_props_grey() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=False)
     assert bitmap.channels == 1
     assert bitmap.bits_per_pixel == 8
@@ -63,7 +65,7 @@ def test_bitmap_readonly_props_grey():
     assert not bitmap.is_rgb
 
 
-def test_bitmap_from_array_grey():
+def test_bitmap_from_array_grey() -> None:
     array = np.zeros((48, 64), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array)
     assert bitmap.width == 64
@@ -71,7 +73,7 @@ def test_bitmap_from_array_grey():
     assert bitmap.is_grey
 
 
-def test_bitmap_from_array_rgb():
+def test_bitmap_from_array_rgb() -> None:
     array = np.zeros((48, 64, 3), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array)
     assert bitmap.width == 64
@@ -79,27 +81,27 @@ def test_bitmap_from_array_rgb():
     assert bitmap.is_rgb
 
 
-def test_bitmap_to_array_roundtrip_grey():
+def test_bitmap_to_array_roundtrip_grey() -> None:
     array_in = np.random.randint(0, 256, (48, 64), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array_in)
     array_out = bitmap.to_array()
     np.testing.assert_array_equal(array_in, array_out)
 
 
-def test_bitmap_to_array_roundtrip_rgb():
+def test_bitmap_to_array_roundtrip_rgb() -> None:
     array_in = np.random.randint(0, 256, (48, 64, 3), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array_in)
     array_out = bitmap.to_array()
     np.testing.assert_array_equal(array_in, array_out)
 
 
-def test_bitmap_from_array_linear_colorspace():
+def test_bitmap_from_array_linear_colorspace() -> None:
     array = np.zeros((48, 64, 3), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array, linear_colorspace=True)
     assert bitmap.is_rgb
 
 
-def test_bitmap_clone():
+def test_bitmap_clone() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     cloned = bitmap.clone()
     assert cloned.width == bitmap.width
@@ -107,7 +109,7 @@ def test_bitmap_clone():
     assert cloned.is_rgb == bitmap.is_rgb
 
 
-def test_bitmap_clone_as_grey():
+def test_bitmap_clone_as_grey() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     grey = bitmap.clone_as_grey()
     assert grey.is_grey
@@ -115,7 +117,7 @@ def test_bitmap_clone_as_grey():
     assert grey.height == bitmap.height
 
 
-def test_bitmap_clone_as_rgb():
+def test_bitmap_clone_as_rgb() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=False)
     rgb = bitmap.clone_as_rgb()
     assert rgb.is_rgb
@@ -123,35 +125,35 @@ def test_bitmap_clone_as_rgb():
     assert rgb.height == bitmap.height
 
 
-def test_bitmap_rescale_default_filter():
+def test_bitmap_rescale_default_filter() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=True)
     bitmap.rescale(32, 24)
     assert bitmap.width == 32
     assert bitmap.height == 24
 
 
-def test_bitmap_rescale_explicit_filter():
+def test_bitmap_rescale_explicit_filter() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=True)
     bitmap.rescale(32, 24, filter=pycolmap.BitmapRescaleFilter.BOX)
     assert bitmap.width == 32
     assert bitmap.height == 24
 
 
-def test_bitmap_rot90_once():
+def test_bitmap_rot90_once() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=True)
     bitmap.rot90(1)
     assert bitmap.width == 48
     assert bitmap.height == 64
 
 
-def test_bitmap_rot90_twice():
+def test_bitmap_rot90_twice() -> None:
     bitmap = pycolmap.Bitmap(width=64, height=48, as_rgb=True)
     bitmap.rot90(2)
     assert bitmap.width == 64
     assert bitmap.height == 48
 
 
-def test_bitmap_write_read(tmp_path):
+def test_bitmap_write_read(tmp_path: Path) -> None:
     array = np.random.randint(0, 256, (48, 64, 3), dtype=np.uint8)
     bitmap = pycolmap.Bitmap.from_array(array)
     filepath = str(tmp_path / "test.png")
@@ -163,49 +165,49 @@ def test_bitmap_write_read(tmp_path):
     np.testing.assert_array_equal(loaded.to_array(), array)
 
 
-def test_bitmap_set_jpeg_quality():
+def test_bitmap_set_jpeg_quality() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     bitmap.set_jpeg_quality(85)
 
 
-def test_bitmap_exif_orientation():
+def test_bitmap_exif_orientation() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_orientation()
     # Synthetic bitmap has no EXIF data, so expect None.
     assert result is None
 
 
-def test_bitmap_exif_camera_model():
+def test_bitmap_exif_camera_model() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_camera_model()
     assert result is None
 
 
-def test_bitmap_exif_focal_length():
+def test_bitmap_exif_focal_length() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_focal_length()
     assert result is None
 
 
-def test_bitmap_exif_latitude():
+def test_bitmap_exif_latitude() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_latitude()
     assert result is None
 
 
-def test_bitmap_exif_longitude():
+def test_bitmap_exif_longitude() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_longitude()
     assert result is None
 
 
-def test_bitmap_exif_altitude():
+def test_bitmap_exif_altitude() -> None:
     bitmap = pycolmap.Bitmap(width=32, height=24, as_rgb=True)
     result = bitmap.exif_altitude()
     assert result is None
 
 
-def test_bitmap_thumbnail():
+def test_bitmap_thumbnail() -> None:
     bitmap = pycolmap.Bitmap(width=200, height=100, as_rgb=True)
     scale = bitmap.thumbnail(max_image_size=50)
     # The longest side is scaled to fit max_image_size: 50 / max(200, 100).
@@ -214,7 +216,7 @@ def test_bitmap_thumbnail():
     assert bitmap.height == 25
 
 
-def test_bitmap_thumbnail_noop():
+def test_bitmap_thumbnail_noop() -> None:
     bitmap = pycolmap.Bitmap(width=40, height=30, as_rgb=True)
     scale = bitmap.thumbnail(max_image_size=100)
     assert scale == 1.0

--- a/src/pycolmap/sensor/rig_test.py
+++ b/src/pycolmap/sensor/rig_test.py
@@ -1,22 +1,24 @@
 import pycolmap
 
 
-def _make_sensor(sensor_type, sensor_id):
+def _make_sensor(
+    sensor_type: pycolmap.SensorType, sensor_id: int
+) -> pycolmap.sensor_t:
     return pycolmap.sensor_t(type=sensor_type, id=sensor_id)
 
 
-def test_rig_init():
+def test_rig_init() -> None:
     rig = pycolmap.Rig()
     assert rig is not None
 
 
-def test_rig_rig_id_readwrite():
+def test_rig_rig_id_readwrite() -> None:
     rig = pycolmap.Rig()
     rig.rig_id = 5
     assert rig.rig_id == 5
 
 
-def test_rig_add_ref_sensor():
+def test_rig_add_ref_sensor() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     rig.add_ref_sensor(ref_sensor)
@@ -24,7 +26,7 @@ def test_rig_add_ref_sensor():
     assert rig.is_ref_sensor(ref_sensor)
 
 
-def test_rig_add_sensor():
+def test_rig_add_sensor() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -33,7 +35,7 @@ def test_rig_add_sensor():
     assert rig.has_sensor(other_sensor)
 
 
-def test_rig_has_sensor():
+def test_rig_has_sensor() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     missing_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 99)
@@ -42,7 +44,7 @@ def test_rig_has_sensor():
     assert not rig.has_sensor(missing_sensor)
 
 
-def test_rig_is_ref_sensor():
+def test_rig_is_ref_sensor() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -52,7 +54,7 @@ def test_rig_is_ref_sensor():
     assert not rig.is_ref_sensor(other_sensor)
 
 
-def test_rig_num_sensors():
+def test_rig_num_sensors() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     rig.add_ref_sensor(ref_sensor)
@@ -62,14 +64,14 @@ def test_rig_num_sensors():
     assert rig.num_sensors() == 2
 
 
-def test_rig_ref_sensor_id():
+def test_rig_ref_sensor_id() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     rig.add_ref_sensor(ref_sensor)
     assert rig.ref_sensor_id == ref_sensor
 
 
-def test_rig_sensor_ids():
+def test_rig_sensor_ids() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -80,7 +82,7 @@ def test_rig_sensor_ids():
     assert other_sensor in sensor_ids
 
 
-def test_rig_non_ref_sensors():
+def test_rig_non_ref_sensors() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -90,7 +92,7 @@ def test_rig_non_ref_sensors():
     assert other_sensor in non_ref
 
 
-def test_rig_has_sensor_from_rig():
+def test_rig_has_sensor_from_rig() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -100,7 +102,7 @@ def test_rig_has_sensor_from_rig():
     assert not rig.has_sensor_from_rig(other_sensor)
 
 
-def test_rig_sensor_from_rig():
+def test_rig_sensor_from_rig() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -111,7 +113,7 @@ def test_rig_sensor_from_rig():
     assert result is None
 
 
-def test_rig_set_sensor_from_rig():
+def test_rig_set_sensor_from_rig() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -122,7 +124,7 @@ def test_rig_set_sensor_from_rig():
     assert rig.has_sensor_from_rig(other_sensor)
 
 
-def test_rig_reset_sensor_from_rig():
+def test_rig_reset_sensor_from_rig() -> None:
     rig = pycolmap.Rig()
     ref_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 0)
     other_sensor = _make_sensor(pycolmap.SensorType.CAMERA, 1)
@@ -133,12 +135,12 @@ def test_rig_reset_sensor_from_rig():
     assert not rig.has_sensor_from_rig(other_sensor)
 
 
-def test_rig_map_empty():
+def test_rig_map_empty() -> None:
     rig_map = pycolmap.RigMap()
     assert len(rig_map) == 0
 
 
-def test_rig_map_insert_and_access():
+def test_rig_map_insert_and_access() -> None:
     rig_map = pycolmap.RigMap()
     rig = pycolmap.Rig()
     rig.rig_id = 1

--- a/src/pycolmap/sfm/global_mapper_test.py
+++ b/src/pycolmap/sfm/global_mapper_test.py
@@ -3,55 +3,55 @@ from pathlib import Path
 import pycolmap
 
 
-def test_global_mapper_options_init():
+def test_global_mapper_options_init() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options is not None
 
 
-def test_global_mapper_options_image_path():
+def test_global_mapper_options_image_path() -> None:
     options = pycolmap.GlobalMapperOptions()
     options.image_path = "/tmp/images"
     assert options.image_path == Path("/tmp/images")
 
 
-def test_global_mapper_options_ba_gpu_index():
+def test_global_mapper_options_ba_gpu_index() -> None:
     options = pycolmap.GlobalMapperOptions()
     options.ba_gpu_index = "0"
     assert options.ba_gpu_index == "0"
 
 
-def test_global_mapper_options_get_rotation_averaging():
+def test_global_mapper_options_get_rotation_averaging() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options.get_rotation_averaging() is not None
 
 
-def test_global_mapper_options_get_global_positioning():
+def test_global_mapper_options_get_global_positioning() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options.get_global_positioning() is not None
 
 
-def test_global_mapper_options_get_bundle_adjustment():
+def test_global_mapper_options_get_bundle_adjustment() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options.get_bundle_adjustment() is not None
 
 
-def test_global_mapper_options_get_retriangulation():
+def test_global_mapper_options_get_retriangulation() -> None:
     options = pycolmap.GlobalMapperOptions()
     assert options.get_retriangulation() is not None
 
 
-def test_global_pipeline_options_init():
+def test_global_pipeline_options_init() -> None:
     options = pycolmap.GlobalPipelineOptions()
     assert options is not None
 
 
-def test_global_pipeline_options_nested_options():
+def test_global_pipeline_options_nested_options() -> None:
     options = pycolmap.GlobalPipelineOptions()
     options.mapper.min_tri_angle_deg = 2.0
     assert options.mapper.min_tri_angle_deg == 2.0
 
 
-def test_global_pipeline_options_from_dict():
+def test_global_pipeline_options_from_dict() -> None:
     options = pycolmap.GlobalPipelineOptions(
         min_num_matches=20, mapper={"ba_num_iterations": 5}
     )
@@ -59,11 +59,11 @@ def test_global_pipeline_options_from_dict():
     assert options.mapper.ba_num_iterations == 5
 
 
-def test_global_pipeline_callback_model_update():
+def test_global_pipeline_callback_model_update() -> None:
     assert pycolmap.GlobalPipelineCallback.MODEL_UPDATE_CALLBACK is not None
 
 
-def test_global_pipeline_run(tmp_path: Path):
+def test_global_pipeline_run(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"
@@ -84,7 +84,7 @@ def test_global_pipeline_run(tmp_path: Path):
     with pycolmap.Database.open(database_path) as database:
         num_model_updates = 0
 
-        def on_model_update():
+        def on_model_update() -> None:
             nonlocal num_model_updates
             num_model_updates += 1
 

--- a/src/pycolmap/sfm/hierarchical_mapper_test.py
+++ b/src/pycolmap/sfm/hierarchical_mapper_test.py
@@ -3,39 +3,39 @@ from pathlib import Path
 import pycolmap
 
 
-def test_scene_clustering_options_init():
+def test_scene_clustering_options_init() -> None:
     options = pycolmap.SceneClusteringOptions()
     assert options is not None
 
 
-def test_scene_clustering_options_check():
+def test_scene_clustering_options_check() -> None:
     options = pycolmap.SceneClusteringOptions()
     assert options.check()
 
 
-def test_scene_clustering_options_leaf_max_num_images():
+def test_scene_clustering_options_leaf_max_num_images() -> None:
     options = pycolmap.SceneClusteringOptions()
     options.leaf_max_num_images = 100
     assert options.leaf_max_num_images == 100
 
 
-def test_hierarchical_pipeline_options_init():
+def test_hierarchical_pipeline_options_init() -> None:
     options = pycolmap.HierarchicalPipelineOptions()
     assert options is not None
 
 
-def test_hierarchical_pipeline_options_check():
+def test_hierarchical_pipeline_options_check() -> None:
     options = pycolmap.HierarchicalPipelineOptions()
     assert options.check()
 
 
-def test_hierarchical_pipeline_options_num_workers():
+def test_hierarchical_pipeline_options_num_workers() -> None:
     options = pycolmap.HierarchicalPipelineOptions()
     options.num_workers = 2
     assert options.num_workers == 2
 
 
-def test_hierarchical_pipeline_options_nested_options():
+def test_hierarchical_pipeline_options_nested_options() -> None:
     options = pycolmap.HierarchicalPipelineOptions()
     options.clustering_options.image_overlap = 10
     assert options.clustering_options.image_overlap == 10
@@ -43,7 +43,7 @@ def test_hierarchical_pipeline_options_nested_options():
     assert options.incremental_options.min_num_matches == 20
 
 
-def test_hierarchical_pipeline_options_from_dict():
+def test_hierarchical_pipeline_options_from_dict() -> None:
     options = pycolmap.HierarchicalPipelineOptions(
         num_workers=3, clustering_options={"leaf_max_num_images": 50}
     )
@@ -51,7 +51,7 @@ def test_hierarchical_pipeline_options_from_dict():
     assert options.clustering_options.leaf_max_num_images == 50
 
 
-def test_hierarchical_pipeline_run(tmp_path: Path):
+def test_hierarchical_pipeline_run(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"

--- a/src/pycolmap/sfm/incremental_mapper_test.py
+++ b/src/pycolmap/sfm/incremental_mapper_test.py
@@ -3,147 +3,147 @@ from pathlib import Path
 import pycolmap
 
 
-def test_image_selection_method_max_visible_points_num():
+def test_image_selection_method_max_visible_points_num() -> None:
     assert pycolmap.ImageSelectionMethod.MAX_VISIBLE_POINTS_NUM is not None
 
 
-def test_image_selection_method_max_visible_points_ratio():
+def test_image_selection_method_max_visible_points_ratio() -> None:
     assert pycolmap.ImageSelectionMethod.MAX_VISIBLE_POINTS_RATIO is not None
 
 
-def test_image_selection_method_min_uncertainty():
+def test_image_selection_method_min_uncertainty() -> None:
     assert pycolmap.ImageSelectionMethod.MIN_UNCERTAINTY is not None
 
 
-def test_incremental_mapper_options_init():
+def test_incremental_mapper_options_init() -> None:
     options = pycolmap.IncrementalMapperOptions()
     assert options is not None
 
 
-def test_incremental_mapper_options_check():
+def test_incremental_mapper_options_check() -> None:
     options = pycolmap.IncrementalMapperOptions()
     assert options.check()
 
 
-def test_local_bundle_adjustment_report_init():
+def test_local_bundle_adjustment_report_init() -> None:
     report = pycolmap.LocalBundleAdjustmentReport()
     assert report is not None
 
 
-def test_local_bundle_adjustment_report_num_merged_observations():
+def test_local_bundle_adjustment_report_num_merged_observations() -> None:
     report = pycolmap.LocalBundleAdjustmentReport()
     report.num_merged_observations = 5
     assert report.num_merged_observations == 5
 
 
-def test_local_bundle_adjustment_report_num_completed_observations():
+def test_local_bundle_adjustment_report_num_completed_observations() -> None:
     report = pycolmap.LocalBundleAdjustmentReport()
     report.num_completed_observations = 10
     assert report.num_completed_observations == 10
 
 
-def test_local_bundle_adjustment_report_num_filtered_observations():
+def test_local_bundle_adjustment_report_num_filtered_observations() -> None:
     report = pycolmap.LocalBundleAdjustmentReport()
     report.num_filtered_observations = 3
     assert report.num_filtered_observations == 3
 
 
-def test_local_bundle_adjustment_report_num_adjusted_observations():
+def test_local_bundle_adjustment_report_num_adjusted_observations() -> None:
     report = pycolmap.LocalBundleAdjustmentReport()
     report.num_adjusted_observations = 7
     assert report.num_adjusted_observations == 7
 
 
-def test_incremental_pipeline_callback_initial_image_pair():
+def test_incremental_pipeline_callback_initial_image_pair() -> None:
     assert (
         pycolmap.IncrementalPipelineCallback.INITIAL_IMAGE_PAIR_REG_CALLBACK
         is not None
     )
 
 
-def test_incremental_pipeline_callback_next_image():
+def test_incremental_pipeline_callback_next_image() -> None:
     assert (
         pycolmap.IncrementalPipelineCallback.NEXT_IMAGE_REG_CALLBACK is not None
     )
 
 
-def test_incremental_pipeline_callback_last_image():
+def test_incremental_pipeline_callback_last_image() -> None:
     assert (
         pycolmap.IncrementalPipelineCallback.LAST_IMAGE_REG_CALLBACK is not None
     )
 
 
-def test_incremental_pipeline_status_success():
+def test_incremental_pipeline_status_success() -> None:
     assert pycolmap.IncrementalPipelineStatus.SUCCESS is not None
 
 
-def test_incremental_pipeline_status_interrupted():
+def test_incremental_pipeline_status_interrupted() -> None:
     assert pycolmap.IncrementalPipelineStatus.INTERRUPTED is not None
 
 
-def test_incremental_pipeline_status_continue():
+def test_incremental_pipeline_status_continue() -> None:
     assert pycolmap.IncrementalPipelineStatus.CONTINUE is not None
 
 
-def test_incremental_pipeline_status_stop():
+def test_incremental_pipeline_status_stop() -> None:
     assert pycolmap.IncrementalPipelineStatus.STOP is not None
 
 
-def test_incremental_pipeline_status_no_initial_pair():
+def test_incremental_pipeline_status_no_initial_pair() -> None:
     assert pycolmap.IncrementalPipelineStatus.NO_INITIAL_PAIR is not None
 
 
-def test_incremental_pipeline_status_bad_initial_pair():
+def test_incremental_pipeline_status_bad_initial_pair() -> None:
     assert pycolmap.IncrementalPipelineStatus.BAD_INITIAL_PAIR is not None
 
 
-def test_incremental_pipeline_options_init():
+def test_incremental_pipeline_options_init() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     assert options is not None
 
 
-def test_incremental_pipeline_options_min_num_matches():
+def test_incremental_pipeline_options_min_num_matches() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     options.min_num_matches = 20
     assert options.min_num_matches == 20
 
 
-def test_incremental_pipeline_options_check():
+def test_incremental_pipeline_options_check() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     assert options.check()
 
 
-def test_incremental_pipeline_options_is_initial_pair_provided():
+def test_incremental_pipeline_options_is_initial_pair_provided() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     result = options.is_initial_pair_provided()
     assert isinstance(result, bool)
 
 
-def test_incremental_pipeline_options_get_mapper():
+def test_incremental_pipeline_options_get_mapper() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     mapper_options = options.get_mapper()
     assert mapper_options is not None
 
 
-def test_incremental_pipeline_options_get_triangulation():
+def test_incremental_pipeline_options_get_triangulation() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     triangulation_options = options.get_triangulation()
     assert triangulation_options is not None
 
 
-def test_incremental_pipeline_options_get_local_bundle_adjustment():
+def test_incremental_pipeline_options_get_local_bundle_adjustment() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     bundle_adjustment_options = options.get_local_bundle_adjustment()
     assert bundle_adjustment_options is not None
 
 
-def test_incremental_pipeline_options_get_global_bundle_adjustment():
+def test_incremental_pipeline_options_get_global_bundle_adjustment() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     bundle_adjustment_options = options.get_global_bundle_adjustment()
     assert bundle_adjustment_options is not None
 
 
-def test_incremental_pipeline_options_ba_local_backend_readwrite():
+def test_incremental_pipeline_options_ba_local_backend_readwrite() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     options.ba_local_backend = pycolmap.BundleAdjustmentBackend.CERES
     assert options.ba_local_backend == pycolmap.BundleAdjustmentBackend.CERES
@@ -151,7 +151,7 @@ def test_incremental_pipeline_options_ba_local_backend_readwrite():
     assert options.ba_local_backend == pycolmap.BundleAdjustmentBackend.CASPAR
 
 
-def test_incremental_pipeline_options_ba_global_backend_readwrite():
+def test_incremental_pipeline_options_ba_global_backend_readwrite() -> None:
     options = pycolmap.IncrementalPipelineOptions()
     options.ba_global_backend = pycolmap.BundleAdjustmentBackend.CERES
     assert options.ba_global_backend == pycolmap.BundleAdjustmentBackend.CERES
@@ -159,7 +159,7 @@ def test_incremental_pipeline_options_ba_global_backend_readwrite():
     assert options.ba_global_backend == pycolmap.BundleAdjustmentBackend.CASPAR
 
 
-def test_incremental_pipeline_run(tmp_path: Path):
+def test_incremental_pipeline_run(tmp_path: Path) -> None:
     pycolmap.set_random_seed(0)
 
     database_path = tmp_path / "database.db"

--- a/src/pycolmap/sfm/incremental_triangulator_test.py
+++ b/src/pycolmap/sfm/incremental_triangulator_test.py
@@ -1,27 +1,27 @@
 import pycolmap
 
 
-def test_incremental_triangulator_options_init():
+def test_incremental_triangulator_options_init() -> None:
     options = pycolmap.IncrementalTriangulatorOptions()
     assert options is not None
 
 
-def test_incremental_triangulator_options_max_transitivity():
+def test_incremental_triangulator_options_max_transitivity() -> None:
     options = pycolmap.IncrementalTriangulatorOptions()
     options.max_transitivity = 2
     assert options.max_transitivity == 2
 
 
-def test_incremental_triangulator_options_create_max_angle_error():
+def test_incremental_triangulator_options_create_max_angle_error() -> None:
     options = pycolmap.IncrementalTriangulatorOptions()
     options.create_max_angle_error = 3.0
     assert options.create_max_angle_error == 3.0
 
 
-def test_incremental_triangulator_options_check():
+def test_incremental_triangulator_options_check() -> None:
     options = pycolmap.IncrementalTriangulatorOptions()
     assert options.check()
 
 
-def test_incremental_triangulator_class_exists():
+def test_incremental_triangulator_class_exists() -> None:
     assert hasattr(pycolmap, "IncrementalTriangulator")

--- a/src/pycolmap/sfm/observation_manager_test.py
+++ b/src/pycolmap/sfm/observation_manager_test.py
@@ -1,36 +1,38 @@
 import pycolmap
 
 
-def test_image_pair_stat_init():
+def test_image_pair_stat_init() -> None:
     stat = pycolmap.ImagePairStat()
     assert stat is not None
 
 
-def test_image_pair_stat_num_tri_corrs():
+def test_image_pair_stat_num_tri_corrs() -> None:
     stat = pycolmap.ImagePairStat()
     stat.num_tri_corrs = 10
     assert stat.num_tri_corrs == 10
 
 
-def test_image_pair_stat_num_total_corrs():
+def test_image_pair_stat_num_total_corrs() -> None:
     stat = pycolmap.ImagePairStat()
     stat.num_total_corrs = 20
     assert stat.num_total_corrs == 20
 
 
-def test_reprojection_error_type_pixel():
+def test_reprojection_error_type_pixel() -> None:
     assert pycolmap.ReprojectionErrorType.PIXEL is not None
 
 
-def test_reprojection_error_type_normalized():
+def test_reprojection_error_type_normalized() -> None:
     assert pycolmap.ReprojectionErrorType.NORMALIZED is not None
 
 
-def test_reprojection_error_type_angular():
+def test_reprojection_error_type_angular() -> None:
     assert pycolmap.ReprojectionErrorType.ANGULAR is not None
 
 
-def _make_observation_manager(reconstruction):
+def _make_observation_manager(
+    reconstruction: pycolmap.Reconstruction,
+) -> pycolmap.ObservationManager:
     correspondence_graph = pycolmap.CorrespondenceGraph()
     for image_id in reconstruction.images:
         image = reconstruction.image(image_id)
@@ -39,25 +41,33 @@ def _make_observation_manager(reconstruction):
     return pycolmap.ObservationManager(reconstruction, correspondence_graph)
 
 
-def test_observation_manager_init(synthetic_reconstruction):
+def test_observation_manager_init(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     manager = _make_observation_manager(synthetic_reconstruction)
     assert manager is not None
 
 
-def test_observation_manager_image_pairs(synthetic_reconstruction):
+def test_observation_manager_image_pairs(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     manager = _make_observation_manager(synthetic_reconstruction)
     pairs = manager.image_pairs
     assert hasattr(pairs, "__len__")
 
 
-def test_observation_manager_num_observations(synthetic_reconstruction):
+def test_observation_manager_num_observations(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     manager = _make_observation_manager(synthetic_reconstruction)
     image_ids = list(synthetic_reconstruction.images.keys())
     count = manager.num_observations(image_ids[0])
     assert isinstance(count, int)
 
 
-def test_observation_manager_num_correspondences(synthetic_reconstruction):
+def test_observation_manager_num_correspondences(
+    synthetic_reconstruction: pycolmap.Reconstruction,
+) -> None:
     manager = _make_observation_manager(synthetic_reconstruction)
     image_ids = list(synthetic_reconstruction.images.keys())
     count = manager.num_correspondences(image_ids[0])

--- a/src/pycolmap/util/cancellation_test.py
+++ b/src/pycolmap/util/cancellation_test.py
@@ -1,16 +1,18 @@
+from pathlib import Path
+
 import pytest
 
 import pycolmap
 
 
-def test_cancellation_token():
+def test_cancellation_token() -> None:
     token = pycolmap.CancellationToken()
     assert not token.is_cancelled
     token.cancel()
     assert token.is_cancelled
 
 
-def test_cancelled_feature_extraction_raises(tmp_path):
+def test_cancelled_feature_extraction_raises(tmp_path: Path) -> None:
     image_path = tmp_path / "images"
     image_path.mkdir()
     token = pycolmap.CancellationToken()
@@ -25,7 +27,7 @@ def test_cancelled_feature_extraction_raises(tmp_path):
         )
 
 
-def test_cancelled_bundle_adjustment_raises():
+def test_cancelled_bundle_adjustment_raises() -> None:
     options = pycolmap.SyntheticDatasetOptions()
     options.num_cameras_per_rig = 1
     options.num_frames_per_rig = 3
@@ -47,5 +49,5 @@ def test_cancelled_bundle_adjustment_raises():
         "undistort_images",
     ],
 )
-def test_pipeline_accepts_cancellation_token(function_name):
+def test_pipeline_accepts_cancellation_token(function_name: str) -> None:
     assert "cancellation_token" in getattr(pycolmap, function_name).__doc__

--- a/src/pycolmap/util/logging_test.py
+++ b/src/pycolmap/util/logging_test.py
@@ -1,70 +1,72 @@
+from pathlib import Path
+
 import pycolmap
 
 
-def test_logging_level_enum():
+def test_logging_level_enum() -> None:
     assert pycolmap.logging.INFO is not None
     assert pycolmap.logging.WARNING is not None
     assert pycolmap.logging.ERROR is not None
     assert pycolmap.logging.FATAL is not None
 
 
-def test_logging_minloglevel_readwrite():
+def test_logging_minloglevel_readwrite() -> None:
     original = pycolmap.logging.minloglevel
     pycolmap.logging.minloglevel = 0
     assert pycolmap.logging.minloglevel == 0
     pycolmap.logging.minloglevel = original
 
 
-def test_logging_stderrthreshold_readwrite():
+def test_logging_stderrthreshold_readwrite() -> None:
     original = pycolmap.logging.stderrthreshold
     pycolmap.logging.stderrthreshold = 2
     assert pycolmap.logging.stderrthreshold == 2
     pycolmap.logging.stderrthreshold = original
 
 
-def test_logging_log_dir_readwrite():
+def test_logging_log_dir_readwrite() -> None:
     original = pycolmap.logging.log_dir
     assert isinstance(original, str)
     pycolmap.logging.log_dir = original
 
 
-def test_logging_logtostderr_readwrite():
+def test_logging_logtostderr_readwrite() -> None:
     original = pycolmap.logging.logtostderr
     pycolmap.logging.logtostderr = True
     assert pycolmap.logging.logtostderr is True
     pycolmap.logging.logtostderr = original
 
 
-def test_logging_alsologtostderr_readwrite():
+def test_logging_alsologtostderr_readwrite() -> None:
     original = pycolmap.logging.alsologtostderr
     pycolmap.logging.alsologtostderr = True
     assert pycolmap.logging.alsologtostderr is True
     pycolmap.logging.alsologtostderr = original
 
 
-def test_logging_verbose_level_readwrite():
+def test_logging_verbose_level_readwrite() -> None:
     original = pycolmap.logging.verbose_level
     pycolmap.logging.verbose_level = 1
     assert pycolmap.logging.verbose_level == 1
     pycolmap.logging.verbose_level = original
 
 
-def test_logging_info():
+def test_logging_info() -> None:
     pycolmap.logging.info("smoke test info message")
 
 
-def test_logging_warning():
+def test_logging_warning() -> None:
     pycolmap.logging.warning("smoke test warning message")
 
 
-def test_logging_error():
+def test_logging_error() -> None:
     pycolmap.logging.error("smoke test error message")
 
 
-def test_logging_verbose():
+def test_logging_verbose() -> None:
     pycolmap.logging.verbose(1, "smoke test verbose message")
 
 
-def test_logging_set_log_destination(tmp_path):
+def test_logging_set_log_destination(tmp_path: Path) -> None:
     log_dir = str(tmp_path)
     pycolmap.logging.set_log_destination(pycolmap.logging.INFO, log_dir)

--- a/src/pycolmap/util/timer_test.py
+++ b/src/pycolmap/util/timer_test.py
@@ -3,42 +3,42 @@ import time
 import pycolmap
 
 
-def test_timer_init():
+def test_timer_init() -> None:
     timer = pycolmap.Timer()
     assert timer is not None
 
 
-def test_timer_start():
+def test_timer_start() -> None:
     timer = pycolmap.Timer()
     timer.start()
 
 
-def test_timer_restart():
+def test_timer_restart() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.restart()
 
 
-def test_timer_pause():
+def test_timer_pause() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.pause()
 
 
-def test_timer_resume():
+def test_timer_resume() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.pause()
     timer.resume()
 
 
-def test_timer_reset():
+def test_timer_reset() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.reset()
 
 
-def test_timer_elapsed_seconds():
+def test_timer_elapsed_seconds() -> None:
     timer = pycolmap.Timer()
     timer.start()
     time.sleep(0.001)
@@ -46,7 +46,7 @@ def test_timer_elapsed_seconds():
     assert elapsed > 0.0
 
 
-def test_timer_elapsed_micro_seconds():
+def test_timer_elapsed_micro_seconds() -> None:
     timer = pycolmap.Timer()
     timer.start()
     elapsed = timer.elapsed_micro_seconds()
@@ -54,7 +54,7 @@ def test_timer_elapsed_micro_seconds():
     assert elapsed >= 0.0
 
 
-def test_timer_elapsed_minutes():
+def test_timer_elapsed_minutes() -> None:
     timer = pycolmap.Timer()
     timer.start()
     elapsed = timer.elapsed_minutes()
@@ -62,7 +62,7 @@ def test_timer_elapsed_minutes():
     assert elapsed >= 0.0
 
 
-def test_timer_elapsed_hours():
+def test_timer_elapsed_hours() -> None:
     timer = pycolmap.Timer()
     timer.start()
     elapsed = timer.elapsed_hours()
@@ -70,19 +70,19 @@ def test_timer_elapsed_hours():
     assert elapsed >= 0.0
 
 
-def test_timer_print_seconds():
+def test_timer_print_seconds() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.print_seconds()
 
 
-def test_timer_print_minutes():
+def test_timer_print_minutes() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.print_minutes()
 
 
-def test_timer_print_hours():
+def test_timer_print_hours() -> None:
     timer = pycolmap.Timer()
     timer.start()
     timer.print_hours()

--- a/src/pycolmap/util/timestamp_test.py
+++ b/src/pycolmap/util/timestamp_test.py
@@ -3,7 +3,7 @@ import pytest
 import pycolmap
 
 
-def test_timestamp_from_seconds():
+def test_timestamp_from_seconds() -> None:
     # Timestamps are integer nanoseconds.
     assert pycolmap.timestamp_from_seconds(1.5) == 1_500_000_000
     # Rounds to the nearest nanosecond.
@@ -11,18 +11,18 @@ def test_timestamp_from_seconds():
     assert pycolmap.timestamp_from_seconds(0.4e-9) == 0
 
 
-def test_seconds_from_timestamp():
+def test_seconds_from_timestamp() -> None:
     assert pycolmap.seconds_from_timestamp(1_500_000_000) == pytest.approx(1.5)
     assert pycolmap.seconds_from_timestamp(0) == 0.0
 
 
-def test_timestamp_roundtrip():
+def test_timestamp_roundtrip() -> None:
     for seconds in [0.0, 0.001, 1.25, 10.0]:
         t = pycolmap.timestamp_from_seconds(seconds)
         assert pycolmap.seconds_from_timestamp(t) == pytest.approx(seconds)
 
 
-def test_timestamp_diff_seconds():
+def test_timestamp_diff_seconds() -> None:
     t0 = pycolmap.timestamp_from_seconds(1.0)
     t1 = pycolmap.timestamp_from_seconds(2.5)
     assert pycolmap.timestamp_diff_seconds(t1, t0) == pytest.approx(1.5)

--- a/src/pycolmap/util/types_test.py
+++ b/src/pycolmap/util/types_test.py
@@ -1,7 +1,7 @@
 import pycolmap
 
 
-def test_sensor_type_enum():
+def test_sensor_type_enum() -> None:
     assert {k: int(v) for k, v in pycolmap.SensorType.__members__.items()} == {
         "INVALID": -1,
         "CAMERA": 0,
@@ -9,60 +9,60 @@ def test_sensor_type_enum():
     }
 
 
-def test_sensor_type_string_construction():
+def test_sensor_type_string_construction() -> None:
     assert pycolmap.SensorType("CAMERA") == pycolmap.SensorType.CAMERA
     assert pycolmap.SensorType("IMU") == pycolmap.SensorType.IMU
     assert pycolmap.SensorType("INVALID") == pycolmap.SensorType.INVALID
 
 
-def test_sensor_t_default_init():
+def test_sensor_t_default_init() -> None:
     sensor = pycolmap.sensor_t()
     assert sensor is not None
 
 
-def test_sensor_t_init_with_args():
+def test_sensor_t_init_with_args() -> None:
     sensor = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=42)
     assert sensor.type == pycolmap.SensorType.CAMERA
     assert sensor.id == 42
 
 
-def test_sensor_t_readwrite_type():
+def test_sensor_t_readwrite_type() -> None:
     sensor = pycolmap.sensor_t()
     sensor.type = pycolmap.SensorType.IMU
     assert sensor.type == pycolmap.SensorType.IMU
 
 
-def test_sensor_t_readwrite_id():
+def test_sensor_t_readwrite_id() -> None:
     sensor = pycolmap.sensor_t()
     sensor.id = 7
     assert sensor.id == 7
 
 
-def test_data_t_default_init():
+def test_data_t_default_init() -> None:
     data = pycolmap.data_t()
     assert data is not None
 
 
-def test_data_t_init_with_args():
+def test_data_t_init_with_args() -> None:
     sensor = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=1)
     data = pycolmap.data_t(sensor_id=sensor, id=99)
     assert data.id == 99
 
 
-def test_data_t_readwrite_sensor_id():
+def test_data_t_readwrite_sensor_id() -> None:
     data = pycolmap.data_t()
     sensor = pycolmap.sensor_t(type=pycolmap.SensorType.CAMERA, id=5)
     data.sensor_id = sensor
     assert data.sensor_id.id == 5
 
 
-def test_data_t_readwrite_id():
+def test_data_t_readwrite_id() -> None:
     data = pycolmap.data_t()
     data.id = 123
     assert data.id == 123
 
 
-def test_image_pair_to_pair_id_and_roundtrip():
+def test_image_pair_to_pair_id_and_roundtrip() -> None:
     pair_id = pycolmap.image_pair_to_pair_id(1, 2)
     assert isinstance(pair_id, int)
     image_id1, image_id2 = pycolmap.pair_id_to_image_pair(pair_id)
@@ -70,6 +70,6 @@ def test_image_pair_to_pair_id_and_roundtrip():
     assert image_id2 == 2
 
 
-def test_should_swap_image_pair():
+def test_should_swap_image_pair() -> None:
     result = pycolmap.should_swap_image_pair(2, 1)
     assert isinstance(result, bool)

--- a/src/thirdparty/Symforce-Caspar/caspar_generate.py
+++ b/src/thirdparty/Symforce-Caspar/caspar_generate.py
@@ -3,9 +3,10 @@
 
 import inspect
 import sys
+from collections.abc import Callable
 from itertools import combinations
 from pathlib import Path
-from typing import Annotated, get_type_hints
+from typing import Annotated, Any, get_type_hints
 
 # Must be set before importing symforce.symbolic
 precision = sys.argv[2] if len(sys.argv) > 2 else "f32"
@@ -138,8 +139,12 @@ class ConstPinholeSensorFromRig(sf.Pose3):
 
 
 def _make_variant(
-    core_fn, name: str, base_params: list, hints: dict, fixed: dict
-):
+    core_fn: Callable[..., Any],
+    name: str,
+    base_params: list[str],
+    hints: dict[str, Any],
+    fixed: dict[str, Any],
+) -> Callable[..., Any]:
     new_hints = {}
     for p in base_params:
         if p in fixed:
@@ -153,14 +158,14 @@ def _make_variant(
 
     # Caspar calls factors as fn(**symbolic_args), so the wrapper accepts both
     # positional and keyword arguments.
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         merged = {**dict(zip(ordered, args, strict=False)), **kwargs}
         return core_fn(*[merged[p] for p in base_params])
 
     wrapper.__name__ = name
     wrapper.__annotations__ = {p: new_hints[p] for p in ordered}
     wrapper.__annotations__["return"] = hints.get("return")
-    wrapper.__signature__ = inspect.Signature(
+    wrapper.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
         [
             inspect.Parameter(p, inspect.Parameter.POSITIONAL_OR_KEYWORD)
             for p in ordered
@@ -170,13 +175,13 @@ def _make_variant(
 
 
 def register_camera_model(
-    caslib,
+    caslib: CasparLibrary,
     model_name: str,
-    core_fn,
-    fixable_params: dict,
-    must_fix_one_of: T.Optional[set] = None,
+    core_fn: Callable[..., Any],
+    fixable_params: dict[str, Any],
+    must_fix_one_of: set[str] | None = None,
     include_all_fixed: bool = False,
-):
+) -> None:
     hints = get_type_hints(core_fn, include_extras=True)
     base_params = list(inspect.signature(core_fn).parameters.keys())
     fixable_items = list(fixable_params.items())
@@ -229,7 +234,7 @@ def simple_radial_core(
     pose holds rig_from_world; sensor_from_rig is identity for single-camera
     rigs (cam_from_world == rig_from_world in that case).
     """
-    cam_T_world = sensor_from_rig * pose
+    cam_T_world = sensor_from_rig * pose  # type: ignore[operator]
     f, k, cx, cy = calib
     point_cam = cam_T_world * point
     depth = point_cam[2]
@@ -254,7 +259,7 @@ def pinhole_core(
     pose holds rig_from_world; sensor_from_rig is identity for single-camera
     rigs (cam_from_world == rig_from_world in that case).
     """
-    cam_T_world = sensor_from_rig * pose
+    cam_T_world = sensor_from_rig * pose  # type: ignore[operator]
     fx, fy, cx, cy = calib
     point_cam = cam_T_world * point
     depth = point_cam[2]
@@ -281,7 +286,7 @@ def simple_radial_split_core(
     point are tuned independently.
     focal_and_extra = [f, k], principal_point = [cx, cy].
     """
-    calib = sf.V4(
+    calib: Any = sf.V4(
         [
             focal_and_extra[0],
             focal_and_extra[1],
@@ -307,7 +312,9 @@ def pinhole_split_core(
     Used when focal lengths and principal point are tuned independently.
     focal = [fx, fy], principal_point = [cx, cy].
     """
-    calib = sf.V4([focal[0], focal[1], principal_point[0], principal_point[1]])
+    calib: Any = sf.V4(
+        [focal[0], focal[1], principal_point[0], principal_point[1]]
+    )
     return pinhole_core(pose, sensor_from_rig, calib, point, pixel)
 
 


### PR DESCRIPTION
## Summary

- require complete function annotations and check all typed function bodies with mypy
- annotate every tracked Python function, including tests, benchmarks, docs, examples, and the Caspar generator
- include documentation and the Caspar generator in CI type checking
- exempt generated pybind11 stubs from source annotation enforcement and narrowly suppress generated-binding diagnostics

## Testing

- `PYENV_VERSION=colmap scripts/format/python.sh`
- exact CI mypy commands against an installed wheel
- `PYENV_VERSION=colmap pytest` (955 passed)
- `PYENV_VERSION=colmap make -C doc html SPHINXOPTS="-W --keep-going"`
- AST audit confirming no executable behavior changes beyond annotations