### PR TITLE
Stop deriving the hash map backend from the build machine

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -77,8 +77,8 @@ jobs:
           cmake --version
           mkdir -p build
           cd build
-          # Only CI coverage of the non-default BOOST hash map backend. The
-          # bundle ships no headers or libraries, so nothing links against it.
+          # The app bundle ships no headers or libraries, so nothing links
+          # against it and it can use the faster non-default hash map backend.
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.cmakeBuildType }} \

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -77,10 +77,8 @@ jobs:
           cmake --version
           mkdir -p build
           cd build
-          # The only job covering the non-default BOOST hash map backend: the
-          # Ubuntu jobs' apt Boost is too old, and the Windows job exports a
-          # linkable install tree, which must keep the default ABI. This job
-          # publishes a self-contained app bundle, so the backend stays private.
+          # Only CI coverage of the non-default BOOST hash map backend. The
+          # bundle ships no headers or libraries, so nothing links against it.
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.cmakeBuildType }} \

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -77,11 +77,16 @@ jobs:
           cmake --version
           mkdir -p build
           cd build
+          # The only job covering the non-default BOOST hash map backend: the
+          # Ubuntu jobs' apt Boost is too old, and the Windows job exports a
+          # linkable install tree, which must keep the default ABI. This job
+          # publishes a self-contained app bundle, so the backend stays private.
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.cmakeBuildType }} \
             -DTESTS_ENABLED=ON \
             -DWERROR_ENABLED=ON \
+            -DCOLMAP_HASH_MAP_BACKEND=BOOST \
             -DQt6_DIR="$(brew --prefix qt)/lib/cmake/Qt6"
           ninja
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -169,9 +169,9 @@ jobs:
           fi
 
           # Ubuntu's apt Boost (1.74 on 22.04, 1.83 on 24.04) predates
-          # boost::unordered_node_map (Boost >= 1.84), so COLMAP auto-selects the
-          # STD hash map backend here. The BOOST backend is exercised on the
-          # macOS (brew) and Windows (vcpkg) jobs. See COLMAP_HASH_MAP_BACKEND.
+          # boost::unordered_node_map (Boost >= 1.84), so these jobs can only use
+          # the default STD hash map backend. The BOOST backend is exercised on
+          # the macOS (brew) job. See COLMAP_HASH_MAP_BACKEND.
           sudo apt-get update && sudo apt-get install -y \
             build-essential \
             cmake \

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -168,10 +168,6 @@ jobs:
             fi
           fi
 
-          # Ubuntu's apt Boost (1.74 on 22.04, 1.83 on 24.04) predates
-          # boost::unordered_node_map (Boost >= 1.84), so these jobs can only use
-          # the default STD hash map backend. The BOOST backend is exercised on
-          # the macOS (brew) job. See COLMAP_HASH_MAP_BACKEND.
           sudo apt-get update && sudo apt-get install -y \
             build-essential \
             cmake \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -149,8 +149,11 @@ jobs:
             # during CUDA compiler detection.
             $env:CUDAFLAGS = "-allow-unsupported-compiler"
           }
+          # The package ships no headers or libraries, so nothing links against
+          # it and it can use the faster non-default hash map backend.
           cmake .. `
             -GNinja `
+            -DCOLMAP_HASH_MAP_BACKEND=BOOST `
             -DCMAKE_MAKE_PROGRAM=ninja `
             -DCMAKE_BUILD_TYPE=Release `
             -DTESTS_ENABLED=${{ matrix.config.testsEnabled }} `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,12 +78,13 @@ option(CASPAR_ENABLED "Whether to enable CASPAR-accelerated bundle adjustment" O
 option(CASPAR_USE_DOUBLE "Use double precision in Caspar solver" OFF)
 
 # Hash map backend used by the performance-critical scene/SfM containers (see
-# src/colmap/util/hash_containers.h). One of: STD, BOOST, or empty for auto.
-# Auto selects BOOST (faster boost::unordered_flat/node maps) when the available
-# Boost is new enough (>= 1.84, for boost::unordered_node_map) and STD otherwise.
+# src/colmap/util/hash_containers.h). Part of COLMAP's ABI, hence a fixed default
+# rather than one derived from the build machine. BOOST is faster but must be
+# applied to everything loaded alongside COLMAP. AUTO is the old host-dependent
+# selection, kept only for compatibility.
 set(COLMAP_HASH_MAP_BACKEND "" CACHE STRING
-    "Hash map backend for scene/SfM containers: STD, BOOST, or empty for auto")
-set_property(CACHE COLMAP_HASH_MAP_BACKEND PROPERTY STRINGS "" STD BOOST)
+    "Hash map backend for scene/SfM containers: STD, BOOST, or AUTO")
+set_property(CACHE COLMAP_HASH_MAP_BACKEND PROPERTY STRINGS "" STD BOOST AUTO)
 
 if(CASPAR_ENABLED)
     add_compile_definitions(CASPAR_ENABLED)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -26,15 +26,15 @@ find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
 # header-only (boost-unordered is provided by the Boost::boost target), so no
 # extra linking is required.
 #
-# BOOST (boost::unordered_flat/node maps) is preferred, but its node maps
-# (boost::unordered_node_map) require Boost >= 1.84. When COLMAP_HASH_MAP_BACKEND
-# is empty we auto-select BOOST if the found Boost is new enough, else STD (so
-# e.g. builds against the system Boost on older distributions keep working).
+# The containers are data members of classes in public headers, so the backend
+# determines their layout and is part of COLMAP's ABI. The default is therefore
+# fixed, never derived from what happens to be installed here. BOOST (faster,
+# requires Boost >= 1.84 for boost::unordered_node_map) must be applied to
+# everything that ends up in the same process, including the pycolmap wheels.
 #
-# Note: downstream consumers re-run this file via find_package(colmap) with
-# COLMAP_HASH_MAP_BACKEND unset; they get the actual COLMAP_HASH_* macro from the
-# exported colmap targets, so the value re-derived here is only used to keep the
-# selection message and any local sources consistent.
+# find_package(colmap) re-runs this file with COLMAP_HASH_MAP_BACKEND pre-set to
+# the value COLMAP was built with (see colmap-config.cmake.in), so the selection
+# below reproduces that choice instead of re-deriving it.
 set(COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION "1.84.0")
 if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)
     set(_colmap_boost_version "${Boost_VERSION_STRING}")
@@ -43,12 +43,18 @@ else()
 endif()
 string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" COLMAP_HASH_MAP_BACKEND)
 if(NOT COLMAP_HASH_MAP_BACKEND)
+    set(COLMAP_HASH_MAP_BACKEND "STD")
+elseif(COLMAP_HASH_MAP_BACKEND STREQUAL "AUTO")
     if(_colmap_boost_version VERSION_GREATER_EQUAL
        "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION}")
         set(COLMAP_HASH_MAP_BACKEND "BOOST")
     else()
         set(COLMAP_HASH_MAP_BACKEND "STD")
     endif()
+    message(WARNING
+            "COLMAP_HASH_MAP_BACKEND=AUTO selected ${COLMAP_HASH_MAP_BACKEND} "
+            "from Boost ${_colmap_boost_version}, making the ABI depend on the "
+            "build machine. Pass STD or BOOST for a reproducible ABI.")
 endif()
 if(COLMAP_HASH_MAP_BACKEND STREQUAL "STD")
     list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_STD)
@@ -65,7 +71,7 @@ elseif(COLMAP_HASH_MAP_BACKEND STREQUAL "BOOST")
     list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_BOOST)
 else()
     message(FATAL_ERROR "Unknown COLMAP_HASH_MAP_BACKEND "
-            "'${COLMAP_HASH_MAP_BACKEND}' (expected STD, BOOST or empty)")
+            "'${COLMAP_HASH_MAP_BACKEND}' (expected STD, BOOST, AUTO or empty)")
 endif()
 message(STATUS "Using ${COLMAP_HASH_MAP_BACKEND} hash map backend "
         "(Boost ${_colmap_boost_version})")

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -26,14 +26,10 @@ find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
 # header-only (boost-unordered is provided by the Boost::boost target), so no
 # extra linking is required.
 #
-# The containers are data members of classes in public headers, so the backend
-# determines their layout and is part of COLMAP's ABI. The default is therefore
-# fixed, never derived from what happens to be installed here. BOOST (faster,
-# requires Boost >= 1.84 for boost::unordered_node_map) must be applied to
-# everything that ends up in the same process, including the pycolmap wheels.
-#
-# find_package(colmap) re-runs this file with COLMAP_HASH_MAP_BACKEND pre-set to
-# the value COLMAP was built with (see colmap-config.cmake.in), so the selection
+# The backend is part of COLMAP's ABI, so the default is fixed rather than
+# derived from the Boost installed here. BOOST (faster, requires Boost >= 1.84
+# for boost::unordered_node_map) must be applied to everything in the process.
+# find_package(colmap) pre-sets the value COLMAP was built with, so the selection
 # below reproduces that choice instead of re-deriving it.
 set(COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION "1.84.0")
 if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -87,6 +87,20 @@ set(FETCH_POSELIB @FETCH_POSELIB@)
 
 set(FETCH_FAISS @FETCH_FAISS@)
 
+# Backend COLMAP was built with. Pre-setting it keeps the value re-derived by
+# FindDependencies.cmake below in sync with the installed binaries rather than
+# with the consumer's Boost, turning a mismatch into a configure-time error.
+string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" _colmap_requested_hash_map_backend)
+if(_colmap_requested_hash_map_backend AND
+   NOT _colmap_requested_hash_map_backend STREQUAL "@COLMAP_HASH_MAP_BACKEND@")
+    message(WARNING
+            "Ignoring COLMAP_HASH_MAP_BACKEND="
+            "${_colmap_requested_hash_map_backend}: the installed COLMAP was "
+            "built with @COLMAP_HASH_MAP_BACKEND@.")
+endif()
+unset(_colmap_requested_hash_map_backend)
+set(COLMAP_HASH_MAP_BACKEND "@COLMAP_HASH_MAP_BACKEND@")
+
 set(FETCH_ONNX FALSE)
 if(@FETCH_ONNX@)
     if(ONNX_ENABLED AND EXISTS ${PACKAGE_PREFIX_DIR}/share/onnxruntime/cmake)

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -87,9 +87,8 @@ set(FETCH_POSELIB @FETCH_POSELIB@)
 
 set(FETCH_FAISS @FETCH_FAISS@)
 
-# Backend COLMAP was built with. Pre-setting it keeps the value re-derived by
-# FindDependencies.cmake below in sync with the installed binaries rather than
-# with the consumer's Boost, turning a mismatch into a configure-time error.
+# Backend COLMAP was built with. Pre-setting it makes FindDependencies.cmake
+# below follow the installed binaries instead of the consumer's Boost.
 string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" _colmap_requested_hash_map_backend)
 if(_colmap_requested_hash_map_backend AND
    NOT _colmap_requested_hash_map_backend STREQUAL "@COLMAP_HASH_MAP_BACKEND@")

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -166,8 +166,9 @@ Configure and compile COLMAP::
     performance-critical scene and SfM containers, selected via
     ``-DCOLMAP_HASH_MAP_BACKEND=STD|BOOST`` (default: ``STD``). ``BOOST`` is
     faster but requires **Boost >= 1.84** for ``boost::unordered_node_map``;
-    requesting it with an older Boost, such as Ubuntu's apt Boost, is a
-    configuration error. vcpkg installs a new enough ``boost-unordered``.
+    requesting it with an older Boost, such as the apt Boost on Ubuntu 24.04
+    (1.83) and earlier, is a configuration error. vcpkg installs a new enough
+    ``boost-unordered``.
 
     **The backend is part of COLMAP's ABI.** These containers are data members of
     classes in public headers, so ``sizeof(Reconstruction)`` is 320 bytes with

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -164,14 +164,22 @@ Configure and compile COLMAP::
 
     COLMAP can use ``boost::unordered`` flat/node hash maps for the
     performance-critical scene and SfM containers, selected via
-    ``-DCOLMAP_HASH_MAP_BACKEND=BOOST|STD`` (default: auto). Auto selects
-    ``BOOST`` when Boost is recent enough (``boost::unordered_node_map`` requires
-    **Boost >= 1.84**) and falls back to ``STD`` (``std::unordered_map``)
-    otherwise. Ubuntu's default Boost is older than 1.84, so apt-based builds use
-    ``STD``; to use the faster ``BOOST`` backend, build against a newer Boost
-    (e.g. via vcpkg, which installs ``boost-unordered`` automatically) or install
-    Boost >= 1.84 manually. Explicitly requesting ``-DCOLMAP_HASH_MAP_BACKEND=BOOST``
-    with an older Boost is a configuration error.
+    ``-DCOLMAP_HASH_MAP_BACKEND=STD|BOOST`` (default: ``STD``). ``BOOST`` is
+    faster but requires **Boost >= 1.84** for ``boost::unordered_node_map``;
+    requesting it with an older Boost, such as Ubuntu's apt Boost, is a
+    configuration error. vcpkg installs a new enough ``boost-unordered``.
+
+    **The backend is part of COLMAP's ABI.** These containers are data members of
+    classes in public headers, so ``sizeof(Reconstruction)`` is 320 bytes with
+    ``STD`` and 280 with ``BOOST`` on x86-64 Linux, and a mismatch produces no
+    link error, only memory corruption. Every binary sharing COLMAP types in one
+    process must agree, including the prebuilt ``pycolmap`` wheels, which use the
+    default. Query a build with ``colmap -h``, ``pycolmap.__hash_map_backend__``
+    or ``colmap::kHashMapBackend``.
+
+    ``AUTO`` picks the backend from the available Boost version, as older COLMAP
+    releases did. Avoid it: two machines then build different ABIs from the same
+    source and arguments.
 
 Run COLMAP::
 

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -66,7 +66,8 @@ if TYPE_CHECKING:
 __all__ = import_module_symbols(
     globals(), _core, exclude={"cost_functions", "pyceres"}
 )
-__all__.extend(["__version__", "__ceres_version__"])
+__all__.extend(["__version__", "__ceres_version__", "__hash_map_backend__"])
 
 __version__ = _core.__version__
 __ceres_version__ = _core.__ceres_version__
+__hash_map_backend__ = _core.__hash_map_backend__

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -61,6 +61,12 @@
 // unchanged and the hashing semantics are held constant across backends.
 // boost::unordered internally re-mixes a non-avalanching hash such as the
 // identity std::hash<uint32_t>.
+//
+// WARNING: these aliases are data members of classes in public headers, so the
+// backend changes their size and member offsets. Both backends are header-only,
+// so nothing about the choice reaches the linker: mixing binaries built with
+// different backends corrupts memory instead of failing to link. Hence the
+// fixed CMake default, and kHashMapBackend below for checking a binary.
 
 #include <functional>
 
@@ -82,6 +88,9 @@ namespace colmap {
 
 #if defined(COLMAP_HASH_BOOST)
 
+// Identifies the layout of every class storing these containers.
+inline constexpr const char* kHashMapBackend = "boost";
+
 template <class Key,
           class Value,
           class Hash = std::hash<Key>,
@@ -101,6 +110,8 @@ template <class Key, class Hash = std::hash<Key>, class Eq = std::equal_to<Key>>
 using NodeHashSet = boost::unordered_node_set<Key, Hash, Eq>;
 
 #else  // COLMAP_HASH_STD
+
+inline constexpr const char* kHashMapBackend = "std";
 
 template <class Key,
           class Value,

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -63,10 +63,8 @@
 // identity std::hash<uint32_t>.
 //
 // WARNING: these aliases are data members of classes in public headers, so the
-// backend changes their size and member offsets. Both backends are header-only,
-// so nothing about the choice reaches the linker: mixing binaries built with
-// different backends corrupts memory instead of failing to link. Hence the
-// fixed CMake default, and kHashMapBackend below for checking a binary.
+// backend changes their layout. Nothing about the choice reaches the linker, so
+// mixing backends corrupts memory instead of failing to link.
 
 #include <functional>
 

--- a/src/colmap/util/version.cc.in
+++ b/src/colmap/util/version.cc.in
@@ -30,6 +30,7 @@
 
 #include "colmap/util/version.h"
 
+#include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/string.h"
 
@@ -73,8 +74,13 @@ std::string GetBuildInfo() {
 #else
   const char* gpu_info = "without GPU support";
 #endif
-  return StringPrintf(
-      "Commit %s on %s %s", COLMAP_COMMIT_ID, COLMAP_COMMIT_DATE, gpu_info);
+  // The hash map backend is part of the ABI, and otherwise indistinguishable
+  // between two builds of the same commit.
+  return StringPrintf("Commit %s on %s %s, %s hash maps",
+                      COLMAP_COMMIT_ID,
+                      COLMAP_COMMIT_DATE,
+                      gpu_info,
+                      kHashMapBackend);
 }
 
 }  // namespace colmap

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -1,4 +1,5 @@
 #include "colmap/math/random.h"
+#include "colmap/util/hash_containers.h"
 #include "colmap/util/version.h"
 
 #include "pycolmap/helpers.h"
@@ -42,6 +43,10 @@ PYBIND11_MODULE(_core, m) {
   m.attr("has_cuda") = IsGPU(Device::AUTO);
   m.attr("COLMAP_version") = py::str(GetVersionInfo());
   m.attr("COLMAP_build") = py::str(GetBuildInfo());
+  // An extension linking its own COLMAP must share this backend, or the two
+  // disagree about the layout of Reconstruction and friends. Neither the link
+  // nor the import catches that, so expose it for downstreams to assert on.
+  m.attr("__hash_map_backend__") = py::str(kHashMapBackend);
 
   auto PyDevice = py::enum_<Device>(m, "Device")
                       .value("auto", Device::AUTO)

--- a/src/pycolmap/main_test.py
+++ b/src/pycolmap/main_test.py
@@ -11,6 +11,10 @@ def test_ceres_version_is_str() -> None:
     assert len(pycolmap.__ceres_version__) > 0
 
 
+def test_hash_map_backend_is_known() -> None:
+    assert pycolmap.__hash_map_backend__ in ("std", "boost")
+
+
 def test_has_cuda_is_bool() -> None:
     assert isinstance(pycolmap.has_cuda, bool)
 


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/issues/4672

FlatHashMap/FlatHashSet and their node variants are data members of classes in public headers, so COLMAP_HASH_MAP_BACKEND determines the layout of Reconstruction, CorrespondenceGraph, BundleAdjustmentConfig and others: sizeof(Reconstruction) is 320 bytes with STD and 280 with BOOST. Both backends are header-only, so a mismatch changes no mangled name and produces no link error, only memory corruption.

The backend was auto-selected from the Boost found at configure time, which made that layout a property of the build machine rather than of the source and the CMake arguments. The published manylinux pycolmap wheels are built through vcpkg and got BOOST; an apt-based Ubuntu 24.04 build of the same commit gets STD. An extension linking its own COLMAP and sharing bound types with pycolmap in one interpreter then reads those objects at the wrong offsets, since pybind11 keys registration on type_index, which is identical for both layouts.

Default to STD instead, and keep the old behavior available as an explicit AUTO that warns. BOOST stays an opt-in that has to be applied to everything in the process. colmap-config.cmake now pre-sets the value COLMAP was built with, so find_package() consumers reproduce that choice instead of re-deriving it from their own Boost, turning a mismatch into a configure-time error. The choice is also recorded in the binary as colmap::kHashMapBackend, reported by GetBuildInfo(), and exposed as pycolmap.__hash_map_backend__ for downstreams to assert on.

