### PR TITLE
Vendor Boost so the hash map backend does not depend on the host

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -25,6 +25,8 @@ jobs:
             os: ubuntu-26.04,
             qtVersion: 6,
             cmakeBuildType: Release,
+            # The only job building the non-default STD hash map backend.
+            hashMapBackend: STD,
             asanEnabled: false,
             guiEnabled: true,
             cudaEnabled: false,
@@ -169,9 +171,9 @@ jobs:
           fi
 
           # Ubuntu's apt Boost (1.74 on 22.04, 1.83 on 24.04) predates
-          # boost::unordered_node_map (Boost >= 1.84), so COLMAP auto-selects the
-          # STD hash map backend here. The BOOST backend is exercised on the
-          # macOS (brew) and Windows (vcpkg) jobs. See COLMAP_HASH_MAP_BACKEND.
+          # boost::unordered_node_map (Boost >= 1.84), so FETCH_BOOST=AUTO fetches
+          # and builds Boost on these jobs. See FETCH_BOOST and, for the hash map
+          # backend it makes available, COLMAP_HASH_MAP_BACKEND.
           sudo apt-get update && sudo apt-get install -y \
             build-essential \
             cmake \
@@ -231,6 +233,17 @@ jobs:
             sudo apt-get install -y gcovr
           fi
 
+      # These jobs fetch Boost (see FETCH_BOOST), so cache the ~100 MB archive
+      # rather than re-downloading it every run. Only the download is cached, as
+      # the extracted tree is several hundred MB. A stale entry is harmless:
+      # FetchContent re-downloads on URL_HASH mismatch.
+      - name: Restore Boost download cache
+        uses: actions/cache@v6
+        with:
+          path: build/_deps/downloads
+          key: colmap-fetchcontent-v1-${{ hashFiles('cmake/FindDependencies.cmake') }}
+          restore-keys: colmap-fetchcontent-v1-
+
       - name: Configure and build
         run: |
           set -x
@@ -249,6 +262,7 @@ jobs:
             -DGUI_ENABLED=${{ matrix.config.guiEnabled }} \
             -DASAN_ENABLED=${{ matrix.config.asanEnabled }} \
             -DCOVERAGE_ENABLED=${{ matrix.config.coverageEnabled }} \
+            -DCOLMAP_HASH_MAP_BACKEND=${{ matrix.config.hashMapBackend || 'BOOST' }} \
             -DBLA_VENDOR=Intel10_64lp
           ninja -k 10000
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,11 @@ option(LSD_ENABLED "Whether to enable the LSD library" ON)
 option(DOWNLOAD_ENABLED "Whether to enable (automatic) download of resources (requires Curl/OpenSSL)" ON)
 option(UNINSTALL_ENABLED "Whether to create a target to 'uninstall' colmap" ON)
 option(BENCHMARK_ENABLED "Whether to enable runtime benchmarking support" OFF)
+# AUTO fetches Boost only when the system one is too old for the selected hash
+# map backend (see COLMAP_HASH_MAP_BACKEND below).
+set(FETCH_BOOST "AUTO" CACHE STRING
+    "Whether to consume Boost using FetchContent: ON, OFF, or AUTO")
+set_property(CACHE FETCH_BOOST PROPERTY STRINGS AUTO ON OFF)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 option(FETCH_FAISS "Whether to consume faiss using FetchContent or find_package" ON)
 option(FETCH_ONNX "Whether to consume ONNX using FetchContent or find_package" ON)
@@ -77,13 +82,12 @@ option(ALL_SOURCE_TARGET "Whether to create a target for all source files (for V
 option(CASPAR_ENABLED "Whether to enable CASPAR-accelerated bundle adjustment" OFF)
 option(CASPAR_USE_DOUBLE "Use double precision in Caspar solver" OFF)
 
-# Hash map backend used by the performance-critical scene/SfM containers (see
-# src/colmap/util/hash_containers.h). One of: STD, BOOST, or empty for auto.
-# Auto selects BOOST (faster boost::unordered_flat/node maps) when the available
-# Boost is new enough (>= 1.84, for boost::unordered_node_map) and STD otherwise.
-set(COLMAP_HASH_MAP_BACKEND "" CACHE STRING
-    "Hash map backend for scene/SfM containers: STD, BOOST, or empty for auto")
-set_property(CACHE COLMAP_HASH_MAP_BACKEND PROPERTY STRINGS "" STD BOOST)
+# Hash map backend for the scene/SfM containers (see
+# src/colmap/util/hash_containers.h). Part of COLMAP's ABI, hence a fixed
+# default; FETCH_BOOST keeps BOOST available even on old system Boost.
+set(COLMAP_HASH_MAP_BACKEND "BOOST" CACHE STRING
+    "Hash map backend for scene/SfM containers: STD or BOOST")
+set_property(CACHE COLMAP_HASH_MAP_BACKEND PROPERTY STRINGS BOOST STD)
 
 if(CASPAR_ENABLED)
     add_compile_definitions(CASPAR_ENABLED)
@@ -476,6 +480,11 @@ if(GPU_ENABLED)
     list(APPEND COLMAP_EXPORT_LIBS
          colmap_sift_gpu
     )
+endif()
+if(FETCH_BOOST STREQUAL "ON")
+    # Interface target standing in for Boost::boost, see FindDependencies.cmake.
+    # Boost itself installs its own targets and BoostConfig.cmake.
+    list(APPEND COLMAP_EXPORT_LIBS colmap_boost_headers)
 endif()
 if(FETCH_POSELIB)
     list(APPEND COLMAP_EXPORT_LIBS PoseLib)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -118,12 +118,15 @@ if(FETCH_BOOST STREQUAL "ON")
     message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}...")
     FetchContent_MakeAvailable(Boost)
     message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}... done")
-    # The superproject defines Boost::headers where find_package defines
-    # Boost::boost. Alias via an interface target, since Boost::headers is itself
-    # an alias and cannot be aliased again.
+    # The superproject has no equivalent of find_package's monolithic
+    # Boost::boost, and its Boost::headers carries no library headers. Aggregate
+    # the libraries COLMAP includes, or they fall through to a system Boost.
     if(NOT TARGET Boost::boost)
         add_library(colmap_boost_headers INTERFACE)
-        target_link_libraries(colmap_boost_headers INTERFACE Boost::headers)
+        foreach(_colmap_boost_lib IN LISTS COLMAP_BOOST_LIBRARIES)
+            target_link_libraries(colmap_boost_headers
+                                  INTERFACE Boost::${_colmap_boost_lib})
+        endforeach()
         add_library(Boost::boost ALIAS colmap_boost_headers)
     endif()
     set(_colmap_boost_version "${COLMAP_FETCH_BOOST_VERSION}")

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -15,58 +15,120 @@ endif()
 
 find_package(OpenMP REQUIRED COMPONENTS C CXX)
 
-find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
-             graph
-             program_options
-             OPTIONAL_COMPONENTS
-             system)
-
-# Hash map backend selection for the scene/SfM containers. Adds the compile
-# definition consumed by src/colmap/util/hash_containers.h. Both backends are
-# header-only (boost-unordered is provided by the Boost::boost target), so no
-# extra linking is required.
-#
-# BOOST (boost::unordered_flat/node maps) is preferred, but its node maps
-# (boost::unordered_node_map) require Boost >= 1.84. When COLMAP_HASH_MAP_BACKEND
-# is empty we auto-select BOOST if the found Boost is new enough, else STD (so
-# e.g. builds against the system Boost on older distributions keep working).
-#
-# Note: downstream consumers re-run this file via find_package(colmap) with
-# COLMAP_HASH_MAP_BACKEND unset; they get the actual COLMAP_HASH_* macro from the
-# exported colmap targets, so the value re-derived here is only used to keep the
-# selection message and any local sources consistent.
-set(COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION "1.84.0")
-if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)
-    set(_colmap_boost_version "${Boost_VERSION_STRING}")
-else()
-    set(_colmap_boost_version "${Boost_VERSION}")
-endif()
+# Hash map backend for the scene/SfM containers, consumed by
+# src/colmap/util/hash_containers.h. The containers are data members of classes
+# in public headers, so this is part of COLMAP's ABI: a fixed default, never one
+# derived from the build machine. Resolved before Boost because it decides which
+# Boost version COLMAP needs.
 string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" COLMAP_HASH_MAP_BACKEND)
 if(NOT COLMAP_HASH_MAP_BACKEND)
-    if(_colmap_boost_version VERSION_GREATER_EQUAL
-       "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION}")
-        set(COLMAP_HASH_MAP_BACKEND "BOOST")
-    else()
-        set(COLMAP_HASH_MAP_BACKEND "STD")
-    endif()
+    set(COLMAP_HASH_MAP_BACKEND "BOOST")
 endif()
 if(COLMAP_HASH_MAP_BACKEND STREQUAL "STD")
     list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_STD)
 elseif(COLMAP_HASH_MAP_BACKEND STREQUAL "BOOST")
-    if(_colmap_boost_version VERSION_LESS
-       "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION}")
-        message(FATAL_ERROR
-                "COLMAP_HASH_MAP_BACKEND=BOOST requires Boost >= "
-                "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION} "
-                "(boost::unordered_node_map), but found Boost "
-                "${_colmap_boost_version}. Upgrade Boost or set "
-                "-DCOLMAP_HASH_MAP_BACKEND=STD.")
-    endif()
     list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_BOOST)
 else()
     message(FATAL_ERROR "Unknown COLMAP_HASH_MAP_BACKEND "
             "'${COLMAP_HASH_MAP_BACKEND}' (expected STD, BOOST or empty)")
 endif()
+
+# The BOOST backend needs Boost >= 1.84 for boost::unordered_node_map, which
+# distributions predate for years. Fetch a pinned Boost then, so the default
+# backend is available everywhere. The fetched superproject replaces the system
+# Boost entirely, so no translation unit mixes headers from two Boost releases.
+# The STD backend imposes no minimum and keeps using the system Boost.
+set(COLMAP_FETCH_BOOST_VERSION "1.88.0")
+if(COLMAP_HASH_MAP_BACKEND STREQUAL "BOOST")
+    set(COLMAP_MIN_BOOST_VERSION "1.84.0")
+else()
+    set(COLMAP_MIN_BOOST_VERSION "0")
+endif()
+# Boost libraries COLMAP includes. Boost::headers aggregates exactly these.
+set(COLMAP_BOOST_LIBRARIES
+    algorithm
+    functional
+    graph
+    heap
+    predef
+    preprocessor
+    program_options
+    property_map
+    property_tree
+    unordered)
+
+string(TOUPPER "${FETCH_BOOST}" FETCH_BOOST)
+if(NOT FETCH_BOOST STREQUAL "ON")
+    # Read the version from the header, not via find_package, whose Boost::
+    # imported targets would collide with the fetched superproject's own.
+    find_path(COLMAP_SYSTEM_BOOST_INCLUDE_DIR boost/version.hpp
+              HINTS ${Boost_ROOT} ${BOOST_ROOT} $ENV{BOOST_ROOT}
+              PATH_SUFFIXES include)
+    set(_colmap_boost_version "0")
+    if(COLMAP_SYSTEM_BOOST_INCLUDE_DIR)
+        file(STRINGS "${COLMAP_SYSTEM_BOOST_INCLUDE_DIR}/boost/version.hpp"
+             _colmap_boost_version_line REGEX "^#define BOOST_VERSION ")
+        string(REGEX MATCH "[0-9]+" _colmap_boost_version_num
+               "${_colmap_boost_version_line}")
+        if(_colmap_boost_version_num)
+            math(EXPR _colmap_boost_major "${_colmap_boost_version_num} / 100000")
+            math(EXPR _colmap_boost_minor
+                 "${_colmap_boost_version_num} / 100 % 1000")
+            math(EXPR _colmap_boost_patch "${_colmap_boost_version_num} % 100")
+            set(_colmap_boost_version
+                "${_colmap_boost_major}.${_colmap_boost_minor}.${_colmap_boost_patch}")
+        endif()
+    endif()
+    if(_colmap_boost_version VERSION_GREATER_EQUAL "${COLMAP_MIN_BOOST_VERSION}")
+        set(FETCH_BOOST "OFF")
+        find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
+                     graph
+                     program_options
+                     OPTIONAL_COMPONENTS
+                     system)
+        if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)
+            set(_colmap_boost_version "${Boost_VERSION_STRING}")
+        endif()
+    elseif(FETCH_BOOST STREQUAL "AUTO")
+        set(FETCH_BOOST "ON")
+    else()
+        message(FATAL_ERROR
+                "COLMAP_HASH_MAP_BACKEND=BOOST requires Boost >= "
+                "${COLMAP_MIN_BOOST_VERSION} but found ${_colmap_boost_version}. "
+                "Set -DFETCH_BOOST=ON to build against a fetched Boost "
+                "${COLMAP_FETCH_BOOST_VERSION}, or "
+                "-DCOLMAP_HASH_MAP_BACKEND=STD to keep the system Boost.")
+    endif()
+endif()
+
+if(FETCH_BOOST STREQUAL "ON")
+    include(FetchContent)
+    set(BOOST_ENABLE_CMAKE ON)
+    set(BOOST_INCLUDE_LIBRARIES ${COLMAP_BOOST_LIBRARIES})
+    # Boost skips install rules as a subproject. Re-enable them so it lands in
+    # COLMAP's prefix, where colmap-config.cmake points downstream consumers.
+    set(BOOST_SKIP_INSTALL_RULES OFF)
+    # Keep the ~100 MB archive in a stable location so CI can cache it. The
+    # extracted tree is far too large to cache.
+    FetchContent_Declare(Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-${COLMAP_FETCH_BOOST_VERSION}/boost-${COLMAP_FETCH_BOOST_VERSION}-cmake.tar.xz
+        URL_HASH SHA256=f48b48390380cfb94a629872346e3a81370dc498896f16019ade727ab72eb1ec
+        DOWNLOAD_DIR ${FETCHCONTENT_BASE_DIR}/downloads
+    )
+    message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}...")
+    FetchContent_MakeAvailable(Boost)
+    message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}... done")
+    # The superproject defines Boost::headers where find_package defines
+    # Boost::boost. Alias via an interface target, since Boost::headers is itself
+    # an alias and cannot be aliased again.
+    if(NOT TARGET Boost::boost)
+        add_library(colmap_boost_headers INTERFACE)
+        target_link_libraries(colmap_boost_headers INTERFACE Boost::headers)
+        add_library(Boost::boost ALIAS colmap_boost_headers)
+    endif()
+    set(_colmap_boost_version "${COLMAP_FETCH_BOOST_VERSION}")
+endif()
+
 message(STATUS "Using ${COLMAP_HASH_MAP_BACKEND} hash map backend "
         "(Boost ${_colmap_boost_version})")
 

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -87,6 +87,27 @@ set(FETCH_POSELIB @FETCH_POSELIB@)
 
 set(FETCH_FAISS @FETCH_FAISS@)
 
+# A fetched Boost was installed into this same prefix. Point find_package(Boost)
+# there and stop fetching, so FindDependencies.cmake below reuses it.
+set(FETCH_BOOST "@FETCH_BOOST@")
+if(FETCH_BOOST STREQUAL "ON")
+    set(Boost_ROOT ${PACKAGE_PREFIX_DIR})
+    set(FETCH_BOOST "OFF")
+endif()
+
+# Backend COLMAP was built with, so FindDependencies.cmake below reproduces it
+# instead of re-deriving it.
+string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" _colmap_requested_hash_map_backend)
+if(_colmap_requested_hash_map_backend AND
+   NOT _colmap_requested_hash_map_backend STREQUAL "@COLMAP_HASH_MAP_BACKEND@")
+    message(WARNING
+            "Ignoring COLMAP_HASH_MAP_BACKEND="
+            "${_colmap_requested_hash_map_backend}: the installed COLMAP was "
+            "built with @COLMAP_HASH_MAP_BACKEND@.")
+endif()
+unset(_colmap_requested_hash_map_backend)
+set(COLMAP_HASH_MAP_BACKEND "@COLMAP_HASH_MAP_BACKEND@")
+
 set(FETCH_ONNX FALSE)
 if(@FETCH_ONNX@)
     if(ONNX_ENABLED AND EXISTS ${PACKAGE_PREFIX_DIR}/share/onnxruntime/cmake)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -162,16 +162,24 @@ Configure and compile COLMAP::
 
 .. note::
 
-    COLMAP can use ``boost::unordered`` flat/node hash maps for the
-    performance-critical scene and SfM containers, selected via
-    ``-DCOLMAP_HASH_MAP_BACKEND=BOOST|STD`` (default: auto). Auto selects
-    ``BOOST`` when Boost is recent enough (``boost::unordered_node_map`` requires
-    **Boost >= 1.84**) and falls back to ``STD`` (``std::unordered_map``)
-    otherwise. Ubuntu's default Boost is older than 1.84, so apt-based builds use
-    ``STD``; to use the faster ``BOOST`` backend, build against a newer Boost
-    (e.g. via vcpkg, which installs ``boost-unordered`` automatically) or install
-    Boost >= 1.84 manually. Explicitly requesting ``-DCOLMAP_HASH_MAP_BACKEND=BOOST``
-    with an older Boost is a configuration error.
+    The scene and SfM containers use ``boost::unordered`` flat/node hash maps,
+    selected via ``-DCOLMAP_HASH_MAP_BACKEND=BOOST|STD`` (default: ``BOOST``).
+
+    **The backend is part of COLMAP's ABI**: the containers are data members of
+    classes in public headers, so ``sizeof(Reconstruction)`` is 280 bytes with
+    ``BOOST`` and 320 with ``STD`` on x86-64 Linux, and a mismatch produces no
+    link error, only memory corruption. Every binary sharing COLMAP types in one
+    process must agree, the prebuilt ``pycolmap`` wheels included. Query a build
+    with ``colmap -h``, ``pycolmap.__hash_map_backend__`` or
+    ``colmap::kHashMapBackend``.
+
+    The default is therefore fixed, not derived from the Boost found on the build
+    machine. ``BOOST`` needs **Boost >= 1.84**, which Ubuntu's apt Boost predates,
+    so ``-DFETCH_BOOST`` decides where Boost comes from: ``AUTO`` (default) falls
+    back to a pinned Boost only when the system one is too old for the selected
+    backend, ``ON`` always fetches, ``OFF`` never does. A fetched Boost replaces
+    the system one entirely and is installed alongside COLMAP for downstream
+    ``find_package(colmap)`` users.
 
 Run COLMAP::
 

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -66,7 +66,8 @@ if TYPE_CHECKING:
 __all__ = import_module_symbols(
     globals(), _core, exclude={"cost_functions", "pyceres"}
 )
-__all__.extend(["__version__", "__ceres_version__"])
+__all__.extend(["__version__", "__ceres_version__", "__hash_map_backend__"])
 
 __version__ = _core.__version__
 __ceres_version__ = _core.__ceres_version__
+__hash_map_backend__ = _core.__hash_map_backend__

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -61,6 +61,12 @@
 // unchanged and the hashing semantics are held constant across backends.
 // boost::unordered internally re-mixes a non-avalanching hash such as the
 // identity std::hash<uint32_t>.
+//
+// WARNING: these aliases are data members of classes in public headers, so the
+// backend changes their size and member offsets, and both are header-only, so
+// nothing reaches the linker. Mixing binaries built with different backends
+// corrupts memory instead of failing to link. Hence the fixed CMake default,
+// and kHashMapBackend for checking a binary.
 
 #include <functional>
 
@@ -82,6 +88,9 @@ namespace colmap {
 
 #if defined(COLMAP_HASH_BOOST)
 
+// Identifies the layout of every class storing these containers.
+inline constexpr const char* kHashMapBackend = "boost";
+
 template <class Key,
           class Value,
           class Hash = std::hash<Key>,
@@ -101,6 +110,8 @@ template <class Key, class Hash = std::hash<Key>, class Eq = std::equal_to<Key>>
 using NodeHashSet = boost::unordered_node_set<Key, Hash, Eq>;
 
 #else  // COLMAP_HASH_STD
+
+inline constexpr const char* kHashMapBackend = "std";
 
 template <class Key,
           class Value,

--- a/src/colmap/util/version.cc.in
+++ b/src/colmap/util/version.cc.in
@@ -30,6 +30,7 @@
 
 #include "colmap/util/version.h"
 
+#include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/string.h"
 
@@ -73,8 +74,13 @@ std::string GetBuildInfo() {
 #else
   const char* gpu_info = "without GPU support";
 #endif
-  return StringPrintf(
-      "Commit %s on %s %s", COLMAP_COMMIT_ID, COLMAP_COMMIT_DATE, gpu_info);
+  // The hash map backend is part of the ABI and otherwise indistinguishable
+  // between two builds of the same commit.
+  return StringPrintf("Commit %s on %s %s, %s hash maps",
+                      COLMAP_COMMIT_ID,
+                      COLMAP_COMMIT_DATE,
+                      gpu_info,
+                      kHashMapBackend);
 }
 
 }  // namespace colmap

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -1,4 +1,5 @@
 #include "colmap/math/random.h"
+#include "colmap/util/hash_containers.h"
 #include "colmap/util/version.h"
 
 #include "pycolmap/helpers.h"
@@ -42,6 +43,10 @@ PYBIND11_MODULE(_core, m) {
   m.attr("has_cuda") = IsGPU(Device::AUTO);
   m.attr("COLMAP_version") = py::str(GetVersionInfo());
   m.attr("COLMAP_build") = py::str(GetBuildInfo());
+  // An extension linking its own COLMAP must share this backend, or the two
+  // disagree about the layout of Reconstruction and friends, which neither the
+  // link nor the import catches.
+  m.attr("__hash_map_backend__") = py::str(kHashMapBackend);
 
   auto PyDevice = py::enum_<Device>(m, "Device")
                       .value("auto", Device::AUTO)

--- a/src/pycolmap/main_test.py
+++ b/src/pycolmap/main_test.py
@@ -11,6 +11,10 @@ def test_ceres_version_is_str() -> None:
     assert len(pycolmap.__ceres_version__) > 0
 
 
+def test_hash_map_backend_is_known() -> None:
+    assert pycolmap.__hash_map_backend__ in ("std", "boost")
+
+
 def test_has_cuda_is_bool() -> None:
     assert isinstance(pycolmap.has_cuda, bool)
 


### PR DESCRIPTION
Fixes https://github.com/colmap/colmap/pull/4672

An alternative to https://github.com/colmap/colmap/pull/4673. Comparing with the other one, this PR always uses boost as backend which keeps the speed up at the sacrifice of vendoring boost when the system boost version is lower than 1.84. 

The hash map backend is auto-selected from the Boost found at configure time, so `sizeof(Reconstruction)` is 280 bytes in the vcpkg-built pycolmap wheels and 320 in an apt-based Ubuntu build of the same commit. Both backends are header-only, so mixing them in one process corrupts memory instead of failing to link.

This fixes the default to `BOOST` and adds `FETCH_BOOST=AUTO`, which checks the system Boost first and fetches a pinned 1.88 only when it is too old for the selected backend. The backend is also exposed as `colmap::kHashMapBackend` / `pycolmap.__hash_map_backend__` so downstreams can assert on it.