### PR TITLE
Add composable Ceres rotation averaging

### DIFF
--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -44,6 +44,7 @@ set(ESTIMATORS_SRCS
     gravity_refinement.h gravity_refinement.cc
     pose.h pose.cc
     rotation_averaging.h rotation_averaging.cc
+    rotation_averaging_ceres.h rotation_averaging_ceres.cc
     rotation_averaging_impl.h rotation_averaging_impl.cc
     triangulation.h triangulation.cc
     two_view_geometry.h two_view_geometry.cc
@@ -145,6 +146,12 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME rotation_averaging_test
     SRCS rotation_averaging_test.cc
+    LINK_LIBS colmap_estimators
+)
+
+COLMAP_ADD_TEST(
+    NAME rotation_averaging_ceres_test
+    SRCS rotation_averaging_ceres_test.cc
     LINK_LIBS colmap_estimators
 )
 

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -500,10 +500,8 @@ bool RotationEstimator::SolveRotationAveraging(
   return true;
 }
 
-void RotationEstimator::InitializeFromMaximumSpanningTree(
-    const PoseGraph& pose_graph,
-    const FlatHashSet<image_t>& active_image_ids,
-    Reconstruction& reconstruction) {
+NodeHashMap<image_t, Rigid3d> ComputeImageRotationsFromMaximumSpanningTree(
+    const PoseGraph& pose_graph, const FlatHashSet<image_t>& active_image_ids) {
   // Compute maximum spanning tree over active images.
   NodeHashMap<image_t, image_t> parents;
   const image_t root = ComputeMaximumPoseGraphSpanningTree(
@@ -513,8 +511,7 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
   // Iterate through the tree to initialize the rotation.
   // Establish child info.
   NodeHashMap<image_t, std::vector<image_t>> children;
-  for (const auto& [image_id, image] : reconstruction.Images()) {
-    if (!active_image_ids.count(image_id)) continue;
+  for (const image_t image_id : active_image_ids) {
     children.emplace(image_id, std::vector<image_t>());
   }
   for (auto& [child, parent] : parents) {
@@ -526,6 +523,7 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
   indexes.push(root);
 
   NodeHashMap<image_t, Rigid3d> cams_from_world;
+  cams_from_world.emplace(root, Rigid3d());
   while (!indexes.empty()) {
     image_t curr = indexes.front();
     indexes.pop();
@@ -542,8 +540,17 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
         (edge.cam2_from_cam1 * cams_from_world[parents[curr]]).rotation();
   }
 
-  InitializeRigRotationsFromImages(
-      cams_from_world, reconstruction, options_.refine_sensor_from_rig);
+  return cams_from_world;
+}
+
+void RotationEstimator::InitializeFromMaximumSpanningTree(
+    const PoseGraph& pose_graph,
+    const FlatHashSet<image_t>& active_image_ids,
+    Reconstruction& reconstruction) {
+  InitializeRigRotationsFromImages(ComputeImageRotationsFromMaximumSpanningTree(
+                                       pose_graph, active_image_ids),
+                                   reconstruction,
+                                   options_.refine_sensor_from_rig);
 }
 
 bool InitializeRigRotationsFromImages(

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -137,6 +137,10 @@ class RotationEstimator {
   const RotationEstimatorOptions options_;
 };
 
+// Computes per-image rotations from the stock maximum spanning tree.
+NodeHashMap<image_t, Rigid3d> ComputeImageRotationsFromMaximumSpanningTree(
+    const PoseGraph& pose_graph, const FlatHashSet<image_t>& active_image_ids);
+
 // Initialize rig rotations by averaging per-image rotations.
 // Estimates cam_from_rig for cameras with unknown calibration,
 // then computes rig_from_world for each frame.

--- a/src/colmap/estimators/rotation_averaging_ceres.cc
+++ b/src/colmap/estimators/rotation_averaging_ceres.cc
@@ -1,0 +1,194 @@
+#include "colmap/estimators/rotation_averaging_ceres.h"
+
+#include "colmap/estimators/cost_functions/manifold.h"
+#include "colmap/estimators/cost_functions/quaternion_utils.h"
+#include "colmap/estimators/rotation_averaging.h"
+#include "colmap/scene/pose_graph.h"
+#include "colmap/scene/reconstruction.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <ceres/rotation.h>
+
+namespace colmap {
+namespace {
+
+struct RelativeRotationError {
+  explicit RelativeRotationError(const Eigen::Quaterniond& cam2_from_cam1)
+      : cam2_from_cam1(cam2_from_cam1) {}
+
+  template <typename T>
+  bool operator()(const T* const rotation1,
+                  const T* const rotation2,
+                  T* residuals) const {
+    const Eigen::Matrix<T, 3, 3> error =
+        EigenQuaternionMap<T>(rotation2).toRotationMatrix().transpose() *
+        cam2_from_cam1.cast<T>().toRotationMatrix() *
+        EigenQuaternionMap<T>(rotation1).toRotationMatrix();
+    ceres::RotationMatrixToAngleAxis(error.data(), residuals);
+    return true;
+  }
+
+  static ceres::CostFunction* Create(const Eigen::Quaterniond& cam2_from_cam1) {
+    return new ceres::AutoDiffCostFunction<RelativeRotationError, 3, 4, 4>(
+        new RelativeRotationError(cam2_from_cam1));
+  }
+
+  const Eigen::Quaterniond cam2_from_cam1;
+};
+
+}  // namespace
+
+CeresRotationAveragerOptions::CeresRotationAveragerOptions() {
+  solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+}
+
+CeresRotationAverager::CeresRotationAverager(
+    std::unique_ptr<ceres::Problem> problem,
+    ceres::Solver::Options solver_options,
+    Reconstruction& reconstruction)
+    : solver_options_(std::move(solver_options)),
+      reconstruction_(reconstruction),
+      problem_(std::move(problem)) {}
+
+ceres::Solver::Summary CeresRotationAverager::Solve() {
+  ceres::Solver::Summary summary;
+  ceres::Solve(solver_options_, problem_.get(), &summary);
+  if (summary.IsSolutionUsable()) {
+    for (const auto& [frame_id, frame] : reconstruction_.Frames()) {
+      if (frame.HasPose() &&
+          problem_->HasParameterBlock(
+              frame.RigFromWorld().rotation().coeffs().data())) {
+        reconstruction_.RegisterFrame(frame_id);
+      }
+    }
+  }
+  return summary;
+}
+
+ceres::Problem& CeresRotationAverager::Problem() { return *problem_; }
+const ceres::Problem& CeresRotationAverager::Problem() const {
+  return *problem_;
+}
+const ceres::Solver::Options& CeresRotationAverager::SolverOptions() const {
+  return solver_options_;
+}
+
+void CeresRotationAverager::AddRelativeRotationResidual(
+    const image_t image_id1,
+    const image_t image_id2,
+    const Eigen::Quaterniond& cam2_from_cam1,
+    std::shared_ptr<ceres::LossFunction> loss_function) {
+  Frame& frame1 =
+      reconstruction_.Frame(reconstruction_.Image(image_id1).FrameId());
+  Frame& frame2 =
+      reconstruction_.Frame(reconstruction_.Image(image_id2).FrameId());
+  double* rotation1 = frame1.RigFromWorld().rotation().coeffs().data();
+  double* rotation2 = frame2.RigFromWorld().rotation().coeffs().data();
+  if (!problem_->HasParameterBlock(rotation1) ||
+      !problem_->HasParameterBlock(rotation2)) {
+    throw std::invalid_argument(
+        "relative rotation residual references an image outside the Ceres "
+        "problem");
+  }
+  ceres::LossFunction* loss = loss_function.get();
+  if (loss != nullptr) {
+    losses_.try_emplace(loss, std::move(loss_function));
+  }
+  problem_->AddResidualBlock(RelativeRotationError::Create(cam2_from_cam1),
+                             loss,
+                             rotation1,
+                             rotation2);
+}
+
+std::unique_ptr<CeresRotationAverager> CreateDefaultCeresRotationAverager(
+    const CeresRotationAveragerOptions& options,
+    const PoseGraph& pose_graph,
+    Reconstruction& reconstruction) {
+  std::shared_ptr<ceres::LossFunction> loss(CreateCeresLossFunction(
+      options.loss_function_type, options.loss_function_scale));
+  FlatHashSet<image_t> image_ids;
+  std::vector<image_pair_t> pair_ids;
+  for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+    if (!reconstruction.ExistsImage(image_id1) ||
+        !reconstruction.ExistsImage(image_id2)) {
+      throw std::invalid_argument("rotation edge references unknown image");
+    }
+    const Image& image1 = reconstruction.Image(image_id1);
+    const Image& image2 = reconstruction.Image(image_id2);
+    if (image1.FrameId() == image2.FrameId() || !image1.IsRefInFrame() ||
+        !image2.IsRefInFrame() || image1.FramePtr()->NumDataIds() != 1 ||
+        image2.FramePtr()->NumDataIds() != 1) {
+      throw std::invalid_argument(
+          "Ceres rotation averaging does not support multi-camera rigs");
+    }
+    image_ids.insert(image_id1);
+    image_ids.insert(image_id2);
+    pair_ids.push_back(pair_id);
+  }
+  if (pair_ids.empty()) {
+    throw std::invalid_argument("Ceres rotation averaging requires edges");
+  }
+  if (pose_graph
+          .ConnectedFrameComponents(reconstruction,
+                                    /*filter_unregistered=*/false)
+          .size() != 1) {
+    throw std::invalid_argument(
+        "Ceres rotation averaging requires a connected pose graph");
+  }
+  std::sort(pair_ids.begin(), pair_ids.end());
+
+  if (!options.skip_initialization) {
+    for (const auto& [image_id, cam_from_world] :
+         ComputeImageRotationsFromMaximumSpanningTree(pose_graph, image_ids)) {
+      Frame& frame =
+          reconstruction.Frame(reconstruction.Image(image_id).FrameId());
+      if (!frame.HasPose()) {
+        Rigid3d rig_from_world;
+        rig_from_world.translation().setConstant(
+            std::numeric_limits<double>::quiet_NaN());
+        frame.SetRigFromWorld(rig_from_world);
+      }
+      frame.RigFromWorld().rotation() = cam_from_world.rotation();
+    }
+  }
+
+  ceres::Problem::Options problem_options;
+  problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+  auto problem = std::make_unique<ceres::Problem>(problem_options);
+  for (const image_t image_id : image_ids) {
+    Frame& frame =
+        reconstruction.Frame(reconstruction.Image(image_id).FrameId());
+    if (!frame.HasPose()) {
+      throw std::invalid_argument(
+          "rotation averaging frame has no initial pose");
+    }
+    double* rotation = frame.RigFromWorld().rotation().coeffs().data();
+    problem->AddParameterBlock(
+        rotation, 4, CreateEigenQuaternionManifold().release());
+  }
+  const image_t root_image_id =
+      *std::min_element(image_ids.begin(), image_ids.end());
+  Frame& root_frame =
+      reconstruction.Frame(reconstruction.Image(root_image_id).FrameId());
+  problem->SetParameterBlockConstant(
+      root_frame.RigFromWorld().rotation().coeffs().data());
+
+  std::unique_ptr<CeresRotationAverager> owner(new CeresRotationAverager(
+      std::move(problem), options.solver_options, reconstruction));
+  for (const image_pair_t pair_id : pair_ids) {
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+    owner->AddRelativeRotationResidual(
+        image_id1,
+        image_id2,
+        pose_graph.Edges().at(pair_id).cam2_from_cam1.rotation(),
+        loss);
+  }
+  return owner;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/rotation_averaging_ceres.h
+++ b/src/colmap/estimators/rotation_averaging_ceres.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "colmap/estimators/ceres_loss.h"
+#include "colmap/math/math.h"
+#include "colmap/util/hash_containers.h"
+#include "colmap/util/types.h"
+
+#include <memory>
+
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+class PoseGraph;
+class Reconstruction;
+
+struct CeresRotationAveragerOptions {
+  CeresLossFunctionType loss_function_type = CeresLossFunctionType::HUBER;
+  double loss_function_scale = DegToRad(5.0);
+
+  // Ceres-Solver options.
+  ceres::Solver::Options solver_options;
+
+  // Match RotationEstimatorOptions initialization behavior.
+  bool skip_initialization = false;
+
+  CeresRotationAveragerOptions();
+};
+
+// Owns exactly one Ceres problem. Parameter blocks in a default problem update
+// Reconstruction rotations directly, so the reconstruction must outlive the
+// owner.
+class CeresRotationAverager {
+ public:
+  CeresRotationAverager(const CeresRotationAverager&) = delete;
+  CeresRotationAverager& operator=(const CeresRotationAverager&) = delete;
+
+  ceres::Solver::Summary Solve();
+  ceres::Problem& Problem();
+  const ceres::Problem& Problem() const;
+  const ceres::Solver::Options& SolverOptions() const;
+  void AddRelativeRotationResidual(
+      image_t image_id1,
+      image_t image_id2,
+      const Eigen::Quaterniond& cam2_from_cam1,
+      std::shared_ptr<ceres::LossFunction> loss_function);
+
+ private:
+  CeresRotationAverager(std::unique_ptr<ceres::Problem> problem,
+                        ceres::Solver::Options solver_options,
+                        Reconstruction& reconstruction);
+
+  ceres::Solver::Options solver_options_;
+  Reconstruction& reconstruction_;
+  FlatHashMap<ceres::LossFunction*, std::shared_ptr<ceres::LossFunction>>
+      losses_;
+  // Destroy the problem before the retained DO_NOT_TAKE_OWNERSHIP losses.
+  std::unique_ptr<ceres::Problem> problem_;
+
+  friend std::unique_ptr<CeresRotationAverager>
+  CreateDefaultCeresRotationAverager(const CeresRotationAveragerOptions&,
+                                     const PoseGraph&,
+                                     Reconstruction&);
+};
+
+std::unique_ptr<CeresRotationAverager> CreateDefaultCeresRotationAverager(
+    const CeresRotationAveragerOptions& options,
+    const PoseGraph& pose_graph,
+    Reconstruction& reconstruction);
+
+}  // namespace colmap

--- a/src/colmap/estimators/rotation_averaging_ceres_test.cc
+++ b/src/colmap/estimators/rotation_averaging_ceres_test.cc
@@ -1,0 +1,160 @@
+#include "colmap/estimators/rotation_averaging_ceres.h"
+
+#include "colmap/scene/frame.h"
+#include "colmap/scene/image.h"
+#include "colmap/scene/pose_graph.h"
+#include "colmap/scene/reconstruction.h"
+#include "colmap/scene/synthetic.h"
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+Eigen::Quaterniond ZRotation(const double angle) {
+  return Eigen::Quaterniond(Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ()));
+}
+
+PoseGraph::Edge Edge(const Eigen::Quaterniond& rotation,
+                     const int num_matches = 10) {
+  PoseGraph::Edge edge;
+  edge.cam2_from_cam1 = Rigid3d(rotation, Eigen::Vector3d::Zero());
+  edge.num_matches = num_matches;
+  return edge;
+}
+
+Reconstruction MakeTrivialReconstruction(const std::vector<image_t>& ids,
+                                         const bool posed = true) {
+  Reconstruction reconstruction;
+  Camera camera =
+      Camera::CreateFromModelId(1, CameraModelId::kSimplePinhole, 10, 10, 5);
+  reconstruction.AddCameraWithTrivialRig(camera);
+  for (const image_t image_id : ids) {
+    Image image;
+    image.SetImageId(image_id);
+    image.SetCameraId(camera.camera_id);
+    if (posed) {
+      reconstruction.AddImageWithTrivialFrame(
+          image,
+          Rigid3d(Eigen::Quaterniond::Identity(),
+                  Eigen::Vector3d(image_id, image_id + 1, image_id + 2)));
+    } else {
+      reconstruction.AddImageWithTrivialFrame(image);
+    }
+  }
+  return reconstruction;
+}
+
+void SetRotation(Reconstruction& reconstruction,
+                 const frame_t frame_id,
+                 const Eigen::Quaterniond& rotation) {
+  Frame& frame = reconstruction.Frame(frame_id);
+  frame.RigFromWorld().rotation() = rotation;
+}
+
+TEST(CeresRotationAverager, RecoversNominalRotations) {
+  Reconstruction reconstruction = MakeTrivialReconstruction({1, 2, 3});
+  const Eigen::Vector3d translation =
+      reconstruction.Frame(2).RigFromWorld().translation();
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(1, 2, Edge(ZRotation(0.2)));
+  pose_graph.AddEdge(2, 3, Edge(ZRotation(-0.1)));
+  CeresRotationAveragerOptions options;
+
+  auto averager =
+      CreateDefaultCeresRotationAverager(options, pose_graph, reconstruction);
+  EXPECT_EQ(averager->Problem().NumParameterBlocks(), 3);
+  EXPECT_EQ(averager->Problem().NumResidualBlocks(), 2);
+  EXPECT_EQ(averager->SolverOptions().linear_solver_type,
+            ceres::SPARSE_NORMAL_CHOLESKY);
+  ASSERT_TRUE(averager->Solve().IsSolutionUsable());
+  EXPECT_NEAR((reconstruction.Image(2).CamFromWorld().rotation() *
+               reconstruction.Image(1).CamFromWorld().rotation().inverse())
+                  .angularDistance(ZRotation(0.2)),
+              0.0,
+              1e-10);
+  EXPECT_EQ(reconstruction.Frame(2).RigFromWorld().translation(), translation);
+}
+
+TEST(CeresRotationAverager, AddsIndividualRelativeRotationResidual) {
+  Reconstruction reconstruction = MakeTrivialReconstruction({1, 2, 3});
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(1, 2, Edge(ZRotation(0.2)));
+  auto averager = CreateDefaultCeresRotationAverager(
+      CeresRotationAveragerOptions(), pose_graph, reconstruction);
+
+  auto loss = std::make_shared<ceres::CauchyLoss>(0.05);
+  averager->AddRelativeRotationResidual(1, 2, ZRotation(0.2), loss);
+  EXPECT_EQ(averager->Problem().NumResidualBlocks(), 2);
+  std::weak_ptr<ceres::LossFunction> retained_loss = loss;
+  loss.reset();
+  EXPECT_FALSE(retained_loss.expired());
+  EXPECT_THROW(averager->AddRelativeRotationResidual(
+                   1, 3, ZRotation(0.2), retained_loss.lock()),
+               std::invalid_argument);
+  EXPECT_TRUE(averager->Solve().IsSolutionUsable());
+}
+
+TEST(CeresRotationAverager, SelectsMstOrSuppliedInitialization) {
+  Reconstruction supplied = MakeTrivialReconstruction({1, 2});
+  SetRotation(supplied, 1, ZRotation(0.7));
+  SetRotation(supplied, 2, ZRotation(0.9));
+  Reconstruction initialized = MakeTrivialReconstruction({1, 2}, false);
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(1, 2, Edge(ZRotation(0.2)));
+
+  auto mst = CreateDefaultCeresRotationAverager(
+      CeresRotationAveragerOptions(), pose_graph, initialized);
+  EXPECT_NEAR((initialized.Frame(2).RigFromWorld().rotation() *
+               initialized.Frame(1).RigFromWorld().rotation().inverse())
+                  .angularDistance(ZRotation(0.2)),
+              0.0,
+              1e-12);
+  EXPECT_TRUE(
+      initialized.Frame(1).RigFromWorld().translation().array().isNaN().all());
+
+  CeresRotationAveragerOptions options;
+  options.skip_initialization = true;
+  auto preserved =
+      CreateDefaultCeresRotationAverager(options, pose_graph, supplied);
+  EXPECT_EQ(supplied.Frame(1).RigFromWorld().rotation().coeffs(),
+            ZRotation(0.7).coeffs());
+  EXPECT_EQ(supplied.Frame(2).RigFromWorld().rotation().coeffs(),
+            ZRotation(0.9).coeffs());
+}
+
+TEST(CeresRotationAverager, RejectsDisconnectedPoseGraph) {
+  Reconstruction reconstruction = MakeTrivialReconstruction({1, 2, 3, 4});
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(1, 2, Edge(ZRotation(0.1)));
+  pose_graph.AddEdge(3, 4, Edge(ZRotation(0.2)));
+  EXPECT_THROW(CreateDefaultCeresRotationAverager(
+                   CeresRotationAveragerOptions(), pose_graph, reconstruction),
+               std::invalid_argument);
+}
+
+TEST(CeresRotationAverager, RejectsMultiCameraRigs) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions dataset_options;
+  dataset_options.num_rigs = 1;
+  dataset_options.num_cameras_per_rig = 2;
+  dataset_options.num_frames_per_rig = 2;
+  dataset_options.num_points3D = 10;
+  SynthesizeDataset(dataset_options, &reconstruction);
+  std::vector<image_t> ref_image_ids;
+  for (const auto& [image_id, image] : reconstruction.Images()) {
+    if (image.IsRefInFrame()) ref_image_ids.push_back(image_id);
+  }
+  ASSERT_EQ(ref_image_ids.size(), 2);
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(ref_image_ids[0], ref_image_ids[1], Edge(ZRotation(0.2)));
+  EXPECT_THROW(CreateDefaultCeresRotationAverager(
+                   CeresRotationAveragerOptions(), pose_graph, reconstruction),
+               std::invalid_argument);
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/pycolmap/estimators/bindings.cc
+++ b/src/pycolmap/estimators/bindings.cc
@@ -7,6 +7,7 @@ void BindAffineTransformEstimator(py::module& m);
 void BindAlignmentEstimator(py::module& m);
 void BindBundleAdjuster(py::module& m);
 void BindCeres(py::module& m);
+void BindCeresRotationAverager(py::module& m);
 void BindCostFunctions(py::module& m);
 void BindCovarianceEstimator(py::module& m);
 void BindEssentialMatrixEstimator(py::module& m);
@@ -25,6 +26,7 @@ void BindEstimators(py::module& m) {
   BindAlignmentEstimator(m);
   BindBundleAdjuster(m);
   BindCostFunctions(m);
+  BindCeresRotationAverager(m);
   BindCovarianceEstimator(m);
   BindEssentialMatrixEstimator(m);
   BindFundamentalMatrixEstimator(m);

--- a/src/pycolmap/estimators/rotation_averaging_ceres.cc
+++ b/src/pycolmap/estimators/rotation_averaging_ceres.cc
@@ -1,0 +1,52 @@
+#include "colmap/estimators/rotation_averaging_ceres.h"
+
+#include "colmap/scene/pose_graph.h"
+#include "colmap/scene/reconstruction.h"
+
+#include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
+
+#include <pybind11/pybind11.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+void BindCeresRotationAverager(py::module& m) {
+  auto PyOptions =
+      py::classh<CeresRotationAveragerOptions>(m,
+                                               "CeresRotationAveragerOptions")
+          .def(py::init<>())
+          .def_readwrite("loss_function_type",
+                         &CeresRotationAveragerOptions::loss_function_type)
+          .def_readwrite("loss_function_scale",
+                         &CeresRotationAveragerOptions::loss_function_scale)
+          .def_readwrite("solver_options",
+                         &CeresRotationAveragerOptions::solver_options)
+          .def_readwrite("skip_initialization",
+                         &CeresRotationAveragerOptions::skip_initialization);
+  MakeDataclass(PyOptions);
+
+  py::classh<CeresRotationAverager>(m, "CeresRotationAverager")
+      .def("solve", &CeresRotationAverager::Solve)
+      .def("add_relative_rotation_residual",
+           &CeresRotationAverager::AddRelativeRotationResidual,
+           "image_id1"_a,
+           "image_id2"_a,
+           "cam2_from_cam1"_a,
+           "loss"_a)
+      .def_property_readonly(
+          "problem",
+          py::overload_cast<>(&CeresRotationAverager::Problem),
+          py::return_value_policy::reference_internal)
+      .def_property_readonly("solver_options",
+                             &CeresRotationAverager::SolverOptions,
+                             py::return_value_policy::copy);
+
+  m.def("create_default_ceres_rotation_averager",
+        &CreateDefaultCeresRotationAverager,
+        "options"_a,
+        "pose_graph"_a,
+        "reconstruction"_a,
+        py::keep_alive<0, 3>());
+}

--- a/src/pycolmap/estimators/rotation_averaging_ceres_test.py
+++ b/src/pycolmap/estimators/rotation_averaging_ceres_test.py
@@ -1,0 +1,38 @@
+import gc
+
+import pytest
+
+import pycolmap
+
+
+def test_ceres_rotation_averager_adds_residual_and_solves():
+    pyceres = pytest.importorskip("pyceres")
+    dataset_options = pycolmap.SyntheticDatasetOptions()
+    dataset_options.num_rigs = 1
+    dataset_options.num_cameras_per_rig = 1
+    dataset_options.num_frames_per_rig = 2
+    dataset_options.num_points3D = 10
+    reconstruction = pycolmap.synthesize_dataset(dataset_options)
+    image_ids = sorted(reconstruction.images)
+
+    pose_graph = pycolmap.PoseGraph()
+    pose_graph.add_edge(
+        *image_ids,
+        pycolmap.PoseGraphEdge(
+            cam2_from_cam1=pycolmap.Rigid3d(), num_matches=10
+        ),
+    )
+    options = pycolmap.CeresRotationAveragerOptions()
+    averager = pycolmap.create_default_ceres_rotation_averager(
+        options, pose_graph, reconstruction
+    )
+    assert averager.problem.num_residual_blocks() == 1
+    loss = pyceres.CauchyLoss(0.05)
+    averager.add_relative_rotation_residual(
+        *image_ids, pycolmap.Rigid3d().rotation, loss
+    )
+    assert averager.problem.num_residual_blocks() == 2
+    del loss
+    del reconstruction
+    gc.collect()
+    assert averager.solve().IsSolutionUsable()


### PR DESCRIPTION
## Motivation

Adding constraints to COLMAP's rotation-averaging problem currently requires hacking its implementation. The existing estimator uses L1-IRLS rather than Ceres.

This PR adds a separate Ceres rotation averager, defaulting to a Huber loss. Following `CreateDefaultBundleAdjuster(...)`, `CreateDefaultCeresRotationAverager(...)` returns the prepared problem so callers can extend it before solving. The existing rotation estimator retains its current behavior.

## Changes

- Add `CeresRotationAveragerOptions`, `CeresRotationAverager`, and `CreateDefaultCeresRotationAverager(...)`.
- Build a Ceres problem with parameter blocks referencing reconstruction-owned frame and sensor rotations, with configurable loss and solver options.
- Expose the prepared problem, solver options, `Solve()`, and insertion of relative-rotation residuals with explicit losses.
- Extract the existing `InitializeFromMaximumSpanningTree(...)` for reuse by both rotation estimators.
- Expose the construction and solve workflow through PyCOLMAP.
