### PR TITLE
Fix NumPy annotations in generated stubs

### DIFF
--- a/benchmark/reconstruction/evaluation/blended_mvs.py
+++ b/benchmark/reconstruction/evaluation/blended_mvs.py
@@ -151,9 +151,7 @@ class DatasetBlendedMVS(Dataset):
             frame = pycolmap.Frame(frame_id=i)
             frame.rig_id = i
             frame.add_data_id(image.data_id)
-            frame.rig_from_world = pycolmap.Rigid3d(  # type: ignore[arg-type]
-                extrinsic  # type: ignore[arg-type]
-            )
+            frame.rig_from_world = pycolmap.Rigid3d(extrinsic)
             sparse_gt.add_camera(camera)
             sparse_gt.add_rig(rig)
             sparse_gt.add_frame(frame)

--- a/benchmark/reconstruction/evaluation/utils_test.py
+++ b/benchmark/reconstruction/evaluation/utils_test.py
@@ -633,10 +633,7 @@ class TestComputeAbsErrors:
         for frame in reconstruction.frames.values():
             world_from_rig = frame.rig_from_world.inverse()
             world_from_rig.rotation = (
-                world_from_rig.rotation
-                * pycolmap.Rotation3d(  # type: ignore[call-overload]
-                    [0, 1, 0, 0]
-                )
+                world_from_rig.rotation * pycolmap.Rotation3d([0, 1, 0, 0])
             )
             world_from_rig.translation += translation
             frame.rig_from_world = world_from_rig.inverse()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,25 +116,16 @@ module = [
   "doc.tests.*",
   "pycolmap",
   "pycolmap.*",
+  "src.pycolmap.*",
 ]
 disable_error_code = ["attr-defined", "name-defined"]
 
-# The generated pybind11 stubs use fixed-shape NumPy annotations that vary
-# between Python platforms and are stricter than the arrays accepted at
-# runtime. Keep annotation checks enabled while suppressing those binding-only
-# incompatibilities in the PyCOLMAP tests.
-[[tool.mypy.overrides]]
-module = ["src.pycolmap.*"]
-disable_error_code = [
-  "arg-type",
-  "assignment",
-  "attr-defined",
-  "name-defined",
-]
-
 # Stubs generated from pybind11 signatures still contain untyped overloads.
+# Some overloads differ only by NumPy shape metadata, which mypy intentionally
+# ignores when determining whether overloads overlap.
 [[tool.mypy.overrides]]
 module = ["pycolmap._core", "pycolmap._core.*"]
 check_untyped_defs = false
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
+disable_error_code = ["overload-cannot-match"]

--- a/python/generate_stubs.sh
+++ b/python/generate_stubs.sh
@@ -6,7 +6,6 @@ OUTPUT=$2
 PACKAGE_NAME="_core"
 echo "Building stubs with $PYTHON_EXEC to $OUTPUT"
 $PYTHON_EXEC -m pybind11_stubgen $PACKAGE_NAME -o $OUTPUT \
-        --numpy-array-use-type-var \
         --enum-class-locations=.+:$PACKAGE_NAME \
         --ignore-invalid-expressions "ceres::*" \
         --print-invalid-expressions-as-is \

--- a/python/pycolmap/panorama.py
+++ b/python/pycolmap/panorama.py
@@ -133,7 +133,7 @@ def get_virtual_camera_rays(
     xy: NDArrayNx2 = np.column_stack([x.ravel(), y.ravel()])
     # The center of the upper left most pixel has coordinate (0.5, 0.5)
     xy += 0.5
-    xy_norm: NDArrayNx2 = camera.cam_from_img(image_points=xy)
+    xy_norm: npt.NDArray[np.float64] = camera.cam_from_img(image_points=xy)
     rays = np.concatenate([xy_norm, np.ones_like(xy_norm[:, :1])], -1)
     rays /= np.linalg.norm(rays, axis=-1, keepdims=True)
     return rays

--- a/python/pycolmap/panorama_test.py
+++ b/python/pycolmap/panorama_test.py
@@ -48,9 +48,7 @@ def test_filter_database_by_covisibility(tmp_path: Path) -> None:
                 use_image_id=True,
             )
         geometry = pycolmap.TwoViewGeometry()
-        geometry.inlier_matches = np.array(  # type: ignore[arg-type, assignment]
-            [[0, 0]], dtype=np.uint32
-        )
+        geometry.inlier_matches = np.array([[0, 0]], dtype=np.uint32)
         database.write_two_view_geometry(1, 2, geometry)
         database.write_two_view_geometry(1, 3, geometry)
 

--- a/src/pycolmap/estimators/affine_transform_test.py
+++ b/src/pycolmap/estimators/affine_transform_test.py
@@ -14,7 +14,7 @@ def test_estimate_affine2d_with_points() -> None:
         np.array([2.0, 1.0]),
         np.array([1.0, 2.0]),
     ]
-    result = pycolmap.estimate_affine2d(source, target)  # type: ignore[arg-type]
+    result = pycolmap.estimate_affine2d(source, target)
     assert result is not None
     result_array = np.array(result)
     assert result_array.shape == (2, 3)

--- a/src/pycolmap/estimators/similarity_transform_test.py
+++ b/src/pycolmap/estimators/similarity_transform_test.py
@@ -17,7 +17,7 @@ def test_estimate_rigid3d_with_coplanar_points() -> None:
         np.array([0.0, 1.0, 0.0]),
         np.array([1.0, 1.0, 0.0]),
     ]
-    result = pycolmap.estimate_rigid3d(source, target)  # type: ignore[arg-type]
+    result = pycolmap.estimate_rigid3d(source, target)
     # May return None for degenerate configurations, but call should succeed
     assert result is None or isinstance(result, pycolmap.Rigid3d)
 
@@ -35,7 +35,7 @@ def test_estimate_sim3d_with_points() -> None:
         np.array([0.0, 2.0, 0.0]),
         np.array([0.0, 0.0, 2.0]),
     ]
-    result = pycolmap.estimate_sim3d(source, target)  # type: ignore[arg-type]
+    result = pycolmap.estimate_sim3d(source, target)
     assert result is None or isinstance(result, pycolmap.Sim3d)
 
 

--- a/src/pycolmap/estimators/two_view_geometry_test.py
+++ b/src/pycolmap/estimators/two_view_geometry_test.py
@@ -33,6 +33,6 @@ def test_compute_squared_sampson_error_with_identity() -> None:
     points1 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     points2 = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     matrix = np.eye(3)
-    residuals = pycolmap.compute_squared_sampson_error(points1, points2, matrix)  # type: ignore[arg-type]
+    residuals = pycolmap.compute_squared_sampson_error(points1, points2, matrix)
     assert isinstance(residuals, list)
     assert len(residuals) == 2

--- a/src/pycolmap/feature/types_test.py
+++ b/src/pycolmap/feature/types_test.py
@@ -182,7 +182,7 @@ def test_keypoints_to_from_matrix_roundtrip() -> None:
     keypoint.a21 = 0.0
     keypoint.a22 = 1.0
     keypoints.append(keypoint)
-    matrix = pycolmap.keypoints_to_matrix(keypoints)  # type: ignore[var-annotated]
+    matrix = pycolmap.keypoints_to_matrix(keypoints)
     assert matrix.shape[0] == 1
     assert matrix.shape[1] == 4
     recovered = pycolmap.keypoints_from_matrix(matrix)
@@ -195,7 +195,7 @@ def test_matches_to_from_matrix_roundtrip() -> None:
     matches = pycolmap.FeatureMatches()
     matches.append(pycolmap.FeatureMatch(0, 5))
     matches.append(pycolmap.FeatureMatch(1, 3))
-    matrix = pycolmap.matches_to_matrix(matches)  # type: ignore[var-annotated]
+    matrix = pycolmap.matches_to_matrix(matches)
     assert matrix.shape == (2, 2)
     recovered = pycolmap.matches_from_matrix(matrix)
     assert len(recovered) == 2

--- a/src/pycolmap/geometry/gps_test.py
+++ b/src/pycolmap/geometry/gps_test.py
@@ -21,7 +21,7 @@ def test_gps_transform_init_with_wgs84() -> None:
 def test_gps_transform_ellipsoid_to_ecef() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    result = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    result = transform.ellipsoid_to_ecef(lat_lon_alt)
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -29,7 +29,7 @@ def test_gps_transform_ellipsoid_to_ecef() -> None:
 def test_gps_transform_ecef_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
     result = transform.ecef_to_ellipsoid(ecef)
     assert len(result) == 1
     assert result[0].shape == (3,)
@@ -38,7 +38,7 @@ def test_gps_transform_ecef_to_ellipsoid() -> None:
 def test_gps_transform_ellipsoid_ecef_roundtrip() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
     roundtrip = transform.ecef_to_ellipsoid(ecef)
     np.testing.assert_array_almost_equal(
         roundtrip[0], lat_lon_alt[0], decimal=5
@@ -51,7 +51,7 @@ def test_gps_transform_ellipsoid_to_enu() -> None:
     ref_lat = 47.0
     ref_lon = 8.0
     ref_alt = 500.0
-    result = transform.ellipsoid_to_enu(lat_lon_alt, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
+    result = transform.ellipsoid_to_enu(lat_lon_alt, ref_lat, ref_lon, ref_alt)
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -59,7 +59,7 @@ def test_gps_transform_ellipsoid_to_enu() -> None:
 def test_gps_transform_ecef_to_enu() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    ecef = transform.ellipsoid_to_ecef(lat_lon_alt)
     ref_ecef = ecef[0]
     result = transform.ecef_to_enu(ecef, ref_ecef)
     assert len(result) == 1
@@ -72,7 +72,7 @@ def test_gps_transform_enu_to_ellipsoid() -> None:
     ref_lon = 8.0
     ref_alt = 500.0
     enu_coords = [np.array([0.0, 0.0, 0.0])]
-    result = transform.enu_to_ellipsoid(enu_coords, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
+    result = transform.enu_to_ellipsoid(enu_coords, ref_lat, ref_lon, ref_alt)
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -83,7 +83,7 @@ def test_gps_transform_enu_to_ecef() -> None:
     ref_lon = 8.0
     ref_alt = 500.0
     enu_coords = [np.array([100.0, 200.0, 50.0])]
-    result = transform.enu_to_ecef(enu_coords, ref_lat, ref_lon, ref_alt)  # type: ignore[arg-type, var-annotated]
+    result = transform.enu_to_ecef(enu_coords, ref_lat, ref_lon, ref_alt)
     assert len(result) == 1
     assert result[0].shape == (3,)
 
@@ -91,7 +91,7 @@ def test_gps_transform_enu_to_ecef() -> None:
 def test_gps_transform_ellipsoid_to_utm() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)
     assert len(utm_coords) == 1
     assert utm_coords[0].shape == (3,)
     assert isinstance(zone, int)
@@ -100,7 +100,7 @@ def test_gps_transform_ellipsoid_to_utm() -> None:
 def test_gps_transform_utm_to_ellipsoid() -> None:
     transform = pycolmap.GPSTransform(pycolmap.GPSTransformEllipsoid.WGS84)
     lat_lon_alt = [np.array([47.0, 8.0, 500.0])]
-    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)  # type: ignore[arg-type, var-annotated]
+    utm_coords, zone = transform.ellipsoid_to_utm(lat_lon_alt)
     is_north = lat_lon_alt[0][0] >= 0
     result = transform.utm_to_ellipsoid(utm_coords, zone, is_north)
     assert len(result) == 1

--- a/src/pycolmap/geometry/rigid3_test.py
+++ b/src/pycolmap/geometry/rigid3_test.py
@@ -109,7 +109,7 @@ def test_rigid3d_interpolate() -> None:
 def test_get_covariance_for_inverse() -> None:
     rigid = pycolmap.Rigid3d()
     covariance = np.eye(6)
-    result = pycolmap.get_covariance_for_inverse(rigid, covariance)  # type: ignore[arg-type]
+    result = pycolmap.get_covariance_for_inverse(rigid, covariance)
     assert result.shape == (6, 6)
 
 
@@ -118,7 +118,7 @@ def test_get_covariance_for_composed_rigid3d() -> None:
     joint_covariance = np.eye(12)
     result = pycolmap.get_covariance_for_composed_rigid3d(
         rigid,
-        joint_covariance,  # type: ignore[arg-type]
+        joint_covariance,
     )
     assert result.shape == (6, 6)
 
@@ -130,7 +130,7 @@ def test_get_covariance_for_relative_rigid3d() -> None:
     result = pycolmap.get_covariance_for_relative_rigid3d(
         rigid1,
         rigid2,
-        joint_covariance,  # type: ignore[arg-type]
+        joint_covariance,
     )
     assert result.shape == (6, 6)
 

--- a/src/pycolmap/geometry/triangulation_test.py
+++ b/src/pycolmap/geometry/triangulation_test.py
@@ -10,10 +10,10 @@ def test_triangulate_point() -> None:
     point1 = np.array([0.0, 0.0])
     point2 = np.array([0.1, 0.0])
     result = pycolmap.triangulate_point(
-        cam1_from_world,  # type: ignore[arg-type]
-        cam2_from_world,  # type: ignore[arg-type]
+        cam1_from_world,
+        cam2_from_world,
         point1,
-        point2,  # type: ignore[arg-type]
+        point2,
     )
     if result is not None:
         assert result.shape == (3,)
@@ -42,10 +42,10 @@ def test_triangulate_point_from_rays() -> None:
     ray2 = cam2_from_world @ np.append(point3d, 1.0)
     ray2 /= np.linalg.norm(ray2)
     result = pycolmap.triangulate_point(
-        cam1_from_world,  # type: ignore[arg-type]
-        cam2_from_world,  # type: ignore[arg-type]
+        cam1_from_world,
+        cam2_from_world,
         ray1,
-        ray2,  # type: ignore[arg-type]
+        ray2,
     )
     assert result is not None
     np.testing.assert_allclose(result, point3d, atol=1e-6)
@@ -60,6 +60,6 @@ def test_triangulate_multi_view_point() -> None:
     for cam_from_world in cams_from_world:
         ray = cam_from_world @ np.append(point3d, 1.0)
         cam_rays.append(ray / np.linalg.norm(ray))
-    result = pycolmap.triangulate_multi_view_point(cams_from_world, cam_rays)  # type: ignore[arg-type]
+    result = pycolmap.triangulate_multi_view_point(cams_from_world, cam_rays)
     assert result is not None
     np.testing.assert_allclose(result, point3d, atol=1e-6)

--- a/src/pycolmap/scene/camera_test.py
+++ b/src/pycolmap/scene/camera_test.py
@@ -77,7 +77,7 @@ def test_camera_params_readwrite(simple_camera: pycolmap.Camera) -> None:
     params = simple_camera.params
     assert len(params) > 0
     new_params = list(params)
-    new_params[0] = 600.0  # type: ignore[call-overload]
+    new_params[0] = 600.0
     simple_camera.params = new_params
     assert simple_camera.params[0] == 600.0
 

--- a/src/pycolmap/scene/correspondence_graph_test.py
+++ b/src/pycolmap/scene/correspondence_graph_test.py
@@ -112,7 +112,7 @@ def test_correspondence_graph_with_two_view_geometry(
 def test_correspondence_graph_extract_matches(
     graph_with_matches: pycolmap.CorrespondenceGraph,
 ) -> None:
-    matches = graph_with_matches.extract_matches_between_images(1, 2)  # type: ignore[var-annotated]
+    matches = graph_with_matches.extract_matches_between_images(1, 2)
     assert matches.shape[0] == 2
 
 

--- a/src/pycolmap/scene/database_test.py
+++ b/src/pycolmap/scene/database_test.py
@@ -78,7 +78,7 @@ def test_database_write_and_read_keypoints(
         dtype=np.float32,
     )
     database.write_keypoints(image_id, keypoints)
-    read_keypoints = database.read_keypoints(image_id)  # type: ignore[var-annotated]
+    read_keypoints = database.read_keypoints(image_id)
     assert read_keypoints.shape[0] == 2
 
 
@@ -105,7 +105,7 @@ def test_database_write_and_read_matches(
     image_id2 = database.write_image(image2)
     matches = np.array([[0, 0], [1, 1]], dtype=np.uint32)
     database.write_matches(image_id, image_id2, matches)
-    read_matches = database.read_matches(image_id, image_id2)  # type: ignore[var-annotated]
+    read_matches = database.read_matches(image_id, image_id2)
     assert read_matches.shape[0] == 2
 
 

--- a/src/pycolmap/scene/two_view_geometry_test.py
+++ b/src/pycolmap/scene/two_view_geometry_test.py
@@ -53,22 +53,22 @@ def test_two_view_geometry_config_readwrite() -> None:
 def test_two_view_geometry_e_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     essential = np.eye(3)
-    geometry.E = essential  # type: ignore[assignment]
-    np.testing.assert_array_almost_equal(geometry.E, essential)  # type: ignore[arg-type]
+    geometry.E = essential
+    np.testing.assert_array_almost_equal(geometry.E, essential)
 
 
 def test_two_view_geometry_f_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     fundamental = np.eye(3)
-    geometry.F = fundamental  # type: ignore[assignment]
-    np.testing.assert_array_almost_equal(geometry.F, fundamental)  # type: ignore[arg-type]
+    geometry.F = fundamental
+    np.testing.assert_array_almost_equal(geometry.F, fundamental)
 
 
 def test_two_view_geometry_h_readwrite() -> None:
     geometry = pycolmap.TwoViewGeometry()
     homography = np.eye(3)
-    geometry.H = homography  # type: ignore[assignment]
-    np.testing.assert_array_almost_equal(geometry.H, homography)  # type: ignore[arg-type]
+    geometry.H = homography
+    np.testing.assert_array_almost_equal(geometry.H, homography)
 
 
 def test_two_view_geometry_cam2_from_cam1_readwrite() -> None:


### PR DESCRIPTION
## Summary

- keep pybind11 3's native NumPy annotations instead of rewriting dimensions into `Literal`/`TypeVar` shapes
- remove all unnecessary `# type: ignore[...]` comments containing `arg-type` across the repository
- narrow the PyCOLMAP test override and suppress only shape-indistinguishable overloads inside generated stubs

This follows up on the review feedback in #4665. Shape information remains available as `Annotated` metadata, while mypy sees the runtime-compatible `ArrayLike` input and dtype-preserving `NDArray` output types.

## Generated annotation example

Before:

```python
def estimate_affine2d(
    src: numpy.ndarray[
        tuple[M, typing.Literal[2]], numpy.dtype[numpy.float64]
    ],
    tgt: numpy.ndarray[
        tuple[M, typing.Literal[2]], numpy.dtype[numpy.float64]
    ],
) -> numpy.ndarray[
    tuple[typing.Literal[2], typing.Literal[3]],
    numpy.dtype[numpy.float64],
] | None: ...
```

After:

```python
def estimate_affine2d(
    src: typing.Annotated[
        numpy.typing.ArrayLike, numpy.float64, "[m, 2]"
    ],
    tgt: typing.Annotated[
        numpy.typing.ArrayLike, numpy.float64, "[m, 2]"
    ],
) -> typing.Annotated[
    numpy.typing.NDArray[numpy.float64], "[2, 3]"
] | None: ...
```

## Testing

- `PYENV_VERSION=colmap scripts/format/python.sh`
- rebuilt and installed the pycolmap wheel with regenerated stubs
- `PYENV_VERSION=colmap mypy --package pycolmap`
- `PYENV_VERSION=colmap mypy --install-types --non-interactive python benchmark doc` in a clean source tree
- `PYENV_VERSION=colmap mypy src/pycolmap src/thirdparty/Symforce-Caspar/caspar_generate.py` in a clean source tree
- `PYENV_VERSION=colmap pytest` (955 passed)
- repository-wide search confirms no tracked `# type: ignore[...]` containing `arg-type` remains
